### PR TITLE
Don't generate Overlay Regions for fixed elements used as backgrounds

### DIFF
--- a/LayoutTests/overlay-region/overlay-background-expected.txt
+++ b/LayoutTests/overlay-region/overlay-background-expected.txt
@@ -1,0 +1,130 @@
+
+(UIView tree root view [class: <class not in allowed list of classes>]
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (subviews
+    (view [class: WKScrollView]
+      (scrolling behavior 2)
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (subviews
+        (view [class: WKContentView]
+          (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+          (layer anchorPoint [x: 0 y: 0])
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+              (layer anchorPoint [x: 0 y: 0])
+              (subviews
+                (view [class: UIView]
+                  (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: WKCompositingView]
+                      (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+                      (layer position [x: 400 y: 400])
+                      (subviews
+                        (view [class: WKCompositingView]
+                          (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (subviews
+                            (view [class: WKCompositingView]
+                              (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (subviews
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (subviews
+                                    (view [class: WKCompositingView]
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+                                      (layer position [x: 400 y: 400])
+                                      (subviews
+                                        (view [class: WKTransformView]
+                                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                              (layer position [x: 400 y: 400])
+                                              (subviews
+                                                (view [class: WKCompositingView]
+                                                  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                                  (layer anchorPoint [x: 0 y: 0]))))))
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+                                          (layer position [x: 400 y: 400]))
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 1000])
+                                          (layer position [x: 400 y: 400]))
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 1000])
+                                          (layer position [x: 400 y: 400]))
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 1000])
+                                          (layer position [x: 400 y: 400]))
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 1000])
+                                          (layer position [x: 400 y: 400]))
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 1000])
+                                          (layer position [x: 400 y: 400]))
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 1000])
+                                          (layer position [x: 400 y: 400]))
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 1000])
+                                          (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+              (layer position [x: 400 y: 400]))
+            (view [class: _UILayerHostView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (view [class: UIView]
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
+              (layer position [x: 400 y: 400]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48]))))))))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 6 y: 6])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 28])
+                      (layer position [x: 6 y: 6]))))))))))))

--- a/LayoutTests/overlay-region/overlay-background.html
+++ b/LayoutTests/overlay-region/overlay-background.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+        .fixed {
+            position: fixed;
+            left: 0;
+            right: 0;
+            height: 50px;
+            background: #F67280;
+            z-index: -1;
+        }
+
+        #header {
+            top: 0;
+        }
+        #footer {
+            top: unset;
+            bottom: 0;
+        }
+
+        .long {
+            position: relative;
+            height: 1000px;
+            background: #355C7D;
+            opacity: 0.5;
+        }
+        .long::before {
+            content: "↓";
+            color: white;
+            font-size: 20em;
+            text-align: center;
+            position: absolute;
+            top: 400px;
+            left: 0;
+            right: 0;
+        }
+
+        #test::after {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            content: "";
+            z-index: -1;
+            background: red;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -408,6 +408,9 @@ EventRegion::EventRegion(Region&& region
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     , Vector<WebCore::InteractionRegion> interactionRegions
 #endif
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    , WebCore::Region scrollOverlayRegion
+#endif
     )
     : m_region(WTFMove(region))
 #if ENABLE(TOUCH_ACTION_REGIONS)
@@ -422,6 +425,9 @@ EventRegion::EventRegion(Region&& region
 #endif
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     , m_interactionRegions(WTFMove(interactionRegions))
+#endif
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    , m_scrollOverlayRegion(WTFMove(scrollOverlayRegion))
 #endif
 {
 }
@@ -450,7 +456,11 @@ void EventRegion::unite(const Region& region, RenderObject& renderer, const Rend
     UNUSED_PARAM(overrideUserModifyIsEditable);
 #endif
 
-#if !ENABLE(TOUCH_ACTION_REGIONS) && !ENABLE(WHEEL_EVENT_REGIONS) && !ENABLE(EDITABLE_REGION)
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    uniteScrollOverlayRegion(region, style);
+#endif
+
+#if !ENABLE(TOUCH_ACTION_REGIONS) && !ENABLE(WHEEL_EVENT_REGIONS) && !ENABLE(EDITABLE_REGION) &&!ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
     UNUSED_PARAM(style);
 #endif
 }
@@ -569,6 +579,14 @@ OptionSet<TouchAction> EventRegion::touchActionsForPoint(const IntPoint& point) 
         return { TouchAction::Auto };
 
     return actions;
+}
+#endif
+
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+void EventRegion::uniteScrollOverlayRegion(const Region& region, const RenderStyle& style)
+{
+    if (style.hasAutoSpecifiedZIndex() || style.specifiedZIndex() > 0)
+        m_scrollOverlayRegion.unite(region);
 }
 #endif
 

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -101,6 +101,9 @@ public:
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     , Vector<WebCore::InteractionRegion>
 #endif
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    , WebCore::Region
+#endif
     );
 
     EventRegionContext makeContext() { return EventRegionContext(*this); }
