### PR TITLE
Remove 64-bit assumptions in testMega*Combo* testb3 tests

### DIFF
--- a/Source/JavaScriptCore/b3/testb3_5.cpp
+++ b/Source/JavaScriptCore/b3/testb3_5.cpp
@@ -309,10 +309,12 @@ void testCheckMegaCombo()
     auto arguments = cCallArgumentValues<intptr_t, size_t>(proc, root);
     Value* base = arguments[0];
     Value* index = arguments[1];
-    index = root->appendNew<Value>(
-        proc, ZExt32, Origin(),
-        root->appendNew<Value>(
-            proc, Trunc, Origin(), index));
+    if (is64Bit()) {
+        index = root->appendNew<Value>(
+            proc, ZExt32, Origin(),
+            root->appendNew<Value>(
+                proc, Trunc, Origin(), index));
+    }
 
     Value* ptr = root->appendNew<Value>(
         proc, Add, Origin(), base,
@@ -363,12 +365,14 @@ void testCheckTrickyMegaCombo()
     BasicBlock* root = proc.addBlock();
     auto arguments = cCallArgumentValues<intptr_t, size_t>(proc, root);
     Value* base = arguments[0];
-    Value* index = root->appendNew<Value>(
-        proc, ZExt32, Origin(),
-        root->appendNew<Value>(proc, Add, Origin(),
-            root->appendNew<Value>(
-                proc, Trunc, Origin(), arguments[1]),
-            root->appendNew<Const32Value>(proc, Origin(), 1)));
+    Value* index = arguments[1];
+    if (is64Bit()) {
+        index = root->appendNew<Value>(proc, ZExt32, Origin(),
+            root->appendNew<Value>(proc, Trunc, Origin(), index));
+    }
+    index = root->appendNew<Value>(proc, Add, Origin(),
+        index,
+        root->appendNew<ConstPtrValue>(proc, Origin(), 1));
 
     Value* ptr = root->appendNew<Value>(
         proc, Add, Origin(), base,
@@ -420,10 +424,12 @@ void testCheckTwoMegaCombos()
     auto arguments = cCallArgumentValues<intptr_t, size_t>(proc, root);
     Value* base = arguments[0];
     Value* index = arguments[1];
-    index = root->appendNew<Value>(
-        proc, ZExt32, Origin(),
-        root->appendNew<Value>(
-            proc, Trunc, Origin(), index));
+    if (is64Bit()) {
+        index = root->appendNew<Value>(
+            proc, ZExt32, Origin(),
+            root->appendNew<Value>(
+                proc, Trunc, Origin(), index));
+    }
 
     Value* ptr = root->appendNew<Value>(
         proc, Add, Origin(), base,
@@ -491,10 +497,12 @@ void testCheckTwoNonRedundantMegaCombos()
 
     Value* base = arguments[0];
     Value* index = arguments[1];
-    index = root->appendNew<Value>(
-        proc, ZExt32, Origin(),
-        root->appendNew<Value>(
-            proc, Trunc, Origin(), index));
+    if (is64Bit()) {
+        index = root->appendNew<Value>(
+            proc, ZExt32, Origin(),
+            root->appendNew<Value>(
+                proc, Trunc, Origin(), index));
+    }
     Value* branchPredicate = root->appendNew<Value>(
         proc, BitAnd, Origin(),
         arguments[2],

--- a/Source/JavaScriptCore/b3/testb3_failingArmV7Tests.inc
+++ b/Source/JavaScriptCore/b3/testb3_failingArmV7Tests.inc
@@ -5,7 +5,6 @@
 "testCallFunctionWithHellaArguments3",
 "testCallPairResult",
 "testCallPairResultRare",
-"testCheck",
 "testCheckAdd",
 "testCheckAdd64",
 "testCheckAdd64Range",


### PR DESCRIPTION
#### e9778f576e0e2c50c7aa8c02b8b5d84db33ac018
<pre>
Remove 64-bit assumptions in testMega*Combo* testb3 tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=282755">https://bugs.webkit.org/show_bug.cgi?id=282755</a>

Reviewed by Justin Michaud.

Make 64-bit parts conditional on is64Bit().

* Source/JavaScriptCore/b3/testb3_5.cpp:
(testCheckMegaCombo):
(testCheckTrickyMegaCombo):
(testCheckTwoMegaCombos):
(testCheckTwoNonRedundantMegaCombos):
* Source/JavaScriptCore/b3/testb3_failingArmV7Tests.inc:

Canonical link: <a href="https://commits.webkit.org/286333@main">https://commits.webkit.org/286333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ef28b4062aa5b1c247d52b512119d075e82a0df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75681 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80168 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26945 "Built successfully") 
| | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59359 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17533 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78748 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39720 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/22490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25274 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68831 "Built successfully and passed tests") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81640 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74943 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3020 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1906 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67588 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66896 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16669 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10845 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97211 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2977 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21251 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3002 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3937 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3009 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->