### PR TITLE
Finish off span adoption in RemoteGraphicsContextGL.h

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -767,7 +767,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align"
-template<typename T, typename U, std::size_t Extent>
+template<typename T, std::size_t Extent, typename U>
 constexpr std::span<T, Extent == std::dynamic_extent ? std::dynamic_extent : (sizeof(U) * Extent) / sizeof(T)> spanReinterpretCast(std::span<U, Extent> span)
 {
     static_assert(std::is_const_v<T> || (!std::is_const_v<T> && !std::is_const_v<U>), "spanReinterpretCast will not remove constness from source");

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -158,11 +158,7 @@ protected:
     using GCGLContext = WebCore::GraphicsContextGLTextureMapperANGLE;
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 #include "RemoteGraphicsContextGLFunctionsGenerated.h" // NOLINT
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 private:
     void paintNativeImageToImageBuffer(WebCore::NativeImage&, WebCore::RenderingResourceIdentifier);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -379,21 +379,21 @@
         assertIsCurrent(workQueue());
         Vector<GCGLfloat, 16> value(valueSize, 0);
         protectedContext()->getFloatv(pname, value);
-        completionHandler(std::span<const float>(reinterpret_cast<const float*>(value.data()), value.size()));
+        completionHandler(spanReinterpretCast<const float>(value.span()));
     }
     void getIntegerv(uint32_t pname, size_t valueSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         Vector<GCGLint, 4> value(valueSize, 0);
         protectedContext()->getIntegerv(pname, value);
-        completionHandler(std::span<const int32_t>(reinterpret_cast<const int32_t*>(value.data()), value.size()));
+        completionHandler(spanReinterpretCast<const int32_t>(value.span()));
     }
     void getIntegeri_v(uint32_t pname, uint32_t index, CompletionHandler<void(std::span<const int32_t, 4>)>&& completionHandler) // NOLINT
     {
         assertIsCurrent(workQueue());
         std::array<GCGLint, 4> value { };
         protectedContext()->getIntegeri_v(pname, index, value);
-        completionHandler(std::span<const int32_t, 4>(reinterpret_cast<const int32_t*>(value.data()), value.size()));
+        completionHandler(spanReinterpretCast<const int32_t, 4>(std::span<const GCGLint, 4>(value)));
     }
     void getInteger64(uint32_t pname, CompletionHandler<void(int64_t)>&& completionHandler)
     {
@@ -423,7 +423,7 @@
         assertIsCurrent(workQueue());
         Vector<GCGLboolean, 4> value(valueSize, 0);
         protectedContext()->getBooleanv(pname, value);
-        completionHandler(std::span<const bool>(reinterpret_cast<const bool*>(value.data()), value.size()));
+        completionHandler(spanReinterpretCast<const bool>(value.span()));
     }
     void getFramebufferAttachmentParameteri(uint32_t target, uint32_t attachment, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
@@ -472,7 +472,7 @@
         std::array<GCGLint, 2> range { };
         GCGLint precision = { };
         protectedContext()->getShaderPrecisionFormat(shaderType, precisionType, range, &precision);
-        completionHandler(std::span<const int32_t, 2>(reinterpret_cast<const int32_t*>(range.data()), range.size()), precision);
+        completionHandler(spanReinterpretCast<const int32_t, 2>(std::span<const GCGLint, 2>(range)), precision);
     }
     void getShaderSource(uint32_t arg0, CompletionHandler<void(String&&)>&& completionHandler)
     {
@@ -504,7 +504,7 @@
             program = m_objectNames.get(program);
         Vector<GCGLfloat, 16> value(valueSize, 0);
         protectedContext()->getUniformfv(program, location, value);
-        completionHandler(std::span<const float>(reinterpret_cast<const float*>(value.data()), value.size()));
+        completionHandler(spanReinterpretCast<const float>(value.span()));
     }
     void getUniformiv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
     {
@@ -513,7 +513,7 @@
             program = m_objectNames.get(program);
         Vector<GCGLint, 4> value(valueSize, 0);
         protectedContext()->getUniformiv(program, location, value);
-        completionHandler(std::span<const int32_t>(reinterpret_cast<const int32_t*>(value.data()), value.size()));
+        completionHandler(spanReinterpretCast<const int32_t>(value.span()));
     }
     void getUniformuiv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(std::span<const uint32_t>)>&& completionHandler)
     {
@@ -522,7 +522,7 @@
             program = m_objectNames.get(program);
         Vector<GCGLuint, 4> value(valueSize, 0);
         protectedContext()->getUniformuiv(program, location, value);
-        completionHandler(std::span<const uint32_t>(reinterpret_cast<const uint32_t*>(value.data()), value.size()));
+        completionHandler(spanReinterpretCast<const uint32_t>(value.span()));
     }
     void getUniformLocation(uint32_t arg0, String&& name, CompletionHandler<void(int32_t)>&& completionHandler)
     {
@@ -1465,7 +1465,7 @@
             program = m_objectNames.get(program);
         Vector<GCGLint, 4> params(paramsSize, 0);
         protectedContext()->getActiveUniformBlockiv(program, uniformBlockIndex, pname, params);
-        completionHandler(std::span<const int32_t>(reinterpret_cast<const int32_t*>(params.data()), params.size()));
+        completionHandler(spanReinterpretCast<const int32_t>(params.span()));
     }
     void getTranslatedShaderSourceANGLE(uint32_t arg0, CompletionHandler<void(String&&)>&& completionHandler)
     {
@@ -1631,7 +1631,7 @@
         assertIsCurrent(workQueue());
         Vector<GCGLint, 4> params(paramsSize, 0);
         protectedContext()->getInternalformativ(target, internalformat, pname, params);
-        completionHandler(std::span<const int32_t>(reinterpret_cast<const int32_t*>(params.data()), params.size()));
+        completionHandler(spanReinterpretCast<const int32_t>(params.span()));
     }
     void setDrawingBufferColorSpace(WebCore::DestinationColorSpace&& arg0)
     {

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -243,6 +243,9 @@ class cpp_type_container(cpp_type):
     def is_dynamic_span(self) -> bool:
         return (self.container_name == "std::span" and self.arity is None) or self.container_name == "GCGLSpanTuple"
 
+    def is_array(self) -> bool:
+        return self.container_name == "std::array"
+
     def get_container_name(self):
         return self.container_name
 
@@ -382,8 +385,14 @@ def cpp_implicit_cast(expr: cpp_expr, type: cpp_type) -> cpp_expr:
 
 
 def cpp_array_reinterpret_cast_conversion(expr: cpp_expr, type: cpp_type_container) -> cpp_expr:
-    element_pointer_type = type.get_contained_type().get_pointer_type()
-    return cpp_expr(type, f"{str(type)}(reinterpret_cast<{element_pointer_type}>({str(expr)}.data()), {str(expr)}.size())")
+    target_value_type = type.get_contained_type().get_decay_type()
+    target_arity = f", {type.arity}" if type.arity else ""
+    source_value_type = expr.type.get_contained_type().get_decay_type()
+    source_arity = f", {expr.type.arity}" if expr.type.arity else ""
+    if expr.type.is_array():
+        return cpp_expr(type, f"spanReinterpretCast<const {target_value_type}{target_arity}>(std::span<const {source_value_type}{source_arity}>({str(expr)}))")
+    else:
+        return cpp_expr(type, f"spanReinterpretCast<const {target_value_type}{target_arity}>({str(expr)}.span())")
 
 
 def cpp_move_expr(expr: cpp_expr) -> cpp_expr:


### PR DESCRIPTION
#### 254d15e9ef1e495f02f8f1a9e8dec6960fc4852d
<pre>
Finish off span adoption in RemoteGraphicsContextGL.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=282709">https://bugs.webkit.org/show_bug.cgi?id=282709</a>
<a href="https://rdar.apple.com/139381582">rdar://139381582</a>

Reviewed by Chris Dumez.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h: No need for
markers anymore.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h: Autogenerated
(getFloatv):
(getIntegerv):
(getIntegeri_v):
(getBooleanv):
(getShaderPrecisionFormat):
(getUniformfv):
(getUniformiv):
(getUniformuiv):
(getActiveUniformBlockiv):
(getInternalformativ):

* Tools/Scripts/generate-gpup-webgl: Use safe span constructors.
(cpp_type_container.is_dynamic_span):
(cpp_type_container):
(cpp_type_container.is_array):
(cpp_array_reinterpret_cast_conversion):

* Source/WTF/wtf/StdLibExtras.h: Reversed the order of U and Extent because it
is useful to be able to specify Extent and infer U.

Canonical link: <a href="https://commits.webkit.org/286282@main">https://commits.webkit.org/286282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39bfd6d7f9b2588c3c10a26796aa68e9e2fb8e05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75441 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79918 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26705 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77557 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2672 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/17418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78508 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64822 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/39570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22311 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25033 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68591 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81399 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74703 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2780 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1756 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67454 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64801 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66744 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10692 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8846 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96971 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11650 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2737 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5558 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21189 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2762 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3697 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2769 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->