### PR TITLE
Pipe pas-heap configs through PAS_PROFILE macros

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
@@ -246,7 +246,7 @@ static PAS_ALWAYS_INLINE pas_bitfit_allocation_result pas_bitfit_page_finish_all
     
     pas_bitfit_page_testing_verify(page);
 
-    PAS_PROFILE(BITFIT_ALLOCATION, begin, size, allocation_mode);
+    PAS_PROFILE(BITFIT_ALLOCATION, &page_config, begin, size, allocation_mode);
 
     return pas_bitfit_allocation_result_create_success(begin);
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_deallocate.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_deallocate.c
@@ -42,7 +42,7 @@ bool pas_try_deallocate_known_large(void* ptr,
     uintptr_t begin;
 
     begin = (uintptr_t)ptr;
-    PAS_PROFILE(TRY_DEALLOCATE_KNOWN_LARGE, begin);
+    PAS_PROFILE(TRY_DEALLOCATE_KNOWN_LARGE, config, begin);
     
     pas_heap_lock_lock();
     

--- a/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
@@ -196,7 +196,7 @@ static PAS_ALWAYS_INLINE bool pas_try_deallocate(void* ptr,
     uintptr_t begin;
 
     begin = (uintptr_t)ptr;
-    PAS_PROFILE(TRY_DEALLOCATE, begin);
+    PAS_PROFILE(TRY_DEALLOCATE, &config, begin);
     ptr = (void*)begin;
 
     if (verbose)

--- a/Source/bmalloc/libpas/src/libpas/pas_get_allocation_size.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_get_allocation_size.h
@@ -123,7 +123,7 @@ static PAS_ALWAYS_INLINE size_t pas_get_allocation_size(void* ptr,
         entry = pas_large_map_find(begin);
         
         if (!pas_large_map_entry_is_empty(entry)) {
-            PAS_PROFILE(LARGE_MAP_FOUND_ENTRY, entry.begin, entry.end);
+            PAS_PROFILE(LARGE_MAP_FOUND_ENTRY, &config, entry.begin, entry.end);
             PAS_ASSERT(entry.begin == begin);
             PAS_ASSERT(entry.end > begin);
             

--- a/Source/bmalloc/libpas/src/libpas/pas_get_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_get_heap.h
@@ -109,7 +109,7 @@ static PAS_ALWAYS_INLINE pas_heap* pas_get_heap(void* ptr,
         entry = pas_large_map_find(begin);
         
         PAS_ASSERT(!pas_large_map_entry_is_empty(entry));
-        PAS_PROFILE(LARGE_MAP_FOUND_ENTRY, entry.begin, entry.end);
+        PAS_PROFILE(LARGE_MAP_FOUND_ENTRY, &config, entry.begin, entry.end);
         PAS_ASSERT(entry.begin == begin);
         PAS_ASSERT(entry.end > begin);
         

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
@@ -148,7 +148,7 @@ static pas_allocation_result allocate_impl(pas_large_heap* heap,
     }
 
     PAS_ASSERT(pas_is_aligned(result.begin, *alignment));
-    PAS_PROFILE(LARGE_HEAP_ALLOCATION, result.begin, *size, allocation_mode);
+    PAS_PROFILE(LARGE_HEAP_ALLOCATION, heap_config, result.begin, *size, allocation_mode);
     
     return result;
 }
@@ -226,7 +226,7 @@ bool pas_large_heap_try_deallocate(uintptr_t begin,
         return false;
     }
 
-    PAS_PROFILE(LARGE_MAP_TOOK_ENTRY, map_entry.begin, map_entry.end);
+    PAS_PROFILE(LARGE_MAP_TOOK_ENTRY, heap_config, map_entry.begin, map_entry.end);
     PAS_ASSERT(pas_heap_config_kind_get_config(
                    pas_heap_for_large_heap(map_entry.heap)->config_kind)
                == heap_config);
@@ -269,7 +269,7 @@ bool pas_large_heap_try_shrink(uintptr_t begin,
     if (pas_large_map_entry_is_empty(map_entry))
         return false;
 
-    PAS_PROFILE(LARGE_MAP_TOOK_ENTRY, map_entry.begin, map_entry.end);
+    PAS_PROFILE(LARGE_MAP_TOOK_ENTRY, heap_config, map_entry.begin, map_entry.end);
     heap = map_entry.heap;
     type = pas_heap_for_large_heap(heap)->type;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -896,7 +896,7 @@ pas_local_allocator_try_allocate_in_primordial_partial_view(
         page_config);
 
     if (result.did_succeed) {
-        PAS_PROFILE(PRIMORDIAL_BUMP_ALLOCATION, result.begin, allocator->object_size, allocation_mode);
+        PAS_PROFILE(PRIMORDIAL_BUMP_ALLOCATION, &page_config, result.begin, allocator->object_size, allocation_mode);
     }
 
     pas_lock_switch(&held_lock, NULL);
@@ -1494,7 +1494,7 @@ pas_local_allocator_try_allocate_with_free_bits(
             (void*)result);
     }
 
-    PAS_PROFILE(LOCAL_FREEBITS_ALLOCATION, result, allocator->object_size, allocation_mode);
+    PAS_PROFILE(LOCAL_FREEBITS_ALLOCATION, &page_config, result, allocator->object_size, allocation_mode);
     
     return pas_allocation_result_create_success(result);
 }
@@ -1539,7 +1539,7 @@ pas_local_allocator_try_allocate_inline_cases(pas_local_allocator* allocator,
         if (verbose)
             pas_log("Returning bump allocation %p.\n", (void*)result);
 
-        PAS_PROFILE(LOCAL_BUMP_ALLOCATION, result, object_size, allocation_mode);
+        PAS_PROFILE(LOCAL_BUMP_ALLOCATION, &config, result, object_size, allocation_mode);
         return pas_allocation_result_create_success(result);
     }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
@@ -139,7 +139,7 @@ pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* la
     uint8_t right_align = pas_get_fast_random(2);
 
     uintptr_t key = (right_align ? (result.begin + page_size + mem_to_waste) : (result.begin + page_size));
-    PAS_PROFILE(PGM_ALLOCATE, key);
+    PAS_PROFILE(PGM_ALLOCATE, heap_config, key);
 
     /* create struct to hold hash map value */
     pas_pgm_storage *value = pas_utility_heap_try_allocate(sizeof(pas_pgm_storage), "pas_pgm_hash_map_VALUE");

--- a/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
@@ -210,7 +210,7 @@ pas_try_reallocate(void* old_ptr,
 {
     uintptr_t begin;
     begin = (uintptr_t)old_ptr;
-    PAS_PROFILE(TRY_REALLOCATE, begin);
+    PAS_PROFILE(TRY_REALLOCATE, &config, begin);
     old_ptr = (void*)begin;
 
     switch (config.fast_megapage_kind_func(begin)) {


### PR DESCRIPTION
#### 291b0b6188a0396e6f8e25b20806480329ac679f
<pre>
Pipe pas-heap configs through PAS_PROFILE macros
<a href="https://bugs.webkit.org/show_bug.cgi?id=282786">https://bugs.webkit.org/show_bug.cgi?id=282786</a>
<a href="https://rdar.apple.com/139474307">rdar://139474307</a>

Reviewed by David Degazio.

This is helpful to have because it allows us to discriminate on heap
size/type when generating profiling data.

* Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h:
(pas_bitfit_page_finish_allocation):
* Source/bmalloc/libpas/src/libpas/pas_deallocate.c:
(pas_try_deallocate_known_large):
* Source/bmalloc/libpas/src/libpas/pas_deallocate.h:
(pas_try_deallocate):
* Source/bmalloc/libpas/src/libpas/pas_get_allocation_size.h:
(pas_get_allocation_size):
* Source/bmalloc/libpas/src/libpas/pas_get_heap.h:
(pas_get_heap):
* Source/bmalloc/libpas/src/libpas/pas_large_heap.c:
(allocate_impl):
(pas_large_heap_try_deallocate):
(pas_large_heap_try_shrink):
* Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h:
(pas_local_allocator_try_allocate_in_primordial_partial_view):
(pas_local_allocator_try_allocate_with_free_bits):
(pas_local_allocator_try_allocate_inline_cases):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_allocate):
* Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h:
(pas_try_reallocate):

Canonical link: <a href="https://commits.webkit.org/286383@main">https://commits.webkit.org/286383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d22717e8add70cada77ae43c184231b62a115cf9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75738 "2 style errors") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/28589 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Running apply-patch; Checked out pull request; compiling") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/80227 "Build was cancelled. Recent messages:Printed configuration") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27011 "Built successfully") 
| | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3026 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/80227 "Build was cancelled. Recent messages:Printed configuration") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17573 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78805 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/28589 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Running apply-patch; Checked out pull request; compiling") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/80227 "Build was cancelled. Recent messages:Printed configuration") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/28589 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Running apply-patch; Checked out pull request; compiling") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25331 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/68888 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/28589 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Running apply-patch; Checked out pull request; compiling") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/81697 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/75000 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/3077 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0; Running apply-patch; Failed to checkout and rebase branch from PR 36352") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1954 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/81697 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/3228 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/28589 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Running apply-patch; Checked out pull request; compiling") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/81697 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/28589 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Running apply-patch; Checked out pull request; compiling") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97268 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11719 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/3034 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21267 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/3060 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/3994 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 36352") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3070 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->