### PR TITLE
http/wpt/mediastream/transfer-videotrackgenerator-track.html is flaky on bots

### DIFF
--- a/LayoutTests/http/wpt/mediastream/transfer-videotrackgenerator-track.html
+++ b/LayoutTests/http/wpt/mediastream/transfer-videotrackgenerator-track.html
@@ -69,6 +69,11 @@ promise_test(async test => {
     assert_equals(track.getCapabilities().width.max, 100, "track capabilities width 1");
     assert_equals(track.getCapabilities().height.max, 100, "track capabilities height 1");
 
+    const frame = new VideoFrame(video);
+    test.add_cleanup(() => frame.close());
+    assert_equals(frame.codedWidth, 100, "video frame width");
+    assert_equals(frame.codedHeight, 100, "video frame height");
+
     worker.postMessage("mute");
     await new Promise(resolve => track.onmute = resolve);
 

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -622,6 +622,30 @@ void MediaStreamTrackPrivate::sourceSettingsChanged(RealtimeMediaSourceSettings&
         observer.trackSettingsChanged(*this);
     });
 }
+
+void MediaStreamTrackPrivate::updateSizeIfNeeded(IntSize size)
+{
+    ASSERT(isOnCreationThread());
+    ASSERT(isVideo());
+
+    auto width = size.width();
+    auto height = size.height();
+    if (static_cast<int>(m_settings.width()) == width && static_cast<int>(m_settings.height()) == height)
+        return;
+
+    m_settings.setWidth(width);
+    m_settings.setHeight(height);
+
+    if (m_capabilities.supportsWidth())
+        m_capabilities.setWidth(extendCapabilityRange(m_capabilities.width(), width));
+    if (m_capabilities.supportsHeight())
+        m_capabilities.setHeight(extendCapabilityRange(m_capabilities.height(), height));
+
+    forEachObserver([this](auto& observer) {
+        observer.trackSettingsChanged(*this);
+    });
+}
+
 void MediaStreamTrackPrivate::sourceConfigurationChanged(String&& label, RealtimeMediaSourceSettings&& settings, RealtimeMediaSourceCapabilities&& capabilities)
 {
     ASSERT(isOnCreationThread());

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
@@ -163,6 +163,8 @@ public:
     enum class ShouldClone : bool { No, Yes };
     UniqueRef<MediaStreamTrackDataHolder> toDataHolder(ShouldClone = ShouldClone::No);
 
+    void updateSizeIfNeeded(IntSize);
+
 private:
     MediaStreamTrackPrivate(Ref<const Logger>&&, Ref<RealtimeMediaSource>&&, String&& id, std::function<void(Function<void()>&&)>&&);
     MediaStreamTrackPrivate(Ref<const Logger>&&, UniqueRef<MediaStreamTrackDataHolder>&&, std::function<void(Function<void()>&&)>&&);

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
@@ -74,6 +74,12 @@ public:
     }
 };
 
+template<typename CapabilityRange, typename T>
+CapabilityRange extendCapabilityRange(const CapabilityRange& range, T value)
+{
+    return { std::min(range.min(), value), std::max(range.max(), value) };
+}
+
 class RealtimeMediaSourceCapabilities {
 public:
     RealtimeMediaSourceCapabilities() = default;


### PR DESCRIPTION
#### fda504ddd3fbebb634f9889b48b21228eb54ace2
<pre>
http/wpt/mediastream/transfer-videotrackgenerator-track.html is flaky on bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=282602">https://bugs.webkit.org/show_bug.cgi?id=282602</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

The test was flaky as the following happened in case of video frame size change (or when starting to receive frames, size going from (0, 0) to non null size):
- VideoTrackGenerator sees that a frame with a new size is enqueued.
- Before enqueuing, it hops to the main thread to notify the source. The source schedules a main thread task to notify all clients, including the MediaStream player.
- When enqueued, the frame is delivered to the MediaStream player which hops to the main thread to check the Video frame size.

There could be a race in terms of size between the two code paths.
This would make MediaStreamTrack settings and video element size inconsistent.

To prevent this, we notify the MediaStreamTrack from the MediaStream player whether the size has changed.
If so, we change settings and capabilities and notify all MediaStreamTrack listeners, including the MediaStream player.

We update MediaPlayerPrivateMediaStreamAVFObjC::processNewVideoFrame and MediaPlayerPrivateMediaStreamAVFObjC::characteristicsChanged accordingly.
Covered by the test no longer being flaky on bots.

* LayoutTests/http/wpt/mediastream/transfer-videotrackgenerator-track.html:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::processNewVideoFrame):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::characteristicsChanged):
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp:
(WebCore::MediaStreamTrackPrivate::updateSizeIfNeeded):
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h:
(WebCore::extendCapabilityRange):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fda504ddd3fbebb634f9889b48b21228eb54ace2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79467 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26267 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2243 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58901 "Found 1 new test failure: http/wpt/mediastream/transfer-videotrackgenerator-track.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17167 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78095 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49060 "Found 1 new test failure: fast/mediastream/mediastreamtrack-video-resize-event.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64448 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39286 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46386 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21951 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24599 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67498 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22300 "Found 3 new test failures: fast/mediastream/getUserMedia-to-canvas-1.html fast/mediastream/getUserMedia-to-canvas-2.html fast/mediastream/mediastreamtrack-video-resize-event.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80947 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2346 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1450 "Found 2 new test failures: fast/mediastream/getUserMedia-to-canvas-2.html fast/mediastream/mediastreamtrack-video-resize-event.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67152 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2495 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64467 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66453 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10391 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8561 "Found 1 new test failure: fast/mediastream/mediastreamtrack-video-resize-event.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2311 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5129 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2339 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3260 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2346 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->