### PR TITLE
Dropped images in outlook.live.com mail compose are not saved as attachments

### DIFF
--- a/Source/WebCore/dom/DataTransfer.h
+++ b/Source/WebCore/dom/DataTransfer.h
@@ -61,8 +61,8 @@ public:
     void setEffectAllowed(const String&);
 
     DataTransferItemList& items(Document&);
-    Vector<String> types() const;
-    Vector<String> typesForItemList() const;
+    Vector<String> types(Document&) const;
+    Vector<String> typesForItemList(Document&) const;
 
     FileList& files(Document*) const;
     FileList& files(Document&) const;
@@ -84,7 +84,7 @@ public:
     bool canWriteData() const;
 
     bool hasFileOfType(const String&);
-    bool hasStringOfType(const String&);
+    bool hasStringOfType(Document&, const String&);
 
     Pasteboard& pasteboard() { return *m_pasteboard; }
     void commitToPasteboard(Pasteboard&);
@@ -137,7 +137,7 @@ private:
     bool shouldSuppressGetAndSetDataToAvoidExposingFilePaths() const;
 
     enum class AddFilesType : bool { No, Yes };
-    Vector<String> types(AddFilesType) const;
+    Vector<String> types(Document&, AddFilesType) const;
     Vector<Ref<File>> filesFromPasteboardAndItemList(ScriptExecutionContext*) const;
 
     String m_originIdentifier;

--- a/Source/WebCore/dom/DataTransfer.idl
+++ b/Source/WebCore/dom/DataTransfer.idl
@@ -39,7 +39,7 @@
 
     undefined setDragImage(Element image, long x, long y);
 
-    readonly attribute FrozenArray<DOMString> types;
+    [CallWith=CurrentDocument] readonly attribute FrozenArray<DOMString> types;
     [CallWith=CurrentDocument] DOMString getData(DOMString format);
     [CallWith=CurrentDocument] undefined setData(DOMString format, DOMString data);
     undefined clearData(optional DOMString format);

--- a/Source/WebCore/dom/DataTransferItemList.cpp
+++ b/Source/WebCore/dom/DataTransferItemList.cpp
@@ -147,16 +147,16 @@ Vector<Ref<DataTransferItem>>& DataTransferItemList::ensureItems() const
     if (m_items)
         return *m_items;
 
+    Ref document = *this->document();
     Ref dataTransfer = m_dataTransfer.get();
     Vector<Ref<DataTransferItem>> items;
-    for (auto& type : dataTransfer->typesForItemList()) {
+    for (auto& type : dataTransfer->typesForItemList(document)) {
         auto lowercasedType = type.convertToASCIILowercase();
         if (shouldExposeTypeInItemList(lowercasedType))
             items.append(DataTransferItem::create(*this, lowercasedType));
     }
 
-    RefPtr document { this->document() };
-    for (auto& file : dataTransfer->files(*document).files())
+    for (auto& file : dataTransfer->files(document).files())
         items.append(DataTransferItem::create(*this, file->type(), file.copyRef()));
 
     m_items = WTFMove(items);

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2544,13 +2544,13 @@ static String convertDragOperationToDropZoneOperation(std::optional<DragOperatio
     return "copy"_s;
 }
 
-static bool hasDropZoneType(DataTransfer& dataTransfer, const String& keyword)
+static bool hasDropZoneType(Document& document, DataTransfer& dataTransfer, const String& keyword)
 {
     if (keyword.startsWith("file:"_s))
         return dataTransfer.hasFileOfType(keyword.substring(5));
 
     if (keyword.startsWith("string:"_s))
-        return dataTransfer.hasStringOfType(keyword.substring(7));
+        return dataTransfer.hasStringOfType(document, keyword.substring(7));
 
     return false;
 }
@@ -2569,7 +2569,7 @@ static bool findDropZone(Node& target, DataTransfer& dataTransfer)
                 if (!dragOperation)
                     dragOperation = operationFromKeyword;
             } else
