### PR TITLE
ARMv7: don't generate invalid Index Air args

### DIFF
--- a/Source/JavaScriptCore/b3/B3MemoryValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3MemoryValueInlines.h
@@ -28,6 +28,7 @@
 #if ENABLE(B3_JIT)
 
 #include "AirArg.h"
+#include "AirHelpers.h"
 #include "AirOpcode.h"
 #include "B3AtomicValue.h"
 
@@ -43,7 +44,7 @@ inline bool MemoryValue::isLegalOffsetImpl(int32_t offset) const
 
     // The opcode is only used on ARM and Air::Move is appropriate for
     // loads/stores.
-    return Air::Arg::isValidAddrForm(Air::Move, offset, accessWidth());
+    return Air::Arg::isValidAddrForm(Air::moveForType(accessType()), offset, accessWidth());
 }
 
 inline bool MemoryValue::requiresSimpleAddr() const

--- a/Source/JavaScriptCore/b3/testb3_failingArmV7Tests.inc
+++ b/Source/JavaScriptCore/b3/testb3_failingArmV7Tests.inc
@@ -52,8 +52,6 @@
 "testLateRegister",
 "testLICM",
 "testLoadPreIndex32WithStore",
-"testMoveConstants",
-"testMoveConstantsWithLargeOffsets",
 "testPinRegisters",
 "testReduceFloatToDoubleValidates",
 "testSimplePatchpoint",


### PR DESCRIPTION
#### f7cebf1b0a52b3de4b43f168bac8d1ceb98f59b6
<pre>
ARMv7: don&apos;t generate invalid Index Air args
<a href="https://bugs.webkit.org/show_bug.cgi?id=282685">https://bugs.webkit.org/show_bug.cgi?id=282685</a>

Reviewed by Justin Michaud.

Not all indexes are valid for floats. Make sure we check that the Air
form is valid and use a fallback if not.

While looking at this, update MemoryValue::isLegalOffsetImpl to pass the
appropriate move type to isValidAddrForm, as, again, floats have
different constraints on ARMv7.

Enable a couple of tests that now pass.

* Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp:
* Source/JavaScriptCore/b3/B3MemoryValueInlines.h:
(JSC::B3::MemoryValue::isLegalOffsetImpl const):
* Source/JavaScriptCore/b3/testb3_failingArmV7Tests.inc:

Canonical link: <a href="https://commits.webkit.org/286298@main">https://commits.webkit.org/286298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44e9a76ee60378ed855164e15f58f7816eaad17b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28071 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79692 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26487 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63810 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2455 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59043 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17285 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49219 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39418 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46597 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22120 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24814 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68378 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22460 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81177 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74494 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2561 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1583 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67294 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2711 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64624 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66584 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/16634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10528 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8690 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96762 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2522 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21139 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2547 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3476 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2556 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->