### PR TITLE
CORS-preflight cache is not partitioned by top-level site

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cors/preflight-cache-partitioning.sub.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/preflight-cache-partitioning.sub.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS The preflight cache should be partitioned
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/preflight-cache-partitioning.sub.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/preflight-cache-partitioning.sub.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/preflight-cache-partitioning.sub.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/preflight-cache-partitioning.sub.window.js
@@ -1,0 +1,42 @@
+// META: script=/common/utils.js
+
+const TEST_PAGE =
+  "http://{{host}}:{{ports[http][0]}}/cors/resources/preflight-cache-partitioning.sub.html";
+const TEST_ANOTHER_PAGE =
+  "http://{{hosts[alt][]}}:{{ports[http][0]}}/cors/resources/preflight-cache-partitioning.sub.html";
+
+promise_test(async t => {
+  let uuid_token = token();
+
+  const TEST_PAGES = [TEST_PAGE, TEST_ANOTHER_PAGE];
+
+  // We will load the same page with different top-level origins to check if the
+  // CORS preflight cache is partitioned. The page will load the iframe with one
+  // origin and trigger the CORS preflight through fetching a cross-origin
+  // resources in the iframe.
+
+  for (let test_page of TEST_PAGES) {
+    let win;
+
+    await new Promise(resolve => {
+      window.onmessage = (e) => {
+        if (e.data.type === "loaded") {
+          resolve();
+        }
+      };
+
+      win = window.open(test_page);
+    });
+
+    await new Promise(resolve => {
+      win.postMessage({ type: "run", token: uuid_token }, "*");
+
+      window.onmessage = (e) => {
+        assert_equals(e.data.type, "pass", e.data.msg);
+        resolve();
+      };
+    });
+
+    win.close();
+  }
+}, "The preflight cache should be partitioned");

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/resources/preflight-cache-partitioning-iframe.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/resources/preflight-cache-partitioning-iframe.sub.html
@@ -1,0 +1,27 @@
+<script>
+window.onmessage = async (e) => {
+  if (e.data.type === "run") {
+    let token = e.data.token;
+    const test_url =
+      `http://{{hosts[alt][]}}:{{ports[http][0]}}/cors/resources/preflight-partitioning.py?token=${token}`;
+
+    let response = await fetch(
+      new Request(test_url, {
+        mode: "cors",
+        method: "GET",
+        headers: [["x-print", token]],
+      })
+    );
+
+    let result = await response.text();
+
+    if (result === "1") {
+      parent.postMessage({ type: "pass", msg: "The CORS preflight was sent" }, "*");
+    } else {
+      parent.postMessage({ type: "fail", msg: "The CORS preflight wasn't sent" }, "*");
+    }
+  }
+};
+
+parent.postMessage({ type: "loaded" }, "*");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/resources/preflight-cache-partitioning.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/resources/preflight-cache-partitioning.sub.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Helper page for testing preflight cache partitioning</title>
+<iframe id="iframe" src="http://{{host}}:{{ports[http][0]}}/cors/resources/preflight-cache-partitioning-iframe.sub.html"></iframe>
+<script>
+window.onmessage = (e) => {
+  switch (e.data.type || "") {
+    case "pass":
+    case "fail":
+    case "loaded":
+      opener.postMessage(e.data, "*");
+      break;
+    default:
+      let iframe = document.getElementById("iframe");
+      iframe.contentWindow.postMessage(e.data, "*");
+      break;
+  }
+};
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/resources/preflight-partitioning.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/resources/preflight-partitioning.py
@@ -1,0 +1,35 @@
+def main(request, response):
+    headers = [(b"Content-Type", b"text/plain")]
+    headers.append((b"Access-Control-Allow-Origin", b"*"))
+
+    if request.method == u"GET":
+        token = request.GET.first(b"token")
+        value = request.server.stash.take(token)
+        if value == None:
+            body = u"0"
+        else:
+            if request.GET.first(b"check", None) == b"keep":
+                request.server.stash.put(token, value)
+            body = u"1"
+
+        return headers, body
+
+    if request.method == u"OPTIONS":
+        if not b"Access-Control-Request-Method" in request.headers:
+            response.set_error(400, u"No Access-Control-Request-Method header")
+            return u"ERROR: No access-control-request-method in preflight!"
+
+        headers.append((b"Access-Control-Allow-Methods",
+                        request.headers[b'Access-Control-Request-Method']))
+
+        if b"max_age" in request.GET:
+            headers.append((b"Access-Control-Max-Age", request.GET[b'max_age']))
+
+        if b"token" in request.GET:
+            request.server.stash.put(request.GET.first(b"token"), 1)
+
+    headers.append((b"Access-Control-Allow-Headers", b"x-print"))
+
+    body = request.headers.get(b"x-print", b"NO")
+
+    return headers, body

