### PR TITLE
pointerevent_touch-action-keyboard WPT test is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-keyboard-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-keyboard-expected.txt
@@ -1,6 +1,6 @@
 Pointer Events touch-action attribute support
 
-Test Description: Test complete
+Test Description: Press DOWN ARROW key, then RIGHT ARROW key. Expected: pan enabled
 
 Note: this test is for keyboard only
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-keyboard.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-keyboard.html
@@ -21,7 +21,7 @@
     </head>
     <body onload="run()">
         <h1>Pointer Events touch-action attribute support</h1>
-        <h4 id="desc">Test Description: Press DOWN ARROW key. Wait for description update. Expected: pan enabled</h4>
+        <h4 id="desc">Test Description: Press DOWN ARROW key, then RIGHT ARROW key. Expected: pan enabled</h4>
         <p>Note: this test is for keyboard only</p>
         <div id="target0">
             <p>
@@ -78,67 +78,65 @@
             <p>Lorem ipsum dolor sit amet...</p>
         </div>
         <script type='text/javascript'>
+            var x_scroll_baseline, y_scroll_baseline, x_scroll, y_scroll;
 
-            var xScrollIsReceived = false;
-            var yScrollIsReceived = false;
-            var xScr0, yScr0, xScr1, yScr1;
+            var got_x_scroll = false;
+            var got_y_scroll = false;
 
-            function run() {
-                var target0 = document.getElementById("target0");
+            async function send_key_to_target(key_code) {
+                return new test_driver.Actions()
+                    .addKeyboard("keyboard1", "keyboard")
+                    .keyDown(key_code, {origin: target0})
+                    .keyUp(key_code, {origin: target0})
+                    .send();
+            }
 
+            async function run() {
                 var test_touchaction = async_test("touch-action attribute test");
-                var actions_promise;
 
-                xScr0 = target0.scrollLeft;
-                yScr0 = target0.scrollTop;
-
-                target0.focus();
-
-                on_event(target0, 'scroll', function(event) {
-                    xScr1 = target0.scrollLeft;
-                    yScr1 = target0.scrollTop;
-
-                    if(xScr1 != xScr0) {
-                        xScrollIsReceived = true;
-                    }
-
-                    if(yScr1 != yScr0) {
-                        test_touchaction.step(function () {
-                            yScrollIsReceived = true;
-                            assert_true(true, "y-scroll received.");
-                        });
-                        updateDescriptionNextStepKeyboard();
-                    }
-
-                    if(xScrollIsReceived && yScrollIsReceived) {
-                        // Make sure the test finishes after all the input actions are completed.
-                        actions_promise.then( () => {
-                            test_touchaction.done();
-                        });
-                        updateDescriptionComplete();
-                    }
-                });
+                const target0 = document.getElementById("target0");
+                const x_scroll_baseline = target0.scrollLeft;
+                const y_scroll_baseline = target0.scrollTop;
 
                 // Inject keyboard scroll inputs.
                 const arrow_down = "\uE015";
                 const arrow_right = "\uE014";
 
-                actions_promise = new test_driver.Actions()
+                on_event(target0, 'scroll', function(event) {
+                    x_scroll = target0.scrollLeft;
+                    y_scroll = target0.scrollTop;
+                    if (y_scroll > y_scroll_baseline && !got_y_scroll) {
+                        test_touchaction.step(function () {
+                            assert_true(true, "content was scrolled down.");
+                        });
+                        got_y_scroll = true;
+                    }
+                    if (x_scroll > x_scroll_baseline && !got_x_scroll) {
+                        test_touchaction.step(function () {
+                            assert_true(true, "content was scrolled right.");
+                        });
+                        got_x_scroll = true;
+                    }
+                    if (got_x_scroll && got_y_scroll) {
+                        test_touchaction.done();
+                    }
+                });
+
+                document.addEventListener('keyup', async function(e) {
+                    if (e.code == "ArrowDown") {
+                        send_key_to_target(arrow_right);
+                    }
+                });
+
+                await new test_driver.Actions()
                     .addPointer("mousePointer1", "mouse")
                     .pointerMove(0, 0, {origin: target0})
                     .pointerDown()
                     .pointerUp()
-                    .addTick()
                     .send();
-                actions_promise = actions_promise
-                    .then(()=>test_driver.send_keys(target0, arrow_down))
-                    .then(()=>test_driver.send_keys(target0, arrow_down))
-                    .then(()=>test_driver.send_keys(target0, arrow_right))
-                    .then(()=>test_driver.send_keys(target0, arrow_right));
-            }
 
-            function updateDescriptionNextStepKeyboard() {
-                document.getElementById('desc').innerHTML = "Test Description: press RIGHT ARROW key.";
+                await send_key_to_target(arrow_down);
+                await send_key_to_target(arrow_down);
             }
         </script>
         <h1>touch-action: none</h1>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -956,6 +956,9 @@ webkit.org/b/244517 imported/w3c/web-platform-tests/content-security-policy/gen/
 webkit.org/b/244517 imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.http.html [ Failure ]
 webkit.org/b/244517 imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.https.html [ Failure ]
 
+# Test started timing out after changes on 11/6/24
+webkit.org/b/282711 imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-keyboard.html [ Failure ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Expected failures.
 #////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
#### af121ecc9ac7dd766a449872dc6e349dbb2c68bf
<pre>
pointerevent_touch-action-keyboard WPT test is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=282651">https://bugs.webkit.org/show_bug.cgi?id=282651</a>
<a href="https://rdar.apple.com/139317785">rdar://139317785</a>

Reviewed by Abrar Rahman Protyasha.

The test now waits for the keyup event to fire for the arrow_down key before sending the
arrow_right key press to avoid flakiness. Assertions now only print once instead of
potentially printing for every scroll event after a key press. Added explicit assertions
for horizontal scrolling and for vertical scrolling for clarity rather than asserting both
in a single statement, and made both check that the scrolling occurred in the correct
direction.

* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-keyboard-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-keyboard.html:

Canonical link: <a href="https://commits.webkit.org/286317@main">https://commits.webkit.org/286317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/760669e9e35a816d61dfb97938f716b94929f0ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75632 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80116 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/26896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2920 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/26896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78699 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64960 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/39678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22446 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25225 "Built successfully") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81591 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/2971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3122 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66850 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16660 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/10809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2928 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/2953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/3888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/2960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->