### PR TITLE
Add API to control JS features available to content scripts

### DIFF
--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -57,6 +57,9 @@ public:
     void didCreateWindowProxy(WindowProxy* controller) { m_jsWindowProxies.add(controller); }
     void didDestroyWindowProxy(WindowProxy* controller) { m_jsWindowProxies.remove(controller); }
 
+    void setAllowAutofill() { m_allowAutofill = true; }
+    bool allowAutofill() const { return m_allowAutofill; }
+
     void setShadowRootIsAlwaysOpen() { m_shadowRootIsAlwaysOpen = true; }
     bool shadowRootIsAlwaysOpen() const { return m_shadowRootIsAlwaysOpen; }
 
@@ -84,6 +87,7 @@ private:
     String m_name;
     Type m_type { Type::Internal };
 
+    bool m_allowAutofill { false };
     bool m_shadowRootIsAlwaysOpen { false };
     bool m_shouldDisableLegacyOverrideBuiltInsBehavior { false };
 };

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1575,6 +1575,34 @@ void HTMLInputElement::setAutofillButtonType(AutoFillButtonType autoFillButtonTy
         cache->autofillTypeChanged(*this);
 }
 
+auto HTMLInputElement::autofillVisibility() const -> AutofillVisibility
+{
+    ASSERT(!autofilledAndObscured() || !autofilledAndViewable());
+    if (autofilledAndObscured())
+        return AutofillVisibility::Hidden;
+    if (autofilledAndViewable())
+        return AutofillVisibility::Visible;
+    return AutofillVisibility::Normal;
+}
+
+void HTMLInputElement::setAutofillVisibility(AutofillVisibility state)
+{
+    switch (state) {
+    case AutofillVisibility::Normal:
+        setAutofilledAndViewable(false);
+        setAutofilledAndObscured(false);
+        break;
+    case AutofillVisibility::Visible:
+        setAutofilledAndViewable(true);
+        setAutofilledAndObscured(false);
+        break;
+    case AutofillVisibility::Hidden:
+        setAutofilledAndViewable(false);
+        setAutofilledAndObscured(true);
+        break;
+    }
+}
+
 #if ENABLE(INPUT_TYPE_COLOR)
 bool HTMLInputElement::alpha()
 {

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -257,6 +257,7 @@ public:
     WEBCORE_EXPORT bool multiple() const;
 
     // AutoFill.
+    using AutofillButtonType = WebCore::AutoFillButtonType;
     bool autofilled() const { return m_isAutoFilled; }
     WEBCORE_EXPORT void setAutofilled(bool = true);
     bool autofilledAndViewable() const { return m_isAutoFilledAndViewable; }
@@ -269,6 +270,13 @@ public:
     bool hasAutofillStrongPasswordButton() const  { return autofillButtonType() == AutoFillButtonType::StrongPassword; }
     bool autofillAvailable() const { return m_isAutoFillAvailable; }
     void setAutofillAvailable(bool autoFillAvailable) { m_isAutoFillAvailable = autoFillAvailable; }
+    enum class AutofillVisibility : uint8_t {
+        Normal,
+        Visible,
+        Hidden,
+    };
+    AutofillVisibility autofillVisibility() const;
+    void setAutofillVisibility(AutofillVisibility);
 
 #if ENABLE(DRAG_SUPPORT)
     // Returns true if the given DragData has more than one dropped file.

--- a/Source/WebCore/html/HTMLInputElement.idl
+++ b/Source/WebCore/html/HTMLInputElement.idl
@@ -19,6 +19,21 @@
  * Boston, MA 02110-1301, USA.
  */
 
+enum AutofillVisibility {
+    "normal",
+    "visible",
+    "hidden",
+};
+
+enum AutofillButtonType {
+    "none",
+    "credentials",
+    "contacts",
+    "strong-password",
+    "credit-card",
+    "loading"
+};
+
 [
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToNativeObject,
@@ -93,6 +108,12 @@
 
     [CEReactions=NotNeeded, Reflect] attribute DOMString align;
     [CEReactions=NotNeeded, Reflect] attribute DOMString useMap;
+
+    // WebKit extension for autofill.
+    [EnabledForWorld=allowAutofill] attribute boolean autofillAvailable;
+    [EnabledForWorld=allowAutofill] attribute boolean autofilled;
+    [EnabledForWorld=allowAutofill] attribute AutofillVisibility autofillVisibility;
+    [EnabledForWorld=allowAutofill] attribute AutofillButtonType autofillButtonType;
 
     // See http://www.w3.org/TR/html-media-capture/
     [CEReactions=NotNeeded, Conditional=MEDIA_CAPTURE, Reflect] attribute DOMString capture;

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -405,6 +405,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/BackgroundFetchState.serialization.in
     Shared/CacheModel.serialization.in
     Shared/CallbackID.serialization.in
+    Shared/ContentWorldData.serialization.in
     Shared/ContextMenuContextData.serialization.in
     Shared/CoordinateSystem.serialization.in
     Shared/DebuggableInfoData.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -269,6 +269,7 @@ $(PROJECT_DIR)/Shared/Cocoa/RemoteObjectInvocation.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/RevealItem.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/SharedCARingBuffer.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+$(PROJECT_DIR)/Shared/ContentWorldData.serialization.in
 $(PROJECT_DIR)/Shared/ContextMenuContextData.serialization.in
 $(PROJECT_DIR)/Shared/CoordinateSystem.serialization.in
 $(PROJECT_DIR)/Shared/Databases/IndexedDB/WebIDBResult.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -599,6 +599,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/SharedCARingBuffer.serialization.in \
 	Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in \
 	Shared/CallbackID.serialization.in \
+	Shared/ContentWorldData.serialization.in \
 	Shared/ContextMenuContextData.serialization.in \
 	Shared/CoordinateSystem.serialization.in \
 	Shared/DebuggableInfoData.serialization.in \

--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -328,6 +328,7 @@ list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
     UIProcess/API/Cocoa/WKContentRuleListStore.h
     UIProcess/API/Cocoa/WKContentRuleListStorePrivate.h
     UIProcess/API/Cocoa/WKContentWorld.h
+    UIProcess/API/Cocoa/WKContentWorldConfiguration.h
     UIProcess/API/Cocoa/WKContentWorldPrivate.h
     UIProcess/API/Cocoa/WKContextMenuElementInfo.h
     UIProcess/API/Cocoa/WKContextMenuElementInfoPrivate.h

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1119,6 +1119,8 @@ def headers_for_type(type):
         'WebKit::CallDownloadDidStart': ['"DownloadManager.h"'],
         'WebKit::ConsumerSharedCARingBufferHandle': ['"SharedCARingBuffer.h"'],
         'WebKit::ContentWorldIdentifier': ['"ContentWorldShared.h"'],
+        'WebKit::ContentWorldData': ['"ContentWorldData.h"'],
+        'WebKit::ContentWorldOption': ['"ContentWorldShared.h"'],
         'WebKit::DocumentEditingContextRequest': ['"DocumentEditingContext.h"'],
         'WebKit::DrawingAreaIdentifier': ['"DrawingAreaInfo.h"'],
         'WebKit::FindDecorationStyle': ['"WebFindOptions.h"'],

--- a/Source/WebKit/Shared/API/Cocoa/WebKitPrivate.h
+++ b/Source/WebKit/Shared/API/Cocoa/WebKitPrivate.h
@@ -43,6 +43,7 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKActivatedElementInfo.h>
 #import <WebKit/_WKAttachment.h>
+#import <WebKit/_WKContentWorldConfiguration.h>
 #import <WebKit/_WKElementAction.h>
 #import <WebKit/_WKFocusedElementInfo.h>
 #import <WebKit/_WKFormInputSession.h>

--- a/Source/WebKit/Shared/ContentWorldData.h
+++ b/Source/WebKit/Shared/ContentWorldData.h
@@ -23,50 +23,17 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
-#import "_WKWebPushSubscriptionDataInternal.h"
-#import <WebCore/WebCoreObjCExtras.h>
-#import <wtf/cocoa/SpanCocoa.h>
+#pragma once
 
-@implementation _WKWebPushSubscriptionData
+#include "ContentWorldShared.h"
+#include <wtf/OptionSet.h>
 
-- (void)dealloc
-{
-    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKWebPushSubscriptionData.class, self))
-        return;
+namespace WebKit {
 
-    _data->API::WebPushSubscriptionData::~WebPushSubscriptionData();
-    [super dealloc];
-}
+struct ContentWorldData {
+    ContentWorldIdentifier identifier;
+    String name;
+    OptionSet<WebKit::ContentWorldOption> options;
+};
 
-- (NSURL *)endpoint
-{
-    return self._protectedData->endpoint();
-}
-
-- (NSData *)applicationServerKey
-{
-    return toNSData(self._protectedData->applicationServerKey()).get();
-}
-
-- (NSData *)authenticationSecret
-{
-    return toNSData(self._protectedData->sharedAuthenticationSecret()).get();
-}
-
-- (NSData *)ecdhPublicKey
-{
-    return toNSData(self._protectedData->clientECDHPublicKey()).get();
-}
-
-- (API::Object&)_apiObject
-{
-    return *_data;
-}
-
-- (Ref<API::WebPushSubscriptionData>)_protectedData
-{
-    return *_data;
-}
-
-@end
+} // namespace WebKit

