### PR TITLE
Use HashMap instead of UncheckedKeyHashMap in WebCore/Modules

### DIFF
--- a/Source/WebCore/Modules/cache/CacheStorageConnection.h
+++ b/Source/WebCore/Modules/cache/CacheStorageConnection.h
@@ -73,7 +73,7 @@ private:
     uint64_t computeRealBodySize(const DOMCacheEngine::ResponseBody&);
 
 protected:
-    UncheckedKeyHashMap<uint64_t, uint64_t> m_opaqueResponseToSizeWithPaddingMap;
+    HashMap<uint64_t, uint64_t> m_opaqueResponseToSizeWithPaddingMap;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/cookie-store/CookieStore.h
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.h
@@ -94,7 +94,7 @@ private:
     WeakPtr<CookieJar> m_cookieJar;
     String m_host;
     uint64_t m_nextPromiseIdentifier { 0 };
-    UncheckedKeyHashMap<uint64_t, Ref<DeferredPromise>> m_promises;
+    HashMap<uint64_t, Ref<DeferredPromise>> m_promises;
 };
 
 }

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -64,12 +64,12 @@ static bool isHTTPQuotedStringTokenCodePoint(UChar c)
 struct MimeType {
     String type;
     String subtype;
-    UncheckedKeyHashMap<String, String> parameters;
+    HashMap<String, String> parameters;
 };
 
-static UncheckedKeyHashMap<String, String> parseParameters(StringView input, size_t position)
+static HashMap<String, String> parseParameters(StringView input, size_t position)
 {
-    UncheckedKeyHashMap<String, String> parameters;
+    HashMap<String, String> parameters;
     while (position < input.length()) {
         while (position < input.length() && isTabOrSpace(input[position]))
             position++;

--- a/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h
+++ b/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h
@@ -82,15 +82,15 @@ private:
 
     WeakPtr<WorkerGlobalScope, WeakPtrImplWithEventTargetData> m_scope;
     RefPtr<FileSystemStorageConnection> m_mainThreadConnection;
-    UncheckedKeyHashMap<CallbackIdentifier, FileSystemStorageConnection::SameEntryCallback> m_sameEntryCallbacks;
-    UncheckedKeyHashMap<CallbackIdentifier, FileSystemStorageConnection::GetHandleCallback> m_getHandleCallbacks;
-    UncheckedKeyHashMap<CallbackIdentifier, FileSystemStorageConnection::ResolveCallback> m_resolveCallbacks;
-    UncheckedKeyHashMap<CallbackIdentifier, FileSystemStorageConnection::GetAccessHandleCallback> m_getAccessHandlCallbacks;
-    UncheckedKeyHashMap<CallbackIdentifier, FileSystemStorageConnection::VoidCallback> m_voidCallbacks;
-    UncheckedKeyHashMap<CallbackIdentifier, FileSystemStorageConnection::GetHandleNamesCallback> m_getHandleNamesCallbacks;
-    UncheckedKeyHashMap<CallbackIdentifier, FileSystemStorageConnection::StringCallback> m_stringCallbacks;
-    UncheckedKeyHashMap<FileSystemSyncAccessHandleIdentifier, Function<void()>> m_accessHandleInvalidationHandlers;
-    UncheckedKeyHashMap<FileSystemSyncAccessHandleIdentifier, WeakPtr<FileSystemSyncAccessHandle>> m_syncAccessHandles;
+    HashMap<CallbackIdentifier, FileSystemStorageConnection::SameEntryCallback> m_sameEntryCallbacks;
+    HashMap<CallbackIdentifier, FileSystemStorageConnection::GetHandleCallback> m_getHandleCallbacks;
+    HashMap<CallbackIdentifier, FileSystemStorageConnection::ResolveCallback> m_resolveCallbacks;
+    HashMap<CallbackIdentifier, FileSystemStorageConnection::GetAccessHandleCallback> m_getAccessHandlCallbacks;
+    HashMap<CallbackIdentifier, FileSystemStorageConnection::VoidCallback> m_voidCallbacks;
+    HashMap<CallbackIdentifier, FileSystemStorageConnection::GetHandleNamesCallback> m_getHandleNamesCallbacks;
+    HashMap<CallbackIdentifier, FileSystemStorageConnection::StringCallback> m_stringCallbacks;
+    HashMap<FileSystemSyncAccessHandleIdentifier, Function<void()>> m_accessHandleInvalidationHandlers;
+    HashMap<FileSystemSyncAccessHandleIdentifier, WeakPtr<FileSystemSyncAccessHandle>> m_syncAccessHandles;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/geolocation/Geolocation.h
+++ b/Source/WebCore/Modules/geolocation/Geolocation.h
@@ -111,8 +111,8 @@ private:
         bool isEmpty() const;
         void getNotifiersVector(GeoNotifierVector&) const;
     private:
-        typedef UncheckedKeyHashMap<int, RefPtr<GeoNotifier>> IdToNotifierMap;
-        typedef UncheckedKeyHashMap<RefPtr<GeoNotifier>, int> NotifierToIdMap;
+        typedef HashMap<int, RefPtr<GeoNotifier>> IdToNotifierMap;
+        typedef HashMap<RefPtr<GeoNotifier>, int> NotifierToIdMap;
         IdToNotifierMap m_idToNotifierMap;
         NotifierToIdMap m_notifierToIdMap;
     };

--- a/Source/WebCore/Modules/highlight/HighlightRegistry.h
+++ b/Source/WebCore/Modules/highlight/HighlightRegistry.h
@@ -54,12 +54,12 @@ public:
 #endif
     
     WEBCORE_EXPORT void addAnnotationHighlightWithRange(Ref<StaticRange>&&);
-    const UncheckedKeyHashMap<AtomString, Ref<Highlight>>& map() const { return m_map; }
+    const HashMap<AtomString, Ref<Highlight>>& map() const { return m_map; }
     const Vector<AtomString>& highlightNames() const { return m_highlightNames; }
     
 private:
     HighlightRegistry() = default;
-    UncheckedKeyHashMap<AtomString, Ref<Highlight>> m_map;
+    HashMap<AtomString, Ref<Highlight>> m_map;
     Vector<AtomString> m_highlightNames;
 
     HighlightVisibility m_highlightVisibility { HighlightVisibility::Hidden };

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.h
@@ -130,9 +130,9 @@ private:
     bool m_closedInServer { false };
 
     RefPtr<IDBTransaction> m_versionChangeTransaction;
-    UncheckedKeyHashMap<IDBResourceIdentifier, RefPtr<IDBTransaction>> m_activeTransactions;
-    UncheckedKeyHashMap<IDBResourceIdentifier, RefPtr<IDBTransaction>> m_committingTransactions;
-    UncheckedKeyHashMap<IDBResourceIdentifier, RefPtr<IDBTransaction>> m_abortingTransactions;
+    HashMap<IDBResourceIdentifier, RefPtr<IDBTransaction>> m_activeTransactions;
+    HashMap<IDBResourceIdentifier, RefPtr<IDBTransaction>> m_committingTransactions;
+    HashMap<IDBResourceIdentifier, RefPtr<IDBTransaction>> m_abortingTransactions;
     
     const EventNames& m_eventNames; // Need to cache this so we can use it from GC threads.
 

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
@@ -144,8 +144,8 @@ private:
     bool m_deleted { false };
 
     mutable Lock m_referencedIndexLock;
-    UncheckedKeyHashMap<String, std::unique_ptr<IDBIndex>> m_referencedIndexes WTF_GUARDED_BY_LOCK(m_referencedIndexLock);
-    UncheckedKeyHashMap<uint64_t, std::unique_ptr<IDBIndex>> m_deletedIndexes WTF_GUARDED_BY_LOCK(m_referencedIndexLock);
+    HashMap<String, std::unique_ptr<IDBIndex>> m_referencedIndexes WTF_GUARDED_BY_LOCK(m_referencedIndexLock);
+    HashMap<uint64_t, std::unique_ptr<IDBIndex>> m_deletedIndexes WTF_GUARDED_BY_LOCK(m_referencedIndexLock);
 };
 
 WebCoreOpaqueRoot root(IDBObjectStore*);

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -252,12 +252,12 @@ private:
     Deque<RefPtr<IDBClient::TransactionOperation>> m_pendingTransactionOperationQueue;
     Deque<IDBClient::TransactionOperation*> m_transactionOperationsInProgressQueue;
     Deque<RefPtr<IDBClient::TransactionOperation>> m_abortQueue;
