### PR TITLE
[resultsdbpy] Fix _find() method in commit_controller.py return amount to abide by the limit amount passed.

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/commit_controller.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/commit_controller.py
@@ -197,7 +197,7 @@ class CommitController(HasCommitContext):
                         results_for_repo += self.commit_context.find_commits_in_range(repository, b, limit=limit - len(results_for_repo), begin=begin, end=end)
                 result += results_for_repo
 
-            return sorted(result)
+            return sorted(result)[:limit]
 
     def find(self):
         AssertRequest.is_type()

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/commit_controller_unittest.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/commit_controller_unittest.py
@@ -235,6 +235,26 @@ class CommitControllerTest(FlaskTestCase, WaitForDockerTestCase):
 
     @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
     @FlaskTestCase.run_with_webserver()
+    def test_find_limit(self, client, **kwargs):
+        self.register_all_commits(client)
+
+        response = client.get(self.URL + '/api/commits/find')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(9, len(response.json()))
+        self.assertEqual(len([Commit.from_json(element) for element in response.json()]), 9)
+
+        response = client.get(self.URL + '/api/commits/find?limit=1')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(1, len(response.json()))
+        self.assertEqual(len([Commit.from_json(element) for element in response.json()]), 1)
+
+        response = client.get(self.URL + '/api/commits/find?limit=5')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(5, len(response.json()))
+        self.assertEqual(len([Commit.from_json(element) for element in response.json()]), 5)
+
+    @WaitForDockerTestCase.mock_if_no_docker(mock_redis=FakeStrictRedis, mock_cassandra=MockCassandraContext)
+    @FlaskTestCase.run_with_webserver()
     def test_next(self, client, **kwargs):
         self.register_all_commits(client)
         response = client.get(self.URL + '/api/commits/next?id=bae5d1e90999')


### PR DESCRIPTION
#### 5c7c628760aa502bbd72bae85f06142f404d36fd
<pre>
[resultsdbpy] Fix _find() method in commit_controller.py return amount to abide by the limit amount passed.
<a href="https://bugs.webkit.org/show_bug.cgi?id=282625">https://bugs.webkit.org/show_bug.cgi?id=282625</a>
<a href="https://rdar.apple.com/139298383">rdar://139298383</a>

Reviewed by NOBODY (OOPS!).

When invoking _find() method in commit_controller.py with an explicit limit argument it returns the
(limit*amount_of_repositories) amount. Slice the list outside the sorted() method by the limit amount specified.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/commit_controller.py:
(CommitController._find):
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/commit_controller_unittest.py:
(CommitControllerTest):
(CommitControllerTest.test_find_limit):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c7c628760aa502bbd72bae85f06142f404d36fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79735 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26529 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77390 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2497 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59074 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17316 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39450 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/74781 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46650 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22165 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24857 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67673 "") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81219 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67321 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/74951 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2754 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66613 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10572 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8725 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2564 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2589 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3519 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2598 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->