### PR TITLE
[Static Analyzer CI] Filter unexpected results using results.webkit.org to reduce build times on EWS

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -6966,7 +6966,7 @@ class ScanBuild(steps.ShellSequence, ShellMixin):
         defer.returnValue(rc)
 
     def addResultsSteps(self):
-        return [ParseStaticAnalyzerResults(), FindUnexpectedStaticAnalyzerResults(expectations=True)]
+        return [ParseStaticAnalyzerResults(), FindUnexpectedStaticAnalyzerResults(use_expectations=True)]
 
     def getResultSummary(self):
         status = ''
@@ -6982,7 +6982,7 @@ class ScanBuildWithoutChange(ScanBuild):
     output_directory = SCAN_BUILD_OUTPUT_DIR + '-baseline'
 
     def addResultsSteps(self):
-        return [ParseStaticAnalyzerResultsWithoutChange(), FindUnexpectedStaticAnalyzerResults(expectations=False)]
+        return [ParseStaticAnalyzerResultsWithoutChange(), FindUnexpectedStaticAnalyzerResults(use_expectations=False)]
 
 
 class ParseStaticAnalyzerResults(shell.ShellCommandNewStyle):
@@ -7040,15 +7040,23 @@ class ParseStaticAnalyzerResultsWithoutChange(ParseStaticAnalyzerResults):
     scan_build_output = SCAN_BUILD_OUTPUT_DIR + '-baseline'
 
 
-class FindUnexpectedStaticAnalyzerResults(shell.ShellCommandNewStyle):
+class FindUnexpectedStaticAnalyzerResults(shell.ShellCommandNewStyle, AddToLogMixin):
     name = 'find-unexpected-static-analyzer-results'
     description = ['finding unexpected static analyzer results']
     descriptionDone = ['found unexpected static analyzer results']
     result_message = ''
+    results_db_log_name = 'results-db'
+    jsonFileName = f'{SCAN_BUILD_OUTPUT_DIR}/unexpected_results.json'
+    logfiles = {'json': jsonFileName}
+    suite = 'safer-cpp-checks'
 
-    def __init__(self, expectations=False, **kwargs):
-        self.expectations = expectations  # If true, results will be compared against checked-in expectations. Otherwise, they're compared against a previous run.
+    def __init__(self, use_expectations=True, was_filtered=False, **kwargs):
+        self.use_expectations = use_expectations  # If true, results will be compared against checked-in expectations. Otherwise, they're compared against a previous run.
         super().__init__(logEnviron=False, **kwargs)
+        self.unexpected_results_filtered = {}
+        self.unexpected_failures_filtered = set()
+        self.unexpected_passes_filtered = set()
+        self.was_filtered = was_filtered  # Allow the unit test to override was_filtered
 
     @defer.inlineCallbacks
     def run(self):
@@ -7056,15 +7064,15 @@ class FindUnexpectedStaticAnalyzerResults(shell.ShellCommandNewStyle):
         if api_key:
             self.env[RESULTS_SERVER_API_KEY] = api_key
         else:
-            self._addToLog('stdio', 'No API key for {} found'.format(RESULTS_DB_URL))
+            yield self._addToLog('stdio', 'No API key for {} found'.format(RESULTS_DB_URL))
 
         self.command = ['python3', 'Tools/Scripts/compare-static-analysis-results', os.path.join(self.getProperty('builddir'), 'build/new')]
         self.command += ['--build-output', SCAN_BUILD_OUTPUT_DIR]
-        if not self.expectations:
+        if not self.use_expectations:
             self.command += ['--archived-dir', os.path.join(self.getProperty('builddir'), 'build/baseline')]
             self.command += ['--scan-build-path', '../llvm-project/clang/tools/scan-build/bin/scan-build']  # Only generate results page on the second comparison
             self.command += ['--delete-results']
