### PR TITLE
Add sandbox telemetry for sandbox extensions

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1093,6 +1093,9 @@
 (deny mach-lookup (with no-report)
     (global-name "com.apple.tccd.system"))
 
+(deny mach-lookup (with telemetry-backtrace)
+    (global-name "com.apple.mobileassetd.v2"))
+
 (with-filter (require-not (state-flag "BlockMobileAssetInWebContentSandbox"))
     (allow mach-lookup
         (require-all
@@ -1131,8 +1134,11 @@
     (global-name "com.apple.PowerManagement.control"))
 
 #if HAVE(STATIC_FONT_REGISTRY)
+(deny mach-lookup (with telemetry-backtrace)
+    (global-name "com.apple.fonts"))
+
 (with-filter (require-not (state-flag "BlockFontServiceInWebContentSandbox"))
-    (allow mach-lookup
+    (allow mach-lookup (with telemetry-backtrace)
         (require-all
             (extension "com.apple.webkit.extension.mach")
             (global-name "com.apple.fonts"))))
@@ -1174,7 +1180,7 @@
 )
 
 (with-filter (require-not (state-flag "BlockOpenDirectoryInWebContentSandbox"))
-    (allow mach-lookup
+    (allow mach-lookup (with telemetry-backtrace)
         (require-all
             (extension "com.apple.webkit.extension.mach")
             (global-name "com.apple.system.opendirectoryd.libinfo"))))
@@ -1348,15 +1354,22 @@
         (global-name "com.apple.analyticsd")
         (global-name "com.apple.diagnosticd")))
 
+(deny mach-lookup (with telemetry-backtrace)
+    (global-name "com.apple.webinspector"))
+
 (with-filter (require-not (state-flag "BlockWebInspectorInWebContentSandbox"))
-    (allow mach-lookup
+    (allow mach-lookup (with telemetry-backtrace)
         (require-all
             (extension "com.apple.webkit.extension.mach")
-            (global-name
-                "com.apple.webinspector"))))
+            (global-name "com.apple.webinspector"))))
+
+(deny mach-lookup (with telemetry-backtrace)
+    (global-name
+        "com.apple.iconservices"
+        "com.apple.iconservices.store"))
 
 (with-filter (require-not (state-flag "BlockIconServicesInWebContentSandbox"))
-    (allow mach-lookup
+    (allow mach-lookup (with telemetry-backtrace)
         (require-all
             (extension "com.apple.webkit.extension.mach")
             (global-name
@@ -1972,14 +1985,14 @@
         (iokit-user-client-class "RootDomainUserClient")))
 
 (when (webcontent_gpu_sandbox_extensions_blocking)
-    (deny iokit-open-service (with telemetry-backtrace))
-    (deny iokit-open-user-client (with telemetry-backtrace)))
+    (deny iokit-open-service (with telemetry))
+    (deny iokit-open-user-client (with telemetry)))
 
 #if HAVE(SANDBOX_STATE_FLAGS)
 (with-filter (state-flag "BlockIOKitInWebContentSandbox")
-    (deny iokit-open-service (with telemetry-backtrace))
-    (deny iokit-open-user-client (with telemetry-backtrace))
-    (deny mach-lookup (with telemetry-backtrace)
+    (deny iokit-open-service (with telemetry))
+    (deny iokit-open-user-client (with telemetry))
+    (deny mach-lookup (with telemetry)
         (require-all
             (require-not (extension "com.apple.webkit.extension.mach"))
             (xpc-service-name "com.apple.MTLCompilerService"))))


### PR DESCRIPTION
#### a288f42395f0cc4cdf1b377765b6813189872ab4
<pre>
Add sandbox telemetry for sandbox extensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=282650">https://bugs.webkit.org/show_bug.cgi?id=282650</a>
<a href="https://rdar.apple.com/139317736">rdar://139317736</a>

Reviewed by Brent Fulgham.

Add sandbox telemetry for XPC/Mach sandbox extensions on macOS. The collected telemetry will
provide more context on how these services are being used.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/286280@main">https://commits.webkit.org/286280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9288f8b5249fae7e78d259a6e64f488142842305

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79580 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26380 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58969 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17228 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64538 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39346 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46502 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24704 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67591 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81057 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2454 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67227 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2604 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64543 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66512 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10452 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8630 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11649 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2415 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5219 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2440 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3369 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2449 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->