### PR TITLE
Make NetworkCache::IOChannel thread-safe

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannel.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannel.h
@@ -44,42 +44,28 @@ namespace NetworkCache {
 class IOChannel : public ThreadSafeRefCounted<IOChannel> {
 public:
     enum class Type { Read, Write, Create };
-    static Ref<IOChannel> open(String&& file, Type type, std::optional<WorkQueue::QOS> qos = { }) { return adoptRef(*new IOChannel(WTFMove(file).isolatedCopy(), type, qos)); }
+    static Ref<IOChannel> open(const String& filePath, Type type, std::optional<WorkQueue::QOS> qos = { }) { return adoptRef(*new IOChannel(filePath, type, qos)); }
 
-    // Using nullptr as queue submits the result to the main queue.
-    // FIXME: We should add WorkQueue::main() instead.
-    // Can be used with either a concurrent WorkQueue or a serial one.
-    void read(size_t offset, size_t, WTF::WorkQueueBase&, Function<void(Data&, int error)>&&);
-    void write(size_t offset, const Data&, WTF::WorkQueueBase&, Function<void(int error)>&&);
-
-    const String& path() const { return m_path; }
-    Type type() const { return m_type; }
-
-#if !USE(GLIB)
-    bool isOpened() const { return FileSystem::isHandleValid(m_fileDescriptor); }
-#else
-    bool isOpened() const { return m_inputStream || m_outputStream; }
-#endif
+    void read(size_t offset, size_t, Ref<WTF::WorkQueueBase>&&, Function<void(Data&&, int error)>&&);
+    void write(size_t offset, const Data&, Ref<WTF::WorkQueueBase>&&, Function<void(int error)>&&);
 
     ~IOChannel();
 
 private:
-    IOChannel(String&& filePath, IOChannel::Type, std::optional<WorkQueue::QOS>);
+    IOChannel(const String& filePath, IOChannel::Type, std::optional<WorkQueue::QOS>);
 
-    String m_path;
-    Type m_type;
-
-#if !USE(GLIB)
-    FileSystem::PlatformFileHandle m_fileDescriptor { FileSystem::invalidPlatformFileHandle };
+#if !PLATFORM(COCOA)
+    Lock m_lock;
 #endif
     std::atomic<bool> m_wasDeleted { false }; // Try to narrow down a crash, https://bugs.webkit.org/show_bug.cgi?id=165659
 #if PLATFORM(COCOA)
     OSObjectPtr<dispatch_io_t> m_dispatchIO;
-#endif
-#if USE(GLIB)
-    GRefPtr<GInputStream> m_inputStream;
-    GRefPtr<GOutputStream> m_outputStream;
-    WorkQueue::QOS m_qos;
+#elif USE(GLIB)
+    GRefPtr<GInputStream> m_inputStream WTF_GUARDED_BY_LOCK(m_lock);
+    GRefPtr<GOutputStream> m_outputStream WTF_GUARDED_BY_LOCK(m_lock);
+    WorkQueue::QOS m_qos WTF_GUARDED_BY_LOCK(m_lock);
+#else // !PLATFORM(COCOA) && !USE(GLIB)
+    FileSystem::PlatformFileHandle m_fileDescriptor WTF_GUARDED_BY_LOCK(m_lock) { FileSystem::invalidPlatformFileHandle };
 #endif
 };
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "NetworkCacheIOChannel.h"
 
+#import "Logging.h"
 #import "NetworkCacheFileSystem.h"
 #import <dispatch/dispatch.h>
 #import <mach/vm_param.h>
@@ -51,16 +52,14 @@ static long dispatchQueueIdentifier(WorkQueue::QOS qos)
     }
 }
 
