### PR TITLE
[macOS] Videos on Bing.com cannot successfully enter fullscreen

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1630,10 +1630,12 @@ public:
     WEBCORE_EXPORT void setNeedsDOMWindowResizeEvent();
     void setNeedsVisualViewportResize();
     void runResizeSteps();
+    void flushDeferredResizeEvents();
 
     void addPendingScrollEventTarget(ContainerNode&);
     void setNeedsVisualViewportScrollEvent();
     void runScrollSteps();
+    void flushDeferredScrollEvents();
 
     void invalidateScrollbars();
 
@@ -2606,7 +2608,9 @@ private:
 
     bool m_hasStyleWithViewportUnits { false };
     bool m_needsDOMWindowResizeEvent { false };
+    bool m_hasDeferredDOMWindowResizeEvent { false };
     bool m_needsVisualViewportResizeEvent { false };
+    bool m_hasDeferredVisualViewportResizeEvent { false };
     bool m_needsVisualViewportScrollEvent { false };
     bool m_isTimerThrottlingEnabled { false };
     bool m_isSuspended { false };

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -711,21 +711,6 @@ void FullscreenManager::setAnimatingFullscreen(bool flag)
     if (m_fullscreenElement)
         emplace(styleInvalidation, *m_fullscreenElement, { { CSSSelector::PseudoClass::InternalAnimatingFullscreenTransition, flag } });
     m_isAnimatingFullscreen = flag;
-
-    if (!m_isAnimatingFullscreen) {
-        Ref<Document> protectedDocument(document());
-        if (m_pendingScheduledResize.contains(ResizeType::DOMWindow))
-            protectedDocument->setNeedsDOMWindowResizeEvent();
-        if (m_pendingScheduledResize.contains(ResizeType::VisualViewport))
-            protectedDocument->setNeedsVisualViewportResize();
-
-        m_pendingScheduledResize = { };
-    }
-}
-
-void FullscreenManager::addPendingScheduledResize(ResizeType type)
-{
-    m_pendingScheduledResize.add(type);
 }
 
 void FullscreenManager::clear()
@@ -733,8 +718,6 @@ void FullscreenManager::clear()
     m_fullscreenElement = nullptr;
     m_pendingFullscreenElement = nullptr;
     m_pendingPromise = nullptr;
-
-    m_pendingScheduledResize = { };
 }
 
 void FullscreenManager::emptyEventQueue()

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -90,12 +90,6 @@ public:
     WEBCORE_EXPORT bool isAnimatingFullscreen() const;
     WEBCORE_EXPORT void setAnimatingFullscreen(bool);
 
-    enum class ResizeType : uint8_t {
-        DOMWindow           = 1 << 0,
-        VisualViewport      = 1 << 1,
-    };
-    void addPendingScheduledResize(ResizeType);
-
     void clear();
     void emptyEventQueue();
 
@@ -130,8 +124,6 @@ private:
     RefPtr<Element> m_fullscreenElement;
     Deque<GCReachableRef<Node>> m_fullscreenChangeEventTargetQueue;
     Deque<GCReachableRef<Node>> m_fullscreenErrorEventTargetQueue;
-
-    OptionSet<ResizeType> m_pendingScheduledResize;
 
     bool m_areKeysEnabledInFullscreen { false };
     bool m_isAnimatingFullscreen { false };

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5201,6 +5201,32 @@ bool Page::isFullscreenManagerEnabled() const
 }
 #endif
 
