### PR TITLE
Fix WPT text-autospace-first-line-001

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-first-line-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-first-line-001-expected.html
@@ -2,17 +2,27 @@
 <meta charset="utf-8">
 <link rel="help" href="https://drafts.csswg.org/css-text-4/#text-autospace-property">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<link rel="match" href="text-autospace-first-line-001-ref.html">
 <style>
 .test {
   font-family: Ahem;
   font-size: 40px;
-  text-autospace: normal;
+  text-autospace: no-autospace;
 }
 .first-line::first-line {
   font-size: 200%;
 }
+.manual-spacing {
+  margin: 0 0.125em;
+}
+.zoom {
+  font-size: 200%;
+}
 </style>
-<div id="container">
-  <div id="test1" class="test first-line">国国XX国<br>国国XX国</div>
+<div id="container" class="test">
+  <div class="zoom">
+    国国<span class="manual-spacing">XX</span>国
+  </div>
+  <div>
+    国国<span class="manual-spacing">XX</span>国
+  </div>
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-first-line-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-first-line-001-expected.txt
@@ -1,5 +1,0 @@
-国国XX国
-国国XX国
-
-FAIL text-autospace-first-line-001 assert_array_equals: expected property 1 to be 90 but got 80 (expected array [80, 90, 80, 90, 80, 40, 45, 40, 45, 40] got [80, 80, 80, 80, 80, 40, 40, 40, 40, 40])
-

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-first-line-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-first-line-001-ref.html
@@ -2,17 +2,27 @@
 <meta charset="utf-8">
 <link rel="help" href="https://drafts.csswg.org/css-text-4/#text-autospace-property">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<link rel="match" href="text-autospace-first-line-001-ref.html">
 <style>
 .test {
   font-family: Ahem;
   font-size: 40px;
-  text-autospace: normal;
+  text-autospace: no-autospace;
 }
 .first-line::first-line {
   font-size: 200%;
 }
+.manual-spacing {
+  margin: 0 0.125em;
+}
+.zoom {
+  font-size: 200%;
+}
 </style>
-<div id="container">
-  <div id="test1" class="test first-line">国国XX国<br>国国XX国</div>
+<div id="container" class="test">
+  <div class="zoom">
+    国国<span class="manual-spacing">XX</span>国
+  </div>
+  <div>
+    国国<span class="manual-spacing">XX</span>国
+  </div>
 </div>


### PR DESCRIPTION
#### 4bfa89ceadd38eee1b86760e64be7835701e23d9
<pre>
Fix WPT text-autospace-first-line-001
<a href="https://bugs.webkit.org/show_bug.cgi?id=282641">https://bugs.webkit.org/show_bug.cgi?id=282641</a>
<a href="https://rdar.apple.com/139313476">rdar://139313476</a>

Reviewed by Tim Nguyen.

Original test assumes Blink&apos;s implementation details: spacing
always added as trailing spacing to the glyph.

We are updating the test to be a ref test instead of using
individual character measuring.

* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-first-line-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-first-line-001-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-first-line-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-first-line-001.html:

Canonical link: <a href="https://commits.webkit.org/286224@main">https://commits.webkit.org/286224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8405373ec9edb7436ec50e8d4d283ec4c529b03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27947 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79557 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26362 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2332 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58956 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17207 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64524 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39331 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46494 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22026 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24686 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67584 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81040 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2436 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67215 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2586 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66499 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/16567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10441 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8620 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11613 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2397 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2422 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3351 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->