### PR TITLE
[macOS] Send playEffect() twice to Gamepad.actuator and it cannot stop with reset()

### DIFF
--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h
@@ -33,13 +33,15 @@
 #import <wtf/TZoneMalloc.h>
 #import <wtf/WeakPtr.h>
 
+OBJC_CLASS CHHapticEngine;
+
 namespace WebCore {
 
 class GameControllerHapticEngines;
 struct GamepadEffectParameters;
 enum class GamepadHapticEffectType : uint8_t;
 
-class GameControllerHapticEffect : public RefCountedAndCanMakeWeakPtr<GameControllerHapticEffect> {
+class GameControllerHapticEffect final : public RefCountedAndCanMakeWeakPtr<GameControllerHapticEffect> {
     WTF_MAKE_TZONE_ALLOCATED(GameControllerHapticEffect);
 public:
     static RefPtr<GameControllerHapticEffect> create(GameControllerHapticEngines&, GamepadHapticEffectType, const GamepadEffectParameters&);
@@ -48,14 +50,19 @@ public:
     void start(CompletionHandler<void(bool)>&&);
     void stop();
 
-    void leftEffectFinishedPlaying();
-    void rightEffectFinishedPlaying();
-
 private:
-    GameControllerHapticEffect(RetainPtr<id>&& leftPlayer, RetainPtr<id>&& rightPlayer);
+    GameControllerHapticEffect(RetainPtr<CHHapticEngine>&& leftEngine, RetainPtr<CHHapticEngine>&& rightEngine, RetainPtr<id>&& leftPlayer, RetainPtr<id>&& rightPlayer);
 
+    void ensureStarted(Function<void(bool)>&&);
+    void startEngine(CHHapticEngine *, Function<void(bool)>&&);
+    void registerNotification(CHHapticEngine *, Function<void(bool)>&&);
+
+    RetainPtr<CHHapticEngine> m_leftEngine;
+    RetainPtr<CHHapticEngine> m_rightEngine;
     RetainPtr<id> m_leftPlayer;
     RetainPtr<id> m_rightPlayer;
+    unsigned m_engineStarted { 0 };
+    unsigned m_playerFinished { 0 };
     CompletionHandler<void(bool)> m_completionHandler;
 };
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
@@ -33,6 +33,9 @@
 #import "GamepadHapticEffectType.h"
 #import "Logging.h"
 #import <cmath>
+#import <wtf/BlockPtr.h>
+#import <wtf/CallbackAggregator.h>
+#import <wtf/RunLoop.h>
 #import <wtf/TZoneMallocInlines.h>
 
 #import "CoreHapticsSoftLink.h"
@@ -54,13 +57,16 @@ static double magnitudeToIntensity(double magnitude)
 
 RefPtr<GameControllerHapticEffect> GameControllerHapticEffect::create(GameControllerHapticEngines& engines, GamepadHapticEffectType type, const GamepadEffectParameters& parameters)
 {
+    double delay = std::max<double>(parameters.startDelay / 1000., 0);
+    double duration = std::clamp<double>(parameters.duration / 1000., 0, GamepadEffectParameters::maximumDuration.seconds());
+
     auto createPlayer = [&](CHHapticEngine *engine, double magnitude) -> RetainPtr<id> {
         NSDictionary* hapticDict = @{
             CHHapticPatternKeyPattern: @[
                 @{ CHHapticPatternKeyEvent: @{
                     CHHapticPatternKeyEventType: CHHapticEventTypeHapticContinuous,
-                    CHHapticPatternKeyTime: [NSNumber numberWithDouble:std::max<double>(parameters.startDelay / 1000., 0)],
-                    CHHapticPatternKeyEventDuration: [NSNumber numberWithDouble:std::clamp<double>(parameters.duration / 1000., 0, GamepadEffectParameters::maximumDuration.seconds())],
+                    CHHapticPatternKeyTime: [NSNumber numberWithDouble:delay],
+                    CHHapticPatternKeyEventDuration: [NSNumber numberWithDouble:duration],
                     CHHapticPatternKeyEventParameters: @[ @{
                         CHHapticPatternKeyParameterID: CHHapticEventParameterIDHapticIntensity,
                         CHHapticPatternKeyParameterValue: [NSNumber numberWithDouble:magnitudeToIntensity(magnitude)],
@@ -79,79 +85,145 @@ RefPtr<GameControllerHapticEffect> GameControllerHapticEffect::create(GameContro
         return retainPtr([engine createPlayerWithPattern:pattern.get() error:&error]);
     };
 
-    RetainPtr<id> leftPlayer;
-    RetainPtr<id> rightPlayer;
+    RetainPtr<CHHapticEngine> leftEngine;
+    RetainPtr<CHHapticEngine> rightEngine;
+    double leftMagnitude = 0;
+    double rightMagnitude = 0;
     switch (type) {
     case GamepadHapticEffectType::DualRumble: {
-        leftPlayer = createPlayer(engines.leftHandleEngine(), parameters.strongMagnitude);
-        rightPlayer = createPlayer(engines.rightHandleEngine(), parameters.weakMagnitude);
+        leftEngine = engines.leftHandleEngine();
+        rightEngine = engines.rightHandleEngine();
+        leftMagnitude = parameters.strongMagnitude;
+        rightMagnitude = parameters.weakMagnitude;
         break;
         }
     case GamepadHapticEffectType::TriggerRumble: {
-        leftPlayer = createPlayer(engines.leftTriggerEngine(), parameters.leftTrigger);
-        rightPlayer = createPlayer(engines.rightTriggerEngine(), parameters.rightTrigger);
+        leftEngine = engines.leftTriggerEngine();
+        rightEngine = engines.rightTriggerEngine();
+        leftMagnitude = parameters.leftTrigger;
+        rightMagnitude = parameters.rightTrigger;
         break;
         }
     }
+    RetainPtr<id> leftPlayer = createPlayer(leftEngine.get(), leftMagnitude);
+    RetainPtr<id> rightPlayer = createPlayer(rightEngine.get(), rightMagnitude);
 
     if (!leftPlayer || !rightPlayer) {
         RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEffect: Failed to create the haptic effect players");
         return nullptr;
     }
-    return adoptRef(new GameControllerHapticEffect(WTFMove(leftPlayer), WTFMove(rightPlayer)));
+    return adoptRef(new GameControllerHapticEffect(WTFMove(leftEngine), WTFMove(rightEngine), WTFMove(leftPlayer), WTFMove(rightPlayer)));
 }
 
-GameControllerHapticEffect::GameControllerHapticEffect(RetainPtr<id>&& leftPlayer, RetainPtr<id>&& rightPlayer)
-    : m_leftPlayer(WTFMove(leftPlayer))
+GameControllerHapticEffect::GameControllerHapticEffect(RetainPtr<CHHapticEngine>&& leftEngine, RetainPtr<CHHapticEngine>&& rightEngine, RetainPtr<id>&& leftPlayer, RetainPtr<id>&& rightPlayer)
+    : m_leftEngine(WTFMove(leftEngine))
+    , m_rightEngine(WTFMove(rightEngine))
+    , m_leftPlayer(WTFMove(leftPlayer))
     , m_rightPlayer(WTFMove(rightPlayer))
 {
 }
 
 GameControllerHapticEffect::~GameControllerHapticEffect()
 {
-    if (m_completionHandler)
-        m_completionHandler(false);
+    stop();
 }
 
 void GameControllerHapticEffect::start(CompletionHandler<void(bool)>&& completionHandler)
 {
+    ASSERT(isMainThread());
     ASSERT(!m_completionHandler);
+
     m_completionHandler = WTFMove(completionHandler);
 
-    NSError *error;
-    if (m_leftPlayer && ![m_leftPlayer startAtTime:0 error:&error]) {
-        RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEffect::start: Failed to start the strong player");
-        m_leftPlayer = nullptr;
-    }
-    if (m_rightPlayer && ![m_rightPlayer startAtTime:0 error:&error]) {
-        RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEffect::start: Failed to start the weak player");
-        m_rightPlayer = nullptr;
-    }
-    if (!m_leftPlayer && !m_rightPlayer)
-        m_completionHandler(false);
+    Ref callbackAggregator = MainRunLoopCallbackAggregator::create([weakThis = WeakPtr { *this }]() mutable {
+        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_completionHandler)
+            protectedThis->m_completionHandler(protectedThis->m_playerFinished == 2);
+    });
+
+    ensureStarted([weakThis = WeakPtr { *this }, callbackAggregator](bool success) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !success)
+            return;
+
+        NSError *error;
+        Vector<RetainPtr<id>> successPlayers;
+        if ([protectedThis->m_leftPlayer startAtTime:0 error:&error])
+            successPlayers.append(protectedThis->m_leftPlayer);
+        else
+            RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEffect::start: Failed to start the strong player");
+
+        if ([protectedThis->m_rightPlayer startAtTime:0 error:&error])
+            successPlayers.append(protectedThis->m_rightPlayer);
+        else
+            RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEffect::start: Failed to start the weak player");
+
+        if (successPlayers.size() != 2) {
+            for (auto& player : successPlayers)
+                [player stopAtTime:0.0 error:&error];
+            return;
+        }
+
+        protectedThis->registerNotification(protectedThis->m_leftEngine.get(), [weakThis = WeakPtr { *protectedThis }, callbackAggregator](bool success) {
+            if (weakThis && success)
+                weakThis->m_playerFinished++;
+        });
+        protectedThis->registerNotification(protectedThis->m_rightEngine.get(), [weakThis = WeakPtr { *protectedThis }, callbackAggregator](bool success) {
+            if (weakThis && success)
+                weakThis->m_playerFinished++;
+        });
+    });
+}
+
+void GameControllerHapticEffect::ensureStarted(Function<void(bool)>&& completionHandler)
+{
+    Ref callbackAggregator = MainRunLoopCallbackAggregator::create([weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
+        bool success = weakThis && weakThis->m_engineStarted == 2;
+        completionHandler(success);
+    });
+
+    startEngine(m_leftEngine.get(), [weakThis = WeakPtr { *this }, callbackAggregator](bool success) {
+        if (weakThis && success)
+            weakThis->m_engineStarted++;
+    });
+    startEngine(m_rightEngine.get(), [weakThis = WeakPtr { *this }, callbackAggregator](bool success) {
+        if (weakThis && success)
+            weakThis->m_engineStarted++;
+    });
+}
+
+void GameControllerHapticEffect::startEngine(CHHapticEngine *engine, Function<void(bool)>&& completionHandler)
+{
+    [engine startWithCompletionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSError* error) mutable {
+        ensureOnMainRunLoop([completionHandler = WTFMove(completionHandler), success = !error]() mutable {
+            completionHandler(success);
+        });
+        if (error)
+            RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEngines::ensureStarted: Failed to start haptic engine");
+    }).get()];
+}
+
+void GameControllerHapticEffect::registerNotification(CHHapticEngine *engine, Function<void(bool)>&& completionHandler)
+{
+    [engine notifyWhenPlayersFinished:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
+        ensureOnMainRunLoop([completionHandler = WTFMove(completionHandler), success = !error] mutable {
+            completionHandler(success);
+        });
+        if (error)
+            RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEngines::registerNotification: Failed to start haptic engine");
+        return CHHapticEngineFinishedActionLeaveEngineRunning;
+    }).get()];
 }
 
 void GameControllerHapticEffect::stop()
 {
+    ASSERT(isMainThread());
+
     NSError *error;
-    if (auto player = std::exchange(m_leftPlayer, nullptr))
-        [player stopAtTime:0.0 error:&error];
-    if (auto player = std::exchange(m_rightPlayer, nullptr))
-        [player stopAtTime:0.0 error:&error];
-}
+    [m_leftPlayer cancelAndReturnError:&error];
+    [m_rightPlayer cancelAndReturnError:&error];
 
-void GameControllerHapticEffect::leftEffectFinishedPlaying()
-{
-    m_leftPlayer = nullptr;
-    if (!m_rightPlayer && m_completionHandler)
-        m_completionHandler(true);
-}
-
-void GameControllerHapticEffect::rightEffectFinishedPlaying()
-{
-    m_rightPlayer = nullptr;
-    if (!m_leftPlayer && m_completionHandler)
-        m_completionHandler(true);
+    if (m_completionHandler)
+        m_completionHandler(false);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h
@@ -42,7 +42,7 @@ class GameControllerHapticEffect;
 struct GamepadEffectParameters;
 enum class GamepadHapticEffectType : uint8_t;
 
-class GameControllerHapticEngines : public RefCountedAndCanMakeWeakPtr<GameControllerHapticEngines> {
+class GameControllerHapticEngines final : public RefCountedAndCanMakeWeakPtr<GameControllerHapticEngines> {
     WTF_MAKE_TZONE_ALLOCATED(GameControllerHapticEngines);
 public:
     static Ref<GameControllerHapticEngines> create(GCController *);
@@ -61,17 +61,12 @@ public:
 private:
     explicit GameControllerHapticEngines(GCController *);
 
-    void ensureStarted(GamepadHapticEffectType, CompletionHandler<void(bool)>&&);
     RefPtr<GameControllerHapticEffect>& currentEffectForType(GamepadHapticEffectType);
 
     RetainPtr<CHHapticEngine> m_leftHandleEngine;
     RetainPtr<CHHapticEngine> m_rightHandleEngine;
     RetainPtr<CHHapticEngine> m_leftTriggerEngine;
     RetainPtr<CHHapticEngine> m_rightTriggerEngine;
-    bool m_failedToStartLeftHandleEngine { false };
-    bool m_failedToStartRightHandleEngine { false };
-    bool m_failedToStartLeftTriggerEngine { false };
-    bool m_failedToStartRightTriggerEngine { false };
     RefPtr<GameControllerHapticEffect> m_currentDualRumbleEffect;
     RefPtr<GameControllerHapticEffect> m_currentTriggerRumbleEffect;
 };

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm
@@ -35,7 +35,6 @@
 #import <GameController/GameController.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/CallbackAggregator.h>
-#import <wtf/CompletionHandler.h>
 #import <wtf/TZoneMallocInlines.h>
 
 #import "GameControllerSoftLink.h"
@@ -47,7 +46,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(GameControllerHapticEngines);
 
 Ref<GameControllerHapticEngines> GameControllerHapticEngines::create(GCController *gamepad)
 {
-    return *adoptRef(new GameControllerHapticEngines(gamepad));
+    return adoptRef(*new GameControllerHapticEngines(gamepad));
 }
 
 GameControllerHapticEngines::GameControllerHapticEngines(GCController *gamepad)
@@ -79,7 +78,7 @@ void GameControllerHapticEngines::playEffect(GamepadHapticEffectType type, const
     // Trying to create pattern players with a 0 duration will fail. However, Games on XBox seem to use such
     // requests to stop vibrating.
     if (!parameters.duration) {
-        if (auto effect = std::exchange(currentEffect, nullptr))
+        if (RefPtr effect = std::exchange(currentEffect, nullptr))
             effect->stop();
         return completionHandler(true);
     }
@@ -88,33 +87,22 @@ void GameControllerHapticEngines::playEffect(GamepadHapticEffectType type, const
     if (!newEffect)
         return completionHandler(false);
 
-    if (currentEffect)
-        currentEffect->stop();
+    if (RefPtr effect = currentEffect)
+        effect->stop();
 
     currentEffect = WTFMove(newEffect);
-    ensureStarted(type, [weakThis = WeakPtr { *this }, type, effect = WeakPtr { *currentEffect }, completionHandler = WTFMove(completionHandler)](bool success) mutable {
+    currentEffect->start([weakThis = WeakPtr { *this }, effect = WeakPtr { *currentEffect }, type, completionHandler = WTFMove(completionHandler)](bool success) mutable {
+        ASSERT(isMainThread());
+
+        completionHandler(success);
+
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
-            return completionHandler(false);
+            return;
 
         auto& currentEffect = protectedThis->currentEffectForType(type);
-        if (!currentEffect || currentEffect.get() != effect.get())
-            return completionHandler(false);
-
-        if (!success) {
+        if (currentEffect.get() == effect.get())
             currentEffect = nullptr;
-            return completionHandler(false);
-        }
-
-        currentEffect->start([weakThis = WTFMove(weakThis), effect = WTFMove(effect), type, completionHandler = WTFMove(completionHandler)](bool success) mutable {
-            completionHandler(success);
-            RefPtr protectedThis = weakThis.get();
-            if (!protectedThis)
-                return;
-            auto& currentEffect = protectedThis->currentEffectForType(type);
-            if (currentEffect.get() == effect.get())
-                currentEffect = nullptr;
-        });
     });
 }
 
@@ -124,71 +112,6 @@ void GameControllerHapticEngines::stopEffects()
         currentEffect->stop();
     if (auto currentEffect = std::exchange(m_currentTriggerRumbleEffect, nullptr))
         currentEffect->stop();
-}
-
-void GameControllerHapticEngines::ensureStarted(GamepadHapticEffectType effectType, CompletionHandler<void(bool)>&& completionHandler)
-{
-    auto callbackAggregator = MainRunLoopCallbackAggregator::create([weakThis = WeakPtr { *this }, effectType, completionHandler = WTFMove(completionHandler)]() mutable {
-        bool success = false;
-        switch (effectType) {
-        case GamepadHapticEffectType::DualRumble:
-            success = weakThis && !weakThis->m_failedToStartLeftHandleEngine && !weakThis->m_failedToStartRightHandleEngine;
-            break;
-        case GamepadHapticEffectType::TriggerRumble:
-            success = weakThis && !weakThis->m_failedToStartLeftTriggerEngine && !weakThis->m_failedToStartRightTriggerEngine;
-            break;
-        }
-        completionHandler(success);
-    });
-    auto startEngine = [weakThis = WeakPtr { *this }](CHHapticEngine *engine, CompletionHandler<void(bool)>&& completionHandler, std::function<void()>&& playersFinished) mutable {
-        [engine startWithCompletionHandler:makeBlockPtr([engine, completionHandler = WTFMove(completionHandler), playersFinished](NSError* error) mutable {
-            ensureOnMainRunLoop([completionHandler = WTFMove(completionHandler), success = !error]() mutable {
-                completionHandler(success);
-            });
-            if (error)
-                RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEngines::ensureStarted: Failed to start haptic engine");
-            [engine notifyWhenPlayersFinished:makeBlockPtr([playersFinished](NSError *) mutable -> CHHapticEngineFinishedAction {
-                ensureOnMainRunLoop([playersFinished] {
-                    playersFinished();
-                });
-                return CHHapticEngineFinishedActionLeaveEngineRunning;
-            }).get()];
-        }).get()];
-    };
-    switch (effectType) {
-    case GamepadHapticEffectType::DualRumble:
-        startEngine(m_leftHandleEngine.get(), [weakThis = WeakPtr { *this }, callbackAggregator](bool success) {
-            if (weakThis)
-                weakThis->m_failedToStartLeftHandleEngine = !success;
-        }, [weakThis = WeakPtr { *this }] {
-            if (weakThis && weakThis->m_currentDualRumbleEffect)
-                Ref { *weakThis->m_currentDualRumbleEffect }->leftEffectFinishedPlaying();
-        });
-        startEngine(m_rightHandleEngine.get(), [weakThis = WeakPtr { *this }, callbackAggregator](bool success) {
-            if (weakThis)
-                weakThis->m_failedToStartRightHandleEngine = !success;
-        }, [weakThis = WeakPtr { *this }] {
-            if (weakThis && weakThis->m_currentDualRumbleEffect)
-                Ref { *weakThis->m_currentDualRumbleEffect }->rightEffectFinishedPlaying();
-        });
-        break;
-    case GamepadHapticEffectType::TriggerRumble:
-        startEngine(m_leftTriggerEngine.get(), [weakThis = WeakPtr { *this }, callbackAggregator](bool success) {
-            if (weakThis)
-                weakThis->m_failedToStartLeftTriggerEngine = !success;
-        }, [weakThis = WeakPtr { *this }] {
-            if (weakThis && weakThis->m_currentTriggerRumbleEffect)
-                Ref { *weakThis->m_currentTriggerRumbleEffect }->leftEffectFinishedPlaying();
-        });
-        startEngine(m_rightTriggerEngine.get(), [weakThis = WeakPtr { *this }, callbackAggregator](bool success) {
-            if (weakThis)
-                weakThis->m_failedToStartRightTriggerEngine = !success;
-        }, [weakThis = WeakPtr { *this }] {
-            if (weakThis && weakThis->m_currentTriggerRumbleEffect)
-                Ref { *weakThis->m_currentTriggerRumbleEffect }->rightEffectFinishedPlaying();
-        });
-        break;
-    }
 }
 
 void GameControllerHapticEngines::stop(CompletionHandler<void()>&& completionHandler)


### PR DESCRIPTION
#### 0a7a483a4ef388c2597b6488f1f46e2b248e75f5
<pre>
[macOS] Send playEffect() twice to Gamepad.actuator and it cannot stop with reset()
<a href="https://bugs.webkit.org/show_bug.cgi?id=279094">https://bugs.webkit.org/show_bug.cgi?id=279094</a>
<a href="https://rdar.apple.com/126589062">rdar://126589062</a>

Reviewed by Chris Dumez.

When sending playEffect() to Gamepad.actuator more than once, the reset() cannot stop the gamepad from vibrating.

The root cause of the issue is requesting a completionHandler invocation to wrong effect object.
Say two sequential playEffect requests is coming.

1. The effect object of request 1 is stored in m_currentDualRumbleEffect and referenced by currentEffect in playEffect() method.
2. In second playEffect(), currentEffect is stopped  before start playing second one. This is in main thread.
3. Notification for stopPlaying is called for first request {*) in CoreHaptics thread.
4. currentEffect is replaced with new effect.
5. Notification arrived in main thread and try to invoke completionHandler targeting to second request. This is wrong because the notification is for first request.

Move the play logic from GameControllerHapticEngines to GameControllerHapticEffect to avoid this confusion.

* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm:
(WebCore::GameControllerHapticEffect::create):
(WebCore::GameControllerHapticEffect::GameControllerHapticEffect):
(WebCore::GameControllerHapticEffect::~GameControllerHapticEffect):
(WebCore::GameControllerHapticEffect::start):
(WebCore::GameControllerHapticEffect::ensureStarted):
(WebCore::GameControllerHapticEffect::startEngine):
(WebCore::GameControllerHapticEffect::registerNotification):
(WebCore::GameControllerHapticEffect::stop):
(WebCore::GameControllerHapticEffect::leftEffectFinishedPlaying): Deleted.
(WebCore::GameControllerHapticEffect::rightEffectFinishedPlaying): Deleted.
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm:
(WebCore::GameControllerHapticEngines::create):
(WebCore::GameControllerHapticEngines::playEffect):
(WebCore::GameControllerHapticEngines::ensureStarted): Deleted.

Canonical link: <a href="https://commits.webkit.org/286286@main">https://commits.webkit.org/286286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce7b9bae4b701aaa975b000a2dddd254ab3de94c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75451 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79928 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26715 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77567 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2682 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59218 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/17423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78518 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64831 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39575 "Found 1 new API test failure: /WPE/TestAuthentication:/webkit/Authentication/authentication-storage (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22320 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25043 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81409 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2790 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1764 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67457 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2941 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66747 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16615 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10697 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8855 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2747 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5568 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2772 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3707 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2779 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->