### PR TITLE
export-w3c-test-changes should allow the branch to be kept on failure

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_exporter.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter.py
@@ -345,10 +345,13 @@ class WebPlatformTestExporter(object):
             _log.info('Error creating a pull request on github. Please ensure that the provided github token has the "public_repo" scope.')
         return pr_number
 
-    def delete_local_branch(self):
-        _log.info('Removing local branch ' + self._branch_name)
-        self._git.checkout('master')
-        self._git.delete_branch(self._branch_name)
+    def delete_local_branch(self, *, is_success=True):
+        if self._options.clean and (is_success or self._options.clean_on_failure):
+            _log.info('Removing local branch ' + self._branch_name)
+            self._git.checkout('master')
+            self._git.delete_branch(self._branch_name)
+        else:
+            _log.info('Keeping local branch ' + self._branch_name)
 
     def create_upload_remote_if_needed(self):
         if not self._wpt_fork_remote in self._git.remote([]):
@@ -365,29 +368,31 @@ class WebPlatformTestExporter(object):
         self.clean()
 
         if not self.create_branch_with_patch(git_patch_file):
-            _log.error("Cannot create web-platform-tests local branch from the patch")
-            self.delete_local_branch()
+            _log.error("Cannot create web-platform-tests local branch from the patch %r", git_patch_file)
+            self.delete_local_branch(is_success=False)
             return
 
-        if git_patch_file:
+        if git_patch_file and self.clean:
             self._filesystem.remove(git_patch_file)
 
         if self._options.use_linter:
             lint_errors = self._linter.lint()
             if lint_errors:
                 _log.error("The wpt linter detected %s linting error(s). Please address the above errors before attempting to export changes to the web-platform-test repository." % (lint_errors,))
-                self.delete_local_branch()
-                self.clean()
+                self.delete_local_branch(is_success=False)
                 return
 
         try:
             if self.push_to_wpt_fork():
                 if self._options.create_pull_request:
                     self.make_pull_request()
+        except Exception:
+            self.delete_local_branch(is_success=False)
+            raise
+        else:
+            self.delete_local_branch(is_success=True)
         finally:
-            self.delete_local_branch()
             _log.info("Finished")
-            self.clean()
 
 
 def parse_args(args):
@@ -426,6 +431,8 @@ def parse_args(args):
     parser.add_argument('-c', '--create-pr', dest='create_pull_request', action='store_true', default=False, help='create pull request to w3c web-platform-tests')
     parser.add_argument('--non-interactive', action='store_true', dest='non_interactive', default=False, help='Never prompt the user, fail as fast as possible.')
     parser.add_argument('--no-linter', action='store_false', dest='use_linter', default=True, help='Disable linter.')
+    parser.add_argument('--no-clean', action='store_false', dest='clean', help='Do not clean up.')
+    parser.add_argument('--clean-on-failure', action='store_true', dest='clean_on_failure', help='Do not clean up on failure.')
 
     options, args = parser.parse_known_args(args)
 


### PR DESCRIPTION
#### c85579a8aa15e58422e888e2aa06e4fb78c91852
<pre>
export-w3c-test-changes should allow the branch to be kept on failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=270348">https://bugs.webkit.org/show_bug.cgi?id=270348</a>
<a href="https://rdar.apple.com/problem/124269575">rdar://problem/124269575</a>

Reviewed by Sihui Liu.

This adds two arguments:

 * --no-clean, which toggles doing any cleanup, even on success
 * --clean-on-failure, which toggles cleaning up on failure

While we&apos;re at it, avoid needlessly running:

    git checkout master
    git reset --hard origin
    git checkout master

at the end of execution. We can just checkout once, and just leave
master as it is.

* Tools/Scripts/webkitpy/w3c/test_exporter.py:
(WebPlatformTestExporter.delete_local_branch):
(WebPlatformTestExporter.do_export):
(parse_args):
* Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py:
(TestExporterTest.test_export):
(TestExporterTest.test_export_with_specific_branch):
(TestExporterTest):
(TestExporterTest.test_export_no_clean):

Canonical link: <a href="https://commits.webkit.org/286253@main">https://commits.webkit.org/286253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6d4741aa16ef074d8990732c9789d8e298abe04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79573 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26373 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77234 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58964 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17219 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78184 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39339 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/74625 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46491 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22041 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24697 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67582 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81050 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2447 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1513 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67225 "Found 1 new test failure: fast/text/crash-letter-spacing-infinite.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64545 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66509 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10451 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8632 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11633 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2408 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2433 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3362 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2442 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->