### PR TITLE
VideoFrame::presentationSize should return IntSize

### DIFF
--- a/Source/WebCore/platform/VideoFrame.h
+++ b/Source/WebCore/platform/VideoFrame.h
@@ -97,7 +97,7 @@ public:
     using CopyCallback = CompletionHandler<void(std::optional<Vector<PlaneLayout>>&&)>;
     void copyTo(std::span<uint8_t>, VideoPixelFormat, Vector<ComputedPlaneLayout>&&, CopyCallback&&);
 
-    virtual FloatSize presentationSize() const = 0;
+    virtual IntSize presentationSize() const = 0;
     virtual uint32_t pixelFormat() const = 0;
 
     virtual bool isRemoteProxy() const { return false; }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -269,7 +269,7 @@ private:
 
     MediaPlayer::NetworkState m_networkState { MediaPlayer::NetworkState::Empty };
     MediaPlayer::ReadyState m_readyState { MediaPlayer::ReadyState::HaveNothing };
-    FloatSize m_intrinsicSize;
+    IntSize m_intrinsicSize;
     float m_volume { 1 };
     DisplayMode m_displayMode { None };
     PlaybackState m_playbackState { PlaybackState::None };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -487,7 +487,7 @@ void MediaPlayerPrivateMediaStreamAVFObjC::load(MediaStreamPrivate& stream)
 {
     INFO_LOG(LOGIDENTIFIER);
 
-    m_intrinsicSize = FloatSize();
+    m_intrinsicSize = { };
 
     m_mediaStreamPrivate = &stream;
     m_mediaStreamPrivate->addObserver(*this);
@@ -770,7 +770,7 @@ void MediaPlayerPrivateMediaStreamAVFObjC::characteristicsChanged()
 {
     SizeChanged sizeChanged = SizeChanged::No;
 
-    FloatSize intrinsicSize = m_mediaStreamPrivate->intrinsicSize();
+    IntSize intrinsicSize = m_mediaStreamPrivate->intrinsicSize();
     if (intrinsicSize.isEmpty() || m_intrinsicSize.isEmpty()) {
         if (intrinsicSize.height() != m_intrinsicSize.height() || intrinsicSize.width() != m_intrinsicSize.width()) {
             m_intrinsicSize = intrinsicSize;

--- a/Source/WebCore/platform/graphics/cv/VideoFrameCV.h
+++ b/Source/WebCore/platform/graphics/cv/VideoFrameCV.h
@@ -48,7 +48,7 @@ public:
     ImageOrientation orientation() const;
 
     // VideoFrame overrides.
-    WEBCORE_EXPORT WebCore::FloatSize presentationSize() const final;
+    WEBCORE_EXPORT WebCore::IntSize presentationSize() const final;
     WEBCORE_EXPORT uint32_t pixelFormat() const final;
     WEBCORE_EXPORT void setOwnershipIdentity(const ProcessIdentity&) final;
     bool isCV() const final { return true; }

--- a/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
+++ b/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
@@ -587,9 +587,9 @@ VideoFrameCV::VideoFrameCV(MediaTime presentationTime, bool isMirrored, Rotation
 
 VideoFrameCV::~VideoFrameCV() = default;
 
-WebCore::FloatSize VideoFrameCV::presentationSize() const
+WebCore::IntSize VideoFrameCV::presentationSize() const
 {
-    return { static_cast<float>(CVPixelBufferGetWidth(m_pixelBuffer.get())), static_cast<float>(CVPixelBufferGetHeight(m_pixelBuffer.get())) };
+    return { static_cast<int>(CVPixelBufferGetWidth(m_pixelBuffer.get())), static_cast<int>(CVPixelBufferGetHeight(m_pixelBuffer.get())) };
 }
 
 uint32_t VideoFrameCV::pixelFormat() const

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3794,7 +3794,7 @@ RefPtr<VideoFrame> MediaPlayerPrivateGStreamer::videoFrameForCurrentTime()
         return nullptr;
 
     auto size = getVideoResolutionFromCaps(gst_sample_get_caps(m_sample.get())).value_or(FloatSize { 0, 0 });
-    return VideoFrameGStreamer::create(WTFMove(convertedSample), size);
+    return VideoFrameGStreamer::create(WTFMove(convertedSample), IntSize(size));
 }
 
 bool MediaPlayerPrivateGStreamer::setVideoSourceOrientation(ImageOrientation orientation)

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
@@ -235,7 +235,7 @@ GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder(const String& codec
             timestamp = m_timestamp;
 
         GST_TRACE_OBJECT(m_harness->element(), "Handling decoded frame with PTS: %" GST_TIME_FORMAT " and duration: %" GST_TIME_FORMAT, GST_TIME_ARGS(timestamp), GST_TIME_ARGS(duration));
-        auto videoFrame = VideoFrameGStreamer::create(WTFMove(outputSample), m_presentationSize, fromGstClockTime(timestamp));
+        auto videoFrame = VideoFrameGStreamer::create(WTFMove(outputSample), IntSize(m_presentationSize), fromGstClockTime(timestamp));
         m_outputCallback(VideoDecoder::DecodedFrame { WTFMove(videoFrame), timestamp, duration });
     });
 }

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
@@ -42,7 +42,7 @@ public:
         Canvas2D
     };
 
-    static Ref<VideoFrameGStreamer> create(GRefPtr<GstSample>&&, const FloatSize& presentationSize, const MediaTime& presentationTime = MediaTime::invalidTime(), Rotation videoRotation = Rotation::None, bool videoMirrored = false, std::optional<VideoFrameTimeMetadata>&& = std::nullopt, std::optional<PlatformVideoColorSpace>&& = std::nullopt);
+    static Ref<VideoFrameGStreamer> create(GRefPtr<GstSample>&&, const IntSize& presentationSize, const MediaTime& presentationTime = MediaTime::invalidTime(), Rotation videoRotation = Rotation::None, bool videoMirrored = false, std::optional<VideoFrameTimeMetadata>&& = std::nullopt, std::optional<PlatformVideoColorSpace>&& = std::nullopt);
 
     static Ref<VideoFrameGStreamer> createWrappedSample(const GRefPtr<GstSample>&, const MediaTime& presentationTime = MediaTime::invalidTime(), Rotation videoRotation = Rotation::None);
 
@@ -63,12 +63,12 @@ public:
 
     RefPtr<ImageGStreamer> convertToImage();
 
-    FloatSize presentationSize() const final { return m_presentationSize; }
+    IntSize presentationSize() const final { return m_presentationSize; }
     uint32_t pixelFormat() const final;
 
 private:
-    VideoFrameGStreamer(GRefPtr<GstSample>&&, const FloatSize& presentationSize, const MediaTime& presentationTime = MediaTime::invalidTime(), Rotation = Rotation::None, bool videoMirrored = false, std::optional<VideoFrameTimeMetadata>&& = std::nullopt, PlatformVideoColorSpace&& = { });
-    VideoFrameGStreamer(const GRefPtr<GstSample>&, const FloatSize& presentationSize, const MediaTime& presentationTime = MediaTime::invalidTime(), Rotation = Rotation::None, PlatformVideoColorSpace&& = { });
+    VideoFrameGStreamer(GRefPtr<GstSample>&&, const IntSize& presentationSize, const MediaTime& presentationTime = MediaTime::invalidTime(), Rotation = Rotation::None, bool videoMirrored = false, std::optional<VideoFrameTimeMetadata>&& = std::nullopt, PlatformVideoColorSpace&& = { });
+    VideoFrameGStreamer(const GRefPtr<GstSample>&, const IntSize& presentationSize, const MediaTime& presentationTime = MediaTime::invalidTime(), Rotation = Rotation::None, PlatformVideoColorSpace&& = { });
 
     bool isGStreamer() const final { return true; }
     Ref<VideoFrame> clone() final;
@@ -76,7 +76,7 @@ private:
     GRefPtr<GstSample> convert(GstVideoFormat, const IntSize&);
 
     GRefPtr<GstSample> m_sample;
-    FloatSize m_presentationSize;
+    IntSize m_presentationSize;
     mutable GstVideoFormat m_cachedVideoFormat { GST_VIDEO_FORMAT_UNKNOWN };
 };
 

