### PR TITLE
Drop unnecessary use of WTF_ALLOW_UNSAFE_BUFFER_USAGE

### DIFF
--- a/Source/JavaScriptCore/assembler/AssemblerBuffer.h
+++ b/Source/JavaScriptCore/assembler/AssemblerBuffer.h
@@ -41,8 +41,6 @@
 #include <wtf/ThreadSpecific.h>
 #include <wtf/UnalignedAccess.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC {
     enum class AssemblerDataType : uint8_t { Code, Hashes };
     template<AssemblerDataType>
@@ -519,7 +517,5 @@ namespace JSC {
     };
 
 } // namespace JSC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(ASSEMBLER)

--- a/Source/JavaScriptCore/assembler/CPU.cpp
+++ b/Source/JavaScriptCore/assembler/CPU.cpp
@@ -35,8 +35,6 @@
 #include "MacroAssembler.h"
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC {
 
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
@@ -148,5 +146,3 @@ bool isX86_64_AVX()
 #endif
 
 } // namespace JSC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/assembler/FastJITPermissions.h
+++ b/Source/JavaScriptCore/assembler/FastJITPermissions.h
@@ -28,8 +28,6 @@
 #include <stdint.h>
 #include <wtf/Platform.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 enum class MemoryRestriction {
     kRwxToRw,
     kRwxToRx,
@@ -176,5 +174,3 @@ NO_RETURN_DUE_TO_CRASH ALWAYS_INLINE void threadSelfRestrict()
 
 #endif // OS(DARWIN) && CPU(ARM64)
 #endif // defined(OS_THREAD_SELF_RESTRICT) && defined(OS_THREAD_SELF_RESTRICT_SUPPORTED)
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64E.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64E.h
@@ -43,8 +43,6 @@
 #include <mach/vm_param.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC {
 
 using Assembler = TARGET_ASSEMBLER;
@@ -398,7 +396,5 @@ public:
 };
 
 } // namespace JSC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(ASSEMBLER) && CPU(ARM64E)

--- a/Source/JavaScriptCore/assembler/SecureARM64EHashPins.cpp
+++ b/Source/JavaScriptCore/assembler/SecureARM64EHashPins.cpp
@@ -32,8 +32,6 @@
 #include <wtf/Condition.h>
 #include <wtf/Lock.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC {
 
 #if CPU(ARM64E) && ENABLE(JIT)
@@ -284,5 +282,3 @@ void SecureARM64EHashPins::deallocatePinForCurrentThread()
 #endif // CPU(ARM64E) && ENABLE(JIT)
 
 } // namespace JSC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/assembler/SecureARM64EHashPinsInlines.h
+++ b/Source/JavaScriptCore/assembler/SecureARM64EHashPinsInlines.h
@@ -29,8 +29,6 @@
 
 #if CPU(ARM64E) && ENABLE(JIT)
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC {
 
 ALWAYS_INLINE uint64_t SecureARM64EHashPins::keyForCurrentThread()
@@ -111,7 +109,5 @@ ALWAYS_INLINE uint64_t SecureARM64EHashPins::pinForCurrentThread()
 }
 
 } // namespace JSC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // CPU(ARM64E) && ENABLE(JIT)

--- a/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
@@ -40,8 +40,6 @@
 #include <sys/mman.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC {
 
 StructureAlignedMemoryAllocator::StructureAlignedMemoryAllocator(CString name)
@@ -110,8 +108,9 @@ public:
             // If we can't find a free block then `freeIndex == m_usedBlocks.bitCount()` and this set will grow the bit vector.
             m_usedBlocks.set(freeIndex);
         }
-
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         auto* block = reinterpret_cast<uint8_t*>(g_jscConfig.startOfStructureHeap) + freeIndex * MarkedBlock::blockSize;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         commitBlock(block);
         return block;
     }
@@ -217,5 +216,3 @@ void StructureAlignedMemoryAllocator::decommitBlock(void* block)
 #endif // CPU(ADDRESS64)
 
 } // namespace JSC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -90,8 +90,6 @@
 #include "WebAssemblyFunction.h"
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC {
 
 JSValue eval(CallFrame* callFrame, JSValue thisValue, JSScope* callerScopeChain, LexicallyScopedFeatures lexicallyScopedFeatures)
@@ -319,6 +317,7 @@ void loadVarargs(JSGlobalObject* globalObject, JSValue* firstElementDest, JSValu
             jsCast<JSArray*>(object)->copyToArguments(globalObject, firstElementDest, offset, length);
             return;
         }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         unsigned i;
         for (i = 0; i < length && object->canGetIndexQuickly(i + offset); ++i)
             firstElementDest[i] = object->getIndexQuickly(i + offset);
@@ -327,6 +326,7 @@ void loadVarargs(JSGlobalObject* globalObject, JSValue* firstElementDest, JSValu
             RETURN_IF_EXCEPTION(scope, void());
             firstElementDest[i] = value;
         }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         return;
     }
     }
