### PR TITLE
Passkey registration broken on Ventura

### DIFF
--- a/Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h
@@ -304,7 +304,7 @@ typedef NS_ENUM(NSInteger, ASCredentialRequestStyle) {
 @property (nonatomic, copy, readonly) NSString *relyingPartyIdentifier;
 @property (nonatomic, copy, readonly) NSData *attestationObject;
 @property (nonatomic, copy, readonly) NSData *rawClientDataJSON;
-@property (nonatomic, copy) NSArray<NSNumber *> *transports;
+@property (nonatomic, copy) NSArray<NSString *> *transports;
 @property (nonatomic, copy, nullable) NSData *extensionOutputsCBOR;
 @property (nonatomic, copy, readonly) NSString *attachment;
 
@@ -321,7 +321,7 @@ typedef NS_ENUM(NSInteger, ASCredentialRequestStyle) {
 @property (nonatomic, copy, readonly) NSData *rawClientDataJSON;
 @property (nonatomic, copy, readonly) NSString *relyingPartyIdentifier;
 @property (nonatomic, copy, readonly) NSData *attestationObject;
-@property (nonatomic, copy) NSArray<NSNumber *> *transports;
+@property (nonatomic, copy) NSArray<NSString *> *transports;
 @property (nonatomic, copy, readonly, nullable) NSData *extensionOutputsCBOR;
 @property (nonatomic, copy, readonly) NSString *attachment;
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -956,14 +956,27 @@ static RetainPtr<ASCCredentialRequestContext> configurationAssertionRequestConte
     return requestContext;
 }
 
-static Vector<WebCore::AuthenticatorTransport> toAuthenticatorTransports(NSArray<NSNumber *> *ascTransports)
+static Vector<WebCore::AuthenticatorTransport> toAuthenticatorTransports(NSArray<NSString *> *ascTransports)
 {
     Vector<WebCore::AuthenticatorTransport> transports;
     transports.reserveInitialCapacity(ascTransports.count);
-    for (NSNumber *ascTransport : ascTransports) {
-        if (WTF::isValidEnum<WebCore::AuthenticatorTransport>(ascTransport.intValue))
-            transports.append(static_cast<WebCore::AuthenticatorTransport>(ascTransport.intValue));
+    for (NSString *ascTransport : ascTransports) {
+        if ([ascTransport isEqualToString:@"usb"])
+            transports.append(WebCore::AuthenticatorTransport::Usb);
+        else if ([ascTransport isEqualToString:@"nfc"])
+            transports.append(WebCore::AuthenticatorTransport::Nfc);
+        else if ([ascTransport isEqualToString:@"ble"])
+            transports.append(WebCore::AuthenticatorTransport::Ble);
+        else if ([ascTransport isEqualToString:@"internal"])
+            transports.append(WebCore::AuthenticatorTransport::Internal);
+        else if ([ascTransport isEqualToString:@"cable"])
+            transports.append(WebCore::AuthenticatorTransport::Cable);
+        else if ([ascTransport isEqualToString:@"hybrid"])
+            transports.append(WebCore::AuthenticatorTransport::Hybrid);
+        else if ([ascTransport isEqualToString:@"smartCard"])
+            transports.append(WebCore::AuthenticatorTransport::SmartCard);
     }
+
     return transports;
 }
 


### PR DESCRIPTION
#### b09d78e4a2ec900e7cec947b4656bd4fb1111478
<pre>
Passkey registration broken on Ventura
<a href="https://bugs.webkit.org/show_bug.cgi?id=282732">https://bugs.webkit.org/show_bug.cgi?id=282732</a>
<a href="https://rdar.apple.com/139368939">rdar://139368939</a>

Reviewed by Brent Fulgham.

ASCPlatformPublicKeyCredentialRegistration.transports was changed from an array
of NSNumbers to NSStrings. This change was not reflected in the WebKit legacy
passkey code path.

This patch updates that code to properly convert the strings to enum values.

* Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::toAuthenticatorTransports):

Canonical link: <a href="https://commits.webkit.org/286345@main">https://commits.webkit.org/286345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96a1a75cb2d6dda732cd851111f9baf8f6498dbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75381 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79856 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26645 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2612 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59157 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17375 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39519 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24972 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81337 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1709 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67406 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2871 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64750 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66686 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10640 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8801 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11688 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2677 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5498 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2702 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3637 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2709 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->