### PR TITLE
REGRESSION(285731@main): [macOS wk2] http/tests/media/fairplay/legacy-fairplay-hls.html is constant failure (flaky test in EWS)

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1915,7 +1915,8 @@ fast/events/drag-and-drop-autoscroll-inner-frame.html [ Pass Failure ]
 
 webkit.org/b/282565 [ Sequoia+ Debug ] imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-sideways-001.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/282726 http/tests/media/fairplay/legacy-fairplay-hls.html [ Failure ]
+# webkit.org/b/280378 [ Sequoia arm64 ] 14x http/tests/media/fairplay/* are constant failures
+[ Sequoia arm64 ] http/tests/media/fairplay/legacy-fairplay-hls.html [ Failure ]
 
 # webkit.org/b/282735 [macOS wk2 x86_64 ] 2 tests in imported/w3c/web-platform-tests/css/css-shapes/shape-outside/supported-shapes are a constant failure (failure in EWS)
 [ x86_64 ] imported/w3c/web-platform-tests/css/css-shapes/shape-outside/supported-shapes/inset/shape-outside-inset-022.html [ ImageOnlyFailure ]

--- a/Source/JavaScriptCore/runtime/GenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/GenericTypedArrayView.h
@@ -47,8 +47,8 @@ public:
     static RefPtr<GenericTypedArrayView> tryCreateUninitialized(size_t length);
     
     typename Adaptor::Type* data() const { return static_cast<typename Adaptor::Type*>(baseAddress()); }
-    typename std::span<const typename Adaptor::Type> span() const { return { data(), length() }; }
-    typename std::span<typename Adaptor::Type> mutableSpan() { return { data(), length() }; }
+    typename std::span<const typename Adaptor::Type> typedSpan() const { return unsafeMakeSpan(data(), length()); }
+    typename std::span<typename Adaptor::Type> typedMutableSpan() { return unsafeMakeSpan(data(), length()); }
 
     bool set(GenericTypedArrayView<Adaptor>* array, size_t offset)
     {

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.cpp
@@ -89,7 +89,7 @@ ExceptionOr<void> GPUComputePassEncoder::setBindGroup(GPUIndex32 index, const GP
     if (offset.hasOverflowed() || offset > dynamicOffsetsData.length())
         return Exception { ExceptionCode::RangeError, "dynamic offsets overflowed"_s };
 
-    m_backing->setBindGroup(index, bindGroup.backing(), dynamicOffsetsData.span(), dynamicOffsetsDataStart, dynamicOffsetsDataLength);
+    m_backing->setBindGroup(index, bindGroup.backing(), dynamicOffsetsData.typedSpan(), dynamicOffsetsDataStart, dynamicOffsetsDataLength);
     return { };
 }
 

--- a/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.cpp
@@ -99,7 +99,7 @@ ExceptionOr<void> GPURenderBundleEncoder::setBindGroup(GPUIndex32 index, const G
     if (offset.hasOverflowed() || offset > dynamicOffsetsData.length())
         return Exception { ExceptionCode::RangeError, "dynamic offsets overflowed"_s };
 
-    m_backing->setBindGroup(index, bindGroup.backing(), dynamicOffsetsData.span(), dynamicOffsetsDataStart, dynamicOffsetsDataLength);
+    m_backing->setBindGroup(index, bindGroup.backing(), dynamicOffsetsData.typedSpan(), dynamicOffsetsDataStart, dynamicOffsetsDataLength);
     return { };
 }
 

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
@@ -105,7 +105,7 @@ ExceptionOr<void> GPURenderPassEncoder::setBindGroup(GPUIndex32 index, const GPU
     if (offset.hasOverflowed() || offset > dynamicOffsetsData.length())
         return Exception { ExceptionCode::RangeError, "dynamic offsets overflowed"_s };
 
-    m_backing->setBindGroup(index, bindGroup.backing(), dynamicOffsetsData.span(), dynamicOffsetsDataStart, dynamicOffsetsDataLength);
+    m_backing->setBindGroup(index, bindGroup.backing(), dynamicOffsetsData.typedSpan(), dynamicOffsetsDataStart, dynamicOffsetsDataLength);
     return { };
 }
 


### PR DESCRIPTION
#### bfa6bc85963e9e0a727c26321a6258dd4cb5498f
<pre>
REGRESSION(285731@main): [macOS wk2] http/tests/media/fairplay/legacy-fairplay-hls.html is constant failure (flaky test in EWS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=282726">https://bugs.webkit.org/show_bug.cgi?id=282726</a>
<a href="https://rdar.apple.com/139392923">rdar://139392923</a>

Reviewed by NOBODY (OOPS!).

In 285731@main, I added a new span() member function to GenericTypedArrayView&lt;T&gt;, which returns
a span&lt;T&gt;. What I hadn&apos;t noticed is that the GenericTypedArrayView&lt;T&gt;&apos;s base class (ArrayBufferView)
already had a span() member function, which returned a `span&lt;uint8_t&gt;`. This hiding of the span()
function and returning a different span type inadvertently changed the behavior of
MediaPlayerPrivateAVFoundation::extractKeyURIKeyIDAndCertificateFromInitData(), which calls
GenericTypedArrayView&lt;T&gt;::span() but expects to be dealing with bytes.

To address the issue, I renamed `span()` to `typedSpan()` on GenericTypedArrayView&lt;T&gt;.

* LayoutTests/platform/mac-wk2/TestExpectations:
Restore the expectations to what they were before the gardening for this regression.

* Source/JavaScriptCore/runtime/GenericTypedArrayView.h:
* Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.cpp:
(WebCore::GPURenderBundleEncoder::setBindGroup):
* Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp:
(WebCore::GPURenderPassEncoder::setBindGroup):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfa6bc85963e9e0a727c26321a6258dd4cb5498f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79947 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26733 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59241 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17436 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/57 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64849 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39598 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22336 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25061 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68619 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22673 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81464 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74731 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2808 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1777 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67485 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2959 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64827 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66778 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10710 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8869 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96999 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2765 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5586 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21199 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2790 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3725 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2797 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->