### PR TITLE
[macOS] Toggling dark mode does not update the scrollbar appearance on <body>

### DIFF
--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -1048,6 +1048,8 @@ void AsyncScrollingCoordinator::setScrollingNodeScrollableAreaGeometry(std::opti
     scrollingNode->setReachableContentsSize(scrollableArea.reachableTotalContentsSize());
     scrollingNode->setScrollableAreaSize(scrollableArea.visibleSize());
 
+    scrollingNode->setUseDarkAppearanceForScrollbars(scrollableArea.useDarkAppearanceForScrollbars());
+
     ScrollableAreaParameters scrollParameters;
     scrollParameters.horizontalScrollElasticity = scrollableArea.horizontalOverscrollBehavior() == OverscrollBehavior::None ? ScrollElasticity::None : scrollableArea.horizontalScrollElasticity();
     scrollParameters.verticalScrollElasticity = scrollableArea.verticalOverscrollBehavior() == OverscrollBehavior::None ? ScrollElasticity::None : scrollableArea.verticalScrollElasticity();
@@ -1059,7 +1061,6 @@ void AsyncScrollingCoordinator::setScrollingNodeScrollableAreaGeometry(std::opti
     scrollParameters.verticalScrollbarMode = scrollableArea.verticalScrollbarMode();
     scrollParameters.horizontalNativeScrollbarVisibility = scrollableArea.horizontalNativeScrollbarVisibility();
     scrollParameters.verticalNativeScrollbarVisibility = scrollableArea.verticalNativeScrollbarVisibility();
-    scrollParameters.useDarkAppearanceForScrollbars = scrollableArea.useDarkAppearanceForScrollbars();
     scrollParameters.scrollbarWidthStyle = scrollableArea.scrollbarWidthStyle();
 
     scrollingNode->setScrollableAreaParameters(scrollParameters);

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
@@ -88,8 +88,6 @@ struct ScrollableAreaParameters {
     NativeScrollbarVisibility horizontalNativeScrollbarVisibility { NativeScrollbarVisibility::Visible };
     NativeScrollbarVisibility verticalNativeScrollbarVisibility { NativeScrollbarVisibility::Visible };
 
-    bool useDarkAppearanceForScrollbars { false };
-
     ScrollbarWidth scrollbarWidthStyle { ScrollbarWidth::Auto };
 
     friend bool operator==(const ScrollableAreaParameters&, const ScrollableAreaParameters&) = default;

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
@@ -66,6 +66,7 @@ ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(
     ScrollbarEnabledState&& scrollbarEnabledState,
     UserInterfaceLayoutDirection scrollbarLayoutDirection,
     ScrollbarWidth scrollbarWidth,
+    bool useDarkAppearanceForScrollbars,
     RequestedKeyboardScrollData&& keyboardScrollData,
     float frameScaleFactor,
     EventTrackingRegions&& eventTrackingRegions,
@@ -116,6 +117,7 @@ ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(
     WTFMove(scrollbarEnabledState),
     scrollbarLayoutDirection,
     scrollbarWidth,
+    useDarkAppearanceForScrollbars,
     WTFMove(keyboardScrollData))
     , m_rootContentsLayer(rootContentsLayer)
     , m_counterScrollingLayer(counterScrollingLayer)

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
@@ -153,6 +153,7 @@ private:
         ScrollbarEnabledState&&,
         UserInterfaceLayoutDirection,
         ScrollbarWidth,
+        bool useDarkAppearanceForScrollbars,
         RequestedKeyboardScrollData&&,
         float frameScaleFactor,
         EventTrackingRegions&&,

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -198,7 +198,7 @@ private:
 enum class ScrollingStateNodeProperty : uint64_t {
     // ScrollingStateNode
     Layer                                       = 1LLU << 0,
-    ChildNodes                                  = 1LLU << 44,
+    ChildNodes                                  = 1LLU << 45,
     // ScrollingStateScrollingNode
     ScrollableAreaSize                          = 1LLU << 1, // Same value as RelatedOverflowScrollingNodes, ViewportConstraints and OverflowScrollingNode
     TotalContentsSize                           = 1LLU << 2, // Same value as LayoutConstraintData
@@ -220,15 +220,16 @@ enum class ScrollingStateNodeProperty : uint64_t {
     ScrolledContentsLayer                       = ScrollContainerLayer << 1,
     HorizontalScrollbarLayer                    = ScrolledContentsLayer << 1,
     VerticalScrollbarLayer                      = HorizontalScrollbarLayer << 1,
-    PainterForScrollbar                         = 1LLU << 43, // Not serialized
+    PainterForScrollbar                         = 1LLU << 44, // Not serialized
     ContentAreaHoverState                       = VerticalScrollbarLayer << 1,
     MouseActivityState                          = ContentAreaHoverState << 1,
     ScrollbarHoverState                         = MouseActivityState << 1,
     ScrollbarEnabledState                       = ScrollbarHoverState << 1,
     ScrollbarLayoutDirection                    = ScrollbarEnabledState << 1,
     ScrollbarWidth                              = ScrollbarLayoutDirection << 1,
+    UseDarkAppearanceForScrollbars              = ScrollbarWidth << 1,
     // ScrollingStateFrameScrollingNode
-    KeyboardScrollData                          = ScrollbarWidth << 1,
+    KeyboardScrollData                          = UseDarkAppearanceForScrollbars << 1,
     FrameScaleFactor                            = KeyboardScrollData << 1,
     EventTrackingRegion                         = FrameScaleFactor << 1,
     RootContentsLayer                           = EventTrackingRegion << 1,
@@ -237,8 +238,8 @@ enum class ScrollingStateNodeProperty : uint64_t {
     ContentShadowLayer                          = InsetClipLayer << 1,
     HeaderHeight                                = ContentShadowLayer << 1,
     FooterHeight                                = HeaderHeight << 1,
-    HeaderLayer                                 = 1LLU << 49, // Not serialized
-    FooterLayer                                 = 1LLU << 42, // Not serialized
+    HeaderLayer                                 = 1LLU << 50, // Not serialized
+    FooterLayer                                 = 1LLU << 43, // Not serialized
     BehaviorForFixedElements                    = FooterHeight << 1,
     TopContentInset                             = BehaviorForFixedElements << 1,
     VisualViewportIsSmallerThanLayoutViewport   = TopContentInset << 1,

--- a/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.cpp
@@ -62,6 +62,7 @@ ScrollingStateOverflowScrollingNode::ScrollingStateOverflowScrollingNode(
     ScrollbarEnabledState&& scrollbarEnabledState,
     UserInterfaceLayoutDirection scrollbarLayoutDirection,
     ScrollbarWidth scrollbarWidth,
+    bool useDarkAppearanceForScrollbars,
     RequestedKeyboardScrollData&& scrollData
 ) : ScrollingStateScrollingNode(
     ScrollingNodeType::Overflow,
@@ -93,6 +94,7 @@ ScrollingStateOverflowScrollingNode::ScrollingStateOverflowScrollingNode(
     WTFMove(scrollbarEnabledState),
     scrollbarLayoutDirection,
     scrollbarWidth,
+    useDarkAppearanceForScrollbars,
     WTFMove(scrollData)
 ) { }
 

--- a/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.h
@@ -71,6 +71,7 @@ private:
         ScrollbarEnabledState&&,
         UserInterfaceLayoutDirection,
         ScrollbarWidth,
+        bool useDarkAppearanceForScrollbars,
         RequestedKeyboardScrollData&&
     );
     ScrollingStateOverflowScrollingNode(ScrollingStateTree&, ScrollingNodeID);

--- a/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.cpp
@@ -62,6 +62,7 @@ ScrollingStatePluginScrollingNode::ScrollingStatePluginScrollingNode(
     ScrollbarEnabledState&& scrollbarEnabledState,
     UserInterfaceLayoutDirection scrollbarLayoutDirection,
     ScrollbarWidth scrollbarWidth,
+    bool useDarkAppearanceForScrollbars,
     RequestedKeyboardScrollData&& scrollData
 ) : ScrollingStateScrollingNode(
     ScrollingNodeType::PluginScrolling,
@@ -93,6 +94,7 @@ ScrollingStatePluginScrollingNode::ScrollingStatePluginScrollingNode(
     WTFMove(scrollbarEnabledState),
     scrollbarLayoutDirection,
     scrollbarWidth,
+    useDarkAppearanceForScrollbars,
     WTFMove(scrollData)
 )
 {

--- a/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.h
@@ -77,6 +77,7 @@ private:
         ScrollbarEnabledState&&,
         UserInterfaceLayoutDirection,
         ScrollbarWidth,
+        bool useDarkAppearanceForScrollbars,
         RequestedKeyboardScrollData&&
     );
 

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
@@ -72,6 +72,7 @@ ScrollingStateScrollingNode::ScrollingStateScrollingNode(
     ScrollbarEnabledState&& scrollbarEnabledState,
     UserInterfaceLayoutDirection scrollbarLayoutDirection,
     ScrollbarWidth scrollbarWidth,
+    bool useDarkAppearanceForScrollbars,
     RequestedKeyboardScrollData&& keyboardScrollData
 ) : ScrollingStateNode(nodeType, nodeID, WTFMove(children), changedProperties, layerID)
     , m_scrollableAreaSize(scrollableAreaSize)
@@ -97,6 +98,7 @@ ScrollingStateScrollingNode::ScrollingStateScrollingNode(
 #endif
     , m_scrollbarLayoutDirection(scrollbarLayoutDirection)
     , m_scrollbarWidth(scrollbarWidth)
+    , m_useDarkAppearanceForScrollbars(useDarkAppearanceForScrollbars)
     , m_isMonitoringWheelEvents(isMonitoringWheelEvents)
     , m_mouseIsOverContentArea(mouseIsOverContentArea)
 {
@@ -126,6 +128,7 @@ ScrollingStateScrollingNode::ScrollingStateScrollingNode(const ScrollingStateScr
 #endif
     , m_scrollbarLayoutDirection(stateNode.scrollbarLayoutDirection())
     , m_scrollbarWidth(stateNode.scrollbarWidth())
+    , m_useDarkAppearanceForScrollbars(stateNode.useDarkAppearanceForScrollbars())
     , m_isMonitoringWheelEvents(stateNode.isMonitoringWheelEvents())
     , m_mouseIsOverContentArea(stateNode.mouseIsOverContentArea())
 {
@@ -397,6 +400,14 @@ void ScrollingStateScrollingNode::setScrollbarWidth(ScrollbarWidth scrollbarWidt
         return;
     m_scrollbarWidth = scrollbarWidth;
     setPropertyChanged(Property::ScrollbarWidth);
+}
+
+void ScrollingStateScrollingNode::setUseDarkAppearanceForScrollbars(bool useDarkAppearanceForScrollbars)
+{
+    if (useDarkAppearanceForScrollbars == m_useDarkAppearanceForScrollbars)
+        return;
+    m_useDarkAppearanceForScrollbars = useDarkAppearanceForScrollbars;
+    setPropertyChanged(Property::UseDarkAppearanceForScrollbars);
 }
 
 void ScrollingStateScrollingNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
@@ -143,6 +143,9 @@ public:
     WEBCORE_EXPORT void setScrollbarWidth(ScrollbarWidth);
     ScrollbarWidth scrollbarWidth() const { return m_scrollbarWidth; }
 
+    WEBCORE_EXPORT void setUseDarkAppearanceForScrollbars(bool);
+    bool useDarkAppearanceForScrollbars() const { return m_useDarkAppearanceForScrollbars; }
+
 protected:
     ScrollingStateScrollingNode(
         ScrollingNodeType,
@@ -174,6 +177,7 @@ protected:
         ScrollbarEnabledState&&,
         UserInterfaceLayoutDirection,
         ScrollbarWidth,
+        bool useDarkAppearanceForScrollbars,
         RequestedKeyboardScrollData&&
     );
     ScrollingStateScrollingNode(ScrollingStateTree&, ScrollingNodeType, ScrollingNodeID);
@@ -216,6 +220,7 @@ private:
     UserInterfaceLayoutDirection m_scrollbarLayoutDirection { UserInterfaceLayoutDirection::LTR };
     ScrollbarWidth m_scrollbarWidth { ScrollbarWidth::Auto };
 
+    bool m_useDarkAppearanceForScrollbars { false };
     bool m_isMonitoringWheelEvents { false };
     bool m_mouseIsOverContentArea { false };
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -121,8 +121,6 @@ public:
     void setCurrentHorizontalSnapPointIndex(std::optional<unsigned>);
     void setCurrentVerticalSnapPointIndex(std::optional<unsigned>);
 
-    bool useDarkAppearanceForScrollbars() const { return m_scrollableAreaParameters.useDarkAppearanceForScrollbars; }
-
     bool eventCanScrollContents(const PlatformWheelEvent&) const;
     
     bool scrolledSinceLastCommit() const { return m_scrolledSinceLastCommit; }

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -77,6 +77,8 @@ public:
     void setEnabled(bool flag) { m_isEnabled = flag; }
     void setScrollbarLayoutDirection(UserInterfaceLayoutDirection);
 
+    void setNeedsDisplay();
+
 private:
     int m_minimumKnobLength { 0 };
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -468,6 +468,11 @@ void ScrollerMac::setScrollbarLayoutDirection(UserInterfaceLayoutDirection scrol
     [m_scrollerImp setUserInterfaceLayoutDirection: scrollbarLayoutDirection == UserInterfaceLayoutDirection::RTL ? NSUserInterfaceLayoutDirectionRightToLeft : NSUserInterfaceLayoutDirectionLeftToRight];
 }
 
+void ScrollerMac::setNeedsDisplay()
+{
+    [m_scrollerImp setNeedsDisplay:YES];
+}
+
 String ScrollerMac::scrollbarState() const
 {
     if (!m_hostLayer || !m_scrollerImp)

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -113,6 +113,8 @@ public:
 
     bool mouseInContentArea() const { return m_mouseInContentArea; }
 
+    void setUseDarkAppearance(bool);
+
     void setScrollbarWidth(ScrollbarWidth);
 
 private:
@@ -136,6 +138,7 @@ private:
     ScrollbarWidth m_scrollbarWidth { ScrollbarWidth::Auto };
     std::atomic<bool> m_usingPresentationValues { false };
     std::atomic<ScrollbarStyle> m_scrollbarStyle { ScrollbarStyle::AlwaysVisible };
+    bool m_useDarkAppearance { false };
     bool m_inLiveResize { false };
     bool m_mouseInContentArea { false };
 };

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -279,11 +279,7 @@ FloatSize ScrollerPairMac::visibleSize() const
 
 bool ScrollerPairMac::useDarkAppearance() const
 {
-    RefPtr node = m_scrollingNode.get();
-    if (!node)
-        return false;
-
-    return node->useDarkAppearanceForScrollbars();
+    return m_useDarkAppearance;
 }
 
 ScrollbarWidth ScrollerPairMac::scrollbarWidthStyle() const
@@ -426,6 +422,16 @@ void ScrollerPairMac::mouseIsInScrollbar(ScrollbarHoverState hoverState)
             horizontalScroller().mouseExitedScrollbar();
     }
     m_scrollbarHoverState = hoverState;
+}
+
+void ScrollerPairMac::setUseDarkAppearance(bool useDarkAppearance)
+{
+    if (m_useDarkAppearance == useDarkAppearance)
+        return;
+    m_useDarkAppearance = useDarkAppearance;
+
+    horizontalScroller().setNeedsDisplay();
+    verticalScroller().setNeedsDisplay();
 }
 
 void ScrollerPairMac::setScrollbarWidth(ScrollbarWidth scrollbarWidth)

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -98,6 +98,9 @@ void ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode(const ScrollingS
         m_scrollerPair->setScrollbarWidth(scrollbarWidth);
     }
 
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::UseDarkAppearanceForScrollbars))
+        m_scrollerPair->setUseDarkAppearance(scrollingStateNode.useDarkAppearanceForScrollbars());
+
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ContentAreaHoverState)) {
         if (scrollingStateNode.mouseIsOverContentArea())
             m_scrollerPair->mouseEnteredContentArea();

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
@@ -94,6 +94,7 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarEnabledState] WebCore::ScrollbarEnabledState scrollbarEnabledState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarLayoutDirection] WebCore::UserInterfaceLayoutDirection scrollbarLayoutDirection();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarWidth] WebCore::ScrollbarWidth scrollbarWidth();
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::UseDarkAppearanceForScrollbars] bool useDarkAppearanceForScrollbars();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::KeyboardScrollData] WebCore::RequestedKeyboardScrollData keyboardScrollData()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::FrameScaleFactor] float frameScaleFactor()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::EventTrackingRegion] WebCore::EventTrackingRegions eventTrackingRegions()
@@ -146,6 +147,7 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarEnabledState] WebCore::ScrollbarEnabledState scrollbarEnabledState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarLayoutDirection] WebCore::UserInterfaceLayoutDirection scrollbarLayoutDirection();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarWidth] WebCore::ScrollbarWidth scrollbarWidth();
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::UseDarkAppearanceForScrollbars] bool useDarkAppearanceForScrollbars();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::KeyboardScrollData] WebCore::RequestedKeyboardScrollData keyboardScrollData()
 };
 
