### PR TITLE
[JSC] Wasm TailCall should say "pinned registers can be clobbered" in OMG

### DIFF
--- a/JSTests/wasm/stress/omg-tail-call-clobber-pinned-registers.js
+++ b/JSTests/wasm/stress/omg-tail-call-clobber-pinned-registers.js
@@ -1,0 +1,4032 @@
+//@ runDefault("--useDollarVM=1", "--jitPolicyScale=0.1")
+function instantiate(moduleBase64, importObject) {
+    let bytes = Uint8Array.fromBase64(moduleBase64);
+    return WebAssembly.instantiate(bytes, importObject);
+  }
+  const log = function (msg) { };
+  const report = $.agent.report;
+  const isJIT = callerIsBBQOrOMGCompiled;
+const extra = {isJIT};
+(async function () {
+/**
+@returns {I32}
+ */
+let fn0 = function () {
+
+return 85;
+};
+/**
+@returns {void}
+ */
+let fn1 = function () {
+};
+/**
+@returns {[I32, F32, FuncRef]}
+ */
+let fn2 = function () {
+
+return [12, 3.8201190663768596e40, null];
+};
+/**
+@returns {void}
+ */
+let fn3 = function () {
+};
+/**
+@returns {void}
+ */
+let fn4 = function () {
+};
+/**
+@returns {void}
+ */
+let fn5 = function () {
+};
+/**
+@returns {void}
+ */
+let fn6 = function () {
+};
+/**
+@returns {void}
+ */
+let fn7 = function () {
+};
+/**
+@returns {I32}
+ */
+let fn8 = function () {
+
+return 6;
+};
+let tag0 = new WebAssembly.Tag({parameters: []});
+let global0 = new WebAssembly.Global({value: 'i64', mutable: true}, 2880611662n);
+let m0 = {fn0, fn2, fn5, fn7, fn8, tag5: tag0};
+let m2 = {fn1, fn3, fn6, global0, tag1: tag0, tag2: tag0, tag4: tag0};
+let m1 = {fn4, tag0, tag3: tag0, tag6: tag0};
+let importObject0 = /** @type {Imports2} */ ({extra, m0, m1, m2});
+let i0 = await instantiate('AGFzbQEAAAABMAdgAAF/YAV/e317fQJ+fWAFf3t9e30Ff3t9e31gBX97fXt9AGAAA399cGAAAGAAAAK7ARICbTADZm4wAAACbTIDZm4xAAUCbTADZm4yAAQCbTIDZm4zAAUCbTEDZm40AAUCbTADZm41AAUCbTIDZm42AAUCbTADZm43AAYCbTADZm44AAAFZXh0cmEFaXNKSVQAAAJtMQR0YWcwBAAFAm0yBHRhZzEEAAYCbTIEdGFnMgQABQJtMQR0YWczBAAGAm0yBHRhZzQEAAYCbTAEdGFnNQQABQJtMQR0YWc2BAAGAm0yB2dsb2JhbDADfgEDAgEGBBcGbwBScABFbwFS4wZwAEJvAUOPA28AKwUGAQOxH/o1DQMBAAUGcAx8AUTSEtihRfjL4Qt7Af0MZVyVM3bkzBQzb6lpqv4ffwtvAdBvC3AB0gMLcAHSCQt9AEMlg2NaC3wBRB7fkCdqwiCTC30BQx+/gdoLfAFEa+y2v9axOssLbwHQbwtwAdIGC34AQrOx64vx2NCJfgsHyQEVA2ZuOQAEBnRhYmxlMwEDB2dsb2JhbDgDCAhnbG9iYWwxMQMLB2dsb2JhbDIDAgZ0YWJsZTABAAZ0YWJsZTQBBAZ0YWJsZTUBBQdtZW1vcnkwAgAIZ2xvYmFsMTADCgdnbG9iYWwzAwMHZ2xvYmFsNgMGCGdsb2JhbDEyAwwEZm4xMAAKB2dsb2JhbDcDBwdnbG9iYWw1AwUGdGFibGUyAQIGdGFibGUxAQEHZ2xvYmFsOQMJB2dsb2JhbDEDAQdnbG9iYWw0AwQJwgMGBXBV0gML0gML0gEL0gcL0gcL0gUL0gML0gAL0gQL0gQL0goL0gIL0gUL0gIL0gML0gIL0gEL0gEL0gAL0gAL0gEL0gYL0gQL0gEL0gQL0gEL0gkL0gQL0gEL0gML0gAL0goL0gUL0gUL0gkL0gYL0ggL0gAL0gYL0gEL0gEL0gkL0gIL0gUL0ggL0gAL0gYL0gIL0gAL0gAL0goL0gAL0gQL0gAL0gYL0ggL0goL0goL0gYL0gIL0gkL0gQL0ggL0goL0gEL0gkL0gUL0gUL0gIL0gAL0gQL0gcL0gML0gUL0gUL0gAL0gAL0gkL0gYL0gEL0goL0gIL0gAL0gML0goLB3Ar0gAL0gML0goL0gQL0gUL0gcL0goL0gQL0gYL0gEL0gcL0goL0gcL0gUL0gkL0gIL0gQL0gQL0gcL0goL0gAL0gML0gcL0ggL0gcL0ggL0gQL0gAL0gYL0ggL0gkL0gcL0gIL0gIL0gIL0gAL0gcL0gcL0gcL0gIL0ggL0gIL0gELAwAYBgMFCQEABQcICAcIBQcIAAEAAgQFAgYIAgNBNwsAAwAICQIBQTILAAcBAwQFBgcKAgNBGAsAAQIMAQEKRQFDBAN/AX4BfQF8IwckCQYADAELDQAjCwJ+IwwMAAALUCMGi9IEBn0PC5GPuyQJQtjS7ol+JABChQH8EAJBAXAOAQAACwsDAQEA', importObject0);
+let {fn9, fn10, global1, global2, global3, global4, global5, global6, global7, global8, global9, global10, global11, global12, memory0, table0, table1, table2, table3, table4, table5} = /**
+  @type {{
+fn9: () => void,
+fn10: () => void,
+global1: WebAssembly.Global,
+global2: WebAssembly.Global,
+global3: WebAssembly.Global,
+global4: WebAssembly.Global,
+global5: WebAssembly.Global,
+global6: WebAssembly.Global,
+global7: WebAssembly.Global,
+global8: WebAssembly.Global,
+global9: WebAssembly.Global,
+global10: WebAssembly.Global,
+global11: WebAssembly.Global,
+global12: WebAssembly.Global,
+memory0: WebAssembly.Memory,
+table0: WebAssembly.Table,
+table1: WebAssembly.Table,
+table2: WebAssembly.Table,
+table3: WebAssembly.Table,
+table4: WebAssembly.Table,
+table5: WebAssembly.Table
+  }} */ (i0.instance.exports);
+table0.set(18, table4);
+table2.set(39, table5);
+table0.set(53, table4);
+table0.set(61, table5);
+table4.set(17, table4);
+table5.set(26, table5);
+table4.set(11, table5);
+table0.set(32, table2);
+table0.set(33, table0);
+table0.set(13, table5);
+table4.set(46, table0);
+table5.set(6, table4);
+table5.set(2, table5);
+table2.set(27, table0);
+table5.set(17, table4);
+table4.set(21, table5);
+table4.set(46, table5);
+table5.set(7, table5);
+global8.value = 0;
+log('calling fn9');
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn9();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn10');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn10();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+/**
+@param {FuncRef} a0
+@returns {FuncRef}
+ */
+let fn11 = function (a0) {
+a0?.toString();
+return a0;
+};
+/**
+@param {FuncRef} a0
+@returns {void}
+ */
+let fn12 = function (a0) {
+a0?.toString();
+};
+/**
+@param {FuncRef} a0
+@returns {void}
+ */
+let fn13 = function (a0) {
+a0?.toString();
+};
+/**
+@param {FuncRef} a0
+@returns {void}
+ */
+let fn14 = function (a0) {
+a0?.toString();
+};
+/**
+@param {FuncRef} a0
+@returns {void}
+ */
+let fn15 = function (a0) {
+a0?.toString();
+};
+let tag13 = new WebAssembly.Tag({parameters: ['anyfunc']});
+let global13 = new WebAssembly.Global({value: 'anyfunc', mutable: true}, global11.value);
+let m4 = {fn14, fn15, global14: global0, memory1: memory0, table8: table5, tag18: tag13, tag19: tag13};
+let m5 = {fn11, fn12, global13, global15: global9, global16: global2, table6: table0, table7: table5, tag13, tag14: tag13, tag15: tag13, tag16: tag13, tag17: tag13};
+let m3 = {fn13};
+let importObject1 = /** @type {Imports2} */ ({m3, m4, m5});
+let i1 = await instantiate('AGFzbQEAAAABMwlgAXsCfHxgAXsBe2ABewBgAXABe2ABcAFwYAFwAGADe31/AGADe31/A3t9f2ADe31/AAL+ARQCbTQHbWVtb3J5MQIDsR/6NQJtNQRmbjExAAQCbTUEZm4xMgAFAm0zBGZuMTMABQJtNARmbjE0AAUCbTQEZm4xNQAFAm01BXRhZzEzBAAFAm01BXRhZzE0BAAFAm01BXRhZzE1BAAFAm01BXRhZzE2BAAFAm01BXRhZzE3BAAFAm00BXRhZzE4BAAFAm00BXRhZzE5BAAFAm01CGdsb2JhbDEzA3ABAm00CGdsb2JhbDE0A34BAm01CGdsb2JhbDE1A3wBAm01CGdsb2JhbDE2A3sBAm01BnRhYmxlNgFvAB4CbTUGdGFibGU3AW8AKQJtNAZ0YWJsZTgBbwAcAwIBBwQaBm8BNNkEcAEK0QRvAD9wAU/JBW8BYGBwABYNHQ4ABgAGAAIABgAIAAUABgAIAAUAAgACAAgABQAGBoABC28B0G8LfwFBDgt+AULVjOyy6gILewH9DDV/BPRShpRSi+/Fbh4+FBILfwFBAgt/AUGlppU1C3AB0gILewH9DEotPXX1Gwuk6Tisqz7PlFsLewH9DLcpR8depwVFRLP2K9xHG10LewH9DPghiclNbmE/Czd0vUU9WDoLcAHSAAsH7QEYCGdsb2JhbDE4AwQEdGFnNwQBBHRhZzgECAV0YWcxMAQKB3RhYmxlMTEBBAV0YWcxMQQMBHRhZzkECQV0YWcxMgQNCGdsb2JhbDIxAwcIZ2xvYmFsMjADBghnbG9iYWwyNwMNCGdsb2JhbDI0AwoHdGFibGUxMwEICGdsb2JhbDI1AwsHdGFibGUxMAEDCGdsb2JhbDI2AwwHdGFibGUxMgEFCGdsb2JhbDIzAwkIZ2xvYmFsMTkDBQhnbG9iYWwxNwMACGdsb2JhbDI4Aw4GdGFibGU5AQIIZ2xvYmFsMjIDCAdtZW1vcnkyAgAJvwMJBgZBNQtwGNIFC9IEC9IEC9IAC9IAC9IBC9IDC9IBC9IBC9IEC9ICC9IFC9IDC9IBC9IBC9IBC9IBC9IEC9IEC9IBC9IDC9IAC9IEC9IDCwEAJQADBAIDAQIBBAIEAAECAQADBAQBAAQAAgQEAgMCBQMFAAEBAQICBEEFCwAFAwUBBQQCBEEJCwABBQdwDdICC9IFC9IDC9IAC9IDC9IEC9IEC9IDC9ICC9IAC9IFC9IDC9IDCwVwS9IDC9IAC9IEC9ICC9ICC9IEC9IEC9ICC9ICC9IFC9IDC9IDC9ICC9IAC9IDC9IAC9IDC9IAC9IFC9IDC9IEC9IDC9IDC9IBC9IFC9IAC9IEC9IDC9IDC9IAC9ICC9IAC9ICC9IBC9IBC9IBC9IFC9IEC9IEC9ICC9IDC9IEC9ICC9IDC9IDC9IFC9IDC9IAC9ICC9IFC9IAC9IFC9ICC9IDC9IEC9IBC9IBC9ICC9ICC9IAC9IEC9IAC9ICC9IFC9IBC9IEC9IAC9ICC9IAC9IEC9IBC9IFC9IAC9IAC9IFCwYIQQULcAHSAAsGBkEbC3AE0gEL0gIL0gML0gQLAgZBIAsAAQUMAQQKnjUBmzULAnABfgFwAHsBfgF7AH0DfwF+AX0BfEHrANIB0gT9DGpafoFgMnXbcOJ/b9QrJ08jAiMDIAJByLABQSZB2MoA/AsA/Wz9+wEgBSAC/QzWo+hLltjGACPbaszMZa0GBgDSAPwQB0H//wNx/QkARQMBBgAkDAZvIwP9HQH9EgMBBgICf9IDBntBCkEoQQj8DAUIQcySLEH//wNx/QQBkgICAAYCQ9IBdRFDzGJ6hSMMJA2Y/AFCzsa11qKn04R/eQZ80gIgAfwAQQJwBH8Cfv0MBkeD1LFerIKcjVQZsKT8eAIAIwokCiQNDAgACwALAAUjCiQOBm8MAwELDAgACyICQQJwBH4DfyALQQFqIgtBF0kEQAwBCwwHAAsABfwQA0ECcAR/Q2kEnn9CtqOujRIMAQAF0gICbwwIAAsACw0CDAILIgcjDQICDAQACwZ8IwMiCCQM0gAGewwDAAEBAAsMBAALJALSBULzl5rZ3H5DRQr8Qv0MDFD2Bg8FRVPZAvI27w8htgIBIQgMAgALIA1DAACAP5IiDUMAAIA/XQ0G0gFDQMaskSIBIgEiAQZ9/QyBtxoGvcELXhIKtBRCr1jTAwAgDUMAAIA/kiINQwAAcEFdDQsjB/1HDAUACwwBCyEBjLwMBAskAiEFQQJwDgYEBAQEAAQECwwDAAtEbVeqf5XYtwJBEAwBCyAKQQFqIgpBL0kNAv3tAQIA/eEBAn/9DL7gN3P3A8DD8/iyQ3K0f7QCewwEAAsACwALDAYBCwJ/QyyM7bfSAf0MdEAEAmBJKLSnA7sjZnOyQyAJQQFqIglBJUkEAQwDCyANQwAAgD+SIg1DAAAEQl0EAQwDCyAKQQFqIgpBAUkEAQwDC0EBQQFwDgEBAQsNAEEBcA4BAAAAC9IA0gTSASMAA3z9DPkea+4Nq9rjpJY2qeRXcVD9DBPg/ffvaWldh7uYM50Y+7YCfELJg4+F8Nie2gwhBUN18fxzPwAkCP0MEHN37DxiUAbAMtdYdtMNqSANQwAAgD+SIg1DAADAQF0NAv3tAQIBJAfSA/wQA/wQB3AlB/wQA/wQAkLf9cHSuXRCovB4IwZDELhCzkRbDjWxJcqv+D8AQQFwDgEBAQv8EAFBqyNBhe64DkGoxwP8CwBBAnAEQAUgC0EBaiILQStJDQIgDkQAAAAAAADwP6AiDkQAAAAAAAAYQGMEQAwDC0TkDwdLMmuo4CQC0gXSBUMuJekIjUEADQDSAvwQAiEC0gRBEw0A/BAGQQJwBHD9DOYMXT946KqzKao/MpMRgkYCf/0MW8OvvqelrFqR3u8Q7hGOYAICBn0MBAv8EAcNA0LHAdIC/QxrmDnmjAA7v7/obQZtOt4k/Qz/0eQD1refnHtGuNdEDYF1IApBAWoiCkEcSQ0GBgAgCkEBaiIKQS1JBAEMCwsCfNIBQdMAJAVDgzCT/0KaASQGQaXGstgBJAkjCgIFAgNEqtwiIDQ0ELYjAiMKQR4RBQYkApwGfgwCC9IDBn/SAUO1fraKQeABDAABCwwFAAsGfQwBBwoNB0EiQQFwDgEAAAvSBUOa2xxHjNIB/QwWe+sAz70b0g/5v8c5x9fJ/agBIAlBAWoiCUEeSQ0MAnAgC0EBaiILQQFJBEAMCgtE2YL/OD/5tiL8A9IA0gP8EAEMBQALDAULIwEkBkOVpqW40gHSAPwJAiMMIgA/APwQA3AlA9IFIwVENKwNBLoDUABDu6GnqSMAEAP8BLU/AAwDAAsMBQtEZG5cQnOzkysMCgALIwbSAfwQCAwAC0EBcA4BAQEFBnAMAgALBgQMAAsGf0GIyjBB+9gDQQBBAPwIAwAGfQwDCyAHIQchAUH//wNxIAE4Ah8jB/wQBwwAC0EBcA4BAQELIgbSAkO7XcXrIwT8EAhBAXAOAQAAAQsgCAZABkBEL4fkyONI/X8MAgsgCUEBaiIJQStJBEAMAwsjB/3AAUI9An1Bu50BDQEMAQALQaO1IQJvDAEAC0QzWRBEb4XbxwwBC9IFRP0pSyLA2yzSJAL8EATSAkT1YlMcZGYFDAJ/PwAMAAALQQJwBH0jBCQEQTtBAnAEfdIBAn0gDEIBfCIMQhpUBEAMBQtEx6LP6EIgbaAMAwALAAXSASMAIQb8EAZBAnAEfj8A/BAGcCUG0gIgAwIFJA4gBgZ9Qt/rpqy8lqV/REbhBmAwfvEo0gE/AEEBcA4BAQELDAILBnz9DEnl1lAOMubxd6uL7q4lLC0gBkHhjpMa/QyC/28e0Wlz5QlvXkE2teAL0gJCqgFCogEMAQALDAMFIAtBAWoiC0ENSQRADAUL0gD9DOo1zKl3KbwnNGqGvXXdyMYCAT8AQQFwDgEAAAsjA/2JAQZ8IwIGfELtAfwQAw0CJAZB+N67Lv0RIggkByAMQgF8IgxCCVQNBgJ+IwAkDkM/68uRBntDAAAAgAwGCwYB/WkMAAsGAQZvIAlBAWoiCUEkSQRADAoLIAtBAWoiC0ELSQRADAoLIAtBAWoiC0EmSQ0JAnv8EAMCfkIfDAcACwAL0gLSAiMMIQgCfUHAsAZBAnAEQAZ9IApBAWoiCkEZSQRADA0LIA5EAAAAAAAA8D+gIg5EAAAAAAAAR0BjDQxBDyADIgYCBQYEDAALIgPSAyMHBgBDbN0E9P0gAiAKQQFqIgpBAkkND/1jBn8MAguzjUGT4OD7fkEEcA4EBAwLAgQLDAcBC/0QQuG5VwwIC/0TIAxCAXwiDEIoVAQBDBALAgACASIAAgEMBgALAAsACwAFQ11kskVEmI1Y4LCCkScjCUECcAR+IApBAWoiCkEWSQRADA0LQvSheAX8EARDdO+b5wwCAAsMBAAL0gQjCyAKQQFqIgpBKkkEAQwPCyAMQgF8IgxCC1QNC/0WBCABIQFB//8DcSABOAC7BUGlAUH//wNxMgHvBCQGQxTTt0fSAPwQBkECcAR+BnsgCkEBaiIKQSVJBEAMDQsjDf3DAcEkCSAAIAlBAWoiCUEDSQ0NIAxCAXwiDEIUVAQBDBELGBEkAyMCQxKMMKL8EARBAnAEfyAKQQFqIgpBFUkNDCAJQQFqIglBDEkNDCMABnAgCkEBaiIKQRtJDQ0gCUEBaiIJQRNJBEAMDgtDpEV2ugwDAQsGAxACIApBAWoiCkEQSQRADA4LIwYgBwwCCyAMQgF8IgxCMFQEAQwRC9IFPwAMAAAFIAlBAWoiCUEkSQ0MQd7UhfsDDAAAC0EDcA4DCAEJCQVB6ZgDQQJwBHzQbwwOAAVDHM+UJQwKAAsgA0EbEQUGJALSBAJwAn8gDEIBfCIMQhdUDQ3SBNIBQvzMoeS3uW4MBgALAAsAC/wQAkECcA4CBgMGC9IAIw0MAQsMCgsGAQYBRBSl9tubgwab/SIAAnAjBf0Mnd8qgzcYm1FLp4O4ukWC2iAKQQFqIgpBC0kNDgJ9IApBAWoiCkEqSQRADAwLIwoMAQALAAvSBUQpkHqUuqcMJkQJfbLPZx9VpAwECwYBDAAL0gUgBQwBAAtB+AH9ywEgDUMAAIA/kiINQwAAJEJdBAEMDAsCAgIB/akBIApBAWoiCkENSQQBDA4LIAtBAWoiC0EXSQ0KIApBAWoiCkESSQ0KIApBAWoiCkEkSQ0KIA5EAAAAAAAA8D+gIg5EAAAAAAAAFEBjBAEMCwsgC0EBaiILQQlJDQ0MAAALBkAMAAv9fgICQQdBEkEB/AwFBCAKQQFqIgpBAkkEAQwLCyAMQgF8IgxCKlQEAQwLC/2DAUECcA4CAAEBAAsgBQwEC/wQBA0E0gUCbwZwIApBAWoiCkEJSQ0J/QzPjoay4QmhH4QWNoscnI2tAgEMAAALBgH8EAdBAXAOAQAAAQsgCUEBaiIJQR5JDQ1E8LrAyicMbAYkAv36ASIIBgICASIAJAtDggy3A/wQBCMN/Qz9GUO/pD4ln5u8EcIR+fbb/Tz8EAQiAiMLIAxCAXwiDEIVVA0PDAAACyALQQFqIgtBCkkNDgYBQSRBJEEA/AwBBgZ9DAILDAgACyQNIA1DAACAP5IiDUMAAPhBXQ0KRC+X3SCJIxSyDAkBC/wQBSACIwUGfCADDAELIAgCfNIAIwMgCkEBaiIKQQBJDQvSA0HlASQIPwD9DGjH5YpAuX7hShuc3EyI4OcGASAKQQFqIgpBJkkNDxgQBgH94QEgCUEBaiIJQSBJDQwL/BABIwYMAwAL/AchBwZ8/QxeeGkqMPHbR5W5sGF+NRfAIAlBAWoiCUENSQQBDAwLIwT8EAb9DHk+8+kODkGA4tDZKinu2JYgDEIBfCIMQgtUBAEMDAsGAiEIDAALQQJwBH/SBQZwIwcgDEIBfCIMQhFUDRAGAPwQBEL0AEEOQQJwDgcJBgYGBgYGCQsMBgsGeyALQQFqIgtBEEkEQAwNC0QrPcza4L/UWwwGCyAKQQFqIgpBHUkNDENkPGRLIQEhAAwCAAUjByANQwAAgD+SIg1DAADwQV0EAQwQCwYBDAALIggCAAIAIAtBAWoiC0EnSQQBDBILIAtBAWoiC0EwSQQBDBILAgEMAAALPwBBAnAEfSAKQQFqIgpBIkkEQAwPC0IDIAIMAwAFIAQGAxAD/QwtKMQP+Z3P/g3GUAwC1+AjQQZBAEEJ/AwBBgsGASAJQQFqIglBDUkEAQwRCws/AEECcARA/BAI/BAAcCUAIwLSASMGDAgABSALQQFqIgtBFEkEQAwQCyACDAQACyAJQQFqIglBEkkEAQwQCwIA/QwHlrOJ/jDLRQ0sNn7b3ZASIAlBAWoiCUEfSQQBDBELBgAGACQDIAtBAWoiC0EwSQ0RIApBAWoiCkEgSQ0R/BACQf//A3H9AAHIByQDRFDIM8wsyyk8DBALDAMLDBQACwALPwBBAnAOAgsKCwsMBwALZQwAC0ECcAR/IAAkC9IBQce/6wIkCRoGQCAMQgF8IgxCAlQNDAtBqAH9DAwBi6ueSRHwo5ysRrCVLAUkC/wQAnEF0gEaQcYADAAACw0MIwkaQQQOAgwCAgsMCAsCBSMJIgJBAXAOAQAAC0EdJQMMAAsjBQ0JDAkLIwhBAXAOAQICCwwACz8AQQFwDgEDAwsgAAYBJAMGe9IBGgJvQwAQZmIMAwALDAcBAQALCyAMQgF8IgxCGlQNBCIIJAv8EAYhAiQGAnAgDkQAAAAAAADwP6AiDkQAAAAAAAAgQGMEQAwFCyAMQgF8IgxCDVQEQAwFC0GXASQF/BAAPwBBAnAEcETR+FYlEgJzVwwEAAX9DCiYGCa6SjEO0PFaP7MGpDYGe0PW8s9/RIbXXpwLkvD/DAULJANEz6ZQDUuY+P/9DJPFevaqRM2W8msDI4gZ75lCISMDIAlBAWoiCUEFSQ0JIApBAWoiCkEkSQQBDAoLIApBAWoiCkEKSQQBDAcLBkDSBNIFIwACBUIM/QwSM7fLtY+SRfZYGwuM1eiOIA1DAACAP5IiDUMAAMhBXQQBDAwLIAlBAWoiCUEvSQ0IJA25RACKZyBrY0YRQ5FI2e/8EAcgCCQNQQJwDgIFBAQBCwJ+IA5EAAAAAAAA8D+gIg5EAAAAAACAQkBjBEAMCAsMAQALUA0ARBBoLVVW1s7i/QyluxdSOpLgDHBVRrZyLoRL/BAIQQFwDgEAAAsGAgZ/IA5EAAAAAAAA8D+gIg5EAAAAAACAQ0BjBEAMCAsjAAwDGULwANIDAkD9DAfSK08QU6KVubipBZZY0gbSAiMHAgIGACAORAAAAAAAAPA/oCIORAAAAAAAADtAYw0O/YEBIAxCAXwiDEIvVAQBDA8LIQggDEIBfCIMQh5UBEAMCwsMAgtBrgEaQQgOAwABAwEL/QwUPaPcua5+F9UZsSCmqDa6BgIhCBgKPwAMAQsgBgwDC0EBcA4BAAAL/RL9DMRnUoKlyr5hXy35iGmx+Er9dfwQABsGQAsGACAJQQFqIglBJEkNCv2BASANQwAAgD+SIg1DAABAQF0EAQwLC/2oAUK9+vUFJAEkC0OmzIepIAAgDEIBfCIMQgJUBAEMCAskAwwECwwKAAs/AEGKK0ECcAR/IApBAWoiCkEHSQ0FIwUMAAAF/BAIDAAAC/0RAgEgDUMAAIA/kiINQwAAQEBdDQkLJA1BAXAOAQAACyACQQJwBEALAgP8EAckCCQK/QyBq3NvCkGF0QcGA8ExgW8aPwBBAXAOAQAACyEIQ209vBEMAQsMAAUgAP2nAf0WBwR+0gEjCwYBQY2j7BUkBdIFRFOsSnpLCWr2DAML/e0BIABBzsSvIkMAAAAADAEABULIAAwAAAskBkKZAUH0yAEkCSEHBn4GfyAKQQFqIgpBIEkNBPwQBgskCELgAQsgBCEDAn1D5m/fPiMOIQPSBEGZxpUQQQJwBG8gDUMAAIA/kiINQwAA+EFdDQRBHiUD0gTSAELDo52DZvwQAEECcAR9Q4e7QKcMAgAFQwOc0SEMAwALIAUkAQwBAAXSBPwQAUH//wNxMgGcBT8A/QyfLf4K4Dx06mJKMm2WrxPTBgAgDkQAAAAAAADwP6AiDkQAAAAAAAAuQGMNCSQH/Qy05vXUbx8pIv5+OaZPFqDOIAlBAWoiCUEwSQ0GCBELDAkACyQEGtIAIwH9EgIBQ+4pipQMAQALIA5EAAAAAAAA8D+gIg5EAAAAAAAALEBjDQQgCUEBaiIJQSxJDQcgCP1nIAtBAWoiC0EnSQ0EJA0gCkEBaiIKQSpJDQcgDkQAAAAAAADwP6AiDkQAAAAAAABDQGMNBCMBIwojAAZvQRIlAAsMBQv8ASQFuSQCIApBAWoiCkEpSQ0CQwr6gMsLGgwAC/0iACQDJAND3M/R4EKO3h0kBkP76lDhRGRYjdjm09WTtpZBuZbOAP0Ma243EtSK3ZQIDUw7SVh8wCQLQQJwBH4gByQBIwEMAAAF0gMaIApBAWoiCkEtSQRADAILIAX9EtIF/BAFIgJBAnAEfSANQwAAgD+SIg1DAAAkQl0EQAwDCyAJQQFqIglBMUkEQAwDC9IDGiABBSABDAAAC0H3kq4eQf//A3H9BQPdBCANQwAAgD+SIg1DAAD4QV0NBSQLAnsGfUOzP9J/GUQBuiO7IrcMkSMGJAYkAkM0WjAEQhoMAgv9DKW+0A5cw51PkNtfjOYLxOUkC5Aa/QxNGo/rfEs4B7k7/hR3fZCjC/0WDyQJ0gDSAf0MjKpqWgjtvLxfHwVIphQ1UkRmyqRBw/YvBCQCIAlBAWoiCUEBSQ0FIAtBAWoiC0EfSQQBDAYLIQAaQ49bkHw/AEECcAR/IAggCkEBaiIKQSVJBAEMBwsgC0EBaiILQSJJBAEMBAskB0H3AAwAAAVCxQEiBQwBAAskCSML0gA/AEH//wNx/QoA4QIkDBokAyACIwJBACQIJAIhAo1Cl7Dl8wEMAAALJAGOjdIAGlxBAnAEfkKhAUEEQRpBAfwMAQQMAAAFIwELIAQCBSEGIAlBAWoiCUETSQRADAILC7WQGkRFkHLqdcP2/wJACyQC0gJB0t2HgQStJAYaIwILnCQCJAoaQxaO8v9DcUdi9wJ7IAgLJAMhAY0jCyALQQFqIgtBEEkEAQwECyQNIQEaBn5E2w2+oK2LNNoCfEGw/vMhIQL9DP422ViM4UjaByxigarbgRoCAP19/BABQQJwBEAMAAAFDAAACyIAIA1DAACAP5IiDUMAADBCXQ0GJAtE0Qc5OwFelkoMAQALAAsMAwv8EAj8EAVwJQUMAQALIA1DAACAP5IiDUMAAMBBXQQBDAML0gUaIA5EAAAAAAAA8D+gIg5EAAAAAAAAMkBjDQLSBBoCANIBGgYA0gI/ACQIQojuiqSjBSQGIwEaGiAEGiQMRIqrMP7Jf9PoIwILDAAACwwDCyQEIwEiB7T9E/35ASQHQq8BJAFE4G51BhSxa44jCCQIJAIjBiQBRPM4MH7tKFWORCWGQqevCyPuDAILDAEACyQD/BAIJAga/BAHJAUkA0TXbHlSMamC7T8A0gAaIQIjAkL39YOtCcNDT6x8RSMMJAz8EAZB//8Dcf0BAugH/aQBJAkCfCAAJAdEvppQyDia7PPSAxoL/QxywgpI/qPAxFZ+TDDqWM9BAgIkAwv8EAI/ACECQfz/A3EgAv4eAgAkCRpCxQBDGxriAiMKEAEaJAZD6QJAcv0TGvwBIAj8EAIGfUP4Io8mIAJBAXAOAQAACyEB/BAFQowBtSIBGmokCCQDJAh5Q5lKtnEaIQUGe/0MgPT2bVr+yDVsx8oVXyIS8AJACwsDACAMQgF8IgxCFVQNACQNRInfN0C2dMniIwEkBkTc/cn6QAXyMQv8EAH8EAZwJQYkDvwQCEECcAR+0gEjBER2xrtA2j98lvwQCCQJnyQCQQDSAfwQBmckBRokCCQEGiMGDAAABdIE/Qz/tS1Dm9iusrTA9QxkHwRRBgELJAs/ACQIGiMGIwvSABpD24BNlf0gAAgQAQsiBboMAAuaZEECcAR+IwEMAAAFIwsCb0EjJQMMAAALJARCBgwAAAtE3ZOO8No58/8jCgYDJAoDfUMRXptk/BAF/Q8GcCADAgUMAQALQS4lBkKbzt/DfiQGC0S0R59S0FxBBgNwPwAEbyMEDAAABUEHJQIjAhoLGtIBGiAKQQFqIgpBL0kEQAwBCyAKQQFqIgpBB0kNASAORAAAAAAAAPA/oCIORAAAAAAAACJAYw0AIwUkBUESJQgGBAsGbyAJQQFqIglBHEkNAUEDJQUYA0T7y9c/8rRfgxoaCyQAJAICBSQACwwBAAv9EwskCyQCIQdBAnAEfSABDAAABT8ABHwjACQAIwIMAAAFRCJ/TGHMQVJMC/wQAyECJALSABr8EAes/RIkDULk7cG5cCEHQ4fVRncLIQEkARokAiQN/BAEJAgaIwv9oQEGeyMMIQhEvBn6jq7d+jEgAiQFJAIjDAMBIApBAWoiCkEiSQ0ACxgAAgEL/eABJAchCEKpASQBGkECcARvQRAlA/wQBEEBcA4BAAABBSMHQwAAAID9IAMkDPwQACQFBn1DUwWa0QshASMEC0S7k/Jpw4k/ipwaJAT9DOwWSqXoSAVTmjwWYmZ/K/oICQALCyoEAQjP+UwMBqpIfQBBpAkLB8jbaWHXpMUAQZguCwnzo8HCHrP7ZfgBAeo=', importObject1);
+let {global17, global18, global19, global20, global21, global22, global23, global24, global25, global26, global27, global28, memory2, table9, table10, table11, table12, table13, tag7, tag8, tag9, tag10, tag11, tag12} = /**
+  @type {{
+global17: WebAssembly.Global,
+global18: WebAssembly.Global,
+global19: WebAssembly.Global,
+global20: WebAssembly.Global,
+global21: WebAssembly.Global,
+global22: WebAssembly.Global,
+global23: WebAssembly.Global,
+global24: WebAssembly.Global,
+global25: WebAssembly.Global,
+global26: WebAssembly.Global,
+global27: WebAssembly.Global,
+global28: WebAssembly.Global,
+memory2: WebAssembly.Memory,
+table9: WebAssembly.Table,
+table10: WebAssembly.Table,
+table11: WebAssembly.Table,
+table12: WebAssembly.Table,
+table13: WebAssembly.Table,
+tag7: WebAssembly.Tag,
+tag8: WebAssembly.Tag,
+tag9: WebAssembly.Tag,
+tag10: WebAssembly.Tag,
+tag11: WebAssembly.Tag,
+tag12: WebAssembly.Tag
+  }} */ (i1.instance.exports);
+table4.set(13, table2);
+table2.set(74, table4);
+table5.set(16, table10);
+table10.set(37, table2);
+table5.set(14, table10);
+table5.set(5, table4);
+table9.set(1, table0);
+global22.value = 0;
+global8.value = 0;
+global9.value = 0;
+global4.value = null;
+log('calling fn9');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn9();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn10');
+report('progress');
+try {
+  for (let k=0; k<25; k++) {
+  let zzz = fn10();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn9');
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn9();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn9');
+report('progress');
+try {
+  for (let k=0; k<22; k++) {
+  let zzz = fn9();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn9');
+report('progress');
+try {
+  for (let k=0; k<12; k++) {
+  let zzz = fn9();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+/**
+@param {I32} a0
+@param {FuncRef} a1
+@returns {[F64, I32]}
+ */
+let fn16 = function (a0, a1) {
+a0?.toString(); a1?.toString();
+return [3.13448624161907e-43, 87];
+};
+/**
+@param {I32} a0
+@param {FuncRef} a1
+@returns {[I32, FuncRef]}
+ */
+let fn18 = function (a0, a1) {
+a0?.toString(); a1?.toString();
+return [75, a1];
+};
+/**
+@param {I32} a0
+@param {FuncRef} a1
+@returns {[F64, I32]}
+ */
+let fn20 = function (a0, a1) {
+a0?.toString(); a1?.toString();
+return [4.0698352600600405e-23, 65];
+};
+/**
+@returns {void}
+ */
+let fn21 = function () {
+
+return fn10();
+};
+/**
+@returns {void}
+ */
+let fn22 = function () {
+
+return fn10();
+};
+let tag25 = new WebAssembly.Tag({parameters: []});
+let global29 = new WebAssembly.Global({value: 'i32', mutable: true}, 3346018448);
+let table15 = new WebAssembly.Table({initial: 99, element: 'anyfunc'});
+let table16 = new WebAssembly.Table({initial: 98, element: 'anyfunc', maximum: 435});
+let table17 = new WebAssembly.Table({initial: 98, element: 'externref'});
+let m6 = {fn16, fn21, global30: global27, table14: table3, table15};
+let m7 = {fn17: fn10, fn18, fn19: fn9, fn22, global31: global2, table16, table17};
+let m8 = {fn20, global29, tag25};
+let importObject2 = /** @type {Imports2} */ ({extra, m6, m7, m8});
+let i2 = await instantiate('AGFzbQEAAAABPwxgAAF/YANwcH0Db3B/YANwcH0DcHB9YANwcH0AYAJ/cAJ8f2ACf3ACf3BgAn9wAGAAAGAAAGAAAGAAAGAAAALMARACbTYEZm4xNgAEAm03BGZuMTcABwJtNwRmbjE4AAUCbTcEZm4xOQAJAm04BGZuMjAABAJtNgRmbjIxAAcCbTcEZm4yMgAJBWV4dHJhBWlzSklUAAACbTgFdGFnMjUEAAkCbTgIZ2xvYmFsMjkDfwECbTYIZ2xvYmFsMzADewECbTcIZ2xvYmFsMzEDewECbTYHdGFibGUxNAFwACcCbTYHdGFibGUxNQFwAGMCbTcHdGFibGUxNgFwAWKzAwJtNwd0YWJsZTE3AW8AYgMDAgsBBAsDbwAXbwFcZ28ALgUGAQHfG8QcDRsNAAsACQAKAAsABwADAAgABwADAAMABwAGAAMGFwN/AUEDC3wBRDMondBkyRh0C28B0G8LB4ABDghnbG9iYWwzMwMDBXRhZzI0BAsFdGFnMjMECghnbG9iYWwzNAMFBGZuMjMACAV0YWcyMAQDBXRhZzIxBAYFdGFnMjIECAdtZW1vcnkzAgAHdGFibGUxOQEECGdsb2JhbDMyAwEHdGFibGUyMAEFB3RhYmxlMTgBAgRmbjI0AAkJigMJAgBBIgsABQUFBQIGBXAs0gcL0ggL0gYL0gML0gYL0gEL0ggL0gQL0gQL0gkL0gEL0ggL0gcL0gML0gcL0gcL0gcL0gEL0gQL0ggL0gcL0gML0gIL0gIL0gcL0gML0gUL0gAL0ggL0gUL0ggL0gcL0gQL0gQL0gQL0gEL0gkL0gIL0gcL0gcL0gcL0gYL0gcL0gYLBgJBEQtwNdIGC9IJC9IFC9IGC9IIC9IHC9IDC9ICC9IGC9IJC9IJC9IFC9IHC9IJC9IHC9IJC9IAC9IBC9IFC9IBC9IBC9IFC9IGC9IEC9IAC9IEC9ICC9IHC9IGC9IDC9IDC9IEC9IAC9IJC9IBC9IGC9IAC9IBC9ICC9IIC9IJC9IDC9IEC9IDC9IIC9IEC9IBC9IEC9IBC9IAC9IAC9IDC9IGCwEAEQUBBAMEAAECCQMBAQAGAwgJAgFBCgsAAgAEBgBBBQtwBdIBC9IDC9IFC9IGC9IICwYBQd8AC3AB0gILBgBBFAtwAdIHCwIAQQgLAAEJCqtIAuYJBgB9AH4DfwF+AX0BfAYI/BAFQQJwBEBBuooDJAAGChkCcAJ/Qf+N5oQHBAgQB/wQA0EAQQJwBH4CCwYH0gJC/iK/QSoGb9ICBkAQB0ECcARwBnD8EAJBAnAEcAYH/BAGBAsJDQELIwIkAQkMCwkLBSMFQRJBBEEG/AwBAPwQBdIEQjwGb/0MgUYLM3m1FRKM0oWR7hseNNIF/BAFQd/0AEECcAR+Q7k7xpDSBNIF0glB3uSwAUMiETOJAnAPAAsABQwKAAsjAAwKCyMEJAT8EAAMCQALDAALDAgABQwGAAsMBwsJBwskBQ0JRIXKwDF/w239ZPwQA3AlA/wQBEEHcA4GBgMBCAAHCQvSAUEJQQxBAfwMAwD8EAYNACMDDAMLAggGfRAHQQZwDgYIBgcBCQMIC/wQAw0GIwNBBnAOBgIHCAYABQIL0gJEdakWWCpj+n/SBAJ9BgcPCwYHBgoGCQIAQQkRBwAMCQALDAYACwwJC/0Mc6Gzl77KWmfDoCMzoFEyFyQBAggJBwtDEFYcVEQwVoq7ReWyakHfAEH+9c6zAQwECwN7DAYACwALAAUMAQALIwQkBEPTYuTIIwL9YiMFPwBBBXAOBQAFAwQGBQsGb9IAIwFD+gLlEP0gAdIAIwT9FNIIIwFDkIZAEtIDIwT9DIFy6a7q+R5bv4aMsFBVQ4UkAj8AQQJwBAcMAAAFIwMMAgALJARDmdDtB/wQBUEEcA4EBQMGBAQLQQJBDUED/AwDAURFsvmwOleMvP0MBuQa1OmCPQZpzPFIE67b/AkCCxpBDA4EAQIDBAIL/BAEDQL8EAANAiMDIwAaQQgOBAABAgMDC/wQAPwQAkECcARwDAMABQwBAAsjBCQEAgYGBAJ7DAIACyQBIwECbwYHDAAAC/wQBdIBQ41O90wGewwFC0IpRF/AL8+jOiYwJARC2QFDkpUtcvwQBQ0CAn8CAAYI0gfSAdIHQr8BPwBDy32kYkEtQf//A3EqAvkHIwUkBUEKDAILDAYAC/wQA0EBcA4AAAv8EAZBBHAODQUFAgUFAwUDAwQFBAUCC/wQBUEEcA4EAgEEAwILJABEmQ2MzUJe3gahAm8MAwAL/BAGDQPSBkLv1MD4uRHSA9IFIwUjBfwQBkH//wNxLwHmAg0DJAX9DPYsOV0qWqZEgguVSvTmiNkkAiQF/BAD/BACcCUC/BAGQQRwDgUDAQICAwALAgcGQBkGcAwBC/wQAyMABEBCGPwQA0EGcA4GBQADAgQBBAtDOf8I4CMAIwMOBQIABAMBAgsMAQv9DLboVJccPrhsuxSU8RW78Nb9Z0RnwOIOefFZ/ES9yl3qF85Ef0OTvZIq/Qw2W8lyILO1ytSWTBEDs6GqQkr9HgBBBGnSBCMDQQNwDgMCAAEAC0TBFmODusNwxSQEBgf8EAFBA3AOAwIAAQELAn4CANIBAnAMAwALAAsAC7X9DE1U4kq+fEIQERniZU585hb9TSMABnAQBw4BAgELQr8BQaqx29sBAnw/ACQDRCLxeP4KpoJwDAAAC5z9DHqEMf8BPrt+otCyFd/61u5DIQoZYUKKAf0SBn5BCBEHAAwBC/wQBCQABnAGCRgCDwtEIkFfjZciyi8kBEGssYWNA0H8/wNx/hACABpBBw4CAAEAC9IEIwL9U0EBcA4BAAALwD4GAXsCcAN/AX4BfQF8EAP9DHSn0GcjYw6VNr5T2pA9pT0jAtIGQ1t5ywxDa4ncUkMAAACAQqIBAm/8EAWy/BAEJAAgAQJ9EAYCCgwAAAsQB0H//wNx/QQDoQf9DEL0TbPWSj+Tf81CmkdJsz4iAyED/cQBIwS2RM2ggguEXwfSQyKfymcMAAALIgIhAiMF/BABQQFwDgEAAAskBQJABgsGbwwBCyQFAggMAQALIwBBAnAOAgABAAAZEAECCAwBAAsCQCMD/BABQQNwDgMBAAIACwZADAAACwwACwN9IAhBAWoiCEEHSQ0ABkAGCyABIgRDAjbY/9IJIAQjAAZ8PwDSCdIABn8DCAwEAAsGCkEFEQoAIwCzQQBBAkEI/AwDAUQwrH9alxCjOwwCCyAHQQFqIgdBD0kNBEPIR6N7Q4dY4wsGfT8ADAEL/Qxcb1KBpBZTXO1/f3mn2+iq/YoBIwU/AAwAAAsNBAZ/DAULQQNwDgMEAgECCz8AQQJwBH4MAgAFDAEACwZ+DAQLw4MjACQDQsnCuc9O/RJECKtPYF3AlH0kBPwQAEECcAQADAEABdIDIAAgAiECRGEv0rYEGZGqngZ/EAdFDQQGB9ICAm8GfgYK/BADrSMDQf//A3EtAPkE0gQjBfwQBA4MBwcAAwkHBgMHBwcDAwsMBQsjAiEDUAwCAAsCcEL6ACMEIwH9oQH9GQYMAgAL0gEjAEECcAQLDAcABQYIBkAgAUHhyPIDDAQLDAEBAQsCCiMDDAMACyMAJAAGC/wQAA0BDAELA3wCB0EHEQsAIAlCAXwiCUIaVARADAkLAn9Bn5k6/BAFcCUF/BACQQJwBEAFAgAMAwALAAskBQwBAAtBAnAEC0Ghh7AHDAYABRAFDAEACwMLBgAMBQvSCSMEJAQgBSIFIQXSCSMB0gdBgwQkACMARQwFAAsMAwsMCAALJAQQA0La864PQ1p32X/9EyQC/BAADAIL/Qy0nO2FQSxurzV/rSLppsHbIwT8EAO4IwH9DPpRBs/5bHfrh3joXPCkFe/9ygEkAv0YBgN+IwH9DJ04BCnPLqXuFJxvwYiKgHhD2G4OYEIxAm8CB0GuuAwMBAALAAsAC/0MykcK9iEX/4SWTm/LVirpXUKxvJOs6fmAfv0eACQCAm9C1Na+p6rpfv0SIANE8sNHfbnnonH8EAQOBAQFAQcECwN9BnsMBQsiA/3jASQCDAQAC/wAQQRwDgQABgQDAwsMAgsMAAtB3sAjPwACQAZv0gP9DAxZR8Rk748v1RHImAau08/9gAEkAgN/BgggBSEEAn0gBdII/BAADQgjAtID0gX9DLCcXKP+vhHhCgaTw9G7yikkAiMCJALSCSMDJAAGewJAEAYCCf0MsyGim7kf45g8+88+nO6dM/0Me0yHXLSD6QrQBuBl+bNNOAwCAAsACwwCAAv9wAFBHEEFcA4FAQQGBQgGC0RxSGZE5hYMBSQEQ3GfG1E/APwQBfwQBAJADAEACwZ9IwL9ff2HAQJvRMaF6+dGrjTkIAIMAQALPwDSACMFJAXSAyAFIwEiAyMFDAMBC/4DAEIy/RL9/QECfwZ+AgsMCAALBgcMCgELDAkLIwLSAP0M25rVCQJgaQuSgCz7WWQzEP0M3NQOPAKZ8murz+cSWnFfd/0MSOWEj9LHhXl+JqhuHJPfYdIDRFwMNK0x6FEVJAQgAEKBAURBOr3Wi5+P9tIABnAMBgsjAkRC0jv2o1ISOEEkDQVEbb0QTVHZdhxDwPVdqEHhAEEJQQD8DAMCAn4GCAwGCwwJAAsAC0QG06gQyFIrI/0U/WADfwwBAAtBBXAOBQMHAAUEBwv9DEYtG6iE2m2OajsHZ/QC2H39fiEDDAYAC0EEcA4NAgECAgMFAQICAQICBQELAn0CCwIIAwg/AEH5iQFB+tgCQcDmAfwKAABBBnAOBgEFCAQCBgQLBgAGcCMFIwQkBANwIwIhAwwHAAsMAAsjA0ECcAQKAgcMBAALAAUQB0EHcA4HBgUCAwAHCQcLRNkn/jZwu2sWJAQhBQIIDAUACwwFC0EGcA4GAQMHBQAEBQALDAYLBgkCQAIHQYMBDQQgB0EBaiIHQQBJDQfSB/wQBUEHcA4HAQYCAAQIBQYLBgAQB0ECcAR+Q5JqoH0gAf0MTxHzJ5p8gqD8z6Dki4CTb0OZJi83PwANCf0MQCdZW8QmNSIuNzu0pS2pRQJwDAMACwAFAnwGCAwACwZ80ghEQJL36npR8FDSBUKNAQwCCyQEDAcAC579FCEDDAkL0gXSCEGgAkEGcA4GAQYEAggFBAsNB0PzsSJo/QxdH4afQcr/uySUSvXzhZQGBn8QBgwICw0FPwDSCUMTbzs0DAILDAALQQURCABD1CE9BUPiR7J/0gICfv0MM4G+qU2wdu6ZYwmAB3Mu9yQBDAMAC/wQAEEEcA4EAwIFAQILIQIjBPwQBEEEcA4EBAEAAgALDQFBA3AOAwADAQALGAICfULaAEJ2VCUC0gZCtgH8EABBAnAEbwwDAAUCCgYLDAELIAdBAWoiB0ErSQ0DIwQjAfwQBQRAQYGqmMsAIwUkBUECcAQHEAdFBEAMBgsMAgAFIwEhAwMHDAIACwALIAlCAXwiCUItVA0EBnwMBgsgAyQCnEGssuMBDQX+AwAkBAYADAILQQJwBAkgAEIA/QxJfUjZP7jnwdtjn1RrZim7JAHSBP0MK/qhJkAz8/BIapU0NFOz3fwQASQD/e8BIAQhBULkAf0S/QwACDEOaUDamoOqTVpMWMmJIQMkAtII/Qyn9QLEwPxnFrykcvgc9gh2JAI/AA0BIAPSBUGUAf0Mr7cAk4hvJJ5JFuW94SEOLfwQAEEEcA4DAQIGAAvSB0IABkAgAPwQAw0GQpCBm8PTsLuKB0KLAYZCywEgAEOF7J3zvA0APwAgAAYFDAALIQENAELA0Qb9EkMAAACAAn8jASIDJAHSBUEzQQJwBAgDfUK0k+eWhX9CfyMB0gBB3gEMAgALAAUMAwALIwACfAYLAgsMBgALGQYLIAlCAXwiCUIlVA0JCQELBnwMAQv9FCQCDAMACxAHDAEACwJwBm9C3IuExLrjxny0Q/EOCwQMBwELIwH9XkR+9C3BC6pLAf0iANIA0ggjBQJ8IAICbwIIBgkMDBkCCwwIAAsMBwELAm8GCQYIDAkLIAdBAWoiB0EnSQ0MGUH7rwoMBgsjBEHyEQwFAAsACwALAAsACwZ+/BADDQggCkMAAIA/kiIKQwAAAEFdBEAMCAsCCwIJIAtEAAAAAAAA8D+gIgtEAAAAAAAAJkBjDQlBxffEgwEMAwALAAtDUXGU+QwGCyMEQ+ApeAZECfJf1InF/v/SCUE2IwIhA0EEcA4EAQcDAgEACyQDDAQLUEO+ig3dIQIOAwEFAAELQQJBIEEB/AwBAP0MElcv2NKJYZN1A9wqso9QMv1qIwUkBf0McTLGncpuXUxDUjN9JQmmtv1SIAAjA/0MQzE/OjqOmplZskXxXfr/YSEDQQJwBHwGCv0MtAPFA1sxm6hD5IgEze129P3gASQCBgkCCgwAAAsQB0MZSJMXDAULBgsGAAYKQqbQ7pr6+LgC0gQCcP0MssjFyTPZdin7hmhg04VimCMC/e8B/UkCfgMJAgcDCwYJGRABEAUgANIIQrWVCwwECwIIBgoGCkEIEQsAGAACChAGAgsMAQALAAsYCCAHQQFqIgdBEUkEQAwCCwJvAgcMEQALAAsACwALAAsACwYIAwv9DEU0sz2Ml3Ku5B54N9J2oepBAAwFAAsMAwELEAdFBEAMCwsMBQALIwQ/AA0FDAUACyABQc8AQQVBAfwMAwEjASAC0gP9DO6C4RltUvPYtKub8QcrQhgkAv0MGCbIES15z0eBDWKZWFIGISIDIwMMAQsQAyAFBnAQBgYL/QyyC6fB9OEk5L7u4EYpoW1zIABBIwJvDAQACwwHCwIJEAYMBAALAgkjBAwFAAsMAwELIARDhh/+//0T0gcjAf0dAMJ6QuoAe4ZE5oMByO08EqpDP68XvZHQcCAARH6E3k4yCYdODAMLQQRwDgQHAwEAAwsMAAsgC0QAAAAAAADwP6AiC0QAAAAAAAAAAGMEQAwFCwwFBRAHRQRADAULIAtEAAAAAAAA8D+gIgtEAAAAAACAR0BjBEAMBQtE/2WflS+NsPlDRjK8ngwDAAsgAQZ/BgtBNAwBCyAJQgF8IglCBVQEQAwFCwJ/DAYACwwACw4CBAAECyMEJAQGBxgEIAlCAXwiCUIRVARADAMLIwBBAXAOBQMDAwMDAwvSAQN70gn8EAENA0Rkhwqv3rChxiQE0gH8EARBAXAOAQMDC9ICQp2k442axKrrAgZvDAMLJAUgANIJRHB9fWCbfY9FJAQjA0EBcA4BAgILQ15rz7WS/AANAQwBAAshAkEhIwHSB9IA/QyUjIXuLgspE//hdsgmNiVgRBXXdo3hCl9yIwAGfQYLPwD8EAINAg0AAn38EAFBAnAOAgEDAQsjBNIEIwH9wAECfkEU/BAGcCUGQpiBroHiAgwAAAu1DAELDAELIQJB//8DcSACOAGVBiQEPwAjA0EBcA4AAAtEEQQWZet6E3ZDNwr7/44jASEDIgI/AAQKIAUjAf2KASQBPwANACIFIADSCCMCBn8MARlBCBEKABAHDAABC0EBcA4BAAABC0IoQ22nS2L9DNdcK5YfUaeQog2c1BQlkSQGcCAAIwP8EANwJQMkBdEkAAIJDAAAC0PpqKh4/QwYIshhNJ6BeU+OFQbx4QW+/aMBIwT8EAFBAnAEBwU/AA0ADAAL/QyIpl3vNhcaDYBh9c+CxN8A/BABJAAkAtIEBkD8EANBAXAOAQAAC/0MhDFzhZ/jUr1xJLOsEtGX7yEDIwBBAnAEbwYIDAABC/0Mq72+xZcktAOcLKsRmGJt3v0YAiQD/Qw5IEdP95rYHOWhTspFW1LDJAIjAAJ/BnBB1QEMAQsMAgvSAyABRJvg+eNjhUP9nSQEBn8jAAwAAQEAAQtBAnAEfgIH/BAFQQJwBHADbyAJQgF8IglCHVQEQAwBCwYIDAMLQaQBQQFwDgECAgALJAUjBD8ABH8MAgAFBggMAwsjAUHOAEEKQRP8DAEC/WgiA9ID0gZC8QDSCPwQBgwAAAsNASMADgEBAQUMAQALDAMLAgvSAtIFQQYNAEOKNVmUBn8MAQtBAXAOAQAACwIKDAAACwMLBgkGCSAJQgF8IglCLlQEQAwDC9IJ0gAjBD8AQQJwDgIBAAEBAAsZEAUMAAsgCUIBfCIJQi9UBEAMAQsgAQNABgAgCUIBfCIJQiBUBEAMAwsjAQJ7AgkQB0UEQAwECwJ+IAhBAWoiCEEHSQ0FDAEACwALIAdBAWoiB0EjSQ0DQTtBAnAEBwwAAAUjBQwGAAsGCyAHQQFqIgdBFEkNA0Kx+fsBDAULIAlCAXwiCUIfVA0CIAhBAWoiCEESSQ0CBn4gBkEBaiIGQSRJBEAMBAtE8Ees5gpP8P/SAEKm1K3yr7oFwrkCfQIICyMAIwMjBP0UDAIAC41B0AEMAgsCQAYJCwsjBD8A/Qwod9NunG7u66YdlZmez210JAJBzAAkAyACu0QlAiT12/hRgdIAGtIHGiAEDAYLQqR7Q3JhEpP9EyQBDAMLJAAGewYIBgoHAUGEAfwQBHAlBAkACwsQBwR/BgpCocQN/Qxbbg1t7YKL7cfdrk5LKDlIDAIACwYLGAFB3tWD1gAMAAAFIwTSBkObCDYf0gH8EAAMAAALIwIMAAALIQMgB0EBaiIHQQBJDQAgBkEBaiIGQR9JDQAQByMFDAMACwALBkA/AETW8drzfrZBu0K+AQwBAQtCMiAFQ6weLishAgwCBQYKBgfSByAD/XwiA/38Af3vASEDQ4PgjSUhAhoLDAALIwH8EAZBAnAEQAYJCwUQBgYL/QxF9MeReSTlAMNJYKLJbuNVQ10aywg/AEECcAR+DAIABUEFEQsADAIACyAA/QwfTMb3jSVJL0GLsr1I56jD/aQB/BADcCUDDAMLDAALAn5C68Dtg6XLDwwAAAsMAAALIAUMAQVE93L2EnS7L00jBEMFBSGyIAAiBAwBAAskBRr8EAL8EARwJQQkBULWgRgDfxADQtzt5+rAy5V8IwU/AEECcAQHIwRECPq0M3hIEIgkBCQEQQURCAAGCCAIQQFqIghBHEkNAgwBC0HjAQ0ABQMHIAhBAWoiCEEYSQ0ACyALRAAAAAAAAPA/oCILRAAAAAAAADBAYwRADAILDAAACyQFuvwCJADSCdIB/Qz+2vNA4Qu8BiRAqJm3/8ZwJAFDms7ldj8AJAAjBdIDPwBB//8Dcf0HAJIE0gUGfyMDDAAACyQDQz8AVf8iAiMC/coBIgMkAUHAAUOGBvLy0gQCfET0tdDiyOmt/j8ADQAMAAskBCAFDAEACwJvBgkLAwfSA0G3AQN+EAPSBCMFDAIACwALAAskBcAkACMC/V79+AEkARokBESBT3NyOWd1OkOyVlIDQovhhqp5GiMB/YMBJAMGQAshAgZ8RPeUH/6oqHI2DAAACyQE/QwRpV0YZX0Ry4pciiSuJIuO0gFEdRP78XDX8DkkBEKyAf0M3Aw9yfVlvT54dApbtneawUL/bUHl2M8BQ0KOwqOMQcIB/BAEGkH//wNxKQNgIAREUhIMxFqbDUMjBQJ8EAUCByACQsQBIwD8EABwJQAMAgALAAskBEEAJAMgAyQBJAUDbxADIwUjBSQF/BACGgvSACMC0gFEIH+/LLyhs0bSABokBBr9eiQCGiQFGkPCYMP8/BAGQQJwBHAgBAwBAAUgBQZ/QZkB/Q8CfkKo3rOBm9KxfwwAAAsaPwAMAAALQQJwDgIAAQELDAABC9IHQaGAodd6GhohAUHUzisGbyMC/aEBBnwjBAZAAm/9DKjhj1YtqTVkXJz2HBLYz4UkAgwBAAsMAgsLJAQkARAFQRklBUKjAQZ8RIrLnLSBhwKzDAALIwIkASQEGiMCJAEZQRMlBgJ/0gUaIwMGfQIKQRVBAEEN/AwDAAwAAAsgAgwAC/0TJALSAUMIBKMPIQL9DJA7YW2j1w4iIw7IBiwd8jv9xwEkAkMG77wqIgIJAQtBAXAOAQAACyQF/BADcCMFJgMkAiMEGgJ//BAA/BABvvwQAwwAAAvSAhojA2r9DI+h9Jq9vqbd3YT1kKP0s1pBkgH8EANCiQEGfAIICxAGAgsLRAA+ox9/9P1/DAALQn4gAiICu5wkBP0SIAK7/SIBIwL8EAQb0gBB6cHdAUH//wNxLQCLBfwQARr8EANwJQMaRDg+PlZ3jKaV/Qxi/BUgtbEbsVCG356MYPZM/QzNMWm+xdHlXmZjDxRcpAGiJAH9YSQBAm9BywAlAyAA0gIjACQDGiEAJAVB2QAlBQsanpu9QuwBtSICIwL9wwH8EAFwJQEhAELxAbQhAhoaIwMaGiEDQuUAGiAE0gka/BAEJANCswEGQAwAAAtEH/+xY5vrB1xCxQsaJAQaIQEkBEPrStxXIQIgAUHbl/2kB0E6RkVB//8DcTEAjgcaIQQadtIIBnBBKSUCC0QJR18xA2nRg0SPXolMgAN1K6REb9Oocba0RkkkBCQEIQDSCSAEIQEaIANDmMmt/yICRAWXxqHp4urYGv0gAyMAJAMkARpBsc4B/BAC/BAFQxAV5g0hAkECcARACyMDsgN8RNCzdSAuLXsIIwI/AP0MEReE/eMjh7t3BJgJ9ZLYR/1NIwQkBP3IAf0M2NYIEBO9PKewFJiLMOV3qv3jAf3KAQJwEAdFDQEgC0QAAAAAAADwP6AiC0QAAAAAAAAqQGMNASABCyEERA5IMJBwfk6I/SIA/QyK0sHJkCkFSY0WT0UdNwFsJAEkAiEDQf//A3EgA/1bAY4HACMBRIsaIsCUwI4YJAT9MUQVMX3x8dVd3SQEQvkBPwD9ECQBtEP3zsQgPwAkACECIwDSASMFJAXSARoDe0EJEQsAQQYRCAAgCUIBfCIJQgVUBEAMAQsGCEEtQQFwDgEAAAEL/QzKgdL36yG8VM+TH8hluRzGJAIGB9IBQr+huqge0gfSBUHSAUEBcA4BAAALIwUkBQYKC0LLop3kjpH7C0MmE8bqIQIGb0EAJQMLJAVC/gEGcP0MFVKu75bnSpfSgL+M//fAKj8ARdIFGgQAQQcRBwAgBkEBaiIGQRlJBEAMBAsCCQwAAAtDIB7haCECIAhBAWoiCEElSQRADAML0gRBFUECQQ/8DAEA0gcaGgMLCyAJQgF8IglCE1QEQAwECyAHQQFqIgdBGUkEQAwDCyAHQQFqIgdBDkkEQAwEC0H9AdIHIwAMAAAF/BAEDAAAC/1tIQMgC0QAAAAAAADwP6AiC0QAAAAAAAAiQGMNAkHDACUCIgADcAYHDAABCwYHIAhBAWoiCEExSQ0BDAALQQURBwAGBwJ9IAtEAAAAAAAA8D+gIgtEAAAAAAAAOkBjDQXSBUHpAEEBcA4BAQELIQILQTMlASMAQSByQQFwDgEBAQsMAAshAAZvIAhBAWoiCEEkSQRADAMLBgsLEAMjBQJ+QrqMyMgFDAAACxoMAAtD7HHvLyECJAUa/RIL0gj9DNag3orO7UvWaMDQWLBQFQr9qgEkAUP8GTukRD9BeIZ3p9sDQyg6cE4hAvwQACQDnv0MgsbjpMa46QBaq0HjIiQIbkHNAP1sPwDSAUK0AXkjASQCGtIG0gj8EAZBAnAEf9IIGkHjy+q+BAwAAAUgB0EBaiIHQRRJBEAMAgsgB0EBaiIHQQRJDQFBsQELQRIkA0H//wNx/VwCtAEkAj8AJADSBxpCAP0SQYKmj8oFPwBC2QBQJAMjBCMDJAMkBD8AHAF/JAMhAxpCury4Bz8AGhoaRHDMmoBBnuNAJAQjBSQFGkESc/2rASEDJAQ/AD8ARbgkBELejrPworR9Bn8CCwsCCAIIDAAAC0LAn7XfernSAxr9FCEDDAAACyMACyQDtCECQQJwBAsFDAAAC0PqtuCXIQIhAiACIQIaPwAkACQBGkTY7Wt4KzQODL0GfkLKAAunJAMjBSAAIQUgAf0MIUk9VAdJdWyS5OkgxSkymiQBPwBBAnAEfCAJQgF8IglCIlQEQAwCC0RtH6FyGbs5ogwAAAUjBAskBES2m17NQJFmpz8AJAMkBCMF/QyLvwiT7xuGqAsKVywbrSJrJAJBACQABnsGCwsCQAsjAQskAhohAPwQAv4DACMC/RkDbkECcAR+0gEaIAlCAXwiCUISVA0BIAJBgx0kAwZ9AgoQBiAKQwAAgD+SIgpDAAAAAF0NAwv9DENnHNa75DundtF9qmpWbOokAUMJSv3//AX9EiID/BAA0gkaJAAGfiMEBm8jBQwACyQF/QyRynHlV7ClJg+71joP45K1IAQhAP0MdySy0ZkIr8ZZIS78LBfvKCQBJAIkBEKUAQsMAQEACyEC/QxPgySvsFPzZseCBf14e+j3/QwMMEoxbmFuy0g43Edz+FW5/ZQB/QypV+MsLE8WAZ+hKUBHsP+vJAEkARohAj8A/BACbyQDIAD9DKfIHDYT8REyuCyCd+isv9MkAT8AJAMaQtUBDAAF0gjSBSME/Ae1PwAkAyECGiMFAkAgBkEBaiIGQRFJDQILJAUGcEEKJQEjBSQFCyEEIwH9YyQDIAEhBBogBSEBIAZBAWoiBkEQSQ0BQs8ADAAAC6ckAD8AJAAkBfwQBPwQAhojAf0hACQEJACn/BAAcCUAIQH8EAJwIAEmAo9B4QAkAI/8BD8AJAMCfSAGQQFqIgZBI0kEQAwCCwILAgtEdlAJ5EhUs/IkBNIBA3tBBREIAEE1IARE6xKurwEo9v9DVcfYdAwDAAsACwALAAv8EAVEL3PAmRFtVsVDlXOrjyECJAQaIQIaIQMLJAT8EAPSBwJ8IwQLJAQaPwACfwJ+0gYjBCQEGvwQAgR9Q5N/tUf8EAQMAgAFQw3VbdILQTtB75i3GkGBxwL8CwD8BQu0/AFB//8Dcf0IARwgAv0gAiQCQcAQ/BAFJAMLbiABAgZClOoFQaGs4KgDQQFwDgEAAAskAyECQQJwBH0/ACQAQ1dIYuoMAAAFQ4dO2c1CusysgHw/ABq5/RQhAwtB9wBB//8DcTEAywQaIQIgABAEPwAGcAYAAgkMAAALQeadAwuzBkALvD8AJANERl+PAim0IRQkBPwQAXAlAQwACwYGIwE/AEEBcA4BAAALJAMgAP0Ms4rpuNw7Uy0LMm57XDfCwAJ7BgA/ANICIAEhBBoEQAUMAAALBgggAwwCC0GX3Q4LJAMjAgtB1B9B//8Dcf0EAoAH/bYB/TEkAQZ8RFKbsXP8AVfbCyMFJAUkBNIAIwBBAnAEbxAGAkAMAAALEAZB4AAlAwVBFyUGRAa77T44+x9PJAQMAAALJAVCMBoaIQEkBETuCQMK3ZVE//0UJAEkAyQCRSQDIQIaj/wQAf0MIdB0IyEYw+oHtJSqVRF4tiQCQf//A3EyAGUCQCMAQQFwDgAAAAsaIQIkBHrSAhoaGiECQj4GQAsaIQIa/fAB/WEkAT8AJANDPVLl/yICkAZ9QyKWCPILIQI/AEECcAQKBQIKAgBD3TyZThoMAgALAAsACxpBECUFIABE0ZMm+6Xv/f8aIwMPCw==', importObject2);
+let {fn23, fn24, global32, global33, global34, memory3, table18, table19, table20, tag20, tag21, tag22, tag23, tag24} = /**
+  @type {{
+fn23: () => void,
+fn24: (a0: FuncRef, a1: FuncRef, a2: F32) => [ExternRef, FuncRef, I32],
+global32: WebAssembly.Global,
+global33: WebAssembly.Global,
+global34: WebAssembly.Global,
+memory3: WebAssembly.Memory,
+table18: WebAssembly.Table,
+table19: WebAssembly.Table,
+table20: WebAssembly.Table,
+tag20: WebAssembly.Tag,
+tag21: WebAssembly.Tag,
+tag22: WebAssembly.Tag,
+tag23: WebAssembly.Tag,
+tag24: WebAssembly.Tag
+  }} */ (i2.instance.exports);
+table2.set(48, table17);
+table19.set(22, table10);
+table2.set(71, table5);
+table10.set(14, table4);
+table20.set(27, table12);
+table19.set(19, table4);
+table20.set(15, table17);
+global28.value = null;
+log('calling fn10');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn10();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn23');
+report('progress');
+try {
+  for (let k=0; k<26; k++) {
+  let zzz = fn23();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn23');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn23();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn23');
+report('progress');
+try {
+  for (let k=0; k<21; k++) {
+  let zzz = fn23();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn24');
+report('progress');
+try {
+  for (let k=0; k<22; k++) {
+  let zzz = fn24(fn23, fn9, global8.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn23');
+report('progress');
+try {
+  for (let k=0; k<16; k++) {
+  let zzz = fn23();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn23');
+report('progress');
+try {
+  for (let k=0; k<10; k++) {
+  let zzz = fn23();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn24');
+report('progress');
+try {
+  for (let k=0; k<28; k++) {
+  let zzz = fn24(fn9, fn9, global8.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn23');
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn23();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+let memory4 = new WebAssembly.Memory({initial: 2991, shared: true, maximum: 6859});
+/**
+@param {FuncRef} a0
+@param {FuncRef} a1
+@param {F32} a2
+@returns {[ExternRef, FuncRef, I32]}
+ */
+let fn25 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return fn24(a0, a1, a2);
+};
+/**
+@param {FuncRef} a0
+@param {FuncRef} a1
+@param {F32} a2
+@returns {[ExternRef, FuncRef, I32]}
+ */
+let fn26 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return fn24(a0, a1, a2);
+};
+/**
+@returns {I32}
+ */
+let fn27 = function () {
+
+return 39;
+};
+/**
+@returns {I32}
+ */
+let fn28 = function () {
+
+return 33;
+};
+/**
+@param {FuncRef} a0
+@param {FuncRef} a1
+@param {F32} a2
+@returns {[FuncRef, FuncRef, F32]}
+ */
+let fn29 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return [a0, a0, 2.9504893834097072e-36];
+};
+let tag30 = new WebAssembly.Tag({parameters: []});
+let tag34 = new WebAssembly.Tag({parameters: []});
+let global35 = new WebAssembly.Global({value: 'anyfunc', mutable: true}, fn10);
+let table25 = new WebAssembly.Table({initial: 98, element: 'anyfunc', maximum: 98});
+let table28 = new WebAssembly.Table({initial: 81, element: 'anyfunc', maximum: 81});
+let table29 = new WebAssembly.Table({initial: 99, element: 'externref', maximum: 226});
+let m9 = {fn26, fn27, global35, memory4, table29, tag31: tag24};
+let m10 = {fn25, fn28, fn29, table22: table20, table23: table18, table24: table3, table27: table10, tag30, tag33: tag0};
+let m11 = {table21: table16, table25, table26: table20, table28, tag32: tag20, tag34, tag35: tag34};
+let importObject3 = /** @type {Imports2} */ ({extra, m9, m10, m11});
+let i3 = await instantiate('AGFzbQEAAAABSglgAAF/YAAAYAAAYAAAYAd7fnB7fnt7BX1wfXBvYAd7fnB7fnt7B3t+cHt+e3tgB3t+cHt+e3sAYANwcH0Db3B/YANwcH0DcHB9AsoCFwJtOQdtZW1vcnk0AgOvF8s1A20xMARmbjI1AAcCbTkEZm4yNgAHAm05BGZuMjcAAANtMTAEZm4yOAAAA20xMARmbjI5AAgFZXh0cmEFaXNKSVQAAANtMTAFdGFnMzAEAAMCbTkFdGFnMzEEAAMDbTExBXRhZzMyBAADA20xMAV0YWczMwQAAQNtMTEFdGFnMzQEAAIDbTExBXRhZzM1BAABAm05CGdsb2JhbDM1A3ABA20xMQd0YWJsZTIxAXAAFwNtMTAHdGFibGUyMgFvATeQBQNtMTAHdGFibGUyMwFwAFwDbTEwB3RhYmxlMjQBcAAYA20xMQd0YWJsZTI1AXABYmIDbTExB3RhYmxlMjYBbwED2AIDbTEwB3RhYmxlMjcBbwEFpQYDbTExB3RhYmxlMjgBcAFRUQJtOQd0YWJsZTI5AW8BY+IBAwIBAAQJAm8AY3ABX8ACDQ0GAAEAAwADAAYAAgAGBmIKbwHQbwt8AURYOQ3FgsfCSAt+AUL0uqTm9AALcADSBAt/AUG63QILfAFEEt2+cJjCd00LewH9DAzm4gIDmo+wRpi+qDqgyG0LcAHSBAt9AUMOI9XOC3wBRGultpfC/v5/Cwe7ARMFdGFnMjkEBAd0YWJsZTMxAQoEZm4zMAABCGdsb2JhbDQ0AwkIZ2xvYmFsMzkDBAV0YWcyOAQCCGdsb2JhbDM2AwEIZ2xvYmFsMzgDAwV0YWcyNwQBCGdsb2JhbDQzAwgIZ2xvYmFsNDUDCgV0YWcyNgQAB21lbW9yeTUCAARmbjMxAAYIZ2xvYmFsNDEDBgd0YWJsZTMwAQkIZ2xvYmFsMzcDAghnbG9iYWw0MAMFCGdsb2JhbDQyAwcJjwULBgpBygALcALSAgvSAgsDAA0BAwMCAgIFBQYFBAQEAgBBBwsAEAEGAwACAQEAAAACAgICAAQHcErSBQvSAwvSBAvSBQvSBAvSBQvSBAvSAgvSAgvSBAvSAAvSAAvSAAvSAAvSAgvSBgvSAAvSAAvSBAvSAgvSAQvSBgvSAQvSAwvSAQvSAgvSAQvSBAvSBQvSAwvSAQvSAQvSAwvSAAvSBQvSAwvSBAvSAwvSBgvSAQvSBQvSAQvSAQvSAgvSAgvSAQvSAgvSBAvSAQvSBgvSAwvSBAvSAwvSAgvSAgvSAAvSAgvSAAvSBQvSAgvSBAvSAwvSAgvSAwvSAgvSBQvSAQvSBQvSBQvSAQvSAwvSBQvSAwvSBgsCB0EeCwAhAwAFAAIABQYABAMCBAYABAAAAAQDAwQBBQYBAAAFAAUABgdBMQtwINIFC9IAC9IEC9IGC9IFC9IFC9IGC9IGC9IEC9IFC9IGC9IGC9IDC9IFC9IAC9IDC9IEC9IBC9IGC9IAC9ICC9ICC9IBC9IEC9IDC9ICC9IAC9IFC9IEC9ICC9IAC9IECwRBBgsK0gML0gUL0gML0gAL0gYL0gUL0gUL0gAL0gEL0gMLBgdBHQtwNNIFC9IEC9IAC9IEC9IEC9IDC9IEC9IAC9IBC9IDC9IDC9IAC9IDC9IDC9IEC9IFC9IEC9IBC9IAC9IEC9ICC9IEC9ICC9ICC9ICC9IAC9IEC9IAC9IGC9ICC9IAC9ICC9IEC9IDC9IGC9IBC9IAC9IFC9IGC9IAC9IGC9IFC9IEC9IAC9IEC9IDC9IAC9IDC9IBC9IDC9ICC9IFCwYAQRMLcALSAAvSAQsCA0EMCwAEAgMFBgYHQcgAC3AB0gQLDAEJCrIEAa8EBQF7A38BfgF9AXwCAdICQzK52U6LJAnSAwZ7BgMDfwMAIwAjByEAIwVouERlCyQ8InEwbLb9DGCNAlHd7uFGstW7mIgXsfEGfgYAIAAgAEKkBkSxUVqSVR0BtkOVnkeDAn7SAtIA/BAIA3ACAkHTAAJ8IABEYOgIUIHIpywGQBgF/SIBQzgjpTb9IAP9GwJD/lMCWyQJQQJwBAHSASAAIwMjBCMH/X8kByQAIwIkCiQD/V8CQAYCIwb9DFjjtI5oO5a1UPpTik/0QnH9DLnkpbNQTDEQGGKmvCafdXdBogFBAnAEAwYD0gJDvghdj7wMCQsF0gIjCEPVRfPM/BABDAgACyQHIQD8EAQMBwsQBUUEQAwKC0PbXnt9Q+prvdr8EAdBBXAOBQABDAoDAQvSAv0MOs0/2d7R7GtmbB+eZvSvtQwKCwZ7DAIBCwwJAAsCfCMGJAYGAAIDBgAMAQsMAQtC3wEMBhnSACMFDAUAAQtC49bMjf63fkSMwBMrPUoISwJ+AgAGAiMK/RQMDAsgAAwLAAsACwAL/AYkAyQKQQNwDgMJAAcACwwIAAsACwwBC0ECcA4CBQMDCyQD/SEBIwUPAAsACyMAJAAGbwwBAQskAQ0CDAALDAELA38CA9IDRPNeiZZswFVVIABBHEEAQQD8DAQKJAed0gTSA0Kor/jBnIYG/RLSBkH7654DDwALAAsNACQHIwn8EAgPAQsGAgwAABkMAAsgAPwQBgwACwtbCQEGS/NvSbQnAQg870wshMb7/AEHCUtONcEBpABB3Z0DCwhJZOXrjIcRewECPloAQe+TAwsBlwBBhqcCCwfuk0nWkQkGAEGL7QILAbMAQcg+CwgqbDysEXKQFw==', importObject3);
+let {fn30, fn31, global36, global37, global38, global39, global40, global41, global42, global43, global44, global45, memory5, table30, table31, tag26, tag27, tag28, tag29} = /**
+  @type {{
+fn30: (a0: FuncRef, a1: FuncRef, a2: F32) => [ExternRef, FuncRef, I32],
+fn31: () => I32,
+global36: WebAssembly.Global,
+global37: WebAssembly.Global,
+global38: WebAssembly.Global,
+global39: WebAssembly.Global,
+global40: WebAssembly.Global,
+global41: WebAssembly.Global,
+global42: WebAssembly.Global,
+global43: WebAssembly.Global,
+global44: WebAssembly.Global,
+global45: WebAssembly.Global,
+memory5: WebAssembly.Memory,
+table30: WebAssembly.Table,
+table31: WebAssembly.Table,
+tag26: WebAssembly.Tag,
+tag27: WebAssembly.Tag,
+tag28: WebAssembly.Tag,
+tag29: WebAssembly.Tag
+  }} */ (i3.instance.exports);
+table10.set(15, table10);
+table29.set(42, table10);
+table5.set(20, table5);
+table4.set(25, table30);
+table10.set(38, table29);
+table5.set(3, table30);
+table0.set(70, table29);
+table12.set(26, table17);
+table12.set(30, table5);
+table10.set(20, table5);
+table17.set(34, table12);
+table5.set(27, table5);
+table20.set(10, table0);
+table17.set(89, table4);
+table2.set(19, table17);
+table2.set(60, table12);
+table4.set(54, table5);
+table29.set(61, table30);
+table4.set(46, table17);
+table0.set(74, table30);
+table19.set(1, table9);
+table9.set(3, table12);
+table20.set(73, table29);
+global29.value = 0;
+global20.value = 0n;
+global28.value = null;
+log('calling fn23');
+report('progress');
+try {
+  for (let k=0; k<10; k++) {
+  let zzz = fn23();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn30');
+report('progress');
+try {
+  for (let k=0; k<24; k++) {
+  let zzz = fn30(fn9, fn30, global8.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn31');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn31();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn31');
+report('progress');
+try {
+  for (let k=0; k<19; k++) {
+  let zzz = fn31();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn31');
+report('progress');
+try {
+  for (let k=0; k<10; k++) {
+  let zzz = fn31();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn9');
+report('progress');
+try {
+  for (let k=0; k<18; k++) {
+  let zzz = fn9();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn31');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn31();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn31');
+report('progress');
+try {
+  for (let k=0; k<5; k++) {
+  let zzz = fn31();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+/**
+@returns {I32}
+ */
+let fn32 = function () {
+
+return fn31();
+};
+/**
+@param {F32} a0
+@param {F32} a1
+@param {FuncRef} a2
+@returns {void}
+ */
+let fn33 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+};
+/**
+@param {I64} a0
+@returns {void}
+ */
+let fn34 = function (a0) {
+a0?.toString();
+};
+/**
+@returns {void}
+ */
+let fn35 = function () {
+
+return fn9();
+};
+/**
+@param {I64} a0
+@returns {void}
+ */
+let fn36 = function (a0) {
+a0?.toString();
+};
+let tag39 = new WebAssembly.Tag({parameters: ['i64']});
+let tag43 = new WebAssembly.Tag({parameters: []});
+let global51 = new WebAssembly.Global({value: 'externref', mutable: true}, {});
+let global52 = new WebAssembly.Global({value: 'f32', mutable: true}, 460834.7580894743);
+let m12 = {fn32, fn35, global46: global25, global48: global34, global49: global19, global50: global38, tag40: tag22, tag41: tag39, tag42: tag0, tag43};
+let m14 = {fn33, fn37: fn31, global51, tag39};
+let m13 = {fn34, fn36, global47: 451249.3192625079, global52};
+let importObject4 = /** @type {Imports2} */ ({extra, m12, m13, m14});
+let i4 = await instantiate('AGFzbQEAAAABmAEYYAADfXtwYAAAYAAAYAN9fXADfnt7YAN9fXADfX1wYAN9fXAAYAJ7cAN8cHBgAntwAntwYAJ7cABgAX4AYAF+AX5gAX4AYAN/e34Ce3tgA397fgN/e35gA397fgBgBH5wfXsDfX17YAR+cH17BH5wfXtgBH5wfXsAYAAAYAAAYANwcH0Db3B/YANwcH0DcHB9YAABf2AAAAKCAhMDbTEyBGZuMzIAFgNtMTQEZm4zMwAFA20xMwRmbjM0AAsDbTEyBGZuMzUAAgNtMTMEZm4zNgALA20xNARmbjM3ABYFZXh0cmEFaXNKSVQAFgNtMTQFdGFnMzkEAAsDbTEyBXRhZzQwBAASA20xMgV0YWc0MQQACQNtMTIFdGFnNDIEABIDbTEyBXRhZzQzBAASA20xMghnbG9iYWw0NgN7AQNtMTMIZ2xvYmFsNDcDfQADbTEyCGdsb2JhbDQ4A28BA20xMghnbG9iYWw0OQN/AQNtMTIIZ2xvYmFsNTADfgEDbTE0CGdsb2JhbDUxA28BA20xMwhnbG9iYWw1MgN9AQMCARYEDwRvACBvAFJvARS/B3AACwUGAQOyGeogDQ0GAA4ACAAOAA4AFwABBhsCfgFCfgt7Af0MkCfzQkEtzLsKHq/epxRdZgsHeg0FdGFnMzYEAQRmbjM5AAUHdGFibGUzMgEAB21lbW9yeTYCAAd0YWJsZTMzAQEIZ2xvYmFsNTMDAAV0YWczNwQCBXRhZzM4BAMHdGFibGUzNAECCGdsb2JhbDU1AwgHdGFibGUzNQEDCGdsb2JhbDU0AwcEZm4zOAADCeUDCAdwMtIAC9IBC9ICC9IBC9IHC9ICC9IDC9IGC9IAC9IEC9IGC9IFC9IBC9IDC9IDC9IBC9IHC9IDC9IEC9IEC9IHC9IFC9IBC9IDC9ICC9ICC9IBC9IDC9IFC9IGC9IGC9IEC9IAC9IEC9IHC9IHC9ICC9IFC9IGC9IFC9IDC9IGC9IAC9ICC9IDC9IBC9IDC9IBC9IHC9IHCwVwGdICC9IEC9IFC9IBC9IEC9IBC9IBC9IAC9IHC9IGC9IGC9IBC9IBC9IEC9IEC9IBC9IEC9IEC9IDC9IBC9IDC9IEC9IEC9IEC9IFCwVwPtIDC9IHC9IHC9IHC9ICC9IHC9IDC9ICC9IHC9IEC9IDC9ICC9IFC9IEC9IHC9IHC9IBC9IDC9ICC9IDC9IGC9IHC9IEC9IDC9IGC9IGC9IFC9IAC9IDC9IBC9IGC9IDC9IFC9IGC9IEC9IGC9IEC9IEC9ICC9IGC9IHC9IBC9IBC9IDC9IDC9IGC9IEC9IBC9IDC9IEC9IHC9IBC9IDC9IGC9ICC9IDC9IFC9IFC9IAC9IAC9IAC9IFCwMACwAABAECAwABBAEABgNBAQtwBNIAC9IFC9IGC9IHCwIDQQkLAAEBBgNBCAtwAtICC9IECwYDQQkLcAHSAwsMAQMK8QIB7gILAX8CfgJ7AXsCbwF7AHsDfwF+AX0BfAZAEANCoKbW7Z+i4nwGCkEAQQ5BCvwMAQMHCQIARHb4xDkYLE7/0gAjBkPcQL/ZQ1yIAcdBwB8MAwALRNZV7jmhFrou/AMMAgsGCwYKDAALIgFBCBELAwwBCwwACwYXDAALRAAAAAAAAAAAQyYatm9BBkEYQQD8DAED0gHSBkTG+WSi8ZUuuUMFp2rTJAYgAAJAIwYkBvwQAA0AAhIDFwwCAAsACwITAnsCAdICA3BD/ORI+wZ9BkBB1AoEFgwEAAUgCUEBaiIJQRlJDQMMBAALDgQDBgAFBgtB6gAiAA8BC5DSAyMEIgL9DGny/y8WM7g7dJ74koFObwsMAgALQ3vapDEkBtEMBAsGFtIBQ8nTCBgkBtIHQeWuiAMMAAsPC/wQAUECcA4CAAEAC0KArnoGCQYJAwpBCRELAwwBAAskBwsMAAsDAgJwDAIACwALCz8ADQAMAAsLKQMBBRECz3vgAEH9rAMLCa2iy9i1Ey5r6wIAQYa/AgsJynOv6mtfLMiZ', importObject4);
+let {fn38, fn39, global53, global54, global55, memory6, table32, table33, table34, table35, tag36, tag37, tag38} = /**
+  @type {{
+fn38: () => void,
+fn39: () => I32,
+global53: WebAssembly.Global,
+global54: WebAssembly.Global,
+global55: WebAssembly.Global,
+memory6: WebAssembly.Memory,
+table32: WebAssembly.Table,
+table33: WebAssembly.Table,
+table34: WebAssembly.Table,
+table35: WebAssembly.Table,
+tag36: WebAssembly.Tag,
+tag37: WebAssembly.Tag,
+tag38: WebAssembly.Tag
+  }} */ (i4.instance.exports);
+table2.set(22, table32);
+table5.set(5, table33);
+table2.set(31, table10);
+table19.set(22, table5);
+table29.set(12, table5);
+table33.set(18, table2);
+table30.set(26, table10);
+table0.set(17, table32);
+table19.set(13, table29);
+table33.set(49, table0);
+table9.set(6, table10);
+table0.set(51, table20);
+table29.set(48, table19);
+table34.set(16, table2);
+table33.set(54, table30);
+table19.set(19, table2);
+table19.set(0, table29);
+table32.set(24, table34);
+table10.set(26, table17);
+table33.set(6, table4);
+global29.value = 0;
+global9.value = 0;
+global51.value = 'a';
+log('calling fn30');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn30(fn10, fn23, global44.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn38');
+report('progress');
+try {
+  for (let k=0; k<10; k++) {
+  let zzz = fn38();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn38');
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn38();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn38');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn38();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn39');
+report('progress');
+try {
+  for (let k=0; k<12; k++) {
+  let zzz = fn39();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn30');
+report('progress');
+try {
+  for (let k=0; k<6; k++) {
+  let zzz = fn30(fn10, fn39, global44.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn31');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn31();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn24');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn24(fn24, fn30, global44.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn23');
+report('progress');
+try {
+  for (let k=0; k<21; k++) {
+  let zzz = fn23();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn30');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn30(fn23, fn39, global52.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn24');
+report('progress');
+try {
+  for (let k=0; k<15; k++) {
+  let zzz = fn24(fn24, fn24, global44.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn38');
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn38();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn38');
+report('progress');
+try {
+  for (let k=0; k<12; k++) {
+  let zzz = fn38();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+/**
+@returns {void}
+ */
+let fn40 = function () {
+
+return fn9();
+};
+/**
+@returns {void}
+ */
+let fn41 = function () {
+
+return fn38();
+};
+let global58 = new WebAssembly.Global({value: 'f32', mutable: true}, 13099.37117734089);
+let global59 = new WebAssembly.Global({value: 'anyfunc', mutable: true}, global4.value);
+let global60 = new WebAssembly.Global({value: 'f32', mutable: true}, -31170.70987303669);
+let global62 = new WebAssembly.Global({value: 'i32', mutable: true}, 1893196422);
+let global63 = new WebAssembly.Global({value: 'i32', mutable: true}, 1889181766);
+let table37 = new WebAssembly.Table({initial: 61, element: 'externref', maximum: 78});
+let m16 = {fn40, fn42: fn9, global58, global62, table37, tag47: tag36};
+let m17 = {fn41, global57: global42, global60, global61: global36, table36: table33};
+let m15 = {global56: 388380.2152370508, global59, global63, tag48: tag22};
+let importObject5 = /** @type {Imports2} */ ({extra, m15, m16, m17});
+let i5 = await instantiate('AGFzbQEAAAABPg1gAAF/YAACfn5gAABgAABgAX4CfX5gAX4BfmABfgBgAABgAABgA3BwfQNvcH9gA3BwfQNwcH1gAAF/YAAAAusBEANtMTYEZm40MAACA20xNwRmbjQxAAgDbTE2BGZuNDIABwVleHRyYQVpc0pJVAAAA20xNgV0YWc0NwQAAgNtMTUFdGFnNDgEAAIDbTE1CGdsb2JhbDU2A30AA20xNwhnbG9iYWw1NwN7AQNtMTYIZ2xvYmFsNTgDfQEDbTE1CGdsb2JhbDU5A3ABA20xNwhnbG9iYWw2MAN9AQNtMTcIZ2xvYmFsNjEDbwEDbTE2CGdsb2JhbDYyA38BA20xNQhnbG9iYWw2MwN/AQNtMTcHdGFibGUzNgFvADMDbTE2B3RhYmxlMzcBbwE9TgMCAQAECAJwARU2bwBTBQYBA8cCjh4NCQQADAADAAgAAwZJCH4BQigLfQFDcyjv/wt/AUEEC3wBRNx2ei7fScMOC3sB/QzXnkCAZ2EPPFh7qVle3omQC3AB0gALbwHQbwt+AUKm6/fUivhdCwd5DAhnbG9iYWw2OQMPCGdsb2JhbDY2AwoIZ2xvYmFsNjQDCAV0YWc0NgQDB3RhYmxlMzkBAwhnbG9iYWw2OAMNCGdsb2JhbDY3AwsHbWVtb3J5NwIAB3RhYmxlMzgBAgV0YWc0NQQBBXRhZzQ0BAAIZ2xvYmFsNjUDCQnTAgoBADMAAAQEAAEDBAQEBAMABAQCAwQEAAIAAwECAgQAAQECBAICAwIDAwMCAQEEAwADAwIDAgMFcB3SAQvSAwvSAAvSAAvSAgvSAwvSBAvSBAvSBAvSAgvSAwvSBAvSAQvSAQvSAQvSAAvSAQvSAwvSBAvSAAvSAwvSAwvSAgvSAAvSBAvSBAvSAwvSAAvSAwsGAkEIC3AAAgJBEAsABQIBAAQBAQAQAQQEAQQCAQEEAQACBAEBAgYCQQ4LcAfSAQvSAwvSAgvSAgvSBAvSAQvSAAsCAkEBCwAUAgECAAAAAAMBBAQBAwEDBAQCAAABAEUDAgQAAQACAwECAQMCBAQAAwAAAwEDAQECAgAAAAECBAQEAAIDAAMCAAMDAwEAAwIDAwABBAIBAAEEAwEAAQQBAAMDAQQGAkENC3AD0gAL0gEL0gILBgJBDAtwAtIDC9IECwwBBwqZIwGWIwQDfwF+AX0BfBABIwk/AEQX/uP1S3r6/yME0gH9DGRfA/dMotnrbni6G9l7Tp8jACMF0gJB+gAkCiMHQQJwBHACDP0MhbCznBpw/NKzBvskZP7hu9IBQQlBCEEG/AwAAv0MbV6eOOG6vYPX1YSF8pmbidIAQyRPgy/9DDoKRD4WqValxQeMur+Ejnf9gQEkAdIA/BAA/QwQ+OVM32xQ0cZHO1qgjsbLQ4i4K3H9IAAkDLf9DFkQpBtiXl1V5kVW6++ML5tEcIwNsr8M2PH9IgFBAfwQAnAlAiME/AFBAnAEQAIMQtby1MqF4SAkDxACA35Bw/HI/wYGewYIGAD9DILiRj5snfdvxwWuN/p3OWRDk0O7V/wQAUEDcA4DAwQCAwAL/BACDAUACwIFAn0MBAALAAvExPwQAA8LDAALDAELAgcMAAAL/QxTvQ3VxqRAc/3W7i76hQ/J/QwcS1rKt6yLxsCxHEBhbb/+Am8DAhABIAFBAWoiAUEwSQ0AEANFBEAMAQsCcEMYXeMBAn3SAAZ9AgMDCCACQQFqIgJBKkkNAAYDAwMMAQALDAALIAJBAWoiAkEgSQ0FEANFDQUQASADQgF8IgNCFFQEQAwBCyAAQQFqIgBBGUkEQAwBCyMMQYABQQFwDgEBAQsMAAsjBCQEIANCAXwiA0IaVA0DIw3RDAYBC9IC0gD8EANE0GFrFvvs/LlDLjVUnAwAAAsDfBAB0gAjAwwEAAsACwALAAs/AA8BBRAAEAIGfAYLAwggAkEBaiICQQFJBEAMAQv9DKYIBou2kRnPHGuuxXxsLr8jA0GXBiMPBgQ/AESzFSixUMFQ60PD60AL0gREB5gGVMFg1Y/8EAEMAgsDBgIE/BABDwALAAsAC0KyAdIDIwm7BkACfkNx/MR0IwD8EAP8EAMOAgIFBQtCx+PAu6LRswIGfQwBCwZwRKcQ4EtMoYPu/Qy2nCyPu2NVoLpL++WRvUfEIwH9qgEGcAwCCyQDBnAMAgELQREECEGr+9DmeQ0ADAALQcQBDAILIw0CbyMMQRNBF0EB/AwAAgNw/QwfmNu3AWIGNF9P0vUCDuKm/RsAQQFwDgECAgskDSQMDAEAC9EPC7ZBAwwAC0MAAAAAQdUBQQJwBH0CfgIIBgwGDAwACwILA3sjAEOT0sh6DAUACwALQQJwDgIAAQALDAALQY/m9Z97QQJwBEAGAgICDAIACwwBCwwAAAsCDNIBBn8Df/wQAEH//wNx/QgBrAFCLgwDAAsMBgsMBQALIwUjBwZvQQ0RCwLSAdIERNWIgdYITxnYJAv8EAH8EAEOAQUFCyMFAnwCfwYBQQ0RAAIMAQskCAIFRB30O7vEKPB/JAsMAAALDAIL/BABcCUB/QwOJ+0V9BOZ4R9CNqLhCQu30gRExbQk2BERKg8MAwALQfsDDAQLRBPY2PKnAiHdDAEFEAIGBxAAIwQDfAJwIAVEAAAAAAAA8D+gIgVEAAAAAAAALkBjDQEMAgALAAsMAgsjBAwAAAsGb9IA/BADDwsGewICBgwZDAELDAAAC0K6AQIFRNJkpMQXrR28IwIkAkKhAQMFJAhDPwkaGyQJQfXzHyQHQu0ADAEACwALBn4GAgIMQw0NW98kBAwBAAv9DN77LJx2vDDc8cHmYkBIQM/8EAIPCwJ7BgIMAAsGABACQQBBFEEA/AwBAkMXGWph/AQCBkK5srjNtOvHl34jCAJ8/Qw9Eszcx4vE+M3MkvklmEgYQcMAQQFwDgEBAQELQ0GCJ239DBcMdafuReIdymMRjW3WyowMBAtE7g2DKOdLI/QCexAABn9Exl4lfMC18CpEQdy9osiVa2ufDAYLQQJwBAwMAAAFAwcgBEMAAIA/kiIEQwAAOEJdDQAgAkEBaiICQSFJDQAjDAJwAnsgAkEBaiICQS9JDQICfBAADAQACwALAAsACwALQzLq4ZoCfwYMDAAL/BADDAIACwAL0gQjC0H8wgEOAQQECwZ8QsXKzfGMuY3gAQwCC/wCDAUAC/0MPNvkDjoLK5dEp7quGIs/wCMMDAELAgQCBQwAAAsGbwMDBgIgA0IBfCIDQiNUDQFC5gDSA9ID0gECQESTMr3MWmLxfwwGAAtB0wEPCwJ+EAAgAUEBaiIBQR9JBEAMAgtCwwAGBEIzV0ECcAQCBn4GByMHQQJwDgICAAIHBP0MXB7myVBQfz41KyQcsr4i6gwIC9IAIwBEWWrYl7Yg2i8MCAsMAgEACwYHIABBAWoiAEEYSQRADAQLQrYB/RJBz4uBlnoNAAwGCwYLAgcQAQYMDAELBgBB7wEMCwELQQFwDgEAAAvSAUH9AA8ABwAGCwYMGAIjBSMNAnAQACAAQQFqIgBBAkkEQAwGCwJ9AggGARACDAELAgUGBSQPEAIgAUEBaiIBQRlJDQkGcAJ/Iwg/AA8ACw4BAwMLIwYNAgwEGQZwAgIGB0ELQQFBBfwMBAIHAgYHDAALIAJBAWoiAkEfSQRADA0LDAELDAALRLh9LEWbSUNODA4LDA4LIw8MAAAL/BABDAQLQe4APwAMAwALQ2yMHH6LCQILRCaSHCyt1LjrJAtBlQFBAXAOAQkJC2cPC0IbQT8jBAZwBgcQACMPDAMLIABBAWoiAEExSQ0DIAJBAWoiAkELSQRADAQLIANCAXwiA0ICVARADAQLQ1MUnX1ExUeVdQB4HqAjDwwCCz8ArQwBC3kMAAskCAZ7Awj8EAEPAAs/AAwHAQv9/wHSAP0MRDnrlaEhcGq8ppBBHyNf/yQBIwAkBPwQAUECcAR9BgMDC9IBIwYPAAsNABADRQRADAMLEAIHAQNwBn4GfiAAQQFqIgBBIUkEQAwDCwIAIAJBAWoiAkEuSQRADAcLIAFBAWoiAUEMSQ0GBgFE7ECEIp955/gMCwsGBgwDCwYFBgYMBAsQA0UEQAwFCwwFC9ICQQtBBkEC/AwAAkKmAQwCAAsOAQMDAAELAgVDpBwP3ANw0gMjDUTtiPMT8QmsN0KowurZ2qKomn8MAQALAAsMAAsGBNICROcdFO/zPkliJAv9DGLKvSOfaa8pQa0enUidD3P8EAJDhJq1RCMFJA67JAsjDwZ+IAFBAWoiAUEeSQRADAYLQYoBDwuH/BACQQFwDgECAgsMBQALDAcBCxADRQ0BAn/SAAJ9BgH9DPSj+l3SKbxpy+PDlalsR1ECcBAAAwICQCADQgF8IgNCH1QEQAwICwwAAAtE6UnKyvg8rDEGfxACEALSAwJvIwkjB9IA0gBBgKPOAQwGAAtDJBaZfwwEC/wQAj8AQev2A0Gp4Q5B4fYA/AsADAQACwAL/BABDAILRBWvFzlSqOPHDAcLA28GC/wQAUH//wNx/QoDlAEMBwsMAQALDAMBCwR8IwMMBwAFAgMQAgJw/BABDwALAAsACwwFAAUjAgwAAAs/ANIEQTYkBkH9AAwGAAv8EAFD4AAdf7z8EAJwJQIMBAvSAkL2+Y7SdwYEQeAsDwtCAAMFJA8/ACQKAgD8EAIPAAsACwZvAgcjDP3DAQ0AAgsMAQALDAYLAgsCBwIHIwTSBAZ8DAELQfzUpMB6QQFwDgEGBgsMAAALRKnZ6xlPP3O+JAvSBEEAQQJwBAf9DL0JnYZeTyoxyNb1u29QWWcMBAAFDAAACyMO/QwzsyFiWi/qlajltwtG+soADAMAC0H1AA0FPwAMBQALAkADCwYCIANCAXwiA0IjVA0BAgMgAUEBaiIBQSVJBEAMAwvSAgZ/A38GfQYMDAALBgtBDxEIAgwHC/wQA0LIzPXS/f3HA78MCQAZIANCAXwiA0IBVARADAYLAgAJAQELIwYMAgv8EAFBA3AOAwUCAwULDAALDQHSBNID/BADDQNB5QD8EAAPCwYCDAALIAFBAWoiAUEtSQRADAILBnsgA0IBfCIDQgJUBEAMAwsGBxAAIANCAXwiA0IOVA0DIAFBAWoiAUENSQ0DGAYMAwsMBAALEANFDQAgBUQAAAAAAADwP6AiBUQAAAAAAAA+QGMEQAwBCxADRQRADAELBgEgAkEBaiICQRNJDQEGByABQQFqIgFBEEkEQAwDCwICDAAACwYADAQLQQJwDgIDAAMLBgwMAwALRDF+m5iQcPNhA0BDvlwaIP0T/V79DFuz4DadiZ0ElB4BVR7Q2YAMBQAL/RQMBAsjCwZvIwKOIw1DhRiu+7v8AwwHAAtBtODcEQwGAAv8EAMMBQEL/BABDwsGbyMEjyMIJAgGewYAQQZBIkEL/AwAAgJvBgtE4hawBSg+78oGfT8AQQJwBH4DfwYM0gT8EAIMBAsGe/0MxPQe22IwQY79/YxjfNuTVAwHC0L/AQwBAAsABQZwQYiZv4N7JAojBwR+Qa6yBf0Q/BACDAQABUEA0gH9DFOfOFTH6w8X/Bp0ShQKe0AMCQALDAELIwoMBAtDIE3U/wwAAAALA3sjDiQF0gAjAiQCQgECBCQPIABBAWoiAEEdSQRADAILEANFDQEjBgJ8IAJBAWoiAkEMSQRADAML0gM/ACMB/X5B8ABCs96Gm5uS4QIGBP0MBMTgHJ17NizqAyJov/aDLSMDQeAjDAwLDAEACwALAgYGBgMEAnsMAgALAAsjCyMJ0gMjAEH9ti4MBQsGB0O7qWhPJAkMAAtBDxEHAkLeAQYFugwJC7oMCAALAAsMBQtDieyRgNID0gQjDPwQAgwBAAvSAAJ9IwwMBAALAn/SAUT4v5OAHBTBTQZ9BgISAwAACwN8AgcjCgwEAAsACwwGARlEkGZcG1pTqKkMBgtCuwH8EAP9DKSpH8PDU4p/USsl0LjfWW0MBAALQQJwBH0CQAwAAAsjAiMNJA0MAAAFQwPou39DrfLTf47SAkQNtr0nNTT5f/wQAz8ADAcAC0P45NU9AnwCcAIBQcwAPwAkB0ECcAR9AwMGACAFRAAAAAAAAPA/oCIFRAAAAAAAADJAYw0B0gE/APwQAXAlASMLnEIW/Qyh5sKBCDxpBb8bSgCss2mBDAkL/BABcCUBDAcACwAFIwjSA0KKutPe15y+dyMODAYAC/0MCQ7S1E8iJl3ArfzU5H0Div3jAdIAQvzMgIPilJTkcUOJAWOWjY8kAj8ADAMACwALAAvSAdIE/BACQcq4zycjBkECcARwRPCsgTQYLAQsDAUABQYBIwBEfLUjUXdRnKAjAwwBCwZADAAAC1kkBhAAEAICAAYABgMMAAvSAESbfRSootOHJgwHCyMBDAMAC0ECcAQCDAAABSMFDAQAC0P0PNKpJAk/AEECcAR+PwAEfkKCsqXDtvC3MQwBAAUjDfwQAkH//wNx/QkAwwT97QFBEUEJQQD8DAQCDAQACwIEDAEACwwABQMLEAIgAEEBaiIAQQlJDQBB9rYBQf0GQYbpA/wLAAIHIw4MBgALAAsAC7T9DOKoIE6GAFTgxI35hAroEswMAgsMBQtBAnAEfEHXAQ8ABQYDA38gA0IBfCIDQhBUDQAQAvwQAkECcAQIEgMLEANFDQADfAMI/BAD/BACQQJwBAILQQFwDgEDAwABAAtCkpdwQQZBCkEF/AwEAkSwg2qoAvGjxgwHAAsACw8ACwIAQb/FnikjCURYmrEqvsu42QwFAAsACwwDCz8AQQFwDgEBAQv8EAAMAwsGcEEQJQIDeyMDDAMAC0GJiK32eQwDC0EPQQhBAPwMAQIMAQsGfdIBPwAMAgsGfyMN0gBBAEECcAQIAgcMAAALCyMD/QwJr3WLcQr+5KOXC8l0kBEmIwtBAEECcAQDBfwQAwwBAAskC/wQAkECcAQIBkBE+F2Igcu5TU8jDCQBPwAPCwYCC9IDQfmQA/0MuTSykMRHqynkUZE2OHMR9NIEBn0MAQtDITC2vNIC/BAC/Qw5RuFVYEovTQSl2l+m1DeGJAwNABokAowkAkPzNhIZQ8MwDiBCjwEGBQJvDAIACyQOIw8MAAv8EAAPCyMK/BACcBEHAiQMJANDbwuT/yMMPwAPCw8LQ/1KBNYjBw8LCyoHAQOWgnYBAawBA4PYIwECnbUBCZDtV6mVl7JmrwEC+V0AQbf8AAsCMDA=', importObject5);
+let {global64, global65, global66, global67, global68, global69, memory7, table38, table39, tag44, tag45, tag46} = /**
+  @type {{
+global64: WebAssembly.Global,
+global65: WebAssembly.Global,
+global66: WebAssembly.Global,
+global67: WebAssembly.Global,
+global68: WebAssembly.Global,
+global69: WebAssembly.Global,
+memory7: WebAssembly.Memory,
+table38: WebAssembly.Table,
+table39: WebAssembly.Table,
+tag44: WebAssembly.Tag,
+tag45: WebAssembly.Tag,
+tag46: WebAssembly.Tag
+  }} */ (i5.instance.exports);
+table0.set(64, table39);
+table5.set(5, table4);
+table32.set(11, table29);
+table19.set(18, table29);
+table33.set(65, table17);
+table9.set(10, table4);
+table17.set(35, table29);
+table5.set(1, table12);
+table10.set(29, table33);
+table4.set(30, table37);
+table2.set(55, table20);
+table9.set(11, table2);
+table10.set(46, table37);
+table10.set(20, table33);
+table30.set(82, table17);
+table32.set(2, table0);
+table29.set(30, table34);
+table5.set(14, table5);
+table20.set(48, table29);
+global54.value = 0n;
+global36.value = 'a';
+global17.value = null;
+log('calling fn24');
+report('progress');
+try {
+  for (let k=0; k<12; k++) {
+  let zzz = fn24(fn23, fn10, global8.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+/**
+@param {I64} a0
+@param {ExternRef} a1
+@returns {void}
+ */
+let fn45 = function (a0, a1) {
+a0?.toString(); a1?.toString();
+};
+/**
+@param {ExternRef} a0
+@returns {ExternRef}
+ */
+let fn46 = function (a0) {
+a0?.toString();
+return a0;
+};
+/**
+@returns {I32}
+ */
+let fn47 = function () {
+
+return fn31();
+};
+let tag54 = new WebAssembly.Tag({parameters: ['i64', 'externref']});
+let tag58 = new WebAssembly.Tag({parameters: ['externref']});
+let tag60 = new WebAssembly.Tag({parameters: ['anyfunc', 'anyfunc', 'i64']});
+let m20 = {fn43: fn39, table43: table25, table46: table30, table47: table35, tag54, tag56: tag38, tag59: tag58, tag60};
+let m19 = {fn44: fn31, fn47, table42: table38, table45: table10, tag57: tag36, tag58};
+let m18 = {fn45, fn46, table40: table20, table41: table1, table44: table28, table48: table10, tag55: tag20};
+let importObject6 = /** @type {Imports2} */ ({extra, m18, m19, m20});
+let i6 = await instantiate('AGFzbQEAAAAB0AEWYAABf2ABbwF+YAFvAW9gAW8AYANwcH4AYANwcH4DcHB+YANwcH4AYAJ+bwBgAn5vAn5vYAJ+bwBgAX8AYAF/AX9gAX8AYBh/fW9vf3xwb3B/cH99fn1/f3Bwfn59fnACfnBgGH99b29/fHBvcH9wf31+fX9/cHB+fn1+cBh/fW9vf3xwb3B/cH99fn1/f3Bwfn59fnBgGH99b29/fHBvcH9wf31+fX9/cHB+fn1+cABgAABgAABgA3BwfQNvcH9gA3BwfQNwcH1gAAF/YAAAArUCFgNtMjAEZm40MwAUA20xOQRmbjQ0ABQDbTE4BGZuNDUACQNtMTgEZm40NgACA20xOQRmbjQ3ABQFZXh0cmEFaXNKSVQAAANtMjAFdGFnNTQEAAcDbTE4BXRhZzU1BAAQA20yMAV0YWc1NgQAEQNtMTkFdGFnNTcEABEDbTE5BXRhZzU4BAADA20yMAV0YWc1OQQAAwNtMjAFdGFnNjAEAAQDbTE4B3RhYmxlNDABbwFK9gMDbTE4B3RhYmxlNDEBcAA6A20xOQd0YWJsZTQyAXABEpMEA20yMAd0YWJsZTQzAXAAWgNtMTgHdGFibGU0NAFwABMDbTE5B3RhYmxlNDUBbwAgA20yMAd0YWJsZTQ2AW8AUQNtMjAHdGFibGU0NwFwAAIDbTE4B3RhYmxlNDgBbwAdAwQDEgYHBCQJcAFS+gZwAA5vATLFAm8BXOcHcAAicABgbwBhcABgcAEvhwIFBgEDsw/bKQ0TCQAKAAYAEAAEAA8AAwAEAAYADAZVDX4BQrN+C3wBREv7Y0OBJsgiC38BQY71scQFC3AB0gcLfwBB1AALbwHQbwtwAdIBC3AB0gALfgFCOwtvAdBvC30BQzTVdnkLfQBDV5wNJAtvAdBvCwecAh0FdGFnNTEEAgV0YWc0OQQACGdsb2JhbDc0AwQHdGFibGU1NQEPCGdsb2JhbDcxAwEIZ2xvYmFsNzIDAgRmbjUwAAgEZm40OAADB3RhYmxlNDkBBQd0YWJsZTUxAQoIZ2xvYmFsNzcDBwV0YWc1MgQDCGdsb2JhbDc5AwkHdGFibGU1NAENCGdsb2JhbDc2AwYIZ2xvYmFsNzgDCAhnbG9iYWw3NQMFCGdsb2JhbDcwAwAFdGFnNTAEAQRmbjQ5AAcIZ2xvYmFsNzMDAwd0YWJsZTUzAQwFdGFnNTMEBAhnbG9iYWw4MAMLB3RhYmxlNTABCQhnbG9iYWw4MQMMB21lbW9yeTgCAAd0YWJsZTU2ARAHdGFibGU1MgELCdMBCAEAUAQFAAcBAwYIAwAGAgMCAgcGAQIABggFBgQABwECAQMBBQcABQMAAgIDAQQAAwAHAQMCAgcGCAYCAQQBAwMDBQEGBAQABwAFAwgFAQACAgUAB3AC0gML0gcLAwA0BAICAQYEAgEBAQcHBwMHBAAAAQIABgUGAQEIAQgFBQMHAwECCAgFBAAGCAMFBQYDAAAEAgYJQQwLcATSAAvSAQvSBAvSBQsGEEHSAAtwAtICC9IICwYDQRMLcAHSAwsGDUEVC3AB0gYLBgdBAAtwAdIHCwwBAwrbEAOoDQcBcAFvAXwDfwF+AX0BfCMLJAoCFQJA0gP8EAw/AAR90gb8EBEGfgYAAnAGQNIDQ6zTcpAjAyEDROUQPATZu5QMAn3SAyMMQZvzqe8A/BAMcCUMQQBBMkEI/AwAAiQJAgEQAwYDIQQYCQMU/BAGAgtEdaYSbRk+pW9EZH3QJ0vlUuyaPwD8EAVwJQUQAwNAAgAGbwYQDA0ZDA0LDA0AAQABCwYCDAAL0gP8EA0GCwwJCwYLQQNwDgMMBw0MC9IEIwEDcBAFRQ0EEAVFDQIgCEEBaiIIQTFJDQQgCkMAAIA/kiIKQwAAGEJdBEAMAwtCwAEMBQALAAsACwALAAsACwwEAAv8BfwQDwNwRALV1fJitQykQvbFhYSc4J9+DAQAC0ELQcYAQQD8DAARAn0MBwAL/BADAgv8EA1wJQ0CcANwAhQMBAALAAsACwALQQNwDgIGAAULDAQAC9ID0gUgACAD/BAJDAALDQL8EAtBAnAEfwwEAAUMBAALDQIMAgvSCCMF/BADBEAMAwAFDAIAC/wQBA0BBgFB1QFBAnAOAgIDAgskCPwQDiQCQajihIh8DQIGfQwDC7xBAnAOCwICAgECAgECAgEBAQUQAEECcA4BAgELvA0AAgxBA3AOAwIBAAIL0gfSA/wQDUECcA4CAAEAC0ELQTJBBPwMAAIDFQwBAAsDACAJQgF8IglCIVQNACMGAn7SBtIF/BADDQIGbwwDC0MXmRb5A0BClAQMAQALAAsgAo78EAsGQAYUAhQMAgALIwoiAgZvDAILJAX8AAwAC7hEaS/3Q5Lt8vkgBdIIIAQkDCAFIwMhAEEuQShBGPwMAANDKp32uyQK0gVBnihBPkH/1wD8CwAgA0EAQQJwDgICAAILAwsgCUIBfCIJQhRUDQBBAXAOAQICCwILDAAACw0BvEEBcA4BAQELQQFwDgEAAAsGACMJAgIGAgwBCwYDIAX8A0EBcA4BAQELAhRCoAECQAwAAAskAAJ9EAFBAnAEQEQkn4B+kcg+GrYjBAN/IAlCAXwiCUIUVARADAELEAUMBQALAAU/AEEBcA4BAAALBm8CEAJ8DAEACwALIwbSASAF/AMMAgskBSAAQYsbDAEACyMMDAEACyQCRJ7dhVFVbYjhQt4BAm8GFRAFDAMACwYAAhUQBAwEAAsGfQYVBhTSBUKDkPC0kfDEvHynDAMLDQAHC0TqS43ii41axAZ9/BANAgoCCgwIAAsACwwBCwZvDAEBCwwECwYRA3/8EAQMAwALQrbI/pma6kUCfNIBAm8MAgALAAtCvgECQAwBAAsgAkMAAAAADAELBhECAAwBAAsMBQsgASEDQQwRAAkMAQs/APwQCnARAAoGcERoi4eDMJpCdyEFIwYjCCAF/BAIDAELJAcDChAFRQQLDAELAn9CzABD2PUKetIGAnAQBUHyAEEDcA4DAwYBAQskB0KPx4a7/nzSCEGVyecPQQJwBBUGFAwBC0EBcA4BAAABC9ICQsYAQ5cFOC2LIQJB1AEGf9IFIAMkBiMEDAELEAVFDQFBA3AOAgIABQsQBUUNAAYMQQFwDgEAAAsCC0ECcAQAIwYkAwJADAAACwJ8IwEMAAALJAHSBkQ3g/3b7FV0LNIGGvwQDgQUBhUMAAALIAMkA0SpXc2RqnxGOtIC0gFB9doADAIABSABIQBBAwwAAAskAiQBQQ5BwgBBBfwMAA0aQucB/BAEQQJwBG/SBUEHQQJwBG9BywI/AAwIAAVCAHsgAiECtESOWyz5h7oTm0KH1HQkACQBQoarnHwkAPwFUAwIAAsMAAAFBhAYByMMDAUACwYBAwEhBBAEDAMACwtBDgwBAAUjCyQKEAAMBgALIAhBAWoiCEEXSQQLDAILRHD+v02COlbO/AIgCEEBaiIIQQpJDQEMBQsCCgwCAAsAC0EDAwwgC0QAAAAAAADwP6AiC0QAAAAAAAAUQGMECwwBC0ECcAQRAhAjCkIKJAgkCkO4CKnfJAoMAAALBhUGENIEGgsLBQsL0gc/AAwDGSMEuCQBQdsBCwZ9AxQCcNICIAIiAiECIAEkBiAEDAQACwALDAMAC/wQBAwCCwwAAQskDEGeAQYLCyABJAMCDAwBAAsCEUTo1TOtGn3dXvwQAUEBcA4BAAALQTf8EANwJQMkBwIVC9IBGgIVC0HcAAwAAQskAhAEJAJBDiUGBn4jCRADJAkGFSAA/BALQQFwDgEAAAsGEQwACyMICyQAQTslDgJ8REb176Cuuv/zCyQBQZ0BBgsLCxQEA38BfgF9AXwCfQ8ACyQKDAABC5kDCQFwAX4CfQJvAX8DfwF+AX0BfAIRBhUGFAZvQccAJRBBAyUEIwoQBkECcARAEAEjBSQFIQgFIwggBvwQAwJv0gggCEECcAQVAxAjBQJ/BhRBDREUCQMKAwwGDCANQwAAgD+SIg1DAADgQF0NAkHeAEEDcA4CAwoEC0GrAQwJAAsACwMVA0AMBwALAAsMBQALQQVwDgUJBwIECAkLQQVwDgUHAwgBBgML0gJCoMLt6bDdfiMH0gDSBCMMIgcMAwAL0gdEiHbnDsXiw1gCQAIUDAcACwALAAsjAUSmGdAz9udz6aICfwwBAAsMAgv8EBAMAQELBgEjBSMG/BALBgwMAgALQfWJrwFBAnAEAEM26hWr/BAADAAABQMUDAQACwALDAEL0gRBAkHDAEEJ/AwACtIGQ+MEnrIjCSMMEAMGfUHTq463BwwBCwJ+BhUMBAsQAAwBAAshA45EbmqUcAdjxH/SAiMJIgfSBkIN/BACDAALBgtBA3AOAgMBAgALBkAMAwtBA3AOAwIBAAALDAELQYaj3AAkAgwACwseAwIAQcrOAAsCAugBBioyJRnJ8QEJbZlZpTWJQ/mq', importObject6);
+let {fn48, fn49, fn50, global70, global71, global72, global73, global74, global75, global76, global77, global78, global79, global80, global81, memory8, table49, table50, table51, table52, table53, table54, table55, table56, tag49, tag50, tag51, tag52, tag53} = /**
+  @type {{
+fn48: (a0: ExternRef) => ExternRef,
+fn49: (a0: FuncRef, a1: FuncRef, a2: I64) => void,
+fn50: (a0: I64, a1: ExternRef) => void,
+global70: WebAssembly.Global,
+global71: WebAssembly.Global,
+global72: WebAssembly.Global,
+global73: WebAssembly.Global,
+global74: WebAssembly.Global,
+global75: WebAssembly.Global,
+global76: WebAssembly.Global,
+global77: WebAssembly.Global,
+global78: WebAssembly.Global,
+global79: WebAssembly.Global,
+global80: WebAssembly.Global,
+global81: WebAssembly.Global,
+memory8: WebAssembly.Memory,
+table49: WebAssembly.Table,
+table50: WebAssembly.Table,
+table51: WebAssembly.Table,
+table52: WebAssembly.Table,
+table53: WebAssembly.Table,
+table54: WebAssembly.Table,
+table55: WebAssembly.Table,
+table56: WebAssembly.Table,
+tag49: WebAssembly.Tag,
+tag50: WebAssembly.Tag,
+tag51: WebAssembly.Tag,
+tag52: WebAssembly.Tag,
+tag53: WebAssembly.Tag
+  }} */ (i6.instance.exports);
+table29.set(75, table20);
+table9.set(9, table55);
+table33.set(70, table4);
+table34.set(3, table9);
+global0.value = 0n;
+global7.value = 0;
+global59.value = null;
+log('calling fn9');
+report('progress');
+try {
+  for (let k=0; k<22; k++) {
+  let zzz = fn9();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn38');
+report('progress');
+try {
+  for (let k=0; k<20; k++) {
+  let zzz = fn38();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn49');
+report('progress');
+try {
+  for (let k=0; k<15; k++) {
+  let zzz = fn49(fn38, fn24, global78.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn48');
+report('progress');
+try {
+  for (let k=0; k<19; k++) {
+  let zzz = fn48(global34.value);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn49');
+report('progress');
+try {
+  for (let k=0; k<21; k++) {
+  let zzz = fn49(fn24, fn10, global64.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn38');
+report('progress');
+try {
+  for (let k=0; k<29; k++) {
+  let zzz = fn38();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn48');
+report('progress');
+try {
+  for (let k=0; k<9; k++) {
+  let zzz = fn48(global75.value);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn50');
+report('progress');
+try {
+  for (let k=0; k<29; k++) {
+  let zzz = fn50(global54.value, global81.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+/**
+@returns {ExternRef}
+ */
+let fn53 = function () {
+
+return {f:42};
+};
+/**
+@returns {void}
+ */
+let fn54 = function () {
+
+return fn10();
+};
+/**
+@returns {void}
+ */
+let fn55 = function () {
+
+return fn10();
+};
+/**
+@param {ExternRef} a0
+@param {F32} a1
+@returns {void}
+ */
+let fn58 = function (a0, a1) {
+a0?.toString(); a1?.toString();
+};
+/**
+@returns {void}
+ */
+let fn59 = function () {
+
+return fn10();
+};
+/**
+@param {ExternRef} a0
+@param {F32} a1
+@returns {void}
+ */
+let fn60 = function (a0, a1) {
+a0?.toString(); a1?.toString();
+};
+/**
+@returns {void}
+ */
+let fn61 = function () {
+
+return fn9();
+};
+let tag61 = new WebAssembly.Tag({parameters: ['i32']});
+let tag65 = new WebAssembly.Tag({parameters: ['externref', 'f32']});
+let tag68 = new WebAssembly.Tag({parameters: []});
+let global82 = new WebAssembly.Global({value: 'f64', mutable: true}, 654475.7097073357);
+let global83 = new WebAssembly.Global({value: 'anyfunc', mutable: true}, fn9);
+let global87 = new WebAssembly.Global({value: 'anyfunc', mutable: true}, global68.value);
+let m21 = {fn51: fn23, fn52: fn39, fn59, global82, global83, global86: global55, table58: table16, tag62: tag38, tag64: tag45, tag68};
+let m22 = {fn53, fn54, fn57: fn23, fn60, fn61, table57: table37, tag63: tag50, tag65, tag66: tag0, tag67: tag61};
+let m23 = {fn55, fn56: fn31, fn58, fn62: fn39, global84: global44, global85: global26, global87, table59: table31, tag61};
+let importObject7 = /** @type {Imports2} */ ({extra, m21, m22, m23});
+let i7 = await instantiate('AGFzbQEAAAABXRVgAAF/YAJvfQBgAm99Am99YAJvfQBgAAN/fG9gAABgAABgAAFvYAAAYAAAYAF/AX5gAX8Bf2ABfwBgAABgAABgAAF/YAAAYAJ+bwBgAn5vAn5vYAFvAW9gAW8BbwKNAx4DbTIxBGZuNTEACQNtMjEEZm41MgAPA20yMgRmbjUzAAcDbTIyBGZuNTQACQNtMjMEZm41NQAOA20yMwRmbjU2AA8DbTIyBGZuNTcADgNtMjMEZm41OAABA20yMQRmbjU5AAgDbTIyBGZuNjAAAQNtMjIEZm42MQAFA20yMwRmbjYyAA8FZXh0cmEFaXNKSVQAAANtMjMFdGFnNjEEAAwDbTIxBXRhZzYyBAAIA20yMgV0YWc2MwQABgNtMjEFdGFnNjQEAAkDbTIyBXRhZzY1BAABA20yMgV0YWc2NgQAEANtMjIFdGFnNjcEAAwDbTIxBXRhZzY4BAANA20yMQhnbG9iYWw4MgN8AQNtMjEIZ2xvYmFsODMDcAEDbTIzCGdsb2JhbDg0A30BA20yMwhnbG9iYWw4NQN7AQNtMjEIZ2xvYmFsODYDewEDbTIzCGdsb2JhbDg3A3ABA20yMgd0YWJsZTU3AW8BOI8BA20yMQd0YWJsZTU4AXAAYgNtMjMHdGFibGU1OQFwADsDBAMMExEEEQRwAENwASH7BW8AHnABSPoDBQYBA7Af8yoGTQxvAdBvC3AB0gQLbwDQbwtvAdBvC34BQsaxzqOXfwt9AEMAAID/C3AB0ggLcAHSCgt+AUKG1d/D/wMLfgFCPgt9AUOpFsNeC34BQgILB8IBFAhnbG9iYWw5MAMIBGZuNjgADghnbG9iYWw5NQMOCGdsb2JhbDkzAwsHdGFibGU2MgEGBGZuNjYACghnbG9iYWw4OAMGBGZuNjQABgRmbjY1AAgHdGFibGU2MAEDB3RhYmxlNjEBBQRmbjY3AA0IZ2xvYmFsOTYDDwhnbG9iYWw4OQMHCGdsb2JhbDkyAwoIZ2xvYmFsOTgDEQhnbG9iYWw5NwMQCGdsb2JhbDk0Aw0EZm42MwACCGdsb2JhbDkxAwkJ9QYOAwBKDQcKAg0IDwEBCwMKBQwDDQsKBAQLDwgMAAkNAQABDQQIAgUICQcHDwMDBQoDDwAGDgECBAoLCwkPBwkNCwQMBgkEDAcNCQsMDwcHcFrSCwvSAgvSCAvSCAvSAgvSAAvSBwvSCQvSCQvSAwvSCgvSAgvSBwvSAwvSCAvSCgvSAgvSAgvSCQvSDwvSAAvSBgvSAgvSDQvSBAvSDwvSDAvSAgvSAgvSAQvSAwvSCAvSDQvSDQvSBQvSAwvSDAvSAgvSBAvSDwvSAQvSDQvSBwvSAAvSDwvSDgvSCgvSCwvSCQvSDAvSCgvSBwvSCgvSDgvSAQvSAgvSAAvSDwvSDQvSBgvSAgvSCAvSAwvSCgvSBwvSAwvSCQvSDwvSBAvSCAvSBAvSAgvSDwvSCwvSAgvSCQvSDQvSAwvSDAvSCAvSDAvSAgvSAAvSBwvSDQvSDQvSAwvSCgvSCwvSDwsCBEEVCwAMAAYGAQgCCwMADgwABgZBBgtwPNIBC9ILC9IDC9IGC9IEC9IKC9INC9IFC9INC9IJC9IEC9IEC9INC9IPC9IDC9IGC9ILC9IGC9ILC9IOC9IDC9IEC9IFC9IPC9IPC9IPC9INC9INC9INC9IKC9IDC9IDC9IGC9IDC9IEC9IFC9IOC9IHC9IFC9IIC9IIC9IHC9IIC9INC9ILC9IMC9IKC9INC9IJC9IGC9INC9IDC9IHC9IKC9IIC9IKC9IEC9IIC9IBC9IHCwdwCtIBC9IOC9IPC9IMC9IGC9ICC9IJC9IBC9IMC9IPCwIGQQ8LADkACAAMAwcOBwQEDw4CBAIEDgEAAgUKCQMFBQ0LAgQNBQEFCwAADA8GDAYPAQgBBQkKBwYAAwkHAQkGAkEEC3At0g8L0gQL0gAL0gsL0ggL0goL0g0L0gUL0ggL0ggL0goL0gQL0g8L0g8L0gwL0gcL0gIL0gUL0goL0gcL0gQL0gcL0gUL0gYL0gUL0gAL0gIL0gUL0gML0gcL0gkL0gcL0gUL0ggL0gsL0ggL0g8L0ggL0gML0gYL0gEL0gAL0g0L0gwL0gwLBgRBBwtwBtIAC9IDC9IEC9IGC9IIC9IKCwIGQT4LAAQBBQsMBgNBJAtwAdICCwYBQcAAC3AC0gcL0gkLBgZBOQtwAdINCwIGQcUACwABDgYBQS4LcAHSDwsMAQgK6SgDFwYAfwJ8A38BfgF9AXxCHUE0JQAQDw8LtSgKAnwBfwJvAG8BfAF/A38BfgF9AXxC4P2Um33SCiMC/AU/AEECcAQGBRAMEA1BCBEIBAYQQcO2AkHhAEGB4AH8CwAGCUNlte/+/BAAIgNBAnAEcAIAAg8GBELOAKcDC7MkAkO3gVbMQ8auiUUjALYgBQIUIQUDD9IDAn8GCfwQACEHGAkCBAYHBgQGAAZ90gbSCEQcugAjzpmLufwGIwlBowHB/BADDAoLjkE9QQBBAPwMCgEkEAYNDAALQrIBBm/SDkN2ngLfjwZ80gIjAkP+W364Qdn/zQtBA3AOAw8OEA8LIwEMDAsCEwwAAAsCcAMHIAcMDAALAAsjBwwLCwwJC9ENC0T3ed4JayM4IyQAIQENCwZ/DA0L0gRD9PUVAUSs5+OOafuGjZ0gAAZ/IAtCAXwiC0IxVA0EIwv8AUEDcA4DDAsNCwEBC0EDcA4DDAsKDAsGEwwNCyADDAEACwALQQNwDgMJCAcHCwwDAAsAC0EDcA4DBgUEBgsDEyIEAhMgASIGQvACQzOubakjCSMFDAQACwALBhMGEwwBCw8LAhQPAAsPC0ECcAR+0gogAZ8kACMLJBDSC/wQBEEDcA4DBQQDAwAFDAMAC7n8BwJAQvwAQv8AJA+n0gggAiEBBn3SDCACIQHSDSADIgdBBHAOAwQBBgULQ12Zkn9gQQJwBAAGfgwHC0EAQQRwDgQEBgUBBAUMBQALDAEL0gNCAMJBmKU4DAALQQNwDgMBAgMBBQZ9BggMAAsCDQYOBkACfQwDAAsMAwELAhAGf/wQAQwAC0EGcA4GBwAGAQIFBQsMAAsCDgwAAAsMAAsMAws/AAZ9BglE8A0Ggu97RVEhBkIrIAYkAETidCwv/4E3RfwQBEEEcA4EAwUEAAABCwwECyQQrSAAJAb8EAMhAwN8IAbSDyMPIw9CdyMC/BABQQNwDgMCBAMDC/wQBg4DAwECAgskBdIMQt8BJBFEofMbJS7ZdBghAkOWDmG4IwYCEwwAAAvSAELJq/Bvp0EDcA4CAgABC0N4uQqe/BAAQQJwBA8MAgAFDAIAC9IAQRtBAEEA/AwIBEKOyL76zABB8AACfwIODAMACwALTkECcA4BAQALQvmR4+QBAnwMAQALQS9BAEEA/AwJAgZ9DAELkfwQAiAEJAlBAXAOAQAACyQR0g1DkQmkpfwEJAogAAJ8EAgjEUPnJmpGJBBBMEEAQQD8DAQDJAoGBQwAAQsGBEEIEQ0EBnzSAPwQBUH//wNxLQCEBxANIwQjBiQG/Wn9aEPFY0EaRAAAAAAAAACA0g1BBaynQQJwBH8DcPwQAEECcAQIIApBAWoiCkEOSQRADAILEAVBAXAOAQAAAAv8EAUgBQMUBhMCEyIA/BACDAQAC9IEIAQMAAsDFAIUBhMGfyAIQQFqIghBKEkNBUE+EQ8GQQJwBH4gCUEBaiIJQS1JDQYCAEQyzixD/Pm9EgwLAAsABSAKQQFqIgpBL0kEQAwHC0HMAD8ADAEACwJ8IApBAWoiCkELSQRADAcLEAxFBEAMBwsGBULuASAGDAsBAQcFDAALBn8GcAYOQdb35jYMCgsQDEUNCEPoc08JJBAjC/wQBAwJC0Ga7O4NDAILAgwEfxAMRQRADAkLDAEABQIAIAQMBQALAAtFQQFwDgEAAAtEPCC21uDHa9EMAAALBnwgCEEBaiIIQRtJBEAMBwsgBwIKBn0gBgwKCyQQDAIACyQPRBcT0tWE4fF/IAcNACAEDAMLm/wDQQJwDgIHCQkLDAULBhMjDSQHGAYGf9IAIAEgBgwICwILDAAACwYMBgoNAQIEEAxFBEAMBwsQBiAJQQFqIglBAUkNBgwCAAsGEwYTAhMGFAwBCwwBCxgIIAQMAAELIwAMCQtC7gGIAm8jAfwQA0EBcA4BAQELBhEiBAwKCwIAIwUkBRABDAAAC0ECcAQQBg4GBAIHIAYMCgALEAxFBBMMBwsiAAwECwYTIxAGAwYDQcAAEQMBDAQLDAMHBgwJAAvSC0Lg99LL3LyoRUEHDAgLAhQQDEUNBQZ/DAMAC8HSCyADQQJwBHAgB0EDcA4GBAIDAgQCBAAFIwUMAAALBn0GDRAMRQ0JAn8gAwwAAAtBBHAOBAUDAAQACwIHIApBAWoiCkEnSQRADAoLIAAkCQINAkACCfwQAgwNAAsACwALAAsgAAwFCyQCRFlYCORpESlrJAACQAwDAAsACyALQgF8IgtCK1QNBEMgwZ1yAn8MAgALQQJwBA0FIAQMBAALAgFDVmy39gJAEAIhBAYABhAMBgvSB9IA0gjSDNIHQ1rrqn+NPwANAfwQBg0CAnDSCyAC/AfSBEO15CNDQf7Hy6t9DgUCAwUGBAILIAYkAAZ/DAIBCwwACwIMQQZwDgYAAgUEAwEDC0NdQLbGJBAL/BABDAgBCwwKCwwBCyMCIwUkAUOtYGhmXQ0ADAALIQAgA0ECcAR/CAIFIAtCAXwiC0ItVARADAULBkAgCEEBaiIIQQ1JBEAMBgsCcCAIQQFqIghBG0kEQAwHCyANRAAAAAAAAPA/oCINRAAAAAAAADpAYwRADAcLIAtCAXwiC0IuVA0GIAAGEwJ9DAMACyQQIQQGfiAHBgoGCgwLAQsMAAELGAAkDgIOQ9FLpv8kEEOEci7DBnACBQwCAAsGBwwFAAvSAiAGnD8AQQJwDgIBBAELDAIACyAKQQFqIgpBLUkEQAwICwwCAAALIgQQDEUEEwwFC0QX3FHKPYJAjQwKC0Qx+FGn0tn2/wwHCwIOIwdDqAvc24w/AEECcAQO/BAADAcABQwAAAtB0I7qswMMBgALAAtBAnAEDgUCB0Q62f9hyv3HVSICnSMLQcs9DAYACwALQQFBAEEA/AwFBEPHN/0XBn5BCUEAQQD8DAoEBhAMAAvSCvwQBAIMBgwGCgwICyMGIApBAWoiCkEcSQQTDAULIAlBAWoiCUEbSQ0FIApBAWoiCkEhSQQTDAULIAQMCwvSByAHDAYAC/wQBAILAnwCQAYFEgIACz8A/BACcCUCQ17eAehBAUEBcA4BAAALBn0gBAwMAQs/AARADAAABRAIIAIMAQALJBBEvLyTiBJ1nQsiBgwICyMMIAYCfAIIEAxFBEAMCAv8EAYMCAALAAsACwYLBHDSDkPnNtP/IAMCDAwIAAsABQYJIAEkAAZvBgcCCQwDAAtEt+HS+TEhZfH8EAQMCgsYAwIUJAYGBhgEAhAMAgALAAsgCUEBaiIJQQlJBBMMBgsjBwwBCz8ABgpBAEEAQQD8DAADDAILDAILQ3tcpYMkEPwQAwwGCwQJBQwAAAtBxgEgAwwFAAELQckAQQBBAPwMCQEkDouOQuyKlafS4KfNd7lEYuuKFkqyqDMgBSALQgF8IgtCD1QEEwwDCxAMRQQTDAMLAhQMAQALBhNDTjUd5gIBBgIGb/wQBkEBcA4EAgICAgIACw8HB0G24wNBAXAOAQEBC0QJBeaHuT9vEgwJC0EHDAULIgD8EAUMBAsMBwALAAsACyMMJA0kBdIF0gcGQAwAAAsjASAADwUCBSADDAEACwALQQJwBAcCfgYIRN9vqZ/NOfn/DAUL/BACAgsgAAwGAAsACwAFAglBDEEAQQD8DAsDDAAACyMGDwALRD2xEPIUzU4U/BABDgIAAgALvbQ/ACMMRAOXvkmIFTJ7/AIGDEEBcA4BAAAAC/wQASIHQQJwBH4CBkHF7obYBEECcAR+AxAMAgALAAUMAQAL/BACQQFwDgEBAQsgAyEDBgAjBQZ9EAPSDj8AAwojAAwFAAu0DAABC/wEDAEL0gMjCgwABQIGIwUCcPwQAvwQBUECcAQQEAFBAnAOAgIAAgsCC0EBcA4BAgILDQEMAQALIARDHuq8k/wEDAELIAcCCwwAAAtEFw1xTUlt2I0MAgsjAT8A0gRB3OcAQQFBA/wIBgDSAdIA/BADQQJwBBAFDAAAC0Hzn/UAAgsDbyACPwBBAXAOAQMDCwwDAAsCChANIANBAnAEBgwAAAXSBSMIBhQMBQsMBAALBhAMAAsGCQwAC9IBROW9bDRVuHoSIgEhAQNwQQoRBgQCCdIL0gHSDwZ9IAhBAWoiCEEwSQ0CDAEACyQCIAAMBQsCEAYOBgQGDgMFROKmmrLcjG4ZDAgACyAHAnAGCRAMRQ0GBgQgC0IBfCILQghUDQcMBQALBhMYCgwDAQtDU4tjJCQQDAMACyQM/BAEcCMMJgT8EANBAnAEENIE0gX8EAYOBAMAAQQAAQsMAgsGDwwDC0ECcA4CAQIBBwANAUSa3lf8TUd8bgwGCwZwBhAGcAwECwwBCwYFEAtBAnAEfAwBAAUMBAALmvwQBSMDQqzq55OKgIoEDAUL/BABvo1DSOTx8IyTIwEgBSQGAm8MAwALQeSlswIOAgIBAgskBSIEAhMgBdIMQ1175f+7IwP9XiMCIAMNArsjC4vSANINIwYMAAALJAbSDvwQBUECcA4CAAEAC9IJQvQB0g/SCAZ/0gQCbxAMQQJwBHACDkEWQQBBAPwMCQP8EAIQDRALQQJwDgIABAQLAhAGDwwBCwQNIxF7DAcABQJ+DAEACwALEAQDCSAJQQFqIglBJUkNAPwQAwwEAAsQBQwDC0K0AQwFAAUMAwALIAD8EAVBAXAOAQICC0LnlLzro/qclAHSCfwQBQwACwYKQQFwDgEBAQsMAgvSCULR5/HkiY0YDAEAC0TSO+tBMVRpgZ+ZIAX8EAACCkECcAQFBgUMAAsGCUE2QQBBAPwMCwYCDQwCAAsQBiAGJAADfAwBAAsMBQsFBgkMAQsQAUECcAQPDAEABdINIAMNAUHq3wEMAAALQQJwBA8MAQAFDAEACw4BAAALQfQAEA1EPZeOmHV1bJQkABALBAACfCAFDAYACwAFAgYCBgwBAAsAC9IM0g7SBSMKJA4jDUHcBkECcAQG0gNB3QFBAXAOAQAAC0EtQQBBAPwMAwMkDUH9AUECcAQJQvsAQu/z//ezx9oAQQAMAQAFEANDP4mhhotDDpnmeiAFJAn8EABBAXAOAQAAC0P/uW0d/BADDAALA3AgCkEBaiIKQTBJDQAGDyALQgF8IgtCJlQEQAwCCwJAAgcgCEEBaiIIQSlJBEAMBAsGDQINQwOtDcv8EAZBAnAEABAAIAlBAWoiCUEKSQ0GQqG73Jfrmww/AAIKQf//A3EoAaACDQIGEAwACyAMQwAAgD+SIgxDAAAcQl0NB0QVf0C59678fwwLAAsABQIQBgUMAQABCxAADAABAQsMAgALDAQLBwYGCwwACwwDCyACIwUkAQZ//BAECyMIIAYMBwALAAtC4QEgA0ECcA4CAgMCCxANAg8QCz8ADAAAC6wCQCMQBn0CECALQgF8IgtCGFQNA9IOQeMgEA3SB0OD6K5ukCQCIxEkDkG6kQIEBgwBAAUgBSEFBkAMAgtCGQwGAAtC8AF5AnAjDgwGAAsGbwYJBm8gCkEBaiIKQTFJBEAMBwtEvQLTO/3b2UwMCgtBhYPsAUECcARvDAMABUQ15j8RqGkLfgwKAAsiAAwKCyAMQwAAgD+SIgxDAAC4QV0NBAwDCwwIAQsgCEEBaiIIQRVJBEAMAwsCDSAMQwAAgD+SIgxDAAAwQl0NAwJABg4LDAAACwsMAQv8EAYCCg0BIAlBAWoiCUEOSQ0CIAlBAWoiCUEkSQRADAMLIAAPAAvEuQwFAAskDxAMRQ0A0gNDrxgBeiQCIwIkAhoQDEUNACAFDAUACwJvIATSCEO1rYipBm8gBCQJQcAAEQ8GswJ/PwCyuwwGAAshByMPDAIL0dID0gsa0gYjCkN2/54IQajH6xs/ACIHBnBC/ol1IAEMBQAZAg9BKQsCC0KS/rnmkcqf0AcMBAALAgtBAnAEfwIQAnAMAQALAAvSAtIHCQIFIwQGQAsgBwwBAAvSBCABDAYACyEHAgcCCUMd1CJ9AkAQCAwAAAuPJAIQAgIUBhMMAwskCSMODAUACwALEAHSDEHltdIDQQJwBA8QBQwAAAVCqJ5lJAoCbwZ+EgILDAUACwALQQF4IgMhBz8ABgsMAAvSCkEYIAIGQAskAEH//wNxLwEUIQcgAQwGCwIUDwALBn4QCxANBn8GCQwAC9IFQRxEuOeiSqqNSVwMBwv8EAVwJQUMAgsMAgAACyQM/BADcCMMJgMGcAMEAn5ERdOpdChU//8MBwALAAsMAQskBfwQAXAjBSYBkCQCDAILBhQiBSQJEAFB//8DcS8A4QcCfUEAQdP03gEhA0ECcAQNDAAABQwAAAsGDwIHEAwCDEEBcA4BAAALIwgMAwALBhMGFAsiBAwDCw8ACwN+IwkjAJwMBgALAAs/AEECcAQP/BAADAAABUInPwAMAAALAgoQDSMF0G8kCSQHQtG8sr7mwsGUcQsMARlBFCUFCw8LAn78EAIhB9IOGkEMEQYEQfswQQJwBA1B3JEdQQFwDgEAAAtCAULCAQwBAAsCfyACDAMACwQQAgcQBUEBcA4BAQELDAQLDAALGgZADAALQbYPAgxBAXAOAQAAC9IJBn8QA0LAAfwQAwwACwZwEAQGBQsQC0ECcAQAAgRCue8fIxFRDAEACwAFAw4GDQtDW+uD6wZ9IApBAWoiCkEDSQ0B/BAADAILQbEKDAEACwZwAnwGBAZ/IAEMAhkjBCMHJA0aIAcLDAMLA3wCAEEdBgoMAQv8EAADDAwFAAtB/gEMAAELDAMACwwACwwEAQALDAEACyEHAg4MAAALIw0LJAchBxpDjOygftIGGiQQGgN8BgULBgUDD9IFGgZ+IApBAWoiCkEJSQ0D0gBEVR9quKERrz0MBQunDQEMAQALQQFwDgAAC0SqM2A4OUdwJgsMAQtCqfyR2vKw12s/ACEDwiQKJAYMAAskAA8LGAUAfwN/AX4BfQF8Ag8SBgtBAXAOAQAACwtICABBpjsLBVbc/nypAQcsRz0YDlCOAQGuAQnp658B9gnsdfEBCJSd85qII0bvAgBBkb8DCwJeEgEHgoQHnGDh1gEGlxzV348F', importObject7);
+let {fn63, fn64, fn65, fn66, fn67, fn68, global88, global89, global90, global91, global92, global93, global94, global95, global96, global97, global98, table60, table61, table62} = /**
+  @type {{
+fn63: () => ExternRef,
+fn64: () => void,
+fn65: () => void,
+fn66: () => void,
+fn67: (a0: I32) => void,
+fn68: (a0: ExternRef) => ExternRef,
+global88: WebAssembly.Global,
+global89: WebAssembly.Global,
+global90: WebAssembly.Global,
+global91: WebAssembly.Global,
+global92: WebAssembly.Global,
+global93: WebAssembly.Global,
+global94: WebAssembly.Global,
+global95: WebAssembly.Global,
+global96: WebAssembly.Global,
+global97: WebAssembly.Global,
+global98: WebAssembly.Global,
+table60: WebAssembly.Table,
+table61: WebAssembly.Table,
+table62: WebAssembly.Table
+  }} */ (i7.instance.exports);
+table2.set(46, table20);
+table37.set(25, table10);
+table49.set(2, table29);
+table4.set(20, table55);
+table9.set(12, table9);
+table5.set(19, table61);
+table37.set(46, table5);
+table10.set(34, table52);
+table2.set(45, table19);
+table32.set(2, table4);
+table33.set(63, table37);
+table29.set(28, table37);
+table20.set(17, table0);
+table17.set(20, table20);
+table33.set(9, table30);
+table0.set(75, table10);
+table34.set(18, table19);
+table12.set(9, table9);
+table10.set(39, table30);
+table4.set(43, table2);
+table39.set(69, table49);
+table19.set(11, table5);
+global60.value = 0;
+global1.value = 0;
+log('calling fn63');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn63();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn65');
+report('progress');
+try {
+  for (let k=0; k<28; k++) {
+  let zzz = fn65();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn66();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn63');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn63();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn68');
+report('progress');
+try {
+  for (let k=0; k<14; k++) {
+  let zzz = fn68(global91.value);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn24');
+report('progress');
+try {
+  for (let k=0; k<19; k++) {
+  let zzz = fn24(fn9, fn68, global58.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<24; k++) {
+  let zzz = fn67(global66.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn64');
+report('progress');
+try {
+  for (let k=0; k<20; k++) {
+  let zzz = fn64();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn50');
+report('progress');
+try {
+  for (let k=0; k<20; k++) {
+  let zzz = fn50(global78.value, global81.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn50');
+report('progress');
+try {
+  for (let k=0; k<8; k++) {
+  let zzz = fn50(global69.value, global3.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn63');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn63();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+/**
+@param {FuncRef} a0
+@param {FuncRef} a1
+@param {F32} a2
+@returns {[FuncRef, FuncRef, F32]}
+ */
+let fn69 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return [a1, a0, 9.29983885129791e-33];
+};
+/**
+@returns {I32}
+ */
+let fn70 = function () {
+
+return fn31();
+};
+/**
+@returns {I32}
+ */
+let fn71 = function () {
+
+return fn31();
+};
+/**
+@param {FuncRef} a0
+@param {FuncRef} a1
+@param {F32} a2
+@returns {[ExternRef, FuncRef, I32]}
+ */
+let fn73 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return fn24(a0, a1, a2);
+};
+/**
+@param {FuncRef} a0
+@param {FuncRef} a1
+@param {F32} a2
+@returns {[FuncRef, FuncRef, F32]}
+ */
+let fn75 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return [a0, a1, 0.47701066743035864e16];
+};
+/**
+@param {ExternRef} a0
+@returns {void}
+ */
+let fn77 = function (a0) {
+a0?.toString();
+};
+/**
+@param {ExternRef} a0
+@returns {void}
+ */
+let fn78 = function (a0) {
+a0?.toString();
+};
+let global100 = new WebAssembly.Global({value: 'anyfunc', mutable: true}, global89.value);
+let global102 = new WebAssembly.Global({value: 'f32', mutable: true}, 565151.8639143361);
+let global104 = new WebAssembly.Global({value: 'externref', mutable: true}, {});
+let global106 = new WebAssembly.Global({value: 'f32', mutable: true}, 249230.90880255518);
+let m26 = {fn70, fn71, fn72: fn39, global104, global106, memory9: memory2, table69: table4};
+let m25 = {fn69, fn74: fn49, global99: global97, global101: global55, table63: table39, table64: table28};
+let m24 = {fn73, fn75, fn76: fn31, fn77, fn78, global100, global102, global103: global82, global105: global26, table65: table29, table66: table16, table67: table25, table68: table19};
+let importObject8 = /** @type {Imports2} */ ({extra, m24, m25, m26});
+let i8 = await instantiate('AGFzbQEAAAABgQEYYAABf2ABewF/YAF7AXtgAXsAYAN7f3sBe2ADe397A3t/e2ADe397AGABbwBgAW8Bb2ABbwBgAABgAABgA3BwfQNvcH9gA3BwfQNwcH1gAAF/YAAAYAJ+bwBgAn5vAn5vYAFvAW9gAW8Bb2ADcHB+AGADcHB+A3BwfmAAAW9gAAACjAMbA20yNgdtZW1vcnk5AgOxH/o1A20yNQRmbjY5AA0DbTI2BGZuNzAADgNtMjYEZm43MQAAA20yNgRmbjcyAA4DbTI0BGZuNzMADANtMjUEZm43NAAUA20yNARmbjc1AA0DbTI0BGZuNzYADgNtMjQEZm43NwAJA20yNARmbjc4AAcFZXh0cmEFaXNKSVQAAANtMjUIZ2xvYmFsOTkDfQEDbTI0CWdsb2JhbDEwMANwAQNtMjUJZ2xvYmFsMTAxA3sBA20yNAlnbG9iYWwxMDIDfQEDbTI0CWdsb2JhbDEwMwN8AQNtMjYJZ2xvYmFsMTA0A28BA20yNAlnbG9iYWwxMDUDewEDbTI2CWdsb2JhbDEwNgN9AQNtMjUHdGFibGU2MwFvAAQDbTI1B3RhYmxlNjQBcAFE5wMDbTI0B3RhYmxlNjUBbwBjA20yNAd0YWJsZTY2AXABV8oDA20yNAd0YWJsZTY3AXABVoEBA20yNAd0YWJsZTY4AW8ADgNtMjYHdGFibGU2OQFvACcDAgERBB4JbwEqvgRvAFBvABVwAEhvAEFvAAdwACNvAD9wABQNCwUAEAAPAAcADwADBg4CbwHQbwt9AUPmTtP/CwenAREEZm44MAAIBGZuNzkABwlnbG9iYWwxMDkDCAV0YWc3MAQCB3RhYmxlNzUBDQd0YWJsZTcyAQkJZ2xvYmFsMTA3AwMJZ2xvYmFsMTEwAwkHdGFibGU3MQEIB3RhYmxlNzABBwd0YWJsZTc0AQsHdGFibGU3NgEPB3RhYmxlNzMBCglnbG9iYWwxMDgDBARmbjgxAAsIbWVtb3J5MTACAAV0YWc2OQQBCagCCgMANQsLBAQDCwYGAQABCAIGAwoDAQQJCgAFCQYACwIKCQYFCAgBAwgAAgcABgYCAQUBBgYLCwcKAgpBCgsAOQMBAAgLCAQHCgoCBAsLBQoJBAkLCgYEBQALBgYFAAYDAAMFBQELBgkEBQcDAQQFCAgDCwUDAggBAgMAGAMBBwAEBwECBwsACQAGBQgECgADBwoACQMAVQQHCgcABQUJBgIGAQgGAgYGCAQDAwQJBgoKBwkDCwsHCAkGBQkBCQIICgUAAgIJAAoICQQDCAoCAwEABAYEBgUGAwQEBAoFBAQHCgsLAAUFBAoECgsGAUEbC3AC0gAL0gYLAgNBIwsABQECAwcKAgpBNAsAAQQCDUEeCwABBQINQQELAAIICQYNQQQLcAHSCwsMAQcK/SsB+isNAn4AcAB8AX8BfgF7An0BbwJ+A38BfgF9AXzSBwN9IwCMJANCob3wqRghCgYKQbb0ioEC/QxnpY7E7Ajb8MjEUdYPJq0rBgMCAf11BgP9pwEkAkEAQQBBAPwMBgFCEULKASELw0MpDEaCA3sjBgICBgECfNIJ/BANQf//A3ExALwFw0KheFkMAQALAnACFkH4AQwGAAsAC0L7ALpDjEUmqCMFBgkGCAwACwYHIgEGBwYSEAgCABACQQZwDgULBAIICgMLQQZwDgYJAwoBBwIKCxAJDAkL/QwUhMbsygEwjL61uv8u4dc+IgbSB0EyIweNAnADfAYX/Qy93LGU+SxCQIZVR4mvHj1VBgMkBhAKRQ0IIAxBAWoiDEEPSQRADA4LAgoMBgALEApFBEAMDgsCAAwCAAuzBnwgEEMAAIA/kiIQQwAAQEJdBEAMBAsgAQIHAnsCCyMBDAcACwALAAsMBQtELdZte1VAIxdlDAoLEApFBEAMAgsMCwvSAwJ9AhZCis3E+HX9DO1INWfVJVvcCettSa6l4H4MBwALAAsAC9IARJSG8xr4h4t1QgAGfAwDAAEBCz8ADAMAC0Q2CLB+qs5Jb0MzYNGkIQf8BkQaBNEAYMZK/dIAQ+TdrH+LRP+PD3N0H+Sx/RQMAwEL/Qyk5JlmQcNJbRvQSARfD4v6BgEMAwAAAQsMAQtEbB/kGwbevsUkBNIJ/QyCNcjR36Lxs5Ht174QTGbZDAELDAMLAgIMAAALJAJBgIn70gVBA3AOAwMEAQELAgIMAAALJAJB/jxBA3AOAwMAAgMLEApFBEAMBAtE+rCwArwJr5gkBCANQQFqIg1BAkkNAyMD/BACQQJwDgIBAgILQQJwDgIAAQALQQFwDgEAAAsgDkEBaiIOQRRJDQAgD0IBfCIPQiVUDQAGFwwAAAsGDwJwEAJBAXAOAQEBAQsjBQZARJOKvds7Ok7ORICs98y/ii52/QyOVLXB8Z3ghOnAvZWzgiPBJAKkIwAgCEIIAn4CCwMPCAEBCwwDAAsAC1JBAnAOAgABAAtCC/0MSG/NrY9qy9PFtfBuBr2cfAJ9DAEACyQDAgH9DHNWtLLcueoBNyv+6awESeb9twEGAyQCEAMMAQELAgBBBEEBcA4JAgICAgICAgICAgtBAnAEABAKRQ0DRE+lzFjgxgMi/AkAIAtBBEEAQQD8DAEBAn0MAwALAAX8EAcjAfwQCg0CJAENAgwCAAtBAXAOCQEBAQEBAQEBAQEACwZ9EApFDQL8EAMgAiECDQFDnQbRdQwACyIHRBwI06Uf9W1N/RQGAiQC/QzeuXhaV/Gjb/g9uq2DbOKt/fkBBnwGCyMC/BAPRLLhdrR0ql2mDAEBC0EnEQ4DAm8CAAJ8BgAMBgsMAQALAAtBAnAEQNICBn0MBQv8EA5BAnAOAgQABAALBn8GAAMO/QzxtbS2exn219giCCfmwQCnDAUACwwAAQcDDAULQQJwBH4MBQAF0gtBG0EBcA4BBQULBm/SBtIFIwEjAyQD/BAFQQFwDgEFBQELDAEAC0ECcARADAAABQwAAAsCe9IJIwECfwwFAAsACwIBDAMAC0EBcA4BAwML/BAJQQJwBBdBAkT2e6GosfM7cEIQIAEiCSIJBhIYAyQFQ3slmZ8kACMB0gZD1nNn/vwA/QzwvSe030sLQnbIHVPMqmnnDAIABUGXAfwQAPwQBHAlBP0Mhri+NHfz+XoH0s80tBtwtP3hAQYDDAMZDAELIApEt0bf8gk/we8kBCICxESGriHOtpLiJUIg0grSAyMGDAILQQIRBw0gCUK2ASIFBn8gDkEBaiIOQR5JBEAMBQsMAwv8EA1BAXAOAQICCyMEPwADfgYWIwJD+xwuZv0M09krd+nTZWf1QsgXwqCipQICAgMGAwwCC0Gu2QBB//8Dcf0GAVAhBgYKQSURDgNDwzbz3CQDDQEMAAvSCNIC/QxMuocuvG1LAlyY+nrluKzMAgEMBQALQQJwDgIABQUBCwMLBnAgD0IBfCIPQihUDQcGCkS3SKMie5Kf4bb9DNI+hpDoKQ7fjbuVDpbXnZUMBgtESHtAQwF062cjCfwQB/wQAnAlAgwDCyQBROhAXudNuPh/QryPAkSffUSczD2KcZ0kBAJAAg9C39S1hPCftQkjAgZAQdEADQIgDEEBaiIMQRJJBEAMBwtBywFBBHAOBAIIAQACCwwDCwwGC0LmAVpBAnAECgJ/IBFEAAAAAAAA8D+gIhFEAAAAAAAAJkBjDQUMBwALAAUjB9IE/BAAQ6ymETv8AUECcA4BBgALQ0CTT2uNQaDgvJsGDQUGfQIOBn9Bl4LUAQwACwwAAAtElrGxdTMRgmQkBEEBcA4BBgYBC9IH0goCf0TdTV/ROHdYvEHiAAwAAAsNBUPaxTDRQa29AkG/7gFBkNsC/AoAAEEAQQFwDgEFBQtB5QBBAXAOAQQECwJ9Ag4gDEEBaiIMQRVJDQb9DGsClBzyjLz7mgyuMto9DxMCAv3tAf1qDAUACwALAAtBrQFDOzH92SMB0gIDQAIP/BANDQUCDwwGAAsACwALIwIkBiAABkADDtIA0gQCfiAQQwAAgD+SIhBDAAA0Ql0EQAwICwwGAAsAC0ECcA4CAAQEC3nSAyMHIwYGAQN9QSYRDgNBAXAOAQUFCyAEDAALQQFwDgEDAwELEAkgDEEBaiIMQRhJBEAMBAsMAgALIwIMAAcBEAP8EAJB//8DcS8BwwPSA0LYAXvSAfwQAUECcAQKAgACF9IKAnv9DHd6+pktNMYAchyFHoTnpVMMAAALDAMACwALAAUCFwYLQj4iBSMJPwBB98gCQd+VA0GoqQP8CgAAQQRwDgQAAQQCBAsgDUEBaiINQQRJDQQgDEEBaiIMQRVJBEAMBQsCAAwCAAsNAQwDC0H2AELeACEKQfj/A3EgCv47AwADQAJ7IwgCEkTcWSZkkFiEKv0U/YkBDAEACwALAgEjByEIDAMACwALIwn9EwZwRK9uVliqfIfVAn0JAwtBr9oAQQJwDgUBAQEDAwELCQELQc3siTg/AEEBcA4BAQEBCyIGBgIiBgICDAEACyMCAgNBIUEAQQD8DAENJAIMAAALGQwBC0IUAn8MAQALIgRBAnAEFgJADAAAC9IEIwUDfwJ9Bg8CAAwFAAsDQAwBAAv8EAlBAnAOAgAEAAsQCkUEQAwFCyAQQwAAgD+SIhBDAACwQV0NBEQg4FMkWoLKSwJ9IA9CAXwiD0IaVARADAMLEApFDQUgDUEBaiINQTBJBEAMAwsCD/0MfW7t6tRxARBIGt43uTDfjCMDDAEACwALIgcMAAALBnAgBv2EASALQZq+OSIEDQPSCf0MBpRJLyIqXy9KwPIkg22hoAIDBgP8EAP9GgACA9ICIwkhB/0M0p0yOIxpYwN2M11zgjftNgYCGAMCAwYCBgMMAQtBxQENAiMFDAcLQ59afUvSBkT5gqMI27HwCyQEQQAGQAtBBXAOBwMBAAcAAwECCyAKIAT8EAxGQQRwDgQCAAEGAgsMAQsMAAELQe4BQf//A3EoAURBAXAOAQMDC0KPAT8ADQIiAEEC/BAFcCUF/BAJQQFwDgEEBAtDAAXX0wJ9Ag4QCkUNBCAPQgF8Ig9CClQNBCMDDAEACwALJAAgAQwABSMD/QyypYj/BN0zHprBMvwYyPazJAb9E0RhO0xSjgeD9AJwRAdZIC3VyKzgJAQMAgALAAsMAgvSCSMBBn4GFyMIBgkQCUNXoJVl/AANAUEcQQBBAPwMAgQCDgwCAAv8EARwJQQGfSAPQgF8Ig9CF1QEQAwFC0O/2vB8GdICBnwMAgskBP0MiSVLZvcmQNMgFKSvzkKxRSACQdcBQQJwDgIBAgIAC9IKQRlBAEEA/AwDAz8AQQJwDgIAAQALAn0MAQALvEEBcA4BAAALQpABQYukCkEBcA4BAAALQdeBnYJ4QQJwBHz8EA4hBAYOPwAMAAsGftIK/Qxc81mTLOysVZvXPmsM/lWQBgIHAAMHAhIQCAYOIwkCbxAB/BAHcCUHDAIACyMCIAAMBAsjCCAMQQFqIgxBJkkECAwCCyAMQQFqIgxBBUkECAwCCyAKDAMLBgcgCQMS0UEBcA4BAQELQdfzAUEBcA4BAAAL/Qxl/lo255tu9f7h/dD7zZkoDAEAC7okBBABIgQJAAsCAwID/cgBIwQDbwYWEApFBEAMBwv8EAAiBENxglOOIwJC0wEgByQD/R4BBgIMAAsDfiAOQQFqIg5BBkkEQAwBCxACDQMCQAwAAAsQCkUNAgIPCwYWEApFBEAMBAsgDkEBaiIOQRJJBEAMAgsQAUECcA4BBQQLDAEACwwECwYICwsiCSQFDAMLC/wQCyEEPwBB//8Dcf0EAbgB/BAHIQT9DJpt+brgioPRkI/XB1aYDg8CAQZwIA5BAWoiDkEbSQRADAULIA5BAWoiDkEFSQRADAULEAoMAQskAf2DAUSmBBbEtFcrAQwCC/wQDWlBAnAEDwYWDAELJAUGCwsGDwsFEANBAXAOAQAAC/wQDXAlDSMB0QNwBg7SCUEkRKcPoD/cF95kDAMLGgYKBgoMAQsLQRQlCiQBAg8L/BACIQQgDEEBaiIMQRdJDQMgEEMAAIA/kiIQQwAAEEFdDQNBByUNJAFBHyUDIAoMAQALJAH8EANwIwEmA9ICIwAkBxr8EAwhBCAKDAALIAYjBgZ+0gEaIAoL/R4AIwm8/RwDBgFD0crIV0PbgNQ0JAciCPwBQ1KWEEUhBwwAC0ECcAQPBUIBe0OrLdGLJAnCugwBAAsGfAYK0gNDhm2phkHKh9LHBUEBcA4BAAALIwQYAgwABQYAIBBDAACAP5IiEEMAAABCXQRADAMLQTQLQQJwBBYgDEEBaiIMQSVJDQIgBf0MXnSUhPAS2PucxeAe5yUvcv2KAf2IASIGIwb9ggFB7ANE1b0cYHRh85YMAQAF0gUaQTslCxAIIwggCQwAAAsQCRAKIQRB/JjxkANBAnAEQCAPQgF8Ig9CJFQEQAwDCyMD/BAG/BAJcCUJQ/0Cc4gkAyQIJAcCCiAMQQFqIgxBIkkEQAwECwIXCwsMAAAFDAAAC0GzrqFqIQREtVvi2MXL+gIL0gcCfP0MI+JHPe2ghZLSQQmsrrw6WyQGAgsCe0TVffHbvw5A69IIGgwCAAsACwALBnwGFv0M0iG4xTkm+gDo7q/l8WZBXAZ9AhZBAiUA/BABGkEADgQCAgACAAsMAQEHA0OY5iq/C/wQCyMGJAYhBCIIJAM/AP2MAQYB/BACQQJwBAsFAxcL/QxqMW8sQz0Kp7dSTglh1dKYIwUMAgALPwAMAAsjBQwAC9IJGkRsw1Xz37Nf7P0U/QyEy5N+2PPmP6yuUoc5wsSnJAb9+wECAQMB0gsjByQJ0ggaGiEGQfQAQQJwBH3SCRpDhoFaIgwAAAVD0kk98wwAAAsiByQDQo7rASAJDwALAAtDvMK7rEIV/BAIIwMkA0ECcAQA0gn9DCLrCmc/cgfd71/kScKl+ZMGAyQCGAEgCSQFIAYGAyQCIAxBAWoiDEEUSQ0DC0Rh6VlJPHHu7QwBAAUgDEEBaiIMQRNJBEAMAwtBlwFBAnAEFiARRAAAAAAAAPA/oCIRRAAAAAAAAABAYw0DROBkDvhVOvh/DAIABSMIIgkMAAALIQEGFxkLAwoQAwwBAAsAC/wQBnAlBiEJIwUMAgskBJ4kBCMDjz8AGiQHBn9B0gALIAohACEE/BAPIwIkAgJwIBBDAACAP5IiEEMAABhCXQ0BQ8U7tFv8EAnSB0PIK4FdJAlC+QH9EiEGQ+uFg6P8EAYjAP0TJAZBAnAEfCMEDAAABUH2AEECcAQLC0SfpTNoOAhOFvwQCg0AIwQMAAsGfRAH/BAEcCEEIA1BAWoiDUEgSQ0CAwBBxgBBAnAECiAPQgF8Ig9CH1QNAQULIA9CAXwiD0ImVARADAQLIA9CAXwiD0IKVARADAELBn0QCkUNASME/QycYy/HGENHGMIIXfsVQBMtJAIkBBAKRQRADAULIAP8EABBAnAEFvwQC7MMAwAFIAkCE0N+G9fQQoKD//USIQMCb9IBBnv9DAWy7z1WfoVsi4/M9T5yUsUMAAALAgECbwIAIA5BAWoiDkEOSQRADAgLAntC7QH8EAsMAQALAAsMAQALAAshBAJ7/QxFep5edTldB6BG44QxoyxACyQCIwMkABoGFwsgAQwBAAsAC0ECEQkNIAHSBxoLDAULDAEACyEEIBFEAAAAAAAA8D+gIhFEAAAAAAAAR0BjDQJDS5ZrwwwAC9ILGiQDA3BBD0ECcAQPBSANQQFqIg1BDkkNAwwAAAtBHSUNDAEACwALJAH8EAFwIwEmAf0M9b4scplXJmk1r5vTXGu6/hrSCNIIGhoa/AMhBFBBAkEAQQD8DAAPIQQkASMAJAcaIA1BAWoiDUERSQ0ABhZBzQAlAvwQBg0AQf4FQQFwDgEAAAsGEiMA/BAGQf//A3EuAN0DIQQhCAMSCyEBEAcaA29C3b+HjanFegJwEApFDQMCAAMOIA1BAWoiDUEmSQRADAQLAg4CDwsgDEEBaiIMQQRJDQZBuCDSCD8AIwQjAiQC/AIMAAALC/wQDwwAAAtD554/7iQDQRJBAEEA/AwJD0HZARpEjNeJk1kdRrkkBEECcAR8QreQ9IT0AMMhCkQ/aZOZaTuwef0MHppiiOsNtdp1lo69HuT0ciEGIARBAXAOAwAAAAAFAhcMAAALIAxBAWoiDEEtSQ0EBgAgEEMAAIA/kiIQQwAA0EFdBEAMBgsCABAKRQRADAcLQfABCwvBQQJwBH8GACAGAnsCAPwQAgsGfCADBn1DgjAyRwv8BVcMAgsMAwAL/T4CAyQC/QxAAYyz6y0sKlpYy7EfS+1QJAYLIA1BAWoiDUEVSQRADAULPwBBAnAECgYKIA9CAXwiD0IYVARADAcLAn8MAQALDAMLBm8CfyMDJAcGDiARRAAAAAAAAPA/oCIRRAAAAAAAgEhAYw0KDAMLDgECAgsMAwsMBgsQCkUNBEHO+o4XC0ECcAR9IAcFIwf8EAYMAQALJAdB2gAMAAUgDUEBaiINQQhJBEAMBAsCAPwQDwsMAAALA35CpNDxioedln4jBPwHIQILBm9EdncZr9L8nLoMAQtBsA4DQNIAGgtBAXAOAQMDCyQEAhYQCkUEQAwFCyAOQQFqIg5BHUkNAiAOQQFqIg5BLkkEQAwFC0E9JQILAgkMAwALAAsACxAIRImCxrwQO6k6JATSCtIJGhoDC9IKIwA/AEH8/wNx/hACALcaJAk/ACEEGgtBHiUORDIp0ncn3xtgJAQLAwciASEBQcie0HlBAnAEfwILBhYgDEEBaiIMQSxJBEAMBQsMAQtBAREJDQtBr4KYMwwAAAVBCAwAAAshBAtDhF4QpdIGGgskBxr9DHB26zsSzWKG1N3shHrMIOoGAQYCDAALPwAMAAshBEL7CkENJQULCzoHAEGaywALBvAZZcJGBAEBHwEAAQVyJ8mKSQEJbcuQCzU7CXc7AQhor2FLQ766pAEJQAddgFf+MxwU', importObject8);
+let {fn79, fn80, fn81, global107, global108, global109, global110, memory10, table70, table71, table72, table73, table74, table75, table76, tag69, tag70} = /**
+  @type {{
+fn79: () => I32,
+fn80: (a0: ExternRef) => void,
+fn81: (a0: I64, a1: ExternRef) => [I64, ExternRef],
+global107: WebAssembly.Global,
+global108: WebAssembly.Global,
+global109: WebAssembly.Global,
+global110: WebAssembly.Global,
+memory10: WebAssembly.Memory,
+table70: WebAssembly.Table,
+table71: WebAssembly.Table,
+table72: WebAssembly.Table,
+table73: WebAssembly.Table,
+table74: WebAssembly.Table,
+table75: WebAssembly.Table,
+table76: WebAssembly.Table,
+tag69: WebAssembly.Tag,
+tag70: WebAssembly.Tag
+  }} */ (i8.instance.exports);
+table9.set(21, table10);
+table74.set(48, table33);
+table19.set(16, table32);
+table39.set(70, table0);
+table34.set(9, table2);
+table5.set(31, table30);
+table55.set(78, table30);
+table19.set(1, table20);
+table49.set(18, table12);
+table37.set(53, table9);
+global23.value = 0;
+global78.value = 0n;
+global1.value = 0;
+global79.value = 'a';
+global94.value = null;
+log('calling fn31');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn31();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn81');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn81(global78.value, global51.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn79');
+report('progress');
+try {
+  for (let k=0; k<14; k++) {
+  let zzz = fn79();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn63');
+report('progress');
+try {
+  for (let k=0; k<19; k++) {
+  let zzz = fn63();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn80');
+report('progress');
+try {
+  for (let k=0; k<10; k++) {
+  let zzz = fn80(global51.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+/**
+@param {FuncRef} a0
+@param {FuncRef} a1
+@param {F32} a2
+@returns {[FuncRef, FuncRef, F32]}
+ */
+let fn82 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return [a1, a0, 7.890085854430748e38];
+};
+/**
+@param {I32} a0
+@returns {I32}
+ */
+let fn86 = function (a0) {
+a0?.toString();
+return 69;
+};
+/**
+@param {I32} a0
+@returns {I32}
+ */
+let fn89 = function (a0) {
+a0?.toString();
+return 56;
+};
+/**
+@returns {void}
+ */
+let fn92 = function () {
+
+return fn9();
+};
+/**
+@param {FuncRef} a0
+@param {FuncRef} a1
+@param {I64} a2
+@returns {void}
+ */
+let fn95 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return fn49(a0, a1, a2);
+};
+/**
+@returns {void}
+ */
+let fn98 = function () {
+
+return fn64();
+};
+/**
+@param {FuncRef} a0
+@param {FuncRef} a1
+@param {I64} a2
+@returns {[FuncRef, FuncRef, I64]}
+ */
+let fn99 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return [a1, a1, 944n];
+};
+/**
+@returns {I32}
+ */
+let fn100 = function () {
+
+return fn31();
+};
+let tag76 = new WebAssembly.Tag({parameters: []});
+let global112 = new WebAssembly.Global({value: 'f32', mutable: true}, 301414.7342333485);
+let table81 = new WebAssembly.Table({initial: 55, element: 'anyfunc', maximum: 55});
+let m29 = {fn82, fn83: fn10, fn84: fn81, fn86, fn87: fn10, fn89, fn91: fn67, fn93: fn10, fn96: fn48, fn100, global111: -18796.199513700125, table78: table18, table80: table12};
+let m27 = {fn85: fn79, fn88: fn48, fn90: fn23, fn95, fn97: fn24, fn98, table81};
+let m28 = {fn92, fn94: fn63, fn99, global112, table77: table16, table79: table37, table82: table28, tag76};
+let importObject9 = /** @type {Imports2} */ ({extra, m27, m28, m29});
+let i9 = await instantiate('AGFzbQEAAAABpgEbYAABf2AAAGAAAGAAAGAJfXtwfX57cH5/AGAJfXtwfX57cH5/CX17cH1+e3B+f2AJfXtwfX57cH5/AGAAAGAAAGADcHB9A29wf2ADcHB9A3BwfWAAAX9gAABgAn5vAGACfm8Cfm9gAW8Bb2ABbwFvYANwcH4AYANwcH4DcHB+YAF/AGABfwF/YAABb2AAAGABbwBgAW8Bb2ACfm8Cfm9gAn5vAn5vAvcCHQNtMjkEZm44MgAKA20yOQRmbjgzAAcDbTI5BGZuODQADgNtMjcEZm44NQAAA20yOQRmbjg2ABQDbTI5BGZuODcAFgNtMjcEZm44OAAPA20yOQRmbjg5ABQDbTI3BGZuOTAAAwNtMjkEZm45MQATA20yOARmbjkyAAEDbTI5BGZuOTMACANtMjgEZm45NAAVA20yNwRmbjk1ABEDbTI5BGZuOTYAGANtMjcEZm45NwAJA20yNwRmbjk4ABYDbTI4BGZuOTkAEgNtMjkFZm4xMDAACwVleHRyYQVpc0pJVAAAA20yOAV0YWc3NgQADANtMjkJZ2xvYmFsMTExA30AA20yOAlnbG9iYWwxMTIDfQEDbTI4B3RhYmxlNzcBcAFJ+gYDbTI5B3RhYmxlNzgBcAEQoAYDbTI4B3RhYmxlNzkBbwEwmAcDbTI5B3RhYmxlODABbwAAA20yNwd0YWJsZTgxAXABNzcDbTI4B3RhYmxlODIBcAAUAwMCGQ4EEgRvAGFvAQ3UBG8BOcYGbwErcAUGAQOrCY8ODRsNAA0ABAADABcADAAEAAIAAQAIAAEACAAXABMGLQZ9AUPCCax2C3wBRHNNMhDWMsCVC28B0G8LbwHQbwtwAdIMC34BQufezfwECweeARAFdGFnNzMECQd0YWJsZTg1AQkFdGFnNzEEAglnbG9iYWwxMTMDAgV0YWc3NQQMBWZuMTAxABEFZm4xMDIAFAlnbG9iYWwxMTYDBgV0YWc3MgQECG1lbW9yeTExAgAHdGFibGU4NAEIBXRhZzc0BAoHdGFibGU4MwEHCWdsb2JhbDExNAMECWdsb2JhbDExNQMFCWdsb2JhbDExNwMHCYICDgEAFQMGFQwUCA4UAQ4UDgUIEREFCgYEAQEAYhQCDwYDDQcNAwUPAwAQFQMIDw8SAQkMEhIADRISCQsIChUEEggFAAIODw8CDBQRAAITBgwUChMCFQgQBxIQEgoLFAgCAwAQBwkQChMEAAQCCxMADAYOAwkHAgwGEAoTExADAgVBBAsAEA0ACxADEA0DEg4FCRMQCwMGAEEmC3AB0gALAgFBAAsABgEFCAoLEAYBQQYLcAPSAgvSFAvSFQsCBEEjCwADAxITAgRBHgsAAgQHAgFBBwsAAgYOAgVBBAsAAQkCBEEcCwABDAIBQQsLAAENBgVBDQtwAdIPCwIBQQoLAAERDAEFCqA/ArQVBAN/AX4BfQF8QvYBQQQlBxAV0UECcAQBAghDFCKKJPwQBQZwDAILJAYNAEIUBn3SD/0MjqpKozOBwhySFbg0Qr8GqiMAJAFEJ78SqEpcKbgjBQIXAhcQDgYXBhAYBhAGQ5OMX10MAwvSDAN9EBNFDQD8EAFBAnAEFQIIDAMACwAFAm8CCyAEQQFqIgRBGkkNAwwEAAsACwALAhgGFwYYBg8YAfwQB7gGewYMBgsgBkMAAIA/kiIGQwAABEJdBEAMBwsMBAELQQZwDgYAAwYJBwoJCxAQEAgQE0UNBNIG/BABQQVwDgYFAgYICQUCAQtCxwAkB0EAQQdBAvwMAAH97AFCASQH/QxNGvcbsHlqV1LekyZQ1eK1/BABQQVwDgQECAUBBwELDAELBnxCO3sjACQCJAcMAwvSFQZ8/BAHQQRwDgQGAwQHBgubRM9HYlfAH3CS0ghB/PoBQ9+Lvt0MBAsCGAJ9BgEgBUIBfCIFQitUDQMCAULhIXoCewwHAAsACxgIDAcACwALAAsMAgsjAiMBDAEBAQtCBEPuXS4TQ3ZAKSEMAAtBB0EWQQH8DAEFJAEiANIEIwUhAQJABkACfwwEAAsNARgDDAELQdbUoAENAEOOyASCJAFETC/QnmPCtggkA/wQA0ECcA4HAAABAAAAAAALDAALJAcGBwJ+DAEACyQHEAMNAPwQAA0AIwckBwIHBggCCAYLDAMLAhQaQQwOBAIEAwEEC0Og/MM0IwP8EABBBHAOBAIDAQABCwYIDAIL/BAIQQNwDgMBAAICCwYHAgsMAwALQQJwBAgFEAsgAD8ABhMNABgDIQADfAwEAAsACwMVBgMMAwELDAEACyMCJAECGAIXIwAkAQwBAAsAC0PGkk6vBnsgASQF/BABBhQGEw0A0g0DfdIFQQRBBHAOBAUGAQQFC/wQAEEEcA4EAAMFBAMLDAMLBhMNAgwECwwDCwJAEAz8EAgCFAwAAAsGFA0BAgsCFhAMIwAkAkHx+AJBAEEG/AgEAAYPAnwgAQwBAAsgAQZ7Qem+A0EEQQP8CAQADAUHCgMC0gcgAQwCAAsCASMB/QzYXKgQnjQoIrHsoc0VijPHDAEACxAMBhdBCBEPAUHulQFBo4QDQezDAfwKAAAMAgELQxHQkJv8EAQMBAv8EAYGE0ECcAQW0gEjBNIVQ3KdZ6zSD0NFL2Z3AnwQCwYDDAoLDAcACwAFQxXwwM4jB0H6AA0JJAfSACAAUA4HCAkDAQAHBgkLBhYMAwsCbwYIDAALDAMACyEB0gIGfwwHC0EGcA4FAgUIAAcGCwNADAYACyMEBn/8EAhBBXAOBQUHCAYCBQtBAXAOAQAACyQFBgvSCQZwBn0QCgwICyQBEBAMBwsgACEAJAZEK7ONFsjzbi9EznkhqGKUFXWjJAPSAtIB/QwK5upHpEtwSV7BfuiUaf7pIAD8EAEMAgsCE0EGcA4GAAQHAQYFAQsMBAsGcCMFBhAMAAvSECAA/RLSFP0MuFXjNIPZbjnM1t2CsiGxJkNXi+1/Bn0CbwwFAAshAUHUBQwCAQsjBSQEIwRCrE/SCwJ/AgsMBwALAAtBBHAOBAQDBQYFCyQGDAILDQQGCENOCcy50gcCfwwEAAsjBCEBDAEBCwwEC0EEcA4EAwIBAAML/BAGQQNwDgMAAgEAC/0M3jpbDsFJWyZjKB6koV99Dv0hAEHFAkECcA4CAQAACwwAC9IRIADSFEPtmdd/jf0TBn1BBREBAUEAEQEBAggMAAALAgIQCyMCJAEMAAALBgAjAQZvAggQEwwCAAsCBwwAAAsjBAwACyMADAELQQJwBAcCfAwBAAsABQYIGAJBBBEWAQYLIAHSDgZvPwAMAQv9DK0tjhLrC7fYFnjGuVWVx9wDfwICDAMACwALQQFwDgEBAQELQQFwDgMAAAAAC0LVvsP0gM4BIgAkBxATQQJwBAsDfiACQQFqIgJBLkkEQAwBCyAAQgm6vX0iACEA/BADDAEACwAFRN8em7F0OmJlIwAkAgNvEAM/AAYTQQFwDgEAAAALEAkjBSEBQ+ev0S4MAgALAAtBAnAEbwYLIwYCfQYAA3sgAkEBaiICQQFJDQBDGH9/CiAA0gsaJAcMBQALIwEMAQsMAQALJAEkBiAAIwYkBsIkBwYIGABDAAAAAD8ADQLSEf0M4Y//DNnmmSzKywCQsIGsphoGbwJ9/Qy0sEPJ3kjrQnZF7TCK++rDQZ/q6RtBAnAECwZ+IwQMAwALIQAgAfwQBg4EBAIEBAIF0g0aBhUjBQIPBhAMAAcHQR8CFAN/0gL8EAkMAQALAAtBAnAEQBASQQFwDgEAAAsGfCMDDAALIAACe0PwlHSH0gtBoAHBBhNBAXAOAQAACz8ADAcAC/1eCQALCwsCFyQEIwb9DAmZT2nWAvTzBWyT4DQnDqhDtLupawwCAAsACwwCCwwDCwwBC0ECcAR9AgBBiAEMAAAL/BAAGkHGAgMTQQJwBH9EAAAAAAAA8H8kA0Ht2ZUwDAAABUGp1oABQQJwBAMMAAAFCwIBCwIDDAAACwZ9IwQCbyMECyQEJAVBA0ELQQP8DAABBhYMABkGewwBCxoMAAsDfwJ/BgvSCP0MU/spiisti6vztk64z8mM9P0MCR2yCJA4mz75vFTgLEoMEyABQQcRDwEMBwALDAMACwALBhT9DJcRZicC/sPTmiysSsLtRFL9qQH9YER2zFnV2o2mlv0iAf0fAfwQAw0BDAYLIAJBAWoiAkEqSQ0CDAEBC0H6AyADQQFqIgNBCUkNAUECcA4CAgQCAAALAhNBAXAOAQAAAQELRApWCnwcLQ1S/RRB7+QBIAJBAWoiAkEnSQQUDAELEARBAnAEAgsgAQwCAAtBAnAEfQYCDAALIwE/AEEDcA4DAAMBAAVEAXGxm5S6s6EkAwIICwJw0ggaQsDy7MTBjZjcAnskB0EPJQELQfYBIwAMAwALBULBjePrZyQHEAVD3RsfWQwCAAv9DAp3gxRv92ShKcAeLbcvIVwaDAEFQQQlAgsGQAsGGAshAURIPFXr/ZvxHpskAxATGiMAC/0gAiMC/SADRG03NJys+IWb/SIAQcQARLT885+ILff/A30CFvwQBUEBcA4BAAAAAAtDQ0XjWSAABm9BrrMoGiADQQFqIgNBI0kNASMECwwBAAskAiQDQgokBwN+IwQGbyABCxAGQvq62N7QuwMkB0HDubwCQqjb/rqL8gAkBz8ABhQCEwYUDAILDAEAC0GwjqfLAAYUCwITDAEAC0EWC0ECcAR/Qc75sOh4BkAGAAIAIAdEAAAAAAAA8D+gIgdEAAAAAAAALEBjDQQGDAMWQQAMBQALAgIgAQIPCwYQRFUa13lMA+7WJAML0goaQQcRGAEhAQsCAwsLIAZDAACAP5IiBkMAAIA/XQRADAULDAIACwtCET8ADAELQQJwBAIFC0G46oAHDAAFIARBAWoiBEEPSQ0BQuoARFYZe+NhCVXM0gYaJAMkB0EA/BADDAAAC0ECcAQUIwQkBf0ML/nMB88/mT691zRr+72N4wJ+QpOF65GSzc19DAAACyEAQQxBE0EA/AwAARoMAAAFC0ECcAQBBRATRQRADAILCyQFQeCAu94AEAcGE0EBcA4BAAALIQFC8wELIAEPC+cpBQB+A38BfgF9AXxBBBEIAUSXmelD/7llNyMGRAAAAAAAAAAAIwBDURmD3SABAxf8EAIGE0ECcAQHEANBAnAOAgEAAAsGFQwBCyAGQwAAgD+SIgZDAABwQV0NAQYQBhhBBxEYAQwACyMFBhADDxAGEAYCDwZADAULDAAACyIBIAJBAWoiAkESSQQPDAELDAIACyIBBwgjAiMFQ4XfPgW7BnAGAAwEC0EBcA4BAwMLQwWSjTi7IwJBogEQBw0CQ/4KFUQ/AAZA0gRDluxxcbwNANIEIAD9EkEEQTlBCPwMAQEjA9IL/BAAIAD9DAVAEtDmVxa1ZEz6lmBosyVBy+Wo2wQNA9ID0hQjBSQFIwNDlZvRf40JAQscAX0gAdIBQ5LB15wkAT8AQQFwDgECAgALDAALIwQkBSEBBgAMAQELBhMOAwEAAAELIwL9DEBoWRJnnYACK1I0H6ivOI/SBkE0QQVBAPwMAATSBkSmACz+jaelVwJwBgEGeyMABnv8EAhEI1tov/2X0vBE4erx9yg68/9BEw0EoUHlAA0CQRkOAgIEBAsgACQHDAAL/Qx/90KPbYmgmtv1MJkJFIlwAn7SEkLKNQwAAAs/AEECcA4CAAICAAtB7gANAQwBAAtEVF8hllHhKIIDfUSKQj0RAHnn6QJw0gUgANICRNdFp8+P+oVS0gTSAdIVIwICbwwDAAsACwALJAEGQAwBCz8AQQFwDgEAAAALIANBAWoiA0EaSQQPDAELEAYGDyAFQgF8IgVCD1QNAUNHqsv/JAIMAAsDDyIBBhckBSMA/BACQQFwDgEAAAvSBEGMAQYTQQFwDgEAAAsgARAOJAVEcwVOdIKW+X+9IQBBABAHAhMNAEEJQeEAQQD8DAEBDAALIAEQBiIBAnzSAUHV0t8iAnAGDAwACyABBntC156KkH+6DAILQ4qGpLL9IALSA0G4sPzaeP0Q/foBQaHgvwSz/QzduIe2HCoRsvsz6rjqx+oj/f4BIwEGfv0MMAFZkqvM6x6qiQu+2hwOH9INQt6W16rm/N8AIwHSFCMAQhkMAAALQRFB0gBBAfwMAQXDIwUhASQHJAJCvQHSAiMB/BADQQJwBHACAAJ+0gUgAfwQBwwBAAsAC0ECcARwBgsGCwYDBgACQAwCAAsCfQYI/QyvJlzSN2hbIuVObDwCao+b0gRDrhgfPAwBCwwCC9IOQQcgAAJwAwtEmMz9+euVppgMCQALAAsMBAsMAQEL0gBE0HGUzgwn2foMBQtEnNtU/kiS9v8kA/wQBnAlBiAEQQFqIgRBAEkNBiQEAnv8EAf8EAJwJQL9DL2dF9sMW6Vy6dyzSyV4KHkMAAAL/ZQB/SEB/BAIDQQMBAvSBESF8zKouYnu2wwDBRAIAgL8EAZBAXAOAQAACwYDAhUMAQALEAYgB0QAAAAAAADwP6AiB0QAAAAAAAAwQGMEDwwHCwMQRLWHiSlV/9Pn/BAJQykBuST9E/0VAkEBcA4BAQELIwJDWvKP4f0T0gbSAkQR+8GbjWtTxAwEAAALBgEMAAsQAwZAA0BD8YLu9PwA/Qz/32i2aYt5Cp8oEcZWKxPcIAH9DPUhSECuQq867N34zOWG39pB9p+8tQFBAXAOAQEBCwZ7AnAMAgALDAMLBnwjACQCAgIgAAZ+DAML/BAAEAdBAnAOAgACAgvSEEH6AUEBcA4BAQELJAP97wH8EAMNAP1/IADSAyMFIwKLBm8MAQsgBEEBaiIEQQVJDQYQE0UNBhAGJAT8BSQHJAVDokEwp/wQAkEBcA4BAAABC0ECcAQWAnvSAdIUIAE/AEEBcA4BAQELQbPTvdICQQFwDgEAAAsCCAwAAAsjBkPgknB60gHSBSAA/BAIBhMOAQAAC0EFQT5BDPwMAQUkByMEIAVCAXwiBUIOVA0FAg/8EAYNANIFIAHSB/wQASMEIANBAWoiA0EHSQQPDAYLQQ1BOEEk/AwBBCAEQQFqIgRBFkkNBSAGQwAAgD+SIgZDAABAQV0NBSQFIwckB0ECcAQHDAAABQwAAAsgAQYQDAALEBNFBA8MBwsQE0UNBSAFQgF8IgVCIFQEDwwHCz8AQ31u98MCcAYCDAAL/BAHAhNBAXAOAQAAC0H7wquhAkKfys2aya2h9RFEXIKEuoNG8UVBCRAJQwhgbQEkAgwFAAv8EAkCbyABA29Epz1q3hfWMDMMBgALAAsGFyADQQFqIgNBHUkEDwwHCyADQQFqIgNBLUkEDwwHCyAHRAAAAAAAAPA/oCIHRAAAAAAAADZAYwQPDAgLIAJBAWoiAkEdSQ0HQQgREAEGFwIPBhAYASAAtCMD0gv9DFxXSKHSK2bHnbF0XskRmU5B84PinwEGFEECcAR9Qsu759a5r9u8BadBAnAOAgQDAwUgAP0SPwAMAQALJAL8EAECEwYTDgQFAAQBBQv8EAZBA3AOBgMDBAMEAAALDAMLQQJwDgECAQsgBEEBaiIEQQlJDQggAkEBaiICQSlJBA8MCQsgBUIBfCIFQgFUBA8MCQs/AEP0wt9D0gj9DJH7xYebsMKoh8P2TNxK9GtDfx2tVwNADAIAC/0gAgJ7BggZ/BAEBn4GfUEUDgMEBQIFCyQBQgwYAiQHQQJwBBYjAyAA/BAEQQRwDggDBAQEAQEAAAQAC0Hj7QFBA3AOAwIAAwILDAIACyMEAw8CQBATDgMAAgMCAQsgB0QAAAAAAADwP6AiB0QAAAAAAAAqQGMNCCAEQQFqIgRBBUkNCSQEDAEAC0RodJQeH0eQhwwGAAsMAAtBA3AOAwEDAgELAm/9DGiSlLewzyC/BW26sJ/MMRdBE0ELQQD8DAAF/RUBQQJwBAL9DG1yevRExC0UUMFWJbbcyP0gACQHPwAGFCMFIAVCAXwiBUIxVAQPDAkLEAYgAkEBaiICQQNJBA8MCAtEiKfo1QYZNYgMBgALQQFwDgAAC9IFIAAkB0HHDgYUQxj2RQdCLvwQBUMWDvKZ0hAgANIMIwNBDkEDQQD8DAABJAP9DBG58T1gHL1lDWMKch1Y5pgjAwZ80g7SB0Oonq6W/BABDAELIwZBmNUAAnwGB9IT/BAIDAILIAEGEAN7EAsQEwwDAAsGf0LI4O3KkajQk7p/tCMHJAckAj8ABn/9DKOIIpev7H7pH6QwpTrJmt0jAEHAvMa7f0H//wNx/QcAbCMH/R4A/foB0hP8EAMGE0EBcA4BAAALA3sgA0EBaiIDQS9JDQBC3gAgAQwDAAsjACQC/QwmiCdgJs1fs6NhlntMV9Yp/f0BIwZBAAwAAAsCfRAIQlwkBwIA0gHSB/wQBwwAAAsGFCMEBg8/AENdTcACDAIHCQYDBn4Ge0SrYgpxRpE9xAwIC/2UAdID0gzSBEH5AEEBcA4BAQEBCyQHQfiTAQwHCyAAIwcCcAYB0grSEQZ9IwQGGERkI22aDDGIjSQDEA4hAQIWEAgMAAALAhZD2X9WFiQCAgIQDAZ+/QyFbztArp0SLQJS09fL9py2RLeE8V65+ip1DAwLIwJCHSAA0gr8EAYMCQALAAsJBAALIgEMCgALDAQBC0EGQdkAQQP8DAEBBhZEE/Xjb8OYfuvSC0K5yZyRDiQH/Qwqt+fxnU0BbIYT3L885XBpBn8MAQcD0gBDZ/Pv39IA0gxBGAwACw4BAAAL0gMjBwZvQQMRAQEGf0QQTaufIB6dwyQD0g5DwmcSgwwFAQsGFAwGCwwFCwYYAw8MAQALGAQgBEEBaiIEQRJJBA8MDwv8EABBAnAEFwYPGUHj5gQMCQALEA4GfAMDIANBAWoiA0ErSQ0ABkAGcAIWIANBAWoiA0EXSQRADAQLQQQRAgEMAgALAgAMBQALDAkLDA8LDAIACyAAQeIBQQFwDgEBAQskAyAEQQFqIgRBFUkNDiADQQFqIgNBFEkEDwwQCwZ7EAMaQQkOAAELRCBKy3xHfFx9A3z8EAUNASMDDAgACwwHBUK5f/wQAAwDAAs/AAwCAAv8EAkNCNIE0gbSAdIKQZs7IAAgACEAJAcDFAwHAAtC+sbq8wEhAEH//wNxIAA9AYMB0gnSEELDAAkAC/wQBQwAC0ECcAQLBgsCBwwAAAsGewYIDAALRMOhFfHlYL+FDAwBC/2AARoGAgwAC0Hw88IAIAECDwYXIwEGbwwBAAABC/0MT0uzRy+3qz0PuwA8N81zvP0WCAwICxALBggCFQwBAAsQDgIQDAcACyMFRBKxcvQmi5ssQRNBBkEA/AwABQwNCwIWDAAAC0EjQf//A3EuAf0HBhQGfyMH/Qx2oqMKEcrsMWvP1iPsYHHl/QwOy04DCAk+DO34lPz40P4gIAEhASMEAg/SE/0MHWao329Iy4hwc9Git5vTRkGt0S39DI6KCf3nya8vofN7J4r1BTgGfUQC3QaWZEdk7gwKC/wQAQwKAAsQE0UNDwNv0hBDNhwdygwGAAs/AEEDcA4DBwIKBwtBBXAOBQIIAwUAAgELQQJwBBUGAgsjBUEHERgBAxACEAsL/BACDAgABQIDDAAAC0Gz7/ifBwQDDAAABUQ83aHcxWSNmkEADQj8EAj8EARBBHAODQkJBAQGCQQEAwYJBAkEC0EDQRhBCPwMAQEjBkSgubA7YRy82QwHAAsLDAcLQQJwBEACDAN+Bn8gB0QAAAAAAADwP6AiB0QAAAAAAADwP2MEQAwCCwIHDAQACwYAQv6svK7wAvwQBgwFC/wQAkEEcA4EBAYACQkABwQCEBAOCwwKAQsOBwEBAgIBAgECCyQHCwsGe/0MMA0T/3WYVZTHKlETgbN2FAwACwZ7/QxsWquTBeATFZe35Vfd2pWK/QygmlTi+kKeJ7FuPBx6KdKv/ToMAAvSAANwBgEMAAsgAkEBaiICQRdJBEAMAQsGfwJ+EAsGfkK1yOfu4eR6DAALCwZA/Qy7BHZxxW7unw+BB2lFoTAV0g5EVFlby6tCZvjSB0ENQcIAQQL8DAEFIwEjBv0MEKrsv1wWlT9L0OQZxCaLdESTYw++S9dgwP0iAf3BAfwQAUEBcA4BAAABAQELQ3YcvX8GQAv8EAIMAAtBAnAEDAIBDAAACwULBgD8EAYHC0HiqN09CwwBAAsMCQUQBUHoAUQAAAAAAADwfwwKAAv9DCGX/9Xcg9UIPnnEZJgCCn0gASIBIAEMAgtCvAkkB/0MXUbcwMcs3f9NfipwkenOlxpETd3EzoP+DuAMAgELAxMGFAsCcPwQACADQQFqIgNBJUkEFAwCCwwEAAsACxoYCSAFQgF8IgVCElQNCAwCCwwFGQJ/AgNB2LaTGUEBcA4BAAABCwNvQQBBAEEC/AwABAZ8AgsGCxATRQ0DQfIAGAEMAwALDAMAC/wQBwwCAAvSDT8ADAELBhMMAQsjApEkASABEAYgBUIBfCIFQhRUBA8MBwsgA0EBaiIDQRdJDQYgBkMAAIA/kiIGQwAAUEFdBA8MCAsMAQALQgUkBwYUQQJwBHDSFAJ90gT9DHEp7SlM6bucizIOFXOJcmfSEyMADAAACyQBPwAgAQIYDAAAC0EHEQ8BQQcRGAEMAgAFQQIlAPwQBQwBAAvSBRr8CQQMBAtBAnAEAxAIDAAABf0MvYmPxrG42ZaGMbep3ULTiBpBugFBAXAOAAALQ69ohACR0gpEcpiIqTs+atRB8I3J6gVBAXAOBQQEBAQEBAsDGPwQBUECcAR/QTkCE0EBcA4BAAABAQsGQAIVDAEACyAFQgF8IgVCAlQEDwwDCyQE0gUaDAAAAQALQdkCDAAABdIB0g9EiRneIUw7C+skA9IUGiAAIwEkASQHGiABIwQGEAYPCxkjBAtDH2lke/0MG7UKEnldBw6IKsXsWfdJNkHgpQJB0AFBtPQD/AsA/BAIAhMMAQALAAsCfgYLQSILGgJ70gsaQdoABhNBAXAOAQAAC/wQCUECcAR9Q39NeQoMAAAFQ8Ei3DcLJAH9DJA/CE0VB3S0XzUwaoxCJapCy379HgAMAAAL/BAAIwcMAAALxCEAGkHzERoGEAskBCMFCyACQQFqIgJBGEkEDwwFCyADQQFqIgNBLEkEDwwFCyIBAxALJAUjAUSMLNefuGlmskHQLw4BAwMLDAAFBnwjAwv9FP3tAUOPPyDF/SACGgMMIwL9ExoQECABBhggAkEBaiICQRpJDQYgBEEBaiIEQRVJDQULJAQLAgL8EAFBAXAOBwAAAAAAAAAACwIHIAAGQAYLDAELBhNBA3AOAwEAAAILCyEABgMLAhYCFiABEAYkBAsLCwZ8IwMLDAIAC0LciNmcwYKtEf0MWujFj6m+Na2JewZ10ihi3T8AGv0fAdIHIwQjAUHUuQFB0L8CQaHZAfwLAP0T/BAC/RoCGiQEGvwAEAdBAnAEDAULJAcGfPwQBBoQCP0MxGhMRHS2iOuI/NZsNKWf9RpE3wgSssV8XI8/AEECcA4CAAIAAQsjASQCDAELJAb8EABwIwYmABpENCgF7qzVBBcL/RQaIQEgARATRQ0ABg8GGCACQQFqIgJBJkkNAxgDCwJvBhYMAAtBzgAGFEECcAQMDAAABQYICwtBid3tgwUEf0HWAEH/BUIiJAcMAAAFAn0jAowLGv0MjAFjwL8XRxejopg5sC8xgCMFBn0CQAIVDAEACwALIADDJAcGBxgAQ+Q+yj4MAAuQBkAMAAskAiACQQFqIgJBHUkEDwwFCyAHRAAAAAAAAPA/oCIHRAAAAAAAAChAYwQPDAQLBn0jAAwAAAALJAIGbyMFDAALIAZDAACAP5IiBkMAADBBXQ0EQdbB1LJ5DAAACwYUBwIMAQsL/BAIcCUIIANBAWoiA0EmSQ0BAhALCyEBEBNFBA8MAQskBSMFJAVDySLufyQBGkERJQgiAQsgBEEBaiIEQQxJDQBCLP0S/Qx8UxUR6Inij0BT11XyEBic/bYB/QxZX1C/CRwN8Nu9BFEAnta+0gYaGtIHQaetzwgaQoKZqM6s1o2KpX8hABojBhpB1QHSDhpBAnAEAwwAAAULGiQECyQB/BAJGkSfZmzvJrDCmCQDJAIkAyQGBnzSCRoCbwJAC0EAJQMLBhcjASQBIQEZC0Ru+9H26Y3xfwvSEUKKASEAQeLcCQYUDAALAkAMAAALGtIHGhokA/0UGggHAQsLOAUCAEHgsQMLBNM5EHMCAEHbmgILAAIAQdKKAwsE6TvhXQIAQaTuAAsFKmmYtKEBCAILfLBmvsiW', importObject9);
+let {fn101, fn102, global113, global114, global115, global116, global117, memory11, table83, table84, table85, tag71, tag72, tag73, tag74, tag75} = /**
+  @type {{
+fn101: (a0: FuncRef, a1: FuncRef, a2: I64) => [FuncRef, FuncRef, I64],
+fn102: (a0: I64, a1: ExternRef) => [I64, ExternRef],
+global113: WebAssembly.Global,
+global114: WebAssembly.Global,
+global115: WebAssembly.Global,
+global116: WebAssembly.Global,
+global117: WebAssembly.Global,
+memory11: WebAssembly.Memory,
+table83: WebAssembly.Table,
+table84: WebAssembly.Table,
+table85: WebAssembly.Table,
+tag71: WebAssembly.Tag,
+tag72: WebAssembly.Tag,
+tag73: WebAssembly.Tag,
+tag74: WebAssembly.Tag,
+tag75: WebAssembly.Tag
+  }} */ (i9.instance.exports);
+table39.set(73, table37);
+table74.set(19, table84);
+table74.set(42, table84);
+table70.set(11, table84);
+table71.set(23, table4);
+table30.set(57, table74);
+table2.set(80, table32);
+global4.value = null;
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn67(global63.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn101');
+report('progress');
+try {
+  for (let k=0; k<15; k++) {
+  let zzz = fn101(fn31, fn102, global117.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn65');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn65();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn63');
+report('progress');
+try {
+  for (let k=0; k<8; k++) {
+  let zzz = fn63();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn49');
+report('progress');
+try {
+  for (let k=0; k<26; k++) {
+  let zzz = fn49(fn102, fn101, global64.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn101');
+report('progress');
+try {
+  for (let k=0; k<27; k++) {
+  let zzz = fn101(fn79, fn101, global38.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn102');
+report('progress');
+try {
+  for (let k=0; k<21; k++) {
+  let zzz = fn102(global38.value, global81.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn68');
+report('progress');
+try {
+  for (let k=0; k<18; k++) {
+  let zzz = fn68(global91.value);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn64');
+report('progress');
+try {
+  for (let k=0; k<12; k++) {
+  let zzz = fn64();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<15; k++) {
+  let zzz = fn67(global63.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn80');
+report('progress');
+try {
+  for (let k=0; k<28; k++) {
+  let zzz = fn80(global114.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn50');
+report('progress');
+try {
+  for (let k=0; k<19; k++) {
+  let zzz = fn50(global0.value, global18.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn101');
+report('progress');
+try {
+  for (let k=0; k<27; k++) {
+  let zzz = fn101(fn48, fn50, global96.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn63');
+report('progress');
+try {
+  for (let k=0; k<22; k++) {
+  let zzz = fn63();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn9');
+report('progress');
+try {
+  for (let k=0; k<9; k++) {
+  let zzz = fn9();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn68');
+report('progress');
+try {
+  for (let k=0; k<12; k++) {
+  let zzz = fn68(global81.value);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn24');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn24(fn65, fn30, global107.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn66();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn49');
+report('progress');
+try {
+  for (let k=0; k<18; k++) {
+  let zzz = fn49(fn64, fn23, global20.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn68');
+report('progress');
+try {
+  for (let k=0; k<19; k++) {
+  let zzz = fn68(global109.value);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn79');
+report('progress');
+try {
+  for (let k=0; k<18; k++) {
+  let zzz = fn79();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn102');
+report('progress');
+try {
+  for (let k=0; k<16; k++) {
+  let zzz = fn102(global20.value, global3.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn23');
+report('progress');
+try {
+  for (let k=0; k<12; k++) {
+  let zzz = fn23();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn66();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn23');
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn23();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn64');
+report('progress');
+try {
+  for (let k=0; k<18; k++) {
+  let zzz = fn64();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn31');
+report('progress');
+try {
+  for (let k=0; k<22; k++) {
+  let zzz = fn31();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn79');
+report('progress');
+try {
+  for (let k=0; k<24; k++) {
+  let zzz = fn79();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn63');
+report('progress');
+try {
+  for (let k=0; k<25; k++) {
+  let zzz = fn63();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<19; k++) {
+  let zzz = fn67(global29.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn50');
+report('progress');
+try {
+  for (let k=0; k<20; k++) {
+  let zzz = fn50(global54.value, global81.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn31');
+report('progress');
+try {
+  for (let k=0; k<7; k++) {
+  let zzz = fn31();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn38');
+report('progress');
+try {
+  for (let k=0; k<16; k++) {
+  let zzz = fn38();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn101');
+report('progress');
+try {
+  for (let k=0; k<20; k++) {
+  let zzz = fn101(fn48, fn81, global20.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn38');
+report('progress');
+try {
+  for (let k=0; k<29; k++) {
+  let zzz = fn38();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn65');
+report('progress');
+try {
+  for (let k=0; k<19; k++) {
+  let zzz = fn65();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn66();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn80');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn80(global114.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<9; k++) {
+  let zzz = fn66();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn30');
+report('progress');
+try {
+  for (let k=0; k<10; k++) {
+  let zzz = fn30(fn101, fn23, global107.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn48');
+report('progress');
+try {
+  for (let k=0; k<15; k++) {
+  let zzz = fn48(global115.value);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn63');
+report('progress');
+try {
+  for (let k=0; k<7; k++) {
+  let zzz = fn63();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn38');
+report('progress');
+try {
+  for (let k=0; k<24; k++) {
+  let zzz = fn38();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn102');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn102(global70.value, global81.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn50');
+report('progress');
+try {
+  for (let k=0; k<8; k++) {
+  let zzz = fn50(global70.value, global18.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn68');
+report('progress');
+try {
+  for (let k=0; k<29; k++) {
+  let zzz = fn68(global91.value);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn81');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn81(global70.value, global91.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn68');
+report('progress');
+try {
+  for (let k=0; k<5; k++) {
+  let zzz = fn68(global79.value);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn24');
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn24(fn24, fn24, global97.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn80');
+report('progress');
+try {
+  for (let k=0; k<6; k++) {
+  let zzz = fn80(global75.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn65');
+report('progress');
+try {
+  for (let k=0; k<22; k++) {
+  let zzz = fn65();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn81');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn81(global64.value, global91.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn65');
+report('progress');
+try {
+  for (let k=0; k<10; k++) {
+  let zzz = fn65();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn38');
+report('progress');
+try {
+  for (let k=0; k<24; k++) {
+  let zzz = fn38();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<12; k++) {
+  let zzz = fn67(global40.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn81');
+report('progress');
+try {
+  for (let k=0; k<5; k++) {
+  let zzz = fn81(global0.value, global75.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn49');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn49(fn50, fn10, global95.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn49');
+report('progress');
+try {
+  for (let k=0; k<27; k++) {
+  let zzz = fn49(fn81, fn65, global92.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn64');
+report('progress');
+try {
+  for (let k=0; k<8; k++) {
+  let zzz = fn64();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn102');
+report('progress');
+try {
+  for (let k=0; k<14; k++) {
+  let zzz = fn102(global98.value, global115.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<28; k++) {
+  let zzz = fn67(global63.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn65');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn65();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn48');
+report('progress');
+try {
+  for (let k=0; k<6; k++) {
+  let zzz = fn48(global88.value);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn23');
+report('progress');
+try {
+  for (let k=0; k<26; k++) {
+  let zzz = fn23();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn102');
+report('progress');
+try {
+  for (let k=0; k<25; k++) {
+  let zzz = fn102(global54.value, global91.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn39');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn39();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn68');
+report('progress');
+try {
+  for (let k=0; k<15; k++) {
+  let zzz = fn68(global75.value);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn48');
+report('progress');
+try {
+  for (let k=0; k<29; k++) {
+  let zzz = fn48(global51.value);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn101');
+report('progress');
+try {
+  for (let k=0; k<7; k++) {
+  let zzz = fn101(fn81, fn68, global95.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn65');
+report('progress');
+try {
+  for (let k=0; k<22; k++) {
+  let zzz = fn65();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn81');
+report('progress');
+try {
+  for (let k=0; k<8; k++) {
+  let zzz = fn81(global38.value, global114.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn80');
+report('progress');
+try {
+  for (let k=0; k<14; k++) {
+  let zzz = fn80(global10.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn101');
+report('progress');
+try {
+  for (let k=0; k<5; k++) {
+  let zzz = fn101(fn38, fn9, global117.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn39');
+report('progress');
+try {
+  for (let k=0; k<18; k++) {
+  let zzz = fn39();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn79');
+report('progress');
+try {
+  for (let k=0; k<27; k++) {
+  let zzz = fn79();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn68');
+report('progress');
+try {
+  for (let k=0; k<10; k++) {
+  let zzz = fn68(global91.value);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn65');
+report('progress');
+try {
+  for (let k=0; k<14; k++) {
+  let zzz = fn65();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn64');
+report('progress');
+try {
+  for (let k=0; k<14; k++) {
+  let zzz = fn64();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn63');
+report('progress');
+try {
+  for (let k=0; k<21; k++) {
+  let zzz = fn63();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn80');
+report('progress');
+try {
+  for (let k=0; k<5; k++) {
+  let zzz = fn80(global36.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn102');
+report('progress');
+try {
+  for (let k=0; k<25; k++) {
+  let zzz = fn102(global20.value, global81.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn50');
+report('progress');
+try {
+  for (let k=0; k<12; k++) {
+  let zzz = fn50(global38.value, global3.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn101');
+report('progress');
+try {
+  for (let k=0; k<10; k++) {
+  let zzz = fn101(fn101, fn67, global98.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn39');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn39();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn79');
+report('progress');
+try {
+  for (let k=0; k<10; k++) {
+  let zzz = fn79();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn50');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn50(global0.value, global36.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn81');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn81(global70.value, global34.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn101');
+report('progress');
+try {
+  for (let k=0; k<25; k++) {
+  let zzz = fn101(fn30, fn31, global38.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn10');
+report('progress');
+try {
+  for (let k=0; k<18; k++) {
+  let zzz = fn10();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn30');
+report('progress');
+try {
+  for (let k=0; k<27; k++) {
+  let zzz = fn30(fn64, fn49, global60.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn80');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn80(global51.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn101');
+report('progress');
+try {
+  for (let k=0; k<18; k++) {
+  let zzz = fn101(fn81, fn67, global69.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn48');
+report('progress');
+try {
+  for (let k=0; k<6; k++) {
+  let zzz = fn48(global115.value);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn49');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn49(fn23, fn50, global20.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn80');
+report('progress');
+try {
+  for (let k=0; k<21; k++) {
+  let zzz = fn80(global3.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn80');
+report('progress');
+try {
+  for (let k=0; k<25; k++) {
+  let zzz = fn80(global91.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn79');
+report('progress');
+try {
+  for (let k=0; k<28; k++) {
+  let zzz = fn79();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn48');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn48(global115.value);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn31');
+report('progress');
+try {
+  for (let k=0; k<24; k++) {
+  let zzz = fn31();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn39');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn39();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn80');
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn80(global91.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<15; k++) {
+  let zzz = fn67(global63.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<16; k++) {
+  let zzz = fn66();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn79');
+report('progress');
+try {
+  for (let k=0; k<6; k++) {
+  let zzz = fn79();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn101');
+report('progress');
+try {
+  for (let k=0; k<9; k++) {
+  let zzz = fn101(fn65, fn30, global64.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn48');
+report('progress');
+try {
+  for (let k=0; k<10; k++) {
+  let zzz = fn48(global10.value);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn68');
+report('progress');
+try {
+  for (let k=0; k<27; k++) {
+  let zzz = fn68(global114.value);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn79');
+report('progress');
+try {
+  for (let k=0; k<24; k++) {
+  let zzz = fn79();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn102');
+report('progress');
+try {
+  for (let k=0; k<20; k++) {
+  let zzz = fn102(global95.value, global75.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<29; k++) {
+  let zzz = fn66();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn68');
+report('progress');
+try {
+  for (let k=0; k<14; k++) {
+  let zzz = fn68(global81.value);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn79');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn79();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn102');
+report('progress');
+try {
+  for (let k=0; k<26; k++) {
+  let zzz = fn102(global20.value, global18.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn50');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn50(global69.value, global81.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn49');
+report('progress');
+try {
+  for (let k=0; k<22; k++) {
+  let zzz = fn49(fn38, fn10, global69.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<16; k++) {
+  let zzz = fn66();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn101');
+report('progress');
+try {
+  for (let k=0; k<29; k++) {
+  let zzz = fn101(fn9, fn67, global20.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn102');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn102(global54.value, global115.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn63');
+report('progress');
+try {
+  for (let k=0; k<28; k++) {
+  let zzz = fn63();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn81');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn81(global20.value, global10.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn48');
+report('progress');
+try {
+  for (let k=0; k<15; k++) {
+  let zzz = fn48(global10.value);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn79');
+report('progress');
+try {
+  for (let k=0; k<27; k++) {
+  let zzz = fn79();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn102');
+report('progress');
+try {
+  for (let k=0; k<15; k++) {
+  let zzz = fn102(global98.value, global3.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn49');
+report('progress');
+try {
+  for (let k=0; k<19; k++) {
+  let zzz = fn49(fn101, fn9, global0.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn102');
+report('progress');
+try {
+  for (let k=0; k<6; k++) {
+  let zzz = fn102(global117.value, global3.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn64');
+report('progress');
+try {
+  for (let k=0; k<7; k++) {
+  let zzz = fn64();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<7; k++) {
+  let zzz = fn67(global29.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn81');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn81(global20.value, global88.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn31');
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn31();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn64');
+report('progress');
+try {
+  for (let k=0; k<25; k++) {
+  let zzz = fn64();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn49');
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn49(fn30, fn38, global117.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn30');
+report('progress');
+try {
+  for (let k=0; k<21; k++) {
+  let zzz = fn30(fn79, fn50, global65.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn30');
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn30(fn66, fn101, global97.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<29; k++) {
+  let zzz = fn67(k);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn67');
+report('progress');
+try {
+  for (let k=0; k<12; k++) {
+  let zzz = fn67(global66.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn50');
+report('progress');
+try {
+  for (let k=0; k<12; k++) {
+  let zzz = fn50(global20.value, global75.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn66');
+report('progress');
+try {
+  for (let k=0; k<18; k++) {
+  let zzz = fn66();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn101');
+report('progress');
+try {
+  for (let k=0; k<18; k++) {
+  let zzz = fn101(fn10, fn24, global117.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn24');
+report('progress');
+try {
+  for (let k=0; k<25; k++) {
+  let zzz = fn24(fn39, fn80, global97.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn64');
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn64();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn38');
+report('progress');
+try {
+  for (let k=0; k<25; k++) {
+  let zzz = fn38();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn63');
+report('progress');
+try {
+  for (let k=0; k<25; k++) {
+  let zzz = fn63();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn63');
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn63();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn65');
+report('progress');
+try {
+  for (let k=0; k<5; k++) {
+  let zzz = fn65();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn81');
+report('progress');
+try {
+  for (let k=0; k<12; k++) {
+  let zzz = fn81(global78.value, global18.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn81');
+report('progress');
+try {
+  for (let k=0; k<12; k++) {
+  let zzz = fn81(global69.value, global10.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn64');
+report('progress');
+try {
+  for (let k=0; k<26; k++) {
+  let zzz = fn64();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn65');
+report('progress');
+try {
+  for (let k=0; k<26; k++) {
+  let zzz = fn65();
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn63');
+report('progress');
+try {
+  for (let k=0; k<16; k++) {
+  let zzz = fn63();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn39');
+report('progress');
+try {
+  for (let k=0; k<28; k++) {
+  let zzz = fn39();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+let tables = [table12, table17, table2, table55, table39, table0, table19, table74, table9, table70, table72, table49, table52, table30, table33, table37, table5, table32, table34, table61, table53, table10, table4, table20, table71, table29, table85, table84, table83, table28, table13, table18, table1, table56, table15, table11, table75, table31, table38, table25, table81, table62, table3, table76, table73, table51, table16, table60, table50, table35, table54];
+for (let table of tables) {
+for (let k=0; k < table.length; k++) { table.get(k)?.toString(); }
+}
+})().then(() => {
+  log('after')
+  report('after');
+}).catch(e => {
+  log(e)
+  log('error')
+  report('error');
+})

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -212,7 +212,7 @@ private:
 #define WASM_TRY_POP_EXPRESSION_STACK_INTO(result, what) do { \
         WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't pop empty stack in "_s, what); \
         result = m_expressionStack.takeLast(); \
-        m_context.didPopValueFromStack(result, "WasmFunctionParser.h " STRINGIZE(__LINE__) ""_s); \
+        m_context.didPopValueFromStack(result, "WasmFunctionParser.h " STRINGIZE_VALUE_OF(__LINE__) ""_s); \
     } while (0)
 
     using UnaryOperationHandler = PartialResult (Context::*)(ExpressionType, ExpressionType&);

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -5825,8 +5825,10 @@ auto OMGIRGenerator::addCall(FunctionSpaceIndex functionIndexSpace, const TypeDe
 
     fillCallResults(patchpoint, signature, results);
 
-    if (m_info.callCanClobberInstance(functionIndexSpace))
+    if (m_info.callCanClobberInstance(functionIndexSpace)) {
+        patchpoint->clobberLate(RegisterSetBuilder::wasmPinnedRegisters());
         restoreWebAssemblyGlobalState(m_info.memory, instanceValue(), m_currentBlock);
+    }
 
     if (isTailCallInlineCaller) {
         Stack typedResults;

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -90,7 +90,7 @@ void OMGPlan::dumpDisassembly(CompilationContext& context, LinkBuffer& linkBuffe
         auto forEachInst = scopedLambda<void(B3::Air::Inst&)>([&] (B3::Air::Inst& inst) {
             if (inst.origin && inst.origin != prevOrigin && context.procedure->code().shouldPreserveB3Origins()) {
                 if (String string = inst.origin->compilerConstructionSite(); !string.isNull())
-                    out.println("\033[1;37m", string, "\033[0m");
+                    out.println(string);
                 out.print(b3Prefix);
                 inst.origin->deepDump(context.procedure.get(), out);
                 out.println();

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
@@ -78,7 +78,7 @@ void OSREntryPlan::dumpDisassembly(CompilationContext& context, LinkBuffer& link
         auto forEachInst = scopedLambda<void(B3::Air::Inst&)>([&] (B3::Air::Inst& inst) {
             if (inst.origin && inst.origin != prevOrigin && context.procedure->code().shouldPreserveB3Origins()) {
                 if (String string = inst.origin->compilerConstructionSite(); !string.isNull())
-                    dataLogLn("\033[1;37m", string, "\033[0m");
+                    dataLogLn(string);
                 dataLog(b3Prefix);
                 inst.origin->deepDump(context.procedure.get(), WTF::dataFile());
                 dataLogLn();


### PR DESCRIPTION
#### f35184a412c9dbcef17ded41345d3cf9b097e7b5
<pre>
[JSC] Wasm TailCall should say &quot;pinned registers can be clobbered&quot; in OMG
<a href="https://bugs.webkit.org/show_bug.cgi?id=282635">https://bugs.webkit.org/show_bug.cgi?id=282635</a>
<a href="https://rdar.apple.com/138178964">rdar://138178964</a>

Reviewed by Keith Miller and David Degazio.

We need to say that pinned registers are clobbered for transitive tail-calls
in OMG to correctly restore wasm instance.

* JSTests/wasm/stress/omg-tail-call-clobber-pinned-registers.js: Added.
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addCall):
(JSC::Wasm::OMGIRGenerator::addCallRef):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::addCall):
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::dumpDisassembly):
* Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp:
(JSC::Wasm::OSREntryPlan::dumpDisassembly):

Canonical link: <a href="https://commits.webkit.org/286193@main">https://commits.webkit.org/286193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a48364100ce2770b3c3d7cd8e563893e8b8ca75d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75146 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/54585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/27986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/79603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/26402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/63725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/2370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/79603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/26402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78213 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/63725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/27986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/79603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/63725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/27986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/24726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/68293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/63725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/27986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/81079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/74409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/2476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/2370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/81079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/2626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/27986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/81079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/27986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/96677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11591 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/2437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/96677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/2462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/3391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/2471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->