-    UncheckedKeyHashMap<RefPtr<IDBClient::TransactionOperation>, IDBResultData> m_transactionOperationResultMap;
-    UncheckedKeyHashMap<IDBResourceIdentifier, RefPtr<IDBClient::TransactionOperation>> m_transactionOperationMap;
+    HashMap<RefPtr<IDBClient::TransactionOperation>, IDBResultData> m_transactionOperationResultMap;
+    HashMap<IDBResourceIdentifier, RefPtr<IDBClient::TransactionOperation>> m_transactionOperationMap;
 
     mutable Lock m_referencedObjectStoreLock;
-    UncheckedKeyHashMap<String, std::unique_ptr<IDBObjectStore>> m_referencedObjectStores WTF_GUARDED_BY_LOCK(m_referencedObjectStoreLock);
-    UncheckedKeyHashMap<IDBObjectStoreIdentifier, std::unique_ptr<IDBObjectStore>> m_deletedObjectStores;
+    HashMap<String, std::unique_ptr<IDBObjectStore>> m_referencedObjectStores WTF_GUARDED_BY_LOCK(m_referencedObjectStoreLock);
+    HashMap<IDBObjectStoreIdentifier, std::unique_ptr<IDBObjectStore>> m_deletedObjectStores;
 
     HashSet<RefPtr<IDBRequest>> m_openRequests;
     RefPtr<IDBRequest> m_currentlyCompletingRequest;

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
@@ -572,7 +572,7 @@ void IDBConnectionProxy::forgetTransaction(IDBTransaction& transaction)
 }
 
 template<typename KeyType, typename ValueType, typename FunctionType>
