### PR TITLE
[JSC] Should preserve the index in compileHasIndexedProperty if needed

### DIFF
--- a/JSTests/stress/clobber-new-index-reg-in-enumerator-next-update-index-and-mode.js
+++ b/JSTests/stress/clobber-new-index-reg-in-enumerator-next-update-index-and-mode.js
@@ -1,0 +1,18 @@
+
+let p = new Proxy(() => { }, { getOwnPropertyDescriptor: 0 });
+
+function f2(a0) {
+    for (let _ in a0) {
+        return;
+    }
+    try {
+        f2(f2);
+    } catch { }
+    f2([0]);
+    f2(p);
+}
+
+try {
+    f2();
+} catch (e) {
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1068,8 +1068,8 @@ public:
     // 1) nullopt the exception was handled
     // 2) valid GPRReg containing the exception that won't interfere with silentFill.
     // 3) InvalidGPRReg meaning the exception needs to be loaded from VM.
-    template<typename OperationType, typename ResultRegType>
-    std::optional<GPRReg> tryHandleOrGetExceptionUnderSilentSpill(const auto& plans, ResultRegType result)
+    template<typename OperationType, typename ResultRegType, typename... OtherSpilledRegTypes>
+    std::optional<GPRReg> tryHandleOrGetExceptionUnderSilentSpill(const auto& plans, ResultRegType result, OtherSpilledRegTypes... otherSpilledRegs)
     {
         ASSERT(m_underSilentSpill);
         using ResultType = typename FunctionTraits<OperationType>::ResultType;
@@ -1089,6 +1089,14 @@ public:
             if constexpr (std::is_same_v<GPRReg, ResultRegType> || std::is_same_v<JSValueRegs, ResultRegType>) {
                 spilledRegs.add(GPRInfo::returnValueGPR, IgnoreVectors);
                 spilledRegs.add(result, IgnoreVectors);
+            }
+
+            if constexpr (sizeof...(OtherSpilledRegTypes) > 0) {
+                constexpr auto addRegIfNeeded = [](auto& spilledRegs, auto& reg) ALWAYS_INLINE_LAMBDA {
+                    static_assert(std::is_same_v<GPRReg, std::decay_t<decltype(reg)>> || std::is_same_v<JSValueRegs, std::decay_t<decltype(reg)>>);
+                    spilledRegs.add(reg, IgnoreVectors);
+                };
+                (addRegIfNeeded(spilledRegs, otherSpilledRegs), ...);
             }
 
             if (spilledRegs.buildAndValidate().contains(exceptionReg, IgnoreVectors)) {
@@ -1771,7 +1779,7 @@ public:
     void compileCallNumberConstructor(Node*);
     void compileLogShadowChickenPrologue(Node*);
     void compileLogShadowChickenTail(Node*);
-    void compileHasIndexedProperty(Node*, S_JITOperation_GCZ, const ScopedLambda<std::tuple<GPRReg, GPRReg>()>& prefix);
+    void compileHasIndexedProperty(Node*, S_JITOperation_GCZ, const ScopedLambda<std::tuple<GPRReg, GPRReg>()>& prefix, bool = false);
     void compileExtractCatchLocal(Node*);
     void compileClearCatchLocals(Node*);
     void compileProfileType(Node*);


### PR DESCRIPTION
#### 16d97628d37cf47551e3fed363077536b5d37d5a
<pre>
[JSC] Should preserve the index in compileHasIndexedProperty if needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=278427">https://bugs.webkit.org/show_bug.cgi?id=278427</a>
<a href="https://rdar.apple.com/129328633">rdar://129328633</a>

Reviewed by Keith Miller.

The EnumeratorNextUpdateIndexAndMode node is expected to return two results.
In the fast path for case IndexedMode, the index value should be returned as
one of the results. However, the slow path of compileHasIndexedProperty
triggers a operation call with a single result. So, compileHasIndexedProperty
should preserve the index in compileHasIndexedProperty if needed.

* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:

Originally-landed-as: 280938.256@safari-7619-branch (2936053b96d6). <a href="https://rdar.apple.com/138930137">rdar://138930137</a>
Canonical link: <a href="https://commits.webkit.org/286293@main">https://commits.webkit.org/286293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76a4f20133791ec087721a5252261260688adf7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75327 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79798 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26592 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2551 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59126 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17357 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78394 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64725 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39488 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22219 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24919 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68488 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67728 "") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81284 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74590 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1678 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67373 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2818 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64711 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66650 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10604 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8768 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96858 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11657 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2624 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21158 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2649 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3584 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2656 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->