### PR TITLE
Integrity check for the X25519 JWK import

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X25519.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X25519.https.any-expected.txt
@@ -225,8 +225,8 @@ PASS Missing algorithm name: importKey(jwk(private), {}, true, deriveBits)
 PASS Missing algorithm name: importKey(jwk(private), {}, false, deriveBits)
 PASS Invalid 'kty' field: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits])
 PASS Invalid 'kty' field: importKey(jwk (public) , {name: X25519}, true, [])
-FAIL Import from a non-extractable: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
-FAIL Import from a non-extractable: importKey(jwk (public) , {name: X25519}, true, []) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
+PASS Import from a non-extractable: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits])
+PASS Import from a non-extractable: importKey(jwk (public) , {name: X25519}, true, [])
 PASS Invalid 'use' field: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits])
 PASS Invalid 'crv' field: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits])
 PASS Invalid 'crv' field: importKey(jwk (public) , {name: X25519}, true, [])

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X25519.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X25519.https.any.worker-expected.txt
@@ -225,8 +225,8 @@ PASS Missing algorithm name: importKey(jwk(private), {}, true, deriveBits)
 PASS Missing algorithm name: importKey(jwk(private), {}, false, deriveBits)
 PASS Invalid 'kty' field: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits])
 PASS Invalid 'kty' field: importKey(jwk (public) , {name: X25519}, true, [])
-FAIL Import from a non-extractable: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
-FAIL Import from a non-extractable: importKey(jwk (public) , {name: X25519}, true, []) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
+PASS Import from a non-extractable: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits])
+PASS Import from a non-extractable: importKey(jwk (public) , {name: X25519}, true, [])
 PASS Invalid 'use' field: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits])
 PASS Invalid 'crv' field: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits])
 PASS Invalid 'crv' field: importKey(jwk (public) , {name: X25519}, true, [])

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any-expected.txt
@@ -34,7 +34,7 @@ PASS Can wrap and unwrap X25519 private key keys using pkcs8 and RSA-OAEP
 PASS Can wrap and unwrap X25519 private key keys as non-extractable using pkcs8 and RSA-OAEP
 PASS Can wrap and unwrap X25519 private key keys using jwk and RSA-OAEP
 PASS Can wrap and unwrap X25519 private key keys as non-extractable using jwk and RSA-OAEP
-FAIL Can unwrap X25519 private key non-extractable keys using jwk and RSA-OAEP assert_unreached: Unwrapping a non-extractable JWK as extractable should fail Reached unreachable code
+PASS Can unwrap X25519 private key non-extractable keys using jwk and RSA-OAEP
 PASS Can wrap and unwrap AES-CTR keys using raw and RSA-OAEP
 PASS Can wrap and unwrap AES-CTR keys as non-extractable using raw and RSA-OAEP
 PASS Can wrap and unwrap AES-CTR keys using jwk and RSA-OAEP
@@ -108,7 +108,7 @@ PASS Can wrap and unwrap X25519 private key keys using pkcs8 and AES-CTR
 PASS Can wrap and unwrap X25519 private key keys as non-extractable using pkcs8 and AES-CTR
 PASS Can wrap and unwrap X25519 private key keys using jwk and AES-CTR
 PASS Can wrap and unwrap X25519 private key keys as non-extractable using jwk and AES-CTR
-FAIL Can unwrap X25519 private key non-extractable keys using jwk and AES-CTR assert_unreached: Unwrapping a non-extractable JWK as extractable should fail Reached unreachable code
+PASS Can unwrap X25519 private key non-extractable keys using jwk and AES-CTR
 PASS Can wrap and unwrap AES-CTR keys using raw and AES-CTR
 PASS Can wrap and unwrap AES-CTR keys as non-extractable using raw and AES-CTR
 PASS Can wrap and unwrap AES-CTR keys using jwk and AES-CTR