-void removeItemsMatchingCurrentThread(UncheckedKeyHashMap<KeyType, ValueType>& map, FunctionType&& cleanupFunction)
+void removeItemsMatchingCurrentThread(HashMap<KeyType, ValueType>& map, FunctionType&& cleanupFunction)
 {
     // FIXME: Revisit when introducing WebThread aware thread comparison.
     // https://bugs.webkit.org/show_bug.cgi?id=204345
@@ -586,7 +586,7 @@ void removeItemsMatchingCurrentThread(UncheckedKeyHashMap<KeyType, ValueType>& m
 }
 
 template<typename KeyType, typename ValueType>
-void setMatchingItemsContextSuspended(ScriptExecutionContext& currentContext, UncheckedKeyHashMap<KeyType, ValueType>& map, bool isContextSuspended)
+void setMatchingItemsContextSuspended(ScriptExecutionContext& currentContext, HashMap<KeyType, ValueType>& map, bool isContextSuspended)
 {
     // FIXME: Revisit when introducing WebThread aware thread comparison.
     // https://bugs.webkit.org/show_bug.cgi?id=204345

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
@@ -165,13 +165,13 @@ private:
     Lock m_databaseInfoMapLock;
     Lock m_mainThreadTaskLock;
 
-    UncheckedKeyHashMap<IDBDatabaseConnectionIdentifier, IDBDatabase*> m_databaseConnectionMap WTF_GUARDED_BY_LOCK(m_databaseConnectionMapLock);
-    UncheckedKeyHashMap<IDBResourceIdentifier, RefPtr<IDBOpenDBRequest>> m_openDBRequestMap WTF_GUARDED_BY_LOCK(m_openDBRequestMapLock);
-    UncheckedKeyHashMap<IDBResourceIdentifier, RefPtr<IDBTransaction>> m_pendingTransactions WTF_GUARDED_BY_LOCK(m_transactionMapLock);
-    UncheckedKeyHashMap<IDBResourceIdentifier, RefPtr<IDBTransaction>> m_committingTransactions WTF_GUARDED_BY_LOCK(m_transactionMapLock);
-    UncheckedKeyHashMap<IDBResourceIdentifier, RefPtr<IDBTransaction>> m_abortingTransactions WTF_GUARDED_BY_LOCK(m_transactionMapLock);
-    UncheckedKeyHashMap<IDBResourceIdentifier, RefPtr<TransactionOperation>> m_activeOperations WTF_GUARDED_BY_LOCK(m_transactionOperationLock);
-    UncheckedKeyHashMap<IDBResourceIdentifier, Ref<IDBDatabaseNameAndVersionRequest>> m_databaseInfoCallbacks WTF_GUARDED_BY_LOCK(m_databaseInfoMapLock);
+    HashMap<IDBDatabaseConnectionIdentifier, IDBDatabase*> m_databaseConnectionMap WTF_GUARDED_BY_LOCK(m_databaseConnectionMapLock);
+    HashMap<IDBResourceIdentifier, RefPtr<IDBOpenDBRequest>> m_openDBRequestMap WTF_GUARDED_BY_LOCK(m_openDBRequestMapLock);
+    HashMap<IDBResourceIdentifier, RefPtr<IDBTransaction>> m_pendingTransactions WTF_GUARDED_BY_LOCK(m_transactionMapLock);
+    HashMap<IDBResourceIdentifier, RefPtr<IDBTransaction>> m_committingTransactions WTF_GUARDED_BY_LOCK(m_transactionMapLock);
+    HashMap<IDBResourceIdentifier, RefPtr<IDBTransaction>> m_abortingTransactions WTF_GUARDED_BY_LOCK(m_transactionMapLock);
+    HashMap<IDBResourceIdentifier, RefPtr<TransactionOperation>> m_activeOperations WTF_GUARDED_BY_LOCK(m_transactionOperationLock);
+    HashMap<IDBResourceIdentifier, Ref<IDBDatabaseNameAndVersionRequest>> m_databaseInfoCallbacks WTF_GUARDED_BY_LOCK(m_databaseInfoMapLock);
 
     CrossThreadQueue<CrossThreadTask> m_mainThreadQueue;
     RefPtr<IDBConnectionToServer> m_mainThreadProtector WTF_GUARDED_BY_LOCK(m_mainThreadTaskLock);

--- a/Source/WebCore/Modules/indexeddb/server/IDBServer.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBServer.h
@@ -114,13 +114,13 @@ private:
     void removeDatabasesModifiedSinceForVersion(WallTime, const String&);
     void removeDatabasesWithOriginsForVersion(const Vector<SecurityOriginData>&, const String&);
 
-    UncheckedKeyHashMap<IDBConnectionIdentifier, RefPtr<IDBConnectionToClient>> m_connectionMap;
-    UncheckedKeyHashMap<IDBDatabaseIdentifier, std::unique_ptr<UniqueIDBDatabase>> m_uniqueIDBDatabaseMap;
+    HashMap<IDBConnectionIdentifier, RefPtr<IDBConnectionToClient>> m_connectionMap;
+    HashMap<IDBDatabaseIdentifier, std::unique_ptr<UniqueIDBDatabase>> m_uniqueIDBDatabaseMap;
 
-    UncheckedKeyHashMap<IDBDatabaseConnectionIdentifier, UniqueIDBDatabaseConnection*> m_databaseConnections;
-    UncheckedKeyHashMap<IDBResourceIdentifier, UniqueIDBDatabaseTransaction*> m_transactions;
+    HashMap<IDBDatabaseConnectionIdentifier, UniqueIDBDatabaseConnection*> m_databaseConnections;
+    HashMap<IDBResourceIdentifier, UniqueIDBDatabaseTransaction*> m_transactions;
 
-    UncheckedKeyHashMap<uint64_t, Function<void ()>> m_deleteDatabaseCompletionHandlers;
+    HashMap<uint64_t, Function<void ()>> m_deleteDatabaseCompletionHandlers;
 
     String m_databaseDirectoryPath;
 

--- a/Source/WebCore/Modules/indexeddb/server/IndexValueStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/IndexValueStore.h
@@ -42,7 +42,7 @@ namespace IDBServer {
 
 class MemoryIndex;
 
-typedef UncheckedKeyHashMap<IDBKeyData, std::unique_ptr<IndexValueEntry>, IDBKeyDataHash, IDBKeyDataHashTraits> IndexKeyValueMap;
+typedef HashMap<IDBKeyData, std::unique_ptr<IndexValueEntry>, IDBKeyDataHash, IDBKeyDataHashTraits> IndexKeyValueMap;
 
 class IndexValueStore final : public CanMakeThreadSafeCheckedPtr<IndexValueStore> {
     WTF_MAKE_TZONE_ALLOCATED(IndexValueStore);

--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
@@ -42,7 +42,7 @@ class MemoryIDBBackingStore;
 class MemoryIndex;
 class MemoryObjectStore;
 
-typedef UncheckedKeyHashMap<IDBKeyData, ThreadSafeDataBuffer, IDBKeyDataHash, IDBKeyDataHashTraits> KeyValueMap;
+typedef HashMap<IDBKeyData, ThreadSafeDataBuffer, IDBKeyDataHash, IDBKeyDataHashTraits> KeyValueMap;
 
 class MemoryBackingStoreTransaction final : public CanMakeThreadSafeCheckedPtr<MemoryBackingStoreTransaction> {
     WTF_MAKE_TZONE_ALLOCATED(MemoryBackingStoreTransaction);
@@ -92,15 +92,15 @@ private:
     HashSet<RefPtr<MemoryIndex>> m_indexes;
     HashSet<RefPtr<MemoryIndex>> m_versionChangeAddedIndexes;
 
-    UncheckedKeyHashMap<MemoryObjectStore*, uint64_t> m_originalKeyGenerators;
-    UncheckedKeyHashMap<String, RefPtr<MemoryObjectStore>> m_deletedObjectStores;
-    UncheckedKeyHashMap<String, RefPtr<MemoryIndex>> m_deletedIndexes;
-    UncheckedKeyHashMap<MemoryObjectStore*, std::unique_ptr<KeyValueMap>> m_originalValues;
-    UncheckedKeyHashMap<MemoryObjectStore*, std::unique_ptr<KeyValueMap>> m_clearedKeyValueMaps;
-    UncheckedKeyHashMap<MemoryObjectStore*, std::unique_ptr<IDBKeyDataSet>> m_clearedOrderedKeys;
-    UncheckedKeyHashMap<MemoryObjectStore*, String> m_originalObjectStoreNames;
-    UncheckedKeyHashMap<MemoryIndex*, String> m_originalIndexNames;
-    UncheckedKeyHashMap<MemoryIndex*, std::unique_ptr<IndexValueStore>> m_clearedIndexValueStores;
+    HashMap<MemoryObjectStore*, uint64_t> m_originalKeyGenerators;
+    HashMap<String, RefPtr<MemoryObjectStore>> m_deletedObjectStores;
+    HashMap<String, RefPtr<MemoryIndex>> m_deletedIndexes;
+    HashMap<MemoryObjectStore*, std::unique_ptr<KeyValueMap>> m_originalValues;
+    HashMap<MemoryObjectStore*, std::unique_ptr<KeyValueMap>> m_clearedKeyValueMaps;
+    HashMap<MemoryObjectStore*, std::unique_ptr<IDBKeyDataSet>> m_clearedOrderedKeys;
+    HashMap<MemoryObjectStore*, String> m_originalObjectStoreNames;
+    HashMap<MemoryIndex*, String> m_originalIndexNames;
+    HashMap<MemoryIndex*, std::unique_ptr<IndexValueStore>> m_clearedIndexValueStores;
 };
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/server/MemoryCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryCursor.cpp
@@ -34,9 +34,9 @@ namespace WebCore {
 namespace IDBServer {
 
 static Lock cursorMapLock;
-static UncheckedKeyHashMap<IDBResourceIdentifier, MemoryCursor*>& cursorMap() WTF_REQUIRES_LOCK(cursorMapLock)
+static HashMap<IDBResourceIdentifier, MemoryCursor*>& cursorMap() WTF_REQUIRES_LOCK(cursorMapLock)
 {
-    static NeverDestroyed<UncheckedKeyHashMap<IDBResourceIdentifier, MemoryCursor*>> map;
+    static NeverDestroyed<HashMap<IDBResourceIdentifier, MemoryCursor*>> map;
     return map;
 }
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
@@ -99,10 +99,10 @@ private:
     IDBDatabaseIdentifier m_identifier;
     std::unique_ptr<IDBDatabaseInfo> m_databaseInfo;
 
-    UncheckedKeyHashMap<IDBResourceIdentifier, std::unique_ptr<MemoryBackingStoreTransaction>> m_transactions;
+    HashMap<IDBResourceIdentifier, std::unique_ptr<MemoryBackingStoreTransaction>> m_transactions;
 
-    UncheckedKeyHashMap<IDBObjectStoreIdentifier, RefPtr<MemoryObjectStore>> m_objectStoresByIdentifier;
-    UncheckedKeyHashMap<String, RefPtr<MemoryObjectStore>> m_objectStoresByName;
+    HashMap<IDBObjectStoreIdentifier, RefPtr<MemoryObjectStore>> m_objectStoresByIdentifier;
+    HashMap<String, RefPtr<MemoryObjectStore>> m_objectStoresByName;
 };
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
@@ -104,7 +104,7 @@ private:
 
     std::unique_ptr<IndexValueStore> m_records;
 
-    UncheckedKeyHashMap<IDBResourceIdentifier, std::unique_ptr<MemoryIndexCursor>> m_cursors;
+    HashMap<IDBResourceIdentifier, std::unique_ptr<MemoryIndexCursor>> m_cursors;
     HashSet<MemoryIndexCursor*> m_cleanCursors;
 };
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
@@ -53,7 +53,7 @@ namespace IDBServer {
 
 class MemoryBackingStoreTransaction;
 
-typedef UncheckedKeyHashMap<IDBKeyData, ThreadSafeDataBuffer, IDBKeyDataHash, IDBKeyDataHashTraits> KeyValueMap;
+typedef HashMap<IDBKeyData, ThreadSafeDataBuffer, IDBKeyDataHash, IDBKeyDataHashTraits> KeyValueMap;
 
 class MemoryObjectStore : public RefCounted<MemoryObjectStore>, public CanMakeWeakPtr<MemoryObjectStore> {
 public:
@@ -126,9 +126,9 @@ private:
     std::unique_ptr<IDBKeyDataSet> m_orderedKeys;
 
     void unregisterIndex(MemoryIndex&);
-    UncheckedKeyHashMap<uint64_t, RefPtr<MemoryIndex>> m_indexesByIdentifier;
-    UncheckedKeyHashMap<String, RefPtr<MemoryIndex>> m_indexesByName;
-    UncheckedKeyHashMap<IDBResourceIdentifier, std::unique_ptr<MemoryObjectStoreCursor>> m_cursors;
+    HashMap<uint64_t, RefPtr<MemoryIndex>> m_indexesByIdentifier;
+    HashMap<String, RefPtr<MemoryIndex>> m_indexesByName;
+    HashMap<IDBResourceIdentifier, std::unique_ptr<MemoryObjectStoreCursor>> m_cursors;
 };
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -529,7 +529,7 @@ std::optional<IsSchemaUpgraded> SQLiteIDBBackingStore::ensureValidObjectStoreInf
     return { IsSchemaUpgraded::Yes };
 }
 
-bool SQLiteIDBBackingStore::migrateIndexInfoTableForIDUpdate(const UncheckedKeyHashMap<std::pair<IDBObjectStoreIdentifier, uint64_t>, uint64_t>& indexIDMap)
+bool SQLiteIDBBackingStore::migrateIndexInfoTableForIDUpdate(const HashMap<std::pair<IDBObjectStoreIdentifier, uint64_t>, uint64_t>& indexIDMap)
 {
     SQLiteDatabase& database = *m_sqliteDB;
     SQLiteTransaction transaction(database);
@@ -593,7 +593,7 @@ bool SQLiteIDBBackingStore::migrateIndexInfoTableForIDUpdate(const UncheckedKeyH
     return true;
 }
 
-bool SQLiteIDBBackingStore::migrateIndexRecordsTableForIDUpdate(const UncheckedKeyHashMap<std::pair<IDBObjectStoreIdentifier, uint64_t>, uint64_t>& indexIDMap)
+bool SQLiteIDBBackingStore::migrateIndexRecordsTableForIDUpdate(const HashMap<std::pair<IDBObjectStoreIdentifier, uint64_t>, uint64_t>& indexIDMap)
 {
     SQLiteDatabase& database = *m_sqliteDB;
     SQLiteTransaction transaction(database);
@@ -747,7 +747,7 @@ bool SQLiteIDBBackingStore::addExistingIndex(IDBObjectStoreInfo& objectStoreInfo
     return true;
 }
 
-bool SQLiteIDBBackingStore::handleDuplicateIndexIDs(const UncheckedKeyHashMap<uint64_t, Vector<IDBIndexInfo>>& indexInfoMap, IDBDatabaseInfo& databaseInfo)
+bool SQLiteIDBBackingStore::handleDuplicateIndexIDs(const HashMap<uint64_t, Vector<IDBIndexInfo>>& indexInfoMap, IDBDatabaseInfo& databaseInfo)
 {
     for (auto& iter : indexInfoMap) {
         if (iter.value.size() == 1)
@@ -843,8 +843,8 @@ std::unique_ptr<IDBDatabaseInfo> SQLiteIDBBackingStore::extractExistingDatabaseI
     }
 
     uint64_t maxIndexID = 0;
-    UncheckedKeyHashMap<std::pair<IDBObjectStoreIdentifier, uint64_t>, uint64_t> indexIDMap;
-    UncheckedKeyHashMap<uint64_t, Vector<IDBIndexInfo>> indexInfoMap;
+    HashMap<std::pair<IDBObjectStoreIdentifier, uint64_t>, uint64_t> indexIDMap;
+    HashMap<uint64_t, Vector<IDBIndexInfo>> indexInfoMap;
     {
         auto sql = m_sqliteDB->prepareStatement("SELECT id, name, objectStoreID, keyPath, isUnique, multiEntry FROM IndexInfo;"_s);
         if (!sql) {

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h
@@ -134,12 +134,12 @@ private:
     void closeSQLiteDB();
     void close() final;
 
-    bool migrateIndexInfoTableForIDUpdate(const UncheckedKeyHashMap<std::pair<IDBObjectStoreIdentifier, uint64_t>, uint64_t>& indexIDMap);
-    bool migrateIndexRecordsTableForIDUpdate(const UncheckedKeyHashMap<std::pair<IDBObjectStoreIdentifier, uint64_t>, uint64_t>& indexIDMap);
+    bool migrateIndexInfoTableForIDUpdate(const HashMap<std::pair<IDBObjectStoreIdentifier, uint64_t>, uint64_t>& indexIDMap);
+    bool migrateIndexRecordsTableForIDUpdate(const HashMap<std::pair<IDBObjectStoreIdentifier, uint64_t>, uint64_t>& indexIDMap);
 
     bool removeExistingIndex(uint64_t indexID);
     bool addExistingIndex(IDBObjectStoreInfo&, const IDBIndexInfo&);
-    bool handleDuplicateIndexIDs(const UncheckedKeyHashMap<uint64_t, Vector<IDBIndexInfo>>&, IDBDatabaseInfo&);
+    bool handleDuplicateIndexIDs(const HashMap<uint64_t, Vector<IDBIndexInfo>>&, IDBDatabaseInfo&);
 
     enum class SQL : size_t {
         CreateObjectStoreInfo,
@@ -212,8 +212,8 @@ private:
 
     std::unique_ptr<SQLiteDatabase> m_sqliteDB;
 
-    UncheckedKeyHashMap<IDBResourceIdentifier, std::unique_ptr<SQLiteIDBTransaction>> m_transactions;
-    UncheckedKeyHashMap<IDBResourceIdentifier, SQLiteIDBCursor*> m_cursors;
+    HashMap<IDBResourceIdentifier, std::unique_ptr<SQLiteIDBTransaction>> m_transactions;
+    HashMap<IDBResourceIdentifier, SQLiteIDBCursor*> m_cursors;
 
     String m_databaseDirectory;
 };

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.h
@@ -93,7 +93,7 @@ private:
     CheckedRef<SQLiteIDBBackingStore> m_backingStore;
     CheckedPtr<SQLiteDatabase> m_sqliteDatabase;
     std::unique_ptr<SQLiteTransaction> m_sqliteTransaction;
-    UncheckedKeyHashMap<IDBResourceIdentifier, std::unique_ptr<SQLiteIDBCursor>> m_cursors;
+    HashMap<IDBResourceIdentifier, std::unique_ptr<SQLiteIDBCursor>> m_cursors;
     HashSet<SQLiteIDBCursor*> m_backingStoreCursors;
     Vector<std::pair<String, String>> m_blobTemporaryAndStoredFilenames;
     MemoryCompactRobinHoodHashSet<String> m_blobRemovedFilenames;

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
@@ -180,7 +180,7 @@ private:
     std::unique_ptr<IDBDatabaseInfo> m_mostRecentDeletedDatabaseInfo;
 
     Deque<RefPtr<UniqueIDBDatabaseTransaction>> m_pendingTransactions;
-    UncheckedKeyHashMap<IDBResourceIdentifier, RefPtr<UniqueIDBDatabaseTransaction>> m_inProgressTransactions;
+    HashMap<IDBResourceIdentifier, RefPtr<UniqueIDBDatabaseTransaction>> m_inProgressTransactions;
 
     // The keys into these sets are the object store ID.
     // These sets help to decide which transactions can be started and which must be deferred.

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
@@ -95,7 +95,7 @@ private:
 
     bool m_closePending { false };
 
-    UncheckedKeyHashMap<IDBResourceIdentifier, RefPtr<UniqueIDBDatabaseTransaction>> m_transactionMap;
+    HashMap<IDBResourceIdentifier, RefPtr<UniqueIDBDatabaseTransaction>> m_transactionMap;
 };
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/shared/IndexKey.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IndexKey.h
@@ -49,6 +49,6 @@ private:
     Data m_keys;
 };
 
-typedef UncheckedKeyHashMap<uint64_t, IndexKey> IndexIDToIndexKeyMap;
+typedef HashMap<uint64_t, IndexKey> IndexIDToIndexKeyMap;
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.h
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.h
@@ -46,8 +46,8 @@ private:
     MediaCapabilities() = default;
 
     uint64_t m_nextTaskIdentifier { 0 };
-    UncheckedKeyHashMap<uint64_t, MediaEngineConfigurationFactory::DecodingConfigurationCallback> m_decodingTasks;
-    UncheckedKeyHashMap<uint64_t, MediaEngineConfigurationFactory::EncodingConfigurationCallback> m_encodingTasks;
+    HashMap<uint64_t, MediaEngineConfigurationFactory::DecodingConfigurationCallback> m_decodingTasks;
+    HashMap<uint64_t, MediaEngineConfigurationFactory::EncodingConfigurationCallback> m_encodingTasks;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -569,7 +569,7 @@ bool MediaControlsHost::showMediaControlsContextMenu(HTMLElement& target, String
         PlaybackSpeed,
         ShowMediaStatsTag
     >;
-    UncheckedKeyHashMap<MenuItemIdentifier, MenuData> idMap;
+    HashMap<MenuItemIdentifier, MenuData> idMap;
 
     auto createSubmenu = [] (const String& title, const String& icon, Vector<MenuItem>&& children) -> MenuItem {
 #if USE(UICONTEXTMENU)

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -175,7 +175,7 @@ private:
     std::optional<MediaPositionState> m_positionState;
     std::optional<double> m_lastReportedPosition;
     MonotonicTime m_timeAtLastPositionUpdate;
-    UncheckedKeyHashMap<MediaSessionAction, RefPtr<MediaSessionActionHandler>, IntHash<MediaSessionAction>, WTF::StrongEnumHashTraits<MediaSessionAction>> m_actionHandlers WTF_GUARDED_BY_LOCK(m_actionHandlersLock);
+    HashMap<MediaSessionAction, RefPtr<MediaSessionActionHandler>, IntHash<MediaSessionAction>, WTF::StrongEnumHashTraits<MediaSessionAction>> m_actionHandlers WTF_GUARDED_BY_LOCK(m_actionHandlersLock);
     RefPtr<const Logger> m_logger;
     uint64_t m_logIdentifier { 0 };
 

--- a/Source/WebCore/Modules/mediasource/MediaSourceRegistry.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceRegistry.h
@@ -56,7 +56,7 @@ public:
 private:
     MediaSourceRegistry();
     MemoryCompactRobinHoodHashMap<String, std::pair<RefPtr<MediaSource>, ScriptExecutionContextIdentifier>> m_mediaSources;
-    UncheckedKeyHashMap<ScriptExecutionContextIdentifier, HashSet<String>> m_urlsPerContext;
+    HashMap<ScriptExecutionContextIdentifier, HashSet<String>> m_urlsPerContext;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -255,10 +255,10 @@ void RTCDataChannel::scheduleDispatchEvent(Ref<Event>&& event)
 }
 
 static Lock s_rtcDataChannelLocalMapLock;
-static UncheckedKeyHashMap<RTCDataChannelLocalIdentifier, std::unique_ptr<RTCDataChannelHandler>>& rtcDataChannelLocalMap() WTF_REQUIRES_LOCK(s_rtcDataChannelLocalMapLock)
+static HashMap<RTCDataChannelLocalIdentifier, std::unique_ptr<RTCDataChannelHandler>>& rtcDataChannelLocalMap() WTF_REQUIRES_LOCK(s_rtcDataChannelLocalMapLock)
 {
     ASSERT(s_rtcDataChannelLocalMapLock.isHeld());
-    static LazyNeverDestroyed<UncheckedKeyHashMap<RTCDataChannelLocalIdentifier, std::unique_ptr<RTCDataChannelHandler>>> map;
+    static LazyNeverDestroyed<HashMap<RTCDataChannelLocalIdentifier, std::unique_ptr<RTCDataChannelHandler>>> map;
     static std::once_flag onceKey;
     std::call_once(onceKey, [&] {
         map.construct();

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -180,13 +180,13 @@ private:
 
     String trackIdFromSDPMedia(const GstSDPMedia&);
 
-    UncheckedKeyHashMap<String, RealtimeMediaSource::Type> m_mediaForMid;
+    HashMap<String, RealtimeMediaSource::Type> m_mediaForMid;
 
     GStreamerPeerConnectionBackend& m_peerConnectionBackend;
     GRefPtr<GstElement> m_webrtcBin;
     GRefPtr<GstElement> m_pipeline;
 
-    UncheckedKeyHashMap<String, RefPtr<MediaStream>> m_remoteStreamsById;
+    HashMap<String, RefPtr<MediaStream>> m_remoteStreamsById;
 
     Ref<GStreamerStatsCollector> m_statsCollector;
 
@@ -202,11 +202,11 @@ private:
     UniqueRef<GStreamerDataChannelHandler> findOrCreateIncomingChannelHandler(GRefPtr<GstWebRTCDataChannel>&&);
 
     using DataChannelHandlerIdentifier = ObjectIdentifier<GstWebRTCDataChannel>;
-    UncheckedKeyHashMap<DataChannelHandlerIdentifier, UniqueRef<GStreamerDataChannelHandler>> m_incomingDataChannels;
+    HashMap<DataChannelHandlerIdentifier, UniqueRef<GStreamerDataChannelHandler>> m_incomingDataChannels;
 
     RefPtr<UniqueSSRCGenerator> m_ssrcGenerator;
 
-    UncheckedKeyHashMap<GRefPtr<GstWebRTCRTPTransceiver>, RefPtr<GStreamerIncomingTrackProcessor>> m_trackProcessors;
+    HashMap<GRefPtr<GstWebRTCRTPTransceiver>, RefPtr<GStreamerIncomingTrackProcessor>> m_trackProcessors;
 
     Vector<String> m_pendingIncomingMediaStreamIDs;
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -491,7 +491,7 @@ uint32_t UniqueSSRCGenerator::generateSSRC()
 
 std::optional<int> payloadTypeForEncodingName(StringView encodingName)
 {
-    static UncheckedKeyHashMap<String, int> staticPayloadTypes = {
+    static HashMap<String, int> staticPayloadTypes = {
         { "PCMU"_s, 0 },
         { "PCMA"_s, 8 },
         { "G722"_s, 9 },

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
@@ -198,7 +198,7 @@ private:
     SetRemoteSessionDescriptionObserver<LibWebRTCMediaEndpoint> m_setRemoteSessionDescriptionObserver;
 
     MemoryCompactRobinHoodHashMap<String, RefPtr<MediaStream>> m_remoteStreamsById;
-    UncheckedKeyHashMap<MediaStreamTrack*, Vector<String>> m_remoteStreamsFromRemoteTrack;
+    HashMap<MediaStreamTrack*, Vector<String>> m_remoteStreamsFromRemoteTrack;
 
     bool m_isInitiator { false };
     Timer m_statsLogTimer;

--- a/Source/WebCore/Modules/notifications/Notification.cpp
+++ b/Source/WebCore/Modules/notifications/Notification.cpp
@@ -60,9 +60,9 @@ namespace WebCore {
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(Notification);
 
 static Lock nonPersistentNotificationMapLock;
-static UncheckedKeyHashMap<WTF::UUID, Notification*>& nonPersistentNotificationMap() WTF_REQUIRES_LOCK(nonPersistentNotificationMapLock)
+static HashMap<WTF::UUID, Notification*>& nonPersistentNotificationMap() WTF_REQUIRES_LOCK(nonPersistentNotificationMapLock)
 {
-    static NeverDestroyed<UncheckedKeyHashMap<WTF::UUID, Notification*>> map;
+    static NeverDestroyed<HashMap<WTF::UUID, Notification*>> map;
     return map;
 }
 

--- a/Source/WebCore/Modules/permissions/PermissionStatus.cpp
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.cpp
@@ -48,9 +48,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(PermissionStatus);
 
-static UncheckedKeyHashMap<MainThreadPermissionObserverIdentifier, std::unique_ptr<MainThreadPermissionObserver>>& allMainThreadPermissionObservers()
+static HashMap<MainThreadPermissionObserverIdentifier, std::unique_ptr<MainThreadPermissionObserver>>& allMainThreadPermissionObservers()
 {
-    static MainThreadNeverDestroyed<UncheckedKeyHashMap<MainThreadPermissionObserverIdentifier, std::unique_ptr<MainThreadPermissionObserver>>> map;
+    static MainThreadNeverDestroyed<HashMap<MainThreadPermissionObserverIdentifier, std::unique_ptr<MainThreadPermissionObserver>>> map;
     return map;
 }
 

--- a/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
+++ b/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
@@ -110,9 +110,9 @@ static URL createYouTubeURL(StringView videoID, StringView timeID)
     return URL(URL(), makeString("youtube:"_s, videoID, timeID.isEmpty() ? ""_s : "t="_s, timeID));
 }
 
-static UncheckedKeyHashMap<String, String> queryKeysAndValues(StringView queryString)
+static HashMap<String, String> queryKeysAndValues(StringView queryString)
 {
-    UncheckedKeyHashMap<String, String> queryDictionary;
+    HashMap<String, String> queryDictionary;
     
     size_t queryLength = queryString.length();
     if (!queryLength)
@@ -182,7 +182,7 @@ static bool isYouTubeURL(const URL& url)
         || equalLettersIgnoringASCIICase(hostName, "youtube-nocookie.com"_s);
 }
 
-static const String& valueForKey(const UncheckedKeyHashMap<String, String>& dictionary, const String& key)
+static const String& valueForKey(const HashMap<String, String>& dictionary, const String& key)
 {
     const auto& value = dictionary.find(key);
     if (value == dictionary.end())

--- a/Source/WebCore/Modules/plugins/YouTubePluginReplacement.h
+++ b/Source/WebCore/Modules/plugins/YouTubePluginReplacement.h
@@ -60,7 +60,7 @@ private:
 
     WeakPtr<HTMLPlugInElement, WeakPtrImplWithEventTargetData> m_parentElement;
     RefPtr<YouTubeEmbedShadowElement> m_embedShadowElement;
-    UncheckedKeyHashMap<AtomString, AtomString> m_attributes;
+    HashMap<AtomString, AtomString> m_attributes;
 };
 
 }

--- a/Source/WebCore/Modules/push-api/PushDatabase.h
+++ b/Source/WebCore/Modules/push-api/PushDatabase.h
@@ -125,7 +125,7 @@ private:
 
     Ref<WorkQueue> m_queue;
     UniqueRef<WebCore::SQLiteDatabase> m_db;
-    UncheckedKeyHashMap<ASCIILiteral, UniqueRef<WebCore::SQLiteStatement>> m_statements;
+    HashMap<ASCIILiteral, UniqueRef<WebCore::SQLiteStatement>> m_statements;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
@@ -107,7 +107,7 @@ private:
     WeakPtr<HTMLMediaElement> m_mediaElement;
     uint32_t m_nextId { 0 };
 
-    using CallbackMap = UncheckedKeyHashMap<int32_t, Ref<RemotePlaybackAvailabilityCallback>>;
+    using CallbackMap = HashMap<int32_t, Ref<RemotePlaybackAvailabilityCallback>>;
     CallbackMap m_callbackMap;
 
     using PromiseVector = Vector<Ref<DeferredPromise>>;

--- a/Source/WebCore/Modules/reporting/ReportingScope.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingScope.cpp
@@ -129,7 +129,7 @@ void ReportingScope::parseReportingEndpoints(const String& headerValue, const UR
 }
 
 // https://w3c.github.io/reporting/#process-header
-// FIXME: The value in the UncheckedKeyHashMap should probably be a URL, not a String.
+// FIXME: The value in the HashMap should probably be a URL, not a String.
 MemoryCompactRobinHoodHashMap<String, String> ReportingScope::parseReportingEndpointsFromHeader(const String& headerValue, const URL& baseURL)
 {
     MemoryCompactRobinHoodHashMap<String, String> reportingEndpoints;

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h
@@ -57,7 +57,7 @@ private:
     void visibilityStateChanged() final;
 
     Document& m_document;
-    UncheckedKeyHashMap<WakeLockType, Vector<RefPtr<WakeLockSentinel>>, WTF::IntHash<WakeLockType>, WTF::StrongEnumHashTraits<WakeLockType>> m_wakeLocks;
+    HashMap<WakeLockType, Vector<RefPtr<WakeLockSentinel>>, WTF::IntHash<WakeLockType>, WTF::StrongEnumHashTraits<WakeLockType>> m_wakeLocks;
     std::unique_ptr<SleepDisabler> m_screenLockDisabler;
 };
 

--- a/Source/WebCore/Modules/storage/WorkerStorageConnection.h
+++ b/Source/WebCore/Modules/storage/WorkerStorageConnection.h
@@ -52,9 +52,9 @@ private:
 
     WeakPtr<WorkerGlobalScope, WeakPtrImplWithEventTargetData> m_scope;
     uint64_t m_lastCallbackIdentifier { 0 };
-    UncheckedKeyHashMap<uint64_t, StorageConnection::PersistCallback> m_getPersistedCallbacks;
-    UncheckedKeyHashMap<uint64_t, StorageConnection::GetEstimateCallback> m_getEstimateCallbacks;
-    UncheckedKeyHashMap<uint64_t, StorageConnection::GetDirectoryCallback> m_getDirectoryCallbacks;
+    HashMap<uint64_t, StorageConnection::PersistCallback> m_getPersistedCallbacks;
+    HashMap<uint64_t, StorageConnection::GetEstimateCallback> m_getEstimateCallbacks;
+    HashMap<uint64_t, StorageConnection::GetDirectoryCallback> m_getDirectoryCallbacks;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/web-locks/WebLockManager.h
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.h
@@ -78,10 +78,10 @@ private:
     class MainThreadBridge;
     RefPtr<MainThreadBridge> m_mainThreadBridge;
 
-    UncheckedKeyHashMap<WebLockIdentifier, RefPtr<DeferredPromise>> m_releasePromises;
+    HashMap<WebLockIdentifier, RefPtr<DeferredPromise>> m_releasePromises;
 
     struct LockRequest;
-    UncheckedKeyHashMap<WebLockIdentifier, LockRequest> m_pendingRequests;
+    HashMap<WebLockIdentifier, LockRequest> m_pendingRequests;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/web-locks/WebLockRegistry.h
+++ b/Source/WebCore/Modules/web-locks/WebLockRegistry.h
@@ -77,7 +77,7 @@ private:
     Ref<PerOriginRegistry> ensureRegistryForOrigin(PAL::SessionID, const ClientOrigin&);
     RefPtr<PerOriginRegistry> existingRegistryForOrigin(PAL::SessionID, const ClientOrigin&) const;
 
-    UncheckedKeyHashMap<std::pair<PAL::SessionID, ClientOrigin>, WeakPtr<PerOriginRegistry>> m_perOriginRegistries;
+    HashMap<std::pair<PAL::SessionID, ClientOrigin>, WeakPtr<PerOriginRegistry>> m_perOriginRegistries;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
+++ b/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
@@ -142,7 +142,7 @@ private:
     // If m_isInPlace is true, use m_inPlaceBus as the valid AudioBus; If false, use the default m_internalBus.
     bool m_isInPlace { false };
 
-    using InputsMap = UncheckedKeyHashMap<AudioNodeInput*, AudioConnectionRefPtr<AudioNode>>;
+    using InputsMap = HashMap<AudioNodeInput*, AudioConnectionRefPtr<AudioNode>>;
     InputsMap m_inputs;
     typedef InputsMap::iterator InputsIterator;
     bool m_isEnabled { true };

--- a/Source/WebCore/Modules/webaudio/AudioParamMap.h
+++ b/Source/WebCore/Modules/webaudio/AudioParamMap.h
@@ -48,12 +48,12 @@ public:
     void initializeMapLike(DOMMapAdapter&);
     void add(const String&, Ref<AudioParam>&&);
 
-    const UncheckedKeyHashMap<String, Ref<AudioParam>>& map() const { return m_map; }
+    const HashMap<String, Ref<AudioParam>>& map() const { return m_map; }
 
 private:
     AudioParamMap();
 
-    UncheckedKeyHashMap<String, Ref<AudioParam>> m_map;
+    HashMap<String, Ref<AudioParam>> m_map;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.h
@@ -70,7 +70,7 @@ private:
 
     UniqueRef<OfflineAudioDestinationNode> m_destinationNode;
     RefPtr<DeferredPromise> m_pendingRenderingPromise;
-    UncheckedKeyHashMap<unsigned /* frame */, RefPtr<DeferredPromise>, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> m_suspendRequests;
+    HashMap<unsigned /* frame */, RefPtr<DeferredPromise>, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> m_suspendRequests;
     unsigned m_length;
     bool m_didStartRendering { false };
 };

--- a/Source/WebCore/Modules/webdatabase/Database.cpp
+++ b/Source/WebCore/Modules/webdatabase/Database.cpp
@@ -153,9 +153,9 @@ static bool retrieveTextResultFromDatabase(SQLiteDatabase& db, StringView query,
 // FIXME: move all guid-related functions to a DatabaseVersionTracker class.
 static Lock guidLock;
 
-static UncheckedKeyHashMap<DatabaseGUID, String>& guidToVersionMap() WTF_REQUIRES_LOCK(guidLock)
+static HashMap<DatabaseGUID, String>& guidToVersionMap() WTF_REQUIRES_LOCK(guidLock)
 {
-    static NeverDestroyed<UncheckedKeyHashMap<DatabaseGUID, String>> map;
+    static NeverDestroyed<HashMap<DatabaseGUID, String>> map;
     return map;
 }
 
@@ -171,9 +171,9 @@ static inline void updateGUIDVersionMap(DatabaseGUID guid, const String& newVers
     guidToVersionMap().set(guid, newVersion.isEmpty() ? String() : newVersion.isolatedCopy());
 }
 
-static UncheckedKeyHashMap<DatabaseGUID, HashSet<Database*>>& guidToDatabaseMap() WTF_REQUIRES_LOCK(guidLock)
+static HashMap<DatabaseGUID, HashSet<Database*>>& guidToDatabaseMap() WTF_REQUIRES_LOCK(guidLock)
 {
-    static NeverDestroyed<UncheckedKeyHashMap<DatabaseGUID, HashSet<Database*>>> map;
+    static NeverDestroyed<HashMap<DatabaseGUID, HashSet<Database*>>> map;
     return map;
 }
 

--- a/Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp
@@ -939,7 +939,7 @@ void DatabaseTracker::recordCreatingDatabase(const SecurityOriginData& origin, c
 {
     ASSERT(m_databaseGuard.isHeld());
 
-    // We don't use UncheckedKeyHashMap::ensure here to avoid making an isolated copy of the origin every time.
+    // We don't use HashMap::ensure here to avoid making an isolated copy of the origin every time.
     auto it = m_beingCreated.find(origin);
     if (it == m_beingCreated.end())
         it = m_beingCreated.add(origin.isolatedCopy(), HashCountedSet<String>()).iterator;
@@ -982,7 +982,7 @@ void DatabaseTracker::recordDeletingDatabase(const SecurityOriginData& origin, c
     ASSERT(m_databaseGuard.isHeld());
     ASSERT(canDeleteDatabase(origin, name));
 
-    // We don't use UncheckedKeyHashMap::ensure here to avoid making an isolated copy of the origin every time.
+    // We don't use HashMap::ensure here to avoid making an isolated copy of the origin every time.
     auto it = m_beingDeleted.find(origin);
     if (it == m_beingDeleted.end())
         it = m_beingDeleted.add(origin.isolatedCopy(), MemoryCompactRobinHoodHashSet<String>()).iterator;

--- a/Source/WebCore/Modules/webdatabase/DatabaseTracker.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTracker.h
@@ -161,8 +161,8 @@ private:
     void deleteOriginLockFor(const SecurityOriginData&) WTF_REQUIRES_LOCK(m_databaseGuard);
 
     using DatabaseSet = HashSet<Database*>;
-    using DatabaseNameMap = UncheckedKeyHashMap<String, DatabaseSet*>;
-    using DatabaseOriginMap = UncheckedKeyHashMap<SecurityOriginData, DatabaseNameMap*>;
+    using DatabaseNameMap = HashMap<String, DatabaseSet*>;
+    using DatabaseOriginMap = HashMap<SecurityOriginData, DatabaseNameMap*>;
 
     Lock m_openDatabaseMapGuard;
     mutable std::unique_ptr<DatabaseOriginMap> m_openDatabaseMap WTF_GUARDED_BY_LOCK(m_openDatabaseMapGuard);
@@ -171,15 +171,15 @@ private:
     Lock m_databaseGuard;
     SQLiteDatabase m_database WTF_GUARDED_BY_LOCK(m_databaseGuard);
 
-    using OriginLockMap = UncheckedKeyHashMap<String, Ref<OriginLock>>;
+    using OriginLockMap = HashMap<String, Ref<OriginLock>>;
     OriginLockMap m_originLockMap WTF_GUARDED_BY_LOCK(m_databaseGuard);
 
     String m_databaseDirectoryPath;
 
     DatabaseManagerClient* m_client { nullptr };
 
-    UncheckedKeyHashMap<SecurityOriginData, HashCountedSet<String>> m_beingCreated WTF_GUARDED_BY_LOCK(m_databaseGuard);
-    UncheckedKeyHashMap<SecurityOriginData, MemoryCompactRobinHoodHashSet<String>> m_beingDeleted WTF_GUARDED_BY_LOCK(m_databaseGuard);
+    HashMap<SecurityOriginData, HashCountedSet<String>> m_beingCreated WTF_GUARDED_BY_LOCK(m_databaseGuard);
+    HashMap<SecurityOriginData, MemoryCompactRobinHoodHashSet<String>> m_beingDeleted WTF_GUARDED_BY_LOCK(m_databaseGuard);
     HashSet<SecurityOriginData> m_originsBeingDeleted WTF_GUARDED_BY_LOCK(m_databaseGuard);
     bool isDeletingDatabaseOrOriginFor(const SecurityOriginData&, const String& name) WTF_REQUIRES_LOCK(m_databaseGuard);
     void recordCreatingDatabase(const SecurityOriginData&, const String& name) WTF_REQUIRES_LOCK(m_databaseGuard);

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionCoordinator.h
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionCoordinator.h
@@ -58,7 +58,7 @@ private:
         RefPtr<SQLTransaction> activeWriteTransaction;
     };
     // Maps database names to information about pending transactions
-    typedef UncheckedKeyHashMap<String, CoordinationInfo> CoordinationInfoMap;
+    typedef HashMap<String, CoordinationInfo> CoordinationInfoMap;
     CoordinationInfoMap m_coordinationInfoMap;
     bool m_isShuttingDown;
 

--- a/Source/WebCore/Modules/websockets/WebSocketDeflateFramer.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketDeflateFramer.cpp
@@ -47,7 +47,7 @@ public:
 
 private:
     String handshakeString() final;
-    bool processResponse(const UncheckedKeyHashMap<String, String>&) final;
+    bool processResponse(const HashMap<String, String>&) final;
     String failureReason() final { return m_failureReason; }
 
     WebSocketDeflateFramer& m_framer;
@@ -69,7 +69,7 @@ String WebSocketExtensionDeflateFrame::handshakeString()
     return extensionToken(); // No parameter
 }
 
-bool WebSocketExtensionDeflateFrame::processResponse(const UncheckedKeyHashMap<String, String>& serverParameters)
+bool WebSocketExtensionDeflateFrame::processResponse(const HashMap<String, String>& serverParameters)
 {
     if (m_responseProcessed) {
         m_failureReason = "Received duplicate deflate-frame response"_s;

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp
@@ -68,7 +68,7 @@ const String WebSocketExtensionDispatcher::createHeaderValue() const
     return makeString(interleave(m_processors, [](auto& processor) { return processor->handshakeString(); }, ", "_s));
 }
 
-void WebSocketExtensionDispatcher::appendAcceptedExtension(const String& extensionToken, UncheckedKeyHashMap<String, String>& extensionParameters)
+void WebSocketExtensionDispatcher::appendAcceptedExtension(const String& extensionToken, HashMap<String, String>& extensionParameters)
 {
     m_acceptedExtensionsBuilder.append(m_acceptedExtensionsBuilder.isEmpty() ? ""_s : ", "_s, extensionToken);
     // FIXME: Should use ListHashSet to keep the order of the parameters.
@@ -100,7 +100,7 @@ bool WebSocketExtensionDispatcher::processHeaderValue(const String& headerValue)
     WebSocketExtensionParser parser(headerValueData.data(), headerValueData.data() + headerValueData.length());
     while (!parser.finished()) {
         String extensionToken;
-        UncheckedKeyHashMap<String, String> extensionParameters;
+        HashMap<String, String> extensionParameters;
         if (!parser.parseExtension(extensionToken, extensionParameters)) {
             fail("Sec-WebSocket-Extensions header is invalid"_s);
             return false;

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.h
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.h
@@ -50,7 +50,7 @@ public:
     String failureReason() const;
 
 private:
-    void appendAcceptedExtension(const String& extensionToken, UncheckedKeyHashMap<String, String>& extensionParameters);
+    void appendAcceptedExtension(const String& extensionToken, HashMap<String, String>& extensionParameters);
     void fail(const String& reason);
 
     Vector<std::unique_ptr<WebSocketExtensionProcessor>> m_processors;

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp
@@ -115,7 +115,7 @@ bool WebSocketExtensionParser::consumeCharacter(char character)
     return false;
 }
 
-bool WebSocketExtensionParser::parseExtension(String& extensionToken, UncheckedKeyHashMap<String, String>& extensionParameters)
+bool WebSocketExtensionParser::parseExtension(String& extensionToken, HashMap<String, String>& extensionParameters)
 {
     // Parse extension-token.
     if (!consumeToken())

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionParser.h
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionParser.h
@@ -45,7 +45,7 @@ public:
     }
     bool finished();
     bool parsedSuccessfully();
-    bool parseExtension(String& extensionToken, UncheckedKeyHashMap<String, String>& parameters);
+    bool parseExtension(String& extensionToken, HashMap<String, String>& parameters);
 
 private:
     const String& currentToken() { return m_currentToken; }

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionProcessor.h
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionProcessor.h
@@ -47,10 +47,10 @@ public:
     virtual String handshakeString() = 0;
 
     // This should validate the server's response parameters which are passed
-    // as UncheckedKeyHashMap<key, value>. This may also do something for the extension.
+    // as HashMap<key, value>. This may also do something for the extension.
     // Note that this method may be called more than once when the server
     // response contains duplicate extension token that matches extensionToken().
-    virtual bool processResponse(const UncheckedKeyHashMap<String, String>&) = 0;
+    virtual bool processResponse(const HashMap<String, String>&) = 0;
 
     // If procecssResponse() returns false, this should provide the reason.
     virtual String failureReason() { return makeString("Extension "_s, m_extensionToken, " failed"_s); }


### PR DESCRIPTION
#### 898fa3cab89cb8fb95c8464c4159c6ad6e38c06d
<pre>
Use HashMap instead of UncheckedKeyHashMap in WebCore/Modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=282633">https://bugs.webkit.org/show_bug.cgi?id=282633</a>

Reviewed by Darin Adler.

Use HashMap instead of UncheckedKeyHashMap in WebCore/Modules, for
extra safety. This code is not performance sensitive.

* Source/WebCore/Modules/cache/CacheStorageConnection.h:
* Source/WebCore/Modules/cookie-store/CookieStore.h:
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::parseParameters):
* Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h:
* Source/WebCore/Modules/geolocation/Geolocation.h:
* Source/WebCore/Modules/highlight/HighlightRegistry.h:
(WebCore::HighlightRegistry::map const):
* Source/WebCore/Modules/indexeddb/IDBDatabase.h:
* Source/WebCore/Modules/indexeddb/IDBObjectStore.h:
* Source/WebCore/Modules/indexeddb/IDBTransaction.h:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp:
(WebCore::IDBClient::removeItemsMatchingCurrentThread):
(WebCore::IDBClient::setMatchingItemsContextSuspended):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h:
* Source/WebCore/Modules/indexeddb/server/IDBServer.h:
* Source/WebCore/Modules/indexeddb/server/IndexValueStore.h:
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h:
* Source/WebCore/Modules/indexeddb/server/MemoryCursor.cpp:
* Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h:
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.h:
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h:
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::migrateIndexInfoTableForIDUpdate):
(WebCore::IDBServer::SQLiteIDBBackingStore::migrateIndexRecordsTableForIDUpdate):
(WebCore::IDBServer::SQLiteIDBBackingStore::handleDuplicateIndexIDs):
(WebCore::IDBServer::SQLiteIDBBackingStore::extractExistingDatabaseInfo):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h:
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h:
* Source/WebCore/Modules/indexeddb/shared/IndexKey.h:
* Source/WebCore/Modules/mediacapabilities/MediaCapabilities.h:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::showMediaControlsContextMenu):
* Source/WebCore/Modules/mediasession/MediaSession.h:
* Source/WebCore/Modules/mediasource/MediaSourceRegistry.h:
* Source/WebCore/Modules/mediastream/RTCDataChannel.cpp:
(WebCore::WTF_REQUIRES_LOCK):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::payloadTypeForEncodingName):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h:
* Source/WebCore/Modules/notifications/Notification.cpp:
* Source/WebCore/Modules/permissions/PermissionStatus.cpp:
(WebCore::allMainThreadPermissionObservers):
* Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp:
(WebCore::queryKeysAndValues):
(WebCore::valueForKey):
* Source/WebCore/Modules/plugins/YouTubePluginReplacement.h:
* Source/WebCore/Modules/push-api/PushDatabase.h:
* Source/WebCore/Modules/remoteplayback/RemotePlayback.h:
* Source/WebCore/Modules/reporting/ReportingScope.cpp:
* Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h:
* Source/WebCore/Modules/storage/WorkerStorageConnection.h:
* Source/WebCore/Modules/web-locks/WebLockManager.h:
* Source/WebCore/Modules/web-locks/WebLockRegistry.h:
* Source/WebCore/Modules/webaudio/AudioNodeOutput.h:
* Source/WebCore/Modules/webaudio/AudioParamMap.h:
(WebCore::AudioParamMap::map const):
* Source/WebCore/Modules/webaudio/OfflineAudioContext.h:
* Source/WebCore/Modules/webdatabase/Database.cpp:
(WebCore::WTF_REQUIRES_LOCK):
* Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp:
(WebCore::DatabaseTracker::recordCreatingDatabase):
(WebCore::DatabaseTracker::recordDeletingDatabase):
* Source/WebCore/Modules/webdatabase/DatabaseTracker.h:
* Source/WebCore/Modules/webdatabase/SQLTransactionCoordinator.h:
* Source/WebCore/Modules/websockets/WebSocketDeflateFramer.cpp:
(WebCore::WebSocketExtensionDeflateFrame::processResponse):
* Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp:
(WebCore::WebSocketExtensionDispatcher::appendAcceptedExtension):
(WebCore::WebSocketExtensionDispatcher::processHeaderValue):
* Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.h:
* Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp:
(WebCore::WebSocketExtensionParser::parseExtension):
* Source/WebCore/Modules/websockets/WebSocketExtensionParser.h:
* Source/WebCore/Modules/websockets/WebSocketExtensionProcessor.h:

Canonical link: <a href="https://commits.webkit.org/286187@main">https://commits.webkit.org/286187@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92cb40541bde9dcbff34714753d17c6f990ac698

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79530 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26338 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77198 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2301 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58953 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17203 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49103 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39324 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22002 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24661 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67564 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22342 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81009 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2406 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67209 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2556 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64510 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66493 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10429 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11590 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2369 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2394 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3326 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2409 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->