### PR TITLE
[GStreamer][WebRTC] Latency improvements

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -829,6 +829,11 @@ void connectSimpleBusMessageCallback(GstElement* pipeline, Function<void(GstMess
             break;
         }
         case GST_MESSAGE_LATENCY:
+            // Recalculate the latency, we don't need any special handling
+            // here other than the GStreamer default.
+            // This can happen if the latency of live elements changes, or
+            // for one reason or another a new live element is added or
+            // removed from the pipeline.
             gst_bin_recalculate_latency(GST_BIN_CAST(pipeline.get()));
             break;
         default:

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -401,6 +401,12 @@ bool MediaRecorderPrivateBackend::preparePipeline()
     m_transcoder = adoptGRef(gst_transcoder_new_full("mediastream://", "appsink://", GST_ENCODING_PROFILE(profile.get())));
     gst_transcoder_set_avoid_reencoding(m_transcoder.get(), true);
     m_pipeline = gst_transcoder_get_pipeline(m_transcoder.get());
+
+    auto clock = adoptGRef(gst_system_clock_obtain());
+    gst_pipeline_use_clock(GST_PIPELINE(m_pipeline.get()), clock.get());
+    gst_element_set_base_time(m_pipeline.get(), 0);
+    gst_element_set_start_time(m_pipeline.get(), GST_CLOCK_TIME_NONE);
+
     registerActivePipeline(m_pipeline);
 
     g_signal_connect_swapped(m_pipeline.get(), "source-setup", G_CALLBACK(+[](MediaRecorderPrivateBackend* recorder, GstElement* sourceElement) {

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
@@ -131,6 +131,14 @@ void GStreamerAudioCaptureSource::stopProducingData()
     m_capturer->stop();
 }
 
+std::pair<GstClockTime, GstClockTime> GStreamerAudioCaptureSource::queryLatency()
+{
+    if (!m_capturer)
+        return { GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE };
+
+    return m_capturer->queryLatency();
+}
+
 const RealtimeMediaSourceCapabilities& GStreamerAudioCaptureSource::capabilities()
 {
     if (m_capabilities)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.h
@@ -41,6 +41,8 @@ public:
     GstElement* pipeline() { return m_capturer->pipeline(); }
     GStreamerCapturer* capturer() { return m_capturer.get(); }
 
+    std::pair<GstClockTime, GstClockTime> queryLatency();
+
     void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerAudioCaptureSource>::ref(); }
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerAudioCaptureSource>::deref(); }
     ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerAudioCaptureSource>::controlBlock(); }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -189,6 +189,11 @@ void GStreamerCapturer::setupPipeline()
     }
 
     m_pipeline = makeElement("pipeline");
+    auto clock = adoptGRef(gst_system_clock_obtain());
+    gst_pipeline_use_clock(GST_PIPELINE(m_pipeline.get()), clock.get());
+    gst_element_set_base_time(m_pipeline.get(), 0);
+    gst_element_set_start_time(m_pipeline.get(), GST_CLOCK_TIME_NONE);
+
     registerActivePipeline(m_pipeline);
 
     GRefPtr<GstElement> source = createSource();
@@ -234,6 +239,18 @@ void GStreamerCapturer::stop()
 {
     GST_INFO_OBJECT(pipeline(), "Stopping");
     tearDown(false);
+}
+
+std::pair<GstClockTime, GstClockTime> GStreamerCapturer::queryLatency()
+{
+    if (!m_sink)
+        return { GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE };
+
+    GstClockTime minLatency, maxLatency;
+    if (gst_base_sink_query_latency(GST_BASE_SINK_CAST(m_sink.get()), nullptr, nullptr, &minLatency, &maxLatency))
+        return { minLatency, maxLatency };
+
+    return { GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE };
 }
 
 bool GStreamerCapturer::isInterrupted() const

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
@@ -66,6 +66,8 @@ public:
     void stop();
     WARN_UNUSED_RETURN GRefPtr<GstCaps> caps();
 
