### PR TITLE
[JSC] Stop using Weak for the dependencies in DeferredWorkTimer::TicketData::TicketData

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1663,6 +1663,7 @@ NEVER_INLINE bool Heap::runEndPhase(GCConductor conn)
         if (vm().typeProfiler())
             vm().typeProfiler()->invalidateTypeSetCache(vm());
 
+        cancelDeferredWorkIfNeeded();
         reapWeakHandles();
         pruneStaleEntriesFromWeakGCHashTables();
         sweepArrayBuffers();
@@ -2338,6 +2339,11 @@ void Heap::willStartCollection()
 void Heap::prepareForMarking()
 {
     m_objectSpace.prepareForMarking();
+}
+
+void Heap::cancelDeferredWorkIfNeeded()
+{
+    vm().deferredWorkTimer->cancelPendingWork(vm());
 }
 
 void Heap::reapWeakHandles()

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -718,6 +718,7 @@ private:
     void updateObjectCounts();
     void endMarking();
 
+    void cancelDeferredWorkIfNeeded();
     void reapWeakHandles();
     void pruneStaleEntriesFromWeakGCHashTables();
     void sweepArrayBuffers();

--- a/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
+++ b/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
@@ -56,33 +56,34 @@ public:
         WTF_MAKE_TZONE_ALLOCATED(TicketData);
         WTF_MAKE_NONCOPYABLE(TicketData);
     public:
-        inline static Ref<TicketData> create(WorkType, JSGlobalObject*, JSObject* scriptExecutionOwner, Vector<Weak<JSCell>>&& dependencies);
+        inline static Ref<TicketData> create(WorkType, JSObject* scriptExecutionOwner, Vector<JSCell*>&& dependencies);
 
         WorkType type() const { return m_type; }
         inline VM& vm();
         JSObject* target();
-        inline const FixedVector<Weak<JSCell>>& dependencies(bool mayBeCancelled = false);
+        inline const FixedVector<JSCell*>& dependencies(bool mayBeCancelled = false);
         inline JSObject* scriptExecutionOwner();
-        inline JSGlobalObject* globalObject();
 
         inline void cancel();
-        bool isCancelled() const { return !m_scriptExecutionOwner.get() || !m_globalObject.get(); }
+        // We should not modify dependencies unless it is legitimate to do so during the end of GC.
+        inline void cancelAndClear();
+        bool isCancelled() const { return m_isCancelled; }
 
     private:
-        inline TicketData(WorkType, JSGlobalObject*, JSObject* scriptExecutionOwner, Vector<Weak<JSCell>>&& dependencies);
+        inline TicketData(WorkType, JSObject* scriptExecutionOwner, Vector<JSCell*>&& dependencies);
 
         WorkType m_type;
-        // This is const since we don't want to take the lock when visiting TicketData.
-        const FixedVector<Weak<JSCell>> m_dependencies;
-        Weak<JSObject> m_scriptExecutionOwner;
-        Weak<JSGlobalObject> m_globalObject;
+        FixedVector<JSCell*> m_dependencies;
+        JSObject* m_scriptExecutionOwner { nullptr };
+        bool m_isCancelled { false };
     };
 
     using Ticket = TicketData*;
 
     void doWork(VM&) final;
 
-    JS_EXPORT_PRIVATE Ticket addPendingWork(WorkType, VM&, JSObject* target, Vector<Weak<JSCell>>&& dependencies);
+    JS_EXPORT_PRIVATE Ticket addPendingWork(WorkType, VM&, JSObject* target, Vector<JSCell*>&& dependencies);
+    void cancelPendingWork(VM&);
 
     JS_EXPORT_PRIVATE bool hasAnyPendingWork() const;
     JS_EXPORT_PRIVATE bool hasImminentlyScheduledWork() const;
@@ -118,10 +119,10 @@ private:
 inline JSObject* DeferredWorkTimer::TicketData::target()
 {
     ASSERT(!isCancelled());
-    return jsCast<JSObject*>(m_dependencies.last().get());
+    return jsCast<JSObject*>(m_dependencies.last());
 }
 
-inline const FixedVector<Weak<JSCell>>& DeferredWorkTimer::TicketData::dependencies(bool mayBeCancelled)
+inline const FixedVector<JSCell*>& DeferredWorkTimer::TicketData::dependencies(bool mayBeCancelled)
 {
     ASSERT_UNUSED(mayBeCancelled, mayBeCancelled || !isCancelled());
     return m_dependencies;
@@ -130,13 +131,7 @@ inline const FixedVector<Weak<JSCell>>& DeferredWorkTimer::TicketData::dependenc
 inline JSObject* DeferredWorkTimer::TicketData::scriptExecutionOwner()
 {
     ASSERT(!isCancelled());
-    return m_scriptExecutionOwner.get();
-}
-
-inline JSGlobalObject* DeferredWorkTimer::TicketData::globalObject()
-{
-    ASSERT(!isCancelled());
-    return m_globalObject.get();
+    return m_scriptExecutionOwner;
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -2759,7 +2759,7 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
                 // The check above is just an optimization since between the check and here the mutator could cancel the ticket.
                 constexpr bool mayBeCancelled = true;
                 for (auto& dependency : ticket->dependencies(mayBeCancelled))
-                    visitor.append(dependency);
+                    visitor.appendUnbarriered(dependency);
             }
         }
     }

