### PR TITLE
Reduce use of UncheckedKeyHashMap in WebCore

### DIFF
--- a/Source/WebCore/loader/CrossOriginPreflightResultCache.h
+++ b/Source/WebCore/loader/CrossOriginPreflightResultCache.h
@@ -76,7 +76,7 @@ private:
     friend NeverDestroyed<CrossOriginPreflightResultCache>;
     CrossOriginPreflightResultCache();
 
-    UncheckedKeyHashMap<std::tuple<PAL::SessionID, String, URL>, std::unique_ptr<CrossOriginPreflightResultCacheItem>> m_preflightHashMap;
+    HashMap<std::tuple<PAL::SessionID, String, URL>, std::unique_ptr<CrossOriginPreflightResultCacheItem>> m_preflightHashMap;
 };
 
 inline CrossOriginPreflightResultCacheItem::CrossOriginPreflightResultCacheItem(MonotonicTime absoluteExpiryTime, StoredCredentialsPolicy  storedCredentialsPolicy, HashSet<String>&& methods, HashSet<String, ASCIICaseInsensitiveHash>&& headers)

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -111,7 +111,7 @@ enum class ClearSiteDataValue : uint8_t;
 enum class LoadWillContinueInAnotherProcess : bool;
 enum class ShouldContinue;
 
