### PR TITLE
[JSC] JIT memcpy should be done atomically for certain sizes

### DIFF
--- a/Source/JavaScriptCore/assembler/AssemblerCommon.h
+++ b/Source/JavaScriptCore/assembler/AssemblerCommon.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "OSCheck.h"
+#include <wtf/Atomics.h>
 
 namespace JSC {
 
@@ -354,10 +355,34 @@ enum class MachineCodeCopyMode : uint8_t {
     JITMemcpy,
 };
 
-static void* performJITMemcpy(void *dst, const void *src, size_t n);
+static ALWAYS_INLINE void* memcpyAtomicIfPossible(void* dst, const void* src, size_t n)
+{
+#if !CPU(NEEDS_ALIGNED_ACCESS)
+    // We would like to do atomic write here.
+    switch (n) {
+    case 1:
+        WTF::atomicStore(bitwise_cast<uint8_t*>(dst), *bitwise_cast<const uint8_t*>(src), std::memory_order_relaxed);
+        return dst;
+    case 2:
+        WTF::atomicStore(bitwise_cast<uint16_t*>(dst), *bitwise_cast<const uint16_t*>(src), std::memory_order_relaxed);
+        return dst;
+    case 4:
+        WTF::atomicStore(bitwise_cast<uint32_t*>(dst), *bitwise_cast<const uint32_t*>(src), std::memory_order_relaxed);
+        return dst;
+    case 8:
+        WTF::atomicStore(bitwise_cast<uint64_t*>(dst), *bitwise_cast<const uint64_t*>(src), std::memory_order_relaxed);
+        return dst;
+    default:
+        break;
+    }
+#endif
+    return memcpy(dst, src, n);
+}
+
+static void* performJITMemcpy(void* dst, const void* src, size_t n);
 
 template<MachineCodeCopyMode copy>
-ALWAYS_INLINE void* machineCodeCopy(void *dst, const void *src, size_t n)
+ALWAYS_INLINE void* machineCodeCopy(void* dst, const void* src, size_t n)
 {
 #if CPU(ARM_THUMB2)
     // For thumb instructions, we want to avoid the case where we have
@@ -373,7 +398,7 @@ ALWAYS_INLINE void* machineCodeCopy(void *dst, const void *src, size_t n)
     }
 #endif
     if constexpr (copy == MachineCodeCopyMode::Memcpy)
-        return memcpy(dst, src, n);
+        return memcpyAtomicIfPossible(dst, src, n);
     else
         return performJITMemcpy(dst, src, n);
 }

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -1409,7 +1409,7 @@ void ExecutableAllocator::finishWriting(const void* start, size_t sizeInBytes) {
 void* performJITMemcpyWithMProtect(void *dst, const void *src, size_t n)
 {
     g_jscConfig.fixedVMPoolExecutableAllocator->startWriting(dst, n);
-    memcpy(dst, src, n);
+    memcpyAtomicIfPossible(dst, src, n);
     g_jscConfig.fixedVMPoolExecutableAllocator->finishWriting(dst, n);
     return dst;
 }


### PR DESCRIPTION
#### 169e231fb727160719c17a6470c2b7dfaab851da
<pre>
[JSC] JIT memcpy should be done atomically for certain sizes
<a href="https://bugs.webkit.org/show_bug.cgi?id=282744">https://bugs.webkit.org/show_bug.cgi?id=282744</a>
<a href="https://rdar.apple.com/139416205">rdar://139416205</a>

Reviewed by Yijia Huang.

Some of JIT code repatching needs to be done atomically. But current
performJITMemcpy etc. is just using memcpy so it is not guaranteed.
This patch changes them to use atomic store with size for certain size
cases.

* Source/JavaScriptCore/assembler/AssemblerCommon.h:
(JSC::memcpyAtomicIfPossible):
(JSC::machineCodeCopy):
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::performJITMemcpyWithMProtect):
* Source/JavaScriptCore/jit/ExecutableAllocator.h:
(JSC::performJITMemcpy):

Canonical link: <a href="https://commits.webkit.org/286289@main">https://commits.webkit.org/286289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6a64f5ac10243f5636541d0f41db1276cfb679e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75460 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79938 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/26724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2691 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/26724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78527 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64837 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/39586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22325 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25052 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68610 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81418 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74722 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2799 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1771 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2950 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64815 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/66762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10707 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8860 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96990 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11653 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2756 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/21194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2781 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3716 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2788 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->