+void Page::startDeferringResizeEvents()
+{
+    m_shouldDeferResizeEvents = true;
+}
+
+void Page::flushDeferredResizeEvents()
+{
+    m_shouldDeferResizeEvents = false;
+    forEachDocument([&] (Document& document) {
+        document.flushDeferredResizeEvents();
+    });
+}
+
+void Page::startDeferringScrollEvents()
+{
+    m_shouldDeferScrollEvents = true;
+}
+
+void Page::flushDeferredScrollEvents()
+{
+    m_shouldDeferScrollEvents = false;
+    forEachDocument([&] (Document& document) {
+        document.flushDeferredScrollEvents();
+    });
+}
+
 bool Page::reportScriptTelemetry(const URL& url, ScriptTelemetryCategory category)
 {
     return !url.isEmpty() && m_reportedScriptsWithTelemetry.add({ url, category }).isNewEntry;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1230,6 +1230,14 @@ public:
     WEBCORE_EXPORT bool isFullscreenManagerEnabled() const;
 #endif
 
+    bool shouldDeferResizeEvents() const { return m_shouldDeferResizeEvents; }
+    WEBCORE_EXPORT void startDeferringResizeEvents();
+    WEBCORE_EXPORT void flushDeferredResizeEvents();
+
+    bool shouldDeferScrollEvents() const { return m_shouldDeferScrollEvents; }
+    WEBCORE_EXPORT void startDeferringScrollEvents();
+    WEBCORE_EXPORT void flushDeferredScrollEvents();
+
     bool reportScriptTelemetry(const URL&, ScriptTelemetryCategory);
     bool requiresScriptTelemetryForURL(const URL&) const;
 
@@ -1660,6 +1668,9 @@ private:
     Timer m_activeNowPlayingSessionUpdateTimer;
 
     std::optional<LoginStatus> m_lastAuthentication;
+
+    bool m_shouldDeferResizeEvents { false };
+    bool m_shouldDeferScrollEvents { false };
 }; // class Page
 
 inline Page* Frame::page() const

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9509,6 +9509,26 @@ void WebPageProxy::Internals::setTextFromItemForPopupMenu(WebPopupMenuProxy*, in
     protectedPage()->send(Messages::WebPage::SetTextForActivePopupMenu(index));
 }
 
+void WebPageProxy::startDeferringResizeEvents()
+{
+    internals().protectedPage()->send(Messages::WebPage::StartDeferringResizeEvents());
+}
+
+void WebPageProxy::flushDeferredResizeEvents()
+{
+    internals().protectedPage()->send(Messages::WebPage::FlushDeferredResizeEvents());
+}
+
+void WebPageProxy::startDeferringScrollEvents()
+{
+    internals().protectedPage()->send(Messages::WebPage::StartDeferringScrollEvents());
+}
+
+void WebPageProxy::flushDeferredScrollEvents()
+{
+    internals().protectedPage()->send(Messages::WebPage::FlushDeferredScrollEvents());
+}
+
 bool WebPageProxy::isProcessingKeyboardEvents() const
 {
     return !internals().keyEventQueue.isEmpty();

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1250,6 +1250,12 @@ public:
     struct wpe_view_backend* viewBackend();
 #endif
 
+    void startDeferringResizeEvents();
+    void flushDeferredResizeEvents();
+
+    void startDeferringScrollEvents();
+    void flushDeferredScrollEvents();
+
     bool isProcessingMouseEvents() const;
     void processNextQueuedMouseEvent();
     void sendMouseEvent(WebCore::FrameIdentifier, const NativeWebMouseEvent&, std::optional<Vector<SandboxExtensionHandle>>&&);

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -248,6 +248,8 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [[self window] setAutodisplay:NO];
 ALLOW_DEPRECATED_DECLARATIONS_END
 
+    _page->startDeferringResizeEvents();
+    _page->startDeferringScrollEvents();
     [self _manager]->saveScrollPosition();
     _savedTopContentInset = _page->topContentInset();
     _page->setTopContentInset(0);
@@ -273,7 +275,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _webView.frame = NSInsetRect(contentView.bounds, 0, -_page->topContentInset());
 
     _savedScale = _page->pageScaleFactor();
-    _page->scalePage(1, WebCore::IntPoint(), [] { });
+    _page->scalePageRelativeToScrollPosition(1, { });
     [self _manager]->setAnimatingFullScreen(true);
     [self _manager]->willEnterFullScreen();
 }
@@ -364,7 +366,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         makeResponderFirstResponderIfDescendantOfView(_webView.window, firstResponder, _webView);
         [[_webView window] makeKeyAndOrderFront:self];
 
-        _page->scalePage(_savedScale, WebCore::IntPoint(), [] { });
+        _page->scalePageRelativeToScrollPosition(_savedScale, { });
         [self _manager]->restoreScrollPosition();
         _page->setTopContentInset(_savedTopContentInset);
         [self _manager]->setAnimatingFullScreen(false);