--- a/Source/WebKit/Shared/ContentWorldData.serialization.in
+++ b/Source/WebKit/Shared/ContentWorldData.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Apple Inc. All rights reserved.
+# Copyright (C) 2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,13 +20,16 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-struct WebKit::UserContentControllerParameters {
-    WebKit::UserContentControllerIdentifier identifier;
-    Vector<WebKit::ContentWorldData> userContentWorlds;
-    Vector<WebKit::WebUserScriptData> userScripts;
-    Vector<WebKit::WebUserStyleSheetData> userStyleSheets;
-    Vector<WebKit::WebScriptMessageHandlerData> messageHandlers;
-#if ENABLE(CONTENT_EXTENSIONS)
-    Vector<std::pair<WebKit::WebCompiledContentRuleListData, URL>> contentRuleLists;
-#endif
-}
+header: "ContentWorldData.h"
+
+[OptionSet] enum class WebKit::ContentWorldOption : uint8_t {
+    AllowAutofill,
+    AllowAccessToClosedShadowRoots,
+    DisableLegacyBuiltinOverrides,
+};
+
+struct WebKit::ContentWorldData {
+    WebKit::ContentWorldIdentifier identifier;
+    String name;
+    OptionSet<WebKit::ContentWorldOption> options;
+};

--- a/Source/WebKit/Shared/ContentWorldShared.h
+++ b/Source/WebKit/Shared/ContentWorldShared.h
@@ -39,4 +39,10 @@ inline ContentWorldIdentifier pageContentWorldIdentifier()
     return identifier;
 }
 
