### PR TITLE
REGRESSION (62bde3c): Crash under -[WKWebExtensionAction iconForSize:].

### DIFF
--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <WebCore/Icon.h>
 #import <wtf/HashSet.h>
 #import <wtf/OptionSet.h>
 #import <wtf/RetainPtr.h>
@@ -106,6 +107,11 @@ inline std::optional<String> toOptional(NSString *maybeNil)
     if (maybeNil)
         return maybeNil;
     return std::nullopt;
+}
+
+inline CocoaImage *toCocoaImage(RefPtr<WebCore::Icon> icon)
+{
+    return icon ? icon->image().get() : nil;
 }
 
 enum class JSONOptions {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
@@ -223,16 +223,12 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
 
 - (CocoaImage *)iconForSize:(CGSize)size
 {
-    if (RefPtr icon = self._protectedWebExtension->icon(WebCore::FloatSize(size)))
-        return icon->image().get();
-    return nil;
+    return WebKit::toCocoaImage(self._protectedWebExtension->icon(WebCore::FloatSize(size)));
 }
 
 - (CocoaImage *)actionIconForSize:(CGSize)size
 {
-    if (RefPtr icon = self._protectedWebExtension->actionIcon(WebCore::FloatSize(size)))
-        return icon->image().get();
-    return nil;
+    return WebKit::toCocoaImage(self._protectedWebExtension->actionIcon(WebCore::FloatSize(size)));
 }
 
 - (NSSet<WKWebExtensionPermission> *)requestedPermissions

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm
@@ -30,6 +30,7 @@
 #import "config.h"
 #import "WKWebExtensionActionInternal.h"
 
+#import "CocoaHelpers.h"
 #import "CocoaImage.h"
 #import "WebExtensionAction.h"
 #import "WebExtensionContext.h"
@@ -77,7 +78,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionAction, WebExtensionAction, 
 
 - (CocoaImage *)iconForSize:(CGSize)size
 {
-    return self._protectedWebExtensionAction->icon(WebCore::FloatSize(size))->image().get();
+    return WebKit::toCocoaImage(self._protectedWebExtensionAction->icon(WebCore::FloatSize(size)));
 }
 
 - (NSString *)label

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.mm
@@ -22,6 +22,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 #if !__has_feature(objc_arc)
 #error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
 #endif
@@ -29,6 +30,8 @@
 #import "config.h"
 #import "_WKWebExtensionSidebarInternal.h"
 
+#import "CocoaHelpers.h"
+#import "CocoaImage.h"
 #import "WebExtensionContext.h"
 #import "WebExtensionSidebar.h"
 #import "WebExtensionTab.h"
@@ -53,19 +56,10 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionSidebar, WebExtensionSideba
     return _webExtensionSidebar->title();
 }
 
-#if PLATFORM(MAC)
-- (NSImage *)iconForSize:(CGSize)size
+- (CocoaImage *)iconForSize:(CGSize)size
 {
-    return _webExtensionSidebar->icon(WebCore::FloatSize(size))->image().get();
+    return WebKit::toCocoaImage(_webExtensionSidebar->icon(WebCore::FloatSize(size)));
 }
-#endif
-
-#if PLATFORM(IOS_FAMILY)
-- (UIImage *)iconForSize:(CGSize)size
-{
-    return _webExtensionSidebar->icon(WebCore::FloatSize(size))->image().get();
-}
-#endif
 
 - (SidebarViewControllerType *)viewController
 {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
@@ -32,6 +32,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#import "CocoaHelpers.h"
 #import "WebExtension.h"
 #import "WebExtensionContext.h"
 #import "WebExtensionMenuItem.h"
@@ -281,10 +282,8 @@ CocoaMenuItem *WebExtensionCommand::platformMenuItem() const
 
     result.keyEquivalent = activationKey();
     result.keyEquivalentModifierMask = modifierFlags().toRaw();
-    if (RefPtr context = extensionContext()) {
-        if (RefPtr icon = context->extension().icon(WebCore::FloatSize(16, 16)))
-            result.image = icon->image().get();
-    }
+    if (RefPtr context = extensionContext())
+        result.image = toCocoaImage(context->extension().icon(WebCore::FloatSize(16, 16)));
 
     return result;
 #else

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
@@ -275,11 +275,6 @@ NSArray *WebExtensionMenuItem::matchingPlatformMenuItems(const MenuItemVector& m
     }).get();
 }
 
