### PR TITLE
Require classes using Timer to be ref-counted or CanMakeCheckedPtr

### DIFF
--- a/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
+++ b/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
@@ -62,6 +62,10 @@ public:
 
         std::optional<Seconds> timeUntilFire(JSRunLoopTimer&);
 
+        // Do nothing since this is a singleton.
+        void ref() const { }
+        void deref() const { }
+
     private:
         Lock m_lock;
 

--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -88,6 +88,10 @@ class MemoryPressureHandler {
 public:
     WTF_EXPORT_PRIVATE static MemoryPressureHandler& singleton();
 
+    // Do nothing since this is a singleton.
+    void ref() const { }
+    void deref() const { }
+
     WTF_EXPORT_PRIVATE void install();
 
     WTF_EXPORT_PRIVATE void setMemoryFootprintPollIntervalForTesting(Seconds);

--- a/Source/WTF/wtf/linux/RealTimeThreads.h
+++ b/Source/WTF/wtf/linux/RealTimeThreads.h
@@ -38,6 +38,10 @@ class RealTimeThreads {
 public:
     WTF_EXPORT_PRIVATE static RealTimeThreads& singleton();
 
+    // Do nothing since this is a singleton.
+    void ref() const { }
+    void deref() const { }
+
     void registerThread(Thread&);
 
     WTF_EXPORT_PRIVATE void setEnabled(bool);

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -279,7 +279,7 @@ ExceptionOr<void> MediaSession::setActionHandler(MediaSessionAction action, RefP
         }
         auto platformCommand = platformCommandForMediaSessionAction(action);
         if (platformCommand != PlatformMediaSession::RemoteControlCommandType::NoCommand)
-            PlatformMediaSessionManager::sharedManager().addSupportedCommand(platformCommand);
+            PlatformMediaSessionManager::singleton().addSupportedCommand(platformCommand);
     } else {
         bool containedAction;
         {
@@ -289,7 +289,7 @@ ExceptionOr<void> MediaSession::setActionHandler(MediaSessionAction action, RefP
 
         if (containedAction)
             ALWAYS_LOG(LOGIDENTIFIER, "removing ", action);
-        PlatformMediaSessionManager::sharedManager().removeSupportedCommand(platformCommandForMediaSessionAction(action));
+        PlatformMediaSessionManager::singleton().removeSupportedCommand(platformCommandForMediaSessionAction(action));
     }
 
     notifyActionHandlerObservers();

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -104,7 +104,7 @@ MediaStreamTrack::MediaStreamTrack(ScriptExecutionContext& context, Ref<MediaStr
     m_isInterrupted = m_private->interrupted();
 
     if (m_private->isAudio())
-        PlatformMediaSessionManager::sharedManager().addAudioCaptureSource(*this);
+        PlatformMediaSessionManager::singleton().addAudioCaptureSource(*this);
 }
 
 MediaStreamTrack::~MediaStreamTrack()
@@ -115,7 +115,7 @@ MediaStreamTrack::~MediaStreamTrack()
         return;
 
     if (m_private->isAudio())
-        PlatformMediaSessionManager::sharedManager().removeAudioCaptureSource(*this);
+        PlatformMediaSessionManager::singleton().removeAudioCaptureSource(*this);
 }
 
 const AtomString& MediaStreamTrack::kind() const
@@ -253,7 +253,7 @@ void MediaStreamTrack::stopTrack(StopMode mode)
     m_ended = true;
 
     if (isAudio() && isCaptureTrack())
-        PlatformMediaSessionManager::sharedManager().audioCaptureSourceStateChanged();
+        PlatformMediaSessionManager::singleton().audioCaptureSourceStateChanged();
 
     configureTrackRendering();
 }
@@ -483,7 +483,7 @@ void MediaStreamTrack::trackStarted(MediaStreamTrackPrivate&)
 void MediaStreamTrack::trackEnded(MediaStreamTrackPrivate&)
 {
     if (m_isCaptureTrack && m_private->isAudio())
-        PlatformMediaSessionManager::sharedManager().removeAudioCaptureSource(*this);
+        PlatformMediaSessionManager::singleton().removeAudioCaptureSource(*this);
 
     ALWAYS_LOG(LOGIDENTIFIER);
 
@@ -534,7 +534,7 @@ void MediaStreamTrack::trackMutedChanged(MediaStreamTrackPrivate&)
         m_muted = muted;
 
         if (isAudio() && isCaptureTrack())
-            PlatformMediaSessionManager::sharedManager().audioCaptureSourceStateChanged();
+            PlatformMediaSessionManager::singleton().audioCaptureSourceStateChanged();
 
         dispatchEvent(Event::create(muted ? eventNames().muteEvent : eventNames().unmuteEvent, Event::CanBubble::No, Event::IsCancelable::No));
     };

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -136,7 +136,7 @@ void UserMediaRequest::start()
         break;
     }
 
