### PR TITLE
Support uploading results from compare-static-analysis-results when comparing two runs instead of expectations

### DIFF
--- a/Tools/Scripts/compare-static-analysis-results
+++ b/Tools/Scripts/compare-static-analysis-results
@@ -120,7 +120,7 @@ def create_filtered_results_dir(args, project, result_paths, category='StaticAna
     subprocess.run([args.scan_build, '--generate-index-only', os.path.abspath(path_to_project)])
 
 
-def compare_project_results_to_expectations(args, new_path, project):
+def compare_project_results_to_expectations(args, new_path, project, upload_only=False):
     unexpected_issues_total = set()
     unexpected_result_paths_total = set()
     unexpected_buggy_files = set()
@@ -148,26 +148,27 @@ def compare_project_results_to_expectations(args, new_path, project):
         unexpected_result_paths_total.update(unexpected_result_paths)
         unexpected_issues_total.update(unexpected_issues)
 
-        # Set up JSON object
-        project_results_passes[checker] = list(clean_files)
-        project_results_failures[checker] = list(buggy_files)
+        if not upload_only:
+            # Set up JSON object
+            project_results_passes[checker] = list(clean_files)
+            project_results_failures[checker] = list(buggy_files)
 
-        # Create sorted files for each unexpected list - these need the .txt to be displayed in browser
-        subprocess.run(['mkdir', '-p', f'{args.build_output}/{STATIC_ANALYZER_UNEXPECTED}/{project}'])
-        with open(f'{args.build_output}/{STATIC_ANALYZER_UNEXPECTED}/{project}/UnexpectedPasses{checker}.txt', 'a') as f:
-            f.write('\n'.join(sorted(clean_files)))
-        with open(f'{args.build_output}/{STATIC_ANALYZER_UNEXPECTED}/{project}/UnexpectedFailures{checker}.txt', 'a') as f:
-            f.write('\n'.join(sorted(buggy_files)))
-        with open(f'{new_path}/{project}/UnexpectedIssues{checker}', 'a') as f:
-            f.write('\n'.join(unexpected_issues))
+            # Create sorted files for each unexpected list - these need the .txt to be displayed in browser
+            subprocess.run(['mkdir', '-p', f'{args.build_output}/{STATIC_ANALYZER_UNEXPECTED}/{project}'])
+            with open(f'{args.build_output}/{STATIC_ANALYZER_UNEXPECTED}/{project}/UnexpectedPasses{checker}.txt', 'a') as f:
+                f.write('\n'.join(sorted(clean_files)))
+            with open(f'{args.build_output}/{STATIC_ANALYZER_UNEXPECTED}/{project}/UnexpectedFailures{checker}.txt', 'a') as f:
+                f.write('\n'.join(sorted(buggy_files)))
+            with open(f'{new_path}/{project}/UnexpectedIssues{checker}', 'a') as f:
+                f.write('\n'.join(unexpected_issues))
 
-        print(f'\n{checker}:')
-        if clean_files or buggy_files or unexpected_issues:
-            print(f'    Unexpected passing files: {len(clean_files)}')
-            print(f'    Unexpected failing files: {len(buggy_files)}')
-            print(f'    Unexpected issues: {len(unexpected_issues)}')
-        else:
-            print('    No unexpected results')
+            print(f'\n{checker}:')
+            if clean_files or buggy_files or unexpected_issues:
+                print(f'    Unexpected passing files: {len(clean_files)}')
+                print(f'    Unexpected failing files: {len(buggy_files)}')
+                print(f'    Unexpected issues: {len(unexpected_issues)}')
+            else:
+                print('    No unexpected results')
 
         for file in current_results:
             if not file in project_results_for_upload.keys():
@@ -181,10 +182,10 @@ def compare_project_results_to_expectations(args, new_path, project):
                 project_results_for_upload[file] = {}
             project_results_for_upload[file][checker] = UNEXPECTED_PASS
 
-    if unexpected_issues_total and args.scan_build:
+    if unexpected_issues_total and args.scan_build and not upload_only:
         create_filtered_results_dir(args, project, unexpected_result_paths_total, STATIC_ANALYZER_UNEXPECTED)
 
-    if not unexpected_buggy_files and not unexpected_clean_files and not unexpected_issues_total:
+    if not unexpected_buggy_files and not unexpected_clean_files and not unexpected_issues_total and not upload_only:
         print('No unexpected results!')
 
     return unexpected_buggy_files, unexpected_clean_files, unexpected_issues_total, project_results_passes, project_results_failures, project_results_for_upload
@@ -288,6 +289,7 @@ def main():
     results_for_upload = {}
 
     for project in PROJECTS:
+        project_results_for_upload = None
         print(f'\n------ {project} ------')
         new_path = os.path.abspath(f'{args.new_dir}')
         if args.check_expectations:
@@ -306,6 +308,9 @@ def main():
         unexpected_results_data['passes'][project] = project_results_passes
         unexpected_results_data['failures'][project] = project_results_failures
         if args.report_urls:
+            if not project_results_for_upload:
+                print(f'\nChecking against expectations for results to upload for {project}...')
+                _, _, _, _, _, project_results_for_upload = compare_project_results_to_expectations(args, new_path, project, upload_only=True)
             results_for_upload[project] = project_results_for_upload
 
     if args.build_output:


### PR DESCRIPTION
#### 621a052ef95767ae7dbc57ee33e8a59b286a11da
<pre>
Support uploading results from compare-static-analysis-results when comparing two runs instead of expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=282701">https://bugs.webkit.org/show_bug.cgi?id=282701</a>
<a href="https://rdar.apple.com/139370284">rdar://139370284</a>

Reviewed by Jonathan Bedard.

Previously, running this script with --archived-dir and --report would fail.
This commit adds support for uploading the current run to results db by using the existing logic
for checking against expectations.

* Tools/Scripts/compare-static-analysis-results:
(create_filtered_results_dir):
(compare_project_results_to_expectations): Add upload_only argument and filter logging.
(main): If there&apos;s a report url then we should populate project_results_for_upload.

Canonical link: <a href="https://commits.webkit.org/286234@main">https://commits.webkit.org/286234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20480d1671dec1bff50272fd62fa8a74d0bf3e97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79741 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/26535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2503 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/26535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78346 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/49263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/64668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/39456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/46658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/22163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24863 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/22502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81225 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/2609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/2760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/64666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/66623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11619 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/2570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/2595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/3525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/2604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->