+enum class ContentWorldOption : uint8_t {
+    AllowAutofill = 1 << 0,
+    AllowAccessToClosedShadowRoots = 1 << 1,
+    DisableLegacyBuiltinOverrides = 1 << 2,
+};
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/UserContentControllerParameters.h
+++ b/Source/WebKit/Shared/UserContentControllerParameters.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ContentWorldData.h"
 #include "UserContentControllerIdentifier.h"
 #include "WebCompiledContentRuleListData.h"
 #include "WebUserContentControllerDataTypes.h"
@@ -33,7 +34,7 @@ namespace WebKit {
 
 struct UserContentControllerParameters {
     UserContentControllerIdentifier identifier;
-    Vector<std::pair<ContentWorldIdentifier, String>> userContentWorlds;
+    Vector<ContentWorldData> userContentWorlds;
     Vector<WebUserScriptData> userScripts;
     Vector<WebUserStyleSheetData> userStyleSheets;
     Vector<WebScriptMessageHandlerData> messageHandlers;

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -333,6 +333,7 @@ UIProcess/API/Cocoa/WKBrowsingContextController.mm
 UIProcess/API/Cocoa/WKContentRuleList.mm
 UIProcess/API/Cocoa/WKContentRuleListStore.mm
 UIProcess/API/Cocoa/WKContentWorld.mm
+UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
 UIProcess/API/Cocoa/WKContextMenuElementInfo.mm
 UIProcess/API/Cocoa/WKDownload.mm
 UIProcess/API/Cocoa/WKError.mm

--- a/Source/WebKit/UIProcess/API/APIContentWorld.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.cpp
@@ -63,9 +63,10 @@ static WebKit::ContentWorldIdentifier generateIdentifier()
     return WebKit::ContentWorldIdentifier::generate();
 }
 
-ContentWorld::ContentWorld(const WTF::String& name)
+ContentWorld::ContentWorld(const WTF::String& name, OptionSet<WebKit::ContentWorldOption> options)
     : m_identifier(generateIdentifier())
     , m_name(name)
+    , m_options(options)
 {
     auto addResult = sharedWorldIdentifierMap().add(m_identifier, *this);
     ASSERT_UNUSED(addResult, addResult.isNewEntry);
@@ -77,11 +78,11 @@ ContentWorld::ContentWorld(WebKit::ContentWorldIdentifier identifier)
     ASSERT(m_identifier == WebKit::pageContentWorldIdentifier());
 }
 
-Ref<ContentWorld> ContentWorld::sharedWorldWithName(const WTF::String& name)
+Ref<ContentWorld> ContentWorld::sharedWorldWithName(const WTF::String& name, OptionSet<WebKit::ContentWorldOption> options)
 {
     RefPtr<ContentWorld> newContentWorld;
     auto result = sharedWorldNameMap().ensure(name, [&] {
-        newContentWorld = adoptRef(*new ContentWorld(name));
+        newContentWorld = adoptRef(*new ContentWorld(name, options));
         return WeakRef { *newContentWorld };
     });
     return newContentWorld ? newContentWorld.releaseNonNull() : Ref { result.iterator->value.get() };
@@ -95,7 +96,7 @@ ContentWorld& ContentWorld::pageContentWorld()
 
 ContentWorld& ContentWorld::defaultClientWorld()
 {
-    static NeverDestroyed<RefPtr<ContentWorld>> world(adoptRef(new ContentWorld(WTF::String { })));
+    static NeverDestroyed<RefPtr<ContentWorld>> world(adoptRef(new ContentWorld(WTF::String { }, { })));
     return *world.get();
 }
 

--- a/Source/WebKit/UIProcess/API/APIContentWorld.h
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "APIObject.h"
-#include "ContentWorldShared.h"
+#include "ContentWorldData.h"
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
@@ -40,7 +40,7 @@ namespace API {
 class ContentWorld final : public API::ObjectImpl<API::Object::Type::ContentWorld>, public CanMakeWeakPtr<ContentWorld> {
 public:
     static ContentWorld* worldForIdentifier(WebKit::ContentWorldIdentifier);
-    static Ref<ContentWorld> sharedWorldWithName(const WTF::String&);
+    static Ref<ContentWorld> sharedWorldWithName(const WTF::String&, OptionSet<WebKit::ContentWorldOption> options = { });
     static ContentWorld& pageContentWorld();
     static ContentWorld& defaultClientWorld();
 
@@ -48,17 +48,27 @@ public:
 
     WebKit::ContentWorldIdentifier identifier() const { return m_identifier; }
     const WTF::String& name() const { return m_name; }
-    std::pair<WebKit::ContentWorldIdentifier, WTF::String> worldData() const { return { m_identifier, m_name }; }
+    WebKit::ContentWorldData worldData() const { return { m_identifier, m_name, m_options }; }
+
+    bool allowAutofill() const { return m_options.contains(WebKit::ContentWorldOption::AllowAutofill); }
+    void setAllowAutofill(bool value) { m_options.add(WebKit::ContentWorldOption::AllowAutofill); }
+
+    bool allowAccessToClosedShadowRoots() const { return m_options.contains(WebKit::ContentWorldOption::AllowAccessToClosedShadowRoots); }
+    void setAllowAccessToClosedShadowRoots(bool value) { m_options.add(WebKit::ContentWorldOption::AllowAccessToClosedShadowRoots); }
+
+    bool disableLegacyBuiltinOverrides() const { return m_options.contains(WebKit::ContentWorldOption::DisableLegacyBuiltinOverrides); }
+    void setDisableLegacyBuiltinOverrides(bool value) { m_options.add(WebKit::ContentWorldOption::DisableLegacyBuiltinOverrides); }
 
     void addAssociatedUserContentControllerProxy(WebKit::WebUserContentControllerProxy&);
     void userContentControllerProxyDestroyed(WebKit::WebUserContentControllerProxy&);
 
 private:
-    explicit ContentWorld(const WTF::String&);
+    explicit ContentWorld(const WTF::String&, OptionSet<WebKit::ContentWorldOption>);
     explicit ContentWorld(WebKit::ContentWorldIdentifier);
 
     WebKit::ContentWorldIdentifier m_identifier;
     WTF::String m_name;
+    OptionSet<WebKit::ContentWorldOption> m_options;
     WeakHashSet<WebKit::WebUserContentControllerProxy> m_associatedContentControllerProxies;
 };
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "_WKContentWorldConfiguration.h"
+
+@implementation _WKContentWorldConfiguration {
+    String _name;
+}
+
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
+- (NSString *)name
+{
+    return _name;
+}
+
+- (void)setName:(NSString *)name
+{
+    _name = name;
+}
+
+#pragma mark NSCopying protocol implementation
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    _WKContentWorldConfiguration *clone = [(_WKContentWorldConfiguration *)[[self class] allocWithZone:zone] init];
+
+    clone.name = self.name;
+    clone.allowAutofill = self.allowAutofill;
+    clone.allowAccessToClosedShadowRoots = self.allowAccessToClosedShadowRoots;
+    clone.disableLegacyBuiltinOverrides = self.disableLegacyBuiltinOverrides;
+
+    return clone;
+}
+
+#pragma mark NSSecureCoding protocol implementation
+
++ (BOOL)supportsSecureCoding
+{
+    return YES;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+    [coder encodeObject:self.name forKey:@"name"];
+    [coder encodeBool:self.allowAutofill forKey:@"allowAutofill"];
+    [coder encodeBool:self.allowAccessToClosedShadowRoots forKey:@"allowAccessToClosedShadowRoots"];
+    [coder encodeBool:self.disableLegacyBuiltinOverrides forKey:@"disableLegacyBuiltinOverrides"];
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+    if (!(self = [self init]))
+        return nil;
+
+    self.name = [coder decodeObjectOfClass:[NSString class] forKey:@"name"];
+    self.allowAutofill = [coder decodeBoolForKey:@"allowAutofill"];
+    self.allowAccessToClosedShadowRoots = [coder decodeBoolForKey:@"allowAccessToClosedShadowRoots"];
+    self.disableLegacyBuiltinOverrides = [coder decodeBoolForKey:@"disableLegacyBuiltinOverrides"];
+
+    return self;
+}
+
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldPrivate.h
@@ -24,10 +24,13 @@
  */
 
 #import <WebKit/WKContentWorld.h>
+#import <WebKit/_WKContentWorldConfiguration.h>
 
 @class _WKUserContentWorld;
 
 @interface WKContentWorld (WKPrivate)
+
++ (WKContentWorld *)_worldWithConfiguration:(_WKContentWorldConfiguration *)configuration NS_SWIFT_NAME(worldWithConfiguration(configuration:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h
@@ -23,50 +23,30 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
-#import "_WKWebPushSubscriptionDataInternal.h"
-#import <WebCore/WebCoreObjCExtras.h>
-#import <wtf/cocoa/SpanCocoa.h>
+#import <WebKit/WKFoundation.h>
 
-@implementation _WKWebPushSubscriptionData
+NS_ASSUME_NONNULL_BEGIN
 
-- (void)dealloc
-{
-    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKWebPushSubscriptionData.class, self))
-        return;
+/*! @abstract A WKContentWorldConfiguration object allows you to specify configuration for WKContentWorld.
+@discussion WKContentWorldConfiguration allows applications to specify ways by which extra JavaScript capabilities should be exposed to the script in the environment.
+For example:
+- If your scripts have to access autofill capabilities, you may want to set allowAutofill to YES. */
+WK_SWIFT_UI_ACTOR
+NS_SWIFT_SENDABLE
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+@interface _WKContentWorldConfiguration : NSObject<NSCopying, NSSecureCoding>
 
-    _data->API::WebPushSubscriptionData::~WebPushSubscriptionData();
-    [super dealloc];
-}
+@property (nonatomic, copy) NSString *name;
 
-- (NSURL *)endpoint
-{
-    return self._protectedData->endpoint();
-}
+/*! @abstract A boolean value indicating whether the capability to trigger autofill is exposed to scripts or not. */
+@property (nonatomic) BOOL allowAutofill;
 
-- (NSData *)applicationServerKey
-{
-    return toNSData(self._protectedData->applicationServerKey()).get();
-}
+/*! @abstract A boolean value indicating whether every shadow root should be treated as open mode shadow root or not. */
+@property (nonatomic) BOOL allowAccessToClosedShadowRoots;
 
-- (NSData *)authenticationSecret
-{
-    return toNSData(self._protectedData->sharedAuthenticationSecret()).get();
-}
-
-- (NSData *)ecdhPublicKey
-{
-    return toNSData(self._protectedData->clientECDHPublicKey()).get();
-}
-
-- (API::Object&)_apiObject
-{
-    return *_data;
-}
-
-- (Ref<API::WebPushSubscriptionData>)_protectedData
-{
-    return *_data;
-}
+/*! @abstract A boolean value indicating whether the behavior that elements with a name attribute overrides builtin methods on document object should be disabled or not. */
+@property (nonatomic) BOOL disableLegacyBuiltinOverrides;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm
@@ -33,6 +33,7 @@
 #import <WebCore/RegistrableDomain.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cf/TypeCastsCF.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/spi/cocoa/SecuritySPI.h>
 
 #import <pal/cocoa/CoreTelephonySoftLink.h>

--- a/Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.h
+++ b/Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.h
@@ -28,6 +28,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "WKBrowserEngineDefinitions.h"
+#import "WKWebView.h"
 #import <WebCore/FloatPoint.h>
 #import <WebCore/FloatSize.h>
 #import <wtf/RunLoop.h>
@@ -37,7 +38,6 @@
 @class UIScrollEvent;
 @class UIWindow;
 @class WKBaseScrollView;
-@class WKWebView;
 
 namespace WebKit {
 class PointerTouchCompatibilitySimulator;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1949,6 +1949,7 @@
 		9B47908D25314D8300EC11AB /* MessageArgumentDescriptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B47908C25314D8300EC11AB /* MessageArgumentDescriptions.h */; };
 		9B47908F253151CC00EC11AB /* JSIPCBinding.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B47908E253151CC00EC11AB /* JSIPCBinding.h */; };
 		9B4790912531563200EC11AB /* MessageArgumentDescriptions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9B4790902531563200EC11AB /* MessageArgumentDescriptions.cpp */; };
