### PR TITLE
[macOS] Entering fullscreen with content menu results in visible controls upon exiting

### DIFF
--- a/LayoutTests/media/webkit-media-controls-not-visible-after-exiting-fullscreen-expected.txt
+++ b/LayoutTests/media/webkit-media-controls-not-visible-after-exiting-fullscreen-expected.txt
@@ -1,0 +1,12 @@
+This tests that when controls have been shown and hidden, they continue to be hidden after exiting fullscreen.
+
+RUN(video.src = findMediaFile("video", "content/test"))
+EVENT(canplay)
+RUN(video.controls = false)
+RUN(video.webkitEnterFullscreen())
+EVENT(fullscreenchange)
+RUN(video.webkitExitFullscreen())
+EVENT(fullscreenchange)
+EXPECTED (shadow.querySelector(".media-controls").children.length == '0') OK
+END OF TEST
+

--- a/LayoutTests/media/webkit-media-controls-not-visible-after-exiting-fullscreen.html
+++ b/LayoutTests/media/webkit-media-controls-not-visible-after-exiting-fullscreen.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>webkit-media-controls-not-visible-after-exiting-fullscreen</title>
+    <script src=video-test.js></script>
+    <script src=media-file.js></script>
+    <script>
+    var shadow;
+    async function runTest() {
+        findMediaElement();
+        run('video.src = findMediaFile("video", "content/test")');
+        await waitFor(video, 'canplay');
+        run('video.controls = false');
+        runWithKeyDown('video.webkitEnterFullscreen()');
+        await waitFor(document, 'fullscreenchange');
+
+        await sleepFor(100);
+
+        runWithKeyDown('video.webkitExitFullscreen()');
+        await waitFor(document, 'fullscreenchange');
+
+        if (window.internals) {
+            shadow = internals.shadowRoot(mediaElement);
+            await testExpectedEventually('shadow.querySelector(".media-controls").children.length', 0, '==', 1000);
+        }
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <div>
+        This tests that when controls have been shown and hidden, they continue to be hidden after exiting fullscreen.
+    </div>
+    <video controls></video>
+</body>
+</html>

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -98,6 +98,7 @@ class MediaController
         scheduler.flushScheduledLayoutCallbacks();
 
         shadowRoot.addEventListener("resize", this);
+        shadowRoot.addEventListener("fullscreenchange", this);
 
         media.videoTracks.addEventListener("addtrack", this);
         media.videoTracks.addEventListener("removetrack", this);
@@ -256,6 +257,8 @@ class MediaController
             this._updateControlsIfNeeded();
             // We must immediately perform layouts so that we don't lag behind the media layout size.
             scheduler.flushScheduledLayoutCallbacks();
+        } else if (event.type === "fullscreenchange" && event.currentTarget === this.shadowRoot) {
+            this._updateControlsAvailability();
         } else if (event.type === "keydown" && this.isFullscreen && event.key === " ") {
             this.togglePlayback();
             event.preventDefault();


### PR DESCRIPTION
#### 8f0ce1da8be6deffb27a1eaabf9bb338ef7a3c37
<pre>
[macOS] Entering fullscreen with content menu results in visible controls upon exiting
<a href="https://bugs.webkit.org/show_bug.cgi?id=282767">https://bugs.webkit.org/show_bug.cgi?id=282767</a>
<a href="https://rdar.apple.com/138995480">rdar://138995480</a>

Reviewed by NOBODY (OOPS!).

Similar to 285602@main, listen for the &quot;fullscreenchange&quot; event on the media controls shadow root
and update media controls available upon receiving that event.

* LayoutTests/media/webkit-media-controls-not-visible-after-exiting-fullscreen-expected.txt: Added.
* LayoutTests/media/webkit-media-controls-not-visible-after-exiting-fullscreen.html: Added.
* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController):
(MediaController.prototype.handleEvent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f0ce1da8be6deffb27a1eaabf9bb338ef7a3c37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/152 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28341 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79968 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26754 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77606 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2721 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59237 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17437 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78557 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/61 "Found 1 new test failure: media/webkit-media-controls-not-visible-after-exiting-fullscreen.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39594 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22347 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25082 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67792 "") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81448 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1791 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67477 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2980 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66767 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10720 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8880 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2786 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5607 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2811 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3746 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2818 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->