### PR TITLE
ANGLE: Make translator fuzzer work with old corpus after ShShaderOutput enum changes

### DIFF
--- a/Source/ThirdParty/ANGLE/WebKit/TranslatorFuzzer.cpp
+++ b/Source/ThirdParty/ANGLE/WebKit/TranslatorFuzzer.cpp
@@ -242,6 +242,48 @@ void filterOptions(ShShaderOutput output, ShCompileOptions& options)
 #undef CHECK_VALID_OPTION
 }
 
+ShShaderOutput resolveShaderOutput(ShShaderOutput output)
+{
+    // Constants in ShaderLang.h version 363.
+    switch (static_cast<unsigned>(output)) {
+    case 0x8B45:
+        return SH_ESSL_OUTPUT;
+    case 0x8B46:
+        return SH_GLSL_COMPATIBILITY_OUTPUT;
+    case 0x8B47:
+        return SH_GLSL_130_OUTPUT;
+    case 0x8B80:
+        return SH_GLSL_140_OUTPUT;
+    case 0x8B81:
+        return SH_GLSL_150_CORE_OUTPUT;
+    case 0x8B82:
+        return SH_GLSL_330_CORE_OUTPUT;
+    case 0x8B83:
+        return SH_GLSL_400_CORE_OUTPUT;
+    case 0x8B84:
+        return SH_GLSL_410_CORE_OUTPUT;
+    case 0x8B85:
+        return SH_GLSL_420_CORE_OUTPUT;
+    case 0x8B86:
+        return SH_GLSL_430_CORE_OUTPUT;
+    case 0x8B87:
+        return SH_GLSL_440_CORE_OUTPUT;
+    case 0x8B88:
+        return SH_GLSL_450_CORE_OUTPUT;
+    case 0x8B48:
+        return SH_HLSL_3_0_OUTPUT;
+    case 0x8B49:
+        return SH_HLSL_4_1_OUTPUT;
+    case 0x8B4B:
+        return SH_SPIRV_VULKAN_OUTPUT;
+    case 0x8B4D:
+        return SH_MSL_METAL_OUTPUT;
+    case 0x8B4E:
+        return SH_WGSL_OUTPUT;
+    };
+    return output;
+}
+
 extern "C" size_t LLVMFuzzerCustomMutator(uint8_t *data, size_t size, size_t maxSize, unsigned int seed)
 {
     initializeFuzzer();
@@ -273,6 +315,7 @@ extern "C" int LLVMFuzzerTestOneInput (const uint8_t* data, size_t size)
         return 0;
 
     GLSLDumpHeader header { data };
+    header.output = resolveShaderOutput(header.output);
     filterOptions(header.output, header.options);
     auto* translator = getTranslator(header.type, header.spec, header.output);
     if (!translator)

--- a/Source/ThirdParty/ANGLE/WebKit/TranslatorFuzzerDumpTestCase.cpp
+++ b/Source/ThirdParty/ANGLE/WebKit/TranslatorFuzzerDumpTestCase.cpp
@@ -139,6 +139,7 @@ int main(int argc, const char * argv[])
             }
         }
         GLSLDumpHeader header { &fileData[0] };
+        header.output = resolveShaderOutput(header.output);
         filterOptions(header.output, header.options);
         std::cout << "TEST(CompilerWorksTest, Test" << i << ")";
         std::cout << testContent1;

--- a/Source/ThirdParty/ANGLE/WebKit/TranslatorFuzzerSupport.h
+++ b/Source/ThirdParty/ANGLE/WebKit/TranslatorFuzzerSupport.h
@@ -111,6 +111,7 @@
     MACRO(separateCompoundStructDeclarations, 72, none, msl || wgsl)
 
 void filterOptions(ShShaderOutput output, ShCompileOptions& options);
+ShShaderOutput resolveShaderOutput(ShShaderOutput output);
 
 struct GLSLDumpHeader {
     static constexpr int kHeaderSize = 128;


### PR DESCRIPTION
#### 9936a2ec1d4ee86970ba7cff9c3eeb2e6dbb97ee
<pre>
ANGLE: Make translator fuzzer work with old corpus after ShShaderOutput enum changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=282678">https://bugs.webkit.org/show_bug.cgi?id=282678</a>
<a href="https://rdar.apple.com/problem/139339795">rdar://problem/139339795</a>

Reviewed by Tadeu Zagallo.

ShShaderOutput is part of the corpus sample. In WebKit
15a6eb418d125a5f8b7ed2047c41329a3e3456a3 285655@main
the enum values were updated. Map the old values to the new values, so
that old corpus works.

* Source/ThirdParty/ANGLE/WebKit/TranslatorFuzzer.cpp:
(resolveShaderOutput):
(LLVMFuzzerTestOneInput):
* Source/ThirdParty/ANGLE/WebKit/TranslatorFuzzerDumpTestCase.cpp:
* Source/ThirdParty/ANGLE/WebKit/TranslatorFuzzerSupport.h:

Canonical link: <a href="https://commits.webkit.org/286273@main">https://commits.webkit.org/286273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97c0aa703284ab89b999822b4ad8cf6e2e45ddf7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75415 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/77 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79891 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26679 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/77 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2646 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/17396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78482 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/77 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/64795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/39545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/77 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/22287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25007 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/77 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/22624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81373 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2754 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1732 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2905 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/64778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/66716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/10668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11644 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2711 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2736 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3671 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2743 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->