### PR TITLE
[tvOS] Make it easier to interact with media controls

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/metadata-container.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/metadata-container.css
@@ -34,6 +34,7 @@
     .title-label {
         color: var(--primary-glyph-color);
         font-size: larger;
+        font-weight: 500;
     }
 
     .artist-label {

--- a/Source/WebCore/Modules/modern-media-controls/controls/metadata-container.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/metadata-container.js
@@ -32,9 +32,9 @@ class MetadataContainer extends LayoutNode
         this._title = "";
         this._artist = "";
         
-        this._titleNode = new LayoutNode(`<div id="title-label" class="title-label"></div>`);
         this._artistNode = new LayoutNode(`<div id="artist-label" class="artist-label"></div>`);
-        this.children = [this._titleNode, this._artistNode];
+        this._titleNode = new LayoutNode(`<div id="title-label" class="title-label"></div>`);
+        this.children = [this._artistNode, this._titleNode];
     }
 
     // Public

--- a/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css
@@ -32,33 +32,34 @@
 }
 
 .media-controls.fullscreen.tvos {
-    --tvos-controls-horizontal-margin: 24px;
-    --tvos-controls-vertical-margin: 32px;
-    --tvos-controls-bar-height: 56px;
+    --tvos-bottom-bar-horizontal-margin: 48px;
+    --tvos-controls-bar-height: 62px;
+    --tvos-controls-bottom-margin: 84px;
+    --tvos-controls-top-margin: 60px;
     --tvos-metadata-container-bottom-margin: 16px;
+    --tvos-overflow-button-bottom-margin: 38px;
+    --tvos-time-control-bottom-margin: 30px;
+    --tvos-top-bar-horizontal-margin: 40px;
 }
 
 .media-controls.fullscreen.tvos.uses-ltr-user-interface-layout-direction > .controls-bar.top-left,
 .media-controls.fullscreen.tvos:not(.uses-ltr-user-interface-layout-direction) > .controls-bar.top-right {
     position: absolute;
-    left: var(--tvos-controls-horizontal-margin);
-    right: auto;
-    top: var(--tvos-controls-vertical-margin);
+    left: var(--tvos-top-bar-horizontal-margin);
+    top: var(--tvos-controls-top-margin);
 }
 
 .media-controls.fullscreen.tvos.uses-ltr-user-interface-layout-direction > .controls-bar.top-right,
 .media-controls.fullscreen.tvos:not(.uses-ltr-user-interface-layout-direction) > .controls-bar.top-left {
     position: absolute;
-    left: auto;
-    right: var(--tvos-controls-horizontal-margin);
-    top: var(--tvos-controls-vertical-margin);
+    right: var(--tvos-top-bar-horizontal-margin);
+    top: var(--tvos-controls-top-margin);
 }
 
 .media-controls.fullscreen.tvos > .controls-bar.bottom {
     position: absolute;
-    bottom: var(--tvos-controls-vertical-margin);
-    left: var(--tvos-controls-horizontal-margin);
-    right: var(--tvos-controls-horizontal-margin);
+    bottom: var(--tvos-controls-bottom-margin);
+    left: var(--tvos-bottom-bar-horizontal-margin);
     height: var(--tvos-controls-bar-height);
 }
 
