### PR TITLE
[WebGPU Swift] Fix static assert due to missing RefPtr members

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#import "CommandBuffer.h"
 #import "CommandsMixin.h"
 #import <wtf/FastMalloc.h>
 #import <wtf/Ref.h>


### PR DESCRIPTION
#### 438b43365c2165f8e8f2c5b081b3bf302f5a091d
<pre>
[WebGPU Swift] Fix static assert due to missing RefPtr members
<a href="https://rdar.apple.com/139385377">rdar://139385377</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=282716">https://bugs.webkit.org/show_bug.cgi?id=282716</a>

Unreviewed. A missing import of CommandEncoder.h is causing swift to
fail to import enough of WebGPU::CommandBuffer to satisfy static
assertions. Fixes this error:

    WebKitBuild/Debug/usr/local/include/wtf/WeakPtr.h:91:13: error: static assertion failed due to requirement &apos;HasRefPtrMethods&lt;WebGPU::CommandBuffer&gt;::value || HasCheckedPtrMethods&lt;WebGPU::CommandBuffer&gt;::value || IsDeprecatedWeakRefSmartPointerException&lt;WebGPU::CommandBuffer&gt;::value&apos;: Classes that offer weak pointers should also offer RefPtr or CheckedPtr. Please do not add new exceptions.
                HasRefPtrMethods&lt;T&gt;::value || HasCheckedPtrMethods&lt;T&gt;::value || IsDeprecatedWeakRefSmartPointerException&lt;std::remove_cv_t&lt;T&gt;&gt;::value,
                ^
    Source/WebGPU/WebGPU/CommandEncoder.h:136:95: note: in instantiation of member function &apos;WTF::WeakPtr&lt;WebGPU::CommandBuffer&gt;::get&apos; requested here
        RefPtr&lt;CommandBuffer&gt; protectedCachedCommandBuffer() const { return m_cachedCommandBuffer.get(); }
                                                                                                  ^
    &lt;module-includes&gt;:2:9: note: in file included from &lt;module-includes&gt;:2:
    #import &quot;Headers/WebGPUExt.h&quot;
            ^
    WebKitBuild/Debug/WebGPU.framework/Headers/WebGPUExt.h:170:10: note: in file included from WebKitBuild/Debug/WebGPU.framework/Headers/WebGPUExt.h:170:
    #include &quot;Buffer.h&quot;
             ^
    Source/WebGPU/WebGPU/Buffer.h:28:9: note: in file included from Source/WebGPU/WebGPU/Buffer.h:28:
    #import &quot;Instance.h&quot;
            ^
    Source/WebGPU/WebGPU/Instance.h:38:9: note: in file included from Source/WebGPU/WebGPU/Instance.h:38:
    #import &lt;wtf/WeakPtr.h&gt;
            ^

* Source/WebGPU/WebGPU/CommandEncoder.h:

Canonical link: <a href="https://commits.webkit.org/286255@main">https://commits.webkit.org/286255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3722891740ae504abaa176d4ad85e232759d18c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75329 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28183 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/79800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/26594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63918 "Build is being retried. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (retry)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2553 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/79800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/26594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78396 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/63918 "Build is being retried. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (retry)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64728 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/79800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/63918 "Build is being retried. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (retry)") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/24921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/63918 "Build is being retried. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (retry)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81286 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2669 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64715 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66652 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16588 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/10615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2626 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/2651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/3586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/2658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->