### PR TITLE
[css-masonry] Refactor Overriding of Logical Width during Masonry

### DIFF
--- a/Source/WebCore/rendering/GridMasonryLayout.h
+++ b/Source/WebCore/rendering/GridMasonryLayout.h
@@ -41,8 +41,14 @@ public:
     {
     }
 
+    enum class MasonryLayoutPhase : uint8_t {
+        LayoutPhase,
+        MinContentPhase,
+        MaxContentPhase
+    };
+
     void initializeMasonry(unsigned gridAxisTracks, GridTrackSizingDirection masonryAxisDirection);
-    void performMasonryPlacement(const GridTrackSizingAlgorithm&, unsigned gridAxisTracks, GridTrackSizingDirection masonryAxisDirection);
+    void performMasonryPlacement(const GridTrackSizingAlgorithm&, unsigned gridAxisTracks, GridTrackSizingDirection masonryAxisDirection, GridMasonryLayout::MasonryLayoutPhase);
     LayoutUnit offsetForGridItem(const RenderBox&) const;
     LayoutUnit gridContentSize() const { return m_gridContentSize; };
     LayoutUnit gridGap() const { return m_masonryAxisGridGap; };
@@ -54,11 +60,12 @@ private:
     GridArea gridAreaForDefiniteGridAxisItem(const RenderBox&) const;
 
     void collectMasonryItems();
-    void placeItemsUsingOrderModifiedDocumentOrder(const GridTrackSizingAlgorithm&);
-    void placeItemsWithDefiniteGridAxisPosition(const GridTrackSizingAlgorithm&);
-    void placeItemsWithIndefiniteGridAxisPosition(const GridTrackSizingAlgorithm&);
+    void placeItemsUsingOrderModifiedDocumentOrder(const GridTrackSizingAlgorithm&, GridMasonryLayout::MasonryLayoutPhase);
+    void placeItemsWithDefiniteGridAxisPosition(const GridTrackSizingAlgorithm&, GridMasonryLayout::MasonryLayoutPhase);
+    void placeItemsWithIndefiniteGridAxisPosition(const GridTrackSizingAlgorithm&, GridMasonryLayout::MasonryLayoutPhase);
     void setItemGridAxisContainingBlockToGridArea(const GridTrackSizingAlgorithm&, RenderBox&);
-    void insertIntoGridAndLayoutItem(const GridTrackSizingAlgorithm&, RenderBox&, const GridArea&);
+    void insertIntoGridAndLayoutItem(const GridTrackSizingAlgorithm&, RenderBox&, const GridArea&, GridMasonryLayout::MasonryLayoutPhase);
+    LayoutUnit calculateMasonryIntrinsicLogicalWidth(RenderBox&, GridMasonryLayout::MasonryLayoutPhase);
 
     void resizeAndResetRunningPositions();
     void allocateCapacityForMasonryVectors();

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -500,7 +500,7 @@ void RenderGrid::layoutMasonry(bool relayoutChildren)
             auto gridAxisDirection = masonryAxisDirection == GridTrackSizingDirection::ForRows ? GridTrackSizingDirection::ForColumns : GridTrackSizingDirection::ForRows;
             unsigned gridAxisTracksBeforeAutoPlacement = currentGrid().numTracks(gridAxisDirection);
 
-            m_masonryLayout.performMasonryPlacement(m_trackSizingAlgorithm, gridAxisTracksBeforeAutoPlacement, masonryAxisDirection);
+            m_masonryLayout.performMasonryPlacement(m_trackSizingAlgorithm, gridAxisTracksBeforeAutoPlacement, masonryAxisDirection, GridMasonryLayout::MasonryLayoutPhase::LayoutPhase);
         };
 
         if (areMasonryRows())
@@ -706,29 +706,10 @@ void RenderGrid::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, Layo
 
         // To determine the width of the grid when we have a masonry layout in the column direction we need to perform a layout with the min and max
         // conent sizes. We will override the grid items widths to accomplish this and then calculate the final grid content size after placement.
