### PR TITLE
View transition old snapshots don't get flushed until we try to use them

### DIFF
--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -503,8 +503,7 @@ ExceptionOr<void> ViewTransition::captureOldState()
     for (auto& renderer : captureRenderers) {
         CapturedElement capture;
 
-        capture.oldProperties = copyElementBaseProperties(renderer.get(), capture.oldSize);
-        capture.oldOverflowRect = captureOverflowRect(renderer.get());
+        capture.oldProperties = copyElementBaseProperties(renderer.get(), capture.oldSize, capture.oldOverflowRect, capture.initiallyIntersectsViewport);
         if (RefPtr frame = document()->frame())
             capture.oldImage = snapshotElementVisualOverflowClippedToViewport(*frame, renderer.get(), capture.oldOverflowRect);
         capture.oldLayerToLayoutOffset = layerToLayoutOffset(renderer.get());
@@ -517,6 +516,11 @@ ExceptionOr<void> ViewTransition::captureOldState()
         m_namedElements.add(transitionName, capture);
     }
 
+    for (auto& [name, capturedElement] : m_namedElements.map()) {
+        if (capturedElement->initiallyIntersectsViewport && capturedElement->oldImage && *capturedElement->oldImage)
+            (*capturedElement->oldImage)->flushDrawingContextAsync();
+    }
+
     for (auto& renderer : captureRenderers)
         renderer->setCapturedInViewTransition(false);
 
@@ -527,8 +531,8 @@ bool ViewTransition::updatePropertiesForRenderer(CapturedElement& capturedElemen
 {
     RefPtr<MutableStyleProperties> properties;
     if (renderer) {
-        properties = copyElementBaseProperties(*renderer, capturedElement.newSize);
-        capturedElement.newOverflowRect = captureOverflowRect(*renderer);
+        bool initiallyIntersectsViewport;
+        properties = copyElementBaseProperties(*renderer, capturedElement.newSize, capturedElement.newOverflowRect, initiallyIntersectsViewport);
     } else
         properties = capturedElement.oldProperties;
 
@@ -799,7 +803,7 @@ void ViewTransition::clearViewTransition()
         documentElement->invalidateStyleInternal();
 }
 
-Ref<MutableStyleProperties> ViewTransition::copyElementBaseProperties(RenderLayerModelObject& renderer, LayoutSize& size)
+Ref<MutableStyleProperties> ViewTransition::copyElementBaseProperties(RenderLayerModelObject& renderer, LayoutSize& size, LayoutRect& overflowRect, bool& intersectsViewport)
 {
     std::optional<const Styleable> styleable = Styleable::fromRenderer(renderer);
     ASSERT(styleable);
@@ -816,6 +820,8 @@ Ref<MutableStyleProperties> ViewTransition::copyElementBaseProperties(RenderLaye
 #endif
     };
 
+    overflowRect = captureOverflowRect(renderer);
+
     Ref<MutableStyleProperties> props = styleExtractor.copyProperties(transitionProperties);
     auto& frameView = renderer.view().frameView();
 
@@ -831,6 +837,9 @@ Ref<MutableStyleProperties> ViewTransition::copyElementBaseProperties(RenderLaye
 
             auto offset = -toFloatSize(frameView.visibleContentRect().location());
             transform->translateRight(offset.width(), offset.height());
+
+            auto mapped = transform->mapRect(overflowRect);
+            intersectsViewport = mapped.intersects(frameView.boundsRect());
 
             // Apply the inverse of what will be added by the default value of 'transform-origin',
             // since the computed transform has already included it.

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -67,6 +67,7 @@ public:
     LayoutPoint oldLayerToLayoutOffset;
     LayoutSize oldSize;
     RefPtr<MutableStyleProperties> oldProperties;
+    bool initiallyIntersectsViewport { false };
 
     WeakStyleable newElement;
     LayoutRect newOverflowRect;
@@ -198,7 +199,7 @@ private:
     ViewTransition(Document&, RefPtr<ViewTransitionUpdateCallback>&&, Vector<AtomString>&&);
     ViewTransition(Document&, Vector<AtomString>&&);
 
-    Ref<MutableStyleProperties> copyElementBaseProperties(RenderLayerModelObject&, LayoutSize&);
+    Ref<MutableStyleProperties> copyElementBaseProperties(RenderLayerModelObject&, LayoutSize&, LayoutRect& overflowRect, bool& intersectsViewport);
     bool updatePropertiesForRenderer(CapturedElement&, RenderBoxModelObject*, const AtomString&);
 
     // Setup view transition sub-algorithms.


### PR DESCRIPTION
#### 0c3e3e18a165f40ad1f941562148997465f8baab
<pre>
View transition old snapshots don&apos;t get flushed until we try to use them
<a href="https://bugs.webkit.org/show_bug.cgi?id=282676">https://bugs.webkit.org/show_bug.cgi?id=282676</a>
&lt;<a href="https://rdar.apple.com/139339149">rdar://139339149</a>&gt;

Reviewed by Simon Fraser.

View transition old snapshots get recorded during the &apos;activate&apos; phase which
happens outside of a rendering update.

We have a tradeoff between flushing them immediately so that the work completes
before the rendering update, and flushing more than is needed and having some of
it block the rendering update&apos;s work.

This adds a check if the element being captured in the &apos;old&apos; state intersects
the viewport, and flushes the snapshot if so (after all the snapshot buffers
have been allocated, to prevent rendering work from blocking backend handles
being returned). This isn&apos;t strictly what will be used in the first frame of the
animation, since authors can style and locate the pseudos arbitrarily, but it
should be close enough usually.

GraphicsLayerCARemote::setLayerContentsToImageBuffer already flushes buffers as
they get set, so if we ever use a snapshot that wasn&apos;t included in the initial
flush then it gets flushed at that point.

It also changes the &apos;isDirectlyCompositedImage&apos; path to return false for
elements that are known to be offscreen (inside a position:fixed and we computed
that the backing store can be detached). Without this, we just forward the
ImageBuffer to the relevant GraphicsLayer for every single psuedo, which
triggers the &apos;flush on use&apos; path for everything.

* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::captureOldState):
(WebCore::ViewTransition::updatePropertiesForRenderer):
(WebCore::ViewTransition::copyElementBaseProperties):
* Source/WebCore/dom/ViewTransition.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAllowsBackingStoreDetaching):
(WebCore::RenderLayerBacking::isDirectlyCompositedImage const):
* Source/WebCore/rendering/RenderViewTransitionCapture.cpp:
(WebCore::RenderViewTransitionCapture::image):
* Source/WebCore/rendering/RenderViewTransitionCapture.h:

Canonical link: <a href="https://commits.webkit.org/286553@main">https://commits.webkit.org/286553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b740cca6fdcd28b4fa648a2f6efb1a34d6cdd396

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80773 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27536 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78380 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3590 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59801 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17929 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49698 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65495 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40142 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47096 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22981 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25858 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68224 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23316 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82229 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68021 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3790 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65467 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67333 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16801 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11296 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9399 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3584 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6391 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3607 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7036 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5365 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->