### PR TITLE
RELEASE_ASSERT(a.globalPosition() != b.globalPosition()) is failing for animations with no timeline

### DIFF
--- a/LayoutTests/animations/animation-composite-order-notimeline-expected.txt
+++ b/LayoutTests/animations/animation-composite-order-notimeline-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it doesn't crash.
+
+

--- a/LayoutTests/animations/animation-composite-order-notimeline.html
+++ b/LayoutTests/animations/animation-composite-order-notimeline.html
@@ -1,0 +1,17 @@
+<p>This test passes if it doesn't crash.</p>
+<script>
+if (testRunner)
+    testRunner.dumpAsText();
+
+function eventhandler() {
+    varx = new Animation(new KeyframeEffect(document.documentElement, null, 1), null);
+    varx.pause();
+    htmlvar.crossOrigin = "crossorigin";
+}
+
+function loading() {
+    document.getAnimations();
+}
+</script>
+<body onload=loading()>
+<img id="htmlvar" onerror="eventhandler()" src="x"></img>

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -68,14 +68,13 @@ public:
     virtual AnimationTimelinesController* controller() const { return nullptr; }
 
     virtual TimelineRange defaultRange() const { return { }; }
-
+    static void updateGlobalPosition(WebAnimation&);
 protected:
     AnimationTimeline(std::optional<WebAnimationTime> = std::nullopt);
 
     AnimationCollection m_animations;
 
 private:
-    void updateGlobalPosition(WebAnimation&);
 
     std::optional<WebAnimationTime> m_currentTime;
     std::optional<WebAnimationTime> m_duration;

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -90,6 +90,8 @@ Ref<WebAnimation> WebAnimation::create(Document& document, AnimationEffect* effe
     result->setEffect(effect);
     if (timeline)
         result->setTimeline(timeline);
+    else
+        AnimationTimeline::updateGlobalPosition(result);
 
     InspectorInstrumentation::didCreateWebAnimation(result.get());
 


### PR DESCRIPTION
#### 5ac2cec4ba7e54ce463e0dd3c2fe971845b93a42
<pre>
RELEASE_ASSERT(a.globalPosition() != b.globalPosition()) is failing for animations with no timeline
<a href="https://bugs.webkit.org/show_bug.cgi?id=282704">https://bugs.webkit.org/show_bug.cgi?id=282704</a>
<a href="https://rdar.apple.com/137178526">rdar://137178526</a>

Reviewed by Antoine Quint.

Method updateGlobalPosition was moved from private to public static in AnimationTimeline class so we can call it from WebAnimation&apos;s contructor for those instances which have a nullprt for timeline, the global position of such animations will still be updated (only if such animation&apos;s global position hasn&apos;t been set and can have globalposition).

* Source/WebCore/animation/AnimationTimeline.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::create):

Canonical link: <a href="https://commits.webkit.org/286294@main">https://commits.webkit.org/286294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4df3f24634a6b9ddbd43b246f52b49ba17694b84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79765 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26559 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77420 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2527 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59117 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17339 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39477 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46684 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22189 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24896 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67723 "") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22528 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81250 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2633 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1661 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67367 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66643 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/16621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10589 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8744 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11658 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2594 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5425 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2619 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3549 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2628 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->