@@ -182,7 +182,7 @@ PASS Can wrap and unwrap X25519 private key keys using pkcs8 and AES-CBC
 PASS Can wrap and unwrap X25519 private key keys as non-extractable using pkcs8 and AES-CBC
 PASS Can wrap and unwrap X25519 private key keys using jwk and AES-CBC
 PASS Can wrap and unwrap X25519 private key keys as non-extractable using jwk and AES-CBC
-FAIL Can unwrap X25519 private key non-extractable keys using jwk and AES-CBC assert_unreached: Unwrapping a non-extractable JWK as extractable should fail Reached unreachable code
+PASS Can unwrap X25519 private key non-extractable keys using jwk and AES-CBC
 PASS Can wrap and unwrap AES-CTR keys using raw and AES-CBC
 PASS Can wrap and unwrap AES-CTR keys as non-extractable using raw and AES-CBC
 PASS Can wrap and unwrap AES-CTR keys using jwk and AES-CBC
@@ -256,7 +256,7 @@ PASS Can wrap and unwrap X25519 private key keys using pkcs8 and AES-GCM
 PASS Can wrap and unwrap X25519 private key keys as non-extractable using pkcs8 and AES-GCM
 PASS Can wrap and unwrap X25519 private key keys using jwk and AES-GCM
 PASS Can wrap and unwrap X25519 private key keys as non-extractable using jwk and AES-GCM
-FAIL Can unwrap X25519 private key non-extractable keys using jwk and AES-GCM assert_unreached: Unwrapping a non-extractable JWK as extractable should fail Reached unreachable code
+PASS Can unwrap X25519 private key non-extractable keys using jwk and AES-GCM
 PASS Can wrap and unwrap AES-CTR keys using raw and AES-GCM
 PASS Can wrap and unwrap AES-CTR keys as non-extractable using raw and AES-GCM
 PASS Can wrap and unwrap AES-CTR keys using jwk and AES-GCM

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any.worker-expected.txt
@@ -33,7 +33,7 @@ PASS Can wrap and unwrap X25519 private key keys using pkcs8 and RSA-OAEP
 PASS Can wrap and unwrap X25519 private key keys as non-extractable using pkcs8 and RSA-OAEP
 PASS Can wrap and unwrap X25519 private key keys using jwk and RSA-OAEP
 PASS Can wrap and unwrap X25519 private key keys as non-extractable using jwk and RSA-OAEP
-FAIL Can unwrap X25519 private key non-extractable keys using jwk and RSA-OAEP assert_unreached: Unwrapping a non-extractable JWK as extractable should fail Reached unreachable code
+PASS Can unwrap X25519 private key non-extractable keys using jwk and RSA-OAEP
 PASS Can wrap and unwrap AES-CTR keys using raw and RSA-OAEP
 PASS Can wrap and unwrap AES-CTR keys as non-extractable using raw and RSA-OAEP
 PASS Can wrap and unwrap AES-CTR keys using jwk and RSA-OAEP
@@ -107,7 +107,7 @@ PASS Can wrap and unwrap X25519 private key keys using pkcs8 and AES-CTR
 PASS Can wrap and unwrap X25519 private key keys as non-extractable using pkcs8 and AES-CTR
 PASS Can wrap and unwrap X25519 private key keys using jwk and AES-CTR
 PASS Can wrap and unwrap X25519 private key keys as non-extractable using jwk and AES-CTR
-FAIL Can unwrap X25519 private key non-extractable keys using jwk and AES-CTR assert_unreached: Unwrapping a non-extractable JWK as extractable should fail Reached unreachable code
+PASS Can unwrap X25519 private key non-extractable keys using jwk and AES-CTR
 PASS Can wrap and unwrap AES-CTR keys using raw and AES-CTR
 PASS Can wrap and unwrap AES-CTR keys as non-extractable using raw and AES-CTR
 PASS Can wrap and unwrap AES-CTR keys using jwk and AES-CTR