-static inline CocoaImage* toCocoaImage(RefPtr<WebCore::Icon> icon)
-{
-    return icon ? icon->image().get() : nil;
-}
-
 CocoaMenuItem *WebExtensionMenuItem::platformMenuItem(const WebExtensionMenuItemContextParameters& contextParameters, WebExtensionMenuItem::ForceUnchecked forceUnchecked) const
 {
     ASSERT(extensionContext());

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -1595,7 +1595,7 @@ RefPtr<WebCore::Icon> WebExtension::actionIcon(WebCore::FloatSize size)
     }
 
     if (!actionObject)
-        return nullptr;
+        return icon(size);
 
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
     if (actionObject->getValue(iconVariantsManifestKey)) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -292,6 +292,10 @@ TEST(WKWebExtension, SingleIconVariant)
     auto *icon = [testExtension iconForSize:CGSizeMake(32, 32)];
     EXPECT_NOT_NULL(icon);
     EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(32, 32)));
+
+    icon = [testExtension actionIconForSize:CGSizeMake(32, 32)];
+    EXPECT_NOT_NULL(icon);
+    EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(32, 32)));
 }
 
 TEST(WKWebExtension, AnySizeIconVariant)
@@ -320,6 +324,10 @@ TEST(WKWebExtension, AnySizeIconVariant)
     auto *icon = [testExtension iconForSize:CGSizeMake(64, 64)];
     EXPECT_NOT_NULL(icon);
     EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(64, 64)));
+
+    icon = [testExtension actionIconForSize:CGSizeMake(64, 64)];
+    EXPECT_NOT_NULL(icon);
+    EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(64, 64)));
 }
 
 TEST(WKWebExtension, NoIconVariants)
@@ -336,6 +344,9 @@ TEST(WKWebExtension, NoIconVariants)
     EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     auto *icon = [testExtension iconForSize:CGSizeMake(32, 32)];
+    EXPECT_NULL(icon);
+
+    icon = [testExtension actionIconForSize:CGSizeMake(32, 32)];
     EXPECT_NULL(icon);
 }
 
@@ -369,6 +380,11 @@ TEST(WKWebExtension, IconsAndIconVariantsSpecified)
     EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     auto *icon = [testExtension iconForSize:CGSizeMake(32, 32)];
+    EXPECT_NOT_NULL(icon);
+    EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(32, 32)));
+    EXPECT_TRUE(Util::compareColors(Util::pixelColor(icon), [CocoaColor whiteColor]));
+
+    icon = [testExtension actionIconForSize:CGSizeMake(32, 32)];
     EXPECT_NOT_NULL(icon);
     EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(32, 32)));
     EXPECT_TRUE(Util::compareColors(Util::pixelColor(icon), [CocoaColor whiteColor]));
@@ -460,6 +476,9 @@ TEST(WKWebExtension, ActionIconSingleVariant)
     EXPECT_NOT_NULL(icon);
     EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(32, 32)));
     EXPECT_TRUE(Util::compareColors(Util::pixelColor(icon), [CocoaColor whiteColor]));
+
+    icon = [testExtension iconForSize:CGSizeMake(32, 32)];
+    EXPECT_NULL(icon);
 }
 
 TEST(WKWebExtension, ActionIconAnySizeVariant)
@@ -490,6 +509,9 @@ TEST(WKWebExtension, ActionIconAnySizeVariant)
     auto *icon = [testExtension actionIconForSize:CGSizeMake(64, 64)];
     EXPECT_NOT_NULL(icon);
     EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(64, 64)));