-IOChannel::IOChannel(String&& filePath, Type type, std::optional<WorkQueue::QOS> qos)
-    : m_path(WTFMove(filePath))
-    , m_type(type)
+IOChannel::IOChannel(const String& filePath, Type type, std::optional<WorkQueue::QOS> qos)
 {
-    auto path = FileSystem::fileSystemRepresentation(m_path);
+    auto path = FileSystem::fileSystemRepresentation(filePath);
     int oflag;
     mode_t mode;
     WorkQueue::QOS dispatchQOS;
 
-    switch (m_type) {
+    switch (type) {
     case Type::Create:
         // We don't want to truncate any existing file (with O_TRUNC) as another thread might be mapping it.
         unlink(path.data());
@@ -80,8 +79,6 @@ IOChannel::IOChannel(String&& filePath, Type type, std::optional<WorkQueue::QOS>
     }
 
     int fd = ::open(path.data(), oflag, mode);
-    m_fileDescriptor = fd;
-
     m_dispatchIO = adoptOSObject(dispatch_io_create(DISPATCH_IO_RANDOM, fd, dispatch_get_global_queue(dispatchQueueIdentifier(dispatchQOS), 0), [fd](int) {
         close(fd);
     }));
@@ -96,29 +93,30 @@ IOChannel::~IOChannel()
     RELEASE_ASSERT(!m_wasDeleted.exchange(true));
 }
 
-void IOChannel::read(size_t offset, size_t size, WTF::WorkQueueBase& queue, Function<void(Data&, int error)>&& completionHandler)
+void IOChannel::read(size_t offset, size_t size, Ref<WTF::WorkQueueBase>&& queue, Function<void(Data&&, int error)>&& completionHandler)
 {
-    RefPtr<IOChannel> channel(this);
     bool didCallCompletionHandler = false;
-    dispatch_io_read(m_dispatchIO.get(), offset, size, queue.dispatchQueue(), makeBlockPtr([channel, completionHandler = WTFMove(completionHandler), didCallCompletionHandler](bool done, dispatch_data_t fileData, int error) mutable {
+    dispatch_io_read(m_dispatchIO.get(), offset, size, queue->dispatchQueue(), makeBlockPtr([protectedThis = Ref { *this }, queue, completionHandler = WTFMove(completionHandler), didCallCompletionHandler](bool done, dispatch_data_t fileData, int error) mutable {
         ASSERT_UNUSED(done, done || !didCallCompletionHandler);
         if (didCallCompletionHandler)
             return;
+
         Data data { OSObjectPtr<dispatch_data_t> { fileData } };
-        auto callback = WTFMove(completionHandler);
-        callback(data, error);
+        completionHandler(WTFMove(data), error);
         didCallCompletionHandler = true;
     }).get());
 }
 
-void IOChannel::write(size_t offset, const Data& data, WTF::WorkQueueBase& queue, Function<void(int error)>&& completionHandler)
+void IOChannel::write(size_t offset, const Data& data, Ref<WTF::WorkQueueBase>&& queue, Function<void(int error)>&& completionHandler)
 {
-    RefPtr<IOChannel> channel(this);
     auto dispatchData = data.dispatchData();
-    dispatch_io_write(m_dispatchIO.get(), offset, dispatchData, queue.dispatchQueue(), makeBlockPtr([channel, completionHandler = WTFMove(completionHandler)](bool done, dispatch_data_t fileData, int error) mutable {
-        ASSERT_UNUSED(done, done);
-        auto callback = WTFMove(completionHandler);
-        callback(error);
+    dispatch_io_write(m_dispatchIO.get(), offset, dispatchData, queue->dispatchQueue(), makeBlockPtr([protectedThis = Ref { *this }, queue, completionHandler = WTFMove(completionHandler)](bool done, dispatch_data_t, int error) mutable {
+        if (!done) {
+            RELEASE_LOG_ERROR(NetworkCacheStorage, "IOChannel::write only part of data is written.");
+            return;
+        }
+
+        completionHandler(error);
     }).get());
 }
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelGLib.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelGLib.cpp
@@ -35,13 +35,13 @@
 namespace WebKit {
 namespace NetworkCache {
 
-IOChannel::IOChannel(String&& filePath, Type type, std::optional<WorkQueue::QOS> qos)
-    : m_path(WTFMove(filePath))
-    , m_type(type)
+IOChannel::IOChannel(const String& filePath, Type type, std::optional<WorkQueue::QOS> qos)
 {
-    auto path = FileSystem::fileSystemRepresentation(m_path);
+    auto path = FileSystem::fileSystemRepresentation(filePath);
     GRefPtr<GFile> file = adoptGRef(g_file_new_for_path(path.data()));
-    switch (m_type) {
+
+    Locker locker { m_lock };
+    switch (type) {
     case Type::Create: {
         g_file_delete(file.get(), nullptr, nullptr);
         m_outputStream = adoptGRef(G_OUTPUT_STREAM(g_file_create(file.get(), static_cast<GFileCreateFlags>(G_FILE_CREATE_PRIVATE), nullptr, nullptr)));
@@ -70,18 +70,19 @@ IOChannel::~IOChannel()
     RELEASE_ASSERT(!m_wasDeleted.exchange(true));
 }
 
-void IOChannel::read(size_t offset, size_t size, WTF::WorkQueueBase& queue, Function<void(Data&, int error)>&& completionHandler)
+void IOChannel::read(size_t offset, size_t size, Ref<WTF::WorkQueueBase>&& queue, Function<void(Data&&, int error)>&& completionHandler)
 {
-    RefPtr<IOChannel> protectedThis(this);
+    Locker locker { m_lock };
     if (!m_inputStream) {
-        queue.dispatch([protectedThis = WTFMove(protectedThis), completionHandler = WTFMove(completionHandler)] {
+        queue->dispatch([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] {
             Data data;
-            completionHandler(data, -1);
+            completionHandler(WTFMove(data), -1);
         });
         return;
     }
 
-    Thread::create("IOChannel::read"_s, [this, protectedThis = WTFMove(protectedThis), offset, size, queue = Ref { queue }, completionHandler = WTFMove(completionHandler)]() mutable {
+    Thread::create("IOChannel::read"_s, [this, protectedThis = Ref { *this }, offset, size, queue = Ref { queue }, completionHandler = WTFMove(completionHandler)]() mutable {
+        Locker locker { m_lock };
         GRefPtr<GFileInfo> info = adoptGRef(g_file_input_stream_query_info(G_FILE_INPUT_STREAM(m_inputStream.get()), G_FILE_ATTRIBUTE_STANDARD_SIZE, nullptr, nullptr));
         if (info) {
             auto fileSize = g_file_info_get_size(info.get());
@@ -97,31 +98,32 @@ void IOChannel::read(size_t offset, size_t size, WTF::WorkQueueBase& queue, Func
                     GRefPtr<GBytes> bytes = bufferSize == bytesRead ? buffer : adoptGRef(g_bytes_new_from_bytes(buffer.get(), 0, bytesRead));
                     queue->dispatch([protectedThis = WTFMove(protectedThis), bytes = WTFMove(bytes), completionHandler = WTFMove(completionHandler)]() mutable {
                         Data data(WTFMove(bytes));
-                        completionHandler(data, 0);
+                        completionHandler(WTFMove(data), 0);
                     });
                     return;
                 }
             }
         }
         queue->dispatch([protectedThis = WTFMove(protectedThis), completionHandler = WTFMove(completionHandler)] {
-            Data data;
-            completionHandler(data, -1);
+            completionHandler(Data { }, -1);
         });
     }, ThreadType::Unknown, m_qos)->detach();
 }
 
-void IOChannel::write(size_t offset, const Data& data, WTF::WorkQueueBase& queue, Function<void(int error)>&& completionHandler)
+
+void IOChannel::write(size_t offset, const Data& data, Ref<WTF::WorkQueueBase>&& queue, Function<void(int error)>&& completionHandler)
 {
-    RefPtr<IOChannel> protectedThis(this);
+    Locker locker { m_lock };
     if (!m_outputStream) {
-        queue.dispatch([protectedThis = WTFMove(protectedThis), completionHandler = WTFMove(completionHandler)] {
+        queue->dispatch([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] {
             completionHandler(-1);
         });
         return;
     }
 
     GRefPtr<GBytes> buffer = offset ? adoptGRef(g_bytes_new_from_bytes(data.bytes(), offset, data.size() - offset)) : data.bytes();
-    Thread::create("IOChannel::write"_s, [this, protectedThis = WTFMove(protectedThis), buffer = WTFMove(buffer), queue = Ref { queue }, completionHandler = WTFMove(completionHandler)]() mutable {
+    Thread::create("IOChannel::write"_s, [this, protectedThis = Ref { *this }, buffer = WTFMove(buffer), queue = WTFMove(queue), completionHandler = WTFMove(completionHandler)]() mutable {
+        Locker locker { m_lock };
         gsize buffersize;
         const auto* bufferData = g_bytes_get_data(buffer.get(), &buffersize);
         auto success = g_output_stream_write_all(m_outputStream.get(), bufferData, buffersize, nullptr, nullptr, nullptr);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -769,7 +769,7 @@ void Storage::dispatchReadOperation(std::unique_ptr<ReadOperation> readOperation
         readOperation.timings.recordIOStartTime = MonotonicTime::now();
 
         auto channel = IOChannel::open(WTFMove(recordPath), IOChannel::Type::Read);
-        channel->read(0, std::numeric_limits<size_t>::max(), protectedIOQueue(), [this, &readOperation](const Data& fileData, int error) {
+        channel->read(0, std::numeric_limits<size_t>::max(), protectedIOQueue(), [this, &readOperation](auto fileData, int error) {
             readOperation.timings.recordIOEndTime = MonotonicTime::now();
             if (!error)
                 readRecord(readOperation, fileData);
@@ -1017,7 +1017,7 @@ void Storage::traverseWithinRootPath(const String& rootPath, const String& type,
             ++traverseOperation.activeCount;
 
             auto channel = IOChannel::open(WTFMove(recordPath), IOChannel::Type::Read);
-            channel->read(0, std::numeric_limits<size_t>::max(), WorkQueue::main(), [this, &traverseOperation, worth, bodyShareCount](Data& fileData, int) {
+            channel->read(0, std::numeric_limits<size_t>::max(), WorkQueue::main(), [this, &traverseOperation, worth, bodyShareCount](auto fileData, int) {
                 RecordMetaData metaData;
                 Data headerData;
                 if (decodeRecordHeader(fileData, metaData, headerData, m_salt)) {


### PR DESCRIPTION
#### 66269aa7892043cde78409b3a415bc1e48e58a38
<pre>
Make NetworkCache::IOChannel thread-safe
<a href="https://bugs.webkit.org/show_bug.cgi?id=282616">https://bugs.webkit.org/show_bug.cgi?id=282616</a>
<a href="https://rdar.apple.com/139291512">rdar://139291512</a>

Reviewed by Ben Nham.

In current implementation, NetworkCache::IOChannel is expected to be accessed from different threads, see the
implementation of read() and write(), so we should make it thread-safe with lock. This patch also removes unnecessary
data members of IOChannel, so that we don&apos;t need to make isolated copy of them or protect them.

* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannel.h:
(WebKit::NetworkCache::IOChannel::open):
(WebKit::NetworkCache::IOChannel::WTF_GUARDED_BY_LOCK):
(WebKit::NetworkCache::IOChannel::path const): Deleted.
(WebKit::NetworkCache::IOChannel::type const): Deleted.
(WebKit::NetworkCache::IOChannel::isOpened const): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm:
(WebKit::NetworkCache::IOChannel::IOChannel):
(WebKit::NetworkCache::IOChannel::read):
(WebKit::NetworkCache::IOChannel::write):
* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCurl.cpp:
(WebKit::NetworkCache::IOChannel::IOChannel):
(WebKit::NetworkCache::IOChannel::~IOChannel):
(WebKit::NetworkCache::IOChannel::read):
(WebKit::NetworkCache::IOChannel::write):
* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelGLib.cpp:
(WebKit::NetworkCache::IOChannel::IOChannel):
(WebKit::NetworkCache::IOChannel::read):
(WebKit::NetworkCache::IOChannel::write):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
(WebKit::NetworkCache::Storage::dispatchReadOperation):
(WebKit::NetworkCache::Storage::traverseWithinRootPath):

Canonical link: <a href="https://commits.webkit.org/286259@main">https://commits.webkit.org/286259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48555a36729859d34ee14e958d40ca0af016e799

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75338 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79809 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/26602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2569 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59130 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/26602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78405 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39492 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24929 "Built successfully") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22559 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81294 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2677 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67378 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64713 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66655 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16593 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10612 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8769 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2634 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2659 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3594 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/2666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->