@@ -354,7 +354,9 @@ void setupForwardArgumentsFrame(JSGlobalObject*, CallFrame* execCaller, CallFram
 {
     ASSERT(length == execCaller->argumentCount());
     unsigned offset = execCaller->argumentOffset(0) * sizeof(Register);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     memcpy(reinterpret_cast<char*>(execCallee) + offset, reinterpret_cast<char*>(execCaller) + offset, length * sizeof(Register));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     execCallee->setArgumentCountIncludingThis(length + 1);
 }
 
@@ -779,8 +781,9 @@ private:
                 // its frame.
                 continue;
             }
-
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             record->calleeSaveRegistersBuffer[calleeSavesEntry->offsetAsIndex()] = *(frame + currentEntry.offsetAsIndex());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         }
 #else
         UNUSED_PARAM(visitor);
@@ -1712,5 +1715,3 @@ void printInternal(PrintStream& out, JSC::DebugHookType type)
 }
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -26,8 +26,6 @@
 #include "config.h"
 #include "ExecutableAllocator.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 #if ENABLE(JIT)
 
 #include "ExecutableAllocationFuzz.h"
@@ -1474,5 +1472,3 @@ ExecutableAllocator& ExecutableAllocator::singleton()
 }
 
 } // namespace JSC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.h
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.h
@@ -55,8 +55,6 @@
 #define EXECUTABLE_POOL_WRITABLE true
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC {
 
 static constexpr unsigned jitAllocationGranule = 32;
@@ -208,6 +206,8 @@ static NEVER_INLINE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void dieByJumpingInto
     } while (false)
 #endif // ENABLE(JIT_SCAN_ASSEMBLER_BUFFER_FOR_ZEROES)
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 static ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n)
 {
 #if CPU(ARM64)
@@ -307,6 +307,8 @@ static ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n
     return memcpyAtomicIfPossible(dst, src, n);
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
 class ExecutableAllocator : private ExecutableAllocatorBase {
     WTF_MAKE_TZONE_ALLOCATED(ExecutableAllocator);
 public:
@@ -377,5 +379,3 @@ inline bool isJITPC(void*) { return false; }
 #endif // ENABLE(JIT)
 
 } // namespace JSC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -163,8 +163,6 @@
 #include <wtf/linux/ProcessMemoryFootprint.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 #if OS(DARWIN) || OS(LINUX)
 struct MemoryFootprint : ProcessMemoryFootprint {
     MemoryFootprint(const ProcessMemoryFootprint& src)
@@ -4505,5 +4503,3 @@ int jscmain(int argc, char** argv)
 
     return result;
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/llint/LLIntEntrypoint.cpp
+++ b/Source/JavaScriptCore/llint/LLIntEntrypoint.cpp
@@ -34,8 +34,6 @@
 #include "MaxFrameExtentForSlowPathCall.h"
 #include "StackAlignment.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC { namespace LLInt {
 
 #if CPU(ARM64E) && !ENABLE(C_LOOP)
@@ -275,5 +273,3 @@ unsigned frameRegisterCountFor(CodeBlock* codeBlock)
 }
 
 } } // namespace JSC::LLInt
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -60,8 +60,6 @@
 extern "C" char __llvm_profile_filename[] = "/private/tmp/WebKitPGO/JavaScriptCore_%m_pid%p%c.profraw";
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC {
 
 static_assert(sizeof(bool) == 1, "LLInt and JIT assume sizeof(bool) is always 1 when touching it directly from assembly code.");
@@ -146,5 +144,3 @@ void initialize()
 }
 
 } // namespace JSC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/JSCConfig.cpp
+++ b/Source/JavaScriptCore/runtime/JSCConfig.cpp
@@ -27,8 +27,6 @@
 #include "JSCConfig.h"
 #include <wtf/WTFConfig.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC {
 
 Config& Config::singleton()
@@ -43,5 +41,3 @@ void Config::enableRestrictedOptions()
 }
 
 } // namespace JSC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/JSCConfig.h
+++ b/Source/JavaScriptCore/runtime/JSCConfig.h
@@ -31,8 +31,6 @@
 #include "SecureARM64EHashPins.h"
 #include <wtf/WTFConfig.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC {
 
 class ExecutableAllocator;