@@ -144,12 +147,19 @@ public:
     void clearInteractionRegions();
 #endif
 
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    const Region& scrollOverlayRegion() const { return m_scrollOverlayRegion; }
+#endif
+
 private:
     friend struct IPC::ArgumentCoder<EventRegion, void>;
 #if ENABLE(TOUCH_ACTION_REGIONS)
     void uniteTouchActions(const Region&, OptionSet<TouchAction>);
 #endif
     void uniteEventListeners(const Region&, OptionSet<EventListenerRegionType>);
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    void uniteScrollOverlayRegion(const Region&, const RenderStyle&);
+#endif
 
     Region m_region;
 #if ENABLE(TOUCH_ACTION_REGIONS)
@@ -164,6 +174,9 @@ private:
 #endif
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     Vector<InteractionRegion> m_interactionRegions;
+#endif
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    Region m_scrollOverlayRegion;
 #endif
 };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6087,6 +6087,9 @@ class WebCore::EventRegion {
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     Vector<WebCore::InteractionRegion> m_interactionRegions;
 #endif
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    WebCore::Region m_scrollOverlayRegion;
+#endif
 };
 
 enum class WebCore::PasteboardItemPresentationStyle : uint8_t {

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1163,7 +1163,7 @@ static void addOverlayEventRegions(WebCore::PlatformLayerIdentifier layerID, con
 
     const auto& layerProperties = *it->value;
     if (layerProperties.changedProperties & WebKit::LayerChange::EventRegionChanged) {
-        CGRect rect = layerProperties.eventRegion.region().bounds();
+        CGRect rect = layerProperties.eventRegion.scrollOverlayRegion().bounds();
         if (!CGRectIsEmpty(rect))
             overlayRegionsIDs.add(layerID);
     }


### PR DESCRIPTION
#### ede4f9d2750ec410851690fd28c42ddee8de7140
<pre>
Don&apos;t generate Overlay Regions for fixed elements used as backgrounds
<a href="https://bugs.webkit.org/show_bug.cgi?id=282748">https://bugs.webkit.org/show_bug.cgi?id=282748</a>
&lt;<a href="https://rdar.apple.com/135479679">rdar://135479679</a>&gt;

Reviewed by Mike Wyrzykowski.

Maintain a separate `scrollOverlayRegion` on EventRegion so we can
ignore some elements. Start with skipping fixed elements used as
background.

* Source/WebCore/rendering/EventRegion.h:
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegion::EventRegion):
(WebCore::EventRegion::unite):
(WebCore::EventRegion::uniteScrollOverlayRegion):
(WebCore::EventRegion::scrollOverlayRegion const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
Introduce the new `scrollOverlayRegion`.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(addOverlayEventRegions):
Use the new `EventRegion#scrollOverlayRegion` when generating Overlay Regions.

* LayoutTests/overlay-region/overlay-background-expected.txt: Added.
* LayoutTests/overlay-region/overlay-background.html: Added.
Add a test.

Canonical link: <a href="https://commits.webkit.org/286390@main">https://commits.webkit.org/286390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d34b358a229316dc75bd805a61a04a854e81675

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75877 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28774 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80374 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27143 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3200 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59493 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17653 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78944 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/49369 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65167 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39853 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46769 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22650 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25470 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67884 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81838 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2043 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67723 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3400 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65135 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67030 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16705 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10973 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9101 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3196 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6002 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3217 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4155 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->