-                matched = matched || hasDropZoneType(dataTransfer, keyword.string());
+                matched = matched || hasDropZoneType(target.protectedDocument(), dataTransfer, keyword.string());
             if (matched && dragOperation)
                 break;
         }

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1975,5 +1975,15 @@ bool Quirks::shouldIgnoreContentObservationForClick(const Node& targetNode) cons
 
 #endif // PLATFORM(IOS_FAMILY)
 
+bool Quirks::needsMozillaFileTypeForDataTransfer() const
+{
+    if (!needsQuirks())
+        return false;
+
+    if (m_document->topDocument().url().host() == "outlook.live.com"_s)
+        return true;
+
+    return false;
+}
 
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -221,6 +221,8 @@ public:
     WEBCORE_EXPORT bool shouldIgnoreContentObservationForClick(const Node&) const;
 #endif
 
+    bool needsMozillaFileTypeForDataTransfer() const;
+
 private:
     bool needsQuirks() const;
     bool isDomain(const String&) const;


### PR DESCRIPTION
#### b50c25cd005e09ba7e917a97b9970819d1b91e37
<pre>
Dropped images in outlook.live.com mail compose are not saved as attachments
<a href="https://bugs.webkit.org/show_bug.cgi?id=282639">https://bugs.webkit.org/show_bug.cgi?id=282639</a>
<a href="https://rdar.apple.com/136624720">rdar://136624720</a>

Reviewed by Ryosuke Niwa and Abrar Rahman Protyasha.

When dropping a dragged image into a new message on outlook.live.com, Outlook&apos;s drop event handler
has logic to handle the incoming dropped `DataTransfer` as an attachment:

```
function i(e) {
    let t;
    if (e?.files &amp;&amp; e.files.length &gt; 0 &amp;&amp; (e.types.includes(r.RN) || 1 === e.types.length)) {

        // Handle DataTransfer as email attachment…

    }
```

...where `r.RN` is a constant string, `application/x-moz-file`. This logic currently works for
Firefox (which sets `application/x-moz-file` as a file type) and also works for Chrome (which only
advertises a single `File` type), but this doesn&apos;t work for Safari, where we advertise the dropped
image as a file (i.e. by including `&quot;File&quot;` in `DataTransfer.types`), alongside `text/html` and
`text/uri-list` representations (the latter being included only for dragged remote images with a
HTTP-family URL).

To make file drops work in Outlook, we therefore need to either align Safari&apos;s behavior with Firefox
or Chrome. Aligning to Chrome&apos;s behavior poses some amount of risk (especially with respect to
bincompat), since we&apos;d be losing information about the file drop that could be used by internal
clients, third party clients, or web apps to consume dropped images based on their URLs. Aligning to
Firefox is less risky, but still poses a danger since the presence of `application/x-moz-file` could
be used by web apps to assume that the file drop behaves like Firefox in other ways.

This patch ultimately addresses this compat bug by aligning to Firefox&apos;s behavior, but for Outlook
only, which allows us to keep our existing behavior around exposing `text/html` and `text/uri-list`.

* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::DataTransfer::types const):
(WebCore::DataTransfer::typesForItemList const):

Plumb `Document` through to `DataTransfer::types()`. See above for more details.

(WebCore::DataTransfer::hasStringOfType):
* Source/WebCore/dom/DataTransfer.h:
* Source/WebCore/dom/DataTransfer.idl:
* Source/WebCore/dom/DataTransferItemList.cpp:
(WebCore::DataTransferItemList::ensureItems const):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::hasDropZoneType):
(WebCore::findDropZone):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsMozillaFileTypeForDataTransfer const):
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/286201@main">https://commits.webkit.org/286201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/427da458aa025513efa6da569d3b7081b1060ae6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75139 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79596 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26395 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2363 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/58982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17226 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49145 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64546 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39358 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/46512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22047 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24719 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22386 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81072 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2469 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2619 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64551 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/66530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16552 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10465 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2430 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2455 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/3384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/2464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->