@@ -186,6 +188,7 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarEnabledState] WebCore::ScrollbarEnabledState scrollbarEnabledState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarLayoutDirection] WebCore::UserInterfaceLayoutDirection scrollbarLayoutDirection();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarWidth] WebCore::ScrollbarWidth scrollbarWidth();
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::UseDarkAppearanceForScrollbars] bool useDarkAppearanceForScrollbars();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::KeyboardScrollData] WebCore::RequestedKeyboardScrollData keyboardScrollData()
 }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2840,7 +2840,6 @@ header: <WebCore/ScrollingCoordinatorTypes.h>
     bool allowsVerticalScrolling;
     WebCore::NativeScrollbarVisibility horizontalNativeScrollbarVisibility;
     WebCore::NativeScrollbarVisibility verticalNativeScrollbarVisibility;
-    bool useDarkAppearanceForScrollbars;
     WebCore::ScrollbarWidth scrollbarWidthStyle;
 };
 
@@ -4422,6 +4421,7 @@ header: <WebCore/ScrollingStateNode.h>
     ScrollbarEnabledState
     ScrollbarLayoutDirection
     ScrollbarWidth
+    UseDarkAppearanceForScrollbars
     FrameScaleFactor
     EventTrackingRegion
     RootContentsLayer

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1262,6 +1262,7 @@
 		E532A15F2BDA271F00E79810 /* DataListTextSuggestionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E532A15E2BDA271F00E79810 /* DataListTextSuggestionTests.mm */; };
 		E55999F72B476C2F00A3719F /* FullscreenLayoutParameters.mm in Sources */ = {isa = PBXBuildFile; fileRef = E55999F62B476C2F00A3719F /* FullscreenLayoutParameters.mm */; };
 		E589183C252BC90A0041DED5 /* DateTimeInputsAccessoryViewTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E589183B252BC90A0041DED5 /* DateTimeInputsAccessoryViewTests.mm */; };