-
-        for (auto* gridItem = grid.orderIterator().first(); gridItem; gridItem = grid.orderIterator().next()) {
-            if (grid.orderIterator().shouldSkipChild(*gridItem))
-                continue;
-
-            if (gridItem->style().logicalWidth().isAuto() || gridItem->style().logicalWidth().isPercent())
-                gridItem->setOverridingLogicalWidth(gridItem->computeIntrinsicLogicalWidthUsing(Length(LengthType::MinContent), LayoutUnit(), gridItem->borderAndPaddingLogicalWidth()));
-        }
-
-        m_masonryLayout.performMasonryPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, GridTrackSizingDirection::ForColumns);
-
+        m_masonryLayout.performMasonryPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, GridTrackSizingDirection::ForColumns, GridMasonryLayout::MasonryLayoutPhase::MinContentPhase);
         minLogicalWidth = m_masonryLayout.gridContentSize();
 
-        for (auto* gridItem = grid.orderIterator().first(); gridItem; gridItem = grid.orderIterator().next()) {
-            if (grid.orderIterator().shouldSkipChild(*gridItem))
-                continue;
-
-            if (gridItem->style().logicalWidth().isAuto() || gridItem->style().logicalWidth().isPercent())
-                gridItem->setOverridingLogicalWidth(gridItem->computeIntrinsicLogicalWidthUsing(Length(LengthType::MaxContent), LayoutUnit(), gridItem->borderAndPaddingLogicalWidth()));
-        }
-
-        m_masonryLayout.performMasonryPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, GridTrackSizingDirection::ForColumns);
-
+        m_masonryLayout.performMasonryPlacement(algorithm, gridAxisTracksCountBeforeAutoPlacement, GridTrackSizingDirection::ForColumns, GridMasonryLayout::MasonryLayoutPhase::MaxContentPhase);
         maxLogicalWidth = m_masonryLayout.gridContentSize();
     }
 


### PR DESCRIPTION
#### 578b0cd616d27f530dd49e693bc7d6b4ac93fe4a
<pre>
[css-masonry] Refactor Overriding of Logical Width during Masonry
<a href="https://bugs.webkit.org/show_bug.cgi?id=282638">https://bugs.webkit.org/show_bug.cgi?id=282638</a>
<a href="https://rdar.apple.com/problem/139312026">rdar://problem/139312026</a>

Reviewed by Sammy Gill.

The overriding logical width logic should live in the GridMasonryLayout instead of RenderGrid.

Added an enum to handle the different min, max, and not overriding cases.

There was one special behavior with subgrid containers not being iterated over in the old implementation. I added extra code to handle this behavior.

 * Source/WebCore/rendering/GridMasonryLayout.cpp:
 (WebCore::GridMasonryLayout::performMasonryPlacement):
 (WebCore::GridMasonryLayout::placeItemsUsingOrderModifiedDocumentOrder):
 (WebCore::GridMasonryLayout::placeItemsWithDefiniteGridAxisPosition):
 (WebCore::GridMasonryLayout::placeItemsWithIndefiniteGridAxisPosition):
 (WebCore::GridMasonryLayout::calculateMasonryIntrinsicLogicalWidth):
 (WebCore::GridMasonryLayout::insertIntoGridAndLayoutItem):
 * Source/WebCore/rendering/GridMasonryLayout.h:
 * Source/WebCore/rendering/RenderGrid.cpp:
 (WebCore::RenderGrid::layoutMasonry):
 (WebCore::RenderGrid::computeIntrinsicLogicalWidths const):

Canonical link: <a href="https://commits.webkit.org/286276@main">https://commits.webkit.org/286276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14e92f49087841c1750ed0e94d0695fcd6fea6c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79837 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26628 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59146 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17374 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64746 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39508 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/10 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22242 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24955 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22580 "Found 1 new test failure: media/media-vp8-webm-with-poster.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81320 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2703 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1699 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67394 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64734 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66674 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16609 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10627 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8787 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2660 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5481 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2685 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3620 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2692 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->