+		9B4CE9512CD99B7C00351173 /* _WKContentWorldConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B17FFC52CD975EC002DDA6E /* _WKContentWorldConfiguration.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9B5499AD2362A6F900DF8BA5 /* _WKTextManipulationConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B5499AC2362A6F600DF8BA5 /* _WKTextManipulationConfiguration.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9B5499B22362A7EC00DF8BA5 /* _WKTextManipulationExclusionRule.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B5499B02362A7EC00DF8BA5 /* _WKTextManipulationExclusionRule.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9B5BEC262400F4A90070C6EF /* WebMediaStrategy.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B5BEC242400F4A90070C6EF /* WebMediaStrategy.h */; };
@@ -7088,6 +7089,8 @@
 		9B12A4D42C73C155008A9AAB /* _WKPageLoadTiming.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKPageLoadTiming.h; sourceTree = "<group>"; };
 		9B12A4D52C73C155008A9AAB /* _WKPageLoadTiming.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKPageLoadTiming.mm; sourceTree = "<group>"; };
 		9B12A4DB2C746D16008A9AAB /* _WKPageLoadTimingInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKPageLoadTimingInternal.h; sourceTree = "<group>"; };
+		9B17FFC52CD975EC002DDA6E /* _WKContentWorldConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKContentWorldConfiguration.h; sourceTree = "<group>"; };
+		9B17FFC72CD97EAB002DDA6E /* WKContentWorldConfiguration.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKContentWorldConfiguration.mm; sourceTree = "<group>"; };
 		9B38009C2AEA2D8A0011A892 /* ViewWindowCoordinates.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ViewWindowCoordinates.serialization.in; sourceTree = "<group>"; };
 		9B38009D2AEA2D8B0011A892 /* ViewWindowCoordinates.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewWindowCoordinates.h; sourceTree = "<group>"; };
 		9B47908C25314D8300EC11AB /* MessageArgumentDescriptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MessageArgumentDescriptions.h; sourceTree = "<group>"; };
@@ -7102,6 +7105,8 @@
 		9B5BEC28240101580070C6EF /* RemoteAudioDestinationProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteAudioDestinationProxy.h; sourceTree = "<group>"; };
 		9B5BEC29240101580070C6EF /* RemoteAudioDestinationProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteAudioDestinationProxy.cpp; sourceTree = "<group>"; };
 		9B7F8A502C785725000057F3 /* WebPageLoadTiming.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebPageLoadTiming.h; sourceTree = "<group>"; };
+		9B9513B72CD99DF700E0B6C4 /* ContentWorldData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContentWorldData.h; sourceTree = "<group>"; };
+		9B9513BB2CD99F0A00E0B6C4 /* ContentWorldData.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ContentWorldData.serialization.in; sourceTree = "<group>"; };
 		9BC59D6C1EFCCCB6001E8D09 /* CallbackID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CallbackID.h; sourceTree = "<group>"; };
 		9BF5EC6325410E9900984E77 /* JSIPCBinding.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSIPCBinding.cpp; sourceTree = "<group>"; };
 		9BF622512C3E8559007F7021 /* SharedPreferencesForWebProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SharedPreferencesForWebProcess.cpp; sourceTree = "<group>"; };
@@ -9190,6 +9195,8 @@
 				86BAAFD729A3D29B0013F9A9 /* CallbackID.serialization.in */,
 				D243D71E2CC1764B006D5E35 /* ColorControlSupportsAlpha.h */,
 				CA05397823EE324400A553DC /* ContentAsStringIncludesChildFrames.h */,