@@ -70,9 +71,8 @@
 
 .media-controls.fullscreen.tvos > .metadata-container {
     position: absolute;
-    left: var(--tvos-controls-horizontal-margin);
-    right: var(--tvos-controls-horizontal-margin);
-    bottom: calc(var(--tvos-controls-vertical-margin) + var(--tvos-controls-bar-height) + var(--tvos-metadata-container-bottom-margin));
+    left: var(--tvos-bottom-bar-horizontal-margin);
+    bottom: calc(var(--tvos-controls-bottom-margin) + var(--tvos-controls-bar-height) + var(--tvos-metadata-container-bottom-margin));
 }
 
 .media-controls.fullscreen.tvos .slider.default.disabled > .appearance > .fill > :is(.primary, .secondary) {
@@ -81,7 +81,17 @@
 
 .media-controls.fullscreen.tvos > .controls-bar.overflow {
     position: absolute;
-    left: auto;
-    right: var(--tvos-controls-horizontal-margin);
-    bottom: calc(var(--tvos-controls-vertical-margin) + var(--tvos-controls-bar-height) + var(--tvos-metadata-container-bottom-margin));
+    bottom: calc(var(--tvos-controls-bottom-margin) + var(--tvos-controls-bar-height) + var(--tvos-overflow-button-bottom-margin));
+}
+
+.media-controls.fullscreen.tvos.uses-ltr-user-interface-layout-direction > .controls-bar.overflow {
+    right: var(--tvos-bottom-bar-horizontal-margin);
+}
+
+.media-controls.fullscreen.tvos:not(.uses-ltr-user-interface-layout-direction) > .controls-bar.overflow {
+    left: var(--tvos-bottom-bar-horizontal-margin);
+}
+
+.media-controls.fullscreen.tvos > .controls-bar.bottom > .time-control {
+    margin-bottom: var(--tvos-time-control-bottom-margin);
 }

--- a/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.js
@@ -25,12 +25,12 @@
 
 class TVOSMediaControls extends MediaControls
 {
-    static topButtonsScaleFactor = 1;
-    static backForwardButtonScaleFactor = 1;
-    static playPauseButtonScaleFactor = 2;
-    static overflowButtonScaleFactor = 1;
-    static bottomControlsBarButtonMargin = 48;
-    static bottomControlsBarMargin = 24;
+    static topButtonsScaleFactor = 1.5;
+    static backForwardButtonScaleFactor = 2.5;
+    static playPauseButtonScaleFactor = 3;
+    static overflowButtonScaleFactor = 1.5;
+    static bottomControlsBarButtonMargin = 80;
+    static bottomControlsBarMargin = 48;
 
     constructor(options = {})
     {
@@ -41,6 +41,8 @@ class TVOSMediaControls extends MediaControls
         this.element.classList.add("fullscreen");
         this.element.classList.add("tvos");
 
+        this.closeButton = new CloseButton(this);
+
         this.timeControl.scrubber.allowsRelativeScrubbing = true;
         this.timeControl.scrubber.knobStyle = Slider.KnobStyle.None;
         this.timeControl.timeLabelsAttachment = TimeControl.TimeLabelsAttachment.Below;
@@ -50,17 +52,23 @@ class TVOSMediaControls extends MediaControls
         
         this.overflowButton.addExtraContextMenuOptions(this.tracksButton.contextMenuOptions);
 
+        const singleButtonContainerMargins = {
+            leftMargin: 0,
+            rightMargin: 0,
+            buttonMargin: 0
+        };
+
         this.topLeftControlsBar = new ControlsBar("top-left");
-        this._topLeftControlsBarContainer = this.topLeftControlsBar.addChild(new ButtonsContainer);
+        this._topLeftControlsBarContainer = this.topLeftControlsBar.addChild(new ButtonsContainer(singleButtonContainerMargins));
 
         this.topRightControlsBar = new ControlsBar("top-right");
-        this._topRightControlsBarContainer = this.topRightControlsBar.addChild(new ButtonsContainer);
+        this._topRightControlsBarContainer = this.topRightControlsBar.addChild(new ButtonsContainer(singleButtonContainerMargins));
 
         this.bottomControlsBar.addChild(this.timeControl);
         this._bottomControlsBarContainer = this.bottomControlsBar.addChild(new ButtonsContainer);
 
         this.overflowControlsBar = new ControlsBar("overflow");
-        this._overflowControlsBarContainer = this.overflowControlsBar.addChild(new ButtonsContainer);
+        this._overflowControlsBarContainer = this.overflowControlsBar.addChild(new ButtonsContainer(singleButtonContainerMargins));
 
         this.metadataContainer = new MetadataContainer();
 
@@ -84,7 +92,7 @@ class TVOSMediaControls extends MediaControls
         if (!this._isInitialized)
             return;
 
-        this.fullscreenButton.scaleFactor = TVOSMediaControls.topButtonsScaleFactor;
+        this.closeButton.scaleFactor = TVOSMediaControls.topButtonsScaleFactor;
         this.muteButton.scaleFactor = TVOSMediaControls.topButtonsScaleFactor;
         this.playPauseButton.scaleFactor = TVOSMediaControls.playPauseButtonScaleFactor;
         this.skipForwardButton.scaleFactor = TVOSMediaControls.backForwardButtonScaleFactor;
@@ -115,6 +123,7 @@ class TVOSMediaControls extends MediaControls
         this.overflowControlsBar.width = this._overflowControlsBarContainer.width;
 
         this.timeControl.width = this.bottomControlsBar.width;
+        this.metadataContainer.width = this.bottomControlsBar.width - this.overflowControlsBar.width - ButtonsContainer.Defaults.LeftMargin;
 
         this.topLeftControlsBar.visible = this._topLeftControlsBarContainer.children.some(button => button.visible);
         this.topRightControlsBar.visible = this._topRightControlsBarContainer.children.some(button => button.visible);
@@ -129,7 +138,7 @@ class TVOSMediaControls extends MediaControls
     _topLeftContainerButtons()
     {
         if (this.usesLTRUserInterfaceLayoutDirection)
-            return [this.fullscreenButton];
+            return [this.closeButton];
         return [this.muteButton];
     }
 
@@ -137,7 +146,7 @@ class TVOSMediaControls extends MediaControls
     {
         if (this.usesLTRUserInterfaceLayoutDirection)
             return [this.muteButton];
-        return [this.fullscreenButton];
+        return [this.closeButton];
     }
 
     _bottomContainerButtons()


### PR DESCRIPTION
#### f80eaa09d927361681ec4114161310851afa004c
<pre>
[tvOS] Make it easier to interact with media controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=282774">https://bugs.webkit.org/show_bug.cgi?id=282774</a>
<a href="https://rdar.apple.com/136323290">rdar://136323290</a>

Reviewed by Jer Noble.

Media controls can be difficult to use due to their size and position. Addressed this by doing the following:
- Made controls larger
- Adjusted insets to move controls farther away from eachother and the edges of the view
- Changed the close button to a more prominent X glyph
- Reversed the prominance of the title and artist labels (title should be most prominent)

* Source/WebCore/Modules/modern-media-controls/controls/metadata-container.css:
(.title-label):
* Source/WebCore/Modules/modern-media-controls/controls/metadata-container.js:
* Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css:
(.media-controls.fullscreen.tvos):
(.media-controls.fullscreen.tvos.uses-ltr-user-interface-layout-direction &gt; .controls-bar.top-left,):
(.media-controls.fullscreen.tvos.uses-ltr-user-interface-layout-direction &gt; .controls-bar.top-right,):
(.media-controls.fullscreen.tvos &gt; .controls-bar.bottom):
(.media-controls.fullscreen.tvos &gt; .metadata-container):
(.media-controls.fullscreen.tvos &gt; .controls-bar.overflow):
(.media-controls.fullscreen.tvos.uses-ltr-user-interface-layout-direction &gt; .controls-bar.overflow):
(.media-controls.fullscreen.tvos:not(.uses-ltr-user-interface-layout-direction) &gt; .controls-bar.overflow):
(.media-controls.fullscreen.tvos &gt; .controls-bar.bottom &gt; .time-control):
* Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.js:
(TVOSMediaControls.prototype.layout):
(TVOSMediaControls.prototype._topLeftContainerButtons):
(TVOSMediaControls.prototype._topRightContainerButtons):

Canonical link: <a href="https://commits.webkit.org/286357@main">https://commits.webkit.org/286357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a33bd264c3fb1907026f027f64be2b9d56f3599a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80010 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26795 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77647 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59250 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17450 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78598 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39608 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22370 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25123 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/67810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81490 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2870 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1813 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67494 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3021 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66787 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16679 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10743 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8902 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2827 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5648 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2852 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3787 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2859 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->