### PR TITLE
[macOS] -_windowSnapshotInRect:withOptions: should be marked NS_RETURNS_RETAINED

### DIFF
--- a/Source/WebCore/platform/graphics/cg/CGWindowUtilities.cpp
+++ b/Source/WebCore/platform/graphics/cg/CGWindowUtilities.cpp
@@ -32,12 +32,12 @@
 
 namespace WebCore {
 
-CGImageRef cgWindowListCreateImage(CGRect screenBounds, CGWindowListOption listOption, CGWindowID windowID, CGWindowImageOption imageOption)
+RetainPtr<CGImageRef> cgWindowListCreateImage(CGRect screenBounds, CGWindowListOption listOption, CGWindowID windowID, CGWindowImageOption imageOption)
 {
     if (PAL::canLoad_CoreGraphics_CGWindowListCreateImage())
-        return PAL::softLink_CoreGraphics_CGWindowListCreateImage(screenBounds, listOption, windowID, imageOption);
+        return adoptCF(PAL::softLink_CoreGraphics_CGWindowListCreateImage(screenBounds, listOption, windowID, imageOption));
 
-    return nullptr;
+    return { };
 }
 
 }

--- a/Source/WebCore/platform/graphics/cg/CGWindowUtilities.h
+++ b/Source/WebCore/platform/graphics/cg/CGWindowUtilities.h
@@ -32,10 +32,11 @@
 #include "IntRect.h"
 #include <CoreGraphics/CoreGraphics.h>
 #include <math.h>
+#include <wtf/RetainPtr.h>
 
 namespace WebCore {
 
-WEBCORE_EXPORT CGImageRef cgWindowListCreateImage(CGRect, CGWindowListOption, CGWindowID, CGWindowImageOption);
+WEBCORE_EXPORT RetainPtr<CGImageRef> cgWindowListCreateImage(CGRect, CGWindowListOption, CGWindowID, CGWindowImageOption);
 
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -868,7 +868,7 @@ typedef NS_OPTIONS(NSUInteger, WKDisplayCaptureSurfaces) {
 @end
 
 @interface WKWebView (WKWindowSnapshot)
-- (NSImage *)_windowSnapshotInRect:(CGRect)rect withOptions:(CGWindowImageOption)options;
+- (NSImage *)_windowSnapshotInRect:(CGRect)rect withOptions:(CGWindowImageOption)options NS_RETURNS_RETAINED;
 @end
 
 #endif // !TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -237,7 +237,7 @@ static RetainPtr<CGImageRef> createImageWithCopiedData(CGImageRef sourceImage)
     webViewFrame.origin.y = NSMaxY([[[NSScreen screens] objectAtIndex:0] frame]) - NSMaxY(webViewFrame);
 
     CGWindowID windowID = [[_webView window] windowNumber];
-    RetainPtr<CGImageRef> webViewContents = adoptCF(WebCore::cgWindowListCreateImage(NSRectToCGRect(webViewFrame), kCGWindowListOptionIncludingWindow, windowID, kCGWindowImageShouldBeOpaque));
+    RetainPtr webViewContents = WebCore::cgWindowListCreateImage(NSRectToCGRect(webViewFrame), kCGWindowListOptionIncludingWindow, windowID, kCGWindowImageShouldBeOpaque);
 
     // Using the returned CGImage directly would result in calls to the WindowServer every time
     // the image was painted. Instead, copy the image data into our own process to eliminate that
@@ -474,7 +474,7 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
     CGWindowImageOption imageOptions = kCGWindowImageBoundsIgnoreFraming | kCGWindowImageShouldBeOpaque;
     if (captureAtNominalResolution)
         imageOptions |= kCGWindowImageNominalResolution;
-    return adoptCF(WebCore::cgWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, windowID, imageOptions));
+    return WebCore::cgWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, windowID, imageOptions);
 }
 
 - (void)finishedExitFullScreenAnimationAndExitImmediately:(bool)immediately

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4550,7 +4550,7 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
     CGWindowImageOption imageOptions = kCGWindowImageBoundsIgnoreFraming | kCGWindowImageShouldBeOpaque;
     if (captureAtNominalResolution)
         imageOptions |= kCGWindowImageNominalResolution;
-    return adoptCF(WebCore::cgWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, windowID, imageOptions));
+    return WebCore::cgWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, windowID, imageOptions);
 }
 
 RefPtr<ViewSnapshot> WebViewImpl::takeViewSnapshot()

