### PR TITLE
viewTransitionNewPseudoForCapturedElement iterates all names elements unnecessarily.

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4829,6 +4829,16 @@ ElementAnimationRareData& Element::ensureAnimationRareData(const std::optional<S
     return ensureElementRareData().ensureAnimationRareData(pseudoElementIdentifier);
 }
 
+AtomString Element::viewTransitionCapturedName(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
+{
+    return hasRareData() ? elementRareData()->viewTransitionCapturedName(pseudoElementIdentifier) : nullAtom();
+}
+
+void Element::setViewTransitionCapturedName(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, AtomString captureName)
+{
+    return ensureElementRareData().setViewTransitionCapturedName(pseudoElementIdentifier, captureName);
+}
+
 KeyframeEffectStack* Element::keyframeEffectStack(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
 {
     if (auto* animationData = animationRareData(pseudoElementIdentifier))

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -822,6 +822,9 @@ public:
     void updateEffectiveTextDirection();
     void updateEffectiveTextDirectionIfNeeded();
 
+    AtomString viewTransitionCapturedName(const std::optional<Style::PseudoElementIdentifier>&) const;
+    void setViewTransitionCapturedName(const std::optional<Style::PseudoElementIdentifier>&, AtomString);
+
 protected:
     Element(const QualifiedName&, Document&, OptionSet<TypeFlag>);
 

--- a/Source/WebCore/dom/ElementRareData.cpp
+++ b/Source/WebCore/dom/ElementRareData.cpp
@@ -39,6 +39,7 @@ struct SameSizeAsElementRareData : NodeRareData {
     uint8_t contentRelevancy;
     IntPoint savedLayerScrollPosition;
     HashMap<std::optional<Style::PseudoElementIdentifier>, std::unique_ptr<ElementAnimationRareData>> animationRareData;
+    HashMap<std::optional<Style::PseudoElementIdentifier>, AtomString> viewTransitionCapture;
     void* pointers[17];
     void* intersectionObserverData;
     void* typedOMData[2];

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -116,6 +116,9 @@ public:
     ElementAnimationRareData* animationRareData(const std::optional<Style::PseudoElementIdentifier>&) const;
     ElementAnimationRareData& ensureAnimationRareData(const std::optional<Style::PseudoElementIdentifier>&);
 
+    AtomString viewTransitionCapturedName(const std::optional<Style::PseudoElementIdentifier>&) const;
+    void setViewTransitionCapturedName(const std::optional<Style::PseudoElementIdentifier>&, AtomString);
+
     DOMTokenList* partList() const { return m_partList.get(); }
     void setPartList(std::unique_ptr<DOMTokenList>&& partList) { m_partList = WTFMove(partList); }
 
@@ -244,6 +247,8 @@ private:
 
     HashMap<std::optional<Style::PseudoElementIdentifier>, std::unique_ptr<ElementAnimationRareData>> m_animationRareData;
 
+    HashMap<std::optional<Style::PseudoElementIdentifier>, AtomString> m_viewTransitionCapturedName;
+
     RefPtr<PseudoElement> m_beforePseudoElement;
     RefPtr<PseudoElement> m_afterPseudoElement;
 
@@ -318,6 +323,16 @@ inline ElementAnimationRareData& ElementRareData::ensureAnimationRareData(const 
     auto result = m_animationRareData.add(pseudoElementIdentifier, makeUnique<ElementAnimationRareData>());
     ASSERT(result.isNewEntry);
     return *result.iterator->value.get();
+}
+
+inline AtomString ElementRareData::viewTransitionCapturedName(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier) const
+{
+    return m_viewTransitionCapturedName.get(pseudoElementIdentifier);
+}
+
+inline void ElementRareData::setViewTransitionCapturedName(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, AtomString captureName)
+{
+    m_viewTransitionCapturedName.set(pseudoElementIdentifier, captureName);
 }
 
 inline ElementRareData* Element::elementRareData() const

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -961,18 +961,15 @@ void Styleable::queryContainerDidChange() const
 
 bool Styleable::capturedInViewTransition() const
 {
-    RefPtr activeViewTransition = element.document().activeViewTransition();
-    if (!activeViewTransition || activeViewTransition->phase() != ViewTransitionPhase::Animating)
-        return false;
-
-    for (auto& [name, capturedElement] : activeViewTransition->namedElements().map()) {
-        if (auto newStyleable = capturedElement->newElement.styleable()) {
-            if (*newStyleable == *this)
-                return true;
-        }
-    }
-
-    return false;
+    return !element.viewTransitionCapturedName(pseudoElementIdentifier).isNull();
 }
+
+void Styleable::setCapturedInViewTransition(AtomString captureName)
+{
+    element.setViewTransitionCapturedName(pseudoElementIdentifier, captureName);
+    if (CheckedPtr renderer = this->renderer())
+        renderer->setCapturedInViewTransition(!captureName.isNull());
+}
+
 
 } // namespace WebCore

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -85,6 +85,7 @@ struct Styleable {
     bool hasRunningAcceleratedAnimations() const;
 
     bool capturedInViewTransition() const;
+    void setCapturedInViewTransition(AtomString);
 
     KeyframeEffectStack* keyframeEffectStack() const
     {


### PR DESCRIPTION
#### c8e664c1689c9fead17c1c4cfa7b3a09621db0e6
<pre>
viewTransitionNewPseudoForCapturedElement iterates all names elements unnecessarily.
<a href="https://bugs.webkit.org/show_bug.cgi?id=282377">https://bugs.webkit.org/show_bug.cgi?id=282377</a>
&lt;<a href="https://rdar.apple.com/138980780">rdar://138980780</a>&gt;

Reviewed by Tim Nguyen.

Both viewTransitionNewPseudoForCapturedElement and
Styleable::capturedInViewTransition do a linear search over the captured
element, since we can&apos;t retrieve the &apos;view-transition-name&apos; property from style
as it might have changed since the transition started.

Fix this by storing the name that we used for capturing on ElementRareData
(possibly indexed by pseudo element identifier, if relevant). This then becomes
the canonical state for &apos;captured in a view transition&apos;, though we still have
the bit set on RenderObject for fast lookups.

If the renderer gets recreated, then RenderElement::initializeStyle uses
Styleable::capturedInViewTransition to re-initialize the bit, which is now fast.

viewTransitionNewPseudoForCapturedElement can directly lookup the name, and then
do a fast lookup using a different styleable for the appropriate pseudo element.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::viewTransitionCapturedName const):
(WebCore::Element::setViewTransitionCapturedName):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementRareData.cpp:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::viewTransitionCapturedName const):
(WebCore::ElementRareData::setViewTransitionCapturedName):
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::activateViewTransition):
(WebCore::ViewTransition::clearViewTransition):
(WebCore::ViewTransition::viewTransitionNewPseudoForCapturedElement):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::capturedInViewTransition const):
(WebCore::Styleable::setCapturedInViewTransition):
* Source/WebCore/style/Styleable.h:

Canonical link: <a href="https://commits.webkit.org/286400@main">https://commits.webkit.org/286400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcb0774ff610278849fa64b7b45a07b47a191cc4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80397 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27166 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78016 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64071 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3223 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59511 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17671 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65186 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39871 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46790 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22670 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25493 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67905 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23007 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81861 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2066 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67740 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3423 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65154 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67048 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16708 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10993 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9120 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3219 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6025 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3240 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4178 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3247 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->