-            if CURRENT_HOSTNAME in EWS_BUILD_HOSTNAMES and self.getProperty('github.base.ref', DEFAULT_BRANCH) == DEFAULT_BRANCH:
+            if CURRENT_HOSTNAME in EWS_BUILD_HOSTNAMES + TESTING_ENVIRONMENT_HOSTNAMES and self.getProperty('github.base.ref', DEFAULT_BRANCH) == DEFAULT_BRANCH:
                 self.command += [
                     '--builder-name', self.getProperty('buildername', ''),
                     '--build-number', self.getProperty('buildnumber', ''),
@@ -7084,43 +7092,171 @@ class FindUnexpectedStaticAnalyzerResults(shell.ShellCommandNewStyle):
         self.log_observer = logobserver.BufferLogObserver()
         self.addLogObserver('stdio', self.log_observer)
 
+        self.log_observer_json = logobserver.BufferLogObserver()
+        self.addLogObserver('json', self.log_observer_json)
+
         rc = yield super().run()
         if rc != SUCCESS:
             return defer.returnValue(rc)
 
-        self.createResultMessage()
+        self.find_unexpected_results()
+        num_unexpected_results = self.getProperty('num_failing_files', 0) or self.getProperty('num_unexpected_issues', 0) or self.getProperty('num_passing_files', 0)
+        unexpected_results_after_filter = None
+        if self.use_expectations and num_unexpected_results:  # Only consult results database on the first run
+            logTextJson = self.log_observer_json.getStdout()
+            yield self._addToLog('stdio', f'Checking results database for unexpected results...\n')
+            successful_filter = yield self.filter_results_using_results_db(logTextJson)
+            unexpected_results_after_filter = self.getProperty('num_failing_files', 0) or self.getProperty('num_unexpected_issues', 0) or self.getProperty('num_passing_files', 0)
+            if successful_filter and self.was_filtered and unexpected_results_after_filter:  # If there are unexpected results
+                yield self._addToLog('stdio', f'\nSuccessfully filtered results! Updating unexpected_results.json on disk.\n')
+                self.write_unexpected_results_file_to_master()
+            if not successful_filter:
+                yield self._addToLog('stdio', f'\nFailed to consult results database. Falling back to tip-of-tree...\n')
+                # If results db failed, rebuild without changes to verify causation
+                self.build.addStepsAfterCurrentStep([ValidateChange(verifyBugClosed=False, addURLs=False), RevertAppliedChanges(exclude=['new*', 'scan-build-output*']), ScanBuildWithoutChange()])
+                self.result_message = self.createResultMessage()
+                return defer.returnValue(rc)
 
-        unexpected_results = self.getProperty('unexpected_failing_files', 0) or self.getProperty('unexpected_new_issues', 0) or self.getProperty('unexpected_passing_files', 0)
-        if self.expectations and unexpected_results:
-            # If there are unexpected results, rebuild without changes to verify causation
-            self.build.addStepsAfterCurrentStep([ValidateChange(verifyBugClosed=False, addURLs=False), RevertAppliedChanges(exclude=['new*', 'scan-build-output*']), ScanBuildWithoutChange()])
-        elif unexpected_results:
-            # Only save the results if there are failures and it is not the first run
+        # Only save the results if there are unexpected results
+        if self.use_expectations:
+            if not unexpected_results_after_filter:
+                yield self._addToLog('stdio', f'Found no unexpected results after filtering through results database!\n')
+            else:
+                yield self._addToLog('stdio', f'Found unexpected results after filtering through results database!\n')
+                steps_to_add = [DownloadUnexpectedResultsFromMaster(), DeleteStaticAnalyzerResults(results_dir='StaticAnalyzerUnexpectedRegressions')] if self.was_filtered else []
+                steps_to_add += [GenerateSaferCPPResultsIndex(), DeleteStaticAnalyzerResults(), ArchiveStaticAnalyzerResults(), UploadStaticAnalyzerResults(), ExtractStaticAnalyzerTestResults(), DisplaySaferCPPResults()]
+                self.build.addStepsAfterCurrentStep(steps_to_add)
+        elif num_unexpected_results:
             self.build.addStepsAfterCurrentStep([ArchiveStaticAnalyzerResults(), UploadStaticAnalyzerResults(), ExtractStaticAnalyzerTestResults(), DisplaySaferCPPResults()])
+
+        self.result_message = self.createResultMessage()
+
         return defer.returnValue(rc)
 
-    def createResultMessage(self):
+    def write_unexpected_results_file_to_master(self):
+        resultDirectory = f"public_html/results/{self.getProperty('buildername')}/{self.getProperty('change_id')}-{self.getProperty('buildnumber')}"
+        results_data_file = os.path.join(resultDirectory, 'unexpected_results.json')
+        os.makedirs(os.path.dirname(results_data_file), exist_ok=True)
+        with open(results_data_file, "w") as f:
+            results_data_obj = json.dumps(self.unexpected_results_filtered, indent=4)
+            f.write(results_data_obj)
+
+    @defer.inlineCallbacks
+    def filter_results_using_results_db(self, string):
+        if not string:
+            return defer.returnValue(False)
+
+        content_string = LayoutTestFailures._strip_json_wrapper(string.strip())
+        # Workaround for https://github.com/buildbot/buildbot/issues/4906
+        content_string = ''.join(content_string.splitlines())
+        try:
+            results_json = json.loads(content_string)
+        except json.JSONDecodeError:
+            yield self._addToLog(self.results_db_log_name, f'Failed to decode JSON, retrying with workaround\n')
+            content_string += '}'  # Workaround for getStdout() removing the last bracket
+            try:
+                results_json = json.loads(content_string)
+            except json.JSONDecodeError:
+                yield self._addToLog(self.results_db_log_name, f'Failed to decode JSON\n')
+                return defer.returnValue(False)
+
+        self.unexpected_results_filtered = results_json
+
+        identifier = self.getProperty('identifier', None)
+        platform = self.getProperty('platform', None)
+        configuration = {}
+        if platform:
+            configuration['platform'] = platform
+        style = self.getProperty('configuration', None)
+        if style and style in ['debug', 'release']:
+            configuration['style'] = style
+
+        yield self._addToLog(self.results_db_log_name, f'Checking Results database for unexpected results. Identifier: {identifier}, configuration: {configuration}\n')
+        has_commit = False
+        if identifier:
+            has_commit = yield ResultsDatabase.has_commit(commit=identifier)
+            if not has_commit:
+                yield self._addToLog(self.results_db_log_name, f"'{identifier}' could not be found on the results database, falling back to tip-of-tree\n")
+                return defer.returnValue(False)
+
+        has_results = yield ResultsDatabase.get_results(self.suite, commit=identifier, configuration=configuration)
+        if not has_results:
+            yield self._addToLog(self.results_db_log_name, f"{self.suite} results for '{identifier}' could not be found on the results database, falling back to tip-of-tree\n")
+            return defer.returnValue(False)
+
+        filtered_failures = yield self.check_results_db(results_json.get('failures'), 'failures', configuration, identifier)
+        filtered_passes = yield self.check_results_db(results_json.get('passes'), 'passes', configuration, identifier)
+        if filtered_failures is not None:
+            if self.was_filtered:
+                self.setProperty('num_unexpected_issues', 0)
+            self.setProperty('unexpected_failures', list(filtered_failures))
+            self.setProperty('num_failing_files', len(filtered_failures))
+        if filtered_passes is not None:
+            self.setProperty('unexpected_passes', list(filtered_passes))
+            self.setProperty('num_passing_files', len(filtered_passes))
+        successful_filter = filtered_failures is not None or filtered_passes is not None
+        return defer.returnValue(successful_filter)
+
+    @defer.inlineCallbacks
+    def check_results_db(self, results_json, result_type, configuration, identifier):
+        yield self._addToLog(self.results_db_log_name, f'\nChecking for unexpected {result_type}...\n')
+        filtered_results = set()
+        for project, checkers in results_json.items():
+            for checker, files in checkers.items():
+                files_per_checker = list(files)
+                for file in files_per_checker:
+                    test_name = f'{project}/{file}/{checker}'
+                    data = yield ResultsDatabase.does_result_match(
+                        test_name, result_type='FAIL' if result_type == 'failures' else 'PASS',
+                        configuration=configuration,
+                        commit=identifier,
+                        suite=self.suite,
+                        default='PASS'
+                    )
+                    if not data:
+                        yield self._addToLog(self.results_db_log_name, f"Failed to match results for {test_name}, falling back to tip-of-tree\n")
+                        return defer.returnValue(None)
+                    self._addToLog(self.results_db_log_name, f"\n{test_name}: pre-existing={data['does_result_match']}\nResponse from results-db: {data}\n{data['logs']}")
+                    if data['does_result_match']:
+                        yield self._addToLog('stdio', f'Removing {test_name} from unexpected {result_type}.\n')
+                        self.was_filtered = True
+                        self.unexpected_results_filtered[result_type][project][checker].remove(file)
+                    else:
+                        yield self._addToLog('stdio', f'Adding {file} to unexpected {result_type}.\n')
+                        filtered_results.add(file)
+        return defer.returnValue(filtered_results)
+
+    def find_unexpected_results(self):
         log_text = self.log_observer.getStdout()
         match = re.search(r'^Total (new issues|unexpected issues): (\d+)', log_text, re.MULTILINE)
         if match:
-            self.result_message += f"{match.group(2)} new issue{'s' if int(match.group(2)) > 1 else ''} "
-            self.setProperty('unexpected_new_issues', int(match.group(2)))
+            self.setProperty('num_unexpected_issues', int(match.group(2)))
         else:
-            self.setProperty('unexpected_new_issues', 0)
+            self.setProperty('num_unexpected_issues', 0)
 
         match = re.search(r'^Total (new files|unexpected failing files): (\d+)', log_text, re.MULTILINE)
         if match:
-            self.result_message += f"{match.group(2)} failing file{'s' if int(match.group(2)) > 1 else ''} "
-            self.setProperty('unexpected_failing_files', int(match.group(2)))
+            self.setProperty('num_failing_files', int(match.group(2)))
         else:
-            self.setProperty('unexpected_failing_files', 0)
+            self.setProperty('num_failing_files', 0)
 
         match = re.search(r'^Total (fixed files|unexpected passing files): (\d+)', log_text, re.MULTILINE)
         if match:
-            self.result_message += f"{match.group(2)} fixed file{'s' if int(match.group(2)) > 1 else ''}"
-            self.setProperty('unexpected_passing_files', int(match.group(2)))
+            self.setProperty('num_passing_files', int(match.group(2)))
         else:
-            self.setProperty('unexpected_passing_files', 0)
+            self.setProperty('num_passing_files', 0)
+
+    def createResultMessage(self):
+        new_issues = self.getProperty('num_unexpected_issues', 0)
+        failing_files = self.getProperty('num_failing_files', 0)
+        fixed_files = self.getProperty('num_passing_files', 0)
+        result_message = ''
+
+        if not self.was_filtered:
+            result_message += f"{new_issues} new issue{'s' if new_issues > 1 else ''} " if new_issues else ''
+        result_message += f"{failing_files} failing file{'s' if failing_files > 1 else ''} " if failing_files else ''
+        result_message += f"{fixed_files} fixed file{'s' if fixed_files > 1 else ''}" if fixed_files else ''
+        return result_message
 
     def getResultSummary(self):
         status = ''
@@ -7229,7 +7365,7 @@ class DisplaySaferCPPResults(buildstep.BuildStep, AddToLogMixin):
     @defer.inlineCallbacks
     def run(self):
         commands_for_comment = set()
-        num_issues = self.getProperty('unexpected_new_issues', 0)
+        num_issues = self.getProperty('num_unexpected_issues', 0)
         self.resultDirectory = f"public_html/results/{self.getProperty('buildername')}/{self.getProperty('change_id')}-{self.getProperty('buildnumber')}"
         unexpected_results_data = self.loadResultsData(os.path.join(self.resultDirectory, SCAN_BUILD_OUTPUT_DIR, 'unexpected_results.json'))
         is_log = yield self.getFilesPerProject(unexpected_results_data, 'passes', commands_for_comment)
@@ -7240,7 +7376,7 @@ class DisplaySaferCPPResults(buildstep.BuildStep, AddToLogMixin):
                 yield self._addToLog('stdio', f'Ignored {num_issues} pre-existing failure{pluralSuffix}')
             self.addURL("View failures", self.resultDirectoryURL() + SCAN_BUILD_OUTPUT_DIR + "/new-results.html")
         self.createComment(commands_for_comment)
-        if self.getProperty('unexpected_failing_files', 0):
+        if self.getProperty('num_failing_files', 0):
             return defer.returnValue(FAILURE)
         return defer.returnValue(SUCCESS)
 
@@ -7259,7 +7395,7 @@ class DisplaySaferCPPResults(buildstep.BuildStep, AddToLogMixin):
             for checker, files in data.items():
                 if files:
                     total_file_list.update(files)
-                    file_str = '\n'.join(files)
+                    file_str = '\n'.join((sorted(files)))
                     log_content += f'=> {checker}\n\n{file_str}\n\n'
                     command += ' ' + self.CHECKER_ARGS.format(checker=checker, files=' '.join(files))
             if log_content:
@@ -7271,9 +7407,9 @@ class DisplaySaferCPPResults(buildstep.BuildStep, AddToLogMixin):
         return defer.returnValue(is_log)
 
     def createComment(self, commands_for_comment):
-        num_failures = self.getProperty('unexpected_failing_files', 0)
-        num_passes = self.getProperty('unexpected_passing_files', 0)
-        num_issues = self.getProperty('unexpected_new_issues', 0)
+        num_failures = self.getProperty('num_failing_files', 0)
+        num_passes = self.getProperty('num_passing_files', 0)
+        num_issues = self.getProperty('num_unexpected_issues', 0)
 
         if not num_failures and not num_passes:
             return
@@ -7305,7 +7441,7 @@ class DisplaySaferCPPResults(buildstep.BuildStep, AddToLogMixin):
         return 'patch'
 
     def doStepIf(self, step):
-        return self.getProperty('unexpected_failing_files', 0) or self.getProperty('unexpected_passing_files', 0) or self.getProperty('unexpected_new_issues', 0)
+        return self.getProperty('num_failing_files', 0) or self.getProperty('num_passing_files', 0) or self.getProperty('num_unexpected_issues', 0)
 
     def hideStepIf(self, results, step):
         return not self.doStepIf(step)
@@ -7314,9 +7450,9 @@ class DisplaySaferCPPResults(buildstep.BuildStep, AddToLogMixin):
         return f"{S3_RESULTS_URL}{self.resultDirectory.replace('public_html/results/', '') + '/'}"
 
     def getResultSummary(self):
-        num_failures = self.getProperty('unexpected_failing_files', 0)
-        num_passes = self.getProperty('unexpected_passing_files', 0)
-        num_issues = self.getProperty('unexpected_new_issues', 0)
+        num_failures = self.getProperty('num_failing_files', 0)
+        num_passes = self.getProperty('num_passing_files', 0)
+        num_issues = self.getProperty('num_unexpected_issues', 0)
         failing_files = (", ").join(self.getProperty('failures', [])[:self.NUM_TO_DISPLAY])
         passing_files = (", ").join(self.getProperty('passes', [])[:self.NUM_TO_DISPLAY])
         results_summary = ''


### PR DESCRIPTION
#### 94fb4893473fce89ffca8bfc7a9dcab2842a14f6
<pre>
[Static Analyzer CI] Filter unexpected results using results.webkit.org to reduce build times on EWS
<a href="https://bugs.webkit.org/show_bug.cgi?id=282770">https://bugs.webkit.org/show_bug.cgi?id=282770</a>
<a href="https://rdar.apple.com/139393719">rdar://139393719</a>

Reviewed by Jonathan Bedard.

Consult results.webkit.org on the first run of FindUnexpectedStaticAnalyzerResults to determine if
failures and successes on the PR are pre-existing. If so, we can filter those results out.

* Tools/CISupport/ews-build/steps.py:

(FindUnexpectedStaticAnalyzerResults):
    - If self.expectations = True (1st run on PR):
          - Check results database for each unexpected result
           1. If it fails, fall back to rebuilding on ToT.
           2. If it succeeds with no changes, run GenerateSaferCPPResultsIndex, Delete, Archive,
              Upload, Extract, &amp; Display results.
           3. If it succeeds with changes, run DownloadUnexpectedResultsFromMaster, DeleteStaticAnalyzerResults,
              GenerateSaferCPPResultsIndex, then Archive, Upload, Extract, &amp; Display results.
    - If self.expectations = False (2nd run on ToT):
          - These are not new changes and are already running.
          - Compare the PR and ToT results. Then run Archive, Upload, Extract, &amp; Display results.
          - Upload ToT results to results.webkit.org.

(FindUnexpectedStaticAnalyzerResults.run): Add new logic for each case enumerated above.
(FindUnexpectedStaticAnalyzerResults.filter_results_using_results_db): Added.
(FindUnexpectedStaticAnalyzerResults.check_results_db): Added.
(FindUnexpectedStaticAnalyzerResults.find_unexpected_results): Added.
(FindUnexpectedStaticAnalyzerResults.createResultMessage): Added.

Canonical link: <a href="https://commits.webkit.org/287360@main">https://commits.webkit.org/287360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/200ba8ddb746a8f84523926cd127e500e9d1abbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83769 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30339 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6436 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61921 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19838 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51973 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72116 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42225 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49324 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26236 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28710 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70440 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26658 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85159 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6450 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4463 "Found 1 new test failure: imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-peerconnection.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70166 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/78827 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6613 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67988 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69414 "Found 3 new API test failures: /TestWebKit:WebKit.LoadCanceledNoServerRedirectCallback, /TestWebKit:WebKit.GeolocationBasicWithHighAccuracy, /TestWebKit:WebKit2UserMessageRoundTripTest.WKURL (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13464 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12264 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12246 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6403 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6352 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9812 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8144 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->