### PR TITLE
[resultsdbpy] Fix _find() method in commit_controller.py return amount to abide by the limit amount passed.

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/commit_controller.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/commit_controller.py
@@ -197,7 +197,7 @@ class CommitController(HasCommitContext):
                         results_for_repo += self.commit_context.find_commits_in_range(repository, b, limit=limit - len(results_for_repo), begin=begin, end=end)
                 result += results_for_repo
 
-            return sorted(result)
+            return sorted(result)[:limit]
 
     def find(self):
         AssertRequest.is_type()

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/commit_controller_unittest.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/commit_controller_unittest.py
@@ -235,6 +235,26 @@ class CommitControllerTest(FlaskTestCase, WaitForDockerTestCase):
 
     @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
     @FlaskTestCase.run_with_webserver()
+    def test_find_limit(self, client, **kwargs):
+        self.register_all_commits(client)
+
+        response = client.get(self.URL + '/api/commits/find')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(9, len(response.json()))
+        self.assertEqual(len([Commit.from_json(element) for element in response.json()]), 9)
+
+        response = client.get(self.URL + '/api/commits/find?limit=1')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(1, len(response.json()))
+        self.assertEqual(len([Commit.from_json(element) for element in response.json()]), 1)
+
+        response = client.get(self.URL + '/api/commits/find?limit=5')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(5, len(response.json()))
+        self.assertEqual(len([Commit.from_json(element) for element in response.json()]), 5)
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
     def test_next(self, client, **kwargs):
         self.register_all_commits(client)
         response = client.get(self.URL + '/api/commits/next?id=bae5d1e90999')


### PR DESCRIPTION
#### 74589224e4a9dfd0bd386963bf645d8818de0583
<pre>
[resultsdbpy] Fix _find() method in commit_controller.py return amount to abide by the limit amount passed.
<a href="https://bugs.webkit.org/show_bug.cgi?id=282625">https://bugs.webkit.org/show_bug.cgi?id=282625</a>
<a href="https://rdar.apple.com/139298383">rdar://139298383</a>

Reviewed by Jonathan Bedard.

Issue:
Right now when invoking _find() method in commit_controller.py  with an explicit limit argument it returns the (limit*amount_of_repositories) amount.
Fix:
Slice the list outside the sorted() method by the limit amount that was passed.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/commit_controller.py:
(CommitController._find):
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/commit_controller_unittest.py:
(CommitControllerTest.test_find_range_uuid):
(CommitControllerTest):
(CommitControllerTest.test_find_limit):
(CommitControllerTest.test_siblings):

Canonical link: <a href="https://commits.webkit.org/286184@main">https://commits.webkit.org/286184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6c7aab2697815c5fbe3f924478980f2b141612d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79519 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/26322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77188 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2291 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58932 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/26322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64492 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39310 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/74579 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/46452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21996 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/24648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80999 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2396 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/74749 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2546 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64504 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/66483 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/10423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11587 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2359 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2384 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/3310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2394 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->