+		E5A90C282CDAE83900E6C387 /* ScrollbarTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E5A90C272CDAE83800E6C387 /* ScrollbarTests.mm */; };
 		E5AA42F2259128AE00410A3D /* UserInterfaceIdiomUpdate.mm in Sources */ = {isa = PBXBuildFile; fileRef = E5AA42F1259128AE00410A3D /* UserInterfaceIdiomUpdate.mm */; };
 		E5AA8D1D25151CC60051CC45 /* DateInputTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E5AA8D1C25151CC60051CC45 /* DateInputTests.mm */; };
 		EB7067FC2CCC0E9900A94073 /* MixedContentChecker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB6836D32CC967E00073A8E5 /* MixedContentChecker.cpp */; };
@@ -3615,6 +3616,7 @@
 		E57B44C029ABFAA4006069DE /* qr-code.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "qr-code.png"; sourceTree = "<group>"; };
 		E589183B252BC90A0041DED5 /* DateTimeInputsAccessoryViewTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DateTimeInputsAccessoryViewTests.mm; sourceTree = "<group>"; };
 		E59CF8222C2D1E3700891383 /* adaptive-image-glyph.heic */ = {isa = PBXFileReference; lastKnownFileType = file; path = "adaptive-image-glyph.heic"; sourceTree = "<group>"; };
