### PR TITLE
Crash under DownloadProxy::~DownloadProxy()

### DIFF
--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
@@ -87,7 +87,8 @@ void DownloadProxy::cancel(CompletionHandler<void(API::Data*)>&& completionHandl
                 return completionHandler(nullptr);
             protectedThis->m_legacyResumeData = createData(resumeData);
             completionHandler(protectedThis->m_legacyResumeData.get());
-            protectedThis->m_downloadProxyMap->downloadFinished(*protectedThis);
+            if (RefPtr downloadProxyMap = protectedThis->m_downloadProxyMap.get())
+                downloadProxyMap->downloadFinished(*protectedThis);
         });
     } else
         completionHandler(nullptr);
@@ -221,7 +222,8 @@ void DownloadProxy::didFinish()
     m_client->didFinish(*this);
 
     // This can cause the DownloadProxy object to be deleted.
-    m_downloadProxyMap->downloadFinished(*this);
+    if (RefPtr downloadProxyMap = m_downloadProxyMap.get())
+        downloadProxyMap->downloadFinished(*this);
 }
 
 void DownloadProxy::didFail(const ResourceError& error, std::span<const uint8_t> resumeData)
@@ -231,7 +233,8 @@ void DownloadProxy::didFail(const ResourceError& error, std::span<const uint8_t>
     m_client->didFail(*this, error, m_legacyResumeData.get());
 
     // This can cause the DownloadProxy object to be deleted.
-    m_downloadProxyMap->downloadFinished(*this);
+    if (RefPtr downloadProxyMap = m_downloadProxyMap.get())
+        downloadProxyMap->downloadFinished(*this);
 }
 
 void DownloadProxy::setClient(Ref<API::DownloadClient>&& client)

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
@@ -139,7 +139,7 @@ private:
     static Vector<uint8_t> activityAccessToken();
 #endif
 
-    CheckedRef<DownloadProxyMap> m_downloadProxyMap;
+    WeakPtr<DownloadProxyMap> m_downloadProxyMap;
     RefPtr<WebsiteDataStore> m_dataStore;
     Ref<API::DownloadClient> m_client;
     DownloadID m_downloadID;

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.cpp
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.cpp
@@ -62,6 +62,16 @@ DownloadProxyMap::~DownloadProxyMap()
     platformDestroy();
 }
 
+void DownloadProxyMap::ref() const
+{
+    m_process->ref();
+}
+
+void DownloadProxyMap::deref() const
+{
+    m_process->deref();
+}
+
 Ref<NetworkProcessProxy> DownloadProxyMap::protectedProcess()
 {
     return m_process.get();

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
@@ -53,10 +53,9 @@ class WebPageProxy;
 class WebsiteDataStore;
 struct FrameInfoData;
 
-class DownloadProxyMap : public CanMakeWeakPtr<DownloadProxyMap>, public CanMakeCheckedPtr<DownloadProxyMap> {
+class DownloadProxyMap : public CanMakeWeakPtr<DownloadProxyMap> {
     WTF_MAKE_TZONE_ALLOCATED(DownloadProxyMap);
     WTF_MAKE_NONCOPYABLE(DownloadProxyMap);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DownloadProxyMap);
 public:
     explicit DownloadProxyMap(NetworkProcessProxy&);
     ~DownloadProxyMap();
@@ -66,6 +65,9 @@ public:
 
     bool isEmpty() const { return m_downloads.isEmpty(); }
     void invalidate();
+
+    void ref() const;
+    void deref() const;
 
 private:
     Ref<NetworkProcessProxy> protectedProcess();

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -357,7 +357,7 @@ void NetworkProcessProxy::synthesizeAppIsBackground(bool background)
 Ref<DownloadProxy> NetworkProcessProxy::createDownloadProxy(WebsiteDataStore& dataStore, Ref<API::DownloadClient>&& client, const ResourceRequest& resourceRequest, const FrameInfoData& frameInfo, WebPageProxy* originatingPage)
 {
     if (!m_downloadProxyMap)
-        m_downloadProxyMap = makeUnique<DownloadProxyMap>(*this);
+        m_downloadProxyMap = makeUniqueWithoutRefCountedCheck<DownloadProxyMap>(*this);
 
     return m_downloadProxyMap->createDownloadProxy(dataStore, WTFMove(client), resourceRequest, frameInfo, originatingPage);
 }


### PR DESCRIPTION
#### 9f69376c782b8ce1a5026c3de43927234d537125
<pre>
Crash under DownloadProxy::~DownloadProxy()
<a href="https://bugs.webkit.org/show_bug.cgi?id=282611">https://bugs.webkit.org/show_bug.cgi?id=282611</a>
<a href="https://rdar.apple.com/138845738">rdar://138845738</a>

Reviewed by Geoffrey Garen.

DownloadProxy is ref-counted and thus can outlive its DownloadProxyMap.
As a result, DownloadProxy cannot hold a CheckedRef to its DownloadProxyMap.
Switching to a WeakPtr instead.

* Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp:
(WebKit::DownloadProxy::cancel):
(WebKit::DownloadProxy::didFinish):
(WebKit::DownloadProxy::didFail):
* Source/WebKit/UIProcess/Downloads/DownloadProxy.h:
* Source/WebKit/UIProcess/Downloads/DownloadProxyMap.cpp:
(WebKit::DownloadProxyMap::ref const):
(WebKit::DownloadProxyMap::deref const):
* Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::createDownloadProxy):

Canonical link: <a href="https://commits.webkit.org/286182@main">https://commits.webkit.org/286182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4015097cf47abbea6f7d263ccd20c35225b666b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79496 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26299 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58922 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17183 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64476 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39300 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46413 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24625 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67528 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22320 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80971 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2376 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1459 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67178 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64487 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66470 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10408 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8578 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11585 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2333 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2361 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3287 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2368 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->