### PR TITLE
WebKit Bugzilla patch review action redirects non-patches infinitely

### DIFF
--- a/Websites/bugs.webkit.org/template/en/default/email/flagmail.txt.tmpl
+++ b/Websites/bugs.webkit.org/template/en/default/email/flagmail.txt.tmpl
@@ -62,7 +62,7 @@ X-Bugzilla-Type: request
 Attachment [% attidsummary %]
 [%- END %]
 [%# if WEBKIT_CHANGES #%]
-[%+ urlbase %]attachment.cgi?id=[% attachment.id %]&action=review
+[%+ urlbase %]attachment.cgi?id=[% attachment.id %]
 [%# endif // WEBKIT_CHANGES #%]
 [%- END %]
 


### PR DESCRIPTION
#### 26082efe5dfda9f8dc68790b31110f6b0d3aeec3
<pre>
WebKit Bugzilla patch review action redirects non-patches infinitely
<a href="https://bugs.webkit.org/show_bug.cgi?id=254336">https://bugs.webkit.org/show_bug.cgi?id=254336</a>

Reviewed by Alexey Proskuryakov.

Since not many people use Bugzilla for patch reviews anymore, let&apos;s just
remove the review link from our emails. It&apos;s broken for every attachment
that is not a patch, which is almost everything nowadays. Probably not
worth trying to figure out how to insert it conditionally.

* Websites/bugs.webkit.org/template/en/default/email/flagmail.txt.tmpl:

Canonical link: <a href="https://commits.webkit.org/286257@main">https://commits.webkit.org/286257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0446cb84e79cb628779f7348b19c0ceb01b9a393

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28145 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79767 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26570 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2529 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17340 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64701 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39472 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46688 "") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24897 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67694 "") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81252 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2635 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1662 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67361 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2786 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66636 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16589 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10585 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8757 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2596 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2621 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3551 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2630 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->