### PR TITLE
[iPad] store.steampowered.com: Navigation bar doesn’t reveal drop down menus when tapped

### DIFF
--- a/LayoutTests/fast/events/touch/ios/content-observation/add-mouseout-event-listener-on-hover-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/content-observation/add-mouseout-event-listener-on-hover-expected.txt
@@ -1,0 +1,9 @@
+Tap here
+PASS expandedContainer became true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+To run this test manually, tap the green box above; it should expand vertically and stay green.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/fast/events/touch/ios/content-observation/add-mouseout-event-listener-on-hover.html
+++ b/LayoutTests/fast/events/touch/ios/content-observation/add-mouseout-event-listener-on-hover.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../../../resources/js-test.js"></script>
+<script src="../../../../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+expandedContainer = false;
+window.internals?.settings.setContentChangeObserverEnabled(true);
+
+addEventListener("load", async () => {
+    description("To run this test manually, tap the green box above; it should expand vertically and stay green.");
+
+    const target = document.querySelector("div.target");
+    target.addEventListener("mouseenter", async () => {
+        target.addEventListener("mouseout", () => {
+            testFailed("Dispatched mouseout");
+            target.style.height = "48px";
+        }, { once: true });
+
+        await UIHelper.delayFor(150);
+        target.style.height = "400px";
+
+        await UIHelper.delayFor(300);
+        expandedContainer = true;
+    });
+
+    target.addEventListener("click", () => {
+        target.style.background = "tomato";
+        testFailed("Dispatched click");
+    });
+
+    await UIHelper.activateElement(target);
+    await shouldBecomeEqual("expandedContainer", "true");
+    finishJSTest();
+});
+</script>
+<style>
+div.target {
+    width: 240px;
+    height: 48px;
+    line-height: 48px;
+    color: white;
+    font-size: 24px;
+    background: green;
+    text-align: center;
+    transition: height 0.3s ease;
+    border-radius: 4px;
+    overflow: hidden;
+}
+</style>
+</head>
+<body>
+    <div class="target">Tap here</div>
+    <p id="console"></p>
+    <p id="description"></p>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1086,6 +1086,7 @@ public:
 #endif
 
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
+    ContentChangeObserver* contentChangeObserverIfExists() { return m_contentChangeObserver.get(); }
     WEBCORE_EXPORT ContentChangeObserver& contentChangeObserver();
 
     DOMTimerHoldingTank* domTimerHoldingTankIfExists() { return m_domTimerHoldingTank.get(); }

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2458,6 +2458,13 @@ static inline bool tryAddEventListener(Node* targetNode, const AtomString& event
         document->addTouchEventHandler(*targetNode);
 #endif
 
+#if ENABLE(CONTENT_CHANGE_OBSERVER)
+    if (typeInfo.isInCategory(EventCategory::MouseMoveRelated)) {
+        if (WeakPtr observer = document->contentChangeObserverIfExists())
+            observer->didAddMouseMoveRelatedEventListener(eventType, *targetNode);
+    }
+#endif
+
     return true;
 }
 

--- a/Source/WebCore/page/ios/ContentChangeObserver.h
+++ b/Source/WebCore/page/ios/ContentChangeObserver.h
@@ -49,7 +49,6 @@ namespace WebCore {
 
 class Animation;
 class DOMTimer;
-class Element;
 
 class ContentChangeObserver : public CanMakeWeakPtr<ContentChangeObserver> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ContentChangeObserver, WEBCORE_EXPORT);
@@ -76,12 +75,15 @@ public:
     WEBCORE_EXPORT static void didPreventDefaultForEvent(LocalFrame& mainFrame);
     WEBCORE_EXPORT static void didCancelPotentialTap(LocalFrame& mainFrame);
 
+    void setClickTarget(Node& target) { m_clickTarget = target; }
+
     void didSuspendActiveDOMObjects();
     void willDetachPage();
 
     void rendererWillBeDestroyed(const Element&);
     void willNotProceedWithClick();
 
+    void didAddMouseMoveRelatedEventListener(const AtomString& eventType, const Node&);
     void willNotProceedWithFixedObservationTimeWindow();
 
     void setHiddenTouchTarget(Element& targetElement) { m_hiddenTouchTargetElement = targetElement; }
@@ -196,7 +198,7 @@ private:
     
     bool isContentChangeObserverEnabled();
 