@@ -123,9 +121,13 @@ constexpr size_t alignmentOfJSCConfig = std::alignment_of<JSC::Config>::value;
 static_assert(WTF::offsetOfWTFConfigExtension + sizeof(JSC::Config) <= WTF::ConfigSizeToProtect);
 static_assert(roundUpToMultipleOf<alignmentOfJSCConfig>(WTF::offsetOfWTFConfigExtension) == WTF::offsetOfWTFConfigExtension);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 // Workaround to localize bounds safety warnings to this file.
 // FIXME: Use real types to make materializing JSC::Config* bounds-safe and type-safe.
 inline Config* addressOfJSCConfig() { return bitwise_cast<Config*>(&g_wtfConfig.spaceForExtensions); }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #define g_jscConfig (*JSC::addressOfJSCConfig())
 
@@ -140,5 +142,3 @@ ALWAYS_INLINE PURE_FUNCTION uintptr_t startOfStructureHeap()
 }
 
 } // namespace JSC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/JSCPtrTag.cpp
+++ b/Source/JavaScriptCore/runtime/JSCPtrTag.cpp
@@ -34,8 +34,6 @@
 #include <sys/types.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC {
 
 #if CPU(ARM64E) && (ENABLE(PTRTAG_DEBUGGING) || ENABLE(DISASSEMBLER))
@@ -101,5 +99,3 @@ PtrTagCalleeType calleeType(PtrTag tag)
 #endif
 
 } // namespace JSC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -305,8 +305,6 @@
 #include "JSCWrapperMap.h"
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC {
 
 #define CHECK_FEATURE_FLAG_TYPE(capitalName, lowerName, properName, instanceType, jsName, prototypeBase, featureFlag) \
@@ -3408,5 +3406,3 @@ void JSGlobalObject::clearWeakTickets()
 }
 
 } // namespace JSC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -68,8 +68,6 @@
 extern "C" char **environ;
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC {
 
 bool useOSLogOptionHasChanged = false;
@@ -1481,5 +1479,3 @@ bool hasCapacityToUseLargeGigacage()
 }
 
 } // namespace JSC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/Options.h
+++ b/Source/JavaScriptCore/runtime/Options.h
@@ -34,8 +34,6 @@
 #include <wtf/PrintStream.h>
 #include <wtf/StdLibExtras.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 class StringBuilder;
 }
@@ -173,5 +171,3 @@ private:
 };
 
 } // namespace JSC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/StructureID.h
+++ b/Source/JavaScriptCore/runtime/StructureID.h
@@ -31,8 +31,6 @@
 #include <wtf/HashTraits.h>
 #include <wtf/StdIntExtras.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC {
 
 class Structure;
@@ -193,5 +191,3 @@ template<> struct HashTraits<JSC::StructureID> : SimpleClassHashTraits<JSC::Stru
 };
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -160,8 +160,6 @@
 #include "JSWebAssemblyInstance.h"
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(VM);
@@ -307,10 +305,12 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
     symbolStructure.setWithoutWriteBarrier(Symbol::createStructure(*this, nullptr, jsNull()));
     symbolTableStructure.setWithoutWriteBarrier(SymbolTable::createStructure(*this, nullptr, jsNull()));
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     immutableButterflyStructures[arrayIndexFromIndexingType(CopyOnWriteArrayWithInt32) - NumberOfIndexingShapes].setWithoutWriteBarrier(JSImmutableButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithInt32));
     Structure* copyOnWriteArrayWithContiguousStructure = JSImmutableButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithContiguous);
     immutableButterflyStructures[arrayIndexFromIndexingType(CopyOnWriteArrayWithDouble) - NumberOfIndexingShapes].setWithoutWriteBarrier(Options::allowDoubleShape() ? JSImmutableButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithDouble) : copyOnWriteArrayWithContiguousStructure);
     immutableButterflyStructures[arrayIndexFromIndexingType(CopyOnWriteArrayWithContiguous) - NumberOfIndexingShapes].setWithoutWriteBarrier(copyOnWriteArrayWithContiguousStructure);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     sourceCodeStructure.setWithoutWriteBarrier(JSSourceCode::createStructure(*this, nullptr, jsNull()));
     scriptFetcherStructure.setWithoutWriteBarrier(JSScriptFetcher::createStructure(*this, nullptr, jsNull()));
@@ -1752,7 +1752,9 @@ void QueuedTask::run()
         return;
     JSObject* job = jsCast<JSObject*>(m_job);
     JSGlobalObject* globalObject = job->globalObject();
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     runJSMicrotask(globalObject, m_identifier, job, m_arguments[0], m_arguments[1], m_arguments[2], m_arguments[3]);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 template<typename Visitor>
@@ -1834,5 +1836,3 @@ void VM::DrainMicrotaskDelayScope::decrement()
 }
 
 } // namespace JSC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -44,8 +44,6 @@
 #include <wtf/ThreadMessage.h>
 #include <wtf/threads/Signals.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC {
 
 #if ENABLE(SIGNAL_BASED_VM_TRAPS)