--- a/Source/JavaScriptCore/runtime/WaiterListManager.cpp
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.cpp
@@ -219,7 +219,6 @@ void WaiterListManager::notifyWaiterImpl(const AbstractLocker& listLocker, Ref<W
         waiter->scheduleWorkAndClear(listLocker, [resolveResult](DeferredWorkTimer::Ticket ticket) {
             JSPromise* promise = jsCast<JSPromise*>(ticket->target());
             JSGlobalObject* globalObject = promise->globalObject();
-            ASSERT(ticket->globalObject() == globalObject);
             VM& vm = promise->vm();
             JSValue result = resolveResult == ResolveResult::Ok ? vm.smallStrings.okString() : vm.smallStrings.timedOutString();
             promise->resolve(globalObject, result);
@@ -306,7 +305,7 @@ void WaiterListManager::unregister(JSGlobalObject* globalObject)
         Locker listLocker { list->lock };
         list->removeIf(listLocker, [&](Waiter* waiter) {
             if (waiter->isAsync()) {
-                if (auto ticket = waiter->ticket(listLocker); ticket && !ticket->isCancelled() && ticket->globalObject() == globalObject) {
+                if (auto ticket = waiter->ticket(listLocker); ticket && !ticket->isCancelled() && ticket->target()->globalObject() == globalObject) {
                     dataLogLnIf(WaiterListsManagerInternal::verbose,
                         "<WaiterListManager> <Thread:", Thread::current(),
                         "> unregister JSGlobalObject is cancelling waiter=", *waiter,
@@ -391,8 +390,8 @@ void Waiter::dump(PrintStream& out) const
     auto ticket = this->ticket(NoLockingNecessary);
     out.print(", ticket=", RawPointer(ticket.get()));
     if (ticket && !ticket->isCancelled()) {
-        out.print(", m_ticket->globalObject=", RawPointer(ticket->globalObject()));
-        out.print(", m_ticket->target=", RawPointer(jsCast<JSObject*>(ticket->dependencies().last().get())));
+        out.print(", m_ticket->globalObject=", RawPointer(ticket->target()->globalObject()));
+        out.print(", m_ticket->target=", RawPointer(jsCast<JSObject*>(ticket->dependencies().last())));
         out.print(", m_ticket->scriptExecutionOwner=", RawPointer(ticket->scriptExecutionOwner()));
     }
 

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
@@ -47,10 +47,10 @@ StreamingCompiler::StreamingCompiler(VM& vm, CompilerMode compilerMode, JSGlobal
     , m_info(Wasm::ModuleInformation::create())
     , m_parser(m_info.get(), *this)
 {
-    Vector<Weak<JSCell>> dependencies;
-    dependencies.append(Weak<JSCell>(globalObject));
+    Vector<JSCell*> dependencies;
+    dependencies.append(globalObject);
     if (importObject)
-        dependencies.append(Weak<JSCell>(importObject));
+        dependencies.append(importObject);
     m_ticket = vm.deferredWorkTimer->addPendingWork(DeferredWorkTimer::WorkType::AtSomePoint, vm, promise, WTFMove(dependencies));
     ASSERT(vm.deferredWorkTimer->hasPendingWork(m_ticket));
     ASSERT(vm.deferredWorkTimer->hasDependencyInPendingWork(m_ticket, globalObject));
@@ -141,7 +141,7 @@ void StreamingCompiler::didComplete()
     case CompilerMode::Validation: {
         m_vm.deferredWorkTimer->scheduleWorkSoon(ticket, [result = WTFMove(result)](DeferredWorkTimer::Ticket ticket) mutable {
             JSPromise* promise = jsCast<JSPromise*>(ticket->target());
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(ticket->dependencies()[0].get());
+            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(ticket->dependencies()[0]);
             VM& vm = globalObject->vm();
             auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -162,8 +162,8 @@ void StreamingCompiler::didComplete()
     case CompilerMode::FullCompile: {
         m_vm.deferredWorkTimer->scheduleWorkSoon(ticket, [result = WTFMove(result)](DeferredWorkTimer::Ticket ticket) mutable {
             JSPromise* promise = jsCast<JSPromise*>(ticket->target());
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(ticket->dependencies()[0].get());
-            JSObject* importObject = jsCast<JSObject*>(ticket->dependencies()[1].get());
+            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(ticket->dependencies()[0]);
+            JSObject* importObject = jsCast<JSObject*>(ticket->dependencies()[1]);
             VM& vm = globalObject->vm();
             auto scope = DECLARE_THROW_SCOPE(vm);
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
@@ -145,8 +145,8 @@ void JSWebAssembly::webAssemblyModuleValidateAsync(JSGlobalObject* globalObject,
 {
     VM& vm = globalObject->vm();
 
-    Vector<Weak<JSCell>> dependencies;
-    dependencies.append(Weak<JSCell>(globalObject));
+    Vector<JSCell*> dependencies;
+    dependencies.append(globalObject);
 
     auto ticket = vm.deferredWorkTimer->addPendingWork(DeferredWorkTimer::WorkType::ImminentlyScheduled, vm, promise, WTFMove(dependencies));
     Wasm::Module::validateAsync(vm, WTFMove(source), createSharedTask<Wasm::Module::CallbackType>([ticket, promise, globalObject, &vm] (Wasm::Module::ValidationResult&& result) mutable {
@@ -185,9 +185,9 @@ static void instantiate(VM& vm, JSGlobalObject* globalObject, JSPromise* promise
         return;
     }
 
-    Vector<Weak<JSCell>> dependencies;
+    Vector<JSCell*> dependencies;
     // The instance keeps the module alive.
-    dependencies.append(Weak<JSCell>(promise));
+    dependencies.append(promise);
 
     scope.release();
     auto ticket = vm.deferredWorkTimer->addPendingWork(DeferredWorkTimer::WorkType::ImminentlyScheduled, vm, instance, WTFMove(dependencies));
@@ -245,10 +245,10 @@ static void compileAndInstantiate(VM& vm, JSGlobalObject* globalObject, JSPromis
     }
 
     JSCell* moduleKeyCell = identifierToJSValue(vm, moduleKey).asCell();
-    Vector<Weak<JSCell>> dependencies;
+    Vector<JSCell*> dependencies;
     if (importObject)
-        dependencies.append(Weak<JSCell>(importObject));
-    dependencies.append(Weak<JSCell>(moduleKeyCell));
+        dependencies.append(importObject);
+    dependencies.append(moduleKeyCell);
     auto ticket = vm.deferredWorkTimer->addPendingWork(DeferredWorkTimer::WorkType::ImminentlyScheduled, vm, promise, WTFMove(dependencies));
     Wasm::Module::validateAsync(vm, WTFMove(source), createSharedTask<Wasm::Module::CallbackType>([ticket, promise, importObject, moduleKeyCell, globalObject, resolveKind, creationMode, &vm] (Wasm::Module::ValidationResult&& result) mutable {
         vm.deferredWorkTimer->scheduleWorkSoon(ticket, [promise, importObject, moduleKeyCell, globalObject, result = WTFMove(result), resolveKind, creationMode, &vm](DeferredWorkTimer::Ticket) mutable {


### PR DESCRIPTION
#### 6d458f2e184a8684aee8ead2acc0d255a87045a5
<pre>
[JSC] Stop using Weak for the dependencies in DeferredWorkTimer::TicketData::TicketData
<a href="https://bugs.webkit.org/show_bug.cgi?id=282707">https://bugs.webkit.org/show_bug.cgi?id=282707</a>
<a href="https://rdar.apple.com/139211106">rdar://139211106</a>

Reviewed by Yusuke Suzuki and Keith Miller.

JSC::Weak allocation should not be allowed at GC end phase.
Since DeferredWorkTimer::addPendingWork can be triggered at GC
end phase, we should not use JSC::Weak in the TicketDat. Instead
we can directly manage the pending tickets at GC end phase since
JSC::Weak is just ensuring a null reference once the JSCell is dead.

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::runEndPhase):
(JSC::Heap::cancelDeferredWorkIfNeeded):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp:
(JSC::DeferredWorkTimer::TicketData::TicketData):
(JSC::DeferredWorkTimer::TicketData::create):
(JSC::DeferredWorkTimer::TicketData::cancel):
(JSC::DeferredWorkTimer::addPendingWork):
(JSC::DeferredWorkTimer::cancelPendingWork):
* Source/JavaScriptCore/runtime/DeferredWorkTimer.h:
(JSC::DeferredWorkTimer::TicketData::target):
(JSC::DeferredWorkTimer::TicketData::scriptExecutionOwner):
(JSC::DeferredWorkTimer::TicketData::dependencies): Deleted.
(JSC::DeferredWorkTimer::TicketData::globalObject): Deleted.
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::visitChildrenImpl):
* Source/JavaScriptCore/runtime/WaiterListManager.cpp:
(JSC::WaiterListManager::notifyWaiterImpl):
(JSC::WaiterListManager::unregister):
(JSC::Waiter::dump const):
* Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp:
(JSC::Wasm::StreamingCompiler::StreamingCompiler):
(JSC::Wasm::StreamingCompiler::didComplete):
* Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp:
(JSC::JSWebAssembly::webAssemblyModuleValidateAsync):
(JSC::instantiate):
(JSC::compileAndInstantiate):

Canonical link: <a href="https://commits.webkit.org/286378@main">https://commits.webkit.org/286378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5661cab169fd589a14b09bda4c021e189a59b4e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28606 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80243 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27020 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59417 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17585 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78821 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49310 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65070 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39773 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46709 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22552 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25347 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68906 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67826 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81714 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75017 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1963 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67640 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66942 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16700 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10896 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9029 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97284 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3052 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21271 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3077 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4013 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3084 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->