### PR TITLE
REGRESSION (282704@main): [ macOS wk2 ] media/media-vp8-hiddenframes.html is a flaky image only failure.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5669,7 +5669,6 @@ imported/w3c/web-platform-tests/webstorage/document-domain.html [ Skip ]
 
 webkit.org/b/221973 media/media-webm-no-duration.html [ Skip ]
 webkit.org/b/222493 media/media-source/media-source-webm-vp8-malformed-header.html [ Skip ]
-media/media-source/media-source-vp8-hiddenframes.html [ Skip ] # Requires VP8 decoder
 
 # WebXR - Missing modules.
 imported/w3c/web-platform-tests/webxr/anchors [ Skip ]

--- a/LayoutTests/media/media-source/media-source-vp8-hiddenframes.html
+++ b/LayoutTests/media/media-source/media-source-vp8-hiddenframes.html
@@ -1,8 +1,10 @@
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=16; totalPixels=57600" />
+<meta name="fuzzy" content="maxDifference=0-16; totalPixels=0-57600" />
 <title>MSE webm file with alternate reference frame</title>
 <script src="../../resources/testharness.js"></script>
+<script>window.requirePixelDump = true</script>
+<script src=../video-test.js></script>
 <script src="../utilities.js"></script>
 <script>
     // VP8 files were generated such that alternative reference frames were used:
@@ -19,13 +21,17 @@
         let ms = new MediaSource();
         v.src = URL.createObjectURL(ms);
         await once(ms, 'sourceopen');
+        let promise = new Promise(resolve => v.requestVideoFrameCallback(resolve));
         let videosb = ms.addSourceBuffer("video/webm; codecs=vp8");
-        await Promise.all([fetchAndLoad(videosb, '../content/test-vp8-hiddenframes', [''], '.webm') , once(v, 'loadedmetadata')]);
+        await Promise.all([fetchAndLoad(videosb, '../content/test-vp8-hiddenframes', [''], '.webm') , waitFor(v, 'loadedmetadata', true)]);
         ms.endOfStream();
-        v.play();
         // duration of the last frame.
         v.currentTime = v.duration - 0.038;
-        await Promise.all([ once(v, 'ended'), once(v, 'seeked')]);
+        await waitFor(v, 'seeked', true);
+        v.play();
+        await waitFor(v, 'ended', true);
+        // FIXME: await promise; // this promise is never resolved due to webkit.org/b/282782 and webkit.org/b/282797
+        await sleepFor(1000);
 
         if (window.testRunner)
             testRunner.notifyDone();

--- a/LayoutTests/media/media-vp8-hiddenframes.html
+++ b/LayoutTests/media/media-vp8-hiddenframes.html
@@ -3,7 +3,8 @@
 <meta name="fuzzy" content="maxDifference=0-16; totalPixels=0-57600" />
 <title>webm file with alternate reference frame</title>
 <script src="../resources/testharness.js"></script>
-<script src="utilities.js"></script>
+<script>window.requirePixelDump = true</script>
+<script src=video-test.js></script>
 <script>
     // VP8 files were generated such that alternative reference frames were used:
     // $ fmpeg -i dragon.webm -c:v libvpx -vf scale=320:-1 -auto-alt-ref 1 -arnr-maxframes 5 -arnr-strength 3 -pass 1 test-vp8-hiddenframes.webm
@@ -17,11 +18,15 @@
 
         let v = document.getElementsByTagName('video')[0];
         v.src = "content/test-vp8-hiddenframes.webm";
-        await once(v, 'loadedmetadata');
-        v.play();
+        await waitFor(v, 'loadedmetadata', true);
+        let promise = new Promise(resolve => v.requestVideoFrameCallback(resolve));
         // duration of the last frame.
         v.currentTime = v.duration - 0.038;