-using ResourceLoaderMap = UncheckedKeyHashMap<ResourceLoaderIdentifier, RefPtr<ResourceLoader>>;
+using ResourceLoaderMap = HashMap<ResourceLoaderIdentifier, RefPtr<ResourceLoader>>;
 
 enum class AutoplayPolicy : uint8_t {
     Default, // Uses policies specified in document settings.
@@ -670,7 +670,7 @@ private:
     std::optional<CrossOriginOpenerPolicy> m_responseCOOP;
     OptionSet<ClearSiteDataValue> m_responseClearSiteDataValues;
     
-    typedef UncheckedKeyHashMap<RefPtr<ResourceLoader>, RefPtr<SubstituteResource>> SubstituteResourceMap;
+    typedef HashMap<RefPtr<ResourceLoader>, RefPtr<SubstituteResource>> SubstituteResourceMap;
     SubstituteResourceMap m_pendingSubstituteResources;
     Timer m_substituteResourceDeliveryTimer;
 
@@ -690,8 +690,8 @@ private:
 
     DataLoadToken m_dataLoadToken;
 
-    UncheckedKeyHashMap<uint64_t, LinkIcon> m_iconsPendingLoadDecision;
-    UncheckedKeyHashMap<std::unique_ptr<IconLoader>, CompletionHandler<void(FragmentedSharedBuffer*)>> m_iconLoaders;
+    HashMap<uint64_t, LinkIcon> m_iconsPendingLoadDecision;
+    HashMap<std::unique_ptr<IconLoader>, CompletionHandler<void(FragmentedSharedBuffer*)>> m_iconLoaders;
     Vector<LinkIcon> m_linkIcons;
 
 #if ENABLE(APPLICATION_MANIFEST)

--- a/Source/WebCore/loader/ProgressTracker.h
+++ b/Source/WebCore/loader/ProgressTracker.h
@@ -78,7 +78,7 @@ private:
     WeakRef<Page> m_page;
     UniqueRef<ProgressTrackerClient> m_client;
     RefPtr<LocalFrame> m_originatingProgressFrame;
-    UncheckedKeyHashMap<ResourceLoaderIdentifier, std::unique_ptr<ProgressItem>> m_progressItems;
+    HashMap<ResourceLoaderIdentifier, std::unique_ptr<ProgressItem>> m_progressItems;
     Timer m_progressHeartbeatTimer;
 
     long long m_totalPageAndResourceBytesToLoad { 0 };

--- a/Source/WebCore/loader/ResourceLoadStatistics.cpp
+++ b/Source/WebCore/loader/ResourceLoadStatistics.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 
 static Seconds timestampResolution { 5_s };
 
-typedef UncheckedKeyHashMap<RegistrableDomain, unsigned, RegistrableDomain::RegistrableDomainHash, HashTraits<RegistrableDomain>, HashTraits<unsigned>>::KeyValuePairType ResourceLoadStatisticsValue;
+typedef HashMap<RegistrableDomain, unsigned, RegistrableDomain::RegistrableDomainHash, HashTraits<RegistrableDomain>, HashTraits<unsigned>>::KeyValuePairType ResourceLoadStatisticsValue;
 
 static void encodeHashSet(KeyedEncoder& encoder, const String& label,  const String& key, const HashSet<RegistrableDomain>& hashSet)
 {

--- a/Source/WebCore/loader/appcache/ApplicationCache.h
+++ b/Source/WebCore/loader/appcache/ApplicationCache.h
@@ -70,7 +70,7 @@ public:
     void dump();
 #endif
 
-    using ResourceMap = UncheckedKeyHashMap<String, RefPtr<ApplicationCacheResource>>;
+    using ResourceMap = HashMap<String, RefPtr<ApplicationCacheResource>>;
     const ResourceMap& resources() const { return m_resources; }
 
     void setStorageID(unsigned storageID) { m_storageID = storageID; }

--- a/Source/WebCore/loader/appcache/ApplicationCacheGroup.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheGroup.h
@@ -160,7 +160,7 @@ private:
     HashSet<DocumentLoader*> m_associatedDocumentLoaders;
 
     // The URLs and types of pending cache entries.
-    UncheckedKeyHashMap<String, unsigned> m_pendingEntries;
+    HashMap<String, unsigned> m_pendingEntries;
     
     // The total number of items to be processed to update the cache group and the number that have been done.
     int m_progressTotal { 0 };

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.h
@@ -153,7 +153,7 @@ private:
     // we keep a hash set of the hosts of the manifest URLs of all non-obsolete cache groups.
     HashCountedSet<unsigned, AlreadyHashed> m_cacheHostSet;
     
-    UncheckedKeyHashMap<String, ApplicationCacheGroup*> m_cachesInMemory; // Excludes obsolete cache groups.
+    HashMap<String, ApplicationCacheGroup*> m_cachesInMemory; // Excludes obsolete cache groups.
 
     friend class NeverDestroyed<ApplicationCacheStorage>;
 };

--- a/Source/WebCore/loader/archive/ArchiveFactory.cpp
+++ b/Source/WebCore/loader/archive/ArchiveFactory.cpp
@@ -47,7 +47,7 @@
 namespace WebCore {
 
 typedef RefPtr<Archive> RawDataCreationFunction(const URL&, FragmentedSharedBuffer&);
-typedef UncheckedKeyHashMap<String, RawDataCreationFunction*, ASCIICaseInsensitiveHash> ArchiveMIMETypesMap;
+typedef HashMap<String, RawDataCreationFunction*, ASCIICaseInsensitiveHash> ArchiveMIMETypesMap;
 
 // The create functions in the archive classes return RefPtr to concrete subclasses
 // of Archive. This adaptor makes the functions have a uniform return type.

--- a/Source/WebCore/loader/archive/ArchiveResourceCollection.h
+++ b/Source/WebCore/loader/archive/ArchiveResourceCollection.h
@@ -52,8 +52,8 @@ public:
     RefPtr<Archive> popSubframeArchive(const String& frameName, const URL&);
     
 private:    
-    UncheckedKeyHashMap<String, RefPtr<ArchiveResource>> m_subresources;
-    UncheckedKeyHashMap<String, RefPtr<Archive>> m_subframes;
+    HashMap<String, RefPtr<ArchiveResource>> m_subresources;
+    HashMap<String, RefPtr<Archive>> m_subframes;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -200,7 +200,7 @@ private:
         URL imageURL;
     };
 
-    using ContainerContextRequests = UncheckedKeyHashMap<SingleThreadWeakRef<const CachedImageClient>, ContainerContext>;
+    using ContainerContextRequests = HashMap<SingleThreadWeakRef<const CachedImageClient>, ContainerContext>;
     ContainerContextRequests m_pendingContainerContextRequests;
 
     SingleThreadWeakHashSet<CachedImageClient> m_clientsWaitingForAsyncDecoding;

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -124,7 +124,7 @@ public:
     WEBCORE_EXPORT CachedResource* cachedResource(const String& url) const;
     CachedResource* cachedResource(const URL& url) const;
 
-    typedef UncheckedKeyHashMap<String, CachedResourceHandle<CachedResource>> DocumentResourceMap;
+    typedef HashMap<String, CachedResourceHandle<CachedResource>> DocumentResourceMap;
     const DocumentResourceMap& allCachedResources() const { return m_documentResources; }
 
     void notifyFinished(const CachedResource&);

--- a/Source/WebCore/loader/cache/MemoryCache.h
+++ b/Source/WebCore/loader/cache/MemoryCache.h
@@ -170,7 +170,7 @@ public:
     WEBCORE_EXPORT void pruneLiveResourcesToSize(unsigned targetSize, bool shouldDestroyDecodedDataForAllLiveResources = false);
 
 private:
-    using CachedResourceMap = UncheckedKeyHashMap<std::pair<URL, String /* partitionName */>, WeakPtr<CachedResource>>;
+    using CachedResourceMap = HashMap<std::pair<URL, String /* partitionName */>, WeakPtr<CachedResource>>;
     using LRUList = WeakListHashSet<CachedResource>;
 
     MemoryCache();
@@ -211,7 +211,7 @@ private:
     
     // A URL-based map of all resources that are in the cache (including the freshest version of objects that are currently being 
     // referenced by a Web page).
-    typedef UncheckedKeyHashMap<PAL::SessionID, std::unique_ptr<CachedResourceMap>> SessionCachedResourceMap;
+    typedef HashMap<PAL::SessionID, std::unique_ptr<CachedResourceMap>> SessionCachedResourceMap;
     SessionCachedResourceMap m_sessionResources;
 
     Timer m_pruneTimer;

--- a/Source/WebCore/platform/network/CredentialStorage.cpp
+++ b/Source/WebCore/platform/network/CredentialStorage.cpp
@@ -135,7 +135,7 @@ HashSet<SecurityOriginData> CredentialStorage::originsWithCredentials() const
     return origins;
 }
 
