### PR TITLE
[css-masonry] Fix orthogonal item writing mode widths in masonry columns

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1771,7 +1771,6 @@ webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentati
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-fr.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix2.html [ ImageOnlyFailure ]
-webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-columns-item-placement-auto-flow-next-001.html [ Skip ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-004.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005-expected.html
@@ -23,6 +23,9 @@ grid {
 item {
   writing-mode: vertical-lr;
 }
+.hidden {
+  visibility: hidden;
+}
 </style>
 
 <body>
@@ -39,7 +42,7 @@ item {
   <item>9 9</item>
 </grid>
 
-<grid style="grid-template-rows: repeat(4,3ch)">
+<grid style="grid-template-rows: repeat(4,auto)">
   <item>1</item>
   <item>2</item>
   <item>3</item>
@@ -49,29 +52,41 @@ item {
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
+
+  <item class="hidden" style="grid-column: 3; grid-row: 2;">0 0</item>
+  <item class="hidden" style="grid-column: 3; grid-row: 3;">0 0</item>
+  <item class="hidden" style="grid-column: 3; grid-row: 4;">0 0</item>
 </grid>
 
-<grid style="grid-template-rows: 3ch repeat(3,1ch)">
+<grid style="grid-template-rows: repeat(4, auto)">
+  <item style="height:3ch; grid-row:1;">5 5</item>
   <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:3ch; grid-row:1">5 5</item>
   <item>6</item>
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
+
+  <item class="hidden" style="grid-column: 3; grid-row: 2;">0 0</item>
+  <item class="hidden" style="grid-column: 3; grid-row: 3;">0 0</item>
+  <item class="hidden" style="grid-column: 3; grid-row: 4;">0 0</item>
 </grid>
 
-<grid style="grid-template-rows: 3ch repeat(3,1ch)">
+<grid style="grid-template-rows: repeat(4, auto)">
   <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:3ch; grid-column:1">5 5</item>
+  <item style="height:3ch;">5 5</item>
   <item>6</item>
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
+
+  <item class="hidden" style="grid-column: 3; grid-row: 2;">0 0</item>
+  <item class="hidden" style="grid-column: 3; grid-row: 3;">0 0</item>
+  <item class="hidden" style="grid-column: 3; grid-row: 4;">0 0</item>
 </grid>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005-ref.html
@@ -23,6 +23,9 @@ grid {
 item {
   writing-mode: vertical-lr;
 }
+.hidden {
+  visibility: hidden;
+}
 </style>
 
 <body>
@@ -39,7 +42,7 @@ item {
   <item>9 9</item>
 </grid>
 
-<grid style="grid-template-rows: repeat(4,3ch)">
+<grid style="grid-template-rows: repeat(4,auto)">
   <item>1</item>
   <item>2</item>
   <item>3</item>
@@ -49,29 +52,41 @@ item {
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
+
+  <item class="hidden" style="grid-column: 3; grid-row: 2;">0 0</item>
+  <item class="hidden" style="grid-column: 3; grid-row: 3;">0 0</item>
+  <item class="hidden" style="grid-column: 3; grid-row: 4;">0 0</item>
 </grid>
 
-<grid style="grid-template-rows: 3ch repeat(3,1ch)">
+<grid style="grid-template-rows: repeat(4, auto)">
+  <item style="height:3ch; grid-row:1;">5 5</item>
   <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:3ch; grid-row:1">5 5</item>
   <item>6</item>
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
+
+  <item class="hidden" style="grid-column: 3; grid-row: 2;">0 0</item>
+  <item class="hidden" style="grid-column: 3; grid-row: 3;">0 0</item>
+  <item class="hidden" style="grid-column: 3; grid-row: 4;">0 0</item>
 </grid>
 
-<grid style="grid-template-rows: 3ch repeat(3,1ch)">
+<grid style="grid-template-rows: repeat(4, auto)">
   <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:3ch; grid-column:1">5 5</item>
+  <item style="height:3ch;">5 5</item>
   <item>6</item>
   <item>7</item>
   <item>8</item>
   <item>9 9</item>
+
+  <item class="hidden" style="grid-column: 3; grid-row: 2;">0 0</item>
+  <item class="hidden" style="grid-column: 3; grid-row: 3;">0 0</item>
+  <item class="hidden" style="grid-column: 3; grid-row: 4;">0 0</item>
 </grid>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005.html
@@ -55,11 +55,11 @@ item {
 </grid>
 
 <grid title="Fifth item 3ch row 1">
+  <item style="height:3ch; grid-row:1">5 5</item>
   <item>1</item>
   <item>2</item>
   <item>3</item>
   <item>4</item>
-  <item style="height:3ch; grid-row:1">5 5</item>
   <item>6</item>
   <item>7</item>
   <item>8</item>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2252,6 +2252,8 @@ imported/w3c/web-platform-tests/webaudio/the-audio-api/the-mediaelementaudiosour
 
 webkit.org/b/215452 [ Debug ] imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-items-percentage-paddings-002.html [ Pass Failure ]
 
+webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005.html [ ImageOnlyFailure ]
+
 webkit.org/b/231103 imported/w3c/web-platform-tests/css/css-multicol/multicol-gap-percentage-001.html [ Pass Failure ]
 
 # <rdar://problem/30897457> [StressGC] ASSERTION FAILED: view in com.apple.WebCore: WebCore::Widget::getOuterView const + 132

--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -199,6 +199,11 @@ void GridMasonryLayout::insertIntoGridAndLayoutItem(const GridTrackSizingAlgorit
         if (!(gridItem.style().logicalWidth().isAuto() || gridItem.style().logicalWidth().isPercent()))
             return false;
 
+        ASSERT(m_renderGrid.isMasonry(GridTrackSizingDirection::ForColumns));
+
+        if (gridItem.style().writingMode().isOrthogonal(m_renderGrid.style().writingMode()))
+            return false;
+
         if (auto* renderGrid = dynamicDowncast<RenderGrid>(gridItem); renderGrid && renderGrid->isSubgridRows())
             return false;
 


### PR DESCRIPTION
#### 6c070b3d74c42580af4252891da6836ed068f42d
<pre>
[css-masonry] Fix orthogonal item writing mode widths in masonry columns
<a href="https://bugs.webkit.org/show_bug.cgi?id=282717">https://bugs.webkit.org/show_bug.cgi?id=282717</a>
<a href="https://rdar.apple.com/problem/139385456">rdar://problem/139385456</a>

Reviewed by Sammy Gill.

When there is a vertical writing mode in grid-template-columns: masonry, we should not be overriding the logical widths in the min/max content phases.
This could cause a large gap at the end of the grid.

When we are in shouldOverrideLogicalWidth(), if we get past the &apos;if (layoutPhase == MasonryLayoutPhase::LayoutPhase)&apos; we know we must be in masonry columns,
because this will only be called in the computeIntrinsicSizes.

Test Case:
I needed to update test case 05 to handle the new widths.
Our impementation uses the old spec definition where definite items were placed first. That is no longer true, thus needing to update the base test case.

* LayoutTests/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-005.html:
* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::insertIntoGridAndLayoutItem):

Canonical link: <a href="https://commits.webkit.org/286314@main">https://commits.webkit.org/286314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f3182368a44a3343953e3d100c0171afa8a983d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75554 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80034 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26818 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77670 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59264 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17459 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78621 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39621 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22386 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25146 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22723 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81513 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1825 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67506 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3044 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66799 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16659 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10759 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2850 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5672 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2875 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3810 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2882 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->