+		E5A90C272CDAE83800E6C387 /* ScrollbarTests.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = ScrollbarTests.mm; sourceTree = "<group>"; };
 		E5AA42F1259128AE00410A3D /* UserInterfaceIdiomUpdate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = UserInterfaceIdiomUpdate.mm; sourceTree = "<group>"; };
 		E5AA8D1C25151CC60051CC45 /* DateInputTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DateInputTests.mm; sourceTree = "<group>"; };
 		E5F67D662B637F9200CC30DE /* AdaptiveImageGlyph.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AdaptiveImageGlyph.mm; sourceTree = "<group>"; };
@@ -5954,6 +5956,7 @@
 				A57A34EF16AF677200C2501F /* PageVisibilityStateWithWindowChanges.mm */,
 				37C784DE197C8F2E0010A496 /* RenderedImageFromDOMNode.mm */,
 				3722C8681461E03E00C45D00 /* RenderedImageFromDOMRange.mm */,
+				E5A90C272CDAE83800E6C387 /* ScrollbarTests.mm */,
 				0FEFAF63271FC2CD005704D7 /* ScrollingCoordinatorTests.mm */,
 				261516D515B0E60500A2C201 /* SetAndUpdateCacheModel.mm */,
 				52B8CF9515868CF000281053 /* SetDocumentURI.mm */,