-UncheckedKeyHashMap<String, ProtectionSpace>::iterator CredentialStorage::findDefaultProtectionSpaceForURL(const URL& url)
+HashMap<String, ProtectionSpace>::iterator CredentialStorage::findDefaultProtectionSpaceForURL(const URL& url)
 {
     ASSERT(url.protocolIsInHTTPFamily());
     ASSERT(url.isValid());

--- a/Source/WebCore/platform/network/CredentialStorage.h
+++ b/Source/WebCore/platform/network/CredentialStorage.h
@@ -59,10 +59,10 @@ public:
     WEBCORE_EXPORT HashSet<SecurityOriginData> originsWithCredentials() const;
 
 private:
-    UncheckedKeyHashMap<std::pair<String /* partitionName */, ProtectionSpace>, Credential> m_protectionSpaceToCredentialMap;
+    HashMap<std::pair<String /* partitionName */, ProtectionSpace>, Credential> m_protectionSpaceToCredentialMap;
     MemoryCompactRobinHoodHashSet<String> m_originsWithCredentials;
 
-    typedef UncheckedKeyHashMap<String, ProtectionSpace> PathToDefaultProtectionSpaceMap;
+    typedef HashMap<String, ProtectionSpace> PathToDefaultProtectionSpaceMap;
     PathToDefaultProtectionSpaceMap m_pathToDefaultProtectionSpaceMap;
 
     PathToDefaultProtectionSpaceMap::iterator findDefaultProtectionSpaceForURL(const URL&);

--- a/Source/WebCore/platform/network/MIMEHeader.cpp
+++ b/Source/WebCore/platform/network/MIMEHeader.cpp
@@ -43,7 +43,7 @@
 
 namespace WebCore {
 
-typedef UncheckedKeyHashMap<String, String> KeyValueMap;
+typedef HashMap<String, String> KeyValueMap;
 
 static KeyValueMap retrieveKeyValuePairs(WebCore::SharedBufferChunkReader& buffer)
 {

--- a/Source/WebCore/platform/network/ParsedContentType.h
+++ b/Source/WebCore/platform/network/ParsedContentType.h
@@ -66,7 +66,7 @@ private:
     void setContentType(String&&, Mode);
     void setContentTypeParameter(const String&, const String&, Mode);
 
-    typedef UncheckedKeyHashMap<String, String> KeyValuePairs;
+    typedef HashMap<String, String> KeyValuePairs;
     String m_contentType;
     KeyValuePairs m_parameterValues;
     Vector<String> m_parameterNames;

--- a/Source/WebCore/platform/network/ResourceHandle.cpp
+++ b/Source/WebCore/platform/network/ResourceHandle.cpp
@@ -49,7 +49,7 @@ static bool shouldForceContentSniffing;
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ResourceHandleInternal);
 
-typedef UncheckedKeyHashMap<AtomString, ResourceHandle::BuiltinConstructor> BuiltinResourceHandleConstructorMap;
+typedef HashMap<AtomString, ResourceHandle::BuiltinConstructor> BuiltinResourceHandleConstructorMap;
 static BuiltinResourceHandleConstructorMap& builtinResourceHandleConstructorMap()
 {
 #if PLATFORM(IOS_FAMILY)
@@ -66,7 +66,7 @@ void ResourceHandle::registerBuiltinConstructor(const AtomString& protocol, Reso
     builtinResourceHandleConstructorMap().add(protocol, constructor);
 }
 
-typedef UncheckedKeyHashMap<AtomString, ResourceHandle::BuiltinSynchronousLoader> BuiltinResourceHandleSynchronousLoaderMap;
+typedef HashMap<AtomString, ResourceHandle::BuiltinSynchronousLoader> BuiltinResourceHandleSynchronousLoaderMap;
 static BuiltinResourceHandleSynchronousLoaderMap& builtinResourceHandleSynchronousLoaderMap()
 {
     ASSERT(isMainThread());

--- a/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.h
+++ b/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.h
@@ -43,7 +43,7 @@ private:
 
     void performDNSLookup(const String&, Ref<CompletionHandlerWrapper>&&);
 
-    UncheckedKeyHashMap<uint64_t, Ref<CompletionHandlerWrapper>> m_pendingRequests;
+    HashMap<uint64_t, Ref<CompletionHandlerWrapper>> m_pendingRequests;
 };
 
 using DNSResolveQueuePlatform = DNSResolveQueueCFNet;

--- a/Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp
@@ -402,7 +402,7 @@ FormData* httpBodyFromStream(CFReadStreamRef stream)
 
     // Passing the pointer as property appears to be the only way to associate a stream with FormData.
     // A new stream is always created in CFURLRequestCopyHTTPRequestBodyStream (or -[NSURLRequest HTTPBodyStream]),
-    // so a side UncheckedKeyHashMap wouldn't work.
+    // so a side HashMap wouldn't work.
     // Even the stream's context pointer is different from the one we returned from formCreate().
 
     RetainPtr<CFNumberRef> formDataPointerAsCFNumber = adoptCF(static_cast<CFNumberRef>(CFReadStreamCopyProperty(stream, formDataPointerPropertyName)));

--- a/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.h
+++ b/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.h
@@ -52,14 +52,14 @@ private:
     struct Data;
 
     RangeResponseGenerator(WTF::GuaranteedSerialFunctionDispatcher&);
-    UncheckedKeyHashMap<String, std::unique_ptr<Data>>& map();
+    HashMap<String, std::unique_ptr<Data>>& map();
 
     class MediaResourceClient;
     void giveResponseToTasksWithFinishedRanges(Data&);
     void giveResponseToTaskIfBytesInRangeReceived(WebCoreNSURLSessionDataTask *, const ParsedRequestRange&, std::optional<size_t> expectedContentLength, const Data&);
     static std::optional<size_t> expectedContentLengthFromData(const Data&);
 
-    UncheckedKeyHashMap<String, std::unique_ptr<Data>> m_map WTF_GUARDED_BY_CAPABILITY(m_targetDispatcher.get());
+    HashMap<String, std::unique_ptr<Data>> m_map WTF_GUARDED_BY_CAPABILITY(m_targetDispatcher.get());
     Ref<GuaranteedSerialFunctionDispatcher> m_targetDispatcher;
 };
 

--- a/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
+++ b/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
@@ -81,7 +81,7 @@ struct RangeResponseGenerator::Data {
             resource = nullptr;
         }
     }
-    UncheckedKeyHashMap<RetainPtr<WebCoreNSURLSessionDataTask>, std::unique_ptr<RangeResponseGeneratorDataTaskData>> taskData;
+    HashMap<RetainPtr<WebCoreNSURLSessionDataTask>, std::unique_ptr<RangeResponseGeneratorDataTaskData>> taskData;
     SharedBufferBuilder buffer;
     ResourceResponse originalResponse;
     enum class SuccessfullyFinishedLoading : bool { No, Yes } successfullyFinishedLoading { SuccessfullyFinishedLoading::No };
@@ -95,7 +95,7 @@ RangeResponseGenerator::RangeResponseGenerator(GuaranteedSerialFunctionDispatche
 
 RangeResponseGenerator::~RangeResponseGenerator() = default;
 
-UncheckedKeyHashMap<String, std::unique_ptr<RangeResponseGenerator::Data>>& RangeResponseGenerator::map()
+HashMap<String, std::unique_ptr<RangeResponseGenerator::Data>>& RangeResponseGenerator::map()
 {
     assertIsCurrent(m_targetDispatcher.get());
     IGNORE_CLANG_WARNINGS_BEGIN("thread-safety-reference-return")
@@ -125,7 +125,7 @@ static ResourceResponse synthesizedResponseForRange(const ResourceResponse& orig
 void RangeResponseGenerator::removeTask(WebCoreNSURLSessionDataTask *task)
 {
     auto url = task.originalRequest.URL;
-    // UncheckedKeyHashMap::get() crashes if a null String is passed.
+    // HashMap::get() crashes if a null String is passed.
     if (!url)
         return;
     auto* data = map().get(url.absoluteString);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7429,7 +7429,7 @@ String Internals::dumpStyleResolvers()
     document->updateStyleIfNeeded();
 
     unsigned currentIdentifier = 0;
-    UncheckedKeyHashMap<Style::Resolver*, unsigned> resolverIdentifiers;
+    HashMap<Style::Resolver*, unsigned> resolverIdentifiers;
 
     StringBuilder result;
 

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1571,7 +1571,7 @@ private:
     std::unique_ptr<InspectorStubFrontend> m_inspectorFrontend;
     RefPtr<CacheStorageConnection> m_cacheStorageConnection;
 
-    UncheckedKeyHashMap<unsigned, std::unique_ptr<WebCore::SleepDisabler>> m_sleepDisablers;
+    HashMap<unsigned, std::unique_ptr<WebCore::SleepDisabler>> m_sleepDisablers;
 
     std::unique_ptr<TextIterator> m_textIterator;
 

--- a/Source/WebCore/testing/InternalsMapLike.h
+++ b/Source/WebCore/testing/InternalsMapLike.h
@@ -48,7 +48,7 @@ public:
 
 private:
     InternalsMapLike();
-    UncheckedKeyHashMap<String, unsigned> m_values;
+    HashMap<String, unsigned> m_values;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/MockCDMFactory.h
+++ b/Source/WebCore/testing/MockCDMFactory.h
@@ -106,7 +106,7 @@ private:
     bool m_canCreateInstances { true };
     bool m_supportsServerCertificates { true };
     bool m_supportsSessions { true };
-    UncheckedKeyHashMap<String, Vector<Ref<SharedBuffer>>> m_sessions;
+    HashMap<String, Vector<Ref<SharedBuffer>>> m_sessions;
 };
 
 class MockCDM : public CDMPrivate {

--- a/Source/WebCore/testing/ServiceWorkerInternals.h
+++ b/Source/WebCore/testing/ServiceWorkerInternals.h
@@ -81,7 +81,7 @@ private:
 
     ServiceWorkerIdentifier m_identifier;
     RefPtr<DeferredPromise> m_lastNavigationWasAppInitiatedPromise;
-    UncheckedKeyHashMap<uint64_t, RefPtr<DeferredPromise>> m_pushEventPromises;
+    HashMap<uint64_t, RefPtr<DeferredPromise>> m_pushEventPromises;
     uint64_t m_pushEventCounter { 0 };
 };
 

--- a/Source/WebCore/testing/WebFakeXRDevice.h
+++ b/Source/WebCore/testing/WebFakeXRDevice.h
@@ -106,9 +106,9 @@ private:
     Timer m_frameTimer;
     RequestFrameCallback m_FrameCallback;
 #if PLATFORM(COCOA)
-    UncheckedKeyHashMap<PlatformXR::LayerHandle, WebCore::IntSize> m_layers;
+    HashMap<PlatformXR::LayerHandle, WebCore::IntSize> m_layers;
 #else
-    UncheckedKeyHashMap<PlatformXR::LayerHandle, PlatformGLObject> m_layers;
+    HashMap<PlatformXR::LayerHandle, PlatformGLObject> m_layers;
     RefPtr<WebCore::GraphicsContextGL> m_gl;
 #endif
     uint32_t m_layerIndex { 0 };

--- a/Source/WebCore/testing/WebFakeXRInputController.h
+++ b/Source/WebCore/testing/WebFakeXRInputController.h
@@ -83,7 +83,7 @@ private:
     Vector<String> m_profiles;
     PlatformXR::FrameData::InputSourcePose m_pointerOrigin;
     std::optional<PlatformXR::FrameData::InputSourcePose> m_gripOrigin;
-    UncheckedKeyHashMap<FakeXRButtonStateInit::Type, FakeXRButtonStateInit, IntHash<FakeXRButtonStateInit::Type>, WTF::StrongEnumHashTraits<FakeXRButtonStateInit::Type>> m_buttons;
+    HashMap<FakeXRButtonStateInit::Type, FakeXRButtonStateInit, IntHash<FakeXRButtonStateInit::Type>, WTF::StrongEnumHashTraits<FakeXRButtonStateInit::Type>> m_buttons;
     bool m_connected { true };
     bool m_primarySelected { false };
     bool m_simulateSelect { false };

--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
@@ -153,15 +153,15 @@ static ASCIILiteral currentRecordsTableSchemaAlternate()
     return RECORDS_TABLE_SCHEMA_PREFIX "\"Records\"" RECORDS_TABLE_SCHEMA_SUFFIX;
 }
 
-static UncheckedKeyHashMap<URL, ImportedScriptAttributes> stripScriptSources(const MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript>& map)
+static HashMap<URL, ImportedScriptAttributes> stripScriptSources(const MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript>& map)
 {
-    UncheckedKeyHashMap<URL, ImportedScriptAttributes> mapWithoutScripts;
+    HashMap<URL, ImportedScriptAttributes> mapWithoutScripts;
     for (auto& pair : map)
         mapWithoutScripts.add(pair.key, ImportedScriptAttributes { pair.value.responseURL, pair.value.mimeType });
     return mapWithoutScripts;
 }
 
-static MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript> populateScriptSourcesFromDisk(SWScriptStorage& scriptStorage, const ServiceWorkerRegistrationKey& registrationKey, UncheckedKeyHashMap<URL, ImportedScriptAttributes>&& map)
+static MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript> populateScriptSourcesFromDisk(SWScriptStorage& scriptStorage, const ServiceWorkerRegistrationKey& registrationKey, HashMap<URL, ImportedScriptAttributes>&& map)
 {
     MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript> importedScripts;
     for (auto& pair : map) {
@@ -370,7 +370,7 @@ std::optional<Vector<ServiceWorkerContextData>> SWRegistrationDatabase::importRe
         auto scriptResourceMapDataSpan = statement->columnBlobAsSpan(11);
         if (scriptResourceMapDataSpan.size()) {
             WTF::Persistence::Decoder scriptResourceMapDecoder(scriptResourceMapDataSpan);
-            std::optional<UncheckedKeyHashMap<URL, ImportedScriptAttributes>> scriptResourceMapWithoutScripts;
+            std::optional<HashMap<URL, ImportedScriptAttributes>> scriptResourceMapWithoutScripts;
             scriptResourceMapDecoder >> scriptResourceMapWithoutScripts;
             if (!scriptResourceMapWithoutScripts) {
                 RELEASE_LOG_ERROR(ServiceWorker, "SWRegistrationDatabase::importRegistrations failed to decode scriptResourceMapWithoutScripts");


### PR DESCRIPTION
#### 41e87066796a3c165d3f80e2286c756f999fb0c9
<pre>
Reduce use of UncheckedKeyHashMap in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=282642">https://bugs.webkit.org/show_bug.cgi?id=282642</a>

Reviewed by Ryosuke Niwa.

Reduce use of UncheckedKeyHashMap in WebCore, in places that are not
performance sensitive, for safety.

* Source/WebCore/loader/CrossOriginPreflightResultCache.h:
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/ProgressTracker.h:
* Source/WebCore/loader/ResourceLoadStatistics.cpp:
* Source/WebCore/loader/appcache/ApplicationCache.h:
* Source/WebCore/loader/appcache/ApplicationCacheGroup.h:
* Source/WebCore/loader/appcache/ApplicationCacheStorage.h:
* Source/WebCore/loader/archive/ArchiveFactory.cpp:
* Source/WebCore/loader/archive/ArchiveResourceCollection.h:
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/loader/cache/CachedResourceLoader.h:
* Source/WebCore/loader/cache/MemoryCache.h:
* Source/WebCore/platform/network/CredentialStorage.cpp:
(WebCore::CredentialStorage::findDefaultProtectionSpaceForURL):
* Source/WebCore/platform/network/CredentialStorage.h:
* Source/WebCore/platform/network/MIMEHeader.cpp:
* Source/WebCore/platform/network/ParsedContentType.h:
* Source/WebCore/platform/network/ResourceHandle.cpp:
* Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.h:
* Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp:
(WebCore::httpBodyFromStream):
* Source/WebCore/platform/network/cocoa/RangeResponseGenerator.h:
* Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm:
(WebCore::RangeResponseGenerator::map):
(WebCore::RangeResponseGenerator::removeTask):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::dumpStyleResolvers):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/InternalsMapLike.h:
* Source/WebCore/testing/MockCDMFactory.h:
* Source/WebCore/testing/ServiceWorkerInternals.h:
* Source/WebCore/testing/WebFakeXRDevice.h:
* Source/WebCore/testing/WebFakeXRInputController.h:
* Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp:
(WebCore::stripScriptSources):
(WebCore::populateScriptSourcesFromDisk):
(WebCore::SWRegistrationDatabase::importRegistrations):

Canonical link: <a href="https://commits.webkit.org/286207@main">https://commits.webkit.org/286207@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6fd78075aa12f0cfd289fc74e399013cec48a9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79581 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26381 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77242 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58972 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17225 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49146 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39349 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22037 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24705 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81058 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1515 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67229 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2605 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64541 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66515 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10459 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8629 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11600 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2416 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2441 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3370 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2450 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->