### PR TITLE
ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr should be optimized for the case where most references are strong

### DIFF
--- a/Source/JavaScriptCore/runtime/NativeCalleeRegistry.h
+++ b/Source/JavaScriptCore/runtime/NativeCalleeRegistry.h
@@ -47,7 +47,8 @@ public:
     void registerCallee(NativeCallee* callee)
     {
         Locker locker { m_lock };
-        m_calleeSet.add(callee);
+        auto addResult = m_calleeSet.add(callee);
+        ASSERT_UNUSED(addResult, addResult.isNewEntry);
     }
 
     void unregisterCallee(NativeCallee* callee)

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -67,8 +67,8 @@ Callee::Callee(Wasm::CompilationMode compilationMode)
 Callee::Callee(Wasm::CompilationMode compilationMode, FunctionSpaceIndex index, std::pair<const Name*, RefPtr<NameSection>>&& name)
     : NativeCallee(NativeCallee::Category::Wasm, ImplementationVisibility::Public)
     , m_compilationMode(compilationMode)
-    , m_indexOrName(index, WTFMove(name))
     , m_index(index)
+    , m_indexOrName(index, WTFMove(name))
 {
 }
 

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -89,8 +89,8 @@ protected:
 
 private:
     const CompilationMode m_compilationMode;
-    const IndexOrName m_indexOrName;
     const FunctionSpaceIndex m_index;
+    const IndexOrName m_indexOrName;
 
 protected:
     FixedVector<HandlerInfo> m_exceptionHandlers;

--- a/Source/WTF/wtf/Atomics.h
+++ b/Source/WTF/wtf/Atomics.h
@@ -128,8 +128,7 @@ struct Atomic {
 
     // func is supposed to return false if the value is already in the desired state.
     // Returns true if the value was changed. Else returns false.
-    template<typename Func>
-    ALWAYS_INLINE bool transaction(const Func& func, std::memory_order order = std::memory_order_seq_cst)
+    ALWAYS_INLINE bool transaction(const Invocable<bool(T&)> auto& func, std::memory_order order = std::memory_order_seq_cst)
     {
         for (;;) {
             T oldValue = load(std::memory_order_relaxed);

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -3137,21 +3137,6 @@ TEST(WTF_ThreadSafeWeakPtr, RemoveInDestructor)
     }
 }
 
-TEST(WTF_ThreadSafeWeakPtr, WeakRefInDestructor)
-{
-    struct S;
-    static ThreadSafeWeakPtr<S> weakPtr;
-    struct S : ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<S> {
-        ~S() { weakPtr = { *this }; }
-    };
-
-    {
-        auto s = adoptRef(*new S);
-    }
-    auto shouldBeNull = weakPtr.get();
-    EXPECT_NULL(shouldBeNull.get());
-}
-
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DidUpdateRefCountWeakPtrImpl);
 
 class DidUpdateRefCountWeakPtrImpl final {


### PR DESCRIPTION
#### 702a8c0f58a9cc1a99bab360867740121892661c
<pre>
ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr should be optimized for the case where most references are strong
<a href="https://bugs.webkit.org/show_bug.cgi?id=282623">https://bugs.webkit.org/show_bug.cgi?id=282623</a>
<a href="https://rdar.apple.com/139297882">rdar://139297882</a>

Reviewed by Justin Michaud.

This patch optimizes ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr for the case that the object is
only referenced strongly. This comes up a lot for Wasm::Callees as they&apos;re only weakly referenced only
while they are awaiting destruction. To make this work, the pointer to the ControlBlock is now logically
a `union { ControlBlock*; Atomic&lt;uintptr_t&gt; strongOnlyRefCountAndFlag }`.

In this new world it also no longer makes sense to take a WeakPtr to an object during its destructor,
which IMO didn&apos;t really make sense before. The WeakPtr must report the object as dead since the WeakPtr
doesn&apos;t realistically have a way to know if the new strong ref is coming from the thread destroying the
object or not. This patch removes a test case ASSERTing this was possible.

Lastly, this patch moves m_index in Wasm::Callee above m_indexOrName since that reduces padding, thus
Wasm::Callee is no bigger than it was before.

* Source/JavaScriptCore/runtime/NativeCalleeRegistry.h:
(JSC::NativeCalleeRegistry::registerCallee):
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::Callee::Callee):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/WTF/wtf/Atomics.h:
(WTF::Atomic::transaction):
* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::ThreadSafeWeakPtrControlBlock::ThreadSafeWeakPtrControlBlock):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref const):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref const):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::refCount const):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::hasOneRef const):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::controlBlock const):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::isStrongOnly):
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:

Canonical link: <a href="https://commits.webkit.org/286483@main">https://commits.webkit.org/286483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a425ddf46695f161e8c753096425ea5a6463e094

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80635 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27399 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78248 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3458 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/17844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49592 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/65386 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/40050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46988 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22869 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25726 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69309 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68120 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82096 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75408 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3504 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/2270 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3658 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65354 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/67238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16751 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11188 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97662 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3452 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21366 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3475 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/6869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/5233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->