-        await Promise.all([ once(v, 'ended'), once(v, 'seeked')]);
+        await waitFor(v, 'seeked', true);
+        v.play();
+        await waitFor(v, 'ended', true);
+        // FIXME: await promise; // this promise is never resolved due to webkit.org/b/282782 and webkit.org/b/282797
+        await sleepFor(1000);
 
         if (window.testRunner)
             testRunner.notifyDone();

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1171,6 +1171,8 @@ webkit.org/b/218317 media/media-source/media-source-trackid-change.html [ Failur
 webkit.org/b/238201 media/media-source/media-mp4-hevc-bframes.html [ Failure ]
 webkit.org/b/270622 media/media-source/media-managedmse-noresumeafterpause.html [ Timeout ]
 webkit.org/b/271631 media/media-source/media-managedmse-stall-endofstream.html [ Failure ]
+webkit.org/b/282791 media/media-source/media-source-vp8-hiddenframes.html [ ImageOnlyFailure ]
+webkit.org/b/282791 media/media-vp8-hiddenframes.html [ ImageOnlyFailure ]
 
 # GStreamer (< 1.24) doesn't set the track's id to the container's value.
 webkit.org/b/265919 media/track/media-audio-track.html [ Failure ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1151,6 +1151,7 @@ media/media-sources-selection.html [ ImageOnlyFailure ]
 media/media-video-fullrange.html [ Skip ]
 
 # VP9/VP8 are not supported on WK1 and turned off by default
+media/media-source/media-source-vp8-hiddenframes.html [ Skip ]
 media/media-source/media-source-webm-configuration-change.html [ Failure ]
 media/media-source/media-source-webm-configuration-framerate.html [ Failure ]
 media/media-source/media-source-webm-configuration-vp9-header-color.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1787,9 +1787,6 @@ imported/w3c/web-platform-tests/webrtc/simulcast/setParameters-active.https.html
 # webkit.org/b/278801 REGRESSION (280449@main): [ macOS wk2 ] imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept-interrupted.html is a flaky crash 
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept-interrupted.html [ Pass Crash ]
 
-# webkit.org/b/278833 REGRESSION (282704@main): [ macOS wk2 ] media/media-vp8-hiddenframes.html is a flaky image only failure. 
-media/media-vp8-hiddenframes.html [ Pass ImageOnlyFailure ]
-
 # webkit.org/b/278881 [ Sonoma F wk2 ] fast/scrolling/rubber-band-shows-background.html is a flaky image only failure. 
 [ Sonoma+ ] fast/scrolling/rubber-band-shows-background.html [ Pass ImageOnlyFailure ]
 

--- a/Source/WebCore/platform/VideoDecoder.h
+++ b/Source/WebCore/platform/VideoDecoder.h
@@ -39,14 +39,16 @@ public:
     WEBCORE_EXPORT VideoDecoder();
     WEBCORE_EXPORT virtual ~VideoDecoder();
 
-    enum class HardwareAcceleration { Yes, No };
-    enum class HardwareBuffer { Yes, No };
+    enum class HardwareAcceleration : bool { No, Yes };
+    enum class HardwareBuffer : bool { No, Yes };
+    enum class TreatNoOutputAsError : bool { No, Yes };
     struct Config {
         std::span<const uint8_t> description;
         uint64_t width { 0 };
         uint64_t height { 0 };
         HardwareAcceleration decoding { HardwareAcceleration::No };
         HardwareBuffer pixelBuffer { HardwareBuffer::No };
+        TreatNoOutputAsError noOutputAsError { TreatNoOutputAsError::Yes };
         ProcessIdentity resourceOwner { };
     };
 


### PR DESCRIPTION
#### 2cdde9cb8a0dad7c36895cb190d93922b6cd5dab
<pre>
REGRESSION (282704@main): [ macOS wk2 ] media/media-vp8-hiddenframes.html is a flaky image only failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=278833">https://bugs.webkit.org/show_bug.cgi?id=278833</a>
<a href="https://rdar.apple.com/134903291">rdar://134903291</a>

Reviewed by Youenn Fablet.

This commit handles two issues.
1- The test incorrectly failed as we weren&apos;t always ending the test once the last frame was displayed as expected. For now we will simply wait for 1s
2- On Apple platforms other than mac, decoding of videos with alternate&apos;s frame was broken. The WebM demuxer pack all CMSampleBuffer with the same timecode
together so that they can be added to the MSE&apos;s TrackBuffer without issues (as we use the time as key). While the VideoToolbox decoder handled
thos CMSampleBuffer properly, the WebCoreDecompressionSession&apos;s VideoDecoder didn&apos;t. We now iterate over all the inner samples and return the last
deocded frames returned.

* LayoutTests/TestExpectations:
* LayoutTests/media/media-source/media-source-vp8-hiddenframes.html:
* LayoutTests/media/media-vp8-hiddenframes.html:
* LayoutTests/platform/mac-wk2/TestExpectations: Remove failure expectations.
* Source/WebCore/platform/VideoDecoder.h: Add enum to treat no frame as error. This is done to leave the current behaviour of WebCodec which does expect an error. To be further investigated in webkit.org/b/282227
Fly-By, re-order the enum to follow coding style (No first)
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm:
(WebCore::WebCoreDecompressionSession::decodeSampleInternal):
(WebCore::WebCoreDecompressionSession::initializeVideoDecoder):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp:
(WebCore::LibWebRTCVPXInternalVideoDecoder::decode):
(WebCore::LibWebRTCVPXInternalVideoDecoder::LibWebRTCVPXInternalVideoDecoder):

Canonical link: <a href="https://commits.webkit.org/286329@main">https://commits.webkit.org/286329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/343738581f2a1fa1e38cb43ff0a5b3ebcb68046e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75661 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80147 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26925 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77777 "Passed tests") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59337 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17512 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78728 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64987 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39700 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22471 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25254 "Built successfully") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22807 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81620 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1889 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67570 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3151 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66877 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16667 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10826 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2957 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5779 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2982 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3917 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2989 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->