### PR TITLE
[unified-sources] fix issue with `ImageUtilities.h` and `ImageUtilitiesCG.cpp`

### DIFF
--- a/Source/WebCore/platform/graphics/ImageUtilities.h
+++ b/Source/WebCore/platform/graphics/ImageUtilities.h
@@ -30,6 +30,8 @@
 
 namespace WebCore {
 
+class ShareableBitmap;
+
 WEBCORE_EXPORT WorkQueue& sharedImageTranscodingQueue();
 
 // Given a list of files' 'paths' and 'allowedMIMETypes', the function returns a list

--- a/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "ImageUtilities.h"
 
+#include "FloatRect.h"
+#include "GraphicsContext.h"
 #include "Logging.h"
 #include "MIMETypeRegistry.h"
 #include "UTIUtilities.h"


### PR DESCRIPTION
#### d162ce786667e96f92330687877fe80835a90574
<pre>
[unified-sources] fix issue with `ImageUtilities.h` and `ImageUtilitiesCG.cpp`
<a href="https://bugs.webkit.org/show_bug.cgi?id=282757">https://bugs.webkit.org/show_bug.cgi?id=282757</a>
<a href="https://rdar.apple.com/139433497">rdar://139433497</a>

Reviewed by Anne van Kesteren.

Adding a new file in a development branch identified some issues with
missing headers in `Source/WebCore/platform/graphics/ImageUtilities.h`
and `Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp`.

* Source/WebCore/platform/graphics/ImageUtilities.h:
* Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp:

Canonical link: <a href="https://commits.webkit.org/286292@main">https://commits.webkit.org/286292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac41f865dc1d24996bceb2ff364294f45aaf40aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28288 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79915 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26702 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77554 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59209 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17415 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78505 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/43 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39566 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22309 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25030 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22645 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81396 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2777 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1754 "Found 1 new test failure: fast/css/view-transitions-hide-under-page-background-color.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67448 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64799 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66738 "Found 1 new API test failure: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/open-window-default-size (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10690 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8844 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11656 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2734 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5555 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2759 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3694 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2766 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->