### PR TITLE
[scroll-animations] Force render tree creation under TimelineRange::cssToLengthConversionData

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Dynamically changing view-timeline attachment assert_equals: div75 expected "75" but got "3"
+FAIL Dynamically changing view-timeline attachment assert_equals: div75 expected "75" but got "1"
 FAIL Dynamically changing view-timeline-axis assert_equals: vertical expected "25" but got "-1"
 FAIL Dynamically changing view-timeline-inset assert_equals: without inset expected "25" but got "-1"
 FAIL Element with scoped view-timeline becoming display:none assert_equals: display:block expected "25" but got "-1"

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Scroll timeline with percentage range [JavaScript API]
 PASS Scroll timeline with px range [JavaScript API]
-FAIL Scroll timeline with calculated range [JavaScript API] assert_approx_equals: expected a number but got a "object"
-FAIL Scroll timeline with EM range [JavaScript API] assert_approx_equals: expected a number but got a "object"
+PASS Scroll timeline with calculated range [JavaScript API]
+FAIL Scroll timeline with EM range [JavaScript API] assert_approx_equals: expected 0.625 +/- 0.001 but got 0.6111111068725585
 FAIL Scroll timeline with percentage range [CSS] promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
 FAIL Scroll timeline with px range [CSS] promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
 FAIL Scroll timeline with calculated range [CSS] promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-expected.txt
@@ -2,6 +2,6 @@
 FAIL View timeline with range as <name> <percent> pair. assert_equals: Effect at the start of the active phase: cover 0% to cover 100% expected "0.3" but got "0.7"
 FAIL View timeline with range and inferred name or offset. assert_equals: Effect at the start of the active phase: entry to exit expected "0.3" but got "0.7"
 FAIL View timeline with range as <name> <px> pair. assert_equals: Effect at the start of the active phase: cover 20% to cover 100% expected "0.3" but got "0.7"
-FAIL View timeline with range as <name> <percent+px> pair. assert_equals: Effect at the start of the active phase: contain undefined% to contain undefined% expected "0.3" but got "1"
+FAIL View timeline with range as <name> <percent+px> pair. assert_equals: Effect at the start of the active phase: contain undefined% to contain undefined% expected "0.3" but got "0.7"
 FAIL View timeline with range as strings. assert_equals: Effect at the start of the active phase:  to  expected "0.3" but got "1"
 

--- a/Source/WebCore/animation/TimelineRange.cpp
+++ b/Source/WebCore/animation/TimelineRange.cpp
@@ -66,11 +66,11 @@ TimelineRangeValue SingleTimelineRange::serialize() const
 
 static const std::optional<CSSToLengthConversionData> cssToLengthConversionData(RefPtr<Element> element)
 {
+    Ref document = element->document();
     CheckedPtr elementRenderer = element->renderer();
     if (!elementRenderer)
         return std::nullopt;
     CheckedPtr elementParentRenderer = elementRenderer->parent();
-    Ref document = element->document();
     CheckedPtr documentElement = document->documentElement();
     if (!documentElement)
         return std::nullopt;
@@ -86,13 +86,17 @@ static const std::optional<CSSToLengthConversionData> cssToLengthConversionData(
 
 Length SingleTimelineRange::lengthForCSSValue(RefPtr<const CSSPrimitiveValue> value, RefPtr<Element> element)
 {
-    if (!value || value->isCalculated() || !element)
+    if (!value || !element)
         return { };
     if (value->valueID() == CSSValueAuto)
         return { };
 
+    element->protectedDocument()->updateLayoutIgnorePendingStylesheets();
+
     auto conversionData = cssToLengthConversionData(element);
     if (!conversionData) {
+        if (value->isCalculated())
+            return { };
         if (value->isPercentage())
             return Length(value->resolveAsPercentageNoConversionDataRequired(), LengthType::Percent);
         if (value->isPx())


### PR DESCRIPTION
#### e535237203c31345e9c2eabc0869d3b1c69aa8e7
<pre>
[scroll-animations] Force render tree creation under TimelineRange::cssToLengthConversionData
<a href="https://bugs.webkit.org/show_bug.cgi?id=282708">https://bugs.webkit.org/show_bug.cgi?id=282708</a>
<a href="https://rdar.apple.com/139380230">rdar://139380230</a>

Reviewed by NOBODY (OOPS!).

Force render tree creation under TimelineRange::cssToLengthConversionData as we need
conversion data when converting provided animation-range via the JS API. This fixes the
demo <a href="https://scroll-driven-animations.style/demos/cover-to-fixed-header/waapi/">https://scroll-driven-animations.style/demos/cover-to-fixed-header/waapi/</a> where we
flakily wouldn&apos;t play the animation if there was no render tree created when provided the
animation-range.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-expected.txt:
* Source/WebCore/animation/TimelineRange.cpp:
(WebCore::cssToLengthConversionData):
(WebCore::SingleTimelineRange::lengthForCSSValue):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e535237203c31345e9c2eabc0869d3b1c69aa8e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81281 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27989 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78830 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4041 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60134 "Build is in progress. Recent messages:") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18216 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79780 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65869 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40456 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23363 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26313 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68576 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82690 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2698 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68401 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4242 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67653 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11626 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9715 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4036 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6845 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4059 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5817 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->