### PR TITLE
Add URLPattern Component testing

### DIFF
--- a/LayoutTests/fast/urlpattern/urlpattern-component-expected.txt
+++ b/LayoutTests/fast/urlpattern/urlpattern-component-expected.txt
@@ -1,0 +1,3611 @@
+CONSOLE MESSAGE: NotSupportedError: Not implemented.
+Tests URLPattern: URLPattern constructor
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/([^\\/]+?)"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/*. Was /foo/(.*).
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/*. Was /foo/(.*).
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/*. Was /foo/(.*).
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/*. Was /foo/(.*).
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar(.*)"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar(.*)"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar(.*)"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar(.*)"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar?"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar?"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar?"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar?"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar?"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar+"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar+"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar+"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar+"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar+"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/:bar*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/*?. Was /foo/(.*)?.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/*?"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/*?. Was /foo/(.*)?.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/*?"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/*?. Was /foo/(.*)?.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/*?"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/*?. Was /foo/(.*)?.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/*?"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/*?. Was /foo/(.*)?.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/*?"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/*?. Was /foo/(.*)?.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/*?"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/*+. Was /foo/(.*)+.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/*+"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/*+. Was /foo/(.*)+.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/*+"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/*+. Was /foo/(.*)+.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/*+"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/*+. Was /foo/(.*)+.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/*+"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/*+. Was /foo/(.*)+.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/*+"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/*+. Was /foo/(.*)+.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/*+"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/**. Was /foo/(.*)*.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/**"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/**. Was /foo/(.*)*.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/**"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/**. Was /foo/(.*)*.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/**"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/**. Was /foo/(.*)*.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/**"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/**. Was /foo/(.*)*.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/**"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/**. Was /foo/(.*)*.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/**"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/bar. Was /foo{/bar}.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/bar. Was /foo{/bar}.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/bar. Was /foo{/bar}.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/bar. Was /foo{/bar}.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo{/bar}?"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo{/bar}?"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo{/bar}?"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo{/bar}?"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo{/bar}+"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo{/bar}+"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo{/bar}+"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo{/bar}+"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo{/bar}+"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo{/bar}*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo{/bar}*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo{/bar}*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo{/bar}*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo{/bar}*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "(cafÃ©)"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+WARN: shouldBeEqualToString() expects string arguments
+WARN: shouldBe() expects function or string arguments
+FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "(cafÃ©)"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+WARN: shouldBeEqualToString() expects string arguments
+WARN: shouldBe() expects function or string arguments
+FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "(cafÃ©)"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "(cafÃ©)"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+WARN: shouldBeEqualToString() expects string arguments
+WARN: shouldBe() expects function or string arguments
+FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "(cafÃ©)"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+WARN: shouldBeEqualToString() expects string arguments
+WARN: shouldBe() expects function or string arguments
+FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "(cafÃ©)"
+Component: search
+WARN: shouldBeEqualToString() expects string arguments
+WARN: shouldBe() expects function or string arguments
+FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+WARN: shouldBeEqualToString() expects string arguments
+WARN: shouldBe() expects function or string arguments
+FAIL urlPatternComponent should be undefined (of type undefined). Was (cafÃ©) (of type string).
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+WARN: shouldBeEqualToString() expects string arguments
+WARN: shouldBe() expects function or string arguments
+FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
+Component: hash
+PASS urlPatternComponent is "(cafÃ©)"
+Component: protocol
+PASS urlPatternComponent is ":cafÃ©"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is ":cafÃ©"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is ":cafÃ©"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is ":cafÃ©"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is ":cafÃ©"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/:cafÃ©"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is ":cafÃ©"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is ":cafÃ©"
+Component: protocol
+PASS urlPatternComponent is ":℘"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is ":℘"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is ":℘"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is ":℘"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is ":℘"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/:℘"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is ":℘"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is ":℘"
+Component: protocol
+PASS urlPatternComponent is ":㐀"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is ":㐀"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is ":㐀"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is ":㐀"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is ":㐀"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/:㐀"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is ":㐀"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is ":㐀"
+Component: protocol
+FAIL urlPatternComponent should be *. Was (.*).
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+FAIL urlPatternComponent should be *. Was (.*).
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "foo-bar"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "caf%C3%A9"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+FAIL urlPatternComponent should be caf%C3%A9. Was cafÃ©.
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "caf%c3%a9"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "caf%C3%A9"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "caf%C3%A9"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+FAIL urlPatternComponent should be caf%C3%A9. Was cafÃ©.
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+FAIL urlPatternComponent should be caf%C3%A9. Was cafÃ©.
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "caf%c3%a9"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "caf%c3%a9"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "xn--caf-dma.com"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+FAIL urlPatternComponent should be xn--caf-dma.com. Was cafÃ©.com.
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "http"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "http"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "80{20}?"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "http"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+FAIL urlPatternComponent should be 80 . Was .
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+WARN: shouldBeEqualToString() expects string arguments
+WARN: shouldBe() expects function or string arguments
+FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "80"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "http{s}?"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "80"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "80"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+FAIL urlPatternComponent should be *. Was (.*).
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/baz"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/caf%C3%A9"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /caf%C3%A9. Was /cafÃ©.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/caf%c3%a9"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /bar. Was /foo/../bar.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/bar. Was ./foo/bar.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /. Was .
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /bar. Was {/bar}.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /bar. Was \/bar.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/b. Was b.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo/bar. Was foo/bar.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /:name.html. Was :name.html.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "q=caf%C3%A9"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+FAIL urlPatternComponent should be q=caf%C3%A9. Was q=cafÃ©.
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "q=caf%c3%a9"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "caf%C3%A9"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+FAIL urlPatternComponent should be caf%C3%A9. Was cafÃ©.
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "*"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "caf%c3%a9"
+Component: protocol
+PASS urlPatternComponent is "about"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "(blank|sourcedoc)"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "data"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is ":number([0-9]+)"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/(\\m)"
+Component: search
+WARN: shouldBeEqualToString() expects string arguments
+WARN: shouldBe() expects function or string arguments
+FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo!"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo\\:"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be /foo%7B. Was /foo\{.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo\\("
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "javascript"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "var x = 1;"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be var%20x%20=%201;. Was var x = 1;.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "javascript"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "var x = 1;"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "(data|javascript)"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "var x = 1;"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "(https|javascript)"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be var%20x%20=%201;. Was var x = 1;.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+FAIL urlPatternComponent should be var%20x%20=%201;. Was var x = 1;.
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Component: protocol
+PASS urlPatternComponent is "*"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "*"
+Component: port
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+FAIL successfullyParsed should be true. Was false.
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/urlpattern/urlpattern-component.html
+++ b/LayoutTests/fast/urlpattern/urlpattern-component.html
@@ -1,0 +1,2974 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+
+description("Tests URLPattern: URLPattern constructor");
+
+const jsonData = [
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/ba" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [ "https://example.com/foo/bar" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": { "0": "https" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [ "https://example.com/foo/bar/baz" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "hostname": "example.com", "pathname": "/foo/bar" }],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "hostname": "example.com", "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar", "baseURL": "https://example.com" }],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": { "0": "https" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/bar/baz",
+                 "baseURL": "https://example.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "hostname": "example.com", "pathname": "/foo/bar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar", "search": "otherquery",
+                 "hash": "otherhash" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "otherhash", "groups": { "0": "otherhash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "otherquery", "groups": { "0": "otherquery" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar", "search": "otherquery",
+                 "hash": "otherhash" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "otherhash", "groups": { "0": "otherhash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "otherquery", "groups": { "0": "otherquery" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?otherquery#otherhash" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar", "search": "otherquery",
+                 "hash": "otherhash" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "otherhash", "groups": { "0": "otherhash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "otherquery", "groups": { "0": "otherquery" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://example.com/foo/bar" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://example.com/foo/bar?otherquery#otherhash" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "otherhash", "groups": { "0": "otherhash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "otherquery", "groups": { "0": "otherquery" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://example.com/foo/bar?query#hash" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hash": { "input": "hash", "groups": { "0": "hash" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "query", "groups": { "0": "query" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://example.com/foo/bar/baz" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "https://other.com/foo/bar" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [ "http://other.com/foo/bar" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar", "baseURL": "https://example.com" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar/baz",
+                 "baseURL": "https://example.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar", "baseURL": "https://other.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "inputs": [{ "pathname": "/foo/bar", "baseURL": "http://example.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/([^\\/]+?)" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar" }],
+    "inputs": [{ "pathname": "/foo/index.html" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/index.html", "groups": { "bar": "index.html" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar" }],
+    "inputs": [{ "pathname": "/foo/bar/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "bar": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "bar": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "bar": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "bar": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "bar": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "bar": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**" }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo/bar/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo/bar/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*" }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "username": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "password": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "search": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hash": "(café)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "protocol": ":café" }],
+    "inputs": [{ "protocol": "foo" }],
+    "expected_match": {
+      "protocol": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "username": ":café" }],
+    "inputs": [{ "username": "foo" }],
+    "expected_match": {
+      "username": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "password": ":café" }],
+    "inputs": [{ "password": "foo" }],
+    "expected_match": {
+      "password": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hostname": ":café" }],
+    "inputs": [{ "hostname": "foo" }],
+    "expected_match": {
+      "hostname": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:café" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "search": ":café" }],
+    "inputs": [{ "search": "foo" }],
+    "expected_match": {
+      "search": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hash": ":café" }],
+    "inputs": [{ "hash": "foo" }],
+    "expected_match": {
+      "hash": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":\u2118" }],
+    "inputs": [{ "protocol": "foo" }],
+    "expected_match": {
+      "protocol": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "username": ":\u2118" }],
+    "inputs": [{ "username": "foo" }],
+    "expected_match": {
+      "username": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "password": ":\u2118" }],
+    "inputs": [{ "password": "foo" }],
+    "expected_match": {
+      "password": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hostname": ":\u2118" }],
+    "inputs": [{ "hostname": "foo" }],
+    "expected_match": {
+      "hostname": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:\u2118" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "search": ":\u2118" }],
+    "inputs": [{ "search": "foo" }],
+    "expected_match": {
+      "search": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hash": ":\u2118" }],
+    "inputs": [{ "hash": "foo" }],
+    "expected_match": {
+      "hash": { "input": "foo", "groups": { "\u2118": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":\u3400" }],
+    "inputs": [{ "protocol": "foo" }],
+    "expected_match": {
+      "protocol": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "username": ":\u3400" }],
+    "inputs": [{ "username": "foo" }],
+    "expected_match": {
+      "username": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "password": ":\u3400" }],
+    "inputs": [{ "password": "foo" }],
+    "expected_match": {
+      "password": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hostname": ":\u3400" }],
+    "inputs": [{ "hostname": "foo" }],
+    "expected_match": {
+      "hostname": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:\u3400" }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "search": ":\u3400" }],
+    "inputs": [{ "search": "foo" }],
+    "expected_match": {
+      "search": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hash": ":\u3400" }],
+    "inputs": [{ "hash": "foo" }],
+    "expected_match": {
+      "hash": { "input": "foo", "groups": { "\u3400": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": "(.*)" }],
+    "inputs": [{ "protocol" : "café" }],
+    "expected_obj": {
+      "protocol": "*"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "(.*)" }],
+    "inputs": [{ "protocol": "cafe" }],
+    "expected_obj": {
+      "protocol": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "cafe", "groups": { "0": "cafe" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "foo-bar" }],
+    "inputs": [{ "protocol": "foo-bar" }],
+    "expected_match": {
+      "protocol": { "input": "foo-bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "username": "caf%C3%A9" }],
+    "inputs": [{ "username" : "café" }],
+    "expected_match": {
+      "username": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "username": "café" }],
+    "inputs": [{ "username" : "café" }],
+    "expected_obj": {
+      "username": "caf%C3%A9"
+    },
+    "expected_match": {
+      "username": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "username": "caf%c3%a9" }],
+    "inputs": [{ "username" : "café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "password": "caf%C3%A9" }],
+    "inputs": [{ "password" : "café" }],
+    "expected_match": {
+      "password": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "password": "café" }],
+    "inputs": [{ "password" : "café" }],
+    "expected_obj": {
+      "password": "caf%C3%A9"
+    },
+    "expected_match": {
+      "password": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "password": "caf%c3%a9" }],
+    "inputs": [{ "password" : "café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "hostname": "xn--caf-dma.com" }],
+    "inputs": [{ "hostname" : "café.com" }],
+    "expected_match": {
+      "hostname": { "input": "xn--caf-dma.com", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "café.com" }],
+    "inputs": [{ "hostname" : "café.com" }],
+    "expected_obj": {
+      "hostname": "xn--caf-dma.com"
+    },
+    "expected_match": {
+      "hostname": { "input": "xn--caf-dma.com", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "protocol": { "input": "http", "groups": { "0": "http" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "http", "port": "80" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "http", "port": "80{20}?" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http", "port": "80 " }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http{s}?", "port": "80" }],
+    "inputs": [{ "protocol": "http", "port": "80" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "80" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "(.*)" }],
+    "inputs": [{ "port": "invalid80" }],
+    "expected_obj": {
+      "port": "*"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "/foo/./bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/baz" }],
+    "inputs": [{ "pathname": "/foo/bar/../baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/baz", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/caf%C3%A9" }],
+    "inputs": [{ "pathname": "/café" }],
+    "expected_match": {
+      "pathname": { "input": "/caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/café" }],
+    "inputs": [{ "pathname": "/café" }],
+    "expected_obj": {
+      "pathname": "/caf%C3%A9"
+    },
+    "expected_match": {
+      "pathname": { "input": "/caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/caf%c3%a9" }],
+    "inputs": [{ "pathname": "/café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [{ "pathname": "foo/bar", "baseURL": "https://example.com" }],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": { "0": "https" }},
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" }},
+      "pathname": { "input": "/foo/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/../bar" }],
+    "inputs": [{ "pathname": "/bar" }],
+    "expected_obj": {
+      "pathname": "/bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "./foo/bar", "baseURL": "https://example.com" }],
+    "inputs": [{ "pathname": "foo/bar", "baseURL": "https://example.com" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/foo/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "", "baseURL": "https://example.com" }],
+    "inputs": [{ "pathname": "/", "baseURL": "https://example.com" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{/bar}", "baseURL": "https://example.com/foo/" }],
+    "inputs": [{ "pathname": "./bar", "baseURL": "https://example.com/foo/" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "\\/bar", "baseURL": "https://example.com/foo/" }],
+    "inputs": [{ "pathname": "./bar", "baseURL": "https://example.com/foo/" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "b", "baseURL": "https://example.com/foo/" }],
+    "inputs": [{ "pathname": "./b", "baseURL": "https://example.com/foo/" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/foo/b"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/foo/b", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "foo/bar" }],
+    "inputs": [ "https://example.com/foo/bar" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "foo/bar", "baseURL": "https://example.com" }],
+    "inputs": [ "https://example.com/foo/bar" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/foo/bar", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":name.html", "baseURL": "https://example.com" }],
+    "inputs": [ "https://example.com/foo.html"] ,
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/:name.html"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {}},
+      "hostname": { "input": "example.com", "groups": {}},
+      "pathname": { "input": "/foo.html", "groups": { "name": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "search": "q=caf%C3%A9" }],
+    "inputs": [{ "search": "q=café" }],
+    "expected_match": {
+      "search": { "input": "q=caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "search": "q=café" }],
+    "inputs": [{ "search": "q=café" }],
+    "expected_obj": {
+      "search": "q=caf%C3%A9"
+    },
+    "expected_match": {
+      "search": { "input": "q=caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "search": "q=caf%c3%a9" }],
+    "inputs": [{ "search": "q=café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "hash": "caf%C3%A9" }],
+    "inputs": [{ "hash": "café" }],
+    "expected_match": {
+      "hash": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "hash": "café" }],
+    "inputs": [{ "hash": "café" }],
+    "expected_obj": {
+      "hash": "caf%C3%A9"
+    },
+    "expected_match": {
+      "hash": { "input": "caf%C3%A9", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "hash": "caf%c3%a9" }],
+    "inputs": [{ "hash": "café" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "about", "pathname": "(blank|sourcedoc)" }],
+    "inputs": [ "about:blank" ],
+    "expected_match": {
+      "protocol": { "input": "about", "groups": {}},
+      "pathname": { "input": "blank", "groups": { "0": "blank" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "data", "pathname": ":number([0-9]+)" }],
+    "inputs": [ "data:8675309" ],
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {}},
+      "pathname": { "input": "8675309", "groups": { "number": "8675309" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/(\\m)" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": "/foo!" }],
+    "inputs": [{ "pathname": "/foo!" }],
+    "expected_match": {
+      "pathname": { "input": "/foo!", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo\\:" }],
+    "inputs": [{ "pathname": "/foo:" }],
+    "expected_match": {
+      "pathname": { "input": "/foo:", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo\\{" }],
+    "inputs": [{ "pathname": "/foo{" }],
+    "expected_obj": {
+      "pathname": "/foo%7B"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo%7B", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo\\(" }],
+    "inputs": [{ "pathname": "/foo(" }],
+    "expected_match": {
+      "pathname": { "input": "/foo(", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "inputs": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "expected_match": {
+      "protocol": { "input": "javascript", "groups": {}},
+      "pathname": { "input": "var x = 1;", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "var x = 1;" }],
+    "inputs": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "expected_obj": {
+      "pathname": "var%20x%20=%201;"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "inputs": [{ "baseURL": "javascript:var x = 1;" }],
+    "expected_match": {
+      "protocol": { "input": "javascript", "groups": {}},
+      "pathname": { "input": "var x = 1;", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "(data|javascript)", "pathname": "var x = 1;" }],
+    "inputs": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "expected_match": {
+      "protocol": { "input": "javascript", "groups": {"0": "javascript"}},
+      "pathname": { "input": "var x = 1;", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "protocol": "(https|javascript)", "pathname": "var x = 1;" }],
+    "inputs": [{ "protocol": "javascript", "pathname": "var x = 1;" }],
+    "expected_obj": {
+      "pathname": "var%20x%20=%201;"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "var x = 1;" }],
+    "inputs": [{ "pathname": "var x = 1;" }],
+    "expected_obj": {
+      "pathname": "var%20x%20=%201;"
+    },
+    "expected_match": {
+      "pathname": { "input": "var%20x%20=%201;", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [ "./foo/bar", "https://example.com" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": { "0": "https" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }],
+    "inputs": [ { "pathname": "/foo/bar" }, "https://example.com" ],
+    "expected_match": "error"
+  },
+  {
+    "pattern": [ "https://example.com:8080/foo?bar#baz" ],
+    "inputs": [{ "pathname": "/foo", "search": "bar", "hash": "baz",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "*",
+      "password": "*",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "/foo?bar#baz", "https://example.com:8080" ],
+    "inputs": [{ "pathname": "/foo", "search": "bar", "hash": "baz",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": {
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "example.com/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "http{s}?://{*.}?example.com/:product/:endpoint" ],
+    "inputs": [ "https://sub.example.com/foo/bar" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http{s}?",
+      "hostname": "{*.}?example.com",
+      "pathname": "/:product/:endpoint"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "sub.example.com", "groups": { "0": "sub" } },
+      "pathname": { "input": "/foo/bar", "groups": { "product": "foo",
+                                                     "endpoint": "bar" } }
+    }
+  },
+  {
+    "pattern": [ "https://example.com?foo" ],
+    "inputs": [ "https://example.com/?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com#foo" ],
+    "inputs": [ "https://example.com/#foo" ],
+    "exactly_empty_components": [ "port", "search" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/",
+      "hash": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com:8080?foo" ],
+    "inputs": [ "https://example.com:8080/?foo" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com:8080#foo" ],
+    "inputs": [ "https://example.com:8080/#foo" ],
+    "exactly_empty_components": [ "search" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/",
+      "hash": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/?foo" ],
+    "inputs": [ "https://example.com/?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/#foo" ],
+    "inputs": [ "https://example.com/#foo" ],
+    "exactly_empty_components": [ "port", "search" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/",
+      "hash": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/*?foo" ],
+    "inputs": [ "https://example.com/?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/*?foo"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://example.com/*\\?foo" ],
+    "inputs": [ "https://example.com/?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/*",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "" } },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/:name?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/:name?foo"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://example.com/:name\\?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/:name",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/bar", "groups": { "name": "bar" } },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/(bar)?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/(bar)?foo"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://example.com/(bar)\\?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/(bar)",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/bar", "groups": { "0": "bar" } },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/{bar}?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/{bar}?foo"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://example.com/{bar}\\?foo" ],
+    "inputs": [ "https://example.com/bar?foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/bar",
+      "search": "foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/bar", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://example.com/" ],
+    "inputs": [ "https://example.com:8080/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "",
+      "pathname": "/"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "data:foobar" ],
+    "inputs": [ "data:foobar" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "data\\:foobar" ],
+    "inputs": [ "data:foobar" ],
+    "exactly_empty_components": [ "hostname", "port" ],
+    "expected_obj": {
+      "protocol": "data",
+      "pathname": "foobar"
+    },
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {} },
+      "pathname": { "input": "foobar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://{sub.}?example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "{sub.}?example.com",
+      "pathname": "/foo"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://{sub.}?example{.com/}foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "{https://}example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://(sub.)?example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "(sub.)?example.com",
+      "pathname": "/foo"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": { "0": null } },
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://(sub.)?example(.com/)foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "(sub.)?example(.com/)foo",
+      "pathname": "*"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "(https://)example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://{sub{.}}example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://(sub(?:.))?example.com/foo" ],
+    "inputs": [ "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "(sub(?:.))?example.com",
+      "pathname": "/foo"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": { "0": null } },
+      "pathname": { "input": "/foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "file:///foo/bar" ],
+    "inputs": [ "file:///foo/bar" ],
+    "exactly_empty_components": [ "hostname", "port" ],
+    "expected_obj": {
+      "protocol": "file",
+      "pathname": "/foo/bar"
+    },
+    "expected_match": {
+      "protocol": { "input": "file", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "data:" ],
+    "inputs": [ "data:" ],
+    "exactly_empty_components": [ "hostname", "port", "pathname" ],
+    "expected_obj": {
+      "protocol": "data"
+    },
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "foo://bar" ],
+    "inputs": [ "foo://bad_url_browser_interop" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "foo",
+      "hostname": "bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "(café)://foo" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://example.com/foo?bar#baz" ],
+    "inputs": [{ "protocol": "https:",
+                 "search": "?bar",
+                 "hash": "#baz",
+                 "baseURL": "http://example.com/foo" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http{s}?:",
+                  "search": "?bar",
+                  "hash": "#baz" }],
+    "inputs": [ "http://example.com/foo?bar#baz" ],
+    "expected_obj": {
+      "protocol": "http{s}?",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" }},
+      "pathname": { "input": "/foo", "groups": { "0": "/foo" }},
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "?bar#baz", "https://example.com/foo" ],
+    "inputs": [ "?bar#baz", "https://example.com/foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "?bar", "https://example.com/foo#baz" ],
+    "inputs": [ "?bar", "https://example.com/foo#snafu" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "#baz", "https://example.com/foo?bar" ],
+    "inputs": [ "#baz", "https://example.com/foo?bar" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "search": { "input": "bar", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "#baz", "https://example.com/foo" ],
+    "inputs": [ "#baz", "https://example.com/foo" ],
+    "exactly_empty_components": [ "port", "search" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/foo",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": {} },
+      "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*" }],
+    "inputs": [ "foo", "data:data-urls-cannot-be-base-urls" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "*" }],
+    "inputs": [ "foo", "not|a|valid|url" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [ "https://foo\\:bar@example.com" ],
+    "inputs": [ "https://foo:bar@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "foo",
+      "password": "bar",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "username": { "input": "foo", "groups": {} },
+      "password": { "input": "bar", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "https://foo@example.com" ],
+    "inputs": [ "https://foo@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "foo",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "username": { "input": "foo", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "https://\\:bar@example.com" ],
+    "inputs": [ "https://:bar@example.com" ],
+    "exactly_empty_components": [ "username", "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "password": "bar",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "password": { "input": "bar", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "https://:user::pass@example.com" ],
+    "inputs": [ "https://foo:bar@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": ":user",
+      "password": ":pass",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "username": { "input": "foo", "groups": { "user": "foo" } },
+      "password": { "input": "bar", "groups": { "pass": "bar" } },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "https\\:foo\\:bar@example.com" ],
+    "inputs": [ "https:foo:bar@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "foo",
+      "password": "bar",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "username": { "input": "foo", "groups": {} },
+      "password": { "input": "bar", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [ "data\\:foo\\:bar@example.com" ],
+    "inputs": [ "data:foo:bar@example.com" ],
+    "exactly_empty_components": [ "hostname", "port" ],
+    "expected_obj": {
+      "protocol": "data",
+      "pathname": "foo\\:bar@example.com"
+    },
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {} },
+      "pathname": { "input": "foo:bar@example.com", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "https://foo{\\:}bar@example.com" ],
+    "inputs": [ "https://foo:bar@example.com" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "username": "foo%3Abar",
+      "hostname": "example.com"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [ "data{\\:}channel.html", "https://example.com" ],
+    "inputs": [ "https://example.com/data:channel.html" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "pathname": "/data\\:channel.html",
+      "search": "*",
+      "hash": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/data:channel.html", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[\\:\\:1]/" ],
+    "inputs": [ "http://[::1]/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[\\:\\:1]",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::1]", "groups": {} },
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[\\:\\:1]:8080/" ],
+    "inputs": [ "http://[::1]:8080/" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[\\:\\:1]",
+      "port": "8080",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::1]", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[\\:\\:a]/" ],
+    "inputs": [ "http://[::a]/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[\\:\\:a]",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::a]", "groups": {} },
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[:address]/" ],
+    "inputs": [ "http://[::1]/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[:address]",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::1]", "groups": { "address": "::1" }},
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "http://[\\:\\:AB\\::num]/" ],
+    "inputs": [ "http://[::ab:1]/" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "[\\:\\:ab\\::num]",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "[::ab:1]", "groups": { "num": "1" }},
+      "pathname": { "input": "/", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hostname": "[\\:\\:AB\\::num]" }],
+    "inputs": [{ "hostname": "[::ab:1]" }],
+    "expected_obj": {
+      "hostname": "[\\:\\:ab\\::num]"
+    },
+    "expected_match": {
+      "hostname": { "input": "[::ab:1]", "groups": { "num": "1" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "[\\:\\:xY\\::num]" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "{[\\:\\:ab\\::num]}" }],
+    "inputs": [{ "hostname": "[::ab:1]" }],
+    "expected_match": {
+      "hostname": { "input": "[::ab:1]", "groups": { "num": "1" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "{[\\:\\:fé\\::num]}" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "{[\\:\\::num\\:1]}" }],
+    "inputs": [{ "hostname": "[::ab:1]" }],
+    "expected_match": {
+      "hostname": { "input": "[::ab:1]", "groups": { "num": "ab" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "{[\\:\\::num\\:fé]}" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "[*\\:1]" }],
+    "inputs": [{ "hostname": "[::ab:1]" }],
+    "expected_match": {
+      "hostname": { "input": "[::ab:1]", "groups": { "0": "::ab" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "*\\:1]" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://foo{{@}}example.com" ],
+    "inputs": [ "https://foo@example.com" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "https://foo{@example.com" ],
+    "inputs": [ "https://foo@example.com" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "data\\:text/javascript,let x = 100/:tens?5;" ],
+    "inputs": [ "data:text/javascript,let x = 100/5;" ],
+    "exactly_empty_components": [ "hostname", "port" ],
+    "expected_obj": {
+      "protocol": "data",
+      "pathname": "text/javascript,let x = 100/:tens?5;"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "protocol": { "input": "data", "groups": {} },
+      "pathname": { "input": "text/javascript,let x = 100/5;", "groups": { "tens": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:id/:id" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": "/foo", "baseURL": "" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [ "/foo", "" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": "/foo" }, "https://example.com" ],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "pathname": ":name*" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":name+" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":name" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":name*" }],
+    "inputs": [{ "protocol": "foobar" }],
+    "expected_match": {
+      "protocol": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":name+" }],
+    "inputs": [{ "protocol": "foobar" }],
+    "expected_match": {
+      "protocol": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":name" }],
+    "inputs": [{ "protocol": "foobar" }],
+    "expected_match": {
+      "protocol": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "hostname": "bad hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad#hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad%hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad/hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad\\:hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad<hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad>hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad?hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad@hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad[hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad]hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad\\\\hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad^hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad|hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad\nhostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad\rhostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad\thostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{}],
+    "inputs": ["https://example.com/"],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": { "0": "https" }},
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" }},
+      "pathname": { "input": "/", "groups": { "0": "/" }}
+    }
+  },
+  {
+    "pattern": [],
+    "inputs": ["https://example.com/"],
+    "expected_match": {
+      "protocol": { "input": "https", "groups": { "0": "https" }},
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" }},
+      "pathname": { "input": "/", "groups": { "0": "/" }}
+    }
+  },
+  {
+    "pattern": [],
+    "inputs": [{}],
+    "expected_match": {}
+  },
+  {
+    "pattern": [],
+    "inputs": [],
+    "expected_match": { "inputs": [{}] }
+  },
+  {
+    "pattern": [{ "pathname": "(foo)(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "0": "foo", "1": "barbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{(foo)bar}(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "0": "foo", "1": "baz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "(foo)?(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": "(foo)?*"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "0": "foo", "1": "barbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "f", "0": "oobarbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}(barbaz)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "foo", "0": "barbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}{(.*)}" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": "{:foo}(.*)"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "f", "0": "oobarbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}{(.*)bar}" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": ":foo{*bar}"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}{bar(.*)}" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": ":foo{bar*}"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "foo", "0": "baz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}:bar(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": ":foo:bar(.*)"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "f", "bar": "oobarbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}?(.*)" }],
+    "inputs": [{ "pathname": "foobarbaz" }],
+    "expected_obj": {
+      "pathname": ":foo?*"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobarbaz", "groups": { "foo": "f", "0": "oobarbaz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo\\bar}" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo\\.bar}" }],
+    "inputs": [{ "pathname": "foo.bar" }],
+    "expected_obj": {
+      "pathname": "{:foo.bar}"
+    },
+    "expected_match": {
+      "pathname": { "input": "foo.bar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo(foo)bar}" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "{:foo}bar" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo\\bar" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "{:foo}bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo{}(.*)" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "{:foo}(.*)"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "f", "0": "oobar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo{}bar" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "{:foo}bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo{}?bar" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "{:foo}bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "foo": "foo" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*{}**?" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_obj": {
+      "pathname": "*(.*)?"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "0": "foobar", "1": null }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo(baz)(.*)" }],
+    "inputs": [{ "pathname": "bazbar" }],
+    "expected_match": {
+      "pathname": { "input": "bazbar", "groups": { "foo": "baz", "0": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo(baz)bar" }],
+    "inputs": [{ "pathname": "bazbar" }],
+    "expected_match": {
+      "pathname": { "input": "bazbar", "groups": { "foo": "baz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*/*" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "foo/bar", "groups": { "0": "foo", "1": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*\\/*" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_obj": {
+      "pathname": "*/{*}"
+    },
+    "expected_match": {
+      "pathname": { "input": "foo/bar", "groups": { "0": "foo", "1": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*/{*}" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "foo/bar", "groups": { "0": "foo", "1": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "*//*" }],
+    "inputs": [{ "pathname": "foo/bar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/:foo." }],
+    "inputs": [{ "pathname": "/bar." }],
+    "expected_match": {
+      "pathname": { "input": "/bar.", "groups": { "foo": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:foo.." }],
+    "inputs": [{ "pathname": "/bar.." }],
+    "expected_match": {
+      "pathname": { "input": "/bar..", "groups": { "foo": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "./foo" }],
+    "inputs": [{ "pathname": "./foo" }],
+    "expected_match": {
+      "pathname": { "input": "./foo", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "../foo" }],
+    "inputs": [{ "pathname": "../foo" }],
+    "expected_match": {
+      "pathname": { "input": "../foo", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo./" }],
+    "inputs": [{ "pathname": "bar./" }],
+    "expected_match": {
+      "pathname": { "input": "bar./", "groups": { "foo": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":foo../" }],
+    "inputs": [{ "pathname": "bar../" }],
+    "expected_match": {
+      "pathname": { "input": "bar../", "groups": { "foo": "bar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/:foo\\bar" }],
+    "inputs": [{ "pathname": "/bazbar" }],
+    "expected_obj": {
+      "pathname": "{/:foo}bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "/bazbar", "groups": { "foo": "baz" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar" }, { "ignoreCase": true }],
+    "inputs": [{ "pathname": "/FOO/BAR" }],
+    "expected_match": {
+      "pathname": { "input": "/FOO/BAR", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "ignoreCase": true }],
+    "inputs": [{ "pathname": "/FOO/BAR" }],
+    "expected_match": {
+      "pathname": { "input": "/FOO/BAR", "groups": { "0": "/FOO/BAR" } }
+    }
+  },
+  {
+    "pattern": [ "https://example.com:8080/foo?bar#baz",
+                 { "ignoreCase": true }],
+    "inputs": [{ "pathname": "/FOO", "search": "BAR", "hash": "BAZ",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/FOO", "groups": {} },
+      "search": { "input": "BAR", "groups": {} },
+      "hash": { "input": "BAZ", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "/foo?bar#baz", "https://example.com:8080",
+                 { "ignoreCase": true }],
+    "inputs": [{ "pathname": "/FOO", "search": "BAR", "hash": "BAZ",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "example.com",
+      "port": "8080",
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/FOO", "groups": {} },
+      "search": { "input": "BAR", "groups": {} },
+      "hash": { "input": "BAZ", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "/foo?bar#baz", { "ignoreCase": true },
+                 "https://example.com:8080" ],
+    "inputs": [{ "pathname": "/FOO", "search": "BAR", "hash": "BAZ",
+                 "baseURL": "https://example.com:8080" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "search": "foo", "baseURL": "https://example.com/a/+/b" }],
+    "inputs": [{ "search": "foo", "baseURL": "https://example.com/a/+/b" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "pathname": "/a/\\+/b"
+    },
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/a/+/b", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "hash": "foo", "baseURL": "https://example.com/?q=*&v=?&hmm={}&umm=()" }],
+    "inputs": [{ "hash": "foo", "baseURL": "https://example.com/?q=*&v=?&hmm={}&umm=()" }],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "search": "q=\\*&v=\\?&hmm=\\{\\}&umm=\\(\\)"
+    },
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "q=*&v=?&hmm={}&umm=()", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "#foo", "https://example.com/?q=*&v=?&hmm={}&umm=()" ],
+    "inputs": [ "https://example.com/?q=*&v=?&hmm={}&umm=()#foo" ],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "search": "q=\\*&v=\\?&hmm=\\{\\}&umm=\\(\\)",
+      "hash": "foo"
+    },
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "q=*&v=?&hmm={}&umm=()", "groups": {} },
+      "hash": { "input": "foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/([[a-z]--a])" }],
+    "inputs": [{ "pathname": "/a" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/([[a-z]--a])" }],
+    "inputs": [{ "pathname": "/z" }],
+    "expected_match": {
+      "pathname": { "input": "/z", "groups": { "0": "z" } }
+    }
+  },
+    {
+    "pattern": [{ "pathname": "/([\\d&&[0-1]])" }],
+    "inputs": [{ "pathname": "/0" }],
+    "expected_match": {
+      "pathname": { "input": "/0", "groups": { "0": "0" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/([\\d&&[0-1]])" }],
+    "inputs": [{ "pathname": "/3" }],
+    "expected_match": null
+  }
+];
+
+const kComponents = [
+  'protocol',
+  'username',
+  'password',
+  'hostname',
+  'port',
+  'password',
+  'pathname',
+  'search',
+  'hash',
+];
+
+
+function executeURLPatternConstructor(jsonArray) {
+  // Iterate through each object in the array
+  jsonArray.forEach(entry => {
+
+    const pattern = new URLPattern(...entry.pattern);
+
+    entry.expected_obj = entry.expected_obj || {};
+
+    // The compiled URLPattern object should have a property for each
+    // component exposing the compiled pattern string.
+    for (let component of kComponents) {
+      // If the test case explicitly provides an expected pattern string,
+      // then use that.  This is necessary in cases where the original
+      // construction pattern gets canonicalized, etc.
+      let expected = entry.expected_obj[component];
+
+      // If there is no explicit expected pattern string, then compute
+      // the expected value based on the URLPattern constructor args.
+      if (expected == undefined) {
+        // First determine if there is a baseURL present in the pattern
+        // input.  A baseURL can be the source for many component patterns.
+        let baseURL = null;
+        if (entry.pattern.length > 0 && entry.pattern[0].baseURL) {
+          baseURL = new URL(entry.pattern[0].baseURL);
+        } else if (entry.pattern.length > 1 &&
+                  typeof entry.pattern[1] === 'string') {
+          baseURL = new URL(entry.pattern[1]);
+        }
+
+        const EARLIER_COMPONENTS = {
+          protocol: [],
+          hostname: ["protocol"],
+          port: ["protocol", "hostname"],
+          username: [],
+          password: [],
+          pathname: ["protocol", "hostname", "port"],
+          search: ["protocol", "hostname", "port", "pathname"],
+          hash: ["protocol", "hostname", "port", "pathname", "search"],
+        };
+
+        // We automatically populate the expected pattern string using
+        // the following options in priority order:
+        //
+        //  1. If the original input explicitly provided a pattern, then
+        //     echo that back as the expected value.
+        //  2. If an "earlier" component is specified, then a wildcard
+        //     will be used rather than inheriting from the base URL.
+        //  3. If the baseURL exists and provides a component value then
+        //     use that for the expected pattern.
+        //  4. Otherwise fall back on the default pattern of `*` for an
+        //     empty component pattern.
+        //
+        // Note that username and password are never inherited, and will only
+        // need to match if explicitly specified.
+        if (entry.exactly_empty_components &&
+            entry.exactly_empty_components.includes(component)) {
+          expected = '';
+        } else if (typeof entry.pattern[0] === 'object' &&
+            entry.pattern[0][component]) {
+          expected = entry.pattern[0][component];
+        } else if (typeof entry.pattern[0] === 'object' &&
+            EARLIER_COMPONENTS[component].some(c => c in entry.pattern[0])) {
+          expected = '*';
+        } else if (baseURL && component !== 'username' && component !== 'password') {
+          let base_value = baseURL[component];
+          // Unfortunately some URL() getters include separator chars; e.g.
+          // the trailing `:` for the protocol.  Strip those off if necessary.
+          if (component === 'protocol')
+            base_value = base_value.substring(0, base_value.length - 1);
+          else if (component === 'search' || component === 'hash')
+            base_value = base_value.substring(1, base_value.length);
+          expected = base_value;
+        } else {
+          expected = '*';
+        }
+      }
+        newComponent = component;
+        expectedValue = expected;
+        urlPatternComponent = pattern[component];
+
+        debug(`Component: ${newComponent}`); 
+        shouldBeEqualToString("urlPatternComponent", expectedValue);
+      }
+
+
+  });
+}
+
+executeURLPatternConstructor(jsonData);
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 8c8bc4180463af204120fae9c28f7e2f13372923
<pre>
Add URLPattern Component testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=282779">https://bugs.webkit.org/show_bug.cgi?id=282779</a>
<a href="https://rdar.apple.com/139471135">rdar://139471135</a>

Reviewed by Chris Dumez.

Add separate testing for URLPattern constructor

* LayoutTests/fast/urlpattern/urlpattern-component-expected.txt: Added.
* LayoutTests/fast/urlpattern/urlpattern-component.html: Added.

Canonical link: <a href="https://commits.webkit.org/286336@main">https://commits.webkit.org/286336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35f7ff0683ab9cc2ff0acdfa635d76f2de5cbece

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75605 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80085 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26869 "Built successfully") 
| | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59290 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17480 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78672 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64930 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39652 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22415 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25198 "Built successfully") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22756 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81564 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67531 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3095 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66831 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10793 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8934 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11681 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2901 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2926 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3861 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2933 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->