### PR TITLE
REGRESSION (285350@main): Unable to toggle edit menu in overflow scrollers with SelectionHonorsOverflowScrolling off

### DIFF
--- a/LayoutTests/editing/selection/ios/toggle-callout-bar-after-tap-in-selected-non-editable-text.html
+++ b/LayoutTests/editing/selection/ios/toggle-callout-bar-after-tap-in-selected-non-editable-text.html
@@ -21,7 +21,6 @@ body, html {
 #target {
     margin-top: 100px;
 }
-text
 </style>
 <script>
 jsTestIsAsync = true;

--- a/LayoutTests/editing/selection/ios/toggle-edit-menu-after-tap-in-overflow-scroller-expected.txt
+++ b/LayoutTests/editing/selection/ios/toggle-edit-menu-after-tap-in-overflow-scroller-expected.txt
@@ -1,0 +1,15 @@
+Select
+
+This test verifies that tapping selected non-editable text inside an overflow scroller shows or hides the edit menu. To manually test, select the text above, and wait for the edit menu to show; tap inside the selection to dismiss the edit menu
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Observed selection
+PASS Showed edit menu after selecting text
+PASS Dismissed edit menu after tap in selected text
+PASS getSelection().type is "Range"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/toggle-edit-menu-after-tap-in-overflow-scroller.html
+++ b/LayoutTests/editing/selection/ios/toggle-edit-menu-after-tap-in-overflow-scroller.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf8">
+<style>
+body, html {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+}
+
+.text {
+    font-size: 48px;
+    padding: 4px;
+    text-align: center;
+    box-sizing: border-box;
+}
+
+.tall {
+    width: 300px;
+    height: 500px;
+}
+
+.scroller {
+    width: 300px;
+    height: 200px;
+    overflow: scroll;
+    border: 1px solid skyblue;
+    box-sizing: border-box;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that tapping selected non-editable text inside an overflow scroller shows or hides the edit menu. To manually test, select the text above, and wait for the edit menu to show; tap inside the selection to dismiss the edit menu");
+    const text = document.querySelector(".text");
+    text.addEventListener("click", () => {
+        testFailed("Dispatched click during tap");
+    });
+
+    if (!window.testRunner)
+        return;
+
+    await UIHelper.longPressElement(text);
+    await UIHelper.waitForSelectionToAppear();
+    testPassed("Observed selection");
+
+    await UIHelper.waitForMenuToShow();
+    testPassed("Showed edit menu after selecting text");
+
+    await UIHelper.activateElement(text);
+    await UIHelper.waitForMenuToHide();
+    testPassed("Dismissed edit menu after tap in selected text");
+    shouldBeEqualToString("getSelection().type", "Range");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="scroller">
+        <p class="text" onclick="return false;">Select</p>
+        <div class="tall"></div>
+    </div>
+    <p id="description"></p>
+    <p id="console"></p>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -3262,6 +3262,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!pointIsInSelectionRect)
         return NO;
 
+    if (!self.selectionHonorsOverflowScrolling)
+        return YES;
+
     RetainPtr hitView = [self hitTest:point withEvent:nil];
     if (!hitView)
         return NO;


### PR DESCRIPTION
#### 8347b6f3f79108a373e6158bff7db85f538ed3cc
<pre>
REGRESSION (285350@main): Unable to toggle edit menu in overflow scrollers with SelectionHonorsOverflowScrolling off
<a href="https://bugs.webkit.org/show_bug.cgi?id=282618">https://bugs.webkit.org/show_bug.cgi?id=282618</a>
<a href="https://rdar.apple.com/139291824">rdar://139291824</a>

Reviewed by Tim Horton.

After the refactoring in <a href="https://commits.webkit.org/285350@main">https://commits.webkit.org/285350@main</a>, we only consider a tap location to
be inside of the selection rect, if the hit-tested parent scroller is equal to the selection
container&apos;s parent scroller. However, this check only makes sense in the case where the internal
feature flag `SelectionHonorsOverflowScrolling` is enabled; when it&apos;s disabled, the selection
container is always going to be underneath the main `WKScrollView` despite the fact that hit-testing
may find a `WKChildScrollView`.

Fix this legacy case by simply returning early and skipping the parent scroller check altogether
when the new feature flag is disabled.

* LayoutTests/editing/selection/ios/toggle-callout-bar-after-tap-in-selected-non-editable-text.html:
* LayoutTests/editing/selection/ios/toggle-edit-menu-after-tap-in-overflow-scroller-expected.txt: Added.
* LayoutTests/editing/selection/ios/toggle-edit-menu-after-tap-in-overflow-scroller.html: Added.

Add a new layout test to exercise this change.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _pointIsInsideSelectionRect:outBoundingRect:]):

Canonical link: <a href="https://commits.webkit.org/286178@main">https://commits.webkit.org/286178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf4fe1f5055e218beedd101702ccddfded1e8bf1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79497 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/26301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2266 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58923 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/26301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49073 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39301 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46428 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21982 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/24627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67531 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22321 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80973 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2377 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1460 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67179 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2520 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66471 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16524 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10409 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8579 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2335 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2363 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3289 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->