@@ -181,7 +181,7 @@ PASS Can wrap and unwrap X25519 private key keys using pkcs8 and AES-CBC
 PASS Can wrap and unwrap X25519 private key keys as non-extractable using pkcs8 and AES-CBC
 PASS Can wrap and unwrap X25519 private key keys using jwk and AES-CBC
 PASS Can wrap and unwrap X25519 private key keys as non-extractable using jwk and AES-CBC
-FAIL Can unwrap X25519 private key non-extractable keys using jwk and AES-CBC assert_unreached: Unwrapping a non-extractable JWK as extractable should fail Reached unreachable code
+PASS Can unwrap X25519 private key non-extractable keys using jwk and AES-CBC
 PASS Can wrap and unwrap AES-CTR keys using raw and AES-CBC
 PASS Can wrap and unwrap AES-CTR keys as non-extractable using raw and AES-CBC
 PASS Can wrap and unwrap AES-CTR keys using jwk and AES-CBC
@@ -255,7 +255,7 @@ PASS Can wrap and unwrap X25519 private key keys using pkcs8 and AES-GCM
 PASS Can wrap and unwrap X25519 private key keys as non-extractable using pkcs8 and AES-GCM
 PASS Can wrap and unwrap X25519 private key keys using jwk and AES-GCM
 PASS Can wrap and unwrap X25519 private key keys as non-extractable using jwk and AES-GCM
-FAIL Can unwrap X25519 private key non-extractable keys using jwk and AES-GCM assert_unreached: Unwrapping a non-extractable JWK as extractable should fail Reached unreachable code
+PASS Can unwrap X25519 private key non-extractable keys using jwk and AES-GCM
 PASS Can wrap and unwrap AES-CTR keys using raw and AES-GCM
 PASS Can wrap and unwrap AES-CTR keys as non-extractable using raw and AES-GCM
 PASS Can wrap and unwrap AES-CTR keys using jwk and AES-GCM

--- a/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
@@ -110,7 +110,10 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwk(CryptoAlgorithmIdentifier identifie
     case NamedCurve::X25519:
         if (keyData.crv != "X25519"_s)
             return nullptr;
-        // FIXME: Add further checks.
+        if (keyData.key_ops && ((keyData.usages & usages) != usages))
+            return nullptr;
+        if (keyData.ext && !keyData.ext.value() && extractable)
+            return nullptr;
         break;
     }
 


### PR DESCRIPTION
#### 049cd4cf1bf991a083080743403c1ef8e4d34428
<pre>
Integrity check for the X25519 JWK import
<a href="https://bugs.webkit.org/show_bug.cgi?id=282578">https://bugs.webkit.org/show_bug.cgi?id=282578</a>

Reviewed by David Kilzer.

The test case attahced in the bug forces wrapping into a non-extractable
key and the tries to unwrap it into an extractable key. This shouldn&apos;t be
allowed, since the JWK import operation perform internally must ensure the
expected value of the &apos;ext&apos; attribute is the correct one.

This change implements additional integrity checks in the X25518 importKey
operation when it&apos;s using the JWK format.

This bug is the root cause of the failure in one of the X25519 test cases
defined in the wrapKey_unwrapKey.https.any.js file of the WPT WebCrypto API
test suite.

Regarding tests, I&apos;ve added new test cases to the import_key_failures tests
to cover the change in the X25519 JWK import logic. Additionally, this change
also updates the test expectations for this test since it seems it&apos;s all PASS
now for all the platforms.

* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X25519.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X25519.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any.worker-expected.txt:
* Source/WebCore/crypto/keys/CryptoKeyOKP.cpp:
(WebCore::CryptoKeyOKP::importJwk):

Canonical link: <a href="https://commits.webkit.org/287273@main">https://commits.webkit.org/287273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8609107675a9d0bde5c0498612a04fa84cb6e24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83665 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30240 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81158 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6331 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/61855 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/19768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82092 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/51890 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/72035 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42159 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49241 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/26121 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28605 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70356 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85051 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6350 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/70089 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6514 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69339 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17275 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13383 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/12155 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6302 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6262 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9714 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8054 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->