-    enum class Event {
+    enum class Event : uint8_t {
         StartedTouchStartEventDispatching,
         EndedTouchStartEventDispatching,
         WillNotProceedWithClick,
@@ -215,7 +217,8 @@ private:
         StartedFixedObservationTimeWindow,
         EndedFixedObservationTimeWindow,
         WillNotProceedWithFixedObservationTimeWindow,
-        ElementDidBecomeVisible
+        ElementDidBecomeVisible,
+        DidAddMouseoutListenerAboveClickTarget,
     };
     void adjustObservedState(Event);
 
@@ -226,6 +229,7 @@ private:
     WeakHashSet<const Element, WeakPtrImplWithEventTargetData> m_elementsWithDestroyedVisibleRenderer;
     WKContentChange m_observedContentState { WKContentNoChange };
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_hiddenTouchTargetElement;
+    WeakPtr<Node, WeakPtrImplWithEventTargetData> m_clickTarget;
     WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_visibilityCandidateList;
     bool m_touchEventIsBeingDispatched { false };
     bool m_isWaitingForStyleRecalc { false };

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -831,6 +831,7 @@ void WebPage::handleSyntheticClick(Node& nodeRespondingToClick, const WebCore::F
     }
 
     auto& contentChangeObserver = respondingDocument.contentChangeObserver();
+    contentChangeObserver.setClickTarget(nodeRespondingToClick);
     auto targetNodeWentFromHiddenToVisible = contentChangeObserver.hiddenTouchTarget() == &nodeRespondingToClick && ContentChangeObserver::isConsideredVisible(nodeRespondingToClick);
     {
         LOG_WITH_STREAM(ContentObservation, stream << "handleSyntheticClick: node(" << &nodeRespondingToClick << ") " << location);
@@ -866,7 +867,7 @@ void WebPage::handleSyntheticClick(Node& nodeRespondingToClick, const WebCore::F
     auto observedContentChange = contentChangeObserver.observedContentChange();
     auto continueContentObservation = !(observedContentChange == WKContentVisibilityChange || targetNodeTriggersFastPath);
     if (continueContentObservation) {
-        // Wait for callback to completePendingSyntheticClickForContentChangeObserver() to decide whether to send the click event.
+        // Wait for callback to didFinishContentChangeObserving() to decide whether to send the click event.
         const Seconds observationDuration = 32_ms;
         contentChangeObserver.startContentObservationForDuration(observationDuration);
         LOG(ContentObservation, "handleSyntheticClick: Can't decide it yet -> wait.");


### PR DESCRIPTION
#### ce2bebc6a7aa4cc6dff7101c531442d2f5b4ac46
<pre>
[iPad] store.steampowered.com: Navigation bar doesn’t reveal drop down menus when tapped
<a href="https://bugs.webkit.org/show_bug.cgi?id=282763">https://bugs.webkit.org/show_bug.cgi?id=282763</a>
<a href="https://rdar.apple.com/89114638">rdar://89114638</a>

Reviewed by Richard Robinson and Alan Baradlay.

When tapping items in the top navigation menu on store.steampowered.com, the page reveals a hover
menu with more links. This currently manages to bypass all existing content change observation
heuristics, leading to a `click` event being dispatched to the page after `hover`.

At the same time, Steam also adds a click event handler that *dismisses* the open menu when handling
mouse hover. The end result is that Steam schedules logic to begin revealing the menu when handling
`mouseover`, and then immediately dismisses the menu when handling the synthetic `click` event ~32
ms later.

To fix this, we make a small adjustment to `ContentChangeObserver`, so that we recognize the tap
gesture on these menus on steampowered.com as *only* a mouse hover, rather than clicking. While
there isn&apos;t any significant visual change in response to the hover event, we can detect that the
page adds a `mouseout` event listener to a container of the click target during the scope of content
change observation, which is a fairly strong signal that the page intends to know when the mouse has
exited the click target.

* LayoutTests/fast/events/touch/ios/content-observation/add-mouseout-event-listener-on-hover-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/content-observation/add-mouseout-event-listener-on-hover.html: Added.

Add a test case to exercise this heuristic.

* Source/WebCore/dom/Document.h:
(WebCore::Document::contentChangeObserverIfExists):
* Source/WebCore/dom/Node.cpp:
(WebCore::tryAddEventListener):
* Source/WebCore/page/ios/ContentChangeObserver.cpp:
(WebCore::ContentChangeObserver::reset):
(WebCore::ContentChangeObserver::didAddMouseMoveRelatedEventListener):
(WebCore::ContentChangeObserver::adjustObservedState):
* Source/WebCore/page/ios/ContentChangeObserver.h:
(WebCore::ContentChangeObserver::setClickTarget):

Store the current click target (`nodeRespondingToClick`) on the content change observer, so that we
can check against it when observing any event handlers being added on the fly during content
observation.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::handleSyntheticClick):

Canonical link: <a href="https://commits.webkit.org/286320@main">https://commits.webkit.org/286320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9226fe5bb24624026da4dae2c737be701b947a1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28381 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80009 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26794 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77646 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2761 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59251 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17448 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78597 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64884 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39609 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22369 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25122 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81489 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2869 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1812 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67493 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3020 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64860 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66786 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16662 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10745 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8901 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2826 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5647 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2851 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3786 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2858 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->