### PR TITLE
updateAllowsBackingStoreDetaching has wrong coordinates when inside an animated transform.

### DIFF
--- a/LayoutTests/compositing/backing/backing-store-attachment-animated-transform-inside-fixed-expected.txt
+++ b/LayoutTests/compositing/backing/backing-store-attachment-animated-transform-inside-fixed-expected.txt
@@ -1,0 +1,41 @@
+Hi
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (backingStoreAttached 1)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (backingStoreAttached 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 13.00)
+          (preserves3D 1)
+          (backingStoreAttached 0)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (backingStoreAttached 1)
+              (children 1
+                (GraphicsLayer
+                  (bounds 200.00 200.00)
+                  (backingStoreAttached 0)
+                  (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [-2000.00 0.00 0.00 1.00])
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 200.00 200.00)
+                      (drawsContent 1)
+                      (backingStoreAttached 0)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/backing/backing-store-attachment-animated-transform-inside-fixed.html
+++ b/LayoutTests/compositing/backing/backing-store-attachment-animated-transform-inside-fixed.html
@@ -1,0 +1,55 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style>
+@keyframes move {
+  0% { transform: translateX(-2000px); }
+  100% { transform: translateX(-2000px); }
+}
+
+div {
+  width: 200px;
+  height: 200px;
+}
+
+.fixed {
+  position:fixed;
+}
+
+.composited {
+  transform: translateZ(0px);
+}
+
+.animated {
+  animation: 10s both move;
+}
+
+</style>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.onload = function() {
+    if (!window.testRunner)
+        return;
+
+    let output = document.getElementById('layers');
+    output.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_BACKING_STORE_ATTACHED);
+    testRunner.notifyDone();
+};
+</script>
+</head>
+<body>
+
+<div class="fixed">
+  <div class="animated">
+    <div class="composited">Hi</div>
+  </div>
+</div>
+
+<pre id="layers"></pre>
+
+</body>
+</html>