--- a/Source/WebCore/loader/CrossOriginAccessControl.cpp
+++ b/Source/WebCore/loader/CrossOriginAccessControl.cpp
@@ -293,7 +293,7 @@ Expected<void, String> passesAccessControlCheck(const ResourceResponse& response
     return { };
 }
 
-Expected<void, String> validatePreflightResponse(PAL::SessionID sessionID, const ResourceRequest& request, const ResourceResponse& response, StoredCredentialsPolicy storedCredentialsPolicy, const SecurityOrigin& securityOrigin, const CrossOriginAccessControlCheckDisabler* checkDisabler)
+Expected<void, String> validatePreflightResponse(PAL::SessionID sessionID, const ResourceRequest& request, const ResourceResponse& response, StoredCredentialsPolicy storedCredentialsPolicy, const SecurityOrigin& topOrigin, const SecurityOrigin& securityOrigin, const CrossOriginAccessControlCheckDisabler* checkDisabler)
 {
     if (!response.isSuccessful())
         return makeUnexpected(makeString("Preflight response is not successful. Status code: "_s, response.httpStatusCode()));
@@ -308,7 +308,7 @@ Expected<void, String> validatePreflightResponse(PAL::SessionID sessionID, const
 
     auto entry = WTFMove(result.value());
     auto errorDescription = entry->validateMethodAndHeaders(request.httpMethod(), request.httpHeaderFields());
-    CrossOriginPreflightResultCache::singleton().appendEntry(sessionID, securityOrigin.toString(), request.url(), entry.moveToUniquePtr());
+    CrossOriginPreflightResultCache::singleton().appendEntry(sessionID, { topOrigin.data(), securityOrigin.data(), }, request.url(), entry.moveToUniquePtr());
 
     if (errorDescription)
         return makeUnexpected(WTFMove(*errorDescription));

--- a/Source/WebCore/loader/CrossOriginAccessControl.h
+++ b/Source/WebCore/loader/CrossOriginAccessControl.h
@@ -88,7 +88,7 @@ private:
 };
 
 WEBCORE_EXPORT Expected<void, String> passesAccessControlCheck(const ResourceResponse&, StoredCredentialsPolicy, const SecurityOrigin&, const CrossOriginAccessControlCheckDisabler*);
-WEBCORE_EXPORT Expected<void, String> validatePreflightResponse(PAL::SessionID, const ResourceRequest&, const ResourceResponse&, StoredCredentialsPolicy, const SecurityOrigin&, const CrossOriginAccessControlCheckDisabler*);
+WEBCORE_EXPORT Expected<void, String> validatePreflightResponse(PAL::SessionID, const ResourceRequest&, const ResourceResponse&, StoredCredentialsPolicy, const SecurityOrigin& topOrigin, const SecurityOrigin& securityOrigin, const CrossOriginAccessControlCheckDisabler*);
 
 enum class ForNavigation : bool { No, Yes };
 WEBCORE_EXPORT std::optional<ResourceError> validateCrossOriginResourcePolicy(CrossOriginEmbedderPolicyValue, const SecurityOrigin&, const URL&, const ResourceResponse&, ForNavigation, const OriginAccessPatterns&);

--- a/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
@@ -76,7 +76,7 @@ void CrossOriginPreflightChecker::validatePreflightResponse(DocumentThreadableLo
         return;
     }
 
-    auto result = WebCore::validatePreflightResponse(page->sessionID(), request, response, loader.options().storedCredentialsPolicy, loader.securityOrigin(), &CrossOriginAccessControlCheckDisabler::singleton());
+    auto result = WebCore::validatePreflightResponse(page->sessionID(), request, response, loader.options().storedCredentialsPolicy, loader.topOrigin(), loader.securityOrigin(), &CrossOriginAccessControlCheckDisabler::singleton());
     if (!result) {
         loader.document().addConsoleMessage(MessageSource::Security, MessageLevel::Error, result.error());
         loader.preflightFailure(identifier, ResourceError(errorDomainWebKitInternal, 0, request.url(), result.error(), ResourceError::Type::AccessControl));

--- a/Source/WebCore/loader/CrossOriginPreflightResultCache.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightResultCache.cpp
@@ -122,13 +122,13 @@ CrossOriginPreflightResultCache& CrossOriginPreflightResultCache::singleton()
     return cache;
 }
 
-void CrossOriginPreflightResultCache::appendEntry(PAL::SessionID sessionID, const String& origin, const URL& url, std::unique_ptr<CrossOriginPreflightResultCacheItem> preflightResult)
+void CrossOriginPreflightResultCache::appendEntry(PAL::SessionID sessionID, const ClientOrigin& origin, const URL& url, std::unique_ptr<CrossOriginPreflightResultCacheItem> preflightResult)
 {
     ASSERT(isMainThread());
     m_preflightHashMap.set(std::make_tuple(sessionID, origin, url), WTFMove(preflightResult));
 }
 
-bool CrossOriginPreflightResultCache::canSkipPreflight(PAL::SessionID sessionID, const String& origin, const URL& url, StoredCredentialsPolicy storedCredentialsPolicy, const String& method, const HTTPHeaderMap& requestHeaders)
+bool CrossOriginPreflightResultCache::canSkipPreflight(PAL::SessionID sessionID, const ClientOrigin& origin, const URL& url, StoredCredentialsPolicy storedCredentialsPolicy, const String& method, const HTTPHeaderMap& requestHeaders)
 {
     ASSERT(isMainThread());
     auto it = m_preflightHashMap.find(std::make_tuple(sessionID, origin, url));

--- a/Source/WebCore/loader/CrossOriginPreflightResultCache.h
+++ b/Source/WebCore/loader/CrossOriginPreflightResultCache.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "ClientOrigin.h"
 #include "LoaderMalloc.h"
 #include "StoredCredentialsPolicy.h"
 #include <pal/SessionID.h>
@@ -68,15 +69,15 @@ class CrossOriginPreflightResultCache {
     WTF_MAKE_NONCOPYABLE(CrossOriginPreflightResultCache); WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     WEBCORE_EXPORT static CrossOriginPreflightResultCache& singleton();
-    WEBCORE_EXPORT void appendEntry(PAL::SessionID, const String& origin, const URL&, std::unique_ptr<CrossOriginPreflightResultCacheItem>);
-    WEBCORE_EXPORT bool canSkipPreflight(PAL::SessionID, const String& origin, const URL&, StoredCredentialsPolicy, const String& method, const HTTPHeaderMap& requestHeaders);
+    WEBCORE_EXPORT void appendEntry(PAL::SessionID, const ClientOrigin&, const URL&, std::unique_ptr<CrossOriginPreflightResultCacheItem>);
+    WEBCORE_EXPORT bool canSkipPreflight(PAL::SessionID, const ClientOrigin&, const URL&, StoredCredentialsPolicy, const String& method, const HTTPHeaderMap& requestHeaders);
     WEBCORE_EXPORT void clear();
 
 private:
     friend NeverDestroyed<CrossOriginPreflightResultCache>;
     CrossOriginPreflightResultCache();
 
-    HashMap<std::tuple<PAL::SessionID, String, URL>, std::unique_ptr<CrossOriginPreflightResultCacheItem>> m_preflightHashMap;
+    HashMap<std::tuple<PAL::SessionID, ClientOrigin, URL>, std::unique_ptr<CrossOriginPreflightResultCacheItem>> m_preflightHashMap;
 };
 
 inline CrossOriginPreflightResultCacheItem::CrossOriginPreflightResultCacheItem(MonotonicTime absoluteExpiryTime, StoredCredentialsPolicy  storedCredentialsPolicy, HashSet<String>&& methods, HashSet<String, ASCIICaseInsensitiveHash>&& headers)

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -224,7 +224,7 @@ void DocumentThreadableLoader::makeCrossOriginAccessRequest(ResourceRequest&& re
             return;
 
         m_simpleRequest = false;
-        if (RefPtr page = document().page(); page && CrossOriginPreflightResultCache::singleton().canSkipPreflight(page->sessionID(), securityOrigin().toString(), request.url(), m_options.storedCredentialsPolicy, request.httpMethod(), request.httpHeaderFields()))
+        if (RefPtr page = document().page(); page && CrossOriginPreflightResultCache::singleton().canSkipPreflight(page->sessionID(), document().clientOrigin(), request.url(), m_options.storedCredentialsPolicy, request.httpMethod(), request.httpHeaderFields()))
             preflightSuccess(WTFMove(request));
         else
             makeCrossOriginAccessRequestWithPreflight(WTFMove(request));
@@ -729,6 +729,11 @@ bool DocumentThreadableLoader::isAllowedRedirect(const URL& url)
 SecurityOrigin& DocumentThreadableLoader::securityOrigin() const
 {
     return m_origin ? *m_origin : m_document->securityOrigin();
+}
+
+Ref<SecurityOrigin> DocumentThreadableLoader::topOrigin() const
+{
+    return m_document->topOrigin();
 }
 
 Ref<SecurityOrigin> DocumentThreadableLoader::protectedSecurityOrigin() const

--- a/Source/WebCore/loader/DocumentThreadableLoader.h
+++ b/Source/WebCore/loader/DocumentThreadableLoader.h
@@ -109,6 +109,7 @@ class CachedRawResource;
         bool isAllowedByContentSecurityPolicy(const URL&, ContentSecurityPolicy::RedirectResponseReceived, const URL& preRedirectURL = URL());
         bool isResponseAllowedByContentSecurityPolicy(const ResourceResponse&);
 
+        Ref<SecurityOrigin> topOrigin() const;
         SecurityOrigin& securityOrigin() const;
         Ref<SecurityOrigin> protectedSecurityOrigin() const;
         const ContentSecurityPolicy& contentSecurityPolicy() const;

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
@@ -117,7 +117,7 @@ void NetworkCORSPreflightChecker::didReceiveChallenge(WebCore::AuthenticationCha
         return;
     }
 
-    m_networkProcess->protectedAuthenticationManager()->didReceiveAuthenticationChallenge(m_parameters.sessionID, m_parameters.webPageProxyID, m_parameters.topOrigin ? &m_parameters.topOrigin->data() : nullptr, challenge, negotiatedLegacyTLS, WTFMove(completionHandler));
+    m_networkProcess->authenticationManager().didReceiveAuthenticationChallenge(m_parameters.sessionID, m_parameters.webPageProxyID, &m_parameters.topOrigin->data(), challenge, negotiatedLegacyTLS, WTFMove(completionHandler));
 }
 
 void NetworkCORSPreflightChecker::didReceiveResponse(WebCore::ResourceResponse&& response, NegotiatedLegacyTLS, PrivateRelayed, ResponseCompletionHandler&& completionHandler)
@@ -153,7 +153,7 @@ void NetworkCORSPreflightChecker::didCompleteWithError(const WebCore::ResourceEr
 
     CORS_CHECKER_RELEASE_LOG("didComplete http_status_code=%d", m_response.httpStatusCode());
 
-    auto result = validatePreflightResponse(m_parameters.sessionID, m_parameters.originalRequest, m_response, m_parameters.storedCredentialsPolicy, m_parameters.sourceOrigin, m_networkResourceLoader.get());
+    auto result = validatePreflightResponse(m_parameters.sessionID, m_parameters.originalRequest, m_response, m_parameters.storedCredentialsPolicy, m_parameters.topOrigin, m_parameters.sourceOrigin, m_networkResourceLoader.get());
     if (!result) {
         CORS_CHECKER_RELEASE_LOG("didComplete, AccessControl error: %s", result.error().utf8().data());
         m_completionCallback(ResourceError { errorDomainWebKitInternal, 0, m_parameters.originalRequest.url(), result.error(), ResourceError::Type::AccessControl });

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h
@@ -56,7 +56,7 @@ public:
     struct Parameters {
         WebCore::ResourceRequest originalRequest;
         Ref<WebCore::SecurityOrigin> sourceOrigin;
-        RefPtr<WebCore::SecurityOrigin> topOrigin;
+        Ref<WebCore::SecurityOrigin> topOrigin;
         String referrer;
         String userAgent;
         PAL::SessionID sessionID;

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -467,7 +467,7 @@ void NetworkLoadChecker::checkCORSRequestWithPreflight(ResourceRequest&& request
     ASSERT(m_options.mode == FetchOptions::Mode::Cors);
 
     m_isSimpleRequest = false;
-    if (CrossOriginPreflightResultCache::singleton().canSkipPreflight(m_sessionID, m_origin->toString(), request.url(), m_storedCredentialsPolicy, request.httpMethod(), m_originalRequestHeaders)) {
+    if (CrossOriginPreflightResultCache::singleton().canSkipPreflight(m_sessionID, { m_topOrigin->data(), m_origin->data() }, request.url(), m_storedCredentialsPolicy, request.httpMethod(), m_originalRequestHeaders)) {
         LOAD_CHECKER_RELEASE_LOG("checkCORSRequestWithPreflight - preflight can be skipped thanks to cached result");
         updateRequestForAccessControl(request, *origin(), m_storedCredentialsPolicy);
         handler(WTFMove(request));
@@ -480,7 +480,7 @@ void NetworkLoadChecker::checkCORSRequestWithPreflight(ResourceRequest&& request
     NetworkCORSPreflightChecker::Parameters parameters = {
         WTFMove(requestForPreflight),
         *m_origin,
-        m_topOrigin,
+        *m_topOrigin,
         request.httpReferrer(),
         request.httpUserAgent(),
         m_sessionID,


### PR DESCRIPTION
#### eaca76993c7a866c7abdb95cee40df269fa1cf4d
<pre>
CORS-preflight cache is not partitioned by top-level site
<a href="https://rdar.apple.com/135272104">rdar://135272104</a>

Reviewed by Anne van Kesteren.

We were keying the preflight cache with a partition based on the fetch context origin.
After this patch, the partitioning will be based on the fetch context client origin (aka top context origin and fetch context origin).
This follows how other stored data like service workers or IDB are keyed.

This patch is switching NetworkCORSPreflightChecker topOrigin from a RefPtr to a Ref.
NetworkCORSPreflightChecker gets it from NetworkLoadChecker which is created by PingLoad and NetworkResourceLoader from its NetworkResourceLoadParameters.
As can be seen from WebLoaderStrategy code, NetworkResourceLoadParameters source origin and top origin are set even though they are made as RefPtr.
A follow-up patch should change NetworkResourceLoadParameters to use Ref instead of RefPtr.

Covered by imported WPT test.

* LayoutTests/imported/w3c/web-platform-tests/cors/preflight-cache-partitioning.sub.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cors/preflight-cache-partitioning.sub.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cors/preflight-cache-partitioning.sub.window.js: Added.
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/cors/resources/preflight-cache-partitioning-iframe.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cors/resources/preflight-cache-partitioning.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cors/resources/preflight-partitioning.py: Added.
(main):
* Source/WebCore/loader/CrossOriginAccessControl.cpp:
(WebCore::validatePreflightResponse):
* Source/WebCore/loader/CrossOriginAccessControl.h:
* Source/WebCore/loader/CrossOriginPreflightChecker.cpp:
(WebCore::CrossOriginPreflightChecker::validatePreflightResponse):
* Source/WebCore/loader/CrossOriginPreflightResultCache.cpp:
(WebCore::CrossOriginPreflightResultCache::appendEntry):
(WebCore::CrossOriginPreflightResultCache::canSkipPreflight):
* Source/WebCore/loader/CrossOriginPreflightResultCache.h:
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::makeCrossOriginAccessRequest):
(WebCore::DocumentThreadableLoader::topOrigin const):
* Source/WebCore/loader/DocumentThreadableLoader.h:
* Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp:
(WebKit::NetworkCORSPreflightChecker::didReceiveChallenge):
(WebKit::NetworkCORSPreflightChecker::didCompleteWithError):
* Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h:
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::checkCORSRequestWithPreflight):

Originally-landed-as: 280938.345@safari-7619-branch (77592f3b8e28). <a href="https://rdar.apple.com/138936230">rdar://138936230</a>
Canonical link: <a href="https://commits.webkit.org/286250@main">https://commits.webkit.org/286250@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd15241bc625b11d7508ac4c29fa23d843e79415

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75288 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79750 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26544 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77405 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59090 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17329 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49269 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39466 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46665 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22172 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24872 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67682 "") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81234 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2618 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1632 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67336 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2769 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64675 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66628 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10578 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8732 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11631 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2579 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5394 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2604 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3534 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2613 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->