### PR TITLE
Switch margin/border/padding to use WritingMode arg instead of RenderStyle

### DIFF
--- a/Source/WebCore/rendering/FlexibleBoxAlgorithm.cpp
+++ b/Source/WebCore/rendering/FlexibleBoxAlgorithm.cpp
@@ -70,9 +70,9 @@ void FlexLayoutAlgorithm::removeMarginEndFromFlexSizes(FlexLayoutItem& flexLayou
 {
     LayoutUnit margin;
     if (m_flexbox.isHorizontalFlow())
-        margin = flexLayoutItem.renderer->marginEnd(&m_flexbox.style());
+        margin = flexLayoutItem.renderer->marginEnd(m_flexbox.writingMode());
     else
-        margin = flexLayoutItem.renderer->marginAfter(&m_flexbox.style());
+        margin = flexLayoutItem.renderer->marginAfter(m_flexbox.writingMode());
     sumFlexBaseSize -= margin;
     sumHypotheticalMainSize -= margin;
 } 

--- a/Source/WebCore/rendering/GridBaselineAlignment.cpp
+++ b/Source/WebCore/rendering/GridBaselineAlignment.cpp
@@ -63,7 +63,9 @@ LayoutUnit GridBaselineAlignment::ascentForGridItem(const RenderBox& gridItem, G
 
     ASSERT(position == ItemPosition::Baseline || position == ItemPosition::LastBaseline);
     auto baseline = 0_lu;
-    auto gridItemMargin = alignmentAxis == GridAxis::GridColumnAxis ? gridItem.marginBlockStart(m_writingMode) : gridItem.marginInlineStart(m_writingMode);
+    auto gridItemMargin = alignmentAxis == GridAxis::GridColumnAxis
+        ? gridItem.marginBefore(m_writingMode)
+        : gridItem.marginStart(m_writingMode);
     auto& parentStyle = gridItem.parent()->style();
 
     if (alignmentAxis == GridAxis::GridColumnAxis) {

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -2012,7 +2012,7 @@ void GridTrackSizingAlgorithm::setup(GridTrackSizingDirection direction, unsigne
     auto resolveAndSetNonAutoRowStartMarginsOnRowSubgrids = [&] {
         for (auto& subgrid : m_rowSubgridsWithBaselineAlignedItems) {
             const auto subgridSpan = m_renderGrid->gridSpanForGridItem(subgrid, GridTrackSizingDirection::ForColumns);
-            const auto subgridRowStartMargin = subgrid.style().marginBeforeUsing(&m_renderGrid->style());
+            const auto subgridRowStartMargin = subgrid.style().marginBefore(m_renderGrid->writingMode());
             if (!subgridRowStartMargin.isAuto())
                 m_renderGrid->setMarginBeforeForChild(subgrid, minimumValueForLength(subgridRowStartMargin, computeGridSpanSize(tracks(GridTrackSizingDirection::ForColumns), subgridSpan, std::make_optional(m_renderGrid->gridItemOffset(direction)), m_renderGrid->guttersSize(GridTrackSizingDirection::ForColumns, subgridSpan.startLine(), subgridSpan.integerSpan(), this->availableSpace(GridTrackSizingDirection::ForColumns)))));
         }

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -864,8 +864,8 @@ LayoutUnit RenderBlock::marginIntrinsicLogicalWidthForChild(RenderBox& child) co
     // A margin has three types: fixed, percentage, and auto (variable).
     // Auto and percentage margins become 0 when computing min/max width.
     // Fixed margins can be added in as is.
-    Length marginLeft = child.style().marginStartUsing(&style());
-    Length marginRight = child.style().marginEndUsing(&style());
+    Length marginLeft = child.style().marginStart(writingMode());
+    Length marginRight = child.style().marginEnd(writingMode());
     LayoutUnit margin;
     if (marginLeft.isFixed() && !shouldTrimChildMargin(MarginTrimType::InlineStart, child))
         margin += marginLeft.value();
@@ -2287,8 +2287,8 @@ void RenderBlock::computeBlockPreferredLogicalWidths(LayoutUnit& minLogicalWidth
         // A margin basically has three types: fixed, percentage, and auto (variable).
         // Auto and percentage margins simply become 0 when computing min/max width.
         // Fixed margins can be added in as is.
-        Length startMarginLength = childStyle.marginStartUsing(&styleToUse);
-        Length endMarginLength = childStyle.marginEndUsing(&styleToUse);
+        Length startMarginLength = childStyle.marginStart(writingMode());
+        Length endMarginLength = childStyle.marginEnd(writingMode());
         LayoutUnit margin;
         LayoutUnit marginStart;
         LayoutUnit marginEnd;
@@ -2315,7 +2315,9 @@ void RenderBlock::computeBlockPreferredLogicalWidths(LayoutUnit& minLogicalWidth
                 // Determine a left and right max value based off whether or not the floats can fit in the
                 // margins of the object.  For negative margins, we will attempt to overlap the float if the negative margin
                 // is smaller than the float width.
-                bool ltr = containingBlock ? containingBlock->writingMode().isLogicalLeftInlineStart() : styleToUse.writingMode().isLogicalLeftInlineStart();
+                bool ltr = containingBlock
+                    ? containingBlock->writingMode().isLogicalLeftInlineStart()
+                    : writingMode().isLogicalLeftInlineStart();
                 LayoutUnit marginLogicalLeft = ltr ? marginStart : marginEnd;
                 LayoutUnit marginLogicalRight = ltr ? marginEnd : marginStart;
                 LayoutUnit maxLeft = marginLogicalLeft > 0 ? std::max(floatLeftWidth, marginLogicalLeft) : floatLeftWidth + marginLogicalLeft;
@@ -3440,8 +3442,8 @@ bool RenderBlock::computePreferredWidthsForExcludedChildren(LayoutUnit& minWidth
     maxWidth -= scrollbarWidth;
     
     const auto& childStyle = legend->style();
-    auto startMarginLength = childStyle.marginStartUsing(&style());
-    auto endMarginLength = childStyle.marginEndUsing(&style());
+    auto startMarginLength = childStyle.marginStart(writingMode());
+    auto endMarginLength = childStyle.marginEnd(writingMode());
     LayoutUnit margin;
     LayoutUnit marginStart;
     LayoutUnit marginEnd;

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -227,14 +227,14 @@ public:
     LayoutUnit logicalLeftForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.x() : child.y(); }
     void setLogicalLeftForChild(RenderBox& child, LayoutUnit logicalLeft, ApplyLayoutDeltaMode = DoNotApplyLayoutDelta);
     void setLogicalTopForChild(RenderBox& child, LayoutUnit logicalTop, ApplyLayoutDeltaMode = DoNotApplyLayoutDelta);
-    LayoutUnit marginBeforeForChild(const RenderBoxModelObject& child) const { return child.marginBefore(&style()); }
-    LayoutUnit marginAfterForChild(const RenderBoxModelObject& child) const { return child.marginAfter(&style()); }
-    LayoutUnit marginStartForChild(const RenderBoxModelObject& child) const { return child.marginStart(&style()); }
-    LayoutUnit marginEndForChild(const RenderBoxModelObject& child) const { return child.marginEnd(&style()); }
-    void setMarginStartForChild(RenderBox& child, LayoutUnit value) const { child.setMarginStart(value, &style()); }
-    void setMarginEndForChild(RenderBox& child, LayoutUnit value) const { child.setMarginEnd(value, &style()); }
-    void setMarginBeforeForChild(RenderBox& child, LayoutUnit value) const { child.setMarginBefore(value, &style()); }
-    void setMarginAfterForChild(RenderBox& child, LayoutUnit value) const { child.setMarginAfter(value, &style()); }
+    LayoutUnit marginBeforeForChild(const RenderBoxModelObject& child) const { return child.marginBefore(writingMode()); }
+    LayoutUnit marginAfterForChild(const RenderBoxModelObject& child) const { return child.marginAfter(writingMode()); }
+    LayoutUnit marginStartForChild(const RenderBoxModelObject& child) const { return child.marginStart(writingMode()); }
+    LayoutUnit marginEndForChild(const RenderBoxModelObject& child) const { return child.marginEnd(writingMode()); }
+    void setMarginStartForChild(RenderBox& child, LayoutUnit value) const { child.setMarginStart(value, writingMode()); }
+    void setMarginEndForChild(RenderBox& child, LayoutUnit value) const { child.setMarginEnd(value, writingMode()); }
+    void setMarginBeforeForChild(RenderBox& child, LayoutUnit value) const { child.setMarginBefore(value, writingMode()); }
+    void setMarginAfterForChild(RenderBox& child, LayoutUnit value) const { child.setMarginAfter(value, writingMode()); }
     void setTrimmedMarginForChild(RenderBox& child, MarginTrimType);
     LayoutUnit collapsedMarginBeforeForChild(const RenderBox& child) const;
     LayoutUnit collapsedMarginAfterForChild(const RenderBox& child) const;

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1099,7 +1099,7 @@ void RenderBlockFlow::determineLogicalLeftPositionForChild(RenderBox& child, App
     // If the child is being centred then the margin calculated to do that has factored in any offset required to
     // avoid floats, so use it if necessary.
 
-    if (style().textAlign() == TextAlignMode::WebKitCenter || child.style().marginStartUsing(&style()).isAuto())
+    if (style().textAlign() == TextAlignMode::WebKitCenter || child.style().marginStart(writingMode()).isAuto())
         newPosition = std::max(newPosition, positionToAvoidFloats + childMarginStart);
     else if (positionToAvoidFloats > initialStartPosition)
         newPosition = std::max(newPosition, positionToAvoidFloats);
@@ -4632,8 +4632,8 @@ void RenderBlockFlow::computeInlinePreferredLogicalWidths(LayoutUnit& minLogical
                     if (!child->isFloating())
                         lastText = nullptr;
                     LayoutUnit margins;
-                    Length startMargin = childStyle.marginStartUsing(&style());
-                    Length endMargin = childStyle.marginEndUsing(&style());
+                    Length startMargin = childStyle.marginStart(writingMode());
+                    Length endMargin = childStyle.marginEnd(writingMode());
                     if (startMargin.isFixed())
                         margins += LayoutUnit::fromFloatCeil(startMargin.value());
                     if (endMargin.isFixed())

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2993,8 +2993,8 @@ LayoutUnit RenderBox::computeOrTrimInlineMargin(const RenderBlock& containingBlo
 void RenderBox::computeInlineDirectionMargins(const RenderBlock& containingBlock, LayoutUnit containerWidth, std::optional<LayoutUnit> availableSpaceAdjustedWithFloats, LayoutUnit childWidth, LayoutUnit& marginStart, LayoutUnit& marginEnd) const
 {
     const RenderStyle& containingBlockStyle = containingBlock.style();
-    Length marginStartLength = style().marginStartUsing(&containingBlockStyle);
-    Length marginEndLength = style().marginEndUsing(&containingBlockStyle);
+    Length marginStartLength = style().marginStart(containingBlockStyle.writingMode());
+    Length marginEndLength = style().marginEnd(containingBlockStyle.writingMode());
 
     if (isFloating()) {
         marginStart = minimumValueForLength(marginStartLength, containerWidth);
@@ -3830,7 +3830,9 @@ LayoutUnit RenderBox::constrainBlockMarginInAvailableSpaceOrTrim(const RenderBox
         return 0_lu;
     }
     
-    return marginSide == MarginTrimType::BlockStart ? minimumValueForLength(style().marginBeforeUsing(&containingBlock.style()), availableSpace) : minimumValueForLength(style().marginAfterUsing(&containingBlock.style()), availableSpace);
+    return marginSide == MarginTrimType::BlockStart
+        ? minimumValueForLength(style().marginBefore(containingBlock.writingMode()), availableSpace)
+        : minimumValueForLength(style().marginAfter(containingBlock.writingMode()), availableSpace);
 }
 
 LayoutUnit RenderBox::containingBlockLogicalWidthForPositioned(const RenderBoxModelObject& containingBlock, RenderFragmentContainer* fragment, bool checkForPerpendicularWritingMode) const

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -225,36 +225,28 @@ public:
     void setMarginLeft(LayoutUnit margin) { m_marginBox.setLeft(margin); }
     void setMarginRight(LayoutUnit margin) { m_marginBox.setRight(margin); }
 
-    LayoutUnit marginLogicalLeft(const RenderStyle* overrideStyle = nullptr) const { return m_marginBox.logicalLeft((overrideStyle ? overrideStyle : &style())->writingMode()); }
-    LayoutUnit marginLogicalRight(const RenderStyle* overrideStyle = nullptr) const { return m_marginBox.logicalRight((overrideStyle ? overrideStyle : &style())->writingMode()); }
+    LayoutUnit marginLogicalLeft(const WritingMode writingMode) const { return m_marginBox.logicalLeft(writingMode); }
+    LayoutUnit marginLogicalRight(const WritingMode writingMode) const { return m_marginBox.logicalRight(writingMode); }
+    LayoutUnit marginLogicalLeft() const { return marginLogicalLeft(writingMode()); }
+    LayoutUnit marginLogicalRight() const { return marginLogicalRight(writingMode()); }
 
-    LayoutUnit marginBefore(const RenderStyle* overrideStyle = nullptr) const final { return m_marginBox.before((overrideStyle ? overrideStyle : &style())->writingMode()); }
-    LayoutUnit marginAfter(const RenderStyle* overrideStyle = nullptr) const final { return m_marginBox.after((overrideStyle ? overrideStyle : &style())->writingMode()); }
-    LayoutUnit marginStart(const RenderStyle* overrideStyle = nullptr) const final
-    {
-        const RenderStyle* styleToUse = overrideStyle ? overrideStyle : &style();
-        return m_marginBox.start(styleToUse->writingMode());
-    }
-    LayoutUnit marginEnd(const RenderStyle* overrideStyle = nullptr) const final
-    {
-        const RenderStyle* styleToUse = overrideStyle ? overrideStyle : &style();
-        return m_marginBox.end(styleToUse->writingMode());
-    }
-    LayoutUnit marginBlockStart(const WritingMode writingMode) const { return m_marginBox.before(writingMode); }
-    LayoutUnit marginInlineStart(const WritingMode writingMode) const { return m_marginBox.start(writingMode); }
+    LayoutUnit marginBefore(const WritingMode writingMode) const override { return m_marginBox.before(writingMode); }
+    LayoutUnit marginAfter(const WritingMode writingMode) const override { return m_marginBox.after(writingMode); }
+    LayoutUnit marginStart(const WritingMode writingMode) const override { return m_marginBox.start(writingMode); }
+    LayoutUnit marginEnd(const WritingMode writingMode) const override { return m_marginBox.end(writingMode); }
+    LayoutUnit marginBefore() const { return marginBefore(writingMode()); }
+    LayoutUnit marginAfter() const { return marginAfter(writingMode()); }
+    LayoutUnit marginStart() const { return marginStart(writingMode()); }
+    LayoutUnit marginEnd() const { return marginEnd(writingMode()); }
 
-    void setMarginBefore(LayoutUnit value, const RenderStyle* overrideStyle = nullptr) { m_marginBox.setBefore(value, (overrideStyle ? overrideStyle : &style())->writingMode()); }
-    void setMarginAfter(LayoutUnit value, const RenderStyle* overrideStyle = nullptr) { m_marginBox.setAfter(value, (overrideStyle ? overrideStyle : &style())->writingMode()); }
-    void setMarginStart(LayoutUnit value, const RenderStyle* overrideStyle = nullptr)
-    {
-        const RenderStyle* styleToUse = overrideStyle ? overrideStyle : &style();
-        m_marginBox.setStart(value, styleToUse->writingMode());
-    }
-    void setMarginEnd(LayoutUnit value, const RenderStyle* overrideStyle = nullptr)
-    {
-        const RenderStyle* styleToUse = overrideStyle ? overrideStyle : &style();
-        m_marginBox.setEnd(value, styleToUse->writingMode());
-    }
+    void setMarginBefore(LayoutUnit value, const WritingMode writingMode) { m_marginBox.setBefore(value, writingMode); }
+    void setMarginAfter(LayoutUnit value, const WritingMode writingMode) { m_marginBox.setAfter(value, writingMode); }
+    void setMarginStart(LayoutUnit value, const WritingMode writingMode) { m_marginBox.setStart(value, writingMode); }
+    void setMarginEnd(LayoutUnit value, const WritingMode writingMode) { m_marginBox.setEnd(value, writingMode); }
+    void setMarginBefore(LayoutUnit value) { setMarginBefore(value, writingMode()); }
+    void setMarginAfter(LayoutUnit value) { setMarginAfter(value, writingMode()); }
+    void setMarginStart(LayoutUnit value) { setMarginStart(value, writingMode()); }
+    void setMarginEnd(LayoutUnit value) { setMarginEnd(value, writingMode()); }
 
     virtual bool isSelfCollapsingBlock() const { return false; }
     virtual LayoutUnit collapsedMarginBefore() const { return marginBefore(); }

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -168,10 +168,14 @@ public:
     virtual LayoutUnit marginBottom() const = 0;
     virtual LayoutUnit marginLeft() const = 0;
     virtual LayoutUnit marginRight() const = 0;
-    virtual LayoutUnit marginBefore(const RenderStyle* otherStyle = nullptr) const = 0;
-    virtual LayoutUnit marginAfter(const RenderStyle* otherStyle = nullptr) const = 0;
-    virtual LayoutUnit marginStart(const RenderStyle* otherStyle = nullptr) const = 0;
-    virtual LayoutUnit marginEnd(const RenderStyle* otherStyle = nullptr) const = 0;
+    virtual LayoutUnit marginBefore(const WritingMode) const = 0;
+    virtual LayoutUnit marginAfter(const WritingMode) const = 0;
+    virtual LayoutUnit marginStart(const WritingMode) const = 0;
+    virtual LayoutUnit marginEnd(const WritingMode) const = 0;
+    LayoutUnit marginBefore() const { return marginBefore(writingMode()); }
+    LayoutUnit marginAfter() const { return marginAfter(writingMode()); }
+    LayoutUnit marginStart() const { return marginStart(writingMode()); }
+    LayoutUnit marginEnd() const { return marginEnd(writingMode()); }
     LayoutUnit verticalMarginExtent() const { return marginTop() + marginBottom(); }
     LayoutUnit horizontalMarginExtent() const { return marginLeft() + marginRight(); }
     LayoutUnit marginLogicalHeight() const { return marginBefore() + marginAfter(); }

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -951,7 +951,9 @@ bool RenderFlexibleBox::shouldTrimCrossAxisMarginEnd() const
 void RenderFlexibleBox::trimMainAxisMarginStart(const FlexLayoutItem& flexLayoutItem)
 {
     auto horizontalFlow = isHorizontalFlow();
-    flexLayoutItem.mainAxisMargin -= horizontalFlow ? flexLayoutItem.renderer->marginStart(&style()) : flexLayoutItem.renderer->marginBefore(&style());
+    flexLayoutItem.mainAxisMargin -= horizontalFlow
+        ? flexLayoutItem.renderer->marginStart(writingMode())
+        : flexLayoutItem.renderer->marginBefore(writingMode());
     if (horizontalFlow)
         setTrimmedMarginForChild(flexLayoutItem.renderer, MarginTrimType::InlineStart);
     else
@@ -962,7 +964,9 @@ void RenderFlexibleBox::trimMainAxisMarginStart(const FlexLayoutItem& flexLayout
 void RenderFlexibleBox::trimMainAxisMarginEnd(const FlexLayoutItem& flexLayoutItem)
 {
     auto horizontalFlow = isHorizontalFlow();
-    flexLayoutItem.mainAxisMargin -= horizontalFlow ? flexLayoutItem.renderer->marginEnd(&style()) : flexLayoutItem.renderer->marginAfter(&style());
+    flexLayoutItem.mainAxisMargin -= horizontalFlow
+        ? flexLayoutItem.renderer->marginEnd(writingMode())
+        : flexLayoutItem.renderer->marginAfter(writingMode());
     if (horizontalFlow)
         setTrimmedMarginForChild(flexLayoutItem.renderer, MarginTrimType::InlineEnd);
     else

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -1767,9 +1767,8 @@ void RenderGrid::updateAutoMarginsInRowAxisIfNeeded(RenderBox& gridItem)
 {
     ASSERT(!gridItem.isOutOfFlowPositioned());
 
-    const RenderStyle& parentStyle = style();
-    Length marginStart = gridItem.style().marginStartUsing(&parentStyle);
-    Length marginEnd = gridItem.style().marginEndUsing(&parentStyle);
+    Length marginStart = gridItem.style().marginStart(writingMode());
+    Length marginEnd = gridItem.style().marginEnd(writingMode());
     LayoutUnit marginLogicalWidth;
     // We should only consider computed margins if their specified value isn't
     // 'auto', since such computed value may come from a previous layout and may
@@ -1784,12 +1783,12 @@ void RenderGrid::updateAutoMarginsInRowAxisIfNeeded(RenderBox& gridItem)
         return;
 
     if (marginStart.isAuto() && marginEnd.isAuto()) {
-        gridItem.setMarginStart(availableAlignmentSpace / 2, &parentStyle);
-        gridItem.setMarginEnd(availableAlignmentSpace / 2, &parentStyle);
+        gridItem.setMarginStart(availableAlignmentSpace / 2, writingMode());
+        gridItem.setMarginEnd(availableAlignmentSpace / 2, writingMode());
     } else if (marginStart.isAuto()) {
-        gridItem.setMarginStart(availableAlignmentSpace, &parentStyle);
+        gridItem.setMarginStart(availableAlignmentSpace, writingMode());
     } else if (marginEnd.isAuto()) {
-        gridItem.setMarginEnd(availableAlignmentSpace, &parentStyle);
+        gridItem.setMarginEnd(availableAlignmentSpace, writingMode());
     }
 }
 
@@ -1798,9 +1797,8 @@ void RenderGrid::updateAutoMarginsInColumnAxisIfNeeded(RenderBox& gridItem)
 {
     ASSERT(!gridItem.isOutOfFlowPositioned());
 
-    const RenderStyle& parentStyle = style();
-    Length marginBefore = gridItem.style().marginBeforeUsing(&parentStyle);
-    Length marginAfter = gridItem.style().marginAfterUsing(&parentStyle);
+    Length marginBefore = gridItem.style().marginBefore(writingMode());
+    Length marginAfter = gridItem.style().marginAfter(writingMode());
     LayoutUnit marginLogicalHeight;
     // We should only consider computed margins if their specified value isn't
     // 'auto', since such computed value may come from a previous layout and may
@@ -1815,12 +1813,12 @@ void RenderGrid::updateAutoMarginsInColumnAxisIfNeeded(RenderBox& gridItem)
         return;
 
     if (marginBefore.isAuto() && marginAfter.isAuto()) {
-        gridItem.setMarginBefore(availableAlignmentSpace / 2, &parentStyle);
-        gridItem.setMarginAfter(availableAlignmentSpace / 2, &parentStyle);
+        gridItem.setMarginBefore(availableAlignmentSpace / 2, writingMode());
+        gridItem.setMarginAfter(availableAlignmentSpace / 2, writingMode());
     } else if (marginBefore.isAuto()) {
-        gridItem.setMarginBefore(availableAlignmentSpace, &parentStyle);
+        gridItem.setMarginBefore(availableAlignmentSpace, writingMode());
     } else if (marginAfter.isAuto()) {
-        gridItem.setMarginAfter(availableAlignmentSpace, &parentStyle);
+        gridItem.setMarginAfter(availableAlignmentSpace, writingMode());
     }
 }
 
@@ -2230,7 +2228,7 @@ LayoutUnit RenderGrid::logicalOffsetForOutOfFlowGridItem(const RenderBox& gridIt
     bool isFlowAwareRowAxis = GridLayoutFunctions::flowAwareDirectionForGridItem(*this, gridItem, direction) == GridTrackSizingDirection::ForColumns;
     LayoutUnit gridItemPosition = isFlowAwareRowAxis ? gridItem.logicalLeft() : gridItem.logicalTop();
     LayoutUnit gridBorder = isRowAxis ? borderLogicalLeft() : borderBefore();
-    LayoutUnit gridItemMargin = isRowAxis ? gridItem.marginLogicalLeft(&style()) : gridItem.marginBefore(&style());
+    LayoutUnit gridItemMargin = isRowAxis ? gridItem.marginLogicalLeft(writingMode()) : gridItem.marginBefore(writingMode());
     LayoutUnit offset = gridItemPosition - gridBorder - gridItemMargin;
     if (!isRowAxis || writingMode().isLogicalLeftInlineStart())
         return offset;

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -376,24 +376,24 @@ LayoutUnit RenderInline::marginBottom() const
     return computeMargin(this, style().marginBottom());
 }
 
-LayoutUnit RenderInline::marginStart(const RenderStyle* otherStyle) const
+LayoutUnit RenderInline::marginStart(const WritingMode writingMode) const
 {
-    return computeMargin(this, style().marginStartUsing(otherStyle ? otherStyle : &style()));
+    return computeMargin(this, style().marginStart(writingMode));
 }
 
-LayoutUnit RenderInline::marginEnd(const RenderStyle* otherStyle) const
+LayoutUnit RenderInline::marginEnd(const WritingMode writingMode) const
 {
-    return computeMargin(this, style().marginEndUsing(otherStyle ? otherStyle : &style()));
+    return computeMargin(this, style().marginEnd(writingMode));
 }
 
-LayoutUnit RenderInline::marginBefore(const RenderStyle* otherStyle) const
+LayoutUnit RenderInline::marginBefore(const WritingMode writingMode) const
 {
-    return computeMargin(this, style().marginBeforeUsing(otherStyle ? otherStyle : &style()));
+    return computeMargin(this, style().marginBefore(writingMode));
 }
 
-LayoutUnit RenderInline::marginAfter(const RenderStyle* otherStyle) const
+LayoutUnit RenderInline::marginAfter(const WritingMode writingMode) const
 {
-    return computeMargin(this, style().marginAfterUsing(otherStyle ? otherStyle : &style()));
+    return computeMargin(this, style().marginAfter(writingMode));
 }
 
 ASCIILiteral RenderInline::renderName() const

--- a/Source/WebCore/rendering/RenderInline.h
+++ b/Source/WebCore/rendering/RenderInline.h
@@ -42,10 +42,14 @@ public:
     LayoutUnit marginRight() const final;
     LayoutUnit marginTop() const final;
     LayoutUnit marginBottom() const final;
-    LayoutUnit marginBefore(const RenderStyle* otherStyle = 0) const final;
-    LayoutUnit marginAfter(const RenderStyle* otherStyle = 0) const final;
-    LayoutUnit marginStart(const RenderStyle* otherStyle = 0) const final;
-    LayoutUnit marginEnd(const RenderStyle* otherStyle = 0) const final;
+    LayoutUnit marginBefore(const WritingMode) const final;
+    LayoutUnit marginAfter(const WritingMode) const final;
+    LayoutUnit marginStart(const WritingMode) const final;
+    LayoutUnit marginEnd(const WritingMode) const final;
+    LayoutUnit marginBefore() const { return marginBefore(writingMode()); }
+    LayoutUnit marginAfter() const { return marginAfter(writingMode()); }
+    LayoutUnit marginStart() const { return marginStart(writingMode()); }
+    LayoutUnit marginEnd() const { return marginEnd(writingMode()); }
 
     void boundingRects(Vector<LayoutRect>&, const LayoutPoint& accumulatedOffset) const final;
     void absoluteQuads(Vector<FloatQuad>&, bool* wasFixed) const override;

--- a/Source/WebCore/rendering/RenderLineBreak.h
+++ b/Source/WebCore/rendering/RenderLineBreak.h
@@ -68,10 +68,10 @@ private:
     LayoutUnit marginBottom() const final { return 0; }
     LayoutUnit marginLeft() const final { return 0; }
     LayoutUnit marginRight() const final { return 0; }
-    LayoutUnit marginBefore(const RenderStyle*) const final { return 0; }
-    LayoutUnit marginAfter(const RenderStyle*) const final { return 0; }
-    LayoutUnit marginStart(const RenderStyle*) const final { return 0; }
-    LayoutUnit marginEnd(const RenderStyle*) const final { return 0; }
+    LayoutUnit marginBefore(const WritingMode) const final { return 0; }
+    LayoutUnit marginAfter(const WritingMode) const final { return 0; }
+    LayoutUnit marginStart(const WritingMode) const final { return 0; }
+    LayoutUnit marginEnd(const WritingMode) const final { return 0; }
     LayoutUnit offsetWidth() const final { return linesBoundingBox().width(); }
     LayoutUnit offsetHeight() const final { return linesBoundingBox().height(); }
     LayoutRect borderBoundingBox() const final { return LayoutRect(LayoutPoint(), linesBoundingBox().size()); }

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -419,7 +419,7 @@ auto RenderTableCell::localRectsForRepaint(RepaintOutlineBounds repaintOutlineBo
     if (!table()->collapseBorders() || table()->needsSectionRecalc())
         return RenderBlockFlow::localRectsForRepaint(repaintOutlineBounds);
 
-    bool flippedInline = styleForCellFlow().writingMode().isInlineFlipped();
+    bool flippedInline = tableWritingMode().isInlineFlipped();
     LayoutUnit outlineSize { style().outlineSize() };
     LayoutUnit left = std::max(borderHalfLeft(true), outlineSize);
     LayoutUnit right = std::max(borderHalfRight(true), outlineSize);
@@ -619,9 +619,9 @@ CollapsedBorderValue RenderTableCell::computeCollapsedStartBorder(IncludeBorderC
 {
     // For the start border, we need to check, in order of precedence:
     // (1) Our start border.
-    CSSPropertyID startColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderInlineStartColor, styleForCellFlow().writingMode()) : CSSPropertyInvalid;
-    CSSPropertyID endColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderInlineEndColor, styleForCellFlow().writingMode()) : CSSPropertyInvalid;
-    CollapsedBorderValue result(style().borderStart(styleForCellFlow()), includeColor ? style().visitedDependentColorWithColorFilter(startColorProperty) : Color(), BorderPrecedence::Cell);
+    CSSPropertyID startColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderInlineStartColor, tableWritingMode()) : CSSPropertyInvalid;
+    CSSPropertyID endColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderInlineEndColor, tableWritingMode()) : CSSPropertyInvalid;
+    CollapsedBorderValue result(style().borderStart(tableWritingMode()), includeColor ? style().visitedDependentColorWithColorFilter(startColorProperty) : Color(), BorderPrecedence::Cell);
 
     RenderTable* table = this->table();
     if (!table)
@@ -730,9 +730,10 @@ CollapsedBorderValue RenderTableCell::computeCollapsedEndBorder(IncludeBorderCol
 {
     // For end border, we need to check, in order of precedence:
     // (1) Our end border.
-    CSSPropertyID startColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderInlineStartColor, styleForCellFlow().writingMode()) : CSSPropertyInvalid;
-    CSSPropertyID endColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderInlineEndColor, styleForCellFlow().writingMode()) : CSSPropertyInvalid;
-    CollapsedBorderValue result = CollapsedBorderValue(style().borderEnd(styleForCellFlow()), includeColor ? style().visitedDependentColorWithColorFilter(endColorProperty) : Color(), BorderPrecedence::Cell);
+    CSSPropertyID startColorProperty = includeColor
+        ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderInlineStartColor, tableWritingMode()) : CSSPropertyInvalid;
+    CSSPropertyID endColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderInlineEndColor, tableWritingMode()) : CSSPropertyInvalid;
+    CollapsedBorderValue result = CollapsedBorderValue(style().borderEnd(tableWritingMode()), includeColor ? style().visitedDependentColorWithColorFilter(endColorProperty) : Color(), BorderPrecedence::Cell);
 
     RenderTable* table = this->table();
     if (!table)
@@ -843,9 +844,9 @@ CollapsedBorderValue RenderTableCell::computeCollapsedBeforeBorder(IncludeBorder
 {
     // For before border, we need to check, in order of precedence:
     // (1) Our before border.
-    CSSPropertyID beforeColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderBlockStartColor, styleForCellFlow().writingMode()) : CSSPropertyInvalid;
-    CSSPropertyID afterColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderBlockEndColor, styleForCellFlow().writingMode()) : CSSPropertyInvalid;
-    CollapsedBorderValue result = CollapsedBorderValue(style().borderBefore(styleForCellFlow()), includeColor ? style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::Cell);
+    CSSPropertyID beforeColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderBlockStartColor, tableWritingMode()) : CSSPropertyInvalid;
+    CSSPropertyID afterColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderBlockEndColor, tableWritingMode()) : CSSPropertyInvalid;
+    CollapsedBorderValue result = CollapsedBorderValue(style().borderBefore(tableWritingMode()), includeColor ? style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::Cell);
     
     RenderTable* table = this->table();
     if (!table)
@@ -859,7 +860,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedBeforeBorder(IncludeBorder
     }
     
     // (3) Our row's before border.
-    result = chooseBorder(result, CollapsedBorderValue(parent()->style().borderBefore(styleForCellFlow()), includeColor ? parent()->style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::Row));
+    result = chooseBorder(result, CollapsedBorderValue(parent()->style().borderBefore(tableWritingMode()), includeColor ? parent()->style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::Row));
     if (!result.exists())
         return result;
     
@@ -882,7 +883,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedBeforeBorder(IncludeBorder
     RenderTableSection* currSection = section();
     if (!rowIndex()) {
         // (5) Our row group's before border.
-        result = chooseBorder(result, CollapsedBorderValue(currSection->style().borderBefore(styleForCellFlow()), includeColor ? currSection->style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::RowGroup));
+        result = chooseBorder(result, CollapsedBorderValue(currSection->style().borderBefore(tableWritingMode()), includeColor ? currSection->style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::RowGroup));
         if (!result.exists())
             return result;
         
@@ -899,11 +900,11 @@ CollapsedBorderValue RenderTableCell::computeCollapsedBeforeBorder(IncludeBorder
         // (8) Our column and column group's before borders.
         RenderTableCol* colElt = table->colElement(col());
         if (colElt) {
-            result = chooseBorder(result, CollapsedBorderValue(colElt->style().borderBefore(styleForCellFlow()), includeColor ? colElt->style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::Column));
+            result = chooseBorder(result, CollapsedBorderValue(colElt->style().borderBefore(tableWritingMode()), includeColor ? colElt->style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::Column));
             if (!result.exists())
                 return result;
             if (RenderTableCol* enclosingColumnGroup = colElt->enclosingColumnGroup()) {
-                result = chooseBorder(result, CollapsedBorderValue(enclosingColumnGroup->style().borderBefore(styleForCellFlow()), includeColor ? enclosingColumnGroup->style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::ColumnGroup));
+                result = chooseBorder(result, CollapsedBorderValue(enclosingColumnGroup->style().borderBefore(tableWritingMode()), includeColor ? enclosingColumnGroup->style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::ColumnGroup));
                 if (!result.exists())
                     return result;
             }
@@ -940,9 +941,9 @@ CollapsedBorderValue RenderTableCell::computeCollapsedAfterBorder(IncludeBorderC
 {
     // For after border, we need to check, in order of precedence:
     // (1) Our after border.
-    CSSPropertyID beforeColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderBlockStartColor, styleForCellFlow().writingMode()) : CSSPropertyInvalid;
-    CSSPropertyID afterColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderBlockEndColor, styleForCellFlow().writingMode()) : CSSPropertyInvalid;
-    CollapsedBorderValue result = CollapsedBorderValue(style().borderAfter(styleForCellFlow()), includeColor ? style().visitedDependentColorWithColorFilter(afterColorProperty) : Color(), BorderPrecedence::Cell);
+    CSSPropertyID beforeColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderBlockStartColor, tableWritingMode()) : CSSPropertyInvalid;
+    CSSPropertyID afterColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderBlockEndColor, tableWritingMode()) : CSSPropertyInvalid;
+    CollapsedBorderValue result = CollapsedBorderValue(style().borderAfter(tableWritingMode()), includeColor ? style().visitedDependentColorWithColorFilter(afterColorProperty) : Color(), BorderPrecedence::Cell);
     
     RenderTable* table = this->table();
     if (!table)
@@ -950,7 +951,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedAfterBorder(IncludeBorderC
     RenderTableCell* nextCell = table->cellBelow(this);
     if (nextCell) {
         // (2) An after cell's before border.
-        result = chooseBorder(result, CollapsedBorderValue(nextCell->style().borderBefore(styleForCellFlow()), includeColor ? nextCell->style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::Cell));
+        result = chooseBorder(result, CollapsedBorderValue(nextCell->style().borderBefore(tableWritingMode()), includeColor ? nextCell->style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::Cell));
         if (!result.exists())
             return result;
     }
@@ -962,7 +963,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedAfterBorder(IncludeBorderC
     
     // (4) The next row's before border.
     if (nextCell) {
-        result = chooseBorder(result, CollapsedBorderValue(nextCell->parent()->style().borderBefore(styleForCellFlow()), includeColor ? nextCell->parent()->style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::Row));
+        result = chooseBorder(result, CollapsedBorderValue(nextCell->parent()->style().borderBefore(tableWritingMode()), includeColor ? nextCell->parent()->style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::Row));
         if (!result.exists())
             return result;
     }
@@ -971,14 +972,14 @@ CollapsedBorderValue RenderTableCell::computeCollapsedAfterBorder(IncludeBorderC
     RenderTableSection* currSection = section();
     if (rowIndex() + rowSpan() >= currSection->numRows()) {
         // (5) Our row group's after border.
-        result = chooseBorder(result, CollapsedBorderValue(currSection->style().borderAfter(styleForCellFlow()), includeColor ? currSection->style().visitedDependentColorWithColorFilter(afterColorProperty) : Color(), BorderPrecedence::RowGroup));
+        result = chooseBorder(result, CollapsedBorderValue(currSection->style().borderAfter(tableWritingMode()), includeColor ? currSection->style().visitedDependentColorWithColorFilter(afterColorProperty) : Color(), BorderPrecedence::RowGroup));
         if (!result.exists())
             return result;
         
         // (6) Following row group's before border.
         currSection = table->sectionBelow(currSection, SkipEmptySections);
         if (currSection) {
-            result = chooseBorder(result, CollapsedBorderValue(currSection->style().borderBefore(styleForCellFlow()), includeColor ? currSection->style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::RowGroup));
+            result = chooseBorder(result, CollapsedBorderValue(currSection->style().borderBefore(tableWritingMode()), includeColor ? currSection->style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::RowGroup));
             if (!result.exists())
                 return result;
         }
@@ -988,17 +989,17 @@ CollapsedBorderValue RenderTableCell::computeCollapsedAfterBorder(IncludeBorderC
         // (8) Our column and column group's after borders.
         RenderTableCol* colElt = table->colElement(col());
         if (colElt) {
-            result = chooseBorder(result, CollapsedBorderValue(colElt->style().borderAfter(styleForCellFlow()), includeColor ? colElt->style().visitedDependentColorWithColorFilter(afterColorProperty) : Color(), BorderPrecedence::Column));
+            result = chooseBorder(result, CollapsedBorderValue(colElt->style().borderAfter(tableWritingMode()), includeColor ? colElt->style().visitedDependentColorWithColorFilter(afterColorProperty) : Color(), BorderPrecedence::Column));
             if (!result.exists()) return result;
             if (RenderTableCol* enclosingColumnGroup = colElt->enclosingColumnGroup()) {
-                result = chooseBorder(result, CollapsedBorderValue(enclosingColumnGroup->style().borderAfter(styleForCellFlow()), includeColor ? enclosingColumnGroup->style().visitedDependentColorWithColorFilter(afterColorProperty) : Color(), BorderPrecedence::ColumnGroup));
+                result = chooseBorder(result, CollapsedBorderValue(enclosingColumnGroup->style().borderAfter(tableWritingMode()), includeColor ? enclosingColumnGroup->style().visitedDependentColorWithColorFilter(afterColorProperty) : Color(), BorderPrecedence::ColumnGroup));
                 if (!result.exists())
                     return result;
             }
         }
         
         // (9) The table's after border.
-        result = chooseBorder(result, CollapsedBorderValue(table->style().borderAfter(styleForCellFlow()), includeColor ? table->style().visitedDependentColorWithColorFilter(afterColorProperty) : Color(), BorderPrecedence::Table));
+        result = chooseBorder(result, CollapsedBorderValue(table->style().borderAfter(tableWritingMode()), includeColor ? table->style().visitedDependentColorWithColorFilter(afterColorProperty) : Color(), BorderPrecedence::Table));
         if (!result.exists())
             return result;
     }
@@ -1119,7 +1120,7 @@ LayoutUnit RenderTableCell::borderAfter() const
 
 LayoutUnit RenderTableCell::borderHalfLeft(bool outer) const
 {
-    WritingMode writingMode = this->styleForCellFlow().writingMode();
+    WritingMode writingMode = this->tableWritingMode();
     if (writingMode.isHorizontal())
         return writingMode.isInlineLeftToRight() ? borderHalfStart(outer) : borderHalfEnd(outer);
     return writingMode.isBlockLeftToRight() ? borderHalfBefore(outer) : borderHalfAfter(outer);
@@ -1127,7 +1128,7 @@ LayoutUnit RenderTableCell::borderHalfLeft(bool outer) const
 
 LayoutUnit RenderTableCell::borderHalfRight(bool outer) const
 {
-    WritingMode writingMode = this->styleForCellFlow().writingMode();
+    WritingMode writingMode = this->tableWritingMode();
     if (writingMode.isHorizontal())
         return writingMode.isInlineLeftToRight() ? borderHalfEnd(outer) : borderHalfStart(outer);
     return writingMode.isBlockLeftToRight() ? borderHalfAfter(outer) : borderHalfBefore(outer);
@@ -1135,7 +1136,7 @@ LayoutUnit RenderTableCell::borderHalfRight(bool outer) const
 
 LayoutUnit RenderTableCell::borderHalfTop(bool outer) const
 {
-    WritingMode writingMode = this->styleForCellFlow().writingMode();
+    WritingMode writingMode = this->tableWritingMode();
     if (writingMode.isHorizontal())
         return writingMode.isBlockTopToBottom() ? borderHalfBefore(outer) : borderHalfAfter(outer);
     return writingMode.isInlineTopToBottom() ? borderHalfStart(outer) : borderHalfEnd(outer);
@@ -1143,7 +1144,7 @@ LayoutUnit RenderTableCell::borderHalfTop(bool outer) const
 
 LayoutUnit RenderTableCell::borderHalfBottom(bool outer) const
 {
-    WritingMode writingMode = this->styleForCellFlow().writingMode();
+    WritingMode writingMode = this->tableWritingMode();
     if (writingMode.isHorizontal())
         return writingMode.isBlockTopToBottom() ? borderHalfAfter(outer) : borderHalfBefore(outer);
     return writingMode.isInlineTopToBottom() ? borderHalfEnd(outer) : borderHalfStart(outer);
@@ -1153,7 +1154,7 @@ LayoutUnit RenderTableCell::borderHalfStart(bool outer) const
 {
     CollapsedBorderValue border = collapsedStartBorder(DoNotIncludeBorderColor);
     if (border.exists())
-        return CollapsedBorderValue::adjustedCollapsedBorderWidth(border.width(), document().deviceScaleFactor(), !(styleForCellFlow().writingMode().isInlineFlipped() ^ outer));
+        return CollapsedBorderValue::adjustedCollapsedBorderWidth(border.width(), document().deviceScaleFactor(), !(tableWritingMode().isInlineFlipped() ^ outer));
     return 0;
 }
     
@@ -1161,7 +1162,7 @@ LayoutUnit RenderTableCell::borderHalfEnd(bool outer) const
 {
     CollapsedBorderValue border = collapsedEndBorder(DoNotIncludeBorderColor);
     if (border.exists())
-        return CollapsedBorderValue::adjustedCollapsedBorderWidth(border.width(), document().deviceScaleFactor(), styleForCellFlow().writingMode().isInlineFlipped() ^ outer);
+        return CollapsedBorderValue::adjustedCollapsedBorderWidth(border.width(), document().deviceScaleFactor(), tableWritingMode().isInlineFlipped() ^ outer);
     return 0;
 }
 
@@ -1169,7 +1170,7 @@ LayoutUnit RenderTableCell::borderHalfBefore(bool outer) const
 {
     CollapsedBorderValue border = collapsedBeforeBorder(DoNotIncludeBorderColor);
     if (border.exists())
-        return CollapsedBorderValue::adjustedCollapsedBorderWidth(border.width(), document().deviceScaleFactor(), !(styleForCellFlow().writingMode().isBlockFlipped() ^ outer));
+        return CollapsedBorderValue::adjustedCollapsedBorderWidth(border.width(), document().deviceScaleFactor(), !(tableWritingMode().isBlockFlipped() ^ outer));
     return 0;
 }
 
@@ -1177,7 +1178,7 @@ LayoutUnit RenderTableCell::borderHalfAfter(bool outer) const
 {
     CollapsedBorderValue border = collapsedAfterBorder(DoNotIncludeBorderColor);
     if (border.exists())
-        return CollapsedBorderValue::adjustedCollapsedBorderWidth(border.width(), document().deviceScaleFactor(), styleForCellFlow().writingMode().isBlockFlipped() ^ outer);
+        return CollapsedBorderValue::adjustedCollapsedBorderWidth(border.width(), document().deviceScaleFactor(), tableWritingMode().isBlockFlipped() ^ outer);
     return 0;
 }
 
@@ -1291,7 +1292,7 @@ void RenderTableCell::paintCollapsedBorders(PaintInfo& paintInfo, const LayoutPo
     if (!table()->currentBorderValue() || graphicsContext.paintingDisabled())
         return;
 
-    WritingMode writingMode = styleForCellFlow().writingMode();
+    WritingMode writingMode = tableWritingMode();
     CollapsedBorderValue leftVal = cachedCollapsedLeftBorder(writingMode);
     CollapsedBorderValue rightVal = cachedCollapsedRightBorder(writingMode);
     CollapsedBorderValue topVal = cachedCollapsedTopBorder(writingMode);

--- a/Source/WebCore/rendering/RenderTableCell.h
+++ b/Source/WebCore/rendering/RenderTableCell.h
@@ -116,10 +116,8 @@ public:
     static RenderPtr<RenderTableCell> createAnonymousWithParentRenderer(const RenderTableRow&);
     RenderPtr<RenderBox> createAnonymousBoxWithSameTypeAs(const RenderBox&) const override;
 
-    // This function is used to unify which table part's style we use for computing direction and
-    // writing mode. Writing modes are not allowed on internal table boxes.
-    // This means we can safely use the same style in all cases to simplify our code.
-    const RenderStyle& styleForCellFlow() const { return table()->style(); }
+    // Table layout always uses the table's writing mode.
+    const WritingMode tableWritingMode() const { return table()->writingMode(); }
 
     inline const BorderValue& borderAdjoiningTableStart() const;
     inline const BorderValue& borderAdjoiningTableEnd() const;

--- a/Source/WebCore/rendering/RenderTableCellInlines.h
+++ b/Source/WebCore/rendering/RenderTableCellInlines.h
@@ -27,25 +27,25 @@ namespace WebCore {
 inline const BorderValue& RenderTableCell::borderAdjoiningCellAfter(const RenderTableCell& cell)
 {
     ASSERT_UNUSED(cell, table()->cellBefore(&cell) == this);
-    return style().borderEnd(table()->style());
+    return style().borderEnd(tableWritingMode());
 }
 
 inline const BorderValue& RenderTableCell::borderAdjoiningCellBefore(const RenderTableCell& cell)
 {
     ASSERT_UNUSED(cell, table()->cellAfter(&cell) == this);
-    return style().borderStart(table()->style());
+    return style().borderStart(tableWritingMode());
 }
 
 inline const BorderValue& RenderTableCell::borderAdjoiningTableEnd() const
 {
     ASSERT(isFirstOrLastCellInRow());
-    return style().borderEnd(table()->style());
+    return style().borderEnd(tableWritingMode());
 }
 
 inline const BorderValue& RenderTableCell::borderAdjoiningTableStart() const
 {
     ASSERT(isFirstOrLastCellInRow());
-    return style().borderStart(table()->style());
+    return style().borderStart(tableWritingMode());
 }
 
 inline LayoutUnit RenderTableCell::logicalHeightForRowSizing() const

--- a/Source/WebCore/rendering/RenderTableCol.cpp
+++ b/Source/WebCore/rendering/RenderTableCol.cpp
@@ -216,24 +216,24 @@ RenderTableCol* RenderTableCol::nextColumn() const
 
 const BorderValue& RenderTableCol::borderAdjoiningCellStartBorder() const
 {
-    return style().borderStart(table()->style());
+    return style().borderStart(table()->writingMode());
 }
 
 const BorderValue& RenderTableCol::borderAdjoiningCellEndBorder() const
 {
-    return style().borderEnd(table()->style());
+    return style().borderEnd(table()->writingMode());
 }
 
 const BorderValue& RenderTableCol::borderAdjoiningCellBefore(const RenderTableCell& cell) const
 {
     ASSERT_UNUSED(cell, table()->colElement(cell.col() + cell.colSpan()) == this);
-    return style().borderStart(table()->style());
+    return style().borderStart(table()->writingMode());
 }
 
 const BorderValue& RenderTableCol::borderAdjoiningCellAfter(const RenderTableCell& cell) const
 {
     ASSERT_UNUSED(cell, table()->colElement(cell.col() - 1) == this);
-    return style().borderEnd(table()->style());
+    return style().borderEnd(table()->writingMode());
 }
 
 LayoutUnit RenderTableCol::offsetLeft() const

--- a/Source/WebCore/rendering/RenderTableRow.cpp
+++ b/Source/WebCore/rendering/RenderTableRow.cpp
@@ -116,14 +116,14 @@ const BorderValue& RenderTableRow::borderAdjoiningStartCell(const RenderTableCel
 {
     ASSERT_UNUSED(cell, cell.isFirstOrLastCellInRow());
     // FIXME: https://webkit.org/b/79272 - Add support for mixed directionality at the cell level.
-    return style().borderStart(table()->style());
+    return style().borderStart(table()->writingMode());
 }
 
 const BorderValue& RenderTableRow::borderAdjoiningEndCell(const RenderTableCell& cell) const
 {
     ASSERT_UNUSED(cell, cell.isFirstOrLastCellInRow());
     // FIXME: https://webkit.org/b/79272 - Add support for mixed directionality at the cell level.
-    return style().borderEnd(table()->style());
+    return style().borderEnd(table()->writingMode());
 }
 
 void RenderTableRow::didInsertTableCell(RenderTableCell& child, RenderObject* beforeChild)

--- a/Source/WebCore/rendering/RenderTableRowInlines.h
+++ b/Source/WebCore/rendering/RenderTableRowInlines.h
@@ -24,7 +24,7 @@
 
 namespace WebCore {
 
-inline const BorderValue& RenderTableRow::borderAdjoiningTableStart() const { return style().borderStart(table()->style()); }
-inline const BorderValue& RenderTableRow::borderAdjoiningTableEnd() const { return style().borderEnd(table()->style()); }
+inline const BorderValue& RenderTableRow::borderAdjoiningTableStart() const { return style().borderStart(table()->writingMode()); }
+inline const BorderValue& RenderTableRow::borderAdjoiningTableEnd() const { return style().borderEnd(table()->writingMode()); }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -686,13 +686,13 @@ LayoutUnit RenderTableSection::calcOuterBorderBefore() const
 
     LayoutUnit borderWidth;
 
-    const BorderValue& sb = style().borderBefore(table()->style());
+    const BorderValue& sb = style().borderBefore(table()->writingMode());
     if (sb.style() == BorderStyle::Hidden)
         return -1;
     if (sb.style() > BorderStyle::Hidden)
         borderWidth = sb.width();
 
-    const BorderValue& rb = firstRow()->style().borderBefore(table()->style());
+    const BorderValue& rb = firstRow()->style().borderBefore(table()->writingMode());
     if (rb.style() == BorderStyle::Hidden)
         return -1;
     if (rb.style() > BorderStyle::Hidden && rb.width() > borderWidth)
@@ -703,11 +703,11 @@ LayoutUnit RenderTableSection::calcOuterBorderBefore() const
         const CellStruct& current = cellAt(0, c);
         if (current.inColSpan || !current.hasCells())
             continue;
-        const BorderValue& cb = current.primaryCell()->style().borderBefore(table()->style()); // FIXME: Make this work with perpendicular and flipped cells.
+        const BorderValue& cb = current.primaryCell()->style().borderBefore(table()->writingMode()); // FIXME: Make this work with perpendicular and flipped cells.
         // FIXME: Don't repeat for the same col group
         RenderTableCol* colGroup = table()->colElement(c);
         if (colGroup) {
-            const BorderValue& gb = colGroup->style().borderBefore(table()->style());
+            const BorderValue& gb = colGroup->style().borderBefore(table()->writingMode());
             if (gb.style() == BorderStyle::Hidden || cb.style() == BorderStyle::Hidden)
                 continue;
             allHidden = false;
@@ -736,13 +736,13 @@ LayoutUnit RenderTableSection::calcOuterBorderAfter() const
 
     LayoutUnit borderWidth;
 
-    const BorderValue& sb = style().borderAfter(table()->style());
+    const BorderValue& sb = style().borderAfter(table()->writingMode());
     if (sb.style() == BorderStyle::Hidden)
         return -1;
     if (sb.style() > BorderStyle::Hidden)
         borderWidth = sb.width();
 
-    const BorderValue& rb = lastRow()->style().borderAfter(table()->style());
+    const BorderValue& rb = lastRow()->style().borderAfter(table()->writingMode());
     if (rb.style() == BorderStyle::Hidden)
         return -1;
     if (rb.style() > BorderStyle::Hidden && rb.width() > borderWidth)
@@ -753,11 +753,11 @@ LayoutUnit RenderTableSection::calcOuterBorderAfter() const
         const CellStruct& current = cellAt(m_grid.size() - 1, c);
         if (current.inColSpan || !current.hasCells())
             continue;
-        const BorderValue& cb = current.primaryCell()->style().borderAfter(table()->style()); // FIXME: Make this work with perpendicular and flipped cells.
+        const BorderValue& cb = current.primaryCell()->style().borderAfter(table()->writingMode()); // FIXME: Make this work with perpendicular and flipped cells.
         // FIXME: Don't repeat for the same col group
         RenderTableCol* colGroup = table()->colElement(c);
         if (colGroup) {
-            const BorderValue& gb = colGroup->style().borderAfter(table()->style());
+            const BorderValue& gb = colGroup->style().borderAfter(table()->writingMode());
             if (gb.style() == BorderStyle::Hidden || cb.style() == BorderStyle::Hidden)
                 continue;
             allHidden = false;
@@ -786,14 +786,14 @@ LayoutUnit RenderTableSection::calcOuterBorderStart() const
 
     LayoutUnit borderWidth;
 
-    const BorderValue& sb = style().borderStart(table()->style());
+    const BorderValue& sb = style().borderStart(table()->writingMode());
     if (sb.style() == BorderStyle::Hidden)
         return -1;
     if (sb.style() > BorderStyle::Hidden)
         borderWidth = sb.width();
 
     if (RenderTableCol* colGroup = table()->colElement(0)) {
-        const BorderValue& gb = colGroup->style().borderStart(table()->style());
+        const BorderValue& gb = colGroup->style().borderStart(table()->writingMode());
         if (gb.style() == BorderStyle::Hidden)
             return -1;
         if (gb.style() > BorderStyle::Hidden && gb.width() > borderWidth)
@@ -806,8 +806,8 @@ LayoutUnit RenderTableSection::calcOuterBorderStart() const
         if (!current.hasCells())
             continue;
         // FIXME: Don't repeat for the same cell
-        const BorderValue& cb = current.primaryCell()->style().borderStart(table()->style()); // FIXME: Make this work with perpendicular and flipped cells.
-        const BorderValue& rb = current.primaryCell()->parent()->style().borderStart(table()->style());
+        const BorderValue& cb = current.primaryCell()->style().borderStart(table()->writingMode()); // FIXME: Make this work with perpendicular and flipped cells.
+        const BorderValue& rb = current.primaryCell()->parent()->style().borderStart(table()->writingMode());
         if (cb.style() == BorderStyle::Hidden || rb.style() == BorderStyle::Hidden)
             continue;
         allHidden = false;
@@ -829,14 +829,14 @@ LayoutUnit RenderTableSection::calcOuterBorderEnd() const
 
     LayoutUnit borderWidth;
 
-    const BorderValue& sb = style().borderEnd(table()->style());
+    const BorderValue& sb = style().borderEnd(table()->writingMode());
     if (sb.style() == BorderStyle::Hidden)
         return -1;
     if (sb.style() > BorderStyle::Hidden)
         borderWidth = sb.width();
 
     if (RenderTableCol* colGroup = table()->colElement(totalCols - 1)) {
-        const BorderValue& gb = colGroup->style().borderEnd(table()->style());
+        const BorderValue& gb = colGroup->style().borderEnd(table()->writingMode());
         if (gb.style() == BorderStyle::Hidden)
             return -1;
         if (gb.style() > BorderStyle::Hidden && gb.width() > borderWidth)
@@ -849,8 +849,8 @@ LayoutUnit RenderTableSection::calcOuterBorderEnd() const
         if (!current.hasCells())
             continue;
         // FIXME: Don't repeat for the same cell
-        const BorderValue& cb = current.primaryCell()->style().borderEnd(table()->style()); // FIXME: Make this work with perpendicular and flipped cells.
-        const BorderValue& rb = current.primaryCell()->parent()->style().borderEnd(table()->style());
+        const BorderValue& cb = current.primaryCell()->style().borderEnd(table()->writingMode()); // FIXME: Make this work with perpendicular and flipped cells.
+        const BorderValue& rb = current.primaryCell()->parent()->style().borderEnd(table()->writingMode());
         if (cb.style() == BorderStyle::Hidden || rb.style() == BorderStyle::Hidden)
             continue;
         allHidden = false;
@@ -1420,13 +1420,13 @@ unsigned RenderTableSection::numColumns() const
 const BorderValue& RenderTableSection::borderAdjoiningStartCell(const RenderTableCell& cell) const
 {
     ASSERT_UNUSED(cell, cell.isFirstOrLastCellInRow());
-    return style().borderStart(table()->style());
+    return style().borderStart(table()->writingMode());
 }
 
 const BorderValue& RenderTableSection::borderAdjoiningEndCell(const RenderTableCell& cell) const
 {
     ASSERT_UNUSED(cell, cell.isFirstOrLastCellInRow());
-    return style().borderEnd(table()->style());
+    return style().borderEnd(table()->writingMode());
 }
 
 void RenderTableSection::appendColumn(unsigned pos)

--- a/Source/WebCore/rendering/RenderTableSectionInlines.h
+++ b/Source/WebCore/rendering/RenderTableSectionInlines.h
@@ -24,8 +24,8 @@
 
 namespace WebCore {
 
-inline const BorderValue& RenderTableSection::borderAdjoiningTableEnd() const { return style().borderEnd(table()->style()); }
-inline const BorderValue& RenderTableSection::borderAdjoiningTableStart() const { return style().borderStart(table()->style()); }
+inline const BorderValue& RenderTableSection::borderAdjoiningTableEnd() const { return style().borderEnd(table()->writingMode()); }
+inline const BorderValue& RenderTableSection::borderAdjoiningTableStart() const { return style().borderStart(table()->writingMode()); }
 
 inline LayoutUnit RenderTableSection::outerBorderBottom(const WritingMode writingMode) const
 {

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
@@ -241,13 +241,13 @@ static LayoutUnit logicalTopOffset(const RenderBox& renderer)
 {
     switch (renderer.style().shapeOutside()->effectiveCSSBox()) {
     case CSSBoxType::MarginBox:
-        return -renderer.marginBefore(&renderer.containingBlock()->style());
+        return -renderer.marginBefore(renderer.containingBlock()->writingMode());
     case CSSBoxType::BorderBox:
         return 0_lu;
     case CSSBoxType::PaddingBox:
-        return borderBeforeInWritingMode(renderer, renderer.containingBlock()->style().writingMode());
+        return borderBeforeInWritingMode(renderer, renderer.containingBlock()->writingMode());
     case CSSBoxType::ContentBox:
-        return borderAndPaddingBeforeInWritingMode(renderer, renderer.containingBlock()->style().writingMode());
+        return borderAndPaddingBeforeInWritingMode(renderer, renderer.containingBlock()->writingMode());
     case CSSBoxType::FillBox:
         break;
     case CSSBoxType::StrokeBox:
@@ -297,7 +297,7 @@ static LayoutUnit logicalLeftOffset(const RenderBox& renderer)
     
     switch (renderer.style().shapeOutside()->effectiveCSSBox()) {
     case CSSBoxType::MarginBox:
-        return -renderer.marginStart(&renderer.containingBlock()->style());
+        return -renderer.marginStart(renderer.containingBlock()->writingMode());
     case CSSBoxType::BorderBox:
         return 0_lu;
     case CSSBoxType::PaddingBox:

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -3164,9 +3164,9 @@ Color RenderStyle::usedScrollbarTrackColor() const
     return colorResolvingCurrentColor(scrollbarColor().value().trackColor);
 }
 
-const BorderValue& RenderStyle::borderBefore(const RenderStyle& styleForFlow) const
+const BorderValue& RenderStyle::borderBefore(const WritingMode writingMode) const
 {
-    switch (styleForFlow.writingMode().blockDirection()) {
+    switch (writingMode.blockDirection()) {
     case FlowDirection::TopToBottom:
         return borderTop();
     case FlowDirection::BottomToTop:
@@ -3180,9 +3180,9 @@ const BorderValue& RenderStyle::borderBefore(const RenderStyle& styleForFlow) co
     return borderTop();
 }
 
-const BorderValue& RenderStyle::borderAfter(const RenderStyle& styleForFlow) const
+const BorderValue& RenderStyle::borderAfter(const WritingMode writingMode) const
 {
-    switch (styleForFlow.writingMode().blockDirection()) {
+    switch (writingMode.blockDirection()) {
     case FlowDirection::TopToBottom:
         return borderBottom();
     case FlowDirection::BottomToTop:
@@ -3196,23 +3196,23 @@ const BorderValue& RenderStyle::borderAfter(const RenderStyle& styleForFlow) con
     return borderBottom();
 }
 
-const BorderValue& RenderStyle::borderStart(const RenderStyle& styleForFlow) const
+const BorderValue& RenderStyle::borderStart(const WritingMode writingMode) const
 {
-    if (styleForFlow.writingMode().isHorizontal())
-        return styleForFlow.writingMode().isInlineLeftToRight() ? borderLeft() : borderRight();
-    return styleForFlow.writingMode().isInlineTopToBottom() ? borderTop() : borderBottom();
+    if (writingMode.isHorizontal())
+        return writingMode.isInlineLeftToRight() ? borderLeft() : borderRight();
+    return writingMode.isInlineTopToBottom() ? borderTop() : borderBottom();
 }
 
-const BorderValue& RenderStyle::borderEnd(const RenderStyle& styleForFlow) const
+const BorderValue& RenderStyle::borderEnd(const WritingMode writingMode) const
 {
-    if (styleForFlow.writingMode().isHorizontal())
-        return styleForFlow.writingMode().isInlineLeftToRight() ? borderRight() : borderLeft();
-    return styleForFlow.writingMode().isInlineTopToBottom() ? borderBottom() : borderTop();
+    if (writingMode.isHorizontal())
+        return writingMode.isInlineLeftToRight() ? borderRight() : borderLeft();
+    return writingMode.isInlineTopToBottom() ? borderBottom() : borderTop();
 }
 
-float RenderStyle::borderBeforeWidth() const
+float RenderStyle::borderBeforeWidth(const WritingMode writingMode) const
 {
-    switch (writingMode().blockDirection()) {
+    switch (writingMode.blockDirection()) {
     case FlowDirection::TopToBottom:
         return borderTopWidth();
     case FlowDirection::BottomToTop:
@@ -3226,9 +3226,9 @@ float RenderStyle::borderBeforeWidth() const
     return borderTopWidth();
 }
 
-float RenderStyle::borderAfterWidth() const
+float RenderStyle::borderAfterWidth(const WritingMode writingMode) const
 {
-    switch (writingMode().blockDirection()) {
+    switch (writingMode.blockDirection()) {
     case FlowDirection::TopToBottom:
         return borderBottomWidth();
     case FlowDirection::BottomToTop:
@@ -3242,18 +3242,18 @@ float RenderStyle::borderAfterWidth() const
     return borderBottomWidth();
 }
 
-float RenderStyle::borderStartWidth() const
+float RenderStyle::borderStartWidth(const WritingMode writingMode) const
 {
-    if (writingMode().isHorizontal())
-        return writingMode().isInlineLeftToRight() ? borderLeftWidth() : borderRightWidth();
-    return writingMode().isInlineTopToBottom() ? borderTopWidth() : borderBottomWidth();
+    if (writingMode.isHorizontal())
+        return writingMode.isInlineLeftToRight() ? borderLeftWidth() : borderRightWidth();
+    return writingMode.isInlineTopToBottom() ? borderTopWidth() : borderBottomWidth();
 }
 
-float RenderStyle::borderEndWidth() const
+float RenderStyle::borderEndWidth(const WritingMode writingMode) const
 {
-    if (writingMode().isHorizontal())
-        return writingMode().isInlineLeftToRight() ? borderRightWidth() : borderLeftWidth();
-    return writingMode().isInlineTopToBottom() ? borderBottomWidth() : borderTopWidth();
+    if (writingMode.isHorizontal())
+        return writingMode.isInlineLeftToRight() ? borderRightWidth() : borderLeftWidth();
+    return writingMode.isInlineTopToBottom() ? borderBottomWidth() : borderTopWidth();
 }
 
 void RenderStyle::setMarginStart(Length&& margin)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -458,7 +458,13 @@ public:
     inline const Length& maxWidth() const;
     inline const Length& minHeight() const;
     inline const Length& maxHeight() const;
-    
+
+    inline const Length& logicalWidth(const WritingMode) const;
+    inline const Length& logicalHeight(const WritingMode) const;
+    inline const Length& logicalMinWidth(const WritingMode) const;
+    inline const Length& logicalMaxWidth(const WritingMode) const;
+    inline const Length& logicalMinHeight(const WritingMode) const;
+    inline const Length& logicalMaxHeight(const WritingMode) const;
     inline const Length& logicalWidth() const;
     inline const Length& logicalHeight() const;
     inline const Length& logicalMinWidth() const;
@@ -472,15 +478,14 @@ public:
     inline const BorderValue& borderTop() const;
     inline const BorderValue& borderBottom() const;
 
-
-    inline const BorderValue& borderBefore() const;
-    inline const BorderValue& borderAfter() const;
-    inline const BorderValue& borderStart() const;
-    inline const BorderValue& borderEnd() const;
-    const BorderValue& borderBefore(const RenderStyle& styleForFlow) const;
-    const BorderValue& borderAfter(const RenderStyle& styleForFlow) const;
-    const BorderValue& borderStart(const RenderStyle& styleForFlow) const;
-    const BorderValue& borderEnd(const RenderStyle& styleForFlow) const;
+    const BorderValue& borderBefore(const WritingMode) const;
+    const BorderValue& borderAfter(const WritingMode) const;
+    const BorderValue& borderStart(const WritingMode) const;
+    const BorderValue& borderEnd(const WritingMode) const;
+    const BorderValue& borderBefore() const { return borderBefore(writingMode()); }
+    const BorderValue& borderAfter() const { return borderAfter(writingMode()); }
+    const BorderValue& borderStart() const { return borderStart(writingMode()); }
+    const BorderValue& borderEnd() const { return borderEnd(writingMode()); }
 
     inline const NinePieceImage& borderImage() const;
     inline StyleImage* borderImageSource() const;
@@ -516,10 +521,14 @@ public:
     inline bool borderBottomIsTransparent() const;
     inline FloatBoxExtent borderWidth() const;
 
-    float borderBeforeWidth() const;
-    float borderAfterWidth() const;
-    float borderStartWidth() const;
-    float borderEndWidth() const;
+    float borderBeforeWidth(const WritingMode) const;
+    float borderAfterWidth(const WritingMode) const;
+    float borderStartWidth(const WritingMode) const;
+    float borderEndWidth(const WritingMode) const;
+    float borderBeforeWidth() const { return borderBeforeWidth(writingMode()); }
+    float borderAfterWidth() const { return borderAfterWidth(writingMode()); }
+    float borderStartWidth() const { return borderStartWidth(writingMode()); }
+    float borderEndWidth() const { return borderEndWidth(writingMode()); }
 
     inline bool borderIsEquivalentForPainting(const RenderStyle&) const;
 
@@ -666,24 +675,30 @@ public:
     StyleImage* listStyleImage() const;
     ListStylePosition listStylePosition() const { return static_cast<ListStylePosition>(m_inheritedFlags.listStylePosition); }
     inline bool isFixedTableLayout() const;
+
+    inline const LengthBox& marginBox() const;
     inline const Length& marginTop() const;
     inline const Length& marginBottom() const;
     inline const Length& marginLeft() const;
     inline const Length& marginRight() const;
+    inline const Length& marginStart(const WritingMode) const;
+    inline const Length& marginEnd(const WritingMode) const;
+    inline const Length& marginBefore(const WritingMode) const;
+    inline const Length& marginAfter(const WritingMode) const;
     inline const Length& marginBefore() const;
     inline const Length& marginAfter() const;
     inline const Length& marginStart() const;
     inline const Length& marginEnd() const;
-    inline const Length& marginStartUsing(const RenderStyle* otherStyle) const;
-    inline const Length& marginEndUsing(const RenderStyle* otherStyle) const;
-    inline const Length& marginBeforeUsing(const RenderStyle* otherStyle) const;
-    inline const Length& marginAfterUsing(const RenderStyle* otherStyle) const;
 
     inline const LengthBox& paddingBox() const;
     inline const Length& paddingTop() const;
     inline const Length& paddingBottom() const;
     inline const Length& paddingLeft() const;
     inline const Length& paddingRight() const;
+    inline const Length& paddingBefore(const WritingMode) const;
+    inline const Length& paddingAfter(const WritingMode) const;
+    inline const Length& paddingStart(const WritingMode) const;
+    inline const Length& paddingEnd(const WritingMode) const;
     inline const Length& paddingBefore() const;
     inline const Length& paddingAfter() const;
     inline const Length& paddingStart() const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -102,8 +102,6 @@ inline const BlockEllipsis& RenderStyle::blockEllipsis() const { return m_rareIn
 inline BlockStepInsert RenderStyle::blockStepInsert() const { return static_cast<BlockStepInsert>(m_nonInheritedData->rareData->blockStepInsert); }
 inline std::optional<Length> RenderStyle::blockStepSize() const { return m_nonInheritedData->rareData->blockStepSize; }
 inline const BorderData& RenderStyle::border() const { return m_nonInheritedData->surroundData->border; }
-inline const BorderValue& RenderStyle::borderAfter() const { return borderAfter(*this); }
-inline const BorderValue& RenderStyle::borderBefore() const { return borderBefore(*this); }
 inline const BorderValue& RenderStyle::borderBottom() const { return border().bottom(); }
 inline const StyleColor& RenderStyle::borderBottomColor() const { return border().bottom().color(); }
 inline bool RenderStyle::borderBottomIsTransparent() const { return border().bottom().isTransparent(); }
@@ -111,7 +109,6 @@ inline const LengthSize& RenderStyle::borderBottomLeftRadius() const { return bo
 inline const LengthSize& RenderStyle::borderBottomRightRadius() const { return border().bottomRightRadius(); }
 inline BorderStyle RenderStyle::borderBottomStyle() const { return border().bottom().style(); }
 inline float RenderStyle::borderBottomWidth() const { return border().borderBottomWidth(); }
-inline const BorderValue& RenderStyle::borderEnd() const { return borderEnd(*this); }
 inline const NinePieceImage& RenderStyle::borderImage() const { return border().image(); }
 inline NinePieceImageRule RenderStyle::borderImageHorizontalRule() const { return border().image().horizontalRule(); }
 inline const LengthBox& RenderStyle::borderImageOutset() const { return border().image().outset(); }
@@ -132,7 +129,6 @@ inline const StyleColor& RenderStyle::borderRightColor() const { return border()
 inline bool RenderStyle::borderRightIsTransparent() const { return border().right().isTransparent(); }
 inline BorderStyle RenderStyle::borderRightStyle() const { return border().right().style(); }
 inline float RenderStyle::borderRightWidth() const { return border().borderRightWidth(); }
-inline const BorderValue& RenderStyle::borderStart() const { return borderStart(*this); }
 inline const BorderValue& RenderStyle::borderTop() const { return border().top(); }
 inline const StyleColor& RenderStyle::borderTopColor() const { return border().top().color(); }
 inline bool RenderStyle::borderTopIsTransparent() const { return border().top().isTransparent(); }
@@ -563,26 +559,33 @@ inline const AtomString& RenderStyle::lineGrid() const { return m_rareInheritedD
 inline LineSnap RenderStyle::lineSnap() const { return static_cast<LineSnap>(m_rareInheritedData->lineSnap); }
 inline ListStyleType RenderStyle::listStyleType() const { return m_rareInheritedData->listStyleType; }
 inline const Length& RenderStyle::logicalBottom() const { return m_nonInheritedData->surroundData->offset.after(writingMode()); }
-inline const Length& RenderStyle::logicalHeight() const { return writingMode().isHorizontal() ? height() : width(); }
+inline const Length& RenderStyle::logicalHeight() const { return logicalHeight(writingMode()); }
+inline const Length& RenderStyle::logicalHeight(const WritingMode writingMode) const { return writingMode.isHorizontal() ? height() : width(); }
 inline const Length& RenderStyle::logicalLeft() const { return m_nonInheritedData->surroundData->offset.logicalLeft(writingMode()); }
-inline const Length& RenderStyle::logicalMaxHeight() const { return writingMode().isHorizontal() ? maxHeight() : maxWidth(); }
-inline const Length& RenderStyle::logicalMaxWidth() const { return writingMode().isHorizontal() ? maxWidth() : maxHeight(); }
-inline const Length& RenderStyle::logicalMinHeight() const { return writingMode().isHorizontal() ? minHeight() : minWidth(); }
-inline const Length& RenderStyle::logicalMinWidth() const { return writingMode().isHorizontal() ? minWidth() : minHeight(); }
+inline const Length& RenderStyle::logicalMaxHeight() const { return logicalMaxHeight(writingMode()); }
+inline const Length& RenderStyle::logicalMaxHeight(const WritingMode writingMode) const { return writingMode.isHorizontal() ? maxHeight() : maxWidth(); }
+inline const Length& RenderStyle::logicalMaxWidth() const { return logicalMaxWidth(writingMode()); }
+inline const Length& RenderStyle::logicalMaxWidth(const WritingMode writingMode) const { return writingMode.isHorizontal() ? maxWidth() : maxHeight(); }
+inline const Length& RenderStyle::logicalMinHeight() const { return logicalMinHeight(writingMode()); }
+inline const Length& RenderStyle::logicalMinHeight(const WritingMode writingMode) const { return writingMode.isHorizontal() ? minHeight() : minWidth(); }
+inline const Length& RenderStyle::logicalMinWidth() const { return logicalMinWidth(writingMode()); }
+inline const Length& RenderStyle::logicalMinWidth(const WritingMode writingMode) const { return writingMode.isHorizontal() ? minWidth() : minHeight(); }
 inline const Length& RenderStyle::logicalRight() const { return m_nonInheritedData->surroundData->offset.logicalRight(writingMode()); }
 inline const Length& RenderStyle::logicalTop() const { return m_nonInheritedData->surroundData->offset.before(writingMode()); }
-inline const Length& RenderStyle::logicalWidth() const { return writingMode().isHorizontal() ? width() : height(); }
-inline const Length& RenderStyle::marginAfter() const { return m_nonInheritedData->surroundData->margin.after(writingMode()); }
-inline const Length& RenderStyle::marginAfterUsing(const RenderStyle* otherStyle) const { return m_nonInheritedData->surroundData->margin.after(otherStyle->writingMode()); }
-inline const Length& RenderStyle::marginBefore() const { return m_nonInheritedData->surroundData->margin.before(writingMode()); }
-inline const Length& RenderStyle::marginBeforeUsing(const RenderStyle* otherStyle) const { return m_nonInheritedData->surroundData->margin.before(otherStyle->writingMode()); }
+inline const Length& RenderStyle::logicalWidth() const { return logicalWidth(writingMode()); }
+inline const Length& RenderStyle::logicalWidth(const WritingMode writingMode) const { return writingMode.isHorizontal() ? width() : height(); }
+inline const LengthBox& RenderStyle::marginBox() const { return m_nonInheritedData->surroundData->margin; }
+inline const Length& RenderStyle::marginAfter() const { return marginAfter(writingMode()); }
+inline const Length& RenderStyle::marginAfter(const WritingMode writingMode) const { return m_nonInheritedData->surroundData->margin.after(writingMode); }
+inline const Length& RenderStyle::marginBefore() const { return marginBefore(writingMode()); }
+inline const Length& RenderStyle::marginBefore(const WritingMode writingMode) const { return m_nonInheritedData->surroundData->margin.before(writingMode); }
 inline const Length& RenderStyle::marginBottom() const { return m_nonInheritedData->surroundData->margin.bottom(); }
-inline const Length& RenderStyle::marginEnd() const { return m_nonInheritedData->surroundData->margin.end(writingMode()); }
-inline const Length& RenderStyle::marginEndUsing(const RenderStyle* otherStyle) const { return m_nonInheritedData->surroundData->margin.end(otherStyle->writingMode()); }
+inline const Length& RenderStyle::marginEnd() const { return marginEnd(writingMode()); }
+inline const Length& RenderStyle::marginEnd(const WritingMode writingMode) const { return m_nonInheritedData->surroundData->margin.end(writingMode); }
 inline const Length& RenderStyle::marginLeft() const { return m_nonInheritedData->surroundData->margin.left(); }
 inline const Length& RenderStyle::marginRight() const { return m_nonInheritedData->surroundData->margin.right(); }
-inline const Length& RenderStyle::marginStart() const { return m_nonInheritedData->surroundData->margin.start(writingMode()); }
-inline const Length& RenderStyle::marginStartUsing(const RenderStyle* otherStyle) const { return m_nonInheritedData->surroundData->margin.start(otherStyle->writingMode()); }
+inline const Length& RenderStyle::marginStart() const { return marginStart(writingMode()); }
+inline const Length& RenderStyle::marginStart(const WritingMode writingMode) const { return m_nonInheritedData->surroundData->margin.start(writingMode); }
 inline const Length& RenderStyle::marginTop() const { return m_nonInheritedData->surroundData->margin.top(); }
 inline OptionSet<MarginTrimType> RenderStyle::marginTrim() const { return m_nonInheritedData->rareData->marginTrim; }
 inline MarqueeBehavior RenderStyle::marqueeBehavior() const { return static_cast<MarqueeBehavior>(m_nonInheritedData->rareData->marquee->behavior); }
@@ -644,14 +647,18 @@ inline OverflowContinue RenderStyle::overflowContinue() const { return m_nonInhe
 inline OverflowWrap RenderStyle::overflowWrap() const { return static_cast<OverflowWrap>(m_rareInheritedData->overflowWrap); }
 inline OverscrollBehavior RenderStyle::overscrollBehaviorX() const { return static_cast<OverscrollBehavior>(m_nonInheritedData->rareData->overscrollBehaviorX); }
 inline OverscrollBehavior RenderStyle::overscrollBehaviorY() const { return static_cast<OverscrollBehavior>(m_nonInheritedData->rareData->overscrollBehaviorY); }
-inline const Length& RenderStyle::paddingAfter() const { return paddingBox().after(writingMode()); }
-inline const Length& RenderStyle::paddingBefore() const { return paddingBox().before(writingMode()); }
+inline const Length& RenderStyle::paddingAfter() const { return paddingAfter(writingMode()); }
+inline const Length& RenderStyle::paddingAfter(const WritingMode writingMode) const { return paddingBox().after(writingMode); }
+inline const Length& RenderStyle::paddingBefore() const { return paddingBefore(writingMode()); }
+inline const Length& RenderStyle::paddingBefore(const WritingMode writingMode) const { return paddingBox().before(writingMode); }
 inline const Length& RenderStyle::paddingBottom() const { return paddingBox().bottom(); }
 inline const LengthBox& RenderStyle::paddingBox() const { return m_nonInheritedData->surroundData->padding; }
-inline const Length& RenderStyle::paddingEnd() const { return paddingBox().end(writingMode()); }
+inline const Length& RenderStyle::paddingEnd() const { return paddingEnd(writingMode()); }
+inline const Length& RenderStyle::paddingEnd(const WritingMode writingMode) const { return paddingBox().end(writingMode); }
 inline const Length& RenderStyle::paddingLeft() const { return paddingBox().left(); }
 inline const Length& RenderStyle::paddingRight() const { return paddingBox().right(); }
-inline const Length& RenderStyle::paddingStart() const { return paddingBox().start(writingMode()); }
+inline const Length& RenderStyle::paddingStart() const { return paddingStart(writingMode()); }
+inline const Length& RenderStyle::paddingStart(const WritingMode writingMode) const { return paddingBox().start(writingMode); }
 inline const Length& RenderStyle::paddingTop() const { return paddingBox().top(); }
 inline const LengthSize& RenderStyle::pageSize() const { return m_nonInheritedData->rareData->pageSize; }
 inline PageSizeType RenderStyle::pageSizeType() const { return static_cast<PageSizeType>(m_nonInheritedData->rareData->pageSizeType); }


### PR DESCRIPTION
#### ee545145e8f9cfc60843070c17626ad7c6b13b36
<pre>
Switch margin/border/padding to use WritingMode arg instead of RenderStyle
<a href="https://bugs.webkit.org/show_bug.cgi?id=282719">https://bugs.webkit.org/show_bug.cgi?id=282719</a>
<a href="https://rdar.apple.com/problem/139386989">rdar://problem/139386989</a>

Reviewed by Alan Baradlay.

Consistently and directly use an optional WritingMode object
as the argument for logical margin/border/padding getters and setters,
for more readable and adaptable code.

* Source/WebCore/rendering/FlexibleBoxAlgorithm.cpp:
(WebCore::FlexLayoutAlgorithm::removeMarginEndFromFlexSizes const):
* Source/WebCore/rendering/GridBaselineAlignment.cpp:
(WebCore::GridBaselineAlignment::ascentForGridItem const):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::setup):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::marginIntrinsicLogicalWidthForChild const):
(WebCore::RenderBlock::computeBlockPreferredLogicalWidths const):
(WebCore::RenderBlock::computePreferredWidthsForExcludedChildren const):
* Source/WebCore/rendering/RenderBlock.h:
(WebCore::RenderBlock::marginBeforeForChild const):
(WebCore::RenderBlock::marginAfterForChild const):
(WebCore::RenderBlock::marginStartForChild const):
(WebCore::RenderBlock::marginEndForChild const):
(WebCore::RenderBlock::setMarginStartForChild const):
(WebCore::RenderBlock::setMarginEndForChild const):
(WebCore::RenderBlock::setMarginBeforeForChild const):
(WebCore::RenderBlock::setMarginAfterForChild const):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::determineLogicalLeftPositionForChild):
(WebCore::RenderBlockFlow::computeInlinePreferredLogicalWidths const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeInlineDirectionMargins const):
(WebCore::RenderBox::constrainBlockMarginInAvailableSpaceOrTrim const):
* Source/WebCore/rendering/RenderBox.h:
(WebCore::RenderBox::marginLogicalLeft const):
(WebCore::RenderBox::marginLogicalRight const):
(WebCore::RenderBox::marginBefore const):
(WebCore::RenderBox::marginAfter const):
(WebCore::RenderBox::marginStart const):
(WebCore::RenderBox::marginEnd const):
(WebCore::RenderBox::setMarginBefore):
(WebCore::RenderBox::setMarginAfter):
(WebCore::RenderBox::setMarginStart):
(WebCore::RenderBox::setMarginEnd):
(WebCore::RenderBox::marginBlockStart const): Deleted.
(WebCore::RenderBox::marginInlineStart const): Deleted.
* Source/WebCore/rendering/RenderBoxModelObject.h:
(WebCore::RenderBoxModelObject::marginBefore const):
(WebCore::RenderBoxModelObject::marginAfter const):
(WebCore::RenderBoxModelObject::marginStart const):
(WebCore::RenderBoxModelObject::marginEnd const):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::trimMainAxisMarginStart):
(WebCore::RenderFlexibleBox::trimMainAxisMarginEnd):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::updateAutoMarginsInRowAxisIfNeeded):
(WebCore::RenderGrid::updateAutoMarginsInColumnAxisIfNeeded):
(WebCore::RenderGrid::logicalOffsetForOutOfFlowGridItem const):
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::marginStart const):
(WebCore::RenderInline::marginEnd const):
(WebCore::RenderInline::marginBefore const):
(WebCore::RenderInline::marginAfter const):
* Source/WebCore/rendering/RenderInline.h:
(WebCore::RenderInline::marginBefore const):
(WebCore::RenderInline::marginAfter const):
(WebCore::RenderInline::marginStart const):
(WebCore::RenderInline::marginEnd const):
* Source/WebCore/rendering/RenderLineBreak.h:
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::localRectsForRepaint const):
(WebCore::RenderTableCell::computeCollapsedStartBorder const):
(WebCore::RenderTableCell::computeCollapsedEndBorder const):
(WebCore::RenderTableCell::computeCollapsedBeforeBorder const):
(WebCore::RenderTableCell::computeCollapsedAfterBorder const):
(WebCore::RenderTableCell::borderHalfLeft const):
(WebCore::RenderTableCell::borderHalfRight const):
(WebCore::RenderTableCell::borderHalfTop const):
(WebCore::RenderTableCell::borderHalfBottom const):
(WebCore::RenderTableCell::borderHalfStart const):
(WebCore::RenderTableCell::borderHalfEnd const):
(WebCore::RenderTableCell::borderHalfBefore const):
(WebCore::RenderTableCell::borderHalfAfter const):
(WebCore::RenderTableCell::paintCollapsedBorders):
* Source/WebCore/rendering/RenderTableCell.h:
* Source/WebCore/rendering/RenderTableCellInlines.h:
(WebCore::RenderTableCell::borderAdjoiningCellAfter):
(WebCore::RenderTableCell::borderAdjoiningCellBefore):
(WebCore::RenderTableCell::borderAdjoiningTableEnd const):
(WebCore::RenderTableCell::borderAdjoiningTableStart const):
* Source/WebCore/rendering/RenderTableCol.cpp:
(WebCore::RenderTableCol::borderAdjoiningCellStartBorder const):
(WebCore::RenderTableCol::borderAdjoiningCellEndBorder const):
(WebCore::RenderTableCol::borderAdjoiningCellBefore const):
(WebCore::RenderTableCol::borderAdjoiningCellAfter const):
* Source/WebCore/rendering/RenderTableRow.cpp:
(WebCore::RenderTableRow::borderAdjoiningStartCell const):
(WebCore::RenderTableRow::borderAdjoiningEndCell const):
* Source/WebCore/rendering/RenderTableRowInlines.h:
(WebCore::RenderTableRow::borderAdjoiningTableStart const):
(WebCore::RenderTableRow::borderAdjoiningTableEnd const):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::calcOuterBorderBefore const):
(WebCore::RenderTableSection::calcOuterBorderAfter const):
(WebCore::RenderTableSection::calcOuterBorderStart const):
(WebCore::RenderTableSection::calcOuterBorderEnd const):
(WebCore::RenderTableSection::borderAdjoiningStartCell const):
(WebCore::RenderTableSection::borderAdjoiningEndCell const):
* Source/WebCore/rendering/RenderTableSectionInlines.h:
(WebCore::RenderTableSection::borderAdjoiningTableEnd const):
(WebCore::RenderTableSection::borderAdjoiningTableStart const):
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp:
(WebCore::logicalTopOffset):
(WebCore::logicalLeftOffset):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::borderBefore const):
(WebCore::RenderStyle::borderAfter const):
(WebCore::RenderStyle::borderStart const):
(WebCore::RenderStyle::borderEnd const):
(WebCore::RenderStyle::borderBeforeWidth const):
(WebCore::RenderStyle::borderAfterWidth const):
(WebCore::RenderStyle::borderStartWidth const):
(WebCore::RenderStyle::borderEndWidth const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::border const):
(WebCore::RenderStyle::borderBottomWidth const):
(WebCore::RenderStyle::borderRightWidth const):
(WebCore::RenderStyle::logicalHeight const):
(WebCore::RenderStyle::logicalMaxHeight const):
(WebCore::RenderStyle::logicalMaxWidth const):
(WebCore::RenderStyle::logicalMinHeight const):
(WebCore::RenderStyle::logicalMinWidth const):
(WebCore::RenderStyle::logicalWidth const):
(WebCore::RenderStyle::marginBox const):
(WebCore::RenderStyle::marginAfter const):
(WebCore::RenderStyle::marginBefore const):
(WebCore::RenderStyle::marginEnd const):
(WebCore::RenderStyle::marginStart const):
(WebCore::RenderStyle::paddingAfter const):
(WebCore::RenderStyle::paddingBefore const):
(WebCore::RenderStyle::paddingEnd const):
(WebCore::RenderStyle::paddingStart const):
(WebCore::RenderStyle::borderAfter const): Deleted.
(WebCore::RenderStyle::borderBefore const): Deleted.
(WebCore::RenderStyle::borderEnd const): Deleted.
(WebCore::RenderStyle::borderStart const): Deleted.
(WebCore::RenderStyle::marginAfterUsing const): Deleted.
(WebCore::RenderStyle::marginBeforeUsing const): Deleted.
(WebCore::RenderStyle::marginEndUsing const): Deleted.
(WebCore::RenderStyle::marginStartUsing const): Deleted.

Canonical link: <a href="https://commits.webkit.org/286604@main">https://commits.webkit.org/286604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fce7cb407660c6b8c2c4847e509aaa018e2be7b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80927 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27681 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78522 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59903 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18024 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49819 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65613 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40235 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47214 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23102 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26003 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68340 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82378 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2474 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68194 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3934 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65582 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67433 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16834 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11399 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9499 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3728 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6537 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3751 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7181 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5509 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->