### PR TITLE
[TextureMapper] Fix preserve-3D intersection rendering

### DIFF
--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -6,6 +6,8 @@ list(APPEND WebCore_SOURCES
     platform/graphics/texmap/BitmapTexture.cpp
     platform/graphics/texmap/BitmapTexturePool.cpp
     platform/graphics/texmap/ClipStack.cpp
+    platform/graphics/texmap/FloatPlane3D.cpp
+    platform/graphics/texmap/FloatPolygon3D.cpp
     platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
     platform/graphics/texmap/TextureMapper.cpp
     platform/graphics/texmap/TextureMapperAnimation.cpp
@@ -13,6 +15,7 @@ list(APPEND WebCore_SOURCES
     platform/graphics/texmap/TextureMapperFPSCounter.cpp
     platform/graphics/texmap/TextureMapperGCGLPlatformLayer.cpp
     platform/graphics/texmap/TextureMapperLayer.cpp
+    platform/graphics/texmap/TextureMapperLayer3DRenderingContext.cpp
     platform/graphics/texmap/TextureMapperPlatformLayer.cpp
     platform/graphics/texmap/TextureMapperShaderProgram.cpp
 )
@@ -21,6 +24,8 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/texmap/BitmapTexture.h
     platform/graphics/texmap/BitmapTexturePool.h
     platform/graphics/texmap/ClipStack.h
+    platform/graphics/texmap/FloatPlane3D.h
+    platform/graphics/texmap/FloatPolygon3D.h
     platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
     platform/graphics/texmap/GraphicsLayerContentsDisplayDelegateTextureMapper.h
     platform/graphics/texmap/GraphicsLayerTextureMapper.h
@@ -31,6 +36,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/texmap/TextureMapperFPSCounter.h
     platform/graphics/texmap/TextureMapperGLHeaders.h
     platform/graphics/texmap/TextureMapperLayer.h
+    platform/graphics/texmap/TextureMapperLayer3DRenderingContext.h
     platform/graphics/texmap/TextureMapperPlatformLayer.h
     platform/graphics/texmap/TextureMapperPlatformLayerProxy.h
     platform/graphics/texmap/TextureMapperSolidColorLayer.h

--- a/Source/WebCore/platform/graphics/texmap/FloatPlane3D.cpp
+++ b/Source/WebCore/platform/graphics/texmap/FloatPlane3D.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 Jani Hautakangas <jani@kodegood.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FloatPlane3D.h"
+
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FloatPlane3D);
+
+FloatPlane3D::FloatPlane3D(const FloatPoint3D& normal, const FloatPoint3D& point)
+    : m_normal(normal)
+    , m_distanceConstant(m_normal.dot(point))
+{
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/FloatPlane3D.h
+++ b/Source/WebCore/platform/graphics/texmap/FloatPlane3D.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 Jani Hautakangas <jani@kodegood.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FloatPoint3D.h"
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class FloatPlane3D {
+    WTF_MAKE_TZONE_ALLOCATED(FloatPlane3D);
+public:
+    FloatPlane3D(const FloatPoint3D&, const FloatPoint3D&);
+
+    const FloatPoint3D& normal() const { return m_normal; }
+
+    // Getter for the distance from the origin (plane constant d)
+    float distanceConstant() const { return m_distanceConstant; }
+
+    // Signed distance. The sign of the return value is positive
+    // if the point is on the front side of the plane, negative if the
+    // point is on the back side, and zero if the point is on the plane.
+    float distanceToPoint(const FloatPoint3D& point) const
+    {
+        return m_normal.dot(point) - m_distanceConstant;
+    }
+
+private:
+    FloatPoint3D m_normal;
+    float m_distanceConstant;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/FloatPolygon3D.cpp
+++ b/Source/WebCore/platform/graphics/texmap/FloatPolygon3D.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2024 Jani Hautakangas <jani@kodegood.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FloatPolygon3D.h"
+
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FloatPolygon3D);
+
+FloatPolygon3D::FloatPolygon3D(const FloatRect& rect, const TransformationMatrix& transform)
+{
+    m_vertices.append(transform.mapPoint(FloatPoint3D(rect.minXMinYCorner())));
+    m_vertices.append(transform.mapPoint(FloatPoint3D(rect.maxXMinYCorner())));
+    m_vertices.append(transform.mapPoint(FloatPoint3D(rect.maxXMaxYCorner())));
+    m_vertices.append(transform.mapPoint(FloatPoint3D(rect.minXMaxYCorner())));
+
+    if (auto inverse = transform.inverse())
+        m_normal = inverse->transpose().mapPoint(m_normal);
+    else {
+        FloatPoint3D edge1(m_vertices[1].x() - m_vertices[0].x(), m_vertices[1].y() - m_vertices[0].y(), m_vertices[1].z() - m_vertices[0].z());
+        FloatPoint3D edge2(m_vertices[2].x() - m_vertices[0].x(), m_vertices[2].y() - m_vertices[0].y(), m_vertices[2].z() - m_vertices[0].z());
+        m_normal = edge1.cross(edge2);
+    }
+    m_normal.normalize();
+}
+
+FloatPolygon3D::FloatPolygon3D(Vector<FloatPoint3D>&& vertices, const FloatPoint3D& normal)
+    : m_vertices(WTFMove(vertices))
+    , m_normal(normal)
+{
+}
+
+// Splits the polygon into two parts relative to the given plane.
+// Algorithm:
+// - For each edge of the polygon:
+//   - Compute the signed distances of the edge's vertices from the plane.
+//   - If both vertices are on the same side of the plane, add the starting vertex to the corresponding side's list.
+//   - If the edge crosses the plane, compute the intersection point:
+//     - t = di / (di - dj)
+//     - intersectionPoint = vi + t * (vj - vi)
+//     - Add the starting vertex and the intersection point to the appropriate lists.
+// - Construct two new polygons from the collected vertices.
+std::pair<FloatPolygon3D, FloatPolygon3D> FloatPolygon3D::split(const FloatPlane3D& plane) const
+{
+    Vector<FloatPoint3D> positiveVertices;
+    Vector<FloatPoint3D> negativeVertices;
+
+    const float epsilon = std::numeric_limits<float>::epsilon(); // Tolerance for floating point comparisons
+
+    unsigned numberOfVertices = m_vertices.size();
+    for (unsigned i = 0; i < numberOfVertices; ++i) {
+        const FloatPoint3D& vi = m_vertices[i];
+        const FloatPoint3D& vj = m_vertices[(i + 1) % numberOfVertices];
+        float di = plane.distanceToPoint(vi);
+        float dj = plane.distanceToPoint(vj);
+
+        bool viPos = di > epsilon;
+        bool viNeg = di < -epsilon;
+
+        if (viPos) {
+            positiveVertices.append(vi);
+
+            if (dj < -epsilon) {
+                // Edge crosses from positive to negative
+                float t = di / (di - dj);
+                FloatPoint3D intersectionPoint = vi + (vj - vi) * t;
+                positiveVertices.append(intersectionPoint);
+                negativeVertices.append(intersectionPoint);
+            }
+
+        } else if (viNeg) {
+            negativeVertices.append(vi);
+
+            if (dj > epsilon) {
+                // Edge crosses from negative to positive
+                float t = di / (di - dj);
+                FloatPoint3D intersectionPoint = vi + (vj - vi) * t;
+                negativeVertices.append(intersectionPoint);
+                positiveVertices.append(intersectionPoint);
+            }
+
+        } else { // vi is approximately on the plane
+            positiveVertices.append(vi);
+            negativeVertices.append(vi);
+        }
+    }
+
+    // Create new polygons for each side
+    return { { WTFMove(negativeVertices), m_normal }, { WTFMove(positiveVertices), m_normal } };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/FloatPolygon3D.h
+++ b/Source/WebCore/platform/graphics/texmap/FloatPolygon3D.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 Jani Hautakangas <jani@kodegood.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FloatPlane3D.h"
+#include "FloatPoint3D.h"
+#include "FloatRect.h"
+#include "TransformationMatrix.h"
+#include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+// FloatPolygon3D represents planar polygon in 3D space
+
+class FloatPolygon3D {
+    WTF_MAKE_TZONE_ALLOCATED(FloatPolygon3D);
+public:
+    FloatPolygon3D() = default;
+    FloatPolygon3D(const FloatRect&, const TransformationMatrix&);
+
+    const FloatPoint3D& vertexAt(unsigned index) const { return m_vertices[index]; }
+    unsigned numberOfVertices() const { return m_vertices.size(); }
+
+    const FloatPoint3D& normal() const { return m_normal; }
+
+    std::pair<FloatPolygon3D, FloatPolygon3D> split(const FloatPlane3D&) const;
+
+private:
+    FloatPolygon3D(Vector<FloatPoint3D>&&, const FloatPoint3D&);
+
+    Vector<FloatPoint3D> m_vertices;
+    FloatPoint3D m_normal = { 0, 0, 1 };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -26,6 +26,7 @@
 
 #include "BitmapTexture.h"
 #include "FilterOperations.h"
+#include "FloatPolygon.h"
 #include "FloatQuad.h"
 #include "FloatRoundedRect.h"
 #include "GLContext.h"
@@ -1309,6 +1310,68 @@ void TextureMapper::beginClip(const TransformationMatrix& modelViewMatrix, const
     program->setMatrix(program->projectionMatrixLocation(), data().projectionMatrix);
     program->setMatrix(program->modelViewMatrixLocation(), matrix);
     glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+
+    // Clear the state.
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glDisableVertexAttribArray(program->vertexLocation());
+    glStencilMask(0);
+
+    // Increase stencilIndex and apply stencil testing.
+    clipStack().setStencilIndex(stencilIndex * 2);
+    clipStack().applyIfNeeded();
+}
+
+void TextureMapper::beginClip(const TransformationMatrix& modelViewMatrix, const FloatPolygon& polygon)
+{
+    clipStack().push();
+    data().initializeStencil();
+
+    Ref<TextureMapperShaderProgram> program = data().getShaderProgram(TextureMapperShaderProgram::SolidColor);
+
+    glUseProgram(program->programID());
+    glEnableVertexAttribArray(program->vertexLocation());
+
+    unsigned numberOfVertices = polygon.numberOfVertices();
+    Vector<GLfloat> polygonVertices;
+    polygonVertices.reserveCapacity(numberOfVertices * 2);
+    for (unsigned i = 0; i < numberOfVertices; i++) {
+        auto v = polygon.vertexAt(i);
+        polygonVertices.append(v.x());
+        polygonVertices.append(v.y());
+    }
+
+    int stencilIndex = clipStack().getStencilIndex();
+
+    glEnable(GL_STENCIL_TEST);
+
+    // Make sure we don't do any actual drawing.
+    glStencilFunc(GL_NEVER, stencilIndex, stencilIndex);
+
+    // Operate only on the stencilIndex and above.
+    glStencilMask(0xff & ~(stencilIndex - 1));
+
+    // First clear the entire buffer at the current index.
+    static const TransformationMatrix fullProjectionMatrix = TransformationMatrix::rectToRect(FloatRect(0, 0, 1, 1), FloatRect(-1, -1, 2, 2));
+    const GLfloat unitRect[] = { 0, 0, 1, 0, 1, 1, 0, 1 };
+    GLuint vbo = data().getStaticVBO(GL_ARRAY_BUFFER, sizeof(GLfloat) * 8, unitRect);
+    glBindBuffer(GL_ARRAY_BUFFER, vbo);
+    glVertexAttribPointer(program->vertexLocation(), 2, GL_FLOAT, false, 0, 0);
+    program->setMatrix(program->projectionMatrixLocation(), fullProjectionMatrix);
+    program->setMatrix(program->modelViewMatrixLocation(), TransformationMatrix());
+    glStencilOp(GL_ZERO, GL_ZERO, GL_ZERO);
+    glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+
+    // Now apply the current index to the new polygon.
+    GLuint polygonVBO;
+    glGenBuffers(1, &polygonVBO);
+    glBindBuffer(GL_ARRAY_BUFFER, polygonVBO);
+    glBufferData(GL_ARRAY_BUFFER, polygonVertices.size() * sizeof(GLfloat), polygonVertices.data(), GL_STATIC_DRAW);
+    glVertexAttribPointer(program->vertexLocation(), 2, GL_FLOAT, false, 0, 0);
+    glStencilOp(GL_REPLACE, GL_REPLACE, GL_REPLACE);
+    program->setMatrix(program->projectionMatrixLocation(), data().projectionMatrix);
+    program->setMatrix(program->modelViewMatrixLocation(), modelViewMatrix);
+    glDrawArrays(GL_TRIANGLE_FAN, 0, polygonVertices.size() / 2);
+    glDeleteBuffers(1, &polygonVBO);
 
     // Clear the state.
     glBindBuffer(GL_ARRAY_BUFFER, 0);

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -42,6 +42,7 @@ namespace WebCore {
 class TextureMapperGLData;
 class TextureMapperShaderProgram;
 class FilterOperations;
+class FloatPolygon;
 class FloatRoundedRect;
 enum class TextureMapperFlags : uint16_t;
 
@@ -77,6 +78,7 @@ public:
     void bindSurface(BitmapTexture* surface);
     BitmapTexture* currentSurface();
     void beginClip(const TransformationMatrix&, const FloatRoundedRect&);
+    void beginClip(const TransformationMatrix&, const FloatPolygon&);
     WEBCORE_EXPORT void beginPainting(FlipY = FlipY::No, BitmapTexture* = nullptr);
     WEBCORE_EXPORT void endPainting();
     void endClip();

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -82,6 +82,7 @@ public:
     FloatSize size() const { return m_state.size; }
     float opacity() const { return m_state.opacity; }
     TransformationMatrix transform() const { return m_state.transform; }
+    const TransformationMatrix& toSurfaceTransform() const { return m_layerTransforms.combined; }
     WEBCORE_EXPORT void setContentsVisible(bool);
     WEBCORE_EXPORT void setContentsOpaque(bool);
     WEBCORE_EXPORT void setBackfaceVisibility(bool);
@@ -129,6 +130,8 @@ public:
     ALWAYS_INLINE void addDamage(const Damage&);
     ALWAYS_INLINE void addDamage(const FloatRect&);
 
+    FloatRect effectiveLayerRect() const;
+
 private:
     TextureMapperLayer& rootLayer() const
     {
@@ -150,13 +153,9 @@ private:
     struct ComputeTransformData;
     void computeTransformsRecursive(ComputeTransformData&);
 
-    static void sortByZOrder(Vector<TextureMapperLayer* >& array);
-
     TransformationMatrix replicaTransform();
     void removeFromParent();
     void removeAllChildren();
-
-    void paintPreserves3DHolePunch(TextureMapperPlatformLayer*, const TransformationMatrix&, TextureMapperPaintOptions&);
 
     enum class ComputeOverlapRegionMode : uint8_t {
         Intersection,
@@ -186,6 +185,7 @@ private:
     void paintBackdrop(TextureMapperPaintOptions&);
     void applyMask(TextureMapperPaintOptions&);
     void recordDamage(const FloatRect&, const TransformationMatrix&, const TextureMapperPaintOptions&);
+    void collect3DSceneLayers(Vector<TextureMapperLayer*>&);
 
     bool isVisible() const;
 
@@ -209,7 +209,6 @@ private:
     std::unique_ptr<TextureMapperFlattenedLayer> m_flattenedLayer;
     float m_currentOpacity { 1.0 };
     FilterOperations m_currentFilters;
-    float m_centerZ { 0 };
 
     struct State {
         FloatPoint pos;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer3DRenderingContext.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer3DRenderingContext.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2024 Jani Hautakangas <jani@kodegood.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TextureMapperLayer3DRenderingContext.h"
+
+#include "TextureMapperLayer.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextureMapperLayer3DRenderingContext);
+
+void TextureMapperLayer3DRenderingContext::paint(const Vector<TextureMapperLayer*>& layers, const std::function<void(TextureMapperLayer*, const FloatPolygon&)>& paintLayerFunction)
+{
+    if (layers.isEmpty())
+        return;
+
+    Deque<TextureMapperLayerPolygon> layerList;
+    for (auto* layer : layers)
+        layerList.append({ { layer->effectiveLayerRect(), layer->toSurfaceTransform() }, layer, false });
+
+    auto root = makeUnique<TextureMapperLayerNode>(layerList.takeFirst());
+    buildTree(*root, layerList);
+    traverseTreeAndPaint(*root, paintLayerFunction);
+}
+
+// Build BSP tree for rendering polygons with painter's algorithm.
+// For more information:
+// https://en.wikipedia.org/wiki/Binary_space_partitioning
+void TextureMapperLayer3DRenderingContext::buildTree(TextureMapperLayerNode& root, Deque<TextureMapperLayerPolygon>& polygons)
+{
+    if (polygons.isEmpty())
+        return;
+
+    auto& rootGeometry = root.firstPolygon().geometry;
+    FloatPlane3D rootPlane(rootGeometry.normal(), rootGeometry.vertexAt(0));
+
+    Deque<TextureMapperLayerPolygon> backList, frontList;
+    for (auto& polygon : polygons) {
+        switch (classifyPolygon(polygon, rootPlane)) {
+        case PolygonPosition::InFront:
+            frontList.append(WTFMove(polygon));
+            break;
+        case PolygonPosition::Behind:
+            backList.append(WTFMove(polygon));
+            break;
+        case PolygonPosition::Coplanar:
+            root.polygons.append(WTFMove(polygon));
+            break;
+        case PolygonPosition::Intersecting:
+            auto [backGeometry, frontGeometry] = polygon.geometry.split(rootPlane);
+            if (backGeometry.numberOfVertices() > 2)
+                backList.append({ backGeometry, polygon.layer, true });
+            if (frontGeometry.numberOfVertices() > 2)
+                frontList.append({ frontGeometry, polygon.layer, true });
+            break;
+        }
+    }
+
+    if (!frontList.isEmpty()) {
+        root.frontNode = makeUnique<TextureMapperLayerNode>(frontList.takeFirst());
+        buildTree(*root.frontNode, frontList);
+    }
+
+    if (!backList.isEmpty()) {
+        root.backNode = makeUnique<TextureMapperLayerNode>(backList.takeFirst());
+        buildTree(*root.backNode, backList);
+    }
+}
+
+void TextureMapperLayer3DRenderingContext::traverseTreeAndPaint(TextureMapperLayerNode& node, const std::function<void(TextureMapperLayer*, const FloatPolygon&)>& paintLayerFunction)
+{
+    auto& geometry = node.firstPolygon().geometry;
+    FloatPlane3D plane(geometry.normal(), geometry.vertexAt(0));
+
+    auto* frontNode = node.frontNode.get();
+    auto* backNode = node.backNode.get();
+
+    // if polygon is facing away from camera then swap nodes to reverse
+    // the traversal order
+    if (plane.normal().z() < 0)
+        std::swap(frontNode, backNode);
+
+    if (backNode)
+        traverseTreeAndPaint(*backNode, paintLayerFunction);
+
+    for (auto& polygon : node.polygons)
+        paintLayerFunction(polygon.layer, polygon.layerClipArea());
+
+    if (frontNode)
+        traverseTreeAndPaint(*frontNode, paintLayerFunction);
+}
+
+TextureMapperLayer3DRenderingContext::PolygonPosition TextureMapperLayer3DRenderingContext::classifyPolygon(const TextureMapperLayerPolygon& polygon, const FloatPlane3D& plane)
+{
+    const float epsilon = 0.05f; // Tolerance for intersection check
+
+    int inFrontCount = 0;
+    int behindCount = 0;
+    for (unsigned i = 0; i < polygon.geometry.numberOfVertices(); i++) {
+        const auto& vertex = polygon.geometry.vertexAt(i);
+        float distance = plane.distanceToPoint(vertex);
+
+        if (distance > epsilon)
+            inFrontCount++;
+        else if (distance < -epsilon)
+            behindCount++;
+    }
+
+    if (inFrontCount > 0 && behindCount > 0)
+        return PolygonPosition::Intersecting;
+    if (inFrontCount > 0)
+        return PolygonPosition::InFront;
+    if (behindCount > 0)
+        return PolygonPosition::Behind;
+    return PolygonPosition::Coplanar;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer3DRenderingContext.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer3DRenderingContext.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2024 Jani Hautakangas <jani@kodegood.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FloatPlane3D.h"
+#include "FloatPolygon.h"
+#include "FloatPolygon3D.h"
+#include "TextureMapperLayer.h"
+#include <wtf/Deque.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class TextureMapperLayer;
+
+class TextureMapperLayer3DRenderingContext final {
+    WTF_MAKE_TZONE_ALLOCATED(TextureMapperLayerPreserves3DContext);
+public:
+    void paint(const Vector<TextureMapperLayer*>&, const std::function<void(TextureMapperLayer*, const FloatPolygon&)>&);
+
+private:
+    enum class PolygonPosition {
+        InFront,
+        Behind,
+        Coplanar,
+        Intersecting
+    };
+
+    struct TextureMapperLayerPolygon final {
+        FloatPolygon layerClipArea() const
+        {
+            unsigned numVertices = geometry.numberOfVertices();
+            Vector<FloatPoint> vertices;
+            vertices.reserveCapacity(numVertices);
+            auto toLayerTransform = layer->toSurfaceTransform().inverse();
+            if (isSplitted && toLayerTransform) {
+                for (unsigned i = 0; i < numVertices; i++) {
+                    auto v = toLayerTransform->mapPoint(geometry.vertexAt(i));
+                    vertices.append(FloatPoint(v.x(), v.y()));
+                }
+            }
+
+            return { WTFMove(vertices), WindRule::NonZero };
+        }
+
+        FloatPolygon3D geometry;
+        TextureMapperLayer* layer = { nullptr };
+        bool isSplitted = { false };
+    };
+
+    struct TextureMapperLayerNode final {
+        WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
+        explicit TextureMapperLayerNode(TextureMapperLayerPolygon&& polygon)
+        {
+            polygons.append(WTFMove(polygon));
+        }
+
+        const TextureMapperLayerPolygon& firstPolygon() const  { return polygons[0]; }
+
+        Vector<TextureMapperLayerPolygon> polygons;
+        std::unique_ptr<TextureMapperLayerNode> frontNode;
+        std::unique_ptr<TextureMapperLayerNode> backNode;
+    };
+
+    void buildTree(TextureMapperLayerNode&, Deque<TextureMapperLayerPolygon>&);
+    void traverseTreeAndPaint(TextureMapperLayerNode&, const std::function<void(TextureMapperLayer*, const FloatPolygon&)>&);
+    static PolygonPosition classifyPolygon(const TextureMapperLayerPolygon&, const FloatPlane3D&);
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
@@ -1930,6 +1930,13 @@ bool TransformationMatrix::isBackFaceVisible() const
     return zComponentOfTransformedNormal < 0;
 }
 
+TransformationMatrix TransformationMatrix::transpose() const
+{
+    TransformationMatrix transpose;
+    transposeMatrix4(m_matrix, transpose.m_matrix);
+    return transpose;
+}
+
 TextStream& operator<<(TextStream& ts, const TransformationMatrix& transform)
 {
     TextStream::IndentScope indentScope(ts);

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
@@ -440,6 +440,8 @@ public:
     // face would be visible to a camera looking along the negative z-axis in the target space.
     bool isBackFaceVisible() const;
 
+    TransformationMatrix transpose() const;
+
 private:
     // multiply passed 2D point by matrix (assume z=0)
     void multVecMatrix(double x, double y, double& dstX, double& dstY) const;


### PR DESCRIPTION
#### d40d59e4e5506747ab095ac2c3b337679e38265e
<pre>
[TextureMapper] Fix preserve-3D intersection rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=282682">https://bugs.webkit.org/show_bug.cgi?id=282682</a>

Reviewed by Fujii Hironori.

Preserve-3d does not correctly render intersections, and also applying
filters in a 3D scene can break the rendering order. This patch addresses
these issues by implementing the composition and painting logic from the
CSS Transforms Module Level 2.

In a 3D rendering context, rendering and sorting of elements is done as
follows:

1. The element establishing the 3D rendering context, and each other 3D
transformed element participating in the 3D rendering context, is rendered
into its own plane. This plane includes the element’s backgrounds, borders,
other box decorations, content, and descendant elements, excluding any
descendant elements that have their own plane (and their descendants).
This rendering is done according to CSS 2.1,Appendix E, Section E.2 Painting Order.

2. Intersection is performed between this set of planes, according to
Newell’s algorithm, with the planes transformed by the accumulated 3D
transformation matrix. Coplanar 3D transformed elements are rendered in
painting order.

* Source/WebCore/platform/TextureMapper.cmake:
* Source/WebCore/platform/graphics/texmap/FloatPlane3D.cpp: Added.
(WebCore::FloatPlane3D::FloatPlane3D):
* Source/WebCore/platform/graphics/texmap/FloatPlane3D.h: Added.
(WebCore::FloatPlane3D::normal const):
(WebCore::FloatPlane3D::distanceConstant const):
(WebCore::FloatPlane3D::distanceToPoint const):
* Source/WebCore/platform/graphics/texmap/FloatPolygon3D.cpp: Added.
(WebCore::FloatPolygon3D::FloatPolygon3D):
(WebCore::FloatPolygon3D::split const):
* Source/WebCore/platform/graphics/texmap/FloatPolygon3D.h: Added.
(WebCore::FloatPolygon3D::vertexAt const):
(WebCore::FloatPolygon3D::numberOfVertices const):
(WebCore::FloatPolygon3D::normal const):
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapper::beginClip):
* Source/WebCore/platform/graphics/texmap/TextureMapper.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::computeTransformsRecursive):
(WebCore::TextureMapperLayer::paintSelf):
(WebCore::TextureMapperLayer::paintWith3DRenderingContext):
(WebCore::TextureMapperLayer::collect3DSceneLayers):
(WebCore::TextureMapperLayer::effectiveLayerRect const):
(WebCore::TextureMapperLayer::paintPreserves3DHolePunch): Deleted.
(WebCore::TextureMapperLayer::sortByZOrder): Deleted.
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
(WebCore::TextureMapperLayer::toSurfaceTransform const):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer3DRenderingContext.cpp: Added.
(WebCore::TextureMapperLayer3DRenderingContext::paint):
(WebCore::TextureMapperLayer3DRenderingContext::buildTree):
(WebCore::TextureMapperLayer3DRenderingContext::traverseTreeAndPaint):
(WebCore::TextureMapperLayer3DRenderingContext::classifyPolygon):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer3DRenderingContext.h: Added.
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp:
(WebCore::TransformationMatrix::transpose const):
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.h:

Canonical link: <a href="https://commits.webkit.org/286605@main">https://commits.webkit.org/286605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fd2120e5b2cd16166a771365861101e940eed78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80949 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27610 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78454 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59921 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17982 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40250 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47156 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23045 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25932 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68283 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23379 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82305 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2439 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68087 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3864 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65530 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67395 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11354 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9456 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11834 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3658 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6465 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3681 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7110 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5439 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->