### PR TITLE
Expose webClipIdentifier on WKWebPushAction

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.h
@@ -43,7 +43,7 @@ WK_EXTERN
 + (_WKWebPushAction *)_webPushActionWithNotificationResponse:(UNNotificationResponse *)response;
 
 @property (nonatomic, readonly) NSNumber *version;
-@property (nonatomic, readonly) NSString *pushPartition;
+@property (nonatomic, readonly) NSUUID *webClipIdentifier;
 @property (nonatomic, readonly) NSString *type;
 
 - (UIBackgroundTaskIdentifier)beginBackgroundTaskForHandling;


### PR DESCRIPTION
#### 6a3a4d8dc9e4ecdda05a2eb45bcd4278e1905fd0
<pre>
Expose webClipIdentifier on WKWebPushAction
<a href="https://bugs.webkit.org/show_bug.cgi?id=282725">https://bugs.webkit.org/show_bug.cgi?id=282725</a>
<a href="https://rdar.apple.com/136386764">rdar://136386764</a>

Reviewed by Sihui Liu.

When an app is activated as a result of a notification from a service worker on iOS, the embedder
currently has to figure out the identifier of the associated web clip on its own. This should be
moved in to WKWebPushAction instead so it doesn&apos;t have to be duplicated.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushAction.mm:
(uuidFromPushPartition):
(+[_WKWebPushAction webPushActionWithDictionary:]):
(+[_WKWebPushAction _webPushActionWithNotificationResponse:]):

Canonical link: <a href="https://commits.webkit.org/286316@main">https://commits.webkit.org/286316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e80635bb965eed6456a2fb9086dc992d2d5ac42

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80001 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26786 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2753 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59244 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17447 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78589 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/74 "Build is being retried. Recent messages:OS: Sequoia (15.1), Xcode: 16.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 13 new passes 9 flakes 8 failures; Uploaded test results; layout-tests (retry)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64879 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39602 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25114 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81481 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2861 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67486 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66779 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16661 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10744 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8900 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2818 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5639 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2843 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3778 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2850 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->