+				9B9513B72CD99DF700E0B6C4 /* ContentWorldData.h */,
+				9B9513BB2CD99F0A00E0B6C4 /* ContentWorldData.serialization.in */,
 				5129EB1123D0DE7800AF1CD7 /* ContentWorldShared.h */,
 				5106D7BF18BDBE73000AB166 /* ContextMenuContextData.cpp */,
 				5106D7C018BDBE73000AB166 /* ContextMenuContextData.h */,
@@ -11492,6 +11499,7 @@
 				5C4609E222430E4C009943C2 /* _WKContentRuleListAction.h */,
 				5C4609E322430E4D009943C2 /* _WKContentRuleListAction.mm */,
 				5C4609E422430E4D009943C2 /* _WKContentRuleListActionInternal.h */,
+				9B17FFC52CD975EC002DDA6E /* _WKContentWorldConfiguration.h */,
 				1A5704F61BE01FF400874AF1 /* _WKContextMenuElementInfo.h */,
 				1A5704F51BE01FF400874AF1 /* _WKContextMenuElementInfo.mm */,
 				DFEAFFC529664BB200038490 /* _WKContextMenuElementInfoInternal.h */,
@@ -11715,6 +11723,7 @@
 				5CD286501E722F440094FDC8 /* WKContentRuleListStorePrivate.h */,
 				511065FA23EC956B005443D6 /* WKContentWorld.h */,
 				511065F923EC956B005443D6 /* WKContentWorld.mm */,