-    PlatformMediaSessionManager::sharedManager().prepareToSendUserMediaPermissionRequest();
+    PlatformMediaSessionManager::singleton().prepareToSendUserMediaPermissionRequest();
     controller->requestUserMediaAccess(*this);
 }
 

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -127,7 +127,7 @@ ExceptionOr<Ref<AudioContext>> AudioContext::create(Document& document, AudioCon
 AudioContext::AudioContext(Document& document, const AudioContextOptions& contextOptions)
     : BaseAudioContext(document)
     , m_destinationNode(makeUniqueRefWithoutRefCountedCheck<DefaultAudioDestinationNode>(*this, contextOptions.sampleRate))
-    , m_mediaSession(PlatformMediaSession::create(PlatformMediaSessionManager::sharedManager(), *this))
+    , m_mediaSession(PlatformMediaSession::create(PlatformMediaSessionManager::singleton(), *this))
     , m_currentIdentifier(MediaUniqueIdentifier::generate())
 {
     constructCommon();
@@ -660,7 +660,7 @@ bool AudioContext::shouldOverrideBackgroundPlaybackRestriction(PlatformMediaSess
 void AudioContext::defaultDestinationWillBecomeConnected()
 {
     // We might need to interrupt if we previously overrode a background interruption.
-    if (!PlatformMediaSessionManager::sharedManager().isApplicationInBackground() || m_mediaSession->state() == PlatformMediaSession::State::Interrupted) {
+    if (!PlatformMediaSessionManager::singleton().isApplicationInBackground() || m_mediaSession->state() == PlatformMediaSession::State::Interrupted) {
         PlatformMediaSessionManager::updateNowPlayingInfoIfNecessary();
         return;
     }

--- a/Source/WebCore/PAL/pal/HysteresisActivity.h
+++ b/Source/WebCore/PAL/pal/HysteresisActivity.h
@@ -30,6 +30,15 @@
 #include <wtf/TZoneMallocInlines.h>
 
 namespace PAL {
+class HysteresisActivity;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<PAL::HysteresisActivity> : std::true_type { };
+}
+
+namespace PAL {
 
 static const Seconds defaultHysteresisDuration { 5_s };
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
@@ -48,6 +48,10 @@ class AccessibilityAtspi {
 public:
     WEBCORE_EXPORT static AccessibilityAtspi& singleton();
 
+    // Do nothing since this is a singleton.
+    void ref() const { }
+    void deref() const { }
+
     void connect(const String&, const String&);
 
     const char* uniqueName() const;

--- a/Source/WebCore/bindings/js/GCController.h
+++ b/Source/WebCore/bindings/js/GCController.h
@@ -45,6 +45,10 @@ public:
     WEBCORE_EXPORT static GCController& singleton();
     WEBCORE_EXPORT static void dumpHeapForVM(JSC::VM&);
 
+    // Do nothing since this is a singleton.
+    void ref() const { }
+    void deref() const { }
+
     WEBCORE_EXPORT void garbageCollectSoon();
     WEBCORE_EXPORT void garbageCollectNow(); // It's better to call garbageCollectSoon, unless you have a specific reason not to.
     WEBCORE_EXPORT void garbageCollectNowIfNotDoneRecently();

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2351,7 +2351,7 @@ void Document::visibilityStateChanged()
     });
 
 #if ENABLE(MEDIA_STREAM) && PLATFORM(IOS_FAMILY)
-    if (auto mediaSessionManager = PlatformMediaSessionManager::sharedManagerIfExists()) {
+    if (auto mediaSessionManager = PlatformMediaSessionManager::singletonIfExists()) {
         if (!mediaSessionManager->isInterrupted())
             updateCaptureAccordingToMutedState();
     }

--- a/Source/WebCore/dom/DocumentFontLoader.h
+++ b/Source/WebCore/dom/DocumentFontLoader.h
@@ -34,6 +34,15 @@
 #include <wtf/WeakRef.h>
 
 namespace WebCore {
+class DocumentFontLoader;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::DocumentFontLoader> : std::true_type { };
+}
+
+namespace WebCore {
 
 class CachedFont;
 

--- a/Source/WebCore/dom/EventSender.h
+++ b/Source/WebCore/dom/EventSender.h
@@ -31,6 +31,17 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
+template<typename T, typename WeakPtrImpl> class EventSender;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+
+template<typename U, typename WeakPtrImpl>
+struct IsDeprecatedTimerSmartPointerException<WebCore::EventSender<U, WeakPtrImpl>> : std::true_type { };
+}
+
+namespace WebCore {
 
 class Page;
 class WeakPtrImplWithEventTargetData;

--- a/Source/WebCore/editing/SpellChecker.h
+++ b/Source/WebCore/editing/SpellChecker.h
@@ -42,6 +42,9 @@ class SpellChecker;
 namespace WTF {
 template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
 template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::SpellChecker> : std::true_type { };
+
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::SpellChecker> : std::true_type { };
 }
 
 namespace WebCore {

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -775,7 +775,7 @@ std::optional<MediaPlayerIdentifier> HTMLMediaElement::playerIdentifier() const
 
 RefPtr<HTMLMediaElement> HTMLMediaElement::bestMediaElementForRemoteControls(MediaElementSession::PlaybackControlsPurpose purpose, const Document* document)
 {
-    auto selectedSession = PlatformMediaSessionManager::sharedManager().bestEligibleSessionForRemoteControls([&document] (auto& session) {
+    auto selectedSession = PlatformMediaSessionManager::singleton().bestEligibleSessionForRemoteControls([&document] (auto& session) {
         auto* mediaElementSession = dynamicDowncast<MediaElementSession>(session);
         return mediaElementSession && (!document || &mediaElementSession->element().document() == document);
     }, purpose);
@@ -5922,7 +5922,7 @@ void HTMLMediaElement::seekToPlaybackPositionEndedTimerFired()
     if (!m_isScrubbingRemotely)
         return;
 
-    PlatformMediaSessionManager::sharedManager().sessionDidEndRemoteScrubbing(mediaSession());
+    PlatformMediaSessionManager::singleton().sessionDidEndRemoteScrubbing(mediaSession());
     m_isScrubbingRemotely = false;
     m_seekToPlaybackPositionEndedTimer.stop();
 #endif
@@ -6281,7 +6281,7 @@ bool HTMLMediaElement::couldPlayIfEnoughData() const
     if (pausedForUserInteraction())
         return false;
 
-    if (!canProduceAudio() || PlatformMediaSessionManager::sharedManager().hasActiveAudioSession())
+    if (!canProduceAudio() || PlatformMediaSessionManager::singleton().hasActiveAudioSession())
         return true;
 
     if (mediaSession().activeAudioSessionRequired() && mediaSession().blockedBySystemInterruption())
@@ -8191,7 +8191,7 @@ HTMLMediaElement::SleepType HTMLMediaElement::shouldDisableSleep() const
         return SleepType::System;
 #endif
 
-    if (PlatformMediaSessionManager::sharedManager().processIsSuspended())
+    if (PlatformMediaSessionManager::singleton().processIsSuspended())
         return SleepType::None;
 
     bool shouldBeAbleToSleep = mediaType() != PlatformMediaSession::MediaType::VideoAudio;
@@ -9079,7 +9079,7 @@ bool HTMLMediaElement::shouldOverrideBackgroundPlaybackRestriction(PlatformMedia
             INFO_LOG(LOGIDENTIFIER, "returning true because isPlayingToExternalTarget() is true");
             return true;
         }
-        if (PlatformMediaSessionManager::sharedManager().isPlayingToAutomotiveHeadUnit()) {
+        if (PlatformMediaSessionManager::singleton().isPlayingToAutomotiveHeadUnit()) {
             INFO_LOG(LOGIDENTIFIER, "returning true because isPlayingToAutomotiveHeadUnit() is true");
             return true;
         }
@@ -9108,7 +9108,7 @@ bool HTMLMediaElement::shouldOverrideBackgroundPlaybackRestriction(PlatformMedia
             INFO_LOG(LOGIDENTIFIER, "returning true because isPlayingToExternalTarget() is true");
             return true;
         }
-        if (PlatformMediaSessionManager::sharedManager().isPlayingToAutomotiveHeadUnit()) {
+        if (PlatformMediaSessionManager::singleton().isPlayingToAutomotiveHeadUnit()) {
             INFO_LOG(LOGIDENTIFIER, "returning true because isPlayingToAutomotiveHeadUnit() is true");
             return true;
         }

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -175,7 +175,7 @@ private:
 #endif
 
 MediaElementSession::MediaElementSession(HTMLMediaElement& element)
-    : PlatformMediaSession(PlatformMediaSessionManager::sharedManager(), element)
+    : PlatformMediaSession(PlatformMediaSessionManager::singleton(), element)
     , m_element(element)
     , m_restrictions(NoRestrictions)
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
@@ -312,7 +312,7 @@ void MediaElementSession::isVisibleInViewportChanged()
         m_elementIsHiddenUntilVisibleInViewport = false;
 
 #if PLATFORM(COCOA) && !HAVE(CGS_FIX_FOR_RADAR_97530095)
-    PlatformMediaSessionManager::sharedManager().scheduleSessionStatusUpdate();
+    PlatformMediaSessionManager::singleton().scheduleSessionStatusUpdate();
 #endif
 }
 
@@ -337,7 +337,7 @@ void MediaElementSession::clientDataBufferingTimerFired()
     if (state() != PlatformMediaSession::State::Playing || !m_element.elementIsHidden())
         return;
 
-    PlatformMediaSessionManager::SessionRestrictions restrictions = PlatformMediaSessionManager::sharedManager().restrictions(mediaType());
+    PlatformMediaSessionManager::SessionRestrictions restrictions = PlatformMediaSessionManager::singleton().restrictions(mediaType());
     if ((restrictions & PlatformMediaSessionManager::BackgroundTabPlaybackRestricted) == PlatformMediaSessionManager::BackgroundTabPlaybackRestricted)
         pauseSession();
 }
@@ -350,7 +350,7 @@ void MediaElementSession::updateClientDataBuffering()
     m_element.setBufferingPolicy(preferredBufferingPolicy());
 
 #if PLATFORM(IOS_FAMILY)
-    PlatformMediaSessionManager::sharedManager().configureWirelessTargetMonitoring();
+    PlatformMediaSessionManager::singleton().configureWirelessTargetMonitoring();
 #endif
 }
 
@@ -584,7 +584,7 @@ bool MediaElementSession::canShowControlsManager(PlaybackControlsPurpose purpose
     if (client().presentationType() == MediaType::Audio && purpose == PlaybackControlsPurpose::NowPlaying) {
         if (!m_element.hasSource()
             || m_element.error()
-            || (!isLongEnoughForMainContent() && !PlatformMediaSessionManager::sharedManager().registeredAsNowPlayingApplication())) {
+            || (!isLongEnoughForMainContent() && !PlatformMediaSessionManager::singleton().registeredAsNowPlayingApplication())) {
             INFO_LOG(LOGIDENTIFIER, "returning FALSE: audio too short for NowPlaying");
             return false;
         }
@@ -797,7 +797,7 @@ void MediaElementSession::setHasPlaybackTargetAvailabilityListeners(bool hasList
 
 #if PLATFORM(IOS_FAMILY)
     m_hasPlaybackTargetAvailabilityListeners = hasListeners;
-    PlatformMediaSessionManager::sharedManager().configureWirelessTargetMonitoring();
+    PlatformMediaSessionManager::singleton().configureWirelessTargetMonitoring();
 #else
     UNUSED_PARAM(hasListeners);
     m_element.document().playbackTargetPickerClientStateDidChange(*this, m_element.mediaState());

--- a/Source/WebCore/html/ValidationMessage.h
+++ b/Source/WebCore/html/ValidationMessage.h
@@ -45,6 +45,9 @@ class ValidationMessage;
 namespace WTF {
 template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
 template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::ValidationMessage> : std::true_type { };
+
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::ValidationMessage> : std::true_type { };
 }
 
 namespace WebCore {

--- a/Source/WebCore/html/parser/HTMLParserScheduler.h
+++ b/Source/WebCore/html/parser/HTMLParserScheduler.h
@@ -35,6 +35,15 @@
 #endif
 
 namespace WebCore {
+class HTMLParserScheduler;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::HTMLParserScheduler> : std::true_type { };
+}
+
+namespace WebCore {
 
 class Document;
 class HTMLDocumentParser;

--- a/Source/WebCore/inspector/InspectorOverlay.h
+++ b/Source/WebCore/inspector/InspectorOverlay.h
@@ -53,6 +53,15 @@ using ErrorStringOr = Expected<T, ErrorString>;
 }
 
 namespace WebCore {
+class InspectorOverlay;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::InspectorOverlay> : std::true_type { };
+}
+
+namespace WebCore {
 
 class WeakPtrImplWithEventTargetData;
 class FontCascade;

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.h
@@ -37,6 +37,15 @@
 #include <wtf/WeakHashMap.h>
 
 namespace WebCore {
+class InspectorAnimationAgent;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::InspectorAnimationAgent> : std::true_type { };
+}
+
+namespace WebCore {
 
 class AnimationEffect;
 class Element;

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -47,6 +47,15 @@ class CSSFrontendDispatcher;
 }
 
 namespace WebCore {
+class InspectorCSSAgent;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::InspectorCSSAgent> : std::true_type { };
+}
+
+namespace WebCore {
 
 class CSSRule;
 class CSSStyleRule;

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
@@ -48,6 +48,9 @@ class InspectorCanvasAgent;
 namespace WTF {
 template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
 template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::InspectorCanvasAgent> : std::true_type { };
+
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::InspectorCanvasAgent> : std::true_type { };
 }
 
 namespace Inspector {

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -138,6 +138,15 @@
 #include <wtf/text/WTFString.h>
 #include <wtf/unicode/CharacterNames.h>
 
+namespace WebCore {
+class RevalidateStyleAttributeTask;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::RevalidateStyleAttributeTask> : std::true_type { };
+}
+
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -55,6 +55,15 @@ class JSValue;
 }
 
 namespace WebCore {
+class InspectorDOMAgent;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::InspectorDOMAgent> : std::true_type { };
+}
+
+namespace WebCore {
 
 class AXCoreObject;
 class CharacterData;

--- a/Source/WebCore/inspector/agents/WebHeapAgent.cpp
+++ b/Source/WebCore/inspector/agents/WebHeapAgent.cpp
@@ -34,6 +34,15 @@
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+class SendGarbageCollectionEventsTask;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::SendGarbageCollectionEventsTask> : std::true_type { };
+}
+
+namespace WebCore {
 
 using namespace Inspector;
 

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -37,6 +37,9 @@ class ImageLoader;
 namespace WTF {
 template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
 template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::ImageLoader> : std::true_type { };
+
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::ImageLoader> : std::true_type { };
 }
 
 namespace WebCore {

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -858,11 +858,11 @@ void SubresourceLoader::willCancel(const ResourceError& error)
 #else
     m_state = Finishing;
 #endif
-    auto& memoryCache = MemoryCache::singleton();
+    Ref memoryCache = MemoryCache::singleton();
     if (resource->resourceToRevalidate())
-        memoryCache.revalidationFailed(*resource);
+        memoryCache->revalidationFailed(*resource);
     resource->setResourceError(error);
-    memoryCache.remove(*resource);
+    memoryCache->remove(*resource);
 }
 
 void SubresourceLoader::didCancel(LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)

--- a/Source/WebCore/loader/TextTrackLoader.h
+++ b/Source/WebCore/loader/TextTrackLoader.h
@@ -36,12 +36,16 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
+class TextTrackLoader;
 class TextTrackLoaderClient;
 }
 
 namespace WTF {
 template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
 template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::TextTrackLoaderClient> : std::true_type { };
+
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::TextTrackLoader> : std::true_type { };
 }
 
 namespace WebCore {

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -585,10 +585,10 @@ void CachedResource::removeClient(CachedResourceClient& client)
     if (hasClients())
         return;
 
-    auto& memoryCache = MemoryCache::singleton();
+    Ref memoryCache = MemoryCache::singleton();
     if (allowsCaching() && inCache()) {
-        memoryCache.removeFromLiveResourcesSize(*this);
-        memoryCache.removeFromLiveDecodedResourcesList(*this);
+        memoryCache->removeFromLiveResourcesSize(*this);
+        memoryCache->removeFromLiveDecodedResourcesList(*this);
     }
 
     if (deleteIfPossible()) {
@@ -603,7 +603,7 @@ void CachedResource::removeClient(CachedResourceClient& client)
     if (!allowsCaching())
         return;
 
-    memoryCache.pruneSoon();
+    memoryCache->pruneSoon();
 }
 
 void CachedResource::allClientsRemoved()
@@ -688,9 +688,9 @@ void CachedResource::setDecodedSize(unsigned size)
     mutableResponseData().m_decodedSize = size;
    
     if (allowsCaching() && inCache()) {
-        auto& memoryCache = MemoryCache::singleton();
+        Ref memoryCache = MemoryCache::singleton();
         // Now insert into the new LRU list.
-        memoryCache.insertInLRUList(*this);
+        memoryCache->insertInLRUList(*this);
         
         // Insert into or remove from the live decoded list if necessary.
         // When inserting into the LiveDecodedResourcesList it is possible
@@ -699,14 +699,14 @@ void CachedResource::setDecodedSize(unsigned size)
         // violation of the invariant that the list is to be kept sorted
         // by access time. The weakening of the invariant does not pose
         // a problem. For more details please see: https://bugs.webkit.org/show_bug.cgi?id=30209
-        bool inLiveDecodedResourcesList = memoryCache.inLiveDecodedResourcesList(*this);
+        bool inLiveDecodedResourcesList = memoryCache->inLiveDecodedResourcesList(*this);
         if (decodedSize() && !inLiveDecodedResourcesList && hasClients())
-            memoryCache.insertInLiveDecodedResourcesList(*this);
+            memoryCache->insertInLiveDecodedResourcesList(*this);
         else if (!decodedSize() && inLiveDecodedResourcesList)
-            memoryCache.removeFromLiveDecodedResourcesList(*this);
+            memoryCache->removeFromLiveDecodedResourcesList(*this);
 
         // Update the cache's size totals.
-        memoryCache.adjustSize(hasClients(), delta);
+        memoryCache->adjustSize(hasClients(), delta);
     }
 }
 
@@ -725,9 +725,9 @@ void CachedResource::setEncodedSize(unsigned size)
     mutableResponseData().m_encodedSize = size;
 
     if (allowsCaching() && inCache()) {
-        auto& memoryCache = MemoryCache::singleton();
-        memoryCache.insertInLRUList(*this);
-        memoryCache.adjustSize(hasClients(), delta);
+        Ref memoryCache = MemoryCache::singleton();
+        memoryCache->insertInLRUList(*this);
+        memoryCache->adjustSize(hasClients(), delta);
     }
 }
 
@@ -736,9 +736,9 @@ void CachedResource::didAccessDecodedData(MonotonicTime timeStamp)
     m_lastDecodedAccessTime = timeStamp;
     
     if (allowsCaching() && inCache()) {
-        auto& memoryCache = MemoryCache::singleton();
-        memoryCache.moveToEndOfLiveDecodedResourcesListIfPresent(*this);
-        memoryCache.pruneSoon();
+        Ref memoryCache = MemoryCache::singleton();
+        memoryCache->moveToEndOfLiveDecodedResourcesListIfPresent(*this);
+        memoryCache->pruneSoon();
     }
 }
     
@@ -1016,21 +1016,21 @@ unsigned CachedResource::decodedSize() const
     return m_response->m_decodedSize;
 }
 
-inline CachedResource::Callback::Callback(CachedResource& resource, CachedResourceClient& client)
+inline CachedResourceCallback::CachedResourceCallback(CachedResource& resource, CachedResourceClient& client)
     : m_resource(resource)
     , m_client(client)
-    , m_timer(*this, &Callback::timerFired)
+    , m_timer(*this, &CachedResourceCallback::timerFired)
 {
     m_timer.startOneShot(0_s);
 }
 
-inline void CachedResource::Callback::cancel()
+inline void CachedResourceCallback::cancel()
 {
     if (m_timer.isActive())
         m_timer.stop();
 }
 
-void CachedResource::Callback::timerFired()
+void CachedResourceCallback::timerFired()
 {
     CachedResourceHandle { m_resource.get() }->didAddClient(m_client);
 }

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -46,11 +46,15 @@
 
 namespace WebCore {
 class CachedResource;
+class CachedResourceCallback;
 }
 
 namespace WTF {
 template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
 template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CachedResource> : std::true_type { };
+
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::CachedResourceCallback> : std::true_type { };
 }
 
 namespace WebCore {
@@ -336,7 +340,7 @@ protected:
     void clearCachedCryptographicDigests();
 
 private:
-    class Callback;
+    using Callback = CachedResourceCallback;
     template<typename T> friend class CachedResourceClientWalker;
 
     void deleteThis();
@@ -444,10 +448,10 @@ private:
     mutable std::array<std::optional<ResourceCryptographicDigest>, ResourceCryptographicDigest::algorithmCount> m_cryptographicDigests;
 };
 
-class CachedResource::Callback {
+class CachedResourceCallback {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
-    Callback(CachedResource&, CachedResourceClient&);
+    CachedResourceCallback(CachedResource&, CachedResourceClient&);
 
     void cancel();
 

--- a/Source/WebCore/loader/cache/MemoryCache.cpp
+++ b/Source/WebCore/loader/cache/MemoryCache.cpp
@@ -700,10 +700,10 @@ void MemoryCache::removeRequestFromSessionCaches(ScriptExecutionContext& context
         return;
     }
 
-    auto& memoryCache = MemoryCache::singleton();
-    for (auto& resources : memoryCache.m_sessionResources) {
-        if (CachedResourceHandle resource = memoryCache.resourceForRequestImpl(request, *resources.value))
-            memoryCache.remove(*resource);
+    Ref memoryCache = MemoryCache::singleton();
+    for (auto& resources : memoryCache->m_sessionResources) {
+        if (CachedResourceHandle resource = memoryCache->resourceForRequestImpl(request, *resources.value))
+            memoryCache->remove(*resource);
     }
 }
 

--- a/Source/WebCore/loader/cache/MemoryCache.h
+++ b/Source/WebCore/loader/cache/MemoryCache.h
@@ -93,6 +93,10 @@ public:
 
     WEBCORE_EXPORT static MemoryCache& singleton();
 
+    // Do nothing since this is a singleton.
+    void ref() const { }
+    void deref() const { }
+
     WEBCORE_EXPORT CachedResource* resourceForRequest(const ResourceRequest&, PAL::SessionID);
 
     bool add(CachedResource&);

--- a/Source/WebCore/page/AutoscrollController.h
+++ b/Source/WebCore/page/AutoscrollController.h
@@ -31,6 +31,15 @@
 #include <wtf/WallTime.h>
 
 namespace WebCore {
+class AutoscrollController;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::AutoscrollController> : std::true_type { };
+}
+
+namespace WebCore {
 
 class EventHandler;
 class LocalFrame;

--- a/Source/WebCore/page/ImageAnalysisQueue.h
+++ b/Source/WebCore/page/ImageAnalysisQueue.h
@@ -40,6 +40,15 @@ class HysteresisActivity;
 }
 
 namespace WebCore {
+class ImageAnalysisQueue;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::ImageAnalysisQueue> : std::true_type { };
+}
+
+namespace WebCore {
 
 class Document;
 class HTMLImageElement;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2855,7 +2855,7 @@ void Page::stopMediaCapture(MediaProducerMediaCaptureKind kind)
 bool Page::mediaPlaybackExists()
 {
 #if ENABLE(VIDEO)
-    if (auto* platformMediaSessionManager = PlatformMediaSessionManager::sharedManagerIfExists())
+    if (auto* platformMediaSessionManager = PlatformMediaSessionManager::singletonIfExists())
         return !platformMediaSessionManager->hasNoSession();
 #endif
     return false;
@@ -2864,7 +2864,7 @@ bool Page::mediaPlaybackExists()
 bool Page::mediaPlaybackIsPaused()
 {
 #if ENABLE(VIDEO)
-    if (auto* platformMediaSessionManager = PlatformMediaSessionManager::sharedManagerIfExists())
+    if (auto* platformMediaSessionManager = PlatformMediaSessionManager::singletonIfExists())
         return platformMediaSessionManager->mediaPlaybackIsPaused(mediaSessionGroupIdentifier());
 #endif
     return false;
@@ -2873,7 +2873,7 @@ bool Page::mediaPlaybackIsPaused()
 void Page::pauseAllMediaPlayback()
 {
 #if ENABLE(VIDEO)
-    if (auto* platformMediaSessionManager = PlatformMediaSessionManager::sharedManagerIfExists())
+    if (auto* platformMediaSessionManager = PlatformMediaSessionManager::singletonIfExists())
         platformMediaSessionManager->pauseAllMediaPlaybackForGroup(mediaSessionGroupIdentifier());
 #endif
 }
@@ -2885,7 +2885,7 @@ void Page::suspendAllMediaPlayback()
     if (m_mediaPlaybackIsSuspended)
         return;
 
-    if (auto* platformMediaSessionManager = PlatformMediaSessionManager::sharedManagerIfExists())
+    if (auto* platformMediaSessionManager = PlatformMediaSessionManager::singletonIfExists())
         platformMediaSessionManager->suspendAllMediaPlaybackForGroup(mediaSessionGroupIdentifier());
 
     // FIXME: We cannot set m_mediaPlaybackIsSuspended before, see https://bugs.webkit.org/show_bug.cgi?id=192829#c7.
@@ -2910,7 +2910,7 @@ void Page::resumeAllMediaPlayback()
         return;
     m_mediaPlaybackIsSuspended = false;
 
-    if (auto* platformMediaSessionManager = PlatformMediaSessionManager::sharedManagerIfExists())
+    if (auto* platformMediaSessionManager = PlatformMediaSessionManager::singletonIfExists())
         platformMediaSessionManager->resumeAllMediaPlaybackForGroup(mediaSessionGroupIdentifier());
 #endif
 }
@@ -2923,7 +2923,7 @@ void Page::suspendAllMediaBuffering()
         return;
     m_mediaBufferingIsSuspended = true;
 
-    if (auto* platformMediaSessionManager = PlatformMediaSessionManager::sharedManagerIfExists())
+    if (auto* platformMediaSessionManager = PlatformMediaSessionManager::singletonIfExists())
         platformMediaSessionManager->suspendAllMediaBufferingForGroup(mediaSessionGroupIdentifier());
 #endif
 }
@@ -2935,7 +2935,7 @@ void Page::resumeAllMediaBuffering()
         return;
     m_mediaBufferingIsSuspended = false;
 
-    if (auto* platformMediaSessionManager = PlatformMediaSessionManager::sharedManagerIfExists())
+    if (auto* platformMediaSessionManager = PlatformMediaSessionManager::singletonIfExists())
         platformMediaSessionManager->resumeAllMediaBufferingForGroup(mediaSessionGroupIdentifier());
 #endif
 }
@@ -5177,7 +5177,7 @@ void Page::hasActiveNowPlayingSessionChanged()
 
 void Page::activeNowPlayingSessionUpdateTimerFired()
 {
-    bool hasActiveNowPlayingSession = PlatformMediaSessionManager::sharedManager().hasActiveNowPlayingSessionInGroup(mediaSessionGroupIdentifier());
+    bool hasActiveNowPlayingSession = PlatformMediaSessionManager::singleton().hasActiveNowPlayingSessionInGroup(mediaSessionGroupIdentifier());
     if (hasActiveNowPlayingSession == m_hasActiveNowPlayingSession)
         return;
 

--- a/Source/WebCore/page/PerformanceMonitor.h
+++ b/Source/WebCore/page/PerformanceMonitor.h
@@ -31,6 +31,15 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+class PerformanceMonitor;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::PerformanceMonitor> : std::true_type { };
+}
+
+namespace WebCore {
 
 class Page;
 

--- a/Source/WebCore/page/SettingsBase.h
+++ b/Source/WebCore/page/SettingsBase.h
@@ -56,6 +56,15 @@
 #endif
 
 namespace WebCore {
+class SettingsBase;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::SettingsBase> : std::true_type { };
+}
+
+namespace WebCore {
 
 class Page;
 

--- a/Source/WebCore/page/ios/DOMTimerHoldingTank.h
+++ b/Source/WebCore/page/ios/DOMTimerHoldingTank.h
@@ -33,6 +33,15 @@
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
+class DOMTimerHoldingTank;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::DOMTimerHoldingTank> : std::true_type { };
+}
+
+namespace WebCore {
 
 class DOMTimer;
 

--- a/Source/WebCore/page/mac/ServicesOverlayController.h
+++ b/Source/WebCore/page/mac/ServicesOverlayController.h
@@ -38,6 +38,15 @@
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
+class ServicesOverlayController;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::ServicesOverlayController> : std::true_type { };
+}
+
+namespace WebCore {
     
 class LayoutRect;
 class Page;

--- a/Source/WebCore/page/mac/TextIndicatorWindow.h
+++ b/Source/WebCore/page/mac/TextIndicatorWindow.h
@@ -36,6 +36,15 @@ OBJC_CLASS NSView;
 OBJC_CLASS WebTextIndicatorLayer;
 
 namespace WebCore {
+class TextIndicatorWindow;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::TextIndicatorWindow> : std::true_type { };
+}
+
+namespace WebCore {
 
 #if PLATFORM(MAC)
 

--- a/Source/WebCore/page/scrolling/ScrollLatchingController.h
+++ b/Source/WebCore/page/scrolling/ScrollLatchingController.h
@@ -34,8 +34,15 @@
 
 #if ENABLE(WHEEL_EVENT_LATCHING)
 
+namespace WebCore {
+class ScrollLatchingController;
+}
+
 namespace WTF {
 class TextStream;
+
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::ScrollLatchingController> : std::true_type { };
 }
 
 namespace WebCore {

--- a/Source/WebCore/platform/CPUMonitor.h
+++ b/Source/WebCore/platform/CPUMonitor.h
@@ -32,6 +32,15 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+class CPUMonitor;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::CPUMonitor> : std::true_type { };
+}
+
+namespace WebCore {
 
 class CPUMonitor {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(CPUMonitor, WEBCORE_EXPORT);

--- a/Source/WebCore/platform/CaretAnimator.h
+++ b/Source/WebCore/platform/CaretAnimator.h
@@ -42,6 +42,15 @@ class Node;
 class Page;
 class VisibleSelection;
 
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::CaretAnimator> : std::true_type { };
+}
+
+namespace WebCore {
+
 enum class CaretAnimatorType : uint8_t {
     Default,
     Dictation

--- a/Source/WebCore/platform/MainThreadSharedTimer.h
+++ b/Source/WebCore/platform/MainThreadSharedTimer.h
@@ -42,6 +42,10 @@ class MainThreadSharedTimer final : public SharedTimer {
 public:
     static MainThreadSharedTimer& singleton();
 
+    // Do nothing since this is a singleton.
+    void ref() const { }
+    void deref() const { }
+
     void setFiredFunction(Function<void()>&&) override;
     void setFireInterval(Seconds) override;
     void stop() override;

--- a/Source/WebCore/platform/Timer.h
+++ b/Source/WebCore/platform/Timer.h
@@ -31,6 +31,7 @@
 #include <wtf/Function.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/RunLoop.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Threading.h>
@@ -181,6 +182,9 @@ public:
     Timer(TimerFiredClass& object, void (TimerFiredBaseClass::*function)())
         : m_function(std::bind(function, &object))
     {
+        static_assert(WTF::IsDeprecatedTimerSmartPointerException<std::remove_cv_t<TimerFiredClass>>::value,
+            "Classes that use Timer should be ref-counted or CanMakeCheckedPtr. Please do not add new exceptions."
+        );
     }
 
     Timer(Function<void()>&& function)

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -169,9 +169,9 @@ void PlatformMediaSession::setActive(bool active)
     m_active = active;
 
     if (m_active)
-        PlatformMediaSessionManager::sharedManager().addSession(*this);
+        PlatformMediaSessionManager::singleton().addSession(*this);
     else
-        PlatformMediaSessionManager::sharedManager().removeSession(*this);
+        PlatformMediaSessionManager::singleton().removeSession(*this);
 }
 
 void PlatformMediaSession::setState(State state)
@@ -183,7 +183,7 @@ void PlatformMediaSession::setState(State state)
     m_state = state;
     if (m_state == State::Playing && canProduceAudio())
         m_hasPlayedAudiblySinceLastInterruption = true;
-    PlatformMediaSessionManager::sharedManager().sessionStateChanged(*this);
+    PlatformMediaSessionManager::singleton().sessionStateChanged(*this);
 }
 
 size_t PlatformMediaSession::activeInterruptionCount() const
@@ -278,7 +278,7 @@ bool PlatformMediaSession::clientWillBeginPlayback()
 
     SetForScope preparingToPlay(m_preparingToPlay, true);
 
-    if (!PlatformMediaSessionManager::sharedManager().sessionWillBeginPlayback(*this)) {
+    if (!PlatformMediaSessionManager::singleton().sessionWillBeginPlayback(*this)) {
         if (state() == State::Interrupted)
             m_stateToRestore = State::Playing;
         return false;
@@ -302,7 +302,7 @@ bool PlatformMediaSession::processClientWillPausePlayback(DelayCallingUpdateNowP
     }
 
     setState(State::Paused);
-    PlatformMediaSessionManager::sharedManager().sessionWillEndPlayback(*this, shouldDelayCallingUpdateNowPlaying);
+    PlatformMediaSessionManager::singleton().sessionWillEndPlayback(*this, shouldDelayCallingUpdateNowPlaying);
     return true;
 }
 
@@ -332,7 +332,7 @@ void PlatformMediaSession::stopSession()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
     m_client.suspendPlayback();
-    PlatformMediaSessionManager::sharedManager().removeSession(*this);
+    PlatformMediaSessionManager::singleton().removeSession(*this);
 }
 
 PlatformMediaSession::MediaType PlatformMediaSession::mediaType() const
@@ -399,7 +399,7 @@ void PlatformMediaSession::isPlayingToWirelessPlaybackTargetChanged(bool isWirel
 
     m_isPlayingToWirelessPlaybackTarget = isWireless;
 
-    PlatformMediaSessionManager::sharedManager().sessionIsPlayingToWirelessPlaybackTargetChanged(*this);
+    PlatformMediaSessionManager::singleton().sessionIsPlayingToWirelessPlaybackTargetChanged(*this);
 }
 
 PlatformMediaSession::DisplayType PlatformMediaSession::displayType() const
@@ -433,12 +433,12 @@ bool PlatformMediaSession::hasMediaStreamSource() const
 
 void PlatformMediaSession::canProduceAudioChanged()
 {
-    PlatformMediaSessionManager::sharedManager().sessionCanProduceAudioChanged();
+    PlatformMediaSessionManager::singleton().sessionCanProduceAudioChanged();
 }
 
 void PlatformMediaSession::clientCharacteristicsChanged(bool positionChanged)
 {
-    PlatformMediaSessionManager::sharedManager().clientCharacteristicsChanged(*this, positionChanged);
+    PlatformMediaSessionManager::singleton().clientCharacteristicsChanged(*this, positionChanged);
 }
 
 static inline bool isPlayingAudio(PlatformMediaSession::MediaType mediaType)

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -75,7 +75,7 @@ static std::unique_ptr<PlatformMediaSessionManager>& sharedPlatformMediaSessionM
     return platformMediaSessionManager.get();
 }
 
-PlatformMediaSessionManager& PlatformMediaSessionManager::sharedManager()
+PlatformMediaSessionManager& PlatformMediaSessionManager::singleton()
 {
     auto& manager = sharedPlatformMediaSessionManager();
     if (!manager) {
@@ -85,7 +85,7 @@ PlatformMediaSessionManager& PlatformMediaSessionManager::sharedManager()
     return *manager;
 }
 
-PlatformMediaSessionManager* PlatformMediaSessionManager::sharedManagerIfExists()
+PlatformMediaSessionManager* PlatformMediaSessionManager::singletonIfExists()
 {
     return sharedPlatformMediaSessionManager().get();
 }
@@ -99,13 +99,13 @@ std::unique_ptr<PlatformMediaSessionManager> PlatformMediaSessionManager::create
 
 void PlatformMediaSessionManager::updateNowPlayingInfoIfNecessary()
 {
-    if (auto existingManager = PlatformMediaSessionManager::sharedManagerIfExists())
+    if (RefPtr existingManager = PlatformMediaSessionManager::singletonIfExists())
         existingManager->scheduleSessionStatusUpdate();
 }
 
 void PlatformMediaSessionManager::updateAudioSessionCategoryIfNecessary()
 {
-    if (auto existingManager = PlatformMediaSessionManager::sharedManagerIfExists())
+    if (RefPtr existingManager = PlatformMediaSessionManager::singletonIfExists())
         existingManager->scheduleUpdateSessionState();
 }
 

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -51,8 +51,12 @@ class PlatformMediaSessionManager
 {
     WTF_MAKE_TZONE_ALLOCATED(PlatformMediaSessionManager);
 public:
-    WEBCORE_EXPORT static PlatformMediaSessionManager* sharedManagerIfExists();
-    WEBCORE_EXPORT static PlatformMediaSessionManager& sharedManager();
+    WEBCORE_EXPORT static PlatformMediaSessionManager* singletonIfExists();
+    WEBCORE_EXPORT static PlatformMediaSessionManager& singleton();
+
+    // Do nothing since this is a singleton.
+    void ref() const { }
+    void deref() const { }
 
     static void updateNowPlayingInfoIfNecessary();
     static void updateAudioSessionCategoryIfNecessary();

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -66,7 +66,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaSessionManagerCocoa);
 #if PLATFORM(MAC)
 std::unique_ptr<PlatformMediaSessionManager> PlatformMediaSessionManager::create()
 {
-    return makeUnique<MediaSessionManagerCocoa>();
+    return makeUniqueWithoutRefCountedCheck<MediaSessionManagerCocoa>();
 }
 #endif // !PLATFORM(MAC)
 

--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
@@ -123,7 +123,7 @@ std::unique_ptr<PlatformMediaSessionManager> PlatformMediaSessionManager::create
         g_warning("Failed at parsing XML Interface definition: %s", error->message);
         return nullptr;
     }
-    return makeUnique<MediaSessionManagerGLib>(WTFMove(mprisInterface));
+    return makeUniqueWithoutRefCountedCheck<MediaSessionManagerGLib>(WTFMove(mprisInterface));
 }
 
 MediaSessionManagerGLib::MediaSessionManagerGLib(GRefPtr<GDBusNodeInfo>&& mprisInterface)

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h
@@ -46,6 +46,10 @@ class GameControllerGamepadProvider : public GamepadProvider {
 public:
     WEBCORE_EXPORT static GameControllerGamepadProvider& singleton();
 
+    // Do nothing since this is a singleton.
+    void ref() const { }
+    void deref() const { }
+
     WEBCORE_EXPORT void startMonitoringGamepads(GamepadProviderClient&) final;
     WEBCORE_EXPORT void stopMonitoringGamepads(GamepadProviderClient&) final;
     const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() final { return m_gamepadVector; }

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
@@ -49,6 +49,10 @@ public:
 
     virtual ~GamepadProviderLibWPE();
 
+    // Do nothing since this is a singleton.
+    void ref() const { }
+    void deref() const { }
+
     void startMonitoringGamepads(GamepadProviderClient&) final;
     void stopMonitoringGamepads(GamepadProviderClient&) final;
     const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() final { return m_gamepadVector; }

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h
@@ -47,6 +47,10 @@ class HIDGamepadProvider : public GamepadProvider {
 public:
     WEBCORE_EXPORT static HIDGamepadProvider& singleton();
 
+    // Do nothing since this is a singleton.
+    void ref() const { }
+    void deref() const { }
+
     WEBCORE_EXPORT void startMonitoringGamepads(GamepadProviderClient&) final;
     WEBCORE_EXPORT void stopMonitoringGamepads(GamepadProviderClient&) final;
     const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() final { return m_gamepadVector; }

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h
@@ -44,6 +44,10 @@ class ManetteGamepadProvider final : public GamepadProvider {
 public:
     static ManetteGamepadProvider& singleton();
 
+    // Do nothing since this is a singleton.
+    void ref() const { }
+    void deref() const { }
+
     virtual ~ManetteGamepadProvider();
 
     void startMonitoringGamepads(GamepadProviderClient&) final;

--- a/Source/WebCore/platform/generic/ScrollbarsControllerGeneric.h
+++ b/Source/WebCore/platform/generic/ScrollbarsControllerGeneric.h
@@ -34,6 +34,15 @@
 #include "Timer.h"
 
 namespace WebCore {
+class ScrollbarsControllerGeneric;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::ScrollbarsControllerGeneric> : std::true_type { };
+}
+
+namespace WebCore {
 
 class ScrollbarsControllerGeneric final : public ScrollbarsController {
 public:

--- a/Source/WebCore/platform/graphics/FontCache.h
+++ b/Source/WebCore/platform/graphics/FontCache.h
@@ -82,6 +82,15 @@
 #endif
 
 namespace WebCore {
+class FontCache;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::FontCache> : std::true_type { };
+}
+
+namespace WebCore {
 
 class Font;
 class FontCascade;

--- a/Source/WebCore/platform/graphics/ImageFrameAnimator.h
+++ b/Source/WebCore/platform/graphics/ImageFrameAnimator.h
@@ -31,6 +31,15 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+class ImageFrameAnimator;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::ImageFrameAnimator> : std::true_type { };
+}
+
+namespace WebCore {
 
 class BitmapImageSource;
 class ImageFrame;

--- a/Source/WebCore/platform/graphics/MediaPlaybackTargetPicker.h
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTargetPicker.h
@@ -33,6 +33,15 @@
 #include <wtf/RunLoop.h>
 
 namespace WebCore {
+class MediaPlaybackTargetPicker;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::MediaPlaybackTargetPicker> : std::true_type { };
+}
+
+namespace WebCore {
 
 class FloatRect;
 class MediaPlaybackTarget;

--- a/Source/WebCore/platform/graphics/ShadowBlur.cpp
+++ b/Source/WebCore/platform/graphics/ShadowBlur.cpp
@@ -47,6 +47,15 @@
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
+class ScratchBuffer;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::ScratchBuffer> : std::true_type { };
+}
+
+namespace WebCore {
 
 enum {
     LeftLobe = 0,

--- a/Source/WebCore/platform/graphics/ca/TileCoverageMap.h
+++ b/Source/WebCore/platform/graphics/ca/TileCoverageMap.h
@@ -36,6 +36,15 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+class TileCoverageMap;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::TileCoverageMap> : std::true_type { };
+}
+
+namespace WebCore {
 
 class FloatRect;
 class IntPoint;

--- a/Source/WebCore/platform/graphics/ca/TileGrid.h
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.h
@@ -41,6 +41,15 @@ typedef struct CGContext *CGContextRef;
 #endif
 
 namespace WebCore {
+class TileGrid;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::TileGrid> : std::true_type { };
+}
+
+namespace WebCore {
 
 class GraphicsContext;
 class PlatformCALayer;

--- a/Source/WebCore/platform/graphics/cg/CGSubimageCacheWithTimer.h
+++ b/Source/WebCore/platform/graphics/cg/CGSubimageCacheWithTimer.h
@@ -40,6 +40,15 @@
 #define CACHE_SUBIMAGES 1
 
 namespace WebCore {
+class CGSubimageCacheWithTimer;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::CGSubimageCacheWithTimer> : std::true_type { };
+}
+
+namespace WebCore {
 
 #if CACHE_SUBIMAGES
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaEngineConfigurationFactoryCocoa.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/MediaEngineConfigurationFactoryCocoa.cpp
@@ -164,7 +164,7 @@ static std::optional<MediaCapabilitiesInfo> computeMediaCapabilitiesInfo(const M
     if (!configuration.audio->spatialRendering.value_or(false))
         return info;
 
-    auto supportsSpatialPlayback = PlatformMediaSessionManager::sharedManager().supportsSpatialAudioPlaybackForConfiguration(configuration);
+    auto supportsSpatialPlayback = PlatformMediaSessionManager::singleton().supportsSpatialAudioPlaybackForConfiguration(configuration);
     if (!supportsSpatialPlayback.has_value())
         return std::nullopt;
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
@@ -32,6 +32,15 @@
 #include <wtf/RunLoop.h>
 
 namespace WebCore {
+class BitmapTexturePool;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::BitmapTexturePool> : std::true_type { };
+}
+
+namespace WebCore {
 
 class IntSize;
 

--- a/Source/WebCore/platform/ios/LegacyTileCache.h
+++ b/Source/WebCore/platform/ios/LegacyTileCache.h
@@ -42,6 +42,15 @@ OBJC_CLASS LegacyTileLayer;
 OBJC_CLASS WAKWindow;
 
 namespace WebCore {
+class LegacyTileCache;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::LegacyTileCache> : std::true_type { };
+}
+
+namespace WebCore {
 
 class Color;
 class LegacyTileGrid;

--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.h
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.h
@@ -40,6 +40,15 @@ OBJC_CLASS WebScrollerImpDelegate;
 typedef id ScrollerImpPair;
 
 namespace WebCore {
+class ScrollbarsControllerMac;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::ScrollbarsControllerMac> : std::true_type { };
+}
+
+namespace WebCore {
 
 class WheelEventTestMonitor;
 

--- a/Source/WebCore/platform/mock/DeviceOrientationClientMock.h
+++ b/Source/WebCore/platform/mock/DeviceOrientationClientMock.h
@@ -34,6 +34,15 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+class DeviceOrientationClientMock;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::DeviceOrientationClientMock> : std::true_type { };
+}
+
+namespace WebCore {
 
 class DeviceOrientationController;
 

--- a/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
@@ -145,7 +145,7 @@ void MockRealtimeAudioSource::settingsDidChange(OptionSet<RealtimeMediaSourceSet
 void MockRealtimeAudioSource::startProducingData()
 {
 #if PLATFORM(IOS_FAMILY)
-    PlatformMediaSessionManager::sharedManager().sessionCanProduceAudioChanged();
+    PlatformMediaSessionManager::singleton().sessionCanProduceAudioChanged();
     ASSERT(AudioSession::sharedSession().category() == AudioSession::CategoryType::PlayAndRecord);
     ASSERT(AudioSession::sharedSession().mode() == AudioSession::Mode::VideoChat);
 #endif

--- a/Source/WebCore/platform/network/DNSResolveQueue.h
+++ b/Source/WebCore/platform/network/DNSResolveQueue.h
@@ -39,10 +39,13 @@ class DNSResolveQueue {
     friend NeverDestroyed<DNSResolveQueue>;
 
 public:
-    DNSResolveQueue();
     virtual ~DNSResolveQueue() = default;
 
     static DNSResolveQueue& singleton();
+
+    // Do nothing since this is a singleton.
+    void ref() const { }
+    void deref() const { }
 
     virtual void resolve(const String& hostname, uint64_t identifier, DNSCompletionHandler&&) = 0;
     virtual void stopResolve(uint64_t identifier) = 0;
@@ -53,6 +56,7 @@ public:
     }
 
 protected:
+    DNSResolveQueue();
     bool isUsingProxy();
 
     bool m_isUsingProxy { true };

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -36,6 +36,15 @@
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
+class RenderLayerCompositor;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::RenderLayerCompositor> : std::true_type { };
+}
+
+namespace WebCore {
 
 class DisplayRefreshMonitorFactory;
 class FixedPositionViewportConstraints;

--- a/Source/WebCore/rendering/RenderMarquee.h
+++ b/Source/WebCore/rendering/RenderMarquee.h
@@ -49,6 +49,15 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+class RenderMarquee;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebCore::RenderMarquee> : std::true_type { };
+}
+
+namespace WebCore {
 
 class RenderLayer;
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -607,16 +607,16 @@ void Internals::resetToConsistentState(Page& page)
 #if ENABLE(VIDEO)
     page.group().ensureCaptionPreferences().setCaptionDisplayMode(CaptionUserPreferences::CaptionDisplayMode::ForcedOnly);
     page.group().ensureCaptionPreferences().setCaptionsStyleSheetOverride(emptyString());
-    PlatformMediaSessionManager::sharedManager().resetHaveEverRegisteredAsNowPlayingApplicationForTesting();
-    PlatformMediaSessionManager::sharedManager().resetRestrictions();
-    PlatformMediaSessionManager::sharedManager().resetSessionState();
-    PlatformMediaSessionManager::sharedManager().setWillIgnoreSystemInterruptions(true);
-    PlatformMediaSessionManager::sharedManager().applicationWillEnterForeground(false);
+    PlatformMediaSessionManager::singleton().resetHaveEverRegisteredAsNowPlayingApplicationForTesting();
+    PlatformMediaSessionManager::singleton().resetRestrictions();
+    PlatformMediaSessionManager::singleton().resetSessionState();
+    PlatformMediaSessionManager::singleton().setWillIgnoreSystemInterruptions(true);
+    PlatformMediaSessionManager::singleton().applicationWillEnterForeground(false);
     if (page.mediaPlaybackIsSuspended())
         page.resumeAllMediaPlayback();
 #endif
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    PlatformMediaSessionManager::sharedManager().setIsPlayingToAutomotiveHeadUnit(false);
+    PlatformMediaSessionManager::singleton().setIsPlayingToAutomotiveHeadUnit(false);
 #endif
     AXObjectCache::setEnhancedUserInterfaceAccessibility(false);
     AXObjectCache::disableAccessibility();
@@ -686,7 +686,7 @@ void Internals::resetToConsistentState(Page& page)
 #endif
 
 #if ENABLE(MEDIA_SESSION) && USE(GLIB)
-    auto& sessionManager = reinterpret_cast<MediaSessionManagerGLib&>(PlatformMediaSessionManager::sharedManager());
+    auto& sessionManager = reinterpret_cast<MediaSessionManagerGLib&>(PlatformMediaSessionManager::singleton());
     sessionManager.setDBusNotificationsEnabled(false);
 #endif
 
@@ -4817,7 +4817,7 @@ ExceptionOr<void> Internals::beginMediaSessionInterruption(const String& interru
     else
         return Exception { ExceptionCode::InvalidAccessError };
 
-    PlatformMediaSessionManager::sharedManager().beginInterruption(interruption);
+    PlatformMediaSessionManager::singleton().beginInterruption(interruption);
     return { };
 }
 
@@ -4828,27 +4828,27 @@ void Internals::endMediaSessionInterruption(const String& flagsString)
     if (equalLettersIgnoringASCIICase(flagsString, "mayresumeplaying"_s))
         flags = PlatformMediaSession::EndInterruptionFlags::MayResumePlaying;
 
-    PlatformMediaSessionManager::sharedManager().endInterruption(flags);
+    PlatformMediaSessionManager::singleton().endInterruption(flags);
 }
 
 void Internals::applicationWillBecomeInactive()
 {
-    PlatformMediaSessionManager::sharedManager().applicationWillBecomeInactive();
+    PlatformMediaSessionManager::singleton().applicationWillBecomeInactive();
 }
 
 void Internals::applicationDidBecomeActive()
 {
-    PlatformMediaSessionManager::sharedManager().applicationDidBecomeActive();
+    PlatformMediaSessionManager::singleton().applicationDidBecomeActive();
 }
 
 void Internals::applicationWillEnterForeground(bool suspendedUnderLock) const
 {
-    PlatformMediaSessionManager::sharedManager().applicationWillEnterForeground(suspendedUnderLock);
+    PlatformMediaSessionManager::singleton().applicationWillEnterForeground(suspendedUnderLock);
 }
 
 void Internals::applicationDidEnterBackground(bool suspendedUnderLock) const
 {
-    PlatformMediaSessionManager::sharedManager().applicationDidEnterBackground(suspendedUnderLock);
+    PlatformMediaSessionManager::singleton().applicationDidEnterBackground(suspendedUnderLock);
 }
 
 static PlatformMediaSession::MediaType mediaTypeFromString(const String& mediaTypeString)
@@ -4871,8 +4871,8 @@ ExceptionOr<void> Internals::setMediaSessionRestrictions(const String& mediaType
     if (mediaType == PlatformMediaSession::MediaType::None)
         return Exception { ExceptionCode::InvalidAccessError };
 
-    auto restrictions = PlatformMediaSessionManager::sharedManager().restrictions(mediaType);
-    PlatformMediaSessionManager::sharedManager().removeRestriction(mediaType, restrictions);
+    auto restrictions = PlatformMediaSessionManager::singleton().restrictions(mediaType);
+    PlatformMediaSessionManager::singleton().removeRestriction(mediaType, restrictions);
 
     restrictions = PlatformMediaSessionManager::NoRestrictions;
 
@@ -4890,7 +4890,7 @@ ExceptionOr<void> Internals::setMediaSessionRestrictions(const String& mediaType
         if (equalLettersIgnoringASCIICase(restrictionString, "suspendedunderlockplaybackrestricted"_s))
             restrictions |= PlatformMediaSessionManager::SuspendedUnderLockPlaybackRestricted;
     }
-    PlatformMediaSessionManager::sharedManager().addRestriction(mediaType, restrictions);
+    PlatformMediaSessionManager::singleton().addRestriction(mediaType, restrictions);
     return { };
 }
 
@@ -4900,7 +4900,7 @@ ExceptionOr<String> Internals::mediaSessionRestrictions(const String& mediaTypeS
     if (mediaType == PlatformMediaSession::MediaType::None)
         return Exception { ExceptionCode::InvalidAccessError };
 
-    PlatformMediaSessionManager::SessionRestrictions restrictions = PlatformMediaSessionManager::sharedManager().restrictions(mediaType);
+    PlatformMediaSessionManager::SessionRestrictions restrictions = PlatformMediaSessionManager::singleton().restrictions(mediaType);
     if (restrictions == PlatformMediaSessionManager::NoRestrictions)
         return String();
 
@@ -5001,7 +5001,7 @@ ExceptionOr<void> Internals::postRemoteControlCommand(const String& commandStrin
     else
         return Exception { ExceptionCode::InvalidAccessError };
 
-    PlatformMediaSessionManager::sharedManager().processDidReceiveRemoteControlCommand(command, parameter);
+    PlatformMediaSessionManager::singleton().processDidReceiveRemoteControlCommand(command, parameter);
     return { };
 }
 
@@ -5130,20 +5130,20 @@ void Internals::useMockAudioDestinationCocoa()
 void Internals::simulateSystemSleep() const
 {
 #if ENABLE(VIDEO)
-    PlatformMediaSessionManager::sharedManager().processSystemWillSleep();
+    PlatformMediaSessionManager::singleton().processSystemWillSleep();
 #endif
 }
 
 void Internals::simulateSystemWake() const
 {
 #if ENABLE(VIDEO)
-    PlatformMediaSessionManager::sharedManager().processSystemDidWake();
+    PlatformMediaSessionManager::singleton().processSystemDidWake();
 #endif
 }
 
 std::optional<Internals::NowPlayingMetadata> Internals::nowPlayingMetadata() const
 {
-    if (auto nowPlayingInfo = PlatformMediaSessionManager::sharedManager().nowPlayingInfo())
+    if (auto nowPlayingInfo = PlatformMediaSessionManager::singleton().nowPlayingInfo())
         return nowPlayingInfo->metadata;
     return std::nullopt;
 }
@@ -5151,14 +5151,14 @@ std::optional<Internals::NowPlayingMetadata> Internals::nowPlayingMetadata() con
 ExceptionOr<Internals::NowPlayingState> Internals::nowPlayingState() const
 {
 #if ENABLE(VIDEO)
-    auto lastUpdatedNowPlayingInfoUniqueIdentifier = PlatformMediaSessionManager::sharedManager().lastUpdatedNowPlayingInfoUniqueIdentifier();
-    return { { PlatformMediaSessionManager::sharedManager().lastUpdatedNowPlayingTitle(),
-        PlatformMediaSessionManager::sharedManager().lastUpdatedNowPlayingDuration(),
-        PlatformMediaSessionManager::sharedManager().lastUpdatedNowPlayingElapsedTime(),
+    auto lastUpdatedNowPlayingInfoUniqueIdentifier = PlatformMediaSessionManager::singleton().lastUpdatedNowPlayingInfoUniqueIdentifier();
+    return { { PlatformMediaSessionManager::singleton().lastUpdatedNowPlayingTitle(),
+        PlatformMediaSessionManager::singleton().lastUpdatedNowPlayingDuration(),
+        PlatformMediaSessionManager::singleton().lastUpdatedNowPlayingElapsedTime(),
         lastUpdatedNowPlayingInfoUniqueIdentifier ? lastUpdatedNowPlayingInfoUniqueIdentifier->toUInt64() : 0,
-        PlatformMediaSessionManager::sharedManager().hasActiveNowPlayingSession(),
-        PlatformMediaSessionManager::sharedManager().registeredAsNowPlayingApplication(),
-        PlatformMediaSessionManager::sharedManager().haveEverRegisteredAsNowPlayingApplication()
+        PlatformMediaSessionManager::singleton().hasActiveNowPlayingSession(),
+        PlatformMediaSessionManager::singleton().registeredAsNowPlayingApplication(),
+        PlatformMediaSessionManager::singleton().haveEverRegisteredAsNowPlayingApplication()
     } };
 #else
     return Exception { ExceptionCode::InvalidAccessError };
@@ -5312,7 +5312,7 @@ void Internals::mockMediaPlaybackTargetPickerDismissPopup()
 bool Internals::isMonitoringWirelessRoutes() const
 {
 #if ENABLE(VIDEO)
-    return PlatformMediaSessionManager::sharedManager().isMonitoringWirelessTargets();
+    return PlatformMediaSessionManager::singleton().isMonitoringWirelessTargets();
 #else
     return false;
 #endif // ENABLE(VIDEO)
@@ -6866,14 +6866,14 @@ void Internals::setAlwaysAllowLocalWebarchive(bool alwaysAllowLocalWebarchive)
 void Internals::processWillSuspend()
 {
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    PlatformMediaSessionManager::sharedManager().processWillSuspend();
+    PlatformMediaSessionManager::singleton().processWillSuspend();
 #endif
 }
 
 void Internals::processDidResume()
 {
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    PlatformMediaSessionManager::sharedManager().processDidResume();
+    PlatformMediaSessionManager::singleton().processDidResume();
 #endif
 }
 
@@ -6910,7 +6910,7 @@ void Internals::setTransientActivationDuration(double seconds)
 void Internals::setIsPlayingToAutomotiveHeadUnit(bool isPlaying)
 {
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    PlatformMediaSessionManager::sharedManager().setIsPlayingToAutomotiveHeadUnit(isPlaying);
+    PlatformMediaSessionManager::singleton().setIsPlayingToAutomotiveHeadUnit(isPlaying);
 #else
     UNUSED_PARAM(isPlaying);
 #endif
@@ -7318,7 +7318,7 @@ ExceptionOr<Vector<String>> Internals::platformSupportedCommands() const
 {
     if (!contextDocument())
         return Exception { ExceptionCode::InvalidAccessError };
-    auto commands = PlatformMediaSessionManager::sharedManager().supportedCommands();
+    auto commands = PlatformMediaSessionManager::singleton().supportedCommands();
     Vector<String> commandStrings;
     for (auto command : commands)
         commandStrings.append(convertEnumerationToString(command));

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -220,12 +220,12 @@ void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters,
     WTF::Thread::setCurrentThreadIsUserInitiated();
     WebCore::initializeCommonAtomStrings();
 
-    auto& memoryPressureHandler = MemoryPressureHandler::singleton();
-    memoryPressureHandler.setLowMemoryHandler([weakThis = WeakPtr { *this }] (Critical critical, Synchronous synchronous) {
+    Ref memoryPressureHandler = MemoryPressureHandler::singleton();
+    memoryPressureHandler->setLowMemoryHandler([weakThis = WeakPtr { *this }] (Critical critical, Synchronous synchronous) {
         if (RefPtr process = weakThis.get())
             process->lowMemoryHandler(critical, synchronous);
     });
-    memoryPressureHandler.install();
+    memoryPressureHandler->install();
 
 #if PLATFORM(IOS_FAMILY) || ENABLE(ROUTING_ARBITRATION)
     DeprecatedGlobalSettings::setShouldManageAudioSessionCategory(true);

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h
@@ -31,6 +31,15 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
+class DownloadMonitor;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::DownloadMonitor> : std::true_type { };
+}
+
+namespace WebKit {
 
 class Download;
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -305,12 +305,12 @@ void NetworkProcess::initializeNetworkProcess(NetworkProcessCreationParameters&&
 
     m_suppressMemoryPressureHandler = parameters.shouldSuppressMemoryPressureHandler;
     if (!m_suppressMemoryPressureHandler) {
-        auto& memoryPressureHandler = MemoryPressureHandler::singleton();
-        memoryPressureHandler.setLowMemoryHandler([weakThis = WeakPtr { *this }] (Critical critical, Synchronous) {
+        Ref memoryPressureHandler = MemoryPressureHandler::singleton();
+        memoryPressureHandler->setLowMemoryHandler([weakThis = WeakPtr { *this }] (Critical critical, Synchronous) {
             if (RefPtr process = weakThis.get())
                 process->lowMemoryHandler(critical);
         });
-        memoryPressureHandler.install();
+        memoryPressureHandler->install();
     }
 
     setCacheModel(parameters.cacheModel);

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -384,3 +384,8 @@ protected:
 };
 
 } // namespace WebKit
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::NetworkSession::CachedNetworkResourceLoader> : std::true_type { };
+}

--- a/Source/WebKit/NetworkProcess/cache/PrefetchCache.h
+++ b/Source/WebKit/NetworkProcess/cache/PrefetchCache.h
@@ -37,6 +37,15 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
+class PrefetchCache;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::PrefetchCache> : std::true_type { };
+}
+
+namespace WebKit {
 
 class PrefetchCache {
     WTF_MAKE_TZONE_ALLOCATED(PrefetchCache);

--- a/Source/WebKit/NetworkProcess/glib/DNSCache.h
+++ b/Source/WebKit/NetworkProcess/glib/DNSCache.h
@@ -36,6 +36,15 @@
 typedef struct _GInetAddress GInetAddress;
 
 namespace WebKit {
+class DNSCache;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::DNSCache> : std::true_type { };
+}
+
+namespace WebKit {
 
 class DNSCache {
 public:

--- a/Source/WebKit/Shared/SharedStringHashStore.h
+++ b/Source/WebKit/Shared/SharedStringHashStore.h
@@ -31,6 +31,15 @@
 #include <wtf/RunLoop.h>
 
 namespace WebKit {
+class SharedStringHashStore;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::SharedStringHashStore> : std::true_type { };
+}
+
+namespace WebKit {
 
 class SharedStringHashStore {
 public:

--- a/Source/WebKit/Shared/WebMemorySampler.h
+++ b/Source/WebKit/Shared/WebMemorySampler.h
@@ -77,6 +77,10 @@ public:
     void stop();
     bool isRunning() const;
     
+    // Do nothing since this is a singleton.
+    void ref() const { }
+    void deref() const { }
+
 private:
     WebMemorySampler();
     ~WebMemorySampler();

--- a/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
@@ -321,8 +321,7 @@ static NSMutableArray<NSURL *> *readOnlyAccessPaths()
 
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        auto& memoryPressureHandler = MemoryPressureHandler::singleton();
-        memoryPressureHandler.setLowMemoryHandler([self] (Critical, Synchronous) {
+        MemoryPressureHandler::singleton().setLowMemoryHandler([self] (Critical, Synchronous) {
             [self purgeAllWebViews];
         });
     });

--- a/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
@@ -53,6 +53,13 @@
 
 using namespace WebKit;
 
+class UIClient;
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<UIClient> : std::true_type { };
+}
+
 class UIClient : public API::UIClient {
 public:
     explicit UIClient(WebKitWebView* webView)

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -104,6 +104,13 @@
 using namespace WebKit;
 using namespace WebCore;
 
+struct _WebKitWebViewBasePrivate;
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<_WebKitWebViewBasePrivate> : std::true_type { };
+}
+
 #if !USE(GTK4)
 struct ClickCounter {
 public:

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp
@@ -33,6 +33,13 @@
 #include <glib/gi18n-lib.h>
 #include <gtk/gtk.h>
 
+struct WindowStateEvent;
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WindowStateEvent> : std::true_type { };
+}
+
 gboolean webkitWebViewAuthenticate(WebKitWebView* webView, WebKitAuthenticationRequest* request)
 {
     switch (webkit_authentication_request_get_scheme(request)) {

--- a/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h
+++ b/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h
@@ -30,6 +30,15 @@
 #include <wtf/WeakRef.h>
 
 namespace WebKit {
+class BackgroundProcessResponsivenessTimer;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::BackgroundProcessResponsivenessTimer> : std::true_type { };
+}
+
+namespace WebKit {
 
 class WebProcessProxy;
 

--- a/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h
+++ b/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h
@@ -39,6 +39,15 @@
 #endif
 
 namespace WebKit {
+class XPCConnectionTerminationWatchdog;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::XPCConnectionTerminationWatchdog> : std::true_type { };
+}
+
+namespace WebKit {
 
 class AuxiliaryProcessProxy;
 class ProcessAndUIAssertion;

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
@@ -134,4 +134,9 @@ private:
 
 } // namespace WebKit
 
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::DrawingAreaProxyCoordinatedGraphics::DrawingMonitor> : std::true_type { };
+}
+
 SPECIALIZE_TYPE_TRAITS_DRAWING_AREA_PROXY(DrawingAreaProxyCoordinatedGraphics, DrawingAreaType::CoordinatedGraphics)

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h
@@ -44,6 +44,10 @@ class UIGamepadProvider final : public WebCore::GamepadProviderClient {
 public:
     static UIGamepadProvider& singleton();
 
+    // Do nothing since this is a singleton.
+    void ref() const { }
+    void deref() const { }
+
     void processPoolStartedUsingGamepads(WebProcessPool&);
     void processPoolStoppedUsingGamepads(WebProcessPool&);
 

--- a/Source/WebKit/UIProcess/Notifications/glib/NotificationService.cpp
+++ b/Source/WebKit/UIProcess/Notifications/glib/NotificationService.cpp
@@ -67,6 +67,15 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
 namespace WebKit {
+class IconCache;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::IconCache> : std::true_type { };
+}
+
+namespace WebKit {
 
 static const Seconds s_dbusCallTimeout = 20_ms;
 

--- a/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h
+++ b/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h
@@ -31,6 +31,15 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
+class PerActivityStateCPUUsageSampler;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::PerActivityStateCPUUsageSampler> : std::true_type { };
+}
+
+namespace WebKit {
 
 class WebPageProxy;
 class WebProcessPool;

--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -119,6 +119,15 @@ private:
     bool m_isEnabled { true };
 };
 
+} // namespace WebKit
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::ProcessThrottler::ProcessAssertionCache::CachedAssertion> : std::true_type { };
+}
+
+namespace WebKit {
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(ProcessThrottlerProcessAssertionCache, ProcessThrottler::ProcessAssertionCache);
 WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(ProcessThrottlerProcessAssertionCacheCachedAssertion, ProcessThrottler::ProcessAssertionCache::CachedAssertion);
 

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -35,8 +35,15 @@
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
 
+namespace WebKit {
+class ProcessThrottlerTimedActivity;
+}
+
 namespace WTF {
 class TextStream;
+
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::ProcessThrottlerTimedActivity> : std::true_type { };
 }
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/ResponsivenessTimer.h
+++ b/Source/WebKit/UIProcess/ResponsivenessTimer.h
@@ -31,6 +31,15 @@
 #include <wtf/WeakRef.h>
 
 namespace WebKit {
+class ResponsivenessTimer;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::ResponsivenessTimer> : std::true_type { };
+}
+
+namespace WebKit {
 
 class ResponsivenessTimer {
 public:

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -224,7 +224,9 @@ private:
 
     void didStartProvisionalOrSameDocumentLoadForMainFrame();
 
-    class SnapshotRemovalTracker {
+    class SnapshotRemovalTracker : public CanMakeCheckedPtr<SnapshotRemovalTracker> {
+        WTF_MAKE_FAST_ALLOCATED;
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SnapshotRemovalTracker);
     public:
         enum Event : uint8_t {
             VisuallyNonEmptyLayout = 1 << 0,

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
@@ -33,6 +33,15 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
+class WebBackForwardCacheEntry;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::WebBackForwardCacheEntry> : std::true_type { };
+}
+
+namespace WebKit {
 
 class SuspendedPageProxy;
 class WebBackForwardCache;

--- a/Source/WebKit/UIProcess/WebMemoryPressureHandler.cpp
+++ b/Source/WebKit/UIProcess/WebMemoryPressureHandler.cpp
@@ -37,8 +37,8 @@ namespace WebKit {
 
 void installMemoryPressureHandler()
 {
-    auto& memoryPressureHandler = MemoryPressureHandler::singleton();
-    memoryPressureHandler.setLowMemoryHandler([] (Critical critical, Synchronous) {
+    Ref memoryPressureHandler = MemoryPressureHandler::singleton();
+    memoryPressureHandler->setLowMemoryHandler([] (Critical critical, Synchronous) {
 #if PLATFORM(COCOA) || PLATFORM(GTK)
         ViewSnapshotStore::singleton().discardSnapshotImages();
 #endif
@@ -46,7 +46,7 @@ void installMemoryPressureHandler()
         for (auto& processPool : WebProcessPool::allProcessPools())
             processPool->handleMemoryPressureWarning(critical);
     });
-    memoryPressureHandler.install();
+    memoryPressureHandler->install();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebProcessCache.h
+++ b/Source/WebKit/UIProcess/WebProcessCache.h
@@ -108,3 +108,8 @@ private:
 };
 
 } // namespace WebKit
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::WebProcessCache::CachedProcess> : std::true_type { };
+}

--- a/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp
+++ b/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp
@@ -40,6 +40,15 @@
 #endif
 
 namespace WebKit {
+class GeoclueGeolocationProvider;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::GeoclueGeolocationProvider> : std::true_type { };
+}
+
+namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GeoclueGeolocationProvider);
 

--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.h
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.h
@@ -32,6 +32,15 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
+class DisplayVBlankMonitor;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::DisplayVBlankMonitor> : std::true_type { };
+}
+
+namespace WebKit {
 
 using PlatformDisplayID = uint32_t;
 

--- a/Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.h
+++ b/Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.h
@@ -38,6 +38,15 @@
 @class WKDeferringGestureRecognizer;
 
 namespace WebKit {
+class GestureRecognizerConsistencyEnforcer;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::GestureRecognizerConsistencyEnforcer> : std::true_type { };
+}
+
+namespace WebKit {
 
 class GestureRecognizerConsistencyEnforcer {
     WTF_MAKE_TZONE_ALLOCATED(GestureRecognizerConsistencyEnforcer);

--- a/Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.h
+++ b/Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.h
@@ -38,6 +38,15 @@
 @class WKWebView;
 
 namespace WebKit {
+class PointerTouchCompatibilitySimulator;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::PointerTouchCompatibilitySimulator> : std::true_type { };
+}
+
+namespace WebKit {
 
 class PointerTouchCompatibilitySimulator {
     WTF_MAKE_NONCOPYABLE(PointerTouchCompatibilitySimulator);

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -337,7 +337,7 @@ bool GPUProcessConnection::waitForDidInitialize()
 void GPUProcessConnection::didReceiveRemoteCommand(PlatformMediaSession::RemoteControlCommandType type, const PlatformMediaSession::RemoteCommandArgument& argument)
 {
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    PlatformMediaSessionManager::sharedManager().processDidReceiveRemoteControlCommand(type, argument);
+    PlatformMediaSessionManager::singleton().processDidReceiveRemoteControlCommand(type, argument);
 #endif
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -681,6 +681,32 @@ bool WKBundlePageRegisterScrollOperationCompletionCallback(WKBundlePageRef pageR
     return true;
 }
 
+class TimerOwner {
+public:
+    TimerOwner(WTF::Function<void (void*)>&& callback, void* context)
+        : m_timer(*this, &TimerOwner::timerFired)
+        , m_callback(WTFMove(callback))
+        , m_context(context)
+    {
+        m_timer.startOneShot(0_s);
+    }
+
+    void timerFired()
+    {
+        m_callback(m_context);
+        delete this;
+    }
+
+    WebCore::Timer m_timer;
+    WTF::Function<void (void*)> m_callback;
+    void* m_context;
+};
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<TimerOwner> : std::true_type { };
+}
+
 void WKBundlePageCallAfterTasksAndTimers(WKBundlePageRef pageRef, WKBundlePageTestNotificationCallback callback, void* context)
 {
     if (!callback)
@@ -698,27 +724,6 @@ void WKBundlePageCallAfterTasksAndTimers(WKBundlePageRef pageRef, WKBundlePageTe
     WebCore::Document* document = localMainFrame->document();
     if (!document)
         return;
-
-    class TimerOwner {
-    public:
-        TimerOwner(WTF::Function<void (void*)>&& callback, void* context)
-            : m_timer(*this, &TimerOwner::timerFired)
-            , m_callback(WTFMove(callback))
-            , m_context(context)
-        {
-            m_timer.startOneShot(0_s);
-        }
-        
-        void timerFired()
-        {
-            m_callback(m_context);
-            delete this;
-        }
-        
-        WebCore::Timer m_timer;
-        WTF::Function<void (void*)> m_callback;
-        void* m_context;
-    };
     
     document->postTask([=] (WebCore::ScriptExecutionContext&) {
         new TimerOwner(callback, context); // deletes itself when done.

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
@@ -41,6 +41,15 @@ struct FetchOptions;
 }
 
 namespace WebKit {
+class WebLoaderStrategy;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::WebLoaderStrategy> : std::true_type { };
+}
+
+namespace WebKit {
 
 class NetworkProcessConnection;
 class WebFrame;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -172,7 +172,7 @@ void WebPage::platformDidReceiveLoadParameters(const LoadParameters& parameters)
 
 void WebPage::requestActiveNowPlayingSessionInfo(CompletionHandler<void(bool, WebCore::NowPlayingInfo&&)>&& completionHandler)
 {
-    if (auto* sharedManager = WebCore::PlatformMediaSessionManager::sharedManagerIfExists()) {
+    if (auto* sharedManager = WebCore::PlatformMediaSessionManager::singletonIfExists()) {
         if (auto nowPlayingInfo = sharedManager->nowPlayingInfo()) {
             bool registeredAsNowPlayingApplication = sharedManager->registeredAsNowPlayingApplication();
             completionHandler(registeredAsNowPlayingApplication, WTFMove(*nowPlayingInfo));

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingRunLoop.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingRunLoop.h
@@ -37,6 +37,15 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
+class CompositingRunLoop;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::CompositingRunLoop> : std::true_type { };
+}
+
+namespace WebKit {
 
 class CompositingRunLoop {
     WTF_MAKE_NONCOPYABLE(CompositingRunLoop);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -70,6 +70,15 @@ class PaintingEngine;
 }
 
 namespace WebKit {
+class LayerTreeHost;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::LayerTreeHost> : std::true_type { };
+}
+
+namespace WebKit {
 
 class WebPage;
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h
@@ -48,6 +48,15 @@ class Page;
 }
 
 namespace WebKit {
+class LayerTreeHost;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::LayerTreeHost> : std::true_type { };
+}
+
+namespace WebKit {
 
 class WebPage;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9820,7 +9820,7 @@ void WebPage::startObservingNowPlayingMetadata()
             protectedThis->send(Messages::WebPageProxy::NowPlayingMetadataChanged { metadata });
     });
 
-    WebCore::PlatformMediaSessionManager::sharedManager().addNowPlayingMetadataObserver(*m_nowPlayingMetadataObserver);
+    WebCore::PlatformMediaSessionManager::singleton().addNowPlayingMetadataObserver(*m_nowPlayingMetadataObserver);
 #endif
 }
 
@@ -9831,7 +9831,7 @@ void WebPage::stopObservingNowPlayingMetadata()
     if (!nowPlayingMetadataObserver)
         return;
 
-    WebCore::PlatformMediaSessionManager::sharedManager().removeNowPlayingMetadataObserver(*nowPlayingMetadataObserver);
+    WebCore::PlatformMediaSessionManager::singleton().removeNowPlayingMetadataObserver(*nowPlayingMetadataObserver);
 #endif
 }
 

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
@@ -52,6 +52,15 @@ class ShareableBitmapHandle;
 }
 
 namespace WebKit {
+class AcceleratedSurfaceDMABuf;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::AcceleratedSurfaceDMABuf> : std::true_type { };
+}
+
+namespace WebKit {
 
 class WebPage;
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4475,7 +4475,7 @@ void WebPage::applicationWillResignActive()
     [[NSNotificationCenter defaultCenter] postNotificationName:WebUIApplicationWillResignActiveNotification object:nil];
 
     // FIXME(224775): Move to WebProcess
-    if (auto* manager = PlatformMediaSessionManager::sharedManagerIfExists())
+    if (auto* manager = PlatformMediaSessionManager::singletonIfExists())
         manager->applicationWillBecomeInactive();
 
     if (m_page)
@@ -4490,7 +4490,7 @@ void WebPage::applicationDidEnterBackground(bool isSuspendedUnderLock)
     freezeLayerTree(LayerTreeFreezeReason::BackgroundApplication);
 
     // FIXME(224775): Move to WebProcess
-    if (auto* manager = PlatformMediaSessionManager::sharedManagerIfExists())
+    if (auto* manager = PlatformMediaSessionManager::singletonIfExists())
         manager->applicationDidEnterBackground(isSuspendedUnderLock);
 
     if (m_page)
@@ -4512,7 +4512,7 @@ void WebPage::applicationWillEnterForeground(bool isSuspendedUnderLock)
     [[NSNotificationCenter defaultCenter] postNotificationName:WebUIApplicationWillEnterForegroundNotification object:nil userInfo:@{@"isSuspendedUnderLock": @(isSuspendedUnderLock)}];
 
     // FIXME(224775): Move to WebProcess
-    if (auto* manager = PlatformMediaSessionManager::sharedManagerIfExists())
+    if (auto* manager = PlatformMediaSessionManager::singletonIfExists())
         manager->applicationWillEnterForeground(isSuspendedUnderLock);
 
     if (m_page)
@@ -4524,7 +4524,7 @@ void WebPage::applicationDidBecomeActive()
     [[NSNotificationCenter defaultCenter] postNotificationName:WebUIApplicationDidBecomeActiveNotification object:nil];
 
     // FIXME(224775): Move to WebProcess
-    if (auto* manager = PlatformMediaSessionManager::sharedManagerIfExists())
+    if (auto* manager = PlatformMediaSessionManager::singletonIfExists())
         manager->applicationDidBecomeActive();
 
     if (m_page)
@@ -4533,13 +4533,13 @@ void WebPage::applicationDidBecomeActive()
 
 void WebPage::applicationDidEnterBackgroundForMedia(bool isSuspendedUnderLock)
 {
-    if (auto* manager = PlatformMediaSessionManager::sharedManagerIfExists())
+    if (auto* manager = PlatformMediaSessionManager::singletonIfExists())
         manager->applicationDidEnterBackground(isSuspendedUnderLock);
 }
 
 void WebPage::applicationWillEnterForegroundForMedia(bool isSuspendedUnderLock)
 {
-    if (auto* manager = PlatformMediaSessionManager::sharedManagerIfExists())
+    if (auto* manager = PlatformMediaSessionManager::singletonIfExists())
         manager->applicationWillEnterForeground(isSuspendedUnderLock);
 }
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -866,9 +866,9 @@ void WebProcess::setCacheModel(CacheModel cacheModel)
     unsigned backForwardCacheSize = 0;
     calculateMemoryCacheSizes(cacheModel, cacheTotalCapacity, cacheMinDeadCapacity, cacheMaxDeadCapacity, deadDecodedDataDeletionInterval, backForwardCacheSize);
 
-    auto& memoryCache = MemoryCache::singleton();
-    memoryCache.setCapacities(cacheMinDeadCapacity, cacheMaxDeadCapacity, cacheTotalCapacity);
-    memoryCache.setDeadDecodedDataDeletionInterval(deadDecodedDataDeletionInterval);
+    Ref memoryCache = MemoryCache::singleton();
+    memoryCache->setCapacities(cacheMinDeadCapacity, cacheMaxDeadCapacity, cacheTotalCapacity);
+    memoryCache->setDeadDecodedDataDeletionInterval(deadDecodedDataDeletionInterval);
     BackForwardCache::singleton().setMaxSize(backForwardCacheSize);
 
     platformSetCacheModel(cacheModel);
@@ -1631,7 +1631,7 @@ void WebProcess::prepareToSuspend(bool isSuspensionImminent, MonotonicTime estim
 
 #if ENABLE(VIDEO)
     suspendAllMediaBuffering();
-    if (auto* platformMediaSessionManager = PlatformMediaSessionManager::sharedManagerIfExists())
+    if (auto* platformMediaSessionManager = PlatformMediaSessionManager::singletonIfExists())
         platformMediaSessionManager->processWillSuspend();
 #endif
 
@@ -1725,7 +1725,7 @@ void WebProcess::processDidResume()
 #endif
 
 #if ENABLE(VIDEO)
-    if (auto* platformMediaSessionManager = PlatformMediaSessionManager::sharedManagerIfExists())
+    if (auto* platformMediaSessionManager = PlatformMediaSessionManager::singletonIfExists())
         platformMediaSessionManager->processDidResume();
     resumeAllMediaBuffering();
 #endif
@@ -1941,9 +1941,9 @@ RefPtr<API::Object> WebProcess::transformObjectsToHandles(API::Object* object)
 
 void WebProcess::setMemoryCacheDisabled(bool disabled)
 {
-    auto& memoryCache = MemoryCache::singleton();
-    if (memoryCache.disabled() != disabled)
-        memoryCache.setDisabled(disabled);
+    Ref memoryCache = MemoryCache::singleton();
+    if (memoryCache->disabled() != disabled)
+        memoryCache->setDisabled(disabled);
 }
 
 #if ENABLE(SERVICE_CONTROLS)

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -1467,14 +1467,14 @@ void WebProcess::systemWillPowerOn()
 
 void WebProcess::systemWillSleep()
 {
-    if (PlatformMediaSessionManager::sharedManagerIfExists())
-        PlatformMediaSessionManager::sharedManager().processSystemWillSleep();
+    if (PlatformMediaSessionManager::singletonIfExists())
+        PlatformMediaSessionManager::singleton().processSystemWillSleep();
 }
 
 void WebProcess::systemDidWake()
 {
-    if (PlatformMediaSessionManager::sharedManagerIfExists())
-        PlatformMediaSessionManager::sharedManager().processSystemDidWake();
+    if (PlatformMediaSessionManager::singletonIfExists())
+        PlatformMediaSessionManager::singleton().processSystemDidWake();
 }
 #endif
 

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -73,6 +73,10 @@ class WebPushDaemon {
 public:
     static WebPushDaemon& singleton();
 
+    // Do nothing since this is a singleton.
+    void ref() const { }
+    void deref() const { }
+
     void connectionEventHandler(xpc_object_t);
     void connectionAdded(xpc_connection_t);
     void connectionRemoved(xpc_connection_t);

--- a/Source/WebKitLegacy/WebCoreSupport/PingHandle.h
+++ b/Source/WebKitLegacy/WebCoreSupport/PingHandle.h
@@ -36,6 +36,13 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/TZoneMallocInlines.h>
 
+class PingHandle;
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<PingHandle> : std::true_type { };
+}
+
 // This class triggers asynchronous loads independent of the networking context staying alive (i.e., auditing pingbacks).
 // The object just needs to live long enough to ensure the message was actually sent.
 // As soon as any callback is received from the ResourceHandle, this class will cancel the load and delete itself.

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h
@@ -40,6 +40,11 @@
 
 class WebResourceLoadScheduler;
 
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebResourceLoadScheduler> : std::true_type { };
+}
+
 WebResourceLoadScheduler& webResourceLoadScheduler();
 
 class WebResourceLoadScheduler final : public WebCore::LoaderStrategy {

--- a/Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp
@@ -32,6 +32,17 @@
 #include <wtf/threads/BinarySemaphore.h>
 
 namespace TestWebKitAPI {
+class DerivedOneShotTimer;
+class DerivedRepeatingTimer;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<TestWebKitAPI::DerivedOneShotTimer> : std::true_type { };
+template<> struct IsDeprecatedTimerSmartPointerException<TestWebKitAPI::DerivedRepeatingTimer> : std::true_type { };
+}
+
+namespace TestWebKitAPI {
 
 static bool testFinished;
 static int count = 100;

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -37,6 +37,15 @@
 #include <wtf/text/StringBuilder.h>
 
 namespace WTR {
+class TestInvocation;
+}
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WTR::TestInvocation> : std::true_type { };
+}
+
+namespace WTR {
 
 class TestInvocation final : public UIScriptContextDelegate {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Tools/WebKitTestRunner/libwpe/PlatformWebViewClientLibWPE.cpp
+++ b/Tools/WebKitTestRunner/libwpe/PlatformWebViewClientLibWPE.cpp
@@ -58,15 +58,17 @@ void PlatformWebViewClientLibWPE::removeFromWindow()
 PlatformImage PlatformWebViewClientLibWPE::snapshot()
 {
     {
-        struct TimeoutTimer {
+        class TimeoutTimer {
+        public:
             TimeoutTimer()
-                : timer(RunLoop::main(), this, &TimeoutTimer::fired)
+                : m_timer(RunLoop::main(), [] {
+                    RunLoop::main().stop();
+                })
             {
-                timer.startOneShot(1_s / 60);
+                m_timer.startOneShot(1_s / 60);
             }
-
-            void fired() { RunLoop::main().stop(); }
-            RunLoop::Timer timer;
+        private:
+            RunLoop::Timer m_timer;
         } timeoutTimer;
 
         RunLoop::main().run();

--- a/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
@@ -69,29 +69,25 @@ void TestController::platformInitializeContext()
 
 void TestController::platformRunUntil(bool& done, WTF::Seconds timeout)
 {
-    struct TimeoutTimer {
-        TimeoutTimer()
-            : timer(RunLoop::main(), this, &TimeoutTimer::fired)
-        { }
-
-        void fired()
+    bool timedOut = false;
+    class TimeoutTimer {
+    public:
+        TimeoutTimer(WTF::Seconds timeout, bool& timedOut)
+            : m_timer(RunLoop::main(), [&timedOut] {
+                timedOut = true;
+                RunLoop::main().stop();
+            })
         {
-            timedOut = true;
-            RunLoop::main().stop();
+            m_timer.setPriority(G_PRIORITY_DEFAULT_IDLE);
+            if (timeout >= 0_s)
+                m_timer.startOneShot(timeout);
         }
+    private:
+        RunLoop::Timer m_timer;
+    } timeoutTimer(timeout, timedOut);
 
-        RunLoop::Timer timer;
-        bool timedOut { false };
-    } timeoutTimer;
-
-    timeoutTimer.timer.setPriority(G_PRIORITY_DEFAULT_IDLE);
-    if (timeout >= 0_s)
-        timeoutTimer.timer.startOneShot(timeout);
-
-    while (!done && !timeoutTimer.timedOut)
+    while (!done && !timedOut)
         RunLoop::main().run();
-
-    timeoutTimer.timer.stop();
 }
 
 void TestController::platformDidCommitLoadForFrame(WKPageRef, WKFrameRef)


### PR DESCRIPTION
#### 860c2ba52717fbcc180fa51464d1a92fc8d10acd
<pre>
Require classes using Timer to be ref-counted or CanMakeCheckedPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=282590">https://bugs.webkit.org/show_bug.cgi?id=282590</a>

Reviewed by Geoffrey Garen.

Require classes using Timer to be ref-counted or CanMakeCheckedPtr, for safety.
The Timer class leverages this fact to protect the object it is calling the
timeout function on.

* Source/JavaScriptCore/runtime/JSRunLoopTimer.h:
(JSC::JSRunLoopTimer::Manager::ref const):
(JSC::JSRunLoopTimer::Manager::deref const):
* Source/WTF/wtf/MemoryPressureHandler.h:
(WTF::MemoryPressureHandler::ref const):
(WTF::MemoryPressureHandler::deref const):
* Source/WTF/wtf/RunLoop.h:
* Source/WebCore/PAL/pal/HysteresisActivity.h:
* Source/WebCore/bindings/js/GCController.h:
(WebCore::GCController::ref const):
(WebCore::GCController::deref const):
* Source/WebCore/dom/DocumentFontLoader.h:
* Source/WebCore/dom/EventSender.h:
* Source/WebCore/editing/SpellChecker.h:
* Source/WebCore/html/ValidationMessage.h:
* Source/WebCore/html/parser/HTMLParserScheduler.h:
* Source/WebCore/inspector/InspectorOverlay.h:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.h:
* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
* Source/WebCore/inspector/agents/InspectorCanvasAgent.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
* Source/WebCore/inspector/agents/InspectorDOMAgent.h:
* Source/WebCore/inspector/agents/WebHeapAgent.cpp:
* Source/WebCore/loader/ImageLoader.h:
* Source/WebCore/loader/TextTrackLoader.h:
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResourceCallback::CachedResourceCallback):
(WebCore::CachedResourceCallback::cancel):
(WebCore::CachedResourceCallback::timerFired):
(WebCore::CachedResource::Callback::Callback): Deleted.
(WebCore::CachedResource::Callback::cancel): Deleted.
(WebCore::CachedResource::Callback::timerFired): Deleted.
* Source/WebCore/loader/cache/CachedResource.h:
* Source/WebCore/loader/cache/MemoryCache.h:
(WebCore::MemoryCache::ref const):
(WebCore::MemoryCache::deref const):
* Source/WebCore/page/AutoscrollController.h:
* Source/WebCore/page/ImageAnalysisQueue.h:
* Source/WebCore/page/PerformanceMonitor.h:
* Source/WebCore/page/SettingsBase.h:
* Source/WebCore/page/mac/ServicesOverlayController.h:
* Source/WebCore/page/mac/TextIndicatorWindow.h:
* Source/WebCore/page/scrolling/ScrollLatchingController.h:
* Source/WebCore/platform/CPUMonitor.h:
* Source/WebCore/platform/CaretAnimator.h:
* Source/WebCore/platform/Timer.h:
(WebCore::Timer::Timer):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:
(WebCore::PlatformMediaSessionManager::ref const):
(WebCore::PlatformMediaSessionManager::deref const):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::PlatformMediaSessionManager::create):
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h:
(WebCore::GameControllerGamepadProvider::ref const):
(WebCore::GameControllerGamepadProvider::deref const):
* Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h:
(WebCore::HIDGamepadProvider::ref const):
(WebCore::HIDGamepadProvider::deref const):
* Source/WebCore/platform/graphics/FontCache.h:
* Source/WebCore/platform/graphics/ImageFrameAnimator.h:
* Source/WebCore/platform/graphics/MediaPlaybackTargetPicker.h:
* Source/WebCore/platform/graphics/ShadowBlur.cpp:
* Source/WebCore/platform/graphics/ca/TileCoverageMap.h:
* Source/WebCore/platform/graphics/ca/TileGrid.h:
* Source/WebCore/platform/graphics/cg/CGSubimageCacheWithTimer.h:
* Source/WebCore/platform/mac/ScrollbarsControllerMac.h:
* Source/WebCore/platform/mock/DeviceOrientationClientMock.h:
* Source/WebCore/platform/network/DNSResolveQueue.h:
(WebCore::DNSResolveQueue::ref const):
(WebCore::DNSResolveQueue::deref const):
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/rendering/RenderMarquee.h:
* Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h:
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/cache/PrefetchCache.h:
* Source/WebKit/Shared/API/APISerializedScriptValue.cpp:
(API::SharedJSContextWK::singleton):
(API::SharedJSContextWK::ref const):
(API::SharedJSContextWK::deref const):
(API::SharedJSContextWK::SharedJSContextWK):
(API::SerializedScriptValue::deserializeWK):
(API::sharedContext): Deleted.
* Source/WebKit/Shared/SharedStringHashStore.h:
* Source/WebKit/Shared/WebMemorySampler.h:
(WebKit::WebMemorySampler::ref const):
(WebKit::WebMemorySampler::deref const):
* Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm:
(API::SharedJSContext::singleton):
(API::SharedJSContext::ref const):
(API::SharedJSContext::deref const):
(API::SharedJSContext::SharedJSContext):
(API::SerializedScriptValue::deserialize):
(API::coreValueFromNSObject):
(API::sharedContext): Deleted.
* Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h:
* Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h:
* Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h:
* Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h:
* Source/WebKit/UIProcess/ProcessThrottler.cpp:
* Source/WebKit/UIProcess/ProcessThrottler.h:
* Source/WebKit/UIProcess/ResponsivenessTimer.h:
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.h:
* Source/WebKit/UIProcess/WebProcessCache.h:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(TimerOwner::TimerOwner):
(TimerOwner::timerFired):
(WKBundlePageCallAfterTasksAndTimers):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.h:
* Source/WebKit/webpushd/WebPushDaemon.h:
(WebPushD::WebPushDaemon::ref const):
(WebPushD::WebPushDaemon::deref const):
* Source/WebKitLegacy/WebCoreSupport/PingHandle.h:
* Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h:
* Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp:
* Tools/WebKitTestRunner/TestInvocation.h:

Canonical link: <a href="https://commits.webkit.org/286283@main">https://commits.webkit.org/286283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/933884e45b40c609cab44c3db78b55eb981258bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75444 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26708 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77560 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2675 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/17419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78511 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64825 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/39571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22314 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25036 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68594 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81402 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74706 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1759 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2934 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64804 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/66748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16612 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10694 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8849 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96974 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2740 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5561 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/21190 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2765 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3700 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2772 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->