@@ -7114,6 +7117,7 @@
 				F418BE151F71B7DC001970E6 /* RoundedRectTests.cpp in Sources */,
 				4181C62D255A891100AEB0FF /* RTCRtpSFrameTransformerTests.cpp in Sources */,
 				CDCFA7AA1E45183200C2433D /* SampleMap.cpp in Sources */,
+				E5A90C282CDAE83900E6C387 /* ScrollbarTests.mm in Sources */,
 				1AF86FC02CD5526B00AD337C /* ScrollbarWidthCrash.mm in Sources */,
 				0FEFAF64271FC2CD005704D7 /* ScrollingCoordinatorTests.mm in Sources */,
 				CDC0932B21C872C10030C4B0 /* ScrollingDoesNotPauseMedia.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/mac/ScrollbarTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ScrollbarTests.mm
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(MAC)
+
+#import "CGImagePixelReader.h"
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestWKWebView.h"
+#import "WKWebViewConfigurationExtras.h"
+#import <WebCore/Color.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <wtf/RetainPtr.h>
+
+namespace TestWebKitAPI {
+
+static double scrollbarLuminanceForWebView(WKWebView *webView)
+{
+    RetainPtr snapshotImage = adoptNS([webView _windowSnapshotInRect:CGRectNull withOptions:0]);
+    RetainPtr snapshotCGImage = [snapshotImage CGImageForProposedRect:NULL context:nil hints:nil];
+    CGImagePixelReader reader { snapshotCGImage.get()  };
+
+    auto scrollbarTrackColor = reader.at(reader.width() - 10, reader.height() - 10);
+    return scrollbarTrackColor.luminance();
+}
+
+TEST(ScrollbarTests, AppearanceChangeAfterSystemAppearanceChange)
+{
+    RetainPtr configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    [webView setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameAqua]];
+    [webView synchronouslyLoadHTMLString:@"<head><meta name='color-scheme' content='dark light'></head><body style='height: 2000px;'></body>"];
+    [webView stringByEvaluatingJavaScript:@"internals.setUsesOverlayScrollbars(false)"];
+    [webView waitForNextPresentationUpdate];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_GT(scrollbarLuminanceForWebView(webView.get()), 0.5f);
+
+    [webView setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameDarkAqua]];
+    [webView waitForNextPresentationUpdate];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_LT(scrollbarLuminanceForWebView(webView.get()), 0.5f);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 7ecbfb2d01acc3b2ff7dbec9f3e16e6e5f5a29d9
<pre>
[macOS] Toggling dark mode does not update the scrollbar appearance on &lt;body&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=282655">https://bugs.webkit.org/show_bug.cgi?id=282655</a>
<a href="https://rdar.apple.com/138108344">rdar://138108344</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

With UI-side compositing, scrollbar appearance changes are propagated via
`ScrollableAreaParameters`. However, nothing actually tells the scrollbars
to repaint, resulting in a state mismatch between content and its scrollbars.

Fix by adding a new `ScrollingStateNodeProperty`, noting appearance changes,
and ultimately calling `-[NSScrollerImp setNeedsDisplay:]` to trigger a repaint.

* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::setScrollingNodeScrollableAreaGeometry):

The bit on `ScrollableAreaParameters` is now redundant with the information on
the state node.

* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h:
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp:
(WebCore::ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
* Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.cpp:
(WebCore::ScrollingStateOverflowScrollingNode::ScrollingStateOverflowScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.cpp:
(WebCore::ScrollingStatePluginScrollingNode::ScrollingStatePluginScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp:
(WebCore::ScrollingStateScrollingNode::ScrollingStateScrollingNode):
(WebCore::ScrollingStateScrollingNode::setUseDarkAppearanceForScrollbars):
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h:
(WebCore::ScrollingStateScrollingNode::useDarkAppearanceForScrollbars const):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/mac/ScrollerMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(WebCore::ScrollerMac::setNeedsDisplay):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(WebCore::ScrollerPairMac::useDarkAppearance const):
(WebCore::ScrollerPairMac::setUseDarkAppearance):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode):

Ensure a repaint is triggered when appearance changes.

* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/mac/ScrollbarTests.mm: Added.
(TestWebKitAPI::scrollbarLuminanceForWebView):
(TestWebKitAPI::TEST(ScrollbarTests, AppearanceChangeAfterSystemAppearanceChange)):

Add an API test to verify that the scrollbar takes on the correct appearance.

Previously, the scrollbar would remain white after switching to dark mode,
resulting in a luminance close to 1. The test asserts that the scrollbar is a
dark color.

Canonical link: <a href="https://commits.webkit.org/286229@main">https://commits.webkit.org/286229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3830865bc90b6a4ba5845b8c1a5172d5e3b4ca7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79614 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26413 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77274 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2381 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58988 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17234 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39364 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46523 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22061 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24742 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67610 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22400 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81090 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2487 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67262 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2637 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66533 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10470 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8647 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11616 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2448 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5252 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2473 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3402 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2482 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->