### PR TITLE
Add option to generate new index using updated unexpected results in compare-static-analysis-results

### DIFF
--- a/Tools/Scripts/compare-static-analysis-results
+++ b/Tools/Scripts/compare-static-analysis-results
@@ -55,11 +55,19 @@ def parser():
         '--build-output',
         dest='build_output',
         help='Path to the static analyzer output from the new build',
+        required='--generate-results-only' in sys.argv
     )
     parser.add_argument(
         '--scan-build-path',
         dest='scan_build',
-        help='Path to scan-build executable'
+        help='Path to scan-build executable',
+        required='--generate-results-only' in sys.argv
+    )
+    parser.add_argument(
+        '--generate-results-only',
+        dest='generate_filtered_results',
+        action='store_true',
+        default=False
     )
     parser.add_argument(
         '--check-expectations',
@@ -109,6 +117,7 @@ def find_diff(args, file1, file2):
 
 def create_filtered_results_dir(args, project, result_paths, category='StaticAnalyzerRegressions'):
     # Create symlinks to new issues only so that we can run scan-build to generate new index.html files
+    subprocess.run(['rm', '-r', os.path.abspath(f'{args.build_output}/{category}')])
     prefix_path = os.path.abspath(f'{args.build_output}/{category}/{project}/StaticAnalyzerReports')
     subprocess.run(['mkdir', '-p', prefix_path])
     for path_to_report in result_paths:
@@ -276,8 +285,7 @@ def upload_results(options, results):
             sys.stderr.write(f'Failed to upload results\n')
 
 
-def main():
-    args = parser()
+def compare_results(args):
     new_issues_total = set()
     new_files_total = set()
     fixed_files_total = set()
@@ -308,6 +316,7 @@ def main():
         # JSON
         unexpected_results_data['passes'][project] = project_results_passes
         unexpected_results_data['failures'][project] = project_results_failures
+
         if args.report_urls:
             path_for_upload = archive_path or new_path
             if not project_results_for_upload:
@@ -334,8 +343,35 @@ def main():
         if type_total:
             print(f'Total {type}: {len(type_total)}')
 
-    if args.report_urls:
-        upload_results(args, results_for_upload)
+    return results_for_upload
+
+
+def generate_filtered_results(args):
+    report_paths = []
+    print(f'Generating new results index with results from {args.build_output}...')
+
+    with open(os.path.abspath(f"{args.build_output}/unexpected_results.json"), "r") as f:
+        results_data = json.load(f)
+    with open(f'{args.new_dir}/issues_per_file.json') as f:
+        issues_per_file = json.load(f)
+
+    for project, checkers in results_data.get('failures').items():
+        for checker, files in checkers.items():
+            for file in files:
+                report_paths += [path_to_report for path_to_report in issues_per_file[checker][file].values()]
+
+    create_filtered_results_dir(args, project, report_paths, category='StaticAnalyzerRegressions')
+
+
+def main():
+    args = parser()
+
+    if not args.generate_filtered_results:
+        results_for_upload = compare_results(args)
+        if args.report_urls:
+            upload_results(args, results_for_upload)
+    else:
+        generate_filtered_results(args)
 
     # We don't need the full results for EWS runs. Delete full results if option enabled.
     if args.delete_results:


### PR DESCRIPTION
#### f283632e7ab8857dd6bd8f70d3f64889588756c2
<pre>
Add option to generate new index using updated unexpected results in compare-static-analysis-results
<a href="https://bugs.webkit.org/show_bug.cgi?id=282713">https://bugs.webkit.org/show_bug.cgi?id=282713</a>
<a href="https://rdar.apple.com/139383076">rdar://139383076</a>

Reviewed by Ryosuke Niwa.

Add --generate-results-only option. This will be used in Safer-CPP-Checks after comparing the unexpected
results to results database. If there are changes in the results, then we need to generate a new results index,
without performing another comparison.

Usage: compare-static-analysis-results [new-dir] --build-output [scan-build-output] --scan-build-path [scan-build] --generate-results-only

* Tools/Scripts/compare-static-analysis-results:
(parser): Add generate-results-only option.
(compare_results): Separate out comparison logic from main.
(generate_results_only): Read from unexpected_results.json and issues_per_file.json to get paths to the unexpected result files.
    Pass those files into the pre-existing create_filtered_results_dir function to generate an index with new results.
(main): Clean up main.

Canonical link: <a href="https://commits.webkit.org/286309@main">https://commits.webkit.org/286309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae2644f286099339e98de818b0072fdbf6e91940

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75567 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/28418 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80047 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/26831 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77683 "Passed tests") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/2815 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59274 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/26831 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78634 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/28418 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39632 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/28418 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25159 "Built successfully") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/28418 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81526 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/2906 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/2815 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67513 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/3057 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/28418 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66810 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/28418 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11667 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/2863 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/2888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/3823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/2895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->