--- a/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
@@ -206,7 +206,7 @@ static NSRect convertRectToScreen(NSWindow *window, NSRect rect)
     
     CGWindowID windowID = [[_webView window] windowNumber];
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    RetainPtr<CGImageRef> webViewContents = adoptCF(WebCore::cgWindowListCreateImage(NSRectToCGRect(webViewFrame), kCGWindowListOptionIncludingWindow, windowID, kCGWindowImageShouldBeOpaque));
+    RetainPtr webViewContents = WebCore::cgWindowListCreateImage(NSRectToCGRect(webViewFrame), kCGWindowListOptionIncludingWindow, windowID, kCGWindowImageShouldBeOpaque);
 ALLOW_DEPRECATED_DECLARATIONS_END
 
     // Screen updates to be re-enabled in beganEnterFullScreenWithInitialFrame:finalFrame:

--- a/Source/WebKitLegacy/mac/WebView/WebViewPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewPrivate.h
@@ -1055,7 +1055,7 @@ typedef struct WebEdgeInsets {
 
 #if !TARGET_OS_IPHONE
 @interface WebView (WKWindowSnapshot)
-- (NSImage *)_windowSnapshotInRect:(CGRect)rect withOptions:(CGWindowImageOption)options;
+- (NSImage *)_windowSnapshotInRect:(CGRect)rect withOptions:(CGWindowImageOption)options NS_RETURNS_RETAINED;
 @end
 #endif
 

--- a/Tools/DumpRenderTree/mac/PixelDumpSupportMac.mm
+++ b/Tools/DumpRenderTree/mac/PixelDumpSupportMac.mm
@@ -82,7 +82,7 @@ static void paintRepaintRectOverlay(WebView* webView, CGContextRef context)
 static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, CGWindowImageOption imageOptions)
 {
     imageOptions |= kCGWindowImageBoundsIgnoreFraming | kCGWindowImageShouldBeOpaque;
-    return adoptCF(WebCore::cgWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, windowID, imageOptions));
+    return WebCore::cgWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, windowID, imageOptions);
 }
 
 RefPtr<BitmapContext> createBitmapContextFromWebView(bool onscreen, bool incrementalRepaint, bool sweepHorizontally, bool drawSelectionRect)

--- a/Tools/WebKitTestRunner/mac/PlatformWebViewMac.mm
+++ b/Tools/WebKitTestRunner/mac/PlatformWebViewMac.mm
@@ -223,7 +223,7 @@ RetainPtr<CGImageRef> PlatformWebView::windowSnapshotImage()
         options |= kCGWindowImageNominalResolution;
 
     RetainPtr image = adoptNS([platformView() _windowSnapshotInRect:CGRectNull withOptions:options]);
-    return adoptCF([image CGImageForProposedRect:nil context:nil hints:nil]);
+    return [image CGImageForProposedRect:nil context:nil hints:nil];
 }
 
 void PlatformWebView::changeWindowScaleIfNeeded(float newScale)


### PR DESCRIPTION
#### 590c7af23a413f38d58531310cdd19dc83e72715
<pre>
[macOS] -_windowSnapshotInRect:withOptions: should be marked NS_RETURNS_RETAINED
<a href="https://bugs.webkit.org/show_bug.cgi?id=282667">https://bugs.webkit.org/show_bug.cgi?id=282667</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

* Source/WebCore/platform/graphics/cg/CGWindowUtilities.cpp:
(WebCore::cgWindowListCreateImage):

Drive-by fix: make this return a `RetainPtr`, to clarify ownership semantics when calling into this
function.

* Source/WebCore/platform/graphics/cg/CGWindowUtilities.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:

Add `NS_RETURNS_RETAINED` to clarify that this SPI method returns a +1 object.

* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController enterFullScreen:]):
(takeWindowSnapshot):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::takeWindowSnapshot):
* Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm:
(-[WebFullScreenController enterFullScreen:]):
* Source/WebKitLegacy/mac/WebView/WebViewPrivate.h:
* Tools/DumpRenderTree/mac/PixelDumpSupportMac.mm:
(takeWindowSnapshot):
* Tools/WebKitTestRunner/mac/PlatformWebViewMac.mm:
(WTR::PlatformWebView::windowSnapshotImage):

Fix a bad call to `adoptCF` around an unretained pointer.

Canonical link: <a href="https://commits.webkit.org/286226@main">https://commits.webkit.org/286226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be7ca2acd0e2c603067543934d0b4b11a95f31c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79707 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26502 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77363 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59056 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17297 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64641 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39431 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46622 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22137 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24830 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81192 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2576 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1596 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67305 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2726 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64640 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66596 "Found 2 new API test failures: /TestWebKit:WebKit.GetInjectedBundleInitializationUserDataCallback, /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16565 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10544 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8703 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2537 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5342 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2562 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3491 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2571 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->