--- a/LayoutTests/platform/glib/compositing/backing/backing-store-attachment-animated-transform-inside-fixed-expected.txt
+++ b/LayoutTests/platform/glib/compositing/backing/backing-store-attachment-animated-transform-inside-fixed-expected.txt
@@ -1,0 +1,41 @@
+Hi
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (backingStoreAttached 1)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (backingStoreAttached 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 13.00)
+          (preserves3D 1)
+          (backingStoreAttached 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (backingStoreAttached 1)
+              (children 1
+                (GraphicsLayer
+                  (bounds 200.00 200.00)
+                  (backingStoreAttached 1)
+                  (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [-2000.00 0.00 0.00 1.00])
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 200.00 200.00)
+                      (drawsContent 1)
+                      (backingStoreAttached 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/win/compositing/backing/backing-store-attachment-animated-transform-inside-fixed-expected.txt
+++ b/LayoutTests/platform/win/compositing/backing/backing-store-attachment-animated-transform-inside-fixed-expected.txt
@@ -1,0 +1,45 @@
+Hi
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (usingTiledLayer 1)
+  (backingStoreAttached 1)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (backingStoreAttached 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 13.00)
+          (preserves3D 1)
+          (backingStoreAttached 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (usingTiledLayer 1)
+              (backingStoreAttached 1)
+              (children 1
+                (GraphicsLayer
+                  (bounds 200.00 200.00)
+                  (usingTiledLayer 1)
+                  (backingStoreAttached 1)
+                  (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [-2000.00 0.00 0.00 1.00])
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 200.00 200.00)
+                      (usingTiledLayer 1)
+                      (drawsContent 1)
+                      (backingStoreAttached 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -969,7 +969,7 @@ bool RenderLayerBacking::updateCompositedBounds()
     return setCompositedBounds(layerBounds);
 }
 
-void RenderLayerBacking::updateAllowsBackingStoreDetaching(const LayoutRect& absoluteBounds)
+void RenderLayerBacking::updateAllowsBackingStoreDetaching(bool allowDetachingForFixed)
 {
     auto setAllowsBackingStoreDetaching = [&](bool allowDetaching) {
         m_graphicsLayer->setAllowsBackingStoreDetaching(allowDetaching);
@@ -986,18 +986,7 @@ void RenderLayerBacking::updateAllowsBackingStoreDetaching(const LayoutRect& abs
         return;
     }
 
-    // We'll allow detaching if the layer is outside the layout viewport. Fixed layers inside
-    // the layout viewport can be revealed by async scrolling, so we want to pin their backing store.
-    LocalFrameView& frameView = renderer().view().frameView();
-    LayoutRect fixedLayoutRect;
-    if (frameView.useFixedLayout())
-        fixedLayoutRect = renderer().view().unscaledDocumentRect();
-    else
-        fixedLayoutRect = frameView.rectForFixedPositionLayout();
-
-    bool allowDetaching = !fixedLayoutRect.intersects(absoluteBounds);
-    LOG_WITH_STREAM(Compositing, stream << "RenderLayerBacking (layer " << &m_owningLayer << ") updateAllowsBackingStoreDetaching - absoluteBounds " << absoluteBounds << " layoutViewportRect " << fixedLayoutRect << ", allowDetaching " << allowDetaching);
-    setAllowsBackingStoreDetaching(allowDetaching);
+    setAllowsBackingStoreDetaching(allowDetachingForFixed);
 }
 
 void RenderLayerBacking::updateAfterWidgetResize()

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -193,7 +193,7 @@ public:
     // Returns true if changed.
     bool updateCompositedBounds();
     
-    void updateAllowsBackingStoreDetaching(const LayoutRect& absoluteBounds);
+    void updateAllowsBackingStoreDetaching(bool allowDetachingForFixed);
 
 #if ENABLE(ASYNC_SCROLLING)
     bool maintainsEventRegion() const;

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -492,6 +492,8 @@ private:
     bool layerHas3DContent(const RenderLayer&) const;
     bool isRunningTransformAnimation(RenderLayerModelObject&) const;
 
+    bool allowBackingStoreDetachingForFixedPosition(RenderLayer&, const LayoutRect& absoluteBounds);
+
     void appendDocumentOverlayLayers(Vector<Ref<GraphicsLayer>>&);
 
     bool needsCompositingForContentOrOverlays() const;


### PR DESCRIPTION
#### 43d5c16a35e71576fa7967dda20546e9c186f1f1
<pre>
updateAllowsBackingStoreDetaching has wrong coordinates when inside an animated transform.
<a href="https://bugs.webkit.org/show_bug.cgi?id=282727">https://bugs.webkit.org/show_bug.cgi?id=282727</a>
&lt;<a href="https://rdar.apple.com/139393911">rdar://139393911</a>&gt;

Reviewed by Simon Fraser.

When descending through a layer that has an animated transform, the layerExtent
is computed using the post-transform animation extents and the transform itself
isn&apos;t pushed onto the geometry map.

That means for all descendants, overlap bounds are no longer &apos;absolute&apos;, since
they aren&apos;t transformed.

This generally works ok for overlap testing, since everything within the
transform stacking context is in the same coordinate space.

updateAllowsBackingStoreDetaching compares these untransformed coordinates
against the layout viewport though, and this is invalid, leading to backing
stores not being detached.

Actually fixing the layerExtent coordinates to be transformed (with the
transform extents) is complicated unfortunately.

This fixes the symptom by propagating the &apos;allow backing store detaching&apos;
computation down to descendant layers, if they are in the same containing block
chain (and thus are a subset of the extent computed already).

* LayoutTests/compositing/backing/backing-store-attachment-animated-transform-inside-fixed-expected.txt: Added.
* LayoutTests/compositing/backing/backing-store-attachment-animated-transform-inside-fixed.html: Added.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::updateCoverage):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAllowsBackingStoreDetaching):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::CompositingState::stateForPaintOrderChildren const):
(WebCore::RenderLayerCompositor::allowsFixedPositionBackingStoreDetaching):
(WebCore::RenderLayerCompositor::computeCompositingRequirements):
* Source/WebCore/rendering/RenderLayerCompositor.h:

Canonical link: <a href="https://commits.webkit.org/286517@main">https://commits.webkit.org/286517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc5f607a8a6deeef0aa15612bd9f0d243af9c79b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80679 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27435 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78284 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59728 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17867 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79235 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49621 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65409 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40076 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47017 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22892 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25762 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68150 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23227 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82132 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3540 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2299 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67948 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3694 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65377 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67258 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16774 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11217 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9325 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3488 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6295 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3511 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/6938 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->