+
+    icon = [testExtension iconForSize:CGSizeMake(32, 32)];
+    EXPECT_NULL(icon);
 }
 
 TEST(WKWebExtension, ActionNoIconVariants)
@@ -506,6 +528,9 @@ TEST(WKWebExtension, ActionNoIconVariants)
     EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 
     auto *icon = [testExtension actionIconForSize:CGSizeMake(32, 32)];
+    EXPECT_NULL(icon);
+
+    icon = [testExtension iconForSize:CGSizeMake(32, 32)];
     EXPECT_NULL(icon);
 }
 
@@ -543,6 +568,9 @@ TEST(WKWebExtension, ActionIconsAndIconVariantsSpecified)
     EXPECT_NOT_NULL(icon);
     EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(32, 32)));
     EXPECT_TRUE(Util::compareColors(Util::pixelColor(icon), [CocoaColor whiteColor]));
+
+    icon = [testExtension iconForSize:CGSizeMake(32, 32)];
+    EXPECT_NULL(icon);
 }
 #endif // ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
 


### PR DESCRIPTION
#### b8e051cd9c342531744a43a8b59fb973bd9e0e6d
<pre>
REGRESSION (62bde3c): Crash under -[WKWebExtensionAction iconForSize:].
<a href="https://webkit.org/b/282789">https://webkit.org/b/282789</a>
<a href="https://rdar.apple.com/139467453">rdar://139467453</a>

Reviewed by Brian Weinstein and Abrar Rahman Protyasha.

Change WebExtension::actionIcon() to return icon() when no action is
provided in the manifest.

Also use the toCocoaImage() helper everywhere, to avoid manual nil checks.
The nil check was missing in WKWebExtensionAction and _WKWebExtensionSidebar.

* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
(WebKit::toCocoaImage): Added.
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm:
(-[WKWebExtension iconForSize:]): Use toCocoaImage().
(-[WKWebExtension actionIconForSize:]): Ditto.
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm:
(-[WKWebExtensionAction iconForSize:]): Use toCocoaImage().
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.mm:
(-[_WKWebExtensionSidebar iconForSize:]): Use toCocoaImage().
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm:
(WebKit::WebExtensionCommand::platformMenuItem const): Use toCocoaImage().
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm:
(WebKit::toCocoaImage): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::actionIcon): Return icon() instead of nullptr.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST(WKWebExtension, SingleIconVariant)): Added actionIcon test.
(TestWebKitAPI::TEST(WKWebExtension, AnySizeIconVariant)): Ditto.
(TestWebKitAPI::TEST(WKWebExtension, NoIconVariants)): Ditto.
(TestWebKitAPI::TEST(WKWebExtension, IconsAndIconVariantsSpecified)): Ditto.
(TestWebKitAPI::TEST(WKWebExtension, ActionIconSingleVariant)): Added icon test.
(TestWebKitAPI::TEST(WKWebExtension, ActionIconAnySizeVariant)): Ditto.
(TestWebKitAPI::TEST(WKWebExtension, ActionNoIconVariants)): Ditto.
(TestWebKitAPI::TEST(WKWebExtension, ActionIconsAndIconVariantsSpecified)): Ditto.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithBadPath)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithBadImageData)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithBadDataURL)): Added.

Canonical link: <a href="https://commits.webkit.org/286356@main">https://commits.webkit.org/286356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba541ae434a24014605a279cbefaa033c7a6aee7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75723 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80211 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26987 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; compiling") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77839 "Passed tests") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3011 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59403 "Build is in progress. Recent messages:Printed configuration") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/26987 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; compiling") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78790 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65049 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39757 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22528 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/25316 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81682 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3062 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1946 "Build is in progress. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67631 "Build is in progress. Recent messages:Printed configuration") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3213 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65017 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/66932 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10881 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11697 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3019 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5859 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3044 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/3979 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3051 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->