### PR TITLE
walzr.com: Images are vertically stretched.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-max-content-height-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-max-content-height-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-max-content-height.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-max-content-height.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+<link rel="help" href="https://drafts.csswg.org/css2/#inline-replaced-height">
+<meta name="assert" content="max-content height of an image with specified width is computed via aspect ratio">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<img style="width: 100px; height: max-content;" src="../support/60x60-green.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-min-content-height-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-min-content-height-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-min-content-height.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-min-content-height.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+<link rel="help" href="https://drafts.csswg.org/css2/#inline-replaced-height">
+<meta name="assert" content="min-content height of an image with specified width is computed via aspect ratio">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<img style="width: 100px; height: min-content;" src="../support/60x60-green.png">
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -69,6 +69,7 @@
 #include "RenderFragmentContainer.h"
 #include "RenderGeometryMap.h"
 #include "RenderGrid.h"
+#include "RenderImage.h"
 #include "RenderInline.h"
 #include "RenderIterator.h"
 #include "RenderLayerCompositor.h"
@@ -3334,6 +3335,14 @@ std::optional<LayoutUnit> RenderBox::computeIntrinsicLogicalContentHeightUsing(L
     // FIXME: The CSS sizing spec is considering changing what min-content/max-content should resolve to.
     // If that happens, this code will have to change.
     if (logicalHeightLength.isMinContent() || logicalHeightLength.isMaxContent() || logicalHeightLength.isFitContent() || logicalHeightLength.isLegacyIntrinsic()) {
+        if (auto* renderImage = dynamicDowncast<RenderImage>(this)) {
+            auto computedLogicalWidth = style().logicalWidth();
+            if ((logicalHeightLength.isMinContent() || logicalHeightLength.isMaxContent()) && computedLogicalWidth.isFixed() && !style().hasAspectRatio()) {
+                auto intrinsicRatio = renderImage->intrinsicRatio();
+                return resolveHeightForRatio(borderAndPaddingLogicalWidth(), borderAndPaddingLogicalHeight(), LayoutUnit(computedLogicalWidth.value()), intrinsicRatio.transposedSize().aspectRatio(), BoxSizing::ContentBox);
+            }
+        }
+
         if (intrinsicContentHeight)
             return adjustIntrinsicLogicalHeightForBoxSizing(intrinsicContentHeight.value());
         return { };

--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -152,4 +152,11 @@ inline void RenderBox::setLogicalWidth(LayoutUnit size)
         setHeight(size);
 }
 
+inline LayoutUnit resolveHeightForRatio(LayoutUnit borderAndPaddingLogicalWidth, LayoutUnit borderAndPaddingLogicalHeight, LayoutUnit logicalWidth, double aspectRatio, BoxSizing boxSizing)
+{
+    if (boxSizing == BoxSizing::BorderBox)
+        return LayoutUnit((logicalWidth + borderAndPaddingLogicalWidth) * aspectRatio) - borderAndPaddingLogicalHeight;
+    return LayoutUnit(logicalWidth * aspectRatio);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -670,13 +670,6 @@ LayoutUnit RenderReplaced::computeReplacedLogicalWidth(ShouldComputePreferred sh
     return computeReplacedLogicalWidthRespectingMinMaxWidth(intrinsicLogicalWidth(), shouldComputePreferred);
 }
 
-static inline LayoutUnit resolveHeightForRatio(LayoutUnit borderAndPaddingLogicalWidth, LayoutUnit borderAndPaddingLogicalHeight, LayoutUnit logicalWidth, double aspectRatio, BoxSizing boxSizing)
-{
-    if (boxSizing == BoxSizing::BorderBox)
-        return LayoutUnit((logicalWidth + borderAndPaddingLogicalWidth) * aspectRatio) - borderAndPaddingLogicalHeight;
-    return LayoutUnit(logicalWidth * aspectRatio);
-}
-
 LayoutUnit RenderReplaced::computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth) const
 {
     // 10.5 Content height: the 'height' property: http://www.w3.org/TR/CSS21/visudet.html#propdef-height
@@ -920,6 +913,14 @@ void RenderReplaced::layoutShadowContent(const LayoutSize& oldSize)
     }
 
     clearChildNeedsLayout();
+}
+
+FloatSize RenderReplaced::intrinsicRatio() const
+{
+    FloatSize intrinsicRatio;
+    FloatSize constrainedSize;
+    computeAspectRatioInformationForRenderBox(embeddedContentBox(), constrainedSize, intrinsicRatio);
+    return intrinsicRatio;
 }
 
 }

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -40,6 +40,7 @@ public:
     bool setNeedsLayoutIfNeededAfterIntrinsicSizeChange();
 
     LayoutSize intrinsicSize() const final;
+    FloatSize intrinsicRatio() const;
     
     bool isContentLikelyVisibleInViewport();
     bool needsPreferredWidthsRecalculation() const override;


### PR DESCRIPTION
#### 7a3aefde0128d2514b2aeac3caac401118ed5b82
<pre>
walzr.com: Images are vertically stretched.
<a href="https://bugs.webkit.org/show_bug.cgi?id=282634">https://bugs.webkit.org/show_bug.cgi?id=282634</a>
<a href="https://rdar.apple.com/137063317">rdar://137063317</a>

Reviewed by Alan Baradlay.

Images on walzr.com have a fixed width and a computed height of min-content, which is
causing them to vertically stretch.

css-box-sizing-3 defines the min-content size to be: &quot;the size it would have if it was a
float given an auto preferred size in that axis (and no minimum or maximum size in that
axis) and if its containing block was zero-sized in that axis.&quot;

CSS2 defines finding the logical height for floating replaced elements. If the width
is a non-auto computed width, a computed width of auto, and an intrinsic ratio, then
the logical height is computed via the aspect ratio.

RenderBox::computeIntrinsicLogicalContentHeightUsing was simply returning the intrinsic
logical height, which was not correct. Let&apos;s adjust this by adding some new logic to handle
this specific case for images and fall back to other types of content. We also will fall
back to the old logic if an aspect ratio is specified via the aspect-ratio property.
The max-content size is defined similarly (with a difference in the containing block
size for the float) so let&apos;s handle it here too.

<a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes</a>
<a href="https://drafts.csswg.org/css2/#inline-replaced-height">https://drafts.csswg.org/css2/#inline-replaced-height</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-max-content-height-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-max-content-height.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-min-content-height-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/intrinsic-fixed-width-with-min-content-height.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeIntrinsicLogicalContentHeightUsing const):
* Source/WebCore/rendering/RenderBoxInlines.h:
(WebCore::resolveHeightForRatio):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):
* Source/WebCore/rendering/RenderReplaced.h:

Canonical link: <a href="https://commits.webkit.org/286284@main">https://commits.webkit.org/286284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86a0115a6a62f211b3bd3cf9401e11ea0474e02d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75368 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/30 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79841 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26632 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77484 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2599 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59151 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17372 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64753 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39513 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22249 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24959 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81324 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1702 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67401 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2858 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66682 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16613 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10631 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8793 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2664 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5485 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2689 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3624 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2696 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->