+				9B17FFC72CD97EAB002DDA6E /* WKContentWorldConfiguration.mm */,
 				511065FB23EC956B005443D6 /* WKContentWorldInternal.h */,
 				DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */,
 				5CE0C369229F2D4A003695F0 /* WKContextMenuElementInfo.h */,
@@ -16109,6 +16118,7 @@
 				990D28B11C65208D00986977 /* _WKAutomationSessionInternal.h in Headers */,
 				5C4609E7224317B4009943C2 /* _WKContentRuleListAction.h in Headers */,
 				5C4609E8224317BB009943C2 /* _WKContentRuleListActionInternal.h in Headers */,
+				9B4CE9512CD99B7C00351173 /* _WKContentWorldConfiguration.h in Headers */,
 				1A5704F81BE01FF400874AF1 /* _WKContextMenuElementInfo.h in Headers */,
 				DFEAFFC629664BB200038490 /* _WKContextMenuElementInfoInternal.h in Headers */,
 				5C5D238C227A2CDA000B9BDA /* _WKCustomHeaderFields.h in Headers */,

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
@@ -116,6 +116,11 @@ void InjectedBundleScriptWorld::clearWrappers()
     m_world->clearWrappers();
 }
 
+void InjectedBundleScriptWorld::setAllowAutofill()
+{
+    m_world->setAllowAutofill();
+}
+
 void InjectedBundleScriptWorld::makeAllShadowRootsOpen()
 {
     m_world->setShadowRootIsAlwaysOpen();

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
@@ -53,6 +53,7 @@ public:
     WebCore::DOMWrapperWorld& coreWorld();
 
     void clearWrappers();
+    void setAllowAutofill();
     void makeAllShadowRootsOpen();
     void disableOverrideBuiltinsBehavior();
 

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -104,28 +104,36 @@ InjectedBundleScriptWorld* WebUserContentController::worldForIdentifier(ContentW
     return iterator == worldMap().end() ? nullptr : iterator->value.first.ptr();
 }
 
-InjectedBundleScriptWorld* WebUserContentController::addContentWorld(const std::pair<ContentWorldIdentifier, String>& world)
+InjectedBundleScriptWorld* WebUserContentController::addContentWorld(const ContentWorldData& world)
 {
-    if (world.first == pageContentWorldIdentifier())
+    if (world.identifier == pageContentWorldIdentifier())
         return nullptr;
-    
-    auto addResult = worldMap().ensure(world.first, [&] {
+
+    auto addResult = worldMap().ensure(world.identifier, [&] {
 #if PLATFORM(GTK) || PLATFORM(WPE)
         // The GLib API doesn't allow to create script worlds from the UI process. We need to
         // use the existing world created by the web extension if any. The world name is used
         // as the identifier.
-        if (auto* existingWorld = InjectedBundleScriptWorld::find(world.second))
+        if (auto* existingWorld = InjectedBundleScriptWorld::find(world.name))
             return std::make_pair(Ref<InjectedBundleScriptWorld>(*existingWorld), 1);
 #endif
-        return std::make_pair(InjectedBundleScriptWorld::create(world.second, InjectedBundleScriptWorld::Type::User), 1);
+        return std::make_pair(InjectedBundleScriptWorld::create(world.name, InjectedBundleScriptWorld::Type::User), 1);
     });
-    
-    if (addResult.isNewEntry)
-        return addResult.iterator->value.first.ptr();
+
+    if (addResult.isNewEntry) {
+        Ref scriptWorld = addResult.iterator->value.first;
+        if (world.options.contains(ContentWorldOption::AllowAutofill))
+            scriptWorld->setAllowAutofill();
+        if (world.options.contains(ContentWorldOption::AllowAccessToClosedShadowRoots))
+            scriptWorld->makeAllShadowRootsOpen();
+        if (world.options.contains(ContentWorldOption::DisableLegacyBuiltinOverrides))
+            scriptWorld->disableOverrideBuiltinsBehavior();
+        return scriptWorld.ptr();
+    }
     return nullptr;
 }
 
-void WebUserContentController::addContentWorlds(const Vector<std::pair<ContentWorldIdentifier, String>>& worlds)
+void WebUserContentController::addContentWorlds(const Vector<ContentWorldData>& worlds)
 {
     for (auto& world : worlds) {
         if (auto* contentWorld = addContentWorld(world)) {

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
@@ -69,8 +69,8 @@ public:
 
     InjectedBundleScriptWorld* worldForIdentifier(ContentWorldIdentifier);
 
-    void addContentWorlds(const Vector<std::pair<ContentWorldIdentifier, String>>&);
-    InjectedBundleScriptWorld* addContentWorld(const std::pair<ContentWorldIdentifier, String>&);
+    void addContentWorlds(const Vector<ContentWorldData>&);
+    InjectedBundleScriptWorld* addContentWorld(const ContentWorldData&);
     void addUserScripts(Vector<WebUserScriptData>&&, InjectUserScriptImmediately);
     void addUserStyleSheets(const Vector<WebUserStyleSheetData>&);
     void addUserScriptMessageHandlers(const Vector<WebScriptMessageHandlerData>&);

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.messages.in
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.messages.in
@@ -24,7 +24,7 @@
  */
 
 messages -> WebUserContentController {
-    AddContentWorlds(Vector<std::pair<WebKit::ContentWorldIdentifier, String>> worlds);
+    AddContentWorlds(Vector<WebKit::ContentWorldData> worlds);
     RemoveContentWorlds(Vector<WebKit::ContentWorldIdentifier> worldIdentifiers);
 
     AddUserScripts(Vector<WebKit::WebUserScriptData> userScripts, enum:bool WebKit::InjectUserScriptImmediately immediately);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4370,7 +4370,7 @@ void WebPage::runJavaScript(WebFrame* frame, RunJavaScriptParameters&& parameter
     frame->coreLocalFrame()->script().executeAsynchronousUserAgentScriptInWorld(world->coreWorld(), WTFMove(parameters), WTFMove(resolveFunction));
 }
 
-void WebPage::runJavaScriptInFrameInScriptWorld(RunJavaScriptParameters&& parameters, std::optional<WebCore::FrameIdentifier> frameID, const std::pair<ContentWorldIdentifier, String>& worldData, CompletionHandler<void(std::span<const uint8_t>, const std::optional<WebCore::ExceptionDetails>&)>&& completionHandler)
+void WebPage::runJavaScriptInFrameInScriptWorld(RunJavaScriptParameters&& parameters, std::optional<WebCore::FrameIdentifier> frameID, const ContentWorldData& worldData, CompletionHandler<void(std::span<const uint8_t>, const std::optional<WebCore::ExceptionDetails>&)>&& completionHandler)
 {
     WEBPAGE_RELEASE_LOG(Process, "runJavaScriptInFrameInScriptWorld: frameID=%" PRIu64, frameID ? frameID->object().toUInt64() : 0);
     RefPtr webFrame = frameID ? WebProcess::singleton().webFrame(*frameID) : &mainWebFrame();
@@ -4383,7 +4383,7 @@ void WebPage::runJavaScriptInFrameInScriptWorld(RunJavaScriptParameters&& parame
         }
     }
 
-    runJavaScript(webFrame.get(), WTFMove(parameters), worldData.first, [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](std::span<const uint8_t> result, const std::optional<WebCore::ExceptionDetails>& exception) mutable {
+    runJavaScript(webFrame.get(), WTFMove(parameters), worldData.identifier, [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](std::span<const uint8_t> result, const std::optional<WebCore::ExceptionDetails>& exception) mutable {
 #if RELEASE_LOG_DISABLED
         UNUSED_PARAM(this);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2077,7 +2077,7 @@ private:
     void getWebArchiveOfFrame(std::optional<WebCore::FrameIdentifier>, CompletionHandler<void(const std::optional<IPC::SharedBufferReference>&)>&&);
     void getWebArchiveOfFrameWithFileName(WebCore::FrameIdentifier, const Vector<WebCore::MarkupExclusionRule>&, const String& fileName, CompletionHandler<void(const std::optional<IPC::SharedBufferReference>&)>&&);
     void runJavaScript(WebFrame*, WebCore::RunJavaScriptParameters&&, ContentWorldIdentifier, CompletionHandler<void(std::span<const uint8_t>, const std::optional<WebCore::ExceptionDetails>&)>&&);
-    void runJavaScriptInFrameInScriptWorld(WebCore::RunJavaScriptParameters&&, std::optional<WebCore::FrameIdentifier>, const std::pair<ContentWorldIdentifier, String>& worldData, CompletionHandler<void(std::span<const uint8_t>, const std::optional<WebCore::ExceptionDetails>&)>&&);
+    void runJavaScriptInFrameInScriptWorld(WebCore::RunJavaScriptParameters&&, std::optional<WebCore::FrameIdentifier>, const ContentWorldData&, CompletionHandler<void(std::span<const uint8_t>, const std::optional<WebCore::ExceptionDetails>&)>&&);
     void getAccessibilityTreeData(CompletionHandler<void(const std::optional<IPC::SharedBufferReference>&)>&&);
     void updateRenderingWithForcedRepaint(CompletionHandler<void()>&&);
     void takeSnapshot(WebCore::IntRect snapshotRect, WebCore::IntSize bitmapSize, SnapshotOptions, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -236,7 +236,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     GetWebArchiveOfFrame(std::optional<WebCore::FrameIdentifier> frameID) -> (std::optional<IPC::SharedBufferReference> dataReference)
     GetWebArchiveOfFrameWithFileName(WebCore::FrameIdentifier frameID, Vector<WebCore::MarkupExclusionRule> markupExclusionRules, String fileName) -> (std::optional<IPC::SharedBufferReference> dataReference)
 
-    RunJavaScriptInFrameInScriptWorld(struct WebCore::RunJavaScriptParameters parameters, std::optional<WebCore::FrameIdentifier> frameID, std::pair<WebKit::ContentWorldIdentifier, String> world) -> (std::span<const uint8_t> resultData, std::optional<WebCore::ExceptionDetails> details)
+    RunJavaScriptInFrameInScriptWorld(struct WebCore::RunJavaScriptParameters parameters, std::optional<WebCore::FrameIdentifier> frameID, struct WebKit::ContentWorldData world) -> (std::span<const uint8_t> resultData, std::optional<WebCore::ExceptionDetails> details)
 
     GetAccessibilityTreeData() -> (std::optional<IPC::SharedBufferReference> dataReference)
     UpdateRenderingWithForcedRepaint() -> ()


### PR DESCRIPTION
#### e42b814875a017b4a27630c14cf83774d2a96359
<pre>
Add API to control JS features available to content scripts
<a href="https://bugs.webkit.org/show_bug.cgi?id=282591">https://bugs.webkit.org/show_bug.cgi?id=282591</a>
<a href="https://rdar.apple.com/139704339">rdar://139704339</a>

Reviewed by Wenson Hsieh.

This PR introduces _WKContentWorldConfiguration, which controls whether content
script has the capability to autofill, access closed shadow roots, and disable
legacy behavior of element names overriding functions on document prototype.

For autofill, we expose 4 new attributes on HTMLInputElement:
 * autofillAvailable - boolean indicating whether autofill is available or not
   for users.
 * autofilled - boolean indicating whether the input element had been autofilled
   or not.
 * autofillVisibility - specifies the visibility of autofilled text. Possible
   values are &quot;normal&quot;, &quot;visible&quot;, and &quot;hidden&quot;.
 * autofillButtonType - specifies the type of autofill button to display.
   Possible values are &quot;none&quot;, &quot;credentials&quot;, &quot;contacts&quot;, &quot;strong-password&quot;,
   &quot;credit-card&quot;, and &quot;loading&quot;.

* Source/WebCore/bindings/js/DOMWrapperWorld.h:
(WebCore::DOMWrapperWorld::setAllowAutofill):
(WebCore::DOMWrapperWorld::allowAutofill const):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::autofillVisibility const):
(WebCore::HTMLInputElement::setAutofillVisibility):
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/HTMLInputElement.idl:
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/PlatformMac.cmake:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/API/Cocoa/WebKitPrivate.h:
* Source/WebKit/Shared/ContentWorldData.h:
* Source/WebKit/Shared/ContentWorldData.serialization.in:
* Source/WebKit/Shared/ContentWorldShared.h:
* Source/WebKit/Shared/UserContentControllerParameters.h:
* Source/WebKit/Shared/UserContentControllerParameters.serialization.in:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/APIContentWorld.cpp:
(API::ContentWorld::ContentWorld):
(API::ContentWorld::sharedWorldWithName):
(API::ContentWorld::defaultClientWorld):
* Source/WebKit/UIProcess/API/APIContentWorld.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm:
(checkContentWorldOptions):
(+[WKContentWorld worldWithName:]):
(+[WKContentWorld _worldWithConfiguration:]):
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm: Added.
(-[_WKContentWorldConfiguration name]):
(-[_WKContentWorldConfiguration setName:]):
(-[_WKContentWorldConfiguration copyWithZone:]):
(+[_WKContentWorldConfiguration supportsSecureCoding]):
(-[_WKContentWorldConfiguration encodeWithCoder:]):
(-[_WKContentWorldConfiguration initWithCoder:]):
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorldPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushSubscriptionData.mm:
* Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm:
* Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp:
(WebKit::InjectedBundleScriptWorld::setAllowAutofill):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::WebUserContentController::addContentWorld):
(WebKit::WebUserContentController::addContentWorlds):
* Source/WebKit/WebProcess/UserContent/WebUserContentController.h:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::runJavaScriptInFrameInScriptWorld):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm:
(TEST(WKUserContentController, AllowAutofill)):
(TEST(WKUserContentController, AllowAccessToClosedShadowRoots)):
(TEST(WKUserContentController, DisableLegacyBuiltinOverrides)):

Canonical link: <a href="https://commits.webkit.org/286778@main">https://commits.webkit.org/286778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b40aae5eb8b2dffacf9033bddda67277b07e767c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77038 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81588 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28317 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79155 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4369 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60366 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18436 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66128 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40677 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/76544 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47721 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23626 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26643 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68838 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83022 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2965 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68651 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67904 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11878 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9965 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11922 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4364 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7180 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4384 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7819 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6143 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->