@@ -485,5 +483,3 @@ VMTraps::~VMTraps()
 }
 
 } // namespace JSC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/tools/FunctionOverrides.cpp
+++ b/Source/JavaScriptCore/tools/FunctionOverrides.cpp
@@ -38,8 +38,6 @@
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringHash.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace JSC {
 
 /*
@@ -192,6 +190,7 @@ bool FunctionOverrides::initializeOverrideFor(const SourceCode& origCode, Functi
         exitProcess(EXIT_FAILURE); \
     } while (false)
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 static bool hasDisallowedCharacters(const char* str, size_t length)
 {
     while (length--) {
@@ -247,6 +246,7 @@ static String parseClause(const char* keyword, size_t keywordLength, FILE* file,
 
     FAIL_WITH_ERROR(SYNTAX_ERROR, ("'", keyword, "' clause end delimiter '", delimiter, "' not found:\n", builder.toString(), "\n", "Are you missing a '}' before the delimiter?\n"));
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void FunctionOverrides::parseOverridesInFile(const char* fileName)
 {
@@ -286,5 +286,3 @@ void FunctionOverrides::parseOverridesInFile(const char* fileName)
 }
     
 } // namespace JSC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -96,8 +96,6 @@
 #include <wtf/cocoa/CrashReporter.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 using namespace JSC;
 
 IGNORE_WARNINGS_BEGIN("frame-address")
@@ -2940,6 +2938,8 @@ static void callWithStackSizeProbeFunction(Probe::State* state)
 }
 #endif // ENABLE(ASSEMBLER) && OS(DARWIN) && CPU(X86_64)
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(functionCallWithStackSize, SUPPRESS_ASAN, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     DollarVMAssertScope assertScope;
@@ -3029,6 +3029,8 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(functionCallWithStackSize, SUPPRESS_ASA
     return throwVMError(globalObject, throwScope, "Not supported for this platform"_s);
 #endif // ENABLE(ASSEMBLER)
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 // Creates a new global object.
 // Usage: $vm.createGlobalObject()
@@ -4447,5 +4449,3 @@ REFTRACKER_IMPL(StrongRefTracker);
 } // namespace JSC
 
 IGNORE_WARNINGS_END
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 862246ced3a3fe9d865a82caa5162c6c559f30ed
<pre>
Drop unnecessary use of WTF_ALLOW_UNSAFE_BUFFER_USAGE
<a href="https://bugs.webkit.org/show_bug.cgi?id=282714">https://bugs.webkit.org/show_bug.cgi?id=282714</a>

Reviewed by Darin Adler.

Drop unnecessary use of WTF_ALLOW_UNSAFE_BUFFER_USAGE after
recent fixes.

* Source/JavaScriptCore/assembler/AssemblerBuffer.h:
* Source/JavaScriptCore/assembler/CPU.cpp:
* Source/JavaScriptCore/assembler/FastJITPermissions.h:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64E.h:
* Source/JavaScriptCore/assembler/SecureARM64EHashPins.cpp:
* Source/JavaScriptCore/assembler/SecureARM64EHashPinsInlines.h:
* Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp:
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
* Source/JavaScriptCore/jit/ExecutableAllocator.h:
* Source/JavaScriptCore/jsc.cpp:
(jscmain):
* Source/JavaScriptCore/llint/LLIntData.cpp:
* Source/JavaScriptCore/llint/LLIntData.h:
* Source/JavaScriptCore/llint/LLIntEntrypoint.cpp:
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
* Source/JavaScriptCore/runtime/JSCConfig.cpp:
* Source/JavaScriptCore/runtime/JSCConfig.h:
* Source/JavaScriptCore/runtime/JSCPtrTag.cpp:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
* Source/JavaScriptCore/runtime/Options.cpp:
* Source/JavaScriptCore/runtime/Options.h:
* Source/JavaScriptCore/runtime/StructureID.h:
* Source/JavaScriptCore/runtime/VM.cpp:
* Source/JavaScriptCore/runtime/VMTraps.cpp:
* Source/JavaScriptCore/tools/FunctionOverrides.cpp:
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm:
(WebKit::setJSCOptions):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.h:

Canonical link: <a href="https://commits.webkit.org/286360@main">https://commits.webkit.org/286360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0ab623569bfd0280a7c9418f2c1527d133641ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75616 "1 style error") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80098 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26880 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77732 "Passed tests") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59304 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17490 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78683 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64948 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39667 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22432 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25209 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68766 "Built successfully and passed tests") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22770 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81575 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74878 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1859 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67544 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3106 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66846 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10799 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8946 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97146 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11700 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2912 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21228 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2937 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3872 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2944 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->