### PR TITLE
[CSS] @scope start/end are normal (non forgiving) selector list

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/at-scope-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/at-scope-parsing-expected.txt
@@ -14,17 +14,17 @@ PASS @scope (.a) to (& > &) is valid
 PASS @scope (.a) to (> .b) is valid
 PASS @scope (.a) to (+ .b) is valid
 PASS @scope (.a) to (~ .b) is valid
-FAIL @scope () is not valid assert_equals: expected 0 but got 1
-FAIL @scope to () is not valid assert_equals: expected 0 but got 1
-FAIL @scope () to () is not valid assert_equals: expected 0 but got 1
-FAIL @scope (.c <> .d) is not valid assert_equals: expected 0 but got 1
-FAIL @scope (.a, .c <> .d) is not valid assert_equals: expected 0 but got 1
-FAIL @scope (.a <> .b, .c) is not valid assert_equals: expected 0 but got 1
+PASS @scope () is not valid
+PASS @scope to () is not valid
+PASS @scope () to () is not valid
+PASS @scope (.c <> .d) is not valid
+PASS @scope (.a, .c <> .d) is not valid
+PASS @scope (.a <> .b, .c) is not valid
 FAIL @scope (div::before) is not valid assert_equals: expected 0 but got 1
 FAIL @scope (div::after) is not valid assert_equals: expected 0 but got 1
-FAIL @scope (slotted(div)) is not valid assert_equals: expected 0 but got 1
+PASS @scope (slotted(div)) is not valid
 FAIL @scope (.a) to (div::before) is not valid assert_equals: expected 0 but got 1
-FAIL @scope (> &) to (>>) is not valid assert_equals: expected 0 but got 1
+PASS @scope (> &) to (>>) is not valid
 PASS @scope div is not valid
 PASS @scope (.a) unknown (.c) is not valid
 PASS @scope (.a) to unknown (.c) is not valid

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -1067,7 +1067,7 @@ RefPtr<StyleRuleScope> CSSParserImpl::consumeScopeRule(CSSParserTokenRange prelu
                 CSSParserTokenRange selectorListRange = prelude.makeSubRange(selectorListRangeStart, &prelude.peek());
 
                 // Parse the selector list range
-                auto mutableSelectorList = parseMutableCSSSelectorList(selectorListRange, m_context, protectedStyleSheet().get(), ancestorRuleType, CSSParserEnum::IsForgiving::Yes);
+                auto mutableSelectorList = parseMutableCSSSelectorList(selectorListRange, m_context, protectedStyleSheet().get(), ancestorRuleType, CSSParserEnum::IsForgiving::No);
                 if (mutableSelectorList.isEmpty())
                     return false;
 


### PR DESCRIPTION
#### 944256f16387a1e79705e53d40ebb21c6766a7ac
<pre>
[CSS] @scope start/end are normal (non forgiving) selector list
<a href="https://bugs.webkit.org/show_bug.cgi?id=282781">https://bugs.webkit.org/show_bug.cgi?id=282781</a>
<a href="https://rdar.apple.com/139471866">rdar://139471866</a>

Reviewed by Ryan Reno.

<a href="https://github.com/w3c/csswg-drafts/commit/9a7b555711b2405b67e963d1c7494cc2917e4c15">https://github.com/w3c/csswg-drafts/commit/9a7b555711b2405b67e963d1c7494cc2917e4c15</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/at-scope-parsing-expected.txt:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeScopeRule):

Canonical link: <a href="https://commits.webkit.org/286393@main">https://commits.webkit.org/286393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c7259bd88bcea24bfdb5c6e80c7b7eb09eb1f30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75563 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80043 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26827 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77679 "Passed tests") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59271 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17461 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78630 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39629 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22396 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25155 "Built successfully") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81522 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2902 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1834 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67510 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66807 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16707 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10763 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8920 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2859 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5681 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2884 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3819 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2891 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->