@@ -383,6 +385,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         WebKit::NativeWebMouseEvent webEvent(fakeEvent, nil, _webView);
         _page->handleMouseEvent(webEvent);
     }
+    _page->flushDeferredResizeEvents();
+    _page->flushDeferredScrollEvents();
 
     if (_requestedExitFullScreen) {
         _requestedExitFullScreen = NO;
@@ -419,6 +423,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     // See the related comment in enterFullScreen:
     // We will resume the normal behavior in _startExitFullScreenAnimationWithDuration:
     _page->setSuppressVisibilityUpdates(true);
+    _page->startDeferringResizeEvents();
+    _page->startDeferringScrollEvents();
     [_webViewPlaceholder setTarget:nil];
 
     [self _manager]->setAnimatingFullScreen(true);
@@ -536,9 +542,11 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
     // These messages must be sent after the swap or flashing will occur during forceRepaint:
     [self _manager]->setAnimatingFullScreen(false);
     [self _manager]->didExitFullScreen();
-    _page->scalePage(_savedScale, WebCore::IntPoint(), [] { });
+    _page->scalePageRelativeToScrollPosition(_savedScale, { });
     [self _manager]->restoreScrollPosition();
     _page->setTopContentInset(_savedTopContentInset);
+    _page->flushDeferredResizeEvents();
+    _page->flushDeferredScrollEvents();
 
     [CATransaction commit];
     [CATransaction flush];

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3579,6 +3579,26 @@ void WebPage::setLastKnownMousePosition(WebCore::FrameIdentifier frameID, IntPoi
     frame->coreLocalFrame()->eventHandler().setLastKnownMousePosition(eventPoint, globalPoint);
 }
 
+void WebPage::startDeferringResizeEvents()
+{
+    corePage()->startDeferringResizeEvents();
+}
+
+void WebPage::flushDeferredResizeEvents()
+{
+    corePage()->flushDeferredResizeEvents();
+}
+
+void WebPage::startDeferringScrollEvents()
+{
+    corePage()->startDeferringScrollEvents();
+}
+
+void WebPage::flushDeferredScrollEvents()
+{
+    corePage()->flushDeferredScrollEvents();
+}
+
 void WebPage::flushDeferredDidReceiveMouseEvent()
 {
     if (auto info = std::exchange(m_deferredDidReceiveMouseEvent, std::nullopt))

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1761,6 +1761,12 @@ public:
     void setInteractionRegionsEnabled(bool);
 #endif
 
+    void startDeferringResizeEvents();
+    void flushDeferredResizeEvents();
+
+    void startDeferringScrollEvents();
+    void flushDeferredScrollEvents();
+
     void flushDeferredDidReceiveMouseEvent();
 
     void generateTestReport(String&& message, String&& group);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -589,6 +589,12 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     DidEndMagnificationGesture()
 #endif
 
+    StartDeferringResizeEvents();
+    FlushDeferredResizeEvents();
+
+    StartDeferringScrollEvents();
+    FlushDeferredScrollEvents();
+
     FlushDeferredDidReceiveMouseEvent()
 
     PerformHitTestForMouseEvent(WebKit::WebMouseEvent event) -> (struct WebKit::WebHitTestResultData hitTestResult, OptionSet<WebKit::WebEventModifier> modifiers, WebKit::UserData messageBody)

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -128,6 +128,7 @@ Tests/WebKitCocoa/FullscreenAlert.mm
 Tests/WebKitCocoa/FullscreenDelegate.mm
 Tests/WebKitCocoa/FullscreenLayoutConstraints.mm
 Tests/WebKitCocoa/FullscreenRemoveNodeBeforeEnter.mm
+Tests/WebKitCocoa/FullscreenScrollAndResize.mm
 Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm
 Tests/WebKitCocoa/GPUProcess.mm
 Tests/WebKitCocoa/Geolocation.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3478,6 +3478,7 @@
 		CD78E11A1DB7EA360014A2DE /* FullscreenDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenDelegate.mm; sourceTree = "<group>"; };
 		CD78E11B1DB7EA360014A2DE /* FullscreenDelegate.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = FullscreenDelegate.html; sourceTree = "<group>"; };
 		CD7F89DB22A86CDA00D683AE /* WKWebViewSuspendAllMediaPlayback.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewSuspendAllMediaPlayback.mm; sourceTree = "<group>"; };
+		CD7FC5D82CDAF7160032C1FC /* FullscreenScrollAndResize.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenScrollAndResize.mm; sourceTree = "<group>"; };
 		CD8394DE232AF15E00149495 /* media-loading.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "media-loading.html"; sourceTree = "<group>"; };
 		CD89D0381C4EDB2A00040A04 /* WebCoreNSURLSession.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebCoreNSURLSession.mm; sourceTree = "<group>"; };
 		CD9E292B1C90A71F000BB800 /* RequiresUserActionForPlayback.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RequiresUserActionForPlayback.mm; sourceTree = "<group>"; };
@@ -4286,6 +4287,7 @@
 				3F1B52681D3D7129008D60C4 /* FullscreenLayoutConstraints.mm */,
 				A1AD38272C3D9FAF003499BE /* FullscreenLifecycle.mm */,
 				CDDC7C6825FFF6D000224278 /* FullscreenRemoveNodeBeforeEnter.mm */,
+				CD7FC5D82CDAF7160032C1FC /* FullscreenScrollAndResize.mm */,
 				F4BDA42E27F8BF2F00F9647D /* FullscreenVideoTextRecognition.mm */,
 				631EFFF51E7B5E8D00D2EBB8 /* Geolocation.mm */,
 				07E1F6A01FFC3A080096C7EC /* GetDisplayMedia.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenScrollAndResize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenScrollAndResize.mm
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if PLATFORM(MAC)
+// FIXME: Fullscreen tests do not work when run on iOS because the test binary is not a real "app".
+// Enable this test on iOS once that issue is resolved.
+
+#import "PlatformUtilities.h"
+#import "TestWKWebView.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <wtf/RetainPtr.h>
+
+namespace TestWebKitAPI {
+
+TEST(Fullscreen, ScrollAndResize)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration preferences].elementFullscreenEnabled = YES;
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+
+    [webView synchronouslyLoadHTMLString:
+        @"<html><head><style>"
+        @"#spacer { height: 150px; }"
+        @"#target { height: 50px; background-color: green; }"
+        @"</style><script>"
+        @"function logEvent(event) { "
+        @"    document.getElementById('target').appendChild(document.createElement('div')).innerText = event.type;"
+        @"    window.webkit.messageHandlers.testHandler.postMessage(event.type);"
+        @"};"
+        @"window.addEventListener('resize', logEvent);"
+        @"window.addEventListener('scroll', logEvent);"
+        @"window.addEventListener('fullscreenchange', logEvent);"
+        @"</script><body><div id=spacer><div id=target></body></html>"];
+
+    ASSERT_FALSE([webView _isInFullscreen]);
+
+    __block bool didScroll = false;
+    __block bool didResize = false;
+    __block bool didChangeFullscreen = false;
+
+    [webView performAfterReceivingMessage:@"resize" action:^{ didResize = true; }];
+    [webView performAfterReceivingMessage:@"scroll" action:^{ didScroll = true; }];
+    [webView performAfterReceivingMessage:@"fullscreenchange" action:^{ didChangeFullscreen = true; }];
+
+    [webView evaluateJavaScript:@"document.getElementById('target').scrollIntoView()" completionHandler:nil];
+    TestWebKitAPI::Util::run(&didScroll);
+
+    didScroll = false;
+    [webView evaluateJavaScript:@"document.getElementById('target').requestFullscreen()" completionHandler:nil];
+
+    TestWebKitAPI::Util::run(&didChangeFullscreen);
+    TestWebKitAPI::Util::run(&didResize);
+    TestWebKitAPI::Util::run(&didScroll);
+
+    auto logContents = [webView stringByEvaluatingJavaScript:@"document.getElementById('target').innerText"];
+    EXPECT_WK_STREQ("scroll\nfullscreenchange\nresize\nscroll", logContents);
+}
+
+} // namespace TestWebKitAPI
+
+#endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm
@@ -28,6 +28,8 @@
 #import "CocoaImage.h"
 #import "HTTPServer.h"
 #import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestNavigationDelegate.h"
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <wtf/Expected.h>
@@ -36,6 +38,8 @@
 #import <wtf/text/Base64.h>
 
 namespace TestWebKitAPI {
+
+static bool done;
 
 TEST(WebKit, LoadAndDecodeImage)
 {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -131,6 +131,8 @@ static bool alertReceived = false;
 
 namespace TestWebKitAPI {
 
+static bool done;
+
 static RetainPtr<NSURL> testWebPushDaemonLocation()
 {
     return [currentExecutableDirectory() URLByAppendingPathComponent:@"webpushd" isDirectory:NO];


### PR DESCRIPTION
#### fa5e0c0d9325fdd1efad12e2c41021ec0864cfd1
<pre>
[macOS] Videos on Bing.com cannot successfully enter fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=282668">https://bugs.webkit.org/show_bug.cgi?id=282668</a>
<a href="https://rdar.apple.com/126570526">rdar://126570526</a>

Reviewed by Jean-Yves Avenard.

On Bing.com, the page includes a list of iframe elements whose contents
point to youtube.com embeds. As the user scrolls through the page, script
running on Bing.com notes that the iframe elements have been scrolled out
of the viewport, and tears down their contents. During the fullscreen
transition, the iframe contents are in fullscreen mode and are visible in
the top layer, but the div containing those contents has been scrolled
offscreen. Additionally, the code checking for whether the iframes are
visible runs when the window fires the &quot;scroll&quot; and &quot;resize&quot; events, which
are fired during the fullscreen transition.

Two changes are needed to fix this behavior:

1. Calling WebPageProxy::setPageScale()
has the side effect of scrolling the page back to the origin of (0, 0). This
call is replaced with scalePageRelativeToScrollPosition(), which does not
change the scroll position.

2. Defer firing &quot;scroll&quot; and &quot;resize&quot; events until after &quot;fullscreenchange&quot;
fires. This ensures that the page doesn&apos;t get an intermediate state during
the fullscreen transition in which to check the layout of its contents.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setNeedsDOMWindowResizeEvent):
(WebCore::Document::setNeedsVisualViewportResize):
(WebCore::Document::runResizeSteps):
(WebCore::Document::flushDeferredResizeEvents):
(WebCore::Document::runScrollSteps):
(WebCore::Document::flushDeferredScrollEvents):
(WebCore::Document::updateResizeObservations):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::setAnimatingFullscreen):
(WebCore::FullscreenManager::clear):
(WebCore::FullscreenManager::addPendingScheduledResize): Deleted.
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::deferResizeEvents):
(WebCore::Page::flushDeferredResizeEvents):
(WebCore::Page::deferScrollEvents):
(WebCore::Page::flushDeferredScrollEvents):
* Source/WebCore/page/Page.h:
(WebCore::Page::shouldDeferResizeEvents const):
(WebCore::Page::shouldDeferScrollEvents const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::deferResizeEvents):
(WebKit::WebPageProxy::flushDeferredResizeEvents):
(WebKit::WebPageProxy::deferScrollEvents):
(WebKit::WebPageProxy::flushDeferredScrollEvents):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController enterFullScreen:]):
(-[WKFullScreenWindowController finishedEnterFullScreenAnimation:]):
(-[WKFullScreenWindowController exitFullScreen]):
(-[WKFullScreenWindowController finishedExitFullScreenAnimationAndExitImmediately:]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::deferResizeEvents):
(WebKit::WebPage::flushDeferredResizeEvents):
(WebKit::WebPage::deferScrollEvents):
(WebKit::WebPage::flushDeferredScrollEvents):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenScrollAndResize.mm: Added.
(TestWebKitAPI::TEST(Fullscreen, ScrollAndResize)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:

Canonical link: <a href="https://commits.webkit.org/286501@main">https://commits.webkit.org/286501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a9c1d103abdff2cdcbef5d84f2cdbdff146e9ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80549 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27315 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78165 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3374 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59636 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17784 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65308 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39993 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46914 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22793 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25642 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68030 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82010 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2190 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67854 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3572 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67164 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16768 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11120 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9236 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3368 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6174 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3389 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/5078 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/4148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->