### PR TITLE
Avoid unnecessary conversions from ASCIILiteral

### DIFF
--- a/Source/WTF/wtf/Hasher.h
+++ b/Source/WTF/wtf/Hasher.h
@@ -129,6 +129,17 @@ inline void add(Hasher& hasher, const AtomString& string)
     add(hasher, bitwise_cast<uintptr_t>(string.impl()));
 }
 
+inline void add(Hasher& hasher, ASCIILiteral literal)
+{
+    // Chose to hash the characters here. Assuming this is better than hashing the possibly-already-computed hash of the characters.
+    bool remainder = literal.length() & 1;
+    unsigned roundedLength = literal.length() - remainder;
+    for (unsigned i = 0; i < roundedLength; i += 2)
+        add(hasher, (literal[i] << 16) | literal[i + 1]);
+    if (remainder)
+        add(hasher, literal[roundedLength]);
+}
+
 inline void add(Hasher& hasher, const URL& url)
 {
     add(hasher, url.string());

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
@@ -37,7 +37,7 @@
 
 namespace WebCore {
 
-Ref<CachedScriptFetcher> CachedScriptFetcher::create(const String& charset)
+Ref<CachedScriptFetcher> CachedScriptFetcher::create(const AtomString& charset)
 {
     return adoptRef(*new CachedScriptFetcher(charset));
 }

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.h
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.h
@@ -41,10 +41,10 @@ class CachedScriptFetcher : public JSC::ScriptFetcher {
 public:
     virtual CachedResourceHandle<CachedScript> requestModuleScript(Document&, const URL& sourceURL, String&& integrity) const;
 
-    static Ref<CachedScriptFetcher> create(const String& charset);
+    static Ref<CachedScriptFetcher> create(const AtomString& charset);
 
 protected:
-    CachedScriptFetcher(const String& nonce, ReferrerPolicy referrerPolicy, RequestPriority fetchPriorityHint, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
+    CachedScriptFetcher(const String& nonce, ReferrerPolicy referrerPolicy, RequestPriority fetchPriorityHint, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
         : m_nonce(nonce)
         , m_charset(charset)
         , m_initiatorType(initiatorType)
@@ -54,7 +54,7 @@ protected:
     {
     }
 
-    CachedScriptFetcher(const String& charset)
+    CachedScriptFetcher(const AtomString& charset)
         : m_charset(charset)
     {
     }
@@ -63,7 +63,7 @@ protected:
 
 private:
     String m_nonce;
-    String m_charset;
+    AtomString m_charset;
     AtomString m_initiatorType;
     bool m_isInUserAgentShadowTree { false };
     ReferrerPolicy m_referrerPolicy { ReferrerPolicy::EmptyString };

--- a/Source/WebCore/css/StyleRuleImport.cpp
+++ b/Source/WebCore/css/StyleRuleImport.cpp
@@ -1,7 +1,7 @@
 /*
  * (C) 1999-2003 Lars Knoll (knoll@kde.org)
  * (C) 2002-2003 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2002-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2002-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -72,7 +72,7 @@ StyleRuleImport::~StyleRuleImport()
         m_cachedSheet->removeClient(m_styleSheetClient);
 }
 
-void StyleRuleImport::setCSSStyleSheet(const String& href, const URL& baseURL, const String& charset, const CachedCSSStyleSheet* cachedStyleSheet)
+void StyleRuleImport::setCSSStyleSheet(const String& href, const URL& baseURL, ASCIILiteral charset, const CachedCSSStyleSheet* cachedStyleSheet)
 {
     if (m_styleSheet)
         m_styleSheet->clearOwnerRule();

--- a/Source/WebCore/css/StyleRuleImport.h
+++ b/Source/WebCore/css/StyleRuleImport.h
@@ -73,7 +73,7 @@ private:
     public:
         ImportedStyleSheetClient(StyleRuleImport* ownerRule) : m_ownerRule(ownerRule) { }
         virtual ~ImportedStyleSheetClient() = default;
-        void setCSSStyleSheet(const String& href, const URL& baseURL, const String& charset, const CachedCSSStyleSheet* sheet) final
+        void setCSSStyleSheet(const String& href, const URL& baseURL, ASCIILiteral charset, const CachedCSSStyleSheet* sheet) final
         {
             m_ownerRule->setCSSStyleSheet(href, baseURL, charset, sheet);
         }
@@ -81,7 +81,7 @@ private:
         StyleRuleImport* m_ownerRule;
     };
 
-    void setCSSStyleSheet(const String& href, const URL& baseURL, const String& charset, const CachedCSSStyleSheet*);
+    void setCSSStyleSheet(const String& href, const URL& baseURL, ASCIILiteral charset, const CachedCSSStyleSheet*);
     friend class ImportedStyleSheetClient;
 
     StyleRuleImport(const String& href, MQ::MediaQueryList&&, std::optional<CascadeLayerName>&&, SupportsCondition&&);

--- a/Source/WebCore/css/StyleSheetContents.h
+++ b/Source/WebCore/css/StyleSheetContents.h
@@ -86,7 +86,7 @@ public:
     Node* singleOwnerNode() const;
     Document* singleOwnerDocument() const;
 
-    const String& charset() const { return m_parserContext.charset; }
+    ASCIILiteral charset() const { return m_parserContext.charset; }
 
     bool loadCompleted() const { return m_loadCompleted; }
 

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -73,7 +73,7 @@ CSSParserContext::CSSParserContext(const Document& document)
     *this = document.cssParserContext();
 }
 
-CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBaseURL, const String& charset)
+CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBaseURL, ASCIILiteral charset)
     : baseURL { sheetBaseURL.isNull() ? document.baseURL() : sheetBaseURL }
     , charset { charset }
     , mode { document.inQuirksMode() ? HTMLQuirksMode : HTMLStandardMode }

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -61,7 +61,7 @@ struct CSSParserContext {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
     URL baseURL;
-    String charset;
+    ASCIILiteral charset;
     CSSParserMode mode { HTMLStandardMode };
     std::optional<StyleRuleType> enclosingRuleType;
     bool isHTMLDocument : 1 { false };
@@ -109,7 +109,7 @@ struct CSSParserContext {
 
     CSSParserContext(CSSParserMode, const URL& baseURL = URL());
     WEBCORE_EXPORT CSSParserContext(const Document&);
-    CSSParserContext(const Document&, const URL& baseURL, const String& charset = emptyString());
+    CSSParserContext(const Document&, const URL& baseURL, ASCIILiteral charset = ""_s);
     ResolvedURL completeURL(const String&) const;
 
     bool operator==(const CSSParserContext&) const = default;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1942,9 +1942,9 @@ void Document::setVisualUpdatesAllowedByClient(bool visualUpdatesAllowedByClient
         removeVisualUpdatePreventedReasons(VisualUpdatesPreventedReason::Client);
 }
 
-String Document::characterSetWithUTF8Fallback() const
+ASCIILiteral Document::characterSetWithUTF8Fallback() const
 {
-    AtomString name = encoding();
+    auto name = encoding();
     if (!name.isNull())
         return name;
     return "UTF-8"_s;
@@ -2054,12 +2054,6 @@ String Document::contentType() const
         return mimeType;
 
     return "application/xml"_s;
-}
-
-AtomString Document::encoding() const
-{
-    auto encoding = textEncoding().domName();
-    return encoding.isNull() ? nullAtom() : AtomString { encoding };
 }
 
 RefPtr<Range> Document::caretRangeFromPoint(int x, int y, HitTestSource source)
@@ -10385,7 +10379,7 @@ CSSCounterStyleRegistry& Document::counterStyleRegistry()
 CSSParserContext Document::cssParserContext() const
 {
     if (!m_cachedCSSParserContext)
-        m_cachedCSSParserContext = makeUnique<CSSParserContext>(*this, URL { }, emptyString());
+        m_cachedCSSParserContext = makeUnique<CSSParserContext>(*this, URL { }, ""_s);
     return *m_cachedCSSParserContext;
 }
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -536,11 +536,11 @@ public:
 
     WEBCORE_EXPORT String defaultCharsetForLegacyBindings() const;
 
-    inline String charset() const;
-    WEBCORE_EXPORT String characterSetWithUTF8Fallback() const;
+    inline ASCIILiteral charset() const;
+    WEBCORE_EXPORT ASCIILiteral characterSetWithUTF8Fallback() const;
     inline PAL::TextEncoding textEncoding() const;
 
-    WEBCORE_EXPORT AtomString encoding() const;
+    inline ASCIILiteral encoding() const;
 
     WEBCORE_EXPORT void setCharset(const String&); // Used by ObjC / GOBject bindings only.
 

--- a/Source/WebCore/dom/DocumentInlines.h
+++ b/Source/WebCore/dom/DocumentInlines.h
@@ -53,7 +53,15 @@ inline PAL::TextEncoding Document::textEncoding() const
     return PAL::TextEncoding();
 }
 
-inline String Document::charset() const { return Document::encoding(); }
+inline ASCIILiteral Document::encoding() const
+{
+    return textEncoding().domName();
+}
+
+inline ASCIILiteral Document::charset() const
+{
+    return Document::encoding();
+}
 
 inline Quirks& Document::quirks()
 {

--- a/Source/WebCore/dom/InlineClassicScript.cpp
+++ b/Source/WebCore/dom/InlineClassicScript.cpp
@@ -43,7 +43,7 @@ Ref<InlineClassicScript> InlineClassicScript::create(ScriptElement& scriptElemen
         element->isInUserAgentShadowTree()));
 }
 
-InlineClassicScript::InlineClassicScript(const AtomString& nonce, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
+InlineClassicScript::InlineClassicScript(const AtomString& nonce, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
     : ScriptElementCachedScriptFetcher(nonce, ReferrerPolicy::EmptyString, RequestPriority::Auto, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree)
 {
 }

--- a/Source/WebCore/dom/InlineClassicScript.h
+++ b/Source/WebCore/dom/InlineClassicScript.h
@@ -38,7 +38,7 @@ public:
     ScriptType scriptType() const final { return ScriptType::Classic; }
 
 private:
-    InlineClassicScript(const AtomString& nonce, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
+    InlineClassicScript(const AtomString& nonce, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
 };
 
 }

--- a/Source/WebCore/dom/LoadableClassicScript.cpp
+++ b/Source/WebCore/dom/LoadableClassicScript.cpp
@@ -40,7 +40,7 @@
 
 namespace WebCore {
 
-LoadableNonModuleScriptBase::LoadableNonModuleScriptBase(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, RequestPriority fetchPriorityHint,  const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync)
+LoadableNonModuleScriptBase::LoadableNonModuleScriptBase(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, RequestPriority fetchPriorityHint,  const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync)
     : LoadableScript(nonce, policy, fetchPriorityHint, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree)
     , m_integrity(integrity)
     , m_isAsync(isAsync)
@@ -158,12 +158,12 @@ bool LoadableNonModuleScriptBase::load(Document& document, const URL& sourceURL)
     return true;
 }
 
-Ref<LoadableClassicScript> LoadableClassicScript::create(const AtomString& nonce, const AtomString& integrityMetadata, ReferrerPolicy policy, RequestPriority fetchPriorityHint, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync)
+Ref<LoadableClassicScript> LoadableClassicScript::create(const AtomString& nonce, const AtomString& integrityMetadata, ReferrerPolicy policy, RequestPriority fetchPriorityHint, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync)
 {
     return adoptRef(*new LoadableClassicScript(nonce, integrityMetadata, policy, fetchPriorityHint, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree, isAsync));
 }
 
-LoadableClassicScript::LoadableClassicScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, RequestPriority fetchPriorityHint, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync)
+LoadableClassicScript::LoadableClassicScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, RequestPriority fetchPriorityHint, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync)
     : LoadableNonModuleScriptBase(nonce, integrity, policy, fetchPriorityHint, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree, isAsync)
 {
 }

--- a/Source/WebCore/dom/LoadableClassicScript.h
+++ b/Source/WebCore/dom/LoadableClassicScript.h
@@ -58,7 +58,7 @@ public:
     const AtomString& integrity() const { return m_integrity; }
 
 protected:
-    LoadableNonModuleScriptBase(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync);
+    LoadableNonModuleScriptBase(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync);
 
 private:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
@@ -74,14 +74,14 @@ protected:
 
 class LoadableClassicScript final : public LoadableNonModuleScriptBase {
 public:
-    static Ref<LoadableClassicScript> create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync);
+    static Ref<LoadableClassicScript> create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync);
 
     ScriptType scriptType() const final { return ScriptType::Classic; }
 
     void execute(ScriptElement&) final;
 
 private:
-    LoadableClassicScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync);
+    LoadableClassicScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync);
 };
 
 }

--- a/Source/WebCore/dom/LoadableModuleScript.cpp
+++ b/Source/WebCore/dom/LoadableModuleScript.cpp
@@ -35,12 +35,12 @@
 
 namespace WebCore {
 
-Ref<LoadableModuleScript> LoadableModuleScript::create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, RequestPriority fetchPriorityHint, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
+Ref<LoadableModuleScript> LoadableModuleScript::create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, RequestPriority fetchPriorityHint, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
 {
     return adoptRef(*new LoadableModuleScript(nonce, integrity, policy, fetchPriorityHint, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree));
 }
 
-LoadableModuleScript::LoadableModuleScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, RequestPriority fetchPriorityHint, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
+LoadableModuleScript::LoadableModuleScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, RequestPriority fetchPriorityHint, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
     : LoadableScript(nonce, policy, fetchPriorityHint, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree)
     , m_parameters(ModuleFetchParameters::create(JSC::ScriptFetchParameters::Type::JavaScript, integrity, /* isTopLevelModule */ true))
 {

--- a/Source/WebCore/dom/LoadableModuleScript.h
+++ b/Source/WebCore/dom/LoadableModuleScript.h
@@ -38,7 +38,7 @@ class LoadableModuleScript final : public LoadableScript {
 public:
     virtual ~LoadableModuleScript();
 
-    static Ref<LoadableModuleScript> create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
+    static Ref<LoadableModuleScript> create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
 
     bool isLoaded() const final;
     bool hasError() const final;
@@ -58,7 +58,7 @@ public:
     ModuleFetchParameters& parameters() { return m_parameters.get(); }
 
 private:
-    LoadableModuleScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
+    LoadableModuleScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
 
     Ref<ModuleFetchParameters> m_parameters;
     RefPtr<UniquedStringImpl> m_moduleKey;

--- a/Source/WebCore/dom/LoadableScript.cpp
+++ b/Source/WebCore/dom/LoadableScript.cpp
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-LoadableScript::LoadableScript(const AtomString& nonce, ReferrerPolicy policy, RequestPriority fetchPriority, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
+LoadableScript::LoadableScript(const AtomString& nonce, ReferrerPolicy policy, RequestPriority fetchPriority, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
     : ScriptElementCachedScriptFetcher(nonce, policy, fetchPriority, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree)
 {
 }

--- a/Source/WebCore/dom/LoadableScript.h
+++ b/Source/WebCore/dom/LoadableScript.h
@@ -59,7 +59,7 @@ public:
     void removeClient(LoadableScriptClient&);
 
 protected:
-    LoadableScript(const AtomString& nonce, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
+    LoadableScript(const AtomString& nonce, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
 
     void notifyClientFinished();
 

--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -141,7 +141,7 @@ void ProcessingInstruction::checkStyleSheet()
 #endif
             {
                 String charset = attributes->get<HashTranslatorASCIILiteral>("charset"_s);
-                CachedResourceRequest request(document->completeURL(href), CachedResourceLoader::defaultCachedResourceOptions(), std::nullopt, charset.isEmpty() ? document->charset() : WTFMove(charset));
+                CachedResourceRequest request(document->completeURL(href), CachedResourceLoader::defaultCachedResourceOptions(), std::nullopt, charset.isEmpty() ? String::fromLatin1(document->charset()) : WTFMove(charset));
 
                 m_cachedSheet = document->protectedCachedResourceLoader()->requestCSSStyleSheet(WTFMove(request)).value_or(nullptr);
             }
@@ -182,7 +182,7 @@ bool ProcessingInstruction::sheetLoaded()
     return false;
 }
 
-void ProcessingInstruction::setCSSStyleSheet(const String& href, const URL& baseURL, const String& charset, const CachedCSSStyleSheet* sheet)
+void ProcessingInstruction::setCSSStyleSheet(const String& href, const URL& baseURL, ASCIILiteral charset, const CachedCSSStyleSheet* sheet)
 {
     if (!isConnected()) {
         ASSERT(!m_sheet);

--- a/Source/WebCore/dom/ProcessingInstruction.h
+++ b/Source/WebCore/dom/ProcessingInstruction.h
@@ -65,7 +65,7 @@ private:
     void removedFromAncestor(RemovalType, ContainerNode&) override;
 
     void checkStyleSheet();
-    void setCSSStyleSheet(const String& href, const URL& baseURL, const String& charset, const CachedCSSStyleSheet*) override;
+    void setCSSStyleSheet(const String& href, const URL& baseURL, ASCIILiteral charset, const CachedCSSStyleSheet*) override;
 #if ENABLE(XSLT)
     void setXSLStyleSheet(const String& href, const URL& baseURL, const String& sheet) override;
 #endif

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -235,8 +235,8 @@ bool ScriptElement::prepareScript(const TextPosition& scriptStartPosition)
     // According to the spec, the module tag ignores the "charset" attribute as the same to the worker's
     // importScript. But WebKit supports the "charset" for importScript intentionally. So to be consistent,
     // even for the module tags, we handle the "charset" attribute.
-    if (!charsetAttributeValue().isEmpty())
-        m_characterEncoding = charsetAttributeValue();
+    if (auto attributeValue = charsetAttributeValue(); !attributeValue.isEmpty())
+        m_characterEncoding = WTFMove(attributeValue);
     else
         m_characterEncoding = document->charset();
 

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -52,7 +52,7 @@ public:
 
     bool prepareScript(const TextPosition& scriptStartPosition = TextPosition());
 
-    String scriptCharset() const { return m_characterEncoding; }
+    const AtomString& scriptCharset() const { return m_characterEncoding; }
     WEBCORE_EXPORT String scriptContent() const;
     void executeClassicScript(const ScriptSourceCode&);
     void executeModuleScript(LoadableModuleScript&);
@@ -128,7 +128,7 @@ private:
     void updateTaintedOriginFromSourceURL();
 
     virtual String sourceAttributeValue() const = 0;
-    virtual String charsetAttributeValue() const = 0;
+    virtual AtomString charsetAttributeValue() const = 0;
     virtual String typeAttributeValue() const = 0;
     virtual String languageAttributeValue() const = 0;
     virtual ReferrerPolicy referrerPolicy() const = 0;
@@ -151,8 +151,8 @@ private:
     bool m_willExecuteInOrder : 1 { false };
     bool m_childrenChangedByAPI : 1 { false };
     ScriptType m_scriptType : bitWidthOfScriptType { ScriptType::Classic };
-    String m_characterEncoding;
-    String m_fallbackCharacterEncoding;
+    AtomString m_characterEncoding;
+    AtomString m_fallbackCharacterEncoding;
     RefPtr<LoadableScript> m_loadableScript;
 
     // https://html.spec.whatwg.org/multipage/scripting.html#preparation-time-document

--- a/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
+++ b/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
@@ -44,7 +44,7 @@ public:
     const String& crossOriginMode() const { return m_crossOriginMode; }
 
 protected:
-    ScriptElementCachedScriptFetcher(const AtomString& nonce, ReferrerPolicy policy, RequestPriority fetchPriority, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
+    ScriptElementCachedScriptFetcher(const AtomString& nonce, ReferrerPolicy policy, RequestPriority fetchPriority, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
         : CachedScriptFetcher(nonce, policy, fetchPriority, charset, initiatorType, isInUserAgentShadowTree)
         , m_crossOriginMode(crossOriginMode)
     {

--- a/Source/WebCore/dom/TextDecoder.cpp
+++ b/Source/WebCore/dom/TextDecoder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -83,7 +83,7 @@ ExceptionOr<String> TextDecoder::decode(std::optional<BufferSource::VariantType>
 
 String TextDecoder::encoding() const
 {
-    return makeString(asASCIILowercase(StringView::fromLatin1(m_textEncoding.name())));
+    return StringView(m_textEncoding.name()).convertToASCIILowercase();
 }
 
 }

--- a/Source/WebCore/dom/TextEncoder.cpp
+++ b/Source/WebCore/dom/TextEncoder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,11 +33,6 @@
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
-
-String TextEncoder::encoding() const
-{
-    return "utf-8"_s;
-}
 
 RefPtr<Uint8Array> TextEncoder::encode(String&& input) const
 {

--- a/Source/WebCore/dom/TextEncoder.h
+++ b/Source/WebCore/dom/TextEncoder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,7 +41,7 @@ public:
     };
 
     static Ref<TextEncoder> create() { return adoptRef(*new TextEncoder); }
-    String encoding() const;
+    ASCIILiteral encoding() const { return "utf-8"_s; }
     RefPtr<Uint8Array> encode(String&&) const;
     EncodeIntoResult encodeInto(String&&, Ref<Uint8Array>&& destination);
 private:

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -190,8 +190,9 @@ void HTMLDetailsElement::didFinishInsertingNode()
 Vector<RefPtr<HTMLDetailsElement>> HTMLDetailsElement::otherElementsInNameGroup()
 {
     Vector<RefPtr<HTMLDetailsElement>> otherElementsInNameGroup;
+    const auto& detailElementName = attributeWithoutSynchronization(nameAttr);
     for (auto& element : descendantsOfType<HTMLDetailsElement>(rootNode())) {
-        if (&element != this && element.attributeWithoutSynchronization(nameAttr) == attributeWithoutSynchronization(nameAttr))
+        if (&element != this && element.attributeWithoutSynchronization(nameAttr) == detailElementName)
             otherElementsInNameGroup.append(&element);
     }
     return otherElementsInNameGroup;

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -551,7 +551,7 @@ void HTMLLinkElement::initializeStyleSheet(Ref<StyleSheetContents>&& styleSheet,
         m_sheet->contents().setAsOpaque();
 }
 
-void HTMLLinkElement::setCSSStyleSheet(const String& href, const URL& baseURL, const String& charset, const CachedCSSStyleSheet* cachedStyleSheet)
+void HTMLLinkElement::setCSSStyleSheet(const String& href, const URL& baseURL, ASCIILiteral charset, const CachedCSSStyleSheet* cachedStyleSheet)
 {
     unblockRendering();
     if (!isConnected()) {

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -119,7 +119,7 @@ private:
     void initializeStyleSheet(Ref<StyleSheetContents>&&, const CachedCSSStyleSheet&, MediaQueryParserContext);
 
     // from CachedResourceClient
-    void setCSSStyleSheet(const String& href, const URL& baseURL, const String& charset, const CachedCSSStyleSheet*) final;
+    void setCSSStyleSheet(const String& href, const URL& baseURL, ASCIILiteral charset, const CachedCSSStyleSheet*) final;
     bool sheetLoaded() final;
     void notifyLoadedSheetAndAllCriticalSubresources(bool errorOccurred) final;
     void startLoadingDynamicSheet() final;

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -229,9 +229,9 @@ String HTMLScriptElement::sourceAttributeValue() const
     return attributeWithoutSynchronization(srcAttr).string();
 }
 
-String HTMLScriptElement::charsetAttributeValue() const
+AtomString HTMLScriptElement::charsetAttributeValue() const
 {
-    return attributeWithoutSynchronization(charsetAttr).string();
+    return attributeWithoutSynchronization(charsetAttr);
 }
 
 String HTMLScriptElement::typeAttributeValue() const

--- a/Source/WebCore/html/HTMLScriptElement.h
+++ b/Source/WebCore/html/HTMLScriptElement.h
@@ -95,7 +95,7 @@ private:
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const final;
 
     String sourceAttributeValue() const final;
-    String charsetAttributeValue() const final;
+    AtomString charsetAttributeValue() const final;
     String typeAttributeValue() const final;
     String languageAttributeValue() const final;
     bool hasAsyncAttribute() const final;

--- a/Source/WebCore/loader/LinkPreloadResourceClients.h
+++ b/Source/WebCore/loader/LinkPreloadResourceClients.h
@@ -101,7 +101,7 @@ public:
     }
 
 private:
-    void setCSSStyleSheet(const String&, const URL&, const String&, const CachedCSSStyleSheet* resource) final
+    void setCSSStyleSheet(const String&, const URL&, ASCIILiteral, const CachedCSSStyleSheet* resource) final
     {
         ASSERT(resource);
         ASSERT(ownedResource() == resource);

--- a/Source/WebCore/loader/cache/CachedApplicationManifest.cpp
+++ b/Source/WebCore/loader/cache/CachedApplicationManifest.cpp
@@ -59,9 +59,9 @@ void CachedApplicationManifest::setEncoding(const String& chs)
     protectedDecoder()->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
 }
 
-String CachedApplicationManifest::encoding() const
+ASCIILiteral CachedApplicationManifest::encoding() const
 {
-    return String::fromLatin1(protectedDecoder()->encoding().name());
+    return protectedDecoder()->encoding().name();
 }
 
 std::optional<ApplicationManifest> CachedApplicationManifest::process(const URL& manifestURL, const URL& documentURL, Document* document)

--- a/Source/WebCore/loader/cache/CachedApplicationManifest.h
+++ b/Source/WebCore/loader/cache/CachedApplicationManifest.h
@@ -46,7 +46,7 @@ private:
     const TextResourceDecoder* textResourceDecoder() const final { return m_decoder.ptr(); }
     Ref<TextResourceDecoder> protectedDecoder() const;
     void setEncoding(const String&) final;
-    String encoding() const final;
+    ASCIILiteral encoding() const final;
 
     Ref<TextResourceDecoder> m_decoder;
     std::optional<String> m_text;

--- a/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
+++ b/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
@@ -64,7 +64,7 @@ void CachedCSSStyleSheet::didAddClient(CachedResourceClient& client)
     CachedResource::didAddClient(client);
 
     if (!isLoading())
-        downcast<CachedStyleSheetClient>(client).setCSSStyleSheet(m_resourceRequest.url().string(), response().url(), String::fromLatin1(m_decoder->encoding().name()), this);
+        downcast<CachedStyleSheetClient>(client).setCSSStyleSheet(m_resourceRequest.url().string(), response().url(), m_decoder->encoding().name(), this);
 }
 
 void CachedCSSStyleSheet::setEncoding(const String& chs)
@@ -72,9 +72,9 @@ void CachedCSSStyleSheet::setEncoding(const String& chs)
     protectedDecoder()->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
 }
 
-String CachedCSSStyleSheet::encoding() const
+ASCIILiteral CachedCSSStyleSheet::encoding() const
 {
-    return String::fromLatin1(protectedDecoder()->encoding().name());
+    return protectedDecoder()->encoding().name();
 }
 
 const String CachedCSSStyleSheet::sheetText(MIMETypeCheckHint mimeTypeCheckHint, bool* hasValidMIMEType, bool* hasHTTPStatusOK) const
@@ -135,7 +135,7 @@ void CachedCSSStyleSheet::checkNotify(const NetworkLoadMetrics&, LoadWillContinu
 
     CachedResourceClientWalker<CachedStyleSheetClient> walker(*this);
     while (CachedStyleSheetClient* c = walker.next())
-        c->setCSSStyleSheet(m_resourceRequest.url().string(), response().url(), String::fromLatin1(protectedDecoder()->encoding().name()), this);
+        c->setCSSStyleSheet(m_resourceRequest.url().string(), response().url(), protectedDecoder()->encoding().name(), this);
 }
 
 String CachedCSSStyleSheet::responseMIMEType() const

--- a/Source/WebCore/loader/cache/CachedCSSStyleSheet.h
+++ b/Source/WebCore/loader/cache/CachedCSSStyleSheet.h
@@ -55,7 +55,7 @@ private:
     void didAddClient(CachedResourceClient&) final;
 
     void setEncoding(const String&) final;
-    String encoding() const final;
+    ASCIILiteral encoding() const final;
     const TextResourceDecoder* textResourceDecoder() const final { return m_decoder.ptr(); }
     void finishLoading(const FragmentedSharedBuffer*, const NetworkLoadMetrics&) final;
     void destroyDecodedData() final;

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -132,7 +132,7 @@ public:
     virtual void load(CachedResourceLoader&);
 
     virtual void setEncoding(const String&) { }
-    virtual String encoding() const { return String(); }
+    virtual ASCIILiteral encoding() const { return ASCIILiteral(); }
     virtual const TextResourceDecoder* textResourceDecoder() const { return nullptr; }
     virtual void updateBuffer(const FragmentedSharedBuffer&);
     virtual void updateData(const SharedBuffer&);

--- a/Source/WebCore/loader/cache/CachedSVGDocument.cpp
+++ b/Source/WebCore/loader/cache/CachedSVGDocument.cpp
@@ -48,9 +48,9 @@ void CachedSVGDocument::setEncoding(const String& chs)
     protectedDecoder()->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
 }
 
-String CachedSVGDocument::encoding() const
+ASCIILiteral CachedSVGDocument::encoding() const
 {
-    return String::fromLatin1(protectedDecoder()->encoding().name());
+    return protectedDecoder()->encoding().name();
 }
 
 RefPtr<TextResourceDecoder> CachedSVGDocument::protectedDecoder() const

--- a/Source/WebCore/loader/cache/CachedSVGDocument.h
+++ b/Source/WebCore/loader/cache/CachedSVGDocument.h
@@ -41,7 +41,7 @@ public:
 private:
     bool mayTryReplaceEncodedData() const override { return true; }
     void setEncoding(const String&) override;
-    String encoding() const override;
+    ASCIILiteral encoding() const override;
     const TextResourceDecoder* textResourceDecoder() const override { return m_decoder.get(); }
     RefPtr<TextResourceDecoder> protectedDecoder() const;
     void finishLoading(const FragmentedSharedBuffer*, const NetworkLoadMetrics&) override;

--- a/Source/WebCore/loader/cache/CachedScript.cpp
+++ b/Source/WebCore/loader/cache/CachedScript.cpp
@@ -57,9 +57,9 @@ void CachedScript::setEncoding(const String& chs)
     protectedDecoder()->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
 }
 
-String CachedScript::encoding() const
+ASCIILiteral CachedScript::encoding() const
 {
-    return String::fromLatin1(protectedDecoder()->encoding().name());
+    return protectedDecoder()->encoding().name();
 }
 
 StringView CachedScript::script(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)

--- a/Source/WebCore/loader/cache/CachedScript.h
+++ b/Source/WebCore/loader/cache/CachedScript.h
@@ -50,7 +50,7 @@ private:
     bool shouldIgnoreHTTPStatusCodeErrors() const final;
 
     void setEncoding(const String&) final;
-    String encoding() const final;
+    ASCIILiteral encoding() const final;
     const TextResourceDecoder* textResourceDecoder() const final { return m_decoder.get(); }
     RefPtr<TextResourceDecoder> protectedDecoder() const;
     void finishLoading(const FragmentedSharedBuffer*, const NetworkLoadMetrics&) final;

--- a/Source/WebCore/loader/cache/CachedStyleSheetClient.h
+++ b/Source/WebCore/loader/cache/CachedStyleSheetClient.h
@@ -37,7 +37,7 @@ public:
     virtual ~CachedStyleSheetClient() = default;
     static CachedResourceClientType expectedType() { return StyleSheetType; }
     CachedResourceClientType resourceClientType() const override { return expectedType(); }
-    virtual void setCSSStyleSheet(const String& /* href */, const URL& /* baseURL */, const String& /* charset */, const CachedCSSStyleSheet*) { }
+    virtual void setCSSStyleSheet(const String& /* href */, const URL& /* baseURL */, ASCIILiteral /* charset */, const CachedCSSStyleSheet*) { }
     virtual void setXSLStyleSheet(const String& /* href */, const URL& /* baseURL */, const String& /* sheet */) { }
 };
 

--- a/Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp
+++ b/Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp
@@ -61,9 +61,9 @@ void CachedXSLStyleSheet::setEncoding(const String& chs)
     protectedDecoder()->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
 }
 
-String CachedXSLStyleSheet::encoding() const
+ASCIILiteral CachedXSLStyleSheet::encoding() const
 {
-    return String::fromLatin1(protectedDecoder()->encoding().name());
+    return protectedDecoder()->encoding().name();
 }
 
 void CachedXSLStyleSheet::finishLoading(const FragmentedSharedBuffer* data, const NetworkLoadMetrics& metrics)

--- a/Source/WebCore/loader/cache/CachedXSLStyleSheet.h
+++ b/Source/WebCore/loader/cache/CachedXSLStyleSheet.h
@@ -45,7 +45,7 @@ private:
     bool mayTryReplaceEncodedData() const final { return true; }
     void didAddClient(CachedResourceClient&) final;
     void setEncoding(const String&) final;
-    String encoding() const final;
+    ASCIILiteral encoding() const final;
     const TextResourceDecoder* textResourceDecoder() const final { return m_decoder.get(); }
     RefPtr<TextResourceDecoder> protectedDecoder() const;
     void finishLoading(const FragmentedSharedBuffer*, const NetworkLoadMetrics&) final;

--- a/Source/WebCore/svg/SVGScriptElement.h
+++ b/Source/WebCore/svg/SVGScriptElement.h
@@ -59,7 +59,7 @@ private:
 
     // ScriptElement
     String sourceAttributeValue() const final { return href(); }
-    String charsetAttributeValue() const final { return String(); }
+    AtomString charsetAttributeValue() const final { return nullAtom(); }
     String typeAttributeValue() const final { return getAttribute(SVGNames::typeAttr).string(); }
     String languageAttributeValue() const final { return String(); }
     bool hasAsyncAttribute() const final { return false; }

--- a/Source/WebKitLegacy/mac/DOM/DOMDocument.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMDocument.mm
@@ -114,7 +114,7 @@
 - (NSString *)inputEncoding
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->characterSetWithUTF8Fallback();
+    return IMPL->characterSetWithUTF8Fallback().createNSString().autorelease();
 }
 
 - (NSString *)xmlEncoding
@@ -288,7 +288,7 @@
 - (NSString *)charset
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->charset();
+    return IMPL->charset().createNSString().autorelease();
 }
 
 - (void)setCharset:(NSString *)newCharset
@@ -321,7 +321,7 @@
 - (NSString *)characterSet
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->characterSetWithUTF8Fallback();
+    return IMPL->characterSetWithUTF8Fallback().createNSString().autorelease();
 }
 
 - (NSString *)preferredStylesheetSet


### PR DESCRIPTION
#### 78bc243d1e64b30d8a4362fdacf666bffdc33e90
<pre>
Avoid unnecessary conversions from ASCIILiteral
<a href="https://bugs.webkit.org/show_bug.cgi?id=282724">https://bugs.webkit.org/show_bug.cgi?id=282724</a>
&lt;<a href="https://rdar.apple.com/problem/139394432">rdar://problem/139394432</a>&gt;

Reviewed by Chris Dumez.

Over many years of refactoring we&apos;ve wrapped immutable ASCIILiterals in
strings at various points. We should try to pass the basic type when
possible to avoid constructing a String object unless it is needed.

* Source/WTF/wtf/Hasher.h:
(WTF::add):
* Source/WebCore/bindings/js/CachedScriptFetcher.cpp:
(WebCore::CachedScriptFetcher::create):
* Source/WebCore/bindings/js/CachedScriptFetcher.h:
(WebCore::CachedScriptFetcher::CachedScriptFetcher):
* Source/WebCore/css/StyleRuleImport.cpp:
(WebCore::StyleRuleImport::requestStyleSheet):
(WebCore::StyleRuleImport::setCSSStyleSheet):
* Source/WebCore/css/StyleRuleImport.h:
* Source/WebCore/css/StyleSheetContents.h:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::CSSParserContext::CSSParserContext):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::characterSetWithUTF8Fallback const):
(WebCore::Document::cssParserContext const):
(WebCore::Document::encoding const): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentInlines.h:
(WebCore::Document::encoding const):
(WebCore::Document::charset const):
* Source/WebCore/dom/InlineClassicScript.cpp:
(WebCore::InlineClassicScript::InlineClassicScript):
* Source/WebCore/dom/InlineClassicScript.h:
* Source/WebCore/dom/LoadableClassicScript.cpp:
(WebCore::LoadableNonModuleScriptBase::LoadableNonModuleScriptBase):
(WebCore::LoadableClassicScript::create):
(WebCore::LoadableClassicScript::LoadableClassicScript):
* Source/WebCore/dom/LoadableClassicScript.h:
* Source/WebCore/dom/LoadableModuleScript.cpp:
(WebCore::LoadableModuleScript::create):
(WebCore::LoadableModuleScript::LoadableModuleScript):
* Source/WebCore/dom/LoadableModuleScript.h:
* Source/WebCore/dom/LoadableScript.cpp:
(WebCore::LoadableScript::LoadableScript):
* Source/WebCore/dom/LoadableScript.h:
* Source/WebCore/dom/ProcessingInstruction.cpp:
(WebCore::ProcessingInstruction::checkStyleSheet):
(WebCore::ProcessingInstruction::setCSSStyleSheet):
* Source/WebCore/dom/ProcessingInstruction.h:
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::prepareScript):
* Source/WebCore/dom/ScriptElement.h:
(WebCore::ScriptElement::scriptCharset const):
* Source/WebCore/dom/ScriptElementCachedScriptFetcher.h:
(WebCore::ScriptElementCachedScriptFetcher::ScriptElementCachedScriptFetcher):
* Source/WebCore/dom/TextDecoder.cpp:
(WebCore::TextDecoder::encoding const):
* Source/WebCore/dom/TextEncoder.cpp:
(WebCore::TextEncoder::encoding const):
* Source/WebCore/dom/TextEncoder.h:
 * Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::HTMLDetailsElement::otherElementsInNameGroup): Drive-by fix. Avoid doing lookup
Multiple times during loop.
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::setCSSStyleSheet):
* Source/WebCore/html/HTMLLinkElement.h:
* Source/WebCore/html/HTMLScriptElement.cpp:
(WebCore::HTMLScriptElement::charsetAttributeValue const): Drive-by fix. Avoid
Converting to string, when its only use cases are to copy back to an AtomString.
* Source/WebCore/html/HTMLScriptElement.h:
* Source/WebCore/loader/LinkPreloadResourceClients.h:
* Source/WebCore/loader/cache/CachedApplicationManifest.cpp:
(WebCore::CachedApplicationManifest::encoding const):
* Source/WebCore/loader/cache/CachedApplicationManifest.h:
* Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp:
(WebCore::CachedCSSStyleSheet::didAddClient):
(WebCore::CachedCSSStyleSheet::encoding const):
(WebCore::CachedCSSStyleSheet::checkNotify):
* Source/WebCore/loader/cache/CachedCSSStyleSheet.h:
* Source/WebCore/loader/cache/CachedResource.h:
(WebCore::CachedResource::encoding const):
* Source/WebCore/svg/SVGScriptElement.h:
* Source/WebCore/loader/LinkPreloadResourceClients.h:
* Source/WebCore/loader/cache/CachedApplicationManifest.cpp:
(WebCore::CachedApplicationManifest::encoding const):
* Source/WebCore/loader/cache/CachedApplicationManifest.h:
* Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp:
(WebCore::CachedCSSStyleSheet::didAddClient):
(WebCore::CachedCSSStyleSheet::encoding const):
(WebCore::CachedCSSStyleSheet::checkNotify):
* Source/WebCore/loader/cache/CachedCSSStyleSheet.h:
* Source/WebCore/loader/cache/CachedResource.h:
(WebCore::CachedResource::encoding const):
* Source/WebCore/loader/cache/CachedSVGDocument.cpp:
(WebCore::CachedSVGDocument::encoding const):
* Source/WebCore/loader/cache/CachedSVGDocument.h:
* Source/WebCore/loader/cache/CachedScript.cpp:
(WebCore::CachedScript::encoding const):
* Source/WebCore/loader/cache/CachedScript.h:
* Source/WebCore/loader/cache/CachedStyleSheetClient.h:
(WebCore::CachedStyleSheetClient::setCSSStyleSheet):
* Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp:
(WebCore::CachedXSLStyleSheet::encoding const):
* Source/WebCore/loader/cache/CachedXSLStyleSheet.h:
* Source/WebCore/svg/SVGScriptElement.h:
* Source/WebKitLegacy/mac/DOM/DOMDocument.mm:
(-[DOMDocument inputEncoding]):
(-[DOMDocument charset]):
(-[DOMDocument characterSet]):

Canonical link: <a href="https://commits.webkit.org/286364@main">https://commits.webkit.org/286364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c3d6a4133d69923d46ca9d743402551d20878f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75719 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80207 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26983 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77835 "Passed tests") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3007 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59400 "Build is in progress. Recent messages:Printed configuration") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17567 "Build is in progress. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78786 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65046 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39753 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22525 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/25312 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; compiling") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68869 "Built successfully and passed tests") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22861 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81678 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74981 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3058 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1934 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67629 "Build is in progress. Recent messages:Printed configuration") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3209 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66929 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10877 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9014 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97249 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11705 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3015 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5837 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21260 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3040 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3975 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3047 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->