+    std::pair<GstClockTime, GstClockTime> queryLatency();
+
     GstElement* makeElement(const char* factoryName);
     virtual GstElement* createSource();
     GstElement* source() { return m_src.get();  }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp
@@ -42,7 +42,7 @@ static GstElement* webkitMockDeviceCreateElement([[maybe_unused]] GstDevice* dev
 {
     GST_INFO_OBJECT(device, "Creating source element for device %s", name);
     auto* element = makeGStreamerElement("appsrc", name);
-    g_object_set(element, "format", GST_FORMAT_TIME, "is-live", TRUE, nullptr);
+    g_object_set(element, "format", GST_FORMAT_TIME, "is-live", TRUE, "do-timestamp", TRUE, nullptr);
     return element;
 }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
@@ -176,6 +176,14 @@ void GStreamerVideoCaptureSource::sourceCapsChanged(const GstCaps* caps)
         ensureIntrinsicSizeMaintainsAspectRatio();
 }
 
+std::pair<GstClockTime, GstClockTime> GStreamerVideoCaptureSource::queryLatency()
+{
+    if (!m_capturer)
+        return { GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE };
+
+    return m_capturer->queryLatency();
+}
+
 void GStreamerVideoCaptureSource::captureEnded()
 {
     m_capturer->stop();

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h
@@ -46,6 +46,8 @@ public:
     GstElement* pipeline() { return m_capturer->pipeline(); }
     GStreamerCapturer* capturer() { return m_capturer.get(); }
 
+    std::pair<GstClockTime, GstClockTime> queryLatency();
+
     // GStreamerCapturerObserver
     void sourceCapsChanged(const GstCaps*) final;
     void captureEnded() final;


### PR DESCRIPTION
#### 3539c8a950f66fbe6bd7e37a9d90bd9d98f03386
<pre>
[GStreamer][WebRTC] Latency improvements
<a href="https://bugs.webkit.org/show_bug.cgi?id=282756">https://bugs.webkit.org/show_bug.cgi?id=282756</a>

Reviewed by Xabier Rodriguez-Calvar.

When sharing data between pipelines it is recommended to use a shared base time of 0 and -1 start
time on each pipeline. If appsrc is used its handle-segment-change property should be enabled as
well. Then latency queries need to be plumbed as well, this was partly done already for incoming
sources, but wasn&apos;t done yet for capture sources.

With this patch the end-to-end latency on the pc1 demo went from ~10 frames to 3 (or 4 frames).

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::initializePipeline):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::connectSimpleBusMessageCallback):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::handleMessage):
(WebCore::MediaPlayerPrivateGStreamer::createGSTPlayBin):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp:
(WebCore::MediaRecorderPrivateBackend::preparePipeline):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp:
(WebCore::GStreamerAudioCaptureSource::queryLatency):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturer::setupPipeline):
(WebCore::GStreamerCapturer::queryLatency):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp:
(webkitMockDeviceCreateElement):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp:
(WebCore::GStreamerVideoCaptureSource::queryLatency):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h:

Canonical link: <a href="https://commits.webkit.org/286323@main">https://commits.webkit.org/286323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0c67724a4bc5b657d13c13acb914f76a0752bfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/99 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28287 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79937 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26701 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/99 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2668 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59224 "Found 36 new test failures: fast/mediastream/MediaStream-video-element-change-audio-route.html fast/mediastream/MediaStream-video-element-video-tracks-disabled.html fast/mediastream/apply-constraints-audio.html fast/mediastream/audio-unit-reconfigure.html fast/mediastream/camera-unknown-facing-mode.html fast/mediastream/getUserMedia-media-element-display-none.html fast/mediastream/getUserMedia-webaudio.html fast/mediastream/local-audio-playing-event.html fast/mediastream/media-element-current-time.html fast/mediastream/media-stream-renders-first-frame.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17413 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/42 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64819 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39581 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22308 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25029 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81395 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1753 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67450 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2927 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64798 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66740 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16664 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10689 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8843 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2733 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5554 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2758 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3693 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2765 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->