### PR TITLE
Temp commit for EWS run

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -983,6 +983,23 @@ Ref<SecurityOrigin> Document::protectedTopOrigin() const
     return topOrigin();
 }
 
+URL Document::topURL() const
+{
+    if (isTopDocument()) {
+        WTFLogAlways("Brady: isTopDocument, so returning url %s", url().string().utf8().data());
+        return url();
+    }
+
+    if (RefPtr page = this->page()) {
+        WTFLogAlways("Brady: Has a page, so returning main frame url %s", page->mainFrameURL().string().utf8().data());
+        return page->mainFrameURL();
+    }
+
+    WTFLogAlways("Brady: RETURNING EMPTY URL");
+    RELEASE_ASSERT_NOT_REACHED();
+//    return { };
+}
+
 SecurityOrigin& Document::topOrigin() const
 {
     // Keep exact pre-site-isolation behavior to avoid risking changing behavior when site isolation is not enabled.

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1608,6 +1608,7 @@ public:
     SecurityOrigin& securityOrigin() const { return *SecurityContext::securityOrigin(); }
     inline Ref<SecurityOrigin> protectedSecurityOrigin() const; // Defined in DocumentInlines.h.
     WEBCORE_EXPORT SecurityOrigin& topOrigin() const final;
+    URL topURL() const;
     Ref<SecurityOrigin> protectedTopOrigin() const;
     inline ClientOrigin clientOrigin() const;
 

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -107,7 +107,7 @@ static UncheckedKeyHashMap<RegistrableDomain, String>& updatableStorageAccessUse
 #if PLATFORM(IOS_FAMILY)
 static inline bool isYahooMail(Document& document)
 {
-    auto host = document.topDocument().url().host();
+    auto host = document.topURL().host();
     return host.startsWith("mail."_s) && PublicSuffixStore::singleton().topPrivatelyControlledDomain(host).startsWith("yahoo."_s);
 }
 #endif
@@ -143,7 +143,7 @@ bool Quirks::shouldIgnoreInvalidSignal() const
 // or make different helpers
 bool Quirks::isDomain(const String& domainString) const
 {
-    return RegistrableDomain(m_document->topDocument().url()).string() == domainString;
+    return RegistrableDomain(m_document->topURL()).string() == domainString;
 }
 
 bool Quirks::isEmbedDomain(const String& domainString) const
@@ -160,7 +160,7 @@ bool Quirks::needsFormControlToBeMouseFocusable() const
     if (!needsQuirks())
         return false;
 
-    auto host = m_document->topDocument().url().host();
+    auto host = m_document->topURL().host();
     return host == "ceac.state.gov"_s || host.endsWith(".ceac.state.gov"_s);
 #else
     return false;
@@ -242,7 +242,7 @@ bool Quirks::isTouchBarUpdateSuppressedForHiddenContentEditable() const
     if (!needsQuirks())
         return false;
 
-    return m_document->topDocument().url().host() == "docs.google.com"_s;
+    return m_document->topURL().host() == "docs.google.com"_s;
 #else
     return false;
 #endif
@@ -258,7 +258,7 @@ bool Quirks::isNeverRichlyEditableForTouchBar() const
     if (!needsQuirks())
         return false;
 
-    auto& url = m_document->topDocument().url();
+    auto url = m_document->topURL();
     auto host = url.host();
 
     if (host == "onedrive.live.com"_s)
@@ -286,7 +286,7 @@ bool Quirks::shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAr
     if (!needsQuirks())
         return false;
 
-    auto host = m_document->topDocument().url().host();
+    auto host = m_document->topURL().host();
     if (host == "docs.google.com"_s)
         return true;
 #endif
@@ -334,7 +334,7 @@ bool Quirks::shouldDisableWritingSuggestionsByDefault() const
 {
     if (!needsQuirks())
         return false;
-    auto& url = m_document->topDocument().url();
+    auto url = m_document->topURL();
     return url.host() == "safe.menlosecurity.com"_s;
 }
 
@@ -399,14 +399,14 @@ bool Quirks::shouldDisableElementFullscreenQuirk() const
 
 bool Quirks::isAmazon() const
 {
-    return PublicSuffixStore::singleton().topPrivatelyControlledDomain(m_document->topDocument().url().host()).startsWith("amazon."_s);
+    return PublicSuffixStore::singleton().topPrivatelyControlledDomain(m_document->topURL().host()).startsWith("amazon."_s);
 }
 
 #if ENABLE(TOUCH_EVENTS)
 
 bool Quirks::isGoogleMaps() const
 {
-    auto& url = m_document->topDocument().url();
+    auto url = m_document->topURL();
     return PublicSuffixStore::singleton().topPrivatelyControlledDomain(url.host()).startsWith("google."_s) && startsWithLettersIgnoringASCIICase(url.path(), "/maps/"_s);
 }
 
@@ -434,7 +434,7 @@ bool Quirks::shouldDispatchSimulatedMouseEvents(const EventTarget* target) const
         if (isGoogleMaps())
             return ShouldDispatchSimulatedMouseEvents::Yes;
 
-        auto& url = m_document->topDocument().url();
+        auto url = m_document->topURL();
         auto host = url.host();
 
         if (isDomain("wix.com"_s)) {
@@ -529,7 +529,7 @@ bool Quirks::shouldPreventDispatchOfTouchEvent(const AtomString& touchEventType,
     if (!needsQuirks())
         return false;
 
-    if (RefPtr element = dynamicDowncast<Element>(target); element && touchEventType == eventNames().touchendEvent && m_document->topDocument().url().host() == "sites.google.com"_s) {
+    if (RefPtr element = dynamicDowncast<Element>(target); element && touchEventType == eventNames().touchendEvent && m_document->topURL().host() == "sites.google.com"_s) {
         auto& classList = element->classList();
         return classList.contains("DPvwYc"_s) && classList.contains("sm8sCf"_s);
     }
@@ -547,7 +547,7 @@ bool Quirks::shouldAvoidResizingWhenInputViewBoundsChange() const
     if (!needsQuirks())
         return false;
 
-    auto& url = m_document->topDocument().url();
+    auto url = m_document->topURL();
     auto host = url.host();
 
     if (isDomain("live.com"_s))
@@ -585,7 +585,7 @@ bool Quirks::needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommand() const
     if (!needsQuirks())
         return false;
 
-    auto& url = m_document->topDocument().url();
+    auto url = m_document->topURL();
     return url.host() == "docs.google.com"_s && startsWithLettersIgnoringASCIICase(url.path(), "/spreadsheets/"_s);
 #else
     return false;
@@ -882,7 +882,7 @@ bool Quirks::shouldBypassBackForwardCache() const
         return false;
 
     RefPtr document = m_document.get();
-    auto topURL = document->topDocument().url();
+    auto topURL = document->topURL();
     auto host = topURL.host();
     RegistrableDomain registrableDomain { topURL };
 
@@ -937,7 +937,7 @@ bool Quirks::shouldBypassAsyncScriptDeferring() const
         return false;
 
     if (!m_shouldBypassAsyncScriptDeferring) {
-        auto domain = RegistrableDomain { m_document->topDocument().url() };
+        auto domain = RegistrableDomain { m_document->topURL() };
         // Deferring 'mapbox-gl.js' script on bungalow.com causes the script to get in a bad state (rdar://problem/61658940).
         // Deferring the google maps script on sfusd.edu may get the page in a bad state (rdar://116292738).
         m_shouldBypassAsyncScriptDeferring = domain == "bungalow.com"_s || domain == "sfusd.edu"_s;
@@ -1121,7 +1121,7 @@ bool Quirks::hasStorageAccessForAllLoginDomains(const HashSet<RegistrableDomain>
 Quirks::StorageAccessResult Quirks::requestStorageAccessAndHandleClick(CompletionHandler<void(ShouldDispatchClick)>&& completionHandler) const
 {
     RefPtr document = m_document.get();
-    auto firstPartyDomain = RegistrableDomain(document->topDocument().url());
+    auto firstPartyDomain = RegistrableDomain(document->topURL());
     auto domainsInNeedOfStorageAccess = NetworkStorageSession::subResourceDomainsInNeedOfStorageAccessForFirstParty(firstPartyDomain);
     if (!domainsInNeedOfStorageAccess || domainsInNeedOfStorageAccess.value().isEmpty()) {
         completionHandler(ShouldDispatchClick::No);
@@ -1284,7 +1284,7 @@ bool Quirks::requiresUserGestureToPauseInPictureInPicture() const
         return false;
 
     if (!m_requiresUserGestureToPauseInPictureInPicture) {
-        auto domain = RegistrableDomain(m_document->topDocument().url()).string();
+        auto domain = RegistrableDomain(m_document->topURL()).string();
         m_requiresUserGestureToPauseInPictureInPicture = isDomain("facebook.com"_s) || isDomain("twitter.com"_s) || isDomain("reddit.com"_s) || isDomain("forbes.com"_s);
     }
 
@@ -1360,7 +1360,7 @@ bool Quirks::shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFull
         return false;
 
     if (!m_shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk) {
-        auto domain = RegistrableDomain(m_document->topDocument().url());
+        auto domain = RegistrableDomain(m_document->topURL());
         m_shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk = domain == "espn.com"_s || domain == "vimeo.com"_s;
     }
 
@@ -1401,7 +1401,7 @@ bool Quirks::allowLayeredFullscreenVideos() const
         return false;
 
     if (!m_allowLayeredFullscreenVideos) {
-        auto domain = RegistrableDomain(m_document->topDocument().url());
+        auto domain = RegistrableDomain(m_document->topURL());
 
         m_allowLayeredFullscreenVideos = domain == "espn.com"_s;
     }
@@ -1633,7 +1633,7 @@ bool Quirks::shouldPreventOrientationMediaQueryFromEvaluatingToLandscape() const
     if (!needsQuirks())
         return false;
 
-    return shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeInternal(m_document->topDocument().url());
+    return shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeInternal(m_document->topURL());
 }
 
 bool Quirks::shouldFlipScreenDimensions() const
@@ -1642,7 +1642,7 @@ bool Quirks::shouldFlipScreenDimensions() const
     if (!needsQuirks())
         return false;
 
-    return shouldFlipScreenDimensionsInternal(m_document->topDocument().url());
+    return shouldFlipScreenDimensionsInternal(m_document->topURL());
 #else
     return false;
 #endif
@@ -1837,7 +1837,7 @@ bool Quirks::shouldIgnoreTextAutoSizing() const
 {
     if (!needsQuirks())
         return false;
-    return m_document->topDocument().url().host() == "news.ycombinator.com"_s;
+    return m_document->topURL().host() == "news.ycombinator.com"_s;
 }
 #endif
 
@@ -1857,7 +1857,7 @@ String Quirks::scriptToEvaluateBeforeRunningScriptFromURL(const URL& scriptURL)
     if (!needsQuirks())
         return { };
 
-    auto topDomain = RegistrableDomain(m_document->topDocument().url()).string();
+    auto topDomain = RegistrableDomain(m_document->topURL()).string();
     if (UNLIKELY(topDomain == "webex.com"_s && scriptURL.lastPathComponent().startsWith("pushdownload."_s)))
         return "Object.defineProperty(window, 'Touch', { get: () => undefined });"_s;
 #else
@@ -1872,7 +1872,7 @@ bool Quirks::shouldHideCoarsePointerCharacteristics() const
     if (!needsQuirks())
         return false;
 
-    auto topDomain = RegistrableDomain(m_document->topDocument().url()).string();
+    auto topDomain = RegistrableDomain(m_document->topURL()).string();
     if (topDomain == "disneyplus.com"_s)
         return true;
 #endif
@@ -1888,7 +1888,7 @@ bool Quirks::implicitMuteWhenVolumeSetToZero() const
         return false;
 
     if (!m_implicitMuteWhenVolumeSetToZero) {
-        auto domain = RegistrableDomain(m_document->topDocument().url()).string();
+        auto domain = RegistrableDomain(m_document->topURL()).string();
         m_implicitMuteWhenVolumeSetToZero = domain == "hulu.com"_s || domain.endsWith(".hulu.com"_s);
     }
 


### PR DESCRIPTION
#### da728023eed9668f64b9f11853b4520942fceb9a
<pre>
Temp commit for EWS run
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da728023eed9668f64b9f11853b4520942fceb9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79521 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/26324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77190 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2293 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/26324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49092 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/64496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/39316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46441 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/22000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/24650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81001 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2398 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2548 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64508 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66482 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/10426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2361 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/2386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/3312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/2396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->