### PR TITLE
Don't suppress resource not founds errors when checking for valid resources for registered scripts

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
@@ -367,7 +367,7 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         RefPtr extension = m_extension;
         for (NSString *scriptPath in scriptPaths) {
             RefPtr<API::Error> error;
-            if (!extension->resourceStringForPath(scriptPath, error, WebExtension::CacheResult::No, WebExtension::SuppressNotFoundErrors::Yes)) {
+            if (!extension->resourceStringForPath(scriptPath, error)) {
                 recordError(::WebKit::wrapper(*error));
                 *errorMessage = toErrorString(callingAPIName, nil, @"invalid resource '%@'", scriptPath);
                 return false;
@@ -382,7 +382,7 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
 
         for (NSString *styleSheetPath in styleSheetPaths) {
             RefPtr<API::Error> error;
-            if (!extension->resourceStringForPath(styleSheetPath, error, WebExtension::CacheResult::No, WebExtension::SuppressNotFoundErrors::Yes)) {
+            if (!extension->resourceStringForPath(styleSheetPath, error)) {
                 recordError(::WebKit::wrapper(*error));
                 *errorMessage = toErrorString(callingAPIName, nil, @"invalid resource '%@'", styleSheetPath);
                 return false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
@@ -141,6 +141,8 @@ TEST(WKWebExtensionAPIScripting, ErrorsRegisteredContentScript)
         @"browser.test.assertThrows(() => browser.scripting.unregisterContentScripts({ ids: 0 }), /'ids' is expected to be an array of strings, but a number was provided/i)",
         @"browser.test.assertThrows(() => browser.scripting.unregisterContentScripts({ ids: [ 0 ] }), /'ids' is expected to be an array of strings, but a number was provided/i)",
 
+        @"browser.test.assertRejects(() => browser.scripting.registerContentScripts([{ id: '1', matches: ['*://*/*'], js: ['invalidFile.js'] }]), /Invalid resource 'invalidFile.js'/i)",
+
         @"browser.test.notifyPass()"
     ]);
 


### PR DESCRIPTION
#### 08439381f2b3d86c2291fa0c2e4641a4ad57abf2
<pre>
Don&apos;t suppress resource not founds errors when checking for valid resources for registered scripts
<a href="https://bugs.webkit.org/show_bug.cgi?id=282705">https://bugs.webkit.org/show_bug.cgi?id=282705</a>
<a href="https://rdar.apple.com/139374746">rdar://139374746</a>

Reviewed by Brian Weinstein and Timothy Hatcher.

Since we&apos;re suppressing resource not found errors, error is nil. So when we try to dereference it,
it causes a crash.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::createInjectedContentForScripts):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, ErrorsRegisteredContentScript)):

Canonical link: <a href="https://commits.webkit.org/286248@main">https://commits.webkit.org/286248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4591d78d4e6c777e6f68ecc9757c7f7a4df7e22e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79766 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26560 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77421 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2528 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59095 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17334 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78371 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64698 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39471 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22191 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/24888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81251 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2634 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1643 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67343 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66635 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10584 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11630 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2595 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2620 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2629 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->