--- a/Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp
@@ -232,9 +232,9 @@ bool MediaStreamPrivate::muted() const
     return true;
 }
 
-FloatSize MediaStreamPrivate::intrinsicSize() const
+IntSize MediaStreamPrivate::intrinsicSize() const
 {
-    FloatSize size;
+    IntSize size;
     if (m_activeVideoTrack) {
         const RealtimeMediaSourceSettings& setting = m_activeVideoTrack->settings();
         size.setWidth(setting.width());

--- a/Source/WebCore/platform/mediastream/MediaStreamPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamPrivate.h
@@ -109,7 +109,7 @@ public:
     bool hasAudio() const;
     bool muted() const;
 
-    FloatSize intrinsicSize() const;
+    IntSize intrinsicSize() const;
 
     void monitorOrientation(OrientationNotifier&);
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h
@@ -58,14 +58,14 @@ private:
     VideoFrameLibWebRTC(MediaTime, bool isMirrored, Rotation, PlatformVideoColorSpace&&, rtc::scoped_refptr<webrtc::VideoFrameBuffer>&&, ConversionCallback&&);
 
     // VideoFrame
-    FloatSize presentationSize() const final { return m_size; }
+    IntSize presentationSize() const final { return m_size; }
     uint32_t pixelFormat() const final { return m_videoPixelFormat; }
     CVPixelBufferRef pixelBuffer() const final;
 
     Ref<VideoFrame> clone() final;
 
     const rtc::scoped_refptr<webrtc::VideoFrameBuffer> m_buffer;
-    FloatSize m_size;
+    IntSize m_size;
     uint32_t m_videoPixelFormat { 0 };
 
     mutable ConversionCallback m_conversionCallback;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h
@@ -68,7 +68,7 @@ public:
     WebCore::IntSize size() const { return m_size; }
 
     // WebCore::VideoFrame overrides.
-    WebCore::FloatSize presentationSize() const final { return m_size; }
+    WebCore::IntSize presentationSize() const final { return m_size; }
     uint32_t pixelFormat() const final;
     bool isRemoteProxy() const final { return true; }
 #if PLATFORM(COCOA)

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/ImageRotationSessionVT.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/ImageRotationSessionVT.cpp
@@ -44,13 +44,13 @@ TEST(ImageRotationSessionVT, ChangeOfRotationAngle)
 
     rotation.angle = 90;
     auto videoFrame90 = VideoFrameCV::create({ }, false, VideoFrame::Rotation::None, session->rotate(videoFrame, rotation, ImageRotationSessionVT::IsCGImageCompatible::No));
-    EXPECT_EQ(480U, videoFrame90->presentationSize().width());
-    EXPECT_EQ(640U, videoFrame90->presentationSize().height());
+    EXPECT_EQ(480, videoFrame90->presentationSize().width());
+    EXPECT_EQ(640, videoFrame90->presentationSize().height());
 
     rotation.angle = 180;
     auto videoFrame180 = VideoFrameCV::create({ }, false, VideoFrame::Rotation::None, session->rotate(videoFrame, rotation, ImageRotationSessionVT::IsCGImageCompatible::No));
-    EXPECT_EQ(640U, videoFrame180->presentationSize().width());
-    EXPECT_EQ(480U, videoFrame180->presentationSize().height());
+    EXPECT_EQ(640, videoFrame180->presentationSize().width());
+    EXPECT_EQ(480, videoFrame180->presentationSize().height());
 }
 
 #endif


### PR DESCRIPTION
#### aa323239aa2f1571e0f7f8ec3416483f8ef59b36
<pre>
VideoFrame::presentationSize should return IntSize
<a href="https://rdar.apple.com/139265835">rdar://139265835</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=282540">https://bugs.webkit.org/show_bug.cgi?id=282540</a>

Reviewed by Philippe Normand.

Small clean-up to use IntSize for VideoFrame instead of FloatSize, as this is closer to the internal structure representation.

* Source/WebCore/platform/VideoFrame.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::load):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::characteristicsChanged):
* Source/WebCore/platform/graphics/cv/VideoFrameCV.h:
* Source/WebCore/platform/graphics/cv/VideoFrameCV.mm:
(WebCore::VideoFrameCV::presentationSize const):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrame::fromNativeImage):
(WebCore::VideoFrame::createNV12):
(WebCore::VideoFrame::createI420):
(WebCore::VideoFrame::createI420A):
(WebCore::VideoFrameGStreamer::create):
(WebCore::VideoFrameGStreamer::createWrappedSample):
(WebCore::VideoFrameGStreamer::VideoFrameGStreamer):
(WebCore::VideoFrameGStreamer::downloadSample):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h:
* Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp:
(WebCore::MediaStreamPrivate::intrinsicSize const):
* Source/WebCore/platform/mediastream/MediaStreamPrivate.h:
* Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/ImageRotationSessionVT.cpp:
(TestWebKitAPI::TEST(ImageRotationSessionVT, ChangeOfRotationAngle)):

Canonical link: <a href="https://commits.webkit.org/286210@main">https://commits.webkit.org/286210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f01bc29609fa235d27184b6980245a5597c45e7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79453 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26253 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77131 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58889 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17158 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49041 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39275 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46369 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21939 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24585 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67487 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22281 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80933 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2332 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1414 "Found 1 new test failure: fast/selectors/selection-window-inactive-stroke-color.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67141 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2481 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66442 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16556 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10381 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8542 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2297 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5101 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2325 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3246 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2332 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->