### PR TITLE
[WPT] Sync css/css-cascade

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/at-scope-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/at-scope-parsing-expected.txt
@@ -14,9 +14,9 @@ PASS @scope (.a) to (& > &) is valid
 PASS @scope (.a) to (> .b) is valid
 PASS @scope (.a) to (+ .b) is valid
 PASS @scope (.a) to (~ .b) is valid
-PASS @scope () is valid
-PASS @scope to () is valid
-PASS @scope () to () is valid
+FAIL @scope () is not valid assert_equals: expected 0 but got 1
+FAIL @scope to () is not valid assert_equals: expected 0 but got 1
+FAIL @scope () to () is not valid assert_equals: expected 0 but got 1
 FAIL @scope (.c <> .d) is not valid assert_equals: expected 0 but got 1
 FAIL @scope (.a, .c <> .d) is not valid assert_equals: expected 0 but got 1
 FAIL @scope (.a <> .b, .c) is not valid assert_equals: expected 0 but got 1

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/at-scope-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/at-scope-parsing.html
@@ -45,10 +45,10 @@
   test_valid('@scope (.a) to (> .b)');
   test_valid('@scope (.a) to (+ .b)');
   test_valid('@scope (.a) to (~ .b)');
-  test_valid('@scope ()', '@scope');
-  test_valid('@scope to ()', '@scope');
-  test_valid('@scope () to ()', '@scope');
 
+  test_invalid('@scope ()');
+  test_invalid('@scope to ()');
+  test_invalid('@scope () to ()');
   test_invalid('@scope (.c <> .d)');
   test_invalid('@scope (.a, .c <> .d)');
   test_invalid('@scope (.a <> .b, .c)');

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
@@ -17,4 +17,5 @@ PASS :scope within nested and scoped rule (implied &)
 PASS :scope within nested and scoped rule (relative)
 PASS Scoped nested group rule
 PASS Scoped nested within another scope
+PASS Implicit (prelude-less) @scope as a nested group rule
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting.html
@@ -576,3 +576,25 @@ test((t) => {
   assert_equals(getComputedStyle(child).zIndex, '1');
 }, 'Scoped nested within another scope');
 </script>
+
+<template id=test_implicit_scope_nested_group_rule>
+  <div class=nest>
+    <style>
+      .nest {
+        @scope {
+          #child {
+            color: green;
+          }
+        }
+      }
+    </style>
+    <div id=child>Foo</div>
+</div>
+</template>
+<script>
+test((t) => {
+  t.add_cleanup(() => main.replaceChildren());
+  main.append(test_implicit_scope_nested_group_rule.content.cloneNode(true));
+  assert_equals(getComputedStyle(child).color, 'rgb(0, 128, 0)');
+}, 'Implicit (prelude-less) @scope as a nested group rule');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-proximity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-proximity-expected.txt
@@ -3,4 +3,5 @@ PASS Alternating light/dark
 PASS Proximity wins over order of appearance
 PASS Specificity wins over proximity
 PASS Identical root with further proximity is not ignored
+PASS Most proximate match wins under multiple scoping roots
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-proximity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-proximity.html
@@ -139,3 +139,25 @@ test_scope(document.currentScript, () => {
   assert_equals(getComputedStyle(item).borderColor, 'rgb(0, 128, 0)');
 }, 'Identical root with further proximity is not ignored');
 </script>
+
+<template>
+  <style>
+    @scope (.scope) {
+      :where(&) { border-color:green; }
+    }
+    @scope (#outer) {
+      :where(:scope) :where(#inner) { border-color:red; }
+    }
+  </style>
+  <div id=outer class=scope>
+    <div>
+      <div id=inner class=scope>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+test_scope(document.currentScript, () => {
+  assert_equals(getComputedStyle(inner).borderColor, 'rgb(0, 128, 0)');
+}, 'Most proximate match wins under multiple scoping roots');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt
@@ -8,6 +8,6 @@ PASS @scope (#main) { & .b {  } } and #main .b
 PASS @scope (#main) { div .b {  } } and div .b
 PASS @scope (#main) { @scope (.a) { .b {  } } } and .b
 PASS @scope (#main) { :scope .b {  } } and :scope .b
-PASS @scope { & .b {  } } and :scope .b
+FAIL @scope { & .b {  } } and :where(:scope) .b assert_equals: unscoped + scoped expected "2" but got "1"
 PASS @scope (#main) { > .a {  } } and :where(#main) > .a
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity.html
@@ -85,8 +85,10 @@ test_scope_specificity(['@scope (#main)', 'div .b'], 'div .b');
 test_scope_specificity(['@scope (#main)', '@scope (.a)', '.b'], '.b');
 // Explicit `:scope` adds specficity.
 test_scope_specificity(['@scope (#main)', ':scope .b'], ':scope .b');
-// Using & in scoped style with implicit scope root uses `:scope`, which adds specificity
-test_scope_specificity(['@scope', '& .b'], ':scope .b', styleImplicit);
+// Using & in scoped style with implicit scope root matches the same elements
+// as `:scope`, but does not add any specificity.
+// https://github.com/w3c/csswg-drafts/issues/10196
+test_scope_specificity(['@scope', '& .b'], ':where(:scope) .b', styleImplicit);
 // Using relative selector syntax does not add specificity
 test_scope_specificity(['@scope (#main)', '> .a'], ':where(#main) > .a');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/w3c-import.log
@@ -9,12 +9,12 @@ Do NOT modify or remove this file.
 
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
-mask-position-x
-box-decoration-break
-initial-letter
-mask-position-y
 text-size-adjust
 user-select
+initial-letter
+mask-position-x
+mask-position-y
+box-decoration-break
 Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------


### PR DESCRIPTION
#### b5146621c38ece35c0550c8a7a117162154ac071
<pre>
[WPT] Sync css/css-cascade
<a href="https://bugs.webkit.org/show_bug.cgi?id=282766">https://bugs.webkit.org/show_bug.cgi?id=282766</a>

Reviewed by Tim Nguyen.

WPT @ ff335edfbb85c271e3fe402c906237f67cc2d88c

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/at-scope-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/at-scope-parsing.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-proximity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-proximity.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/286301@main">https://commits.webkit.org/286301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc660ad1aeea9585dcfcc1456a9be6321c6e589d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/148 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79964 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26750 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2717 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59235 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17435 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78553 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/62 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64854 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39592 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22341 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25078 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81444 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1785 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67476 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2976 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66766 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16637 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10719 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8874 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2782 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2807 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3742 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2814 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->