### PR TITLE
AX: AXCoreObject::m_id should not be optional

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -469,7 +469,6 @@ accessibility/AccessibilityRenderObject.cpp
 accessibility/AccessibilitySVGObject.cpp
 accessibility/AccessibilitySVGRoot.cpp
 accessibility/AccessibilityScrollView.cpp
-accessibility/AccessibilityScrollbar.cpp
 accessibility/AccessibilitySlider.cpp
 accessibility/AccessibilitySpinButton.cpp
 accessibility/AccessibilityTable.cpp

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -732,8 +732,7 @@ public:
     virtual ~AXCoreObject() = default;
     virtual String dbg() const = 0;
 
-    void setObjectID(AXID axID) { m_id = axID; }
-    std::optional<AXID> objectID() const { return m_id; }
+    AXID objectID() const { return m_id; }
     virtual std::optional<AXID> treeID() const = 0;
     virtual ProcessID processID() const = 0;
 
@@ -1388,8 +1387,8 @@ public:
 #endif
 
 protected:
-    AXCoreObject() = default;
-    explicit AXCoreObject(std::optional<AXID> axID)
+    AXCoreObject() = delete;
+    explicit AXCoreObject(AXID axID)
         : m_id(axID)
     { }
 
@@ -1398,7 +1397,7 @@ private:
     virtual void detachRemoteParts(AccessibilityDetachmentType) = 0;
     virtual void detachPlatformWrapper(AccessibilityDetachmentType) = 0;
 
-    Markable<AXID> m_id;
+    AXID m_id;
 #if PLATFORM(COCOA)
     RetainPtr<WebAccessibilityObjectWrapper> m_wrapper;
 #elif PLATFORM(WIN)
@@ -1413,7 +1412,7 @@ private:
 inline Vector<AXID> axIDs(const AXCoreObject::AccessibilityChildrenVector& objects)
 {
     return WTF::map(objects, [](auto& object) {
-        return *object->objectID();
+        return object->objectID();
     });
 }
 

--- a/Source/WebCore/accessibility/AXImage.cpp
+++ b/Source/WebCore/accessibility/AXImage.cpp
@@ -37,14 +37,14 @@
 
 namespace WebCore {
 
-AXImage::AXImage(RenderImage& renderer)
-    : AccessibilityRenderObject(renderer)
+AXImage::AXImage(AXID axID, RenderImage& renderer)
+    : AccessibilityRenderObject(axID, renderer)
 {
 }
 
-Ref<AXImage> AXImage::create(RenderImage& renderer)
+Ref<AXImage> AXImage::create(AXID axID, RenderImage& renderer)
 {
-    return adoptRef(*new AXImage(renderer));
+    return adoptRef(*new AXImage(axID, renderer));
 }
 
 AccessibilityRole AXImage::determineAccessibilityRole()

--- a/Source/WebCore/accessibility/AXImage.h
+++ b/Source/WebCore/accessibility/AXImage.h
@@ -35,11 +35,11 @@ namespace WebCore {
 
 class AXImage : public AccessibilityRenderObject {
 public:
-    static Ref<AXImage> create(RenderImage&);
+    static Ref<AXImage> create(AXID, RenderImage&);
     virtual ~AXImage() = default;
 
 private:
-    explicit AXImage(RenderImage&);
+    explicit AXImage(AXID, RenderImage&);
 
     AccessibilityRole determineAccessibilityRole() final;
     std::optional<AccessibilityChildrenVector> imageOverlayElements() override;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -414,7 +414,7 @@ TextStream& operator<<(TextStream& stream, const AccessibilitySearchCriteria& cr
     TextStream::GroupScope groupScope(stream);
     auto streamCriteriaObject = [&stream] (ASCIILiteral objectLabel, auto* axObject) {
         stream.startGroup();
-        stream << objectLabel.characters() << " " << axObject << ", ID " << (axObject && axObject->objectID() ? axObject->objectID()->toUInt64() : 0);
+        stream << objectLabel.characters() << " " << axObject << ", ID " << (axObject ? axObject->objectID().toUInt64() : 0);
         stream.endGroup();
     };
 
@@ -1303,7 +1303,7 @@ void streamAXCoreObject(TextStream& stream, const AXCoreObject& object, const Op
 
     if (options & AXStreamOptions::ParentID) {
         auto* parent = object.parentObjectUnignored();
-        stream.dumpProperty("parentID", parent && parent->objectID()? parent->objectID()->toUInt64() : 0);
+        stream.dumpProperty("parentID", parent ? parent->objectID().toUInt64() : 0);
     }
 
     auto id = options & AXStreamOptions::IdentifierAttribute ? object.identifierAttribute() : emptyString();

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -58,6 +58,8 @@ class TextStream;
 namespace WebCore {
 
 class AXRemoteFrame;
+class AccessibilityNodeObject;
+class AccessibilityRenderObject;
 class AccessibilityTable;
 class AccessibilityTableCell;
 class Document;
@@ -300,7 +302,7 @@ public:
 
     // used for objects without backing elements
     AccessibilityObject* create(AccessibilityRole);
-    
+
     // Will only return the AccessibilityObject if it already exists.
     inline AccessibilityObject* get(RenderObject* renderer)
     {
@@ -673,8 +675,7 @@ private:
     AccessibilityObject* focusedObjectForNode(Node*);
     static AccessibilityObject* focusedImageMapUIElement(HTMLAreaElement&);
 
-    AXID getAXID(AccessibilityObject&);
-    AXID generateNewObjectID() const;
+    AXID generateNewObjectID();
 
     void notificationPostTimerFired();
 
@@ -762,7 +763,8 @@ private:
 #endif
 
     // Object creation.
-    Ref<AccessibilityObject> createObjectFromRenderer(RenderObject&);
+    Ref<AccessibilityRenderObject> createObjectFromRenderer(RenderObject&);
+    Ref<AccessibilityNodeObject> createFromNode(Node&);
 
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     const std::optional<PageIdentifier> m_pageID; // constant for object's lifetime.

--- a/Source/WebCore/accessibility/AXRemoteFrame.cpp
+++ b/Source/WebCore/accessibility/AXRemoteFrame.cpp
@@ -28,9 +28,14 @@
 
 namespace WebCore {
 
-Ref<AXRemoteFrame> AXRemoteFrame::create()
+AXRemoteFrame::AXRemoteFrame(AXID axID)
+    : AccessibilityMockObject(axID)
 {
-    return adoptRef(*new AXRemoteFrame);
+}
+
+Ref<AXRemoteFrame> AXRemoteFrame::create(AXID axID)
+{
+    return adoptRef(*new AXRemoteFrame(axID));
 }
 
 LayoutRect AXRemoteFrame::elementRect() const

--- a/Source/WebCore/accessibility/AXRemoteFrame.h
+++ b/Source/WebCore/accessibility/AXRemoteFrame.h
@@ -33,7 +33,7 @@ class RemoteFrame;
 
 class AXRemoteFrame final : public AccessibilityMockObject {
 public:
-    static Ref<AXRemoteFrame> create();
+    static Ref<AXRemoteFrame> create(AXID);
 
 #if PLATFORM(COCOA)
     void initializePlatformElementWithRemoteToken(std::span<const uint8_t>, int);
@@ -44,6 +44,7 @@ public:
 
 private:
     virtual ~AXRemoteFrame() = default;
+    explicit AXRemoteFrame(AXID);
 
     AccessibilityRole determineAccessibilityRole() { return AccessibilityRole::RemoteFrame; }
     bool computeIsIgnored() const { return false; }

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -128,7 +128,7 @@ bool AXSearchManager::matchForSearchKeyAtIndex(RefPtr<AXCoreObject> axObject, co
         auto ranges = axObject->misspellingRanges();
         bool hasMisspelling = !ranges.isEmpty();
         if (hasMisspelling)
-            m_misspellingRanges.set(*axObject->objectID(), WTFMove(ranges));
+            m_misspellingRanges.set(axObject->objectID(), WTFMove(ranges));
         return hasMisspelling;
     }
     case AccessibilitySearchKey::Outline:
@@ -354,8 +354,8 @@ std::optional<AXTextMarkerRange> AXSearchManager::findMatchingRange(Accessibilit
 
     bool forward = criteria.searchDirection == AccessibilitySearchDirection::Next;
     if (match(startObject, criteria)) {
-        ASSERT(m_misspellingRanges.contains(*startObject->objectID()));
-        const auto& ranges = m_misspellingRanges.get(*startObject->objectID());
+        ASSERT(m_misspellingRanges.contains(startObject->objectID()));
+        const auto& ranges = m_misspellingRanges.get(startObject->objectID());
         ASSERT(!ranges.isEmpty());
 
         AXTextMarkerRange startRange { startObject->treeID(), startObject->objectID(), criteria.startRange };
@@ -377,8 +377,8 @@ std::optional<AXTextMarkerRange> AXSearchManager::findMatchingRange(Accessibilit
     if (!objects.isEmpty() && objects[0]) {
         auto& object = *objects[0];
         AXLOG(object);
-        ASSERT(m_misspellingRanges.contains(*object.objectID()));
-        const auto& ranges = m_misspellingRanges.get(*object.objectID());
+        ASSERT(m_misspellingRanges.contains(object.objectID()));
+        const auto& ranges = m_misspellingRanges.get(object.objectID());
         ASSERT(!ranges.isEmpty());
         return forward ? ranges[0] : ranges.last();
     }

--- a/Source/WebCore/accessibility/AccessibilityARIAGridCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridCell.cpp
@@ -37,26 +37,26 @@ namespace WebCore {
     
 using namespace HTMLNames;
 
-AccessibilityARIAGridCell::AccessibilityARIAGridCell(RenderObject& renderer)
-    : AccessibilityTableCell(renderer)
+AccessibilityARIAGridCell::AccessibilityARIAGridCell(AXID axID, RenderObject& renderer)
+    : AccessibilityTableCell(axID, renderer)
 {
 }
 
-AccessibilityARIAGridCell::AccessibilityARIAGridCell(Node& node)
-    : AccessibilityTableCell(node)
+AccessibilityARIAGridCell::AccessibilityARIAGridCell(AXID axID, Node& node)
+    : AccessibilityTableCell(axID, node)
 {
 }
 
 AccessibilityARIAGridCell::~AccessibilityARIAGridCell() = default;
 
-Ref<AccessibilityARIAGridCell> AccessibilityARIAGridCell::create(RenderObject& renderer)
+Ref<AccessibilityARIAGridCell> AccessibilityARIAGridCell::create(AXID axID, RenderObject& renderer)
 {
-    return adoptRef(*new AccessibilityARIAGridCell(renderer));
+    return adoptRef(*new AccessibilityARIAGridCell(axID, renderer));
 }
 
-Ref<AccessibilityARIAGridCell> AccessibilityARIAGridCell::create(Node& node)
+Ref<AccessibilityARIAGridCell> AccessibilityARIAGridCell::create(AXID axID, Node& node)
 {
-    return adoptRef(*new AccessibilityARIAGridCell(node));
+    return adoptRef(*new AccessibilityARIAGridCell(axID, node));
 }
 
 AccessibilityTable* AccessibilityARIAGridCell::parentTable() const

--- a/Source/WebCore/accessibility/AccessibilityARIAGridCell.h
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridCell.h
@@ -34,13 +34,13 @@ namespace WebCore {
     
 class AccessibilityARIAGridCell final : public AccessibilityTableCell {
 public:
-    static Ref<AccessibilityARIAGridCell> create(RenderObject&);
-    static Ref<AccessibilityARIAGridCell> create(Node&);
+    static Ref<AccessibilityARIAGridCell> create(AXID, RenderObject&);
+    static Ref<AccessibilityARIAGridCell> create(AXID, Node&);
     virtual ~AccessibilityARIAGridCell();
 
 private:
-    explicit AccessibilityARIAGridCell(RenderObject&);
-    explicit AccessibilityARIAGridCell(Node&);
+    explicit AccessibilityARIAGridCell(AXID, RenderObject&);
+    explicit AccessibilityARIAGridCell(AXID, Node&);
     bool isAccessibilityARIAGridCellInstance() const override { return true; }
 
     AccessibilityTable* parentTable() const override;

--- a/Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp
@@ -34,26 +34,26 @@
 
 namespace WebCore {
     
-AccessibilityARIAGridRow::AccessibilityARIAGridRow(RenderObject& renderer)
-    : AccessibilityTableRow(renderer)
+AccessibilityARIAGridRow::AccessibilityARIAGridRow(AXID axID, RenderObject& renderer)
+    : AccessibilityTableRow(axID, renderer)
 {
 }
 
-AccessibilityARIAGridRow::AccessibilityARIAGridRow(Node& node)
-    : AccessibilityTableRow(node)
+AccessibilityARIAGridRow::AccessibilityARIAGridRow(AXID axID, Node& node)
+    : AccessibilityTableRow(axID, node)
 {
 }
 
 AccessibilityARIAGridRow::~AccessibilityARIAGridRow() = default;
 
-Ref<AccessibilityARIAGridRow> AccessibilityARIAGridRow::create(RenderObject& renderer)
+Ref<AccessibilityARIAGridRow> AccessibilityARIAGridRow::create(AXID axID, RenderObject& renderer)
 {
-    return adoptRef(*new AccessibilityARIAGridRow(renderer));
+    return adoptRef(*new AccessibilityARIAGridRow(axID, renderer));
 }
 
-Ref<AccessibilityARIAGridRow> AccessibilityARIAGridRow::create(Node& node)
+Ref<AccessibilityARIAGridRow> AccessibilityARIAGridRow::create(AXID axID, Node& node)
 {
-    return adoptRef(*new AccessibilityARIAGridRow(node));
+    return adoptRef(*new AccessibilityARIAGridRow(axID, node));
 }
 
 bool AccessibilityARIAGridRow::isARIATreeGridRow() const

--- a/Source/WebCore/accessibility/AccessibilityARIAGridRow.h
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridRow.h
@@ -36,8 +36,8 @@ class AccessibilityTable;
     
 class AccessibilityARIAGridRow final : public AccessibilityTableRow {
 public:
-    static Ref<AccessibilityARIAGridRow> create(RenderObject&);
-    static Ref<AccessibilityARIAGridRow> create(Node&);
+    static Ref<AccessibilityARIAGridRow> create(AXID, RenderObject&);
+    static Ref<AccessibilityARIAGridRow> create(AXID, Node&);
     virtual ~AccessibilityARIAGridRow();
 
     AccessibilityChildrenVector disclosedRows() override;
@@ -46,8 +46,8 @@ public:
     AXCoreObject* rowHeader() final;
     
 private:
-    explicit AccessibilityARIAGridRow(RenderObject&);
-    explicit AccessibilityARIAGridRow(Node&);
+    explicit AccessibilityARIAGridRow(AXID, RenderObject&);
+    explicit AccessibilityARIAGridRow(AXID, Node&);
     bool isAccessibilityARIAGridRowInstance() const override { return true; }
 
     bool isARIATreeGridRow() const override;

--- a/Source/WebCore/accessibility/AccessibilityARIATable.cpp
+++ b/Source/WebCore/accessibility/AccessibilityARIATable.cpp
@@ -35,26 +35,26 @@ namespace WebCore {
 
 class RenderObject;
 
-AccessibilityARIATable::AccessibilityARIATable(RenderObject& renderer)
-    : AccessibilityTable(renderer)
+AccessibilityARIATable::AccessibilityARIATable(AXID axID, RenderObject& renderer)
+    : AccessibilityTable(axID, renderer)
 {
 }
 
-AccessibilityARIATable::AccessibilityARIATable(Node& node)
-    : AccessibilityTable(node)
+AccessibilityARIATable::AccessibilityARIATable(AXID axID, Node& node)
+    : AccessibilityTable(axID, node)
 {
 }
 
 AccessibilityARIATable::~AccessibilityARIATable() = default;
 
-Ref<AccessibilityARIATable> AccessibilityARIATable::create(RenderObject& renderer)
+Ref<AccessibilityARIATable> AccessibilityARIATable::create(AXID axID, RenderObject& renderer)
 {
-    return adoptRef(*new AccessibilityARIATable(renderer));
+    return adoptRef(*new AccessibilityARIATable(axID, renderer));
 }
 
-Ref<AccessibilityARIATable> AccessibilityARIATable::create(Node& node)
+Ref<AccessibilityARIATable> AccessibilityARIATable::create(AXID axID, Node& node)
 {
-    return adoptRef(*new AccessibilityARIATable(node));
+    return adoptRef(*new AccessibilityARIATable(axID, node));
 }
 
 bool AccessibilityARIATable::isMultiSelectable() const

--- a/Source/WebCore/accessibility/AccessibilityARIATable.h
+++ b/Source/WebCore/accessibility/AccessibilityARIATable.h
@@ -35,13 +35,13 @@ namespace WebCore {
 
 class AccessibilityARIATable final : public AccessibilityTable {
 public:
-    static Ref<AccessibilityARIATable> create(RenderObject&);
-    static Ref<AccessibilityARIATable> create(Node&);
+    static Ref<AccessibilityARIATable> create(AXID, RenderObject&);
+    static Ref<AccessibilityARIATable> create(AXID, Node&);
     virtual ~AccessibilityARIATable();
 
 private:
-    explicit AccessibilityARIATable(RenderObject&);
-    explicit AccessibilityARIATable(Node&);
+    explicit AccessibilityARIATable(AXID, RenderObject&);
+    explicit AccessibilityARIATable(AXID, Node&);
 
     // ARIA treegrids and grids support selected rows.
     bool supportsSelectedRows() const final { return hasGridAriaRole(); }

--- a/Source/WebCore/accessibility/AccessibilityAttachment.cpp
+++ b/Source/WebCore/accessibility/AccessibilityAttachment.cpp
@@ -38,14 +38,14 @@ namespace WebCore {
     
 using namespace HTMLNames;
 
-AccessibilityAttachment::AccessibilityAttachment(RenderAttachment& renderer)
-    : AccessibilityRenderObject(renderer)
+AccessibilityAttachment::AccessibilityAttachment(AXID axID, RenderAttachment& renderer)
+    : AccessibilityRenderObject(axID, renderer)
 {
 }
 
-Ref<AccessibilityAttachment> AccessibilityAttachment::create(RenderAttachment& renderer)
+Ref<AccessibilityAttachment> AccessibilityAttachment::create(AXID axID, RenderAttachment& renderer)
 {
-    return adoptRef(*new AccessibilityAttachment(renderer));
+    return adoptRef(*new AccessibilityAttachment(axID, renderer));
 }
 
 bool AccessibilityAttachment::hasProgress(float* progress) const

--- a/Source/WebCore/accessibility/AccessibilityAttachment.h
+++ b/Source/WebCore/accessibility/AccessibilityAttachment.h
@@ -37,12 +37,12 @@ class RenderAttachment;
     
 class AccessibilityAttachment final : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityAttachment> create(RenderAttachment&);
+    static Ref<AccessibilityAttachment> create(AXID, RenderAttachment&);
     HTMLAttachmentElement* attachmentElement() const;
     bool hasProgress(float* progress = nullptr) const;
     
 private:
-    explicit AccessibilityAttachment(RenderAttachment&);
+    explicit AccessibilityAttachment(AXID, RenderAttachment&);
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::Button; }
 

--- a/Source/WebCore/accessibility/AccessibilityImageMapLink.cpp
+++ b/Source/WebCore/accessibility/AccessibilityImageMapLink.cpp
@@ -39,17 +39,18 @@ namespace WebCore {
     
 using namespace HTMLNames;
 
-AccessibilityImageMapLink::AccessibilityImageMapLink()
-    : m_areaElement(nullptr)
+AccessibilityImageMapLink::AccessibilityImageMapLink(AXID axID)
+    : AccessibilityMockObject(axID)
+    , m_areaElement(nullptr)
     , m_mapElement(nullptr)
 {
 }
 
 AccessibilityImageMapLink::~AccessibilityImageMapLink() = default;
 
-Ref<AccessibilityImageMapLink> AccessibilityImageMapLink::create()
+Ref<AccessibilityImageMapLink> AccessibilityImageMapLink::create(AXID axID)
 {
-    return adoptRef(*new AccessibilityImageMapLink());
+    return adoptRef(*new AccessibilityImageMapLink(axID));
 }
 
 void AccessibilityImageMapLink::setHTMLAreaElement(HTMLAreaElement* element)

--- a/Source/WebCore/accessibility/AccessibilityImageMapLink.h
+++ b/Source/WebCore/accessibility/AccessibilityImageMapLink.h
@@ -36,7 +36,7 @@ namespace WebCore {
     
 class AccessibilityImageMapLink final : public AccessibilityMockObject {
 public:
-    static Ref<AccessibilityImageMapLink> create();
+    static Ref<AccessibilityImageMapLink> create(AXID);
     virtual ~AccessibilityImageMapLink();
     
     void setHTMLAreaElement(HTMLAreaElement*);
@@ -61,7 +61,7 @@ public:
     LayoutRect elementRect() const override;
 
 private:
-    AccessibilityImageMapLink();
+    explicit AccessibilityImageMapLink(AXID);
 
     void detachFromParent() override;
     Path elementPath() const override;

--- a/Source/WebCore/accessibility/AccessibilityLabel.cpp
+++ b/Source/WebCore/accessibility/AccessibilityLabel.cpp
@@ -33,16 +33,16 @@ namespace WebCore {
     
 using namespace HTMLNames;
 
-AccessibilityLabel::AccessibilityLabel(RenderObject& renderer)
-    : AccessibilityRenderObject(renderer)
+AccessibilityLabel::AccessibilityLabel(AXID axID, RenderObject& renderer)
+    : AccessibilityRenderObject(axID, renderer)
 {
 }
 
 AccessibilityLabel::~AccessibilityLabel() = default;
 
-Ref<AccessibilityLabel> AccessibilityLabel::create(RenderObject& renderer)
+Ref<AccessibilityLabel> AccessibilityLabel::create(AXID axID, RenderObject& renderer)
 {
-    return adoptRef(*new AccessibilityLabel(renderer));
+    return adoptRef(*new AccessibilityLabel(axID, renderer));
 }
 
 String AccessibilityLabel::stringValue() const

--- a/Source/WebCore/accessibility/AccessibilityLabel.h
+++ b/Source/WebCore/accessibility/AccessibilityLabel.h
@@ -34,12 +34,12 @@ namespace WebCore {
 
 class AccessibilityLabel final : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityLabel> create(RenderObject&);
+    static Ref<AccessibilityLabel> create(AXID, RenderObject&);
     virtual ~AccessibilityLabel();
 
     bool containsOnlyStaticText() const;
 private:
-    explicit AccessibilityLabel(RenderObject&);
+    explicit AccessibilityLabel(AXID, RenderObject&);
     bool computeIsIgnored() const final { return isIgnoredByDefault(); }
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::Label; }

--- a/Source/WebCore/accessibility/AccessibilityList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityList.cpp
@@ -41,26 +41,26 @@ namespace WebCore {
     
 using namespace HTMLNames;
 
-AccessibilityList::AccessibilityList(RenderObject& renderer)
-    : AccessibilityRenderObject(renderer)
+AccessibilityList::AccessibilityList(AXID axID, RenderObject& renderer)
+    : AccessibilityRenderObject(axID, renderer)
 {
 }
 
-AccessibilityList::AccessibilityList(Node& node)
-    : AccessibilityRenderObject(node)
+AccessibilityList::AccessibilityList(AXID axID, Node& node)
+    : AccessibilityRenderObject(axID, node)
 {
 }
 
 AccessibilityList::~AccessibilityList() = default;
 
-Ref<AccessibilityList> AccessibilityList::create(RenderObject& renderer)
+Ref<AccessibilityList> AccessibilityList::create(AXID axID, RenderObject& renderer)
 {
-    return adoptRef(*new AccessibilityList(renderer));
+    return adoptRef(*new AccessibilityList(axID, renderer));
 }
 
-Ref<AccessibilityList> AccessibilityList::create(Node& node)
+Ref<AccessibilityList> AccessibilityList::create(AXID axID, Node& node)
 {
-    return adoptRef(*new AccessibilityList(node));
+    return adoptRef(*new AccessibilityList(axID, node));
 }
 
 bool AccessibilityList::computeIsIgnored() const

--- a/Source/WebCore/accessibility/AccessibilityList.h
+++ b/Source/WebCore/accessibility/AccessibilityList.h
@@ -34,13 +34,13 @@ namespace WebCore {
     
 class AccessibilityList final : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityList> create(RenderObject&);
-    static Ref<AccessibilityList> create(Node&);
+    static Ref<AccessibilityList> create(AXID, RenderObject&);
+    static Ref<AccessibilityList> create(AXID, Node&);
     virtual ~AccessibilityList();
 
 private:
-    explicit AccessibilityList(RenderObject&);
-    explicit AccessibilityList(Node&);
+    explicit AccessibilityList(AXID, RenderObject&);
+    explicit AccessibilityList(AXID, Node&);
     bool isList() const override { return true; }
     bool isUnorderedList() const override;
     bool isOrderedList() const override;

--- a/Source/WebCore/accessibility/AccessibilityListBox.cpp
+++ b/Source/WebCore/accessibility/AccessibilityListBox.cpp
@@ -42,16 +42,16 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-AccessibilityListBox::AccessibilityListBox(RenderObject& renderer)
-    : AccessibilityRenderObject(renderer)
+AccessibilityListBox::AccessibilityListBox(AXID axID, RenderObject& renderer)
+    : AccessibilityRenderObject(axID, renderer)
 {
 }
 
 AccessibilityListBox::~AccessibilityListBox() = default;
 
-Ref<AccessibilityListBox> AccessibilityListBox::create(RenderObject& renderer)
+Ref<AccessibilityListBox> AccessibilityListBox::create(AXID axID, RenderObject& renderer)
 {
-    return adoptRef(*new AccessibilityListBox(renderer));
+    return adoptRef(*new AccessibilityListBox(axID, renderer));
 }
 
 bool AccessibilityListBox::canSetSelectedChildren() const

--- a/Source/WebCore/accessibility/AccessibilityListBox.h
+++ b/Source/WebCore/accessibility/AccessibilityListBox.h
@@ -34,7 +34,7 @@ namespace WebCore {
 
 class AccessibilityListBox final : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityListBox> create(RenderObject&);
+    static Ref<AccessibilityListBox> create(AXID, RenderObject&);
     virtual ~AccessibilityListBox();
 
     bool canSetSelectedChildren() const override;
@@ -48,7 +48,7 @@ public:
     void addChildren() override;
 
 private:
-    explicit AccessibilityListBox(RenderObject&);
+    explicit AccessibilityListBox(AXID, RenderObject&);
 
     bool isAccessibilityListBoxInstance() const override { return true; }
     AccessibilityObject* listBoxOptionAccessibilityObject(HTMLElement*) const;

--- a/Source/WebCore/accessibility/AccessibilityListBoxOption.cpp
+++ b/Source/WebCore/accessibility/AccessibilityListBoxOption.cpp
@@ -43,16 +43,16 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-AccessibilityListBoxOption::AccessibilityListBoxOption(HTMLElement& element)
-    : AccessibilityNodeObject(&element)
+AccessibilityListBoxOption::AccessibilityListBoxOption(AXID axID, HTMLElement& element)
+    : AccessibilityNodeObject(axID, &element)
 {
 }
 
 AccessibilityListBoxOption::~AccessibilityListBoxOption() = default;
 
-Ref<AccessibilityListBoxOption> AccessibilityListBoxOption::create(HTMLElement& element)
+Ref<AccessibilityListBoxOption> AccessibilityListBoxOption::create(AXID axID, HTMLElement& element)
 {
-    return adoptRef(*new AccessibilityListBoxOption(element));
+    return adoptRef(*new AccessibilityListBoxOption(axID, element));
 }
 
 bool AccessibilityListBoxOption::isEnabled() const

--- a/Source/WebCore/accessibility/AccessibilityListBoxOption.h
+++ b/Source/WebCore/accessibility/AccessibilityListBoxOption.h
@@ -37,14 +37,14 @@ class HTMLSelectElement;
 
 class AccessibilityListBoxOption final : public AccessibilityNodeObject {
 public:
-    static Ref<AccessibilityListBoxOption> create(HTMLElement&);
+    static Ref<AccessibilityListBoxOption> create(AXID, HTMLElement&);
     virtual ~AccessibilityListBoxOption();
 
     bool isSelected() const final;
     void setSelected(bool) final;
 
 private:
-    explicit AccessibilityListBoxOption(HTMLElement&);
+    explicit AccessibilityListBoxOption(AXID, HTMLElement&);
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::ListBoxOption; }
     bool isEnabled() const final;

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
@@ -36,17 +36,17 @@
 
 namespace WebCore {
 
-AccessibilityMathMLElement::AccessibilityMathMLElement(RenderObject& renderer, bool isAnonymousOperator)
-    : AccessibilityRenderObject(renderer)
+AccessibilityMathMLElement::AccessibilityMathMLElement(AXID axID, RenderObject& renderer, bool isAnonymousOperator)
+    : AccessibilityRenderObject(axID, renderer)
     , m_isAnonymousOperator(isAnonymousOperator)
 {
 }
 
 AccessibilityMathMLElement::~AccessibilityMathMLElement() = default;
 
-Ref<AccessibilityMathMLElement> AccessibilityMathMLElement::create(RenderObject& renderer, bool isAnonymousOperator)
+Ref<AccessibilityMathMLElement> AccessibilityMathMLElement::create(AXID axID, RenderObject& renderer, bool isAnonymousOperator)
 {
-    return adoptRef(*new AccessibilityMathMLElement(renderer, isAnonymousOperator));
+    return adoptRef(*new AccessibilityMathMLElement(axID, renderer, isAnonymousOperator));
 }
 
 AccessibilityRole AccessibilityMathMLElement::determineAccessibilityRole()

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.h
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.h
@@ -41,11 +41,11 @@ namespace WebCore {
 class AccessibilityMathMLElement : public AccessibilityRenderObject {
 
 public:
-    static Ref<AccessibilityMathMLElement> create(RenderObject&, bool isAnonymousOperator);
+    static Ref<AccessibilityMathMLElement> create(AXID, RenderObject&, bool isAnonymousOperator);
     virtual ~AccessibilityMathMLElement();
 
 protected:
-    explicit AccessibilityMathMLElement(RenderObject&, bool isAnonymousOperator);
+    explicit AccessibilityMathMLElement(AXID, RenderObject&, bool isAnonymousOperator);
 
 private:
     AccessibilityRole determineAccessibilityRole() final;

--- a/Source/WebCore/accessibility/AccessibilityMediaObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMediaObject.cpp
@@ -41,16 +41,16 @@ namespace WebCore {
     
 using namespace HTMLNames;
 
-AccessibilityMediaObject::AccessibilityMediaObject(RenderObject& renderer)
-    : AccessibilityRenderObject(renderer)
+AccessibilityMediaObject::AccessibilityMediaObject(AXID axID, RenderObject& renderer)
+    : AccessibilityRenderObject(axID, renderer)
 {
 }
 
 AccessibilityMediaObject::~AccessibilityMediaObject() = default;
 
-Ref<AccessibilityMediaObject> AccessibilityMediaObject::create(RenderObject& renderer)
+Ref<AccessibilityMediaObject> AccessibilityMediaObject::create(AXID axID, RenderObject& renderer)
 {
-    return adoptRef(*new AccessibilityMediaObject(renderer));
+    return adoptRef(*new AccessibilityMediaObject(axID, renderer));
 }
 
 bool AccessibilityMediaObject::computeIsIgnored() const

--- a/Source/WebCore/accessibility/AccessibilityMediaObject.h
+++ b/Source/WebCore/accessibility/AccessibilityMediaObject.h
@@ -36,7 +36,7 @@ namespace WebCore {
     
 class AccessibilityMediaObject final : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityMediaObject> create(RenderObject&);
+    static Ref<AccessibilityMediaObject> create(AXID, RenderObject&);
     virtual ~AccessibilityMediaObject();
     
     void enterFullscreen() const;
@@ -49,8 +49,9 @@ public:
     bool isMuted() const;
 
 private:
+    explicit AccessibilityMediaObject(AXID, RenderObject&);
+
     enum class AXSeekDirection : bool { Backward, Forward };
-    explicit AccessibilityMediaObject(RenderObject&);
     bool computeIsIgnored() const final;
     bool isMediaObject() const final { return true; }
     

--- a/Source/WebCore/accessibility/AccessibilityMenuList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuList.cpp
@@ -33,14 +33,14 @@
 
 namespace WebCore {
 
-AccessibilityMenuList::AccessibilityMenuList(RenderMenuList& renderer)
-    : AccessibilityRenderObject(renderer)
+AccessibilityMenuList::AccessibilityMenuList(AXID axID, RenderMenuList& renderer)
+    : AccessibilityRenderObject(axID, renderer)
 {
 }
 
-Ref<AccessibilityMenuList> AccessibilityMenuList::create(RenderMenuList& renderer)
+Ref<AccessibilityMenuList> AccessibilityMenuList::create(AXID axID, RenderMenuList& renderer)
 {
-    return adoptRef(*new AccessibilityMenuList(renderer));
+    return adoptRef(*new AccessibilityMenuList(axID, renderer));
 }
 
 bool AccessibilityMenuList::press()

--- a/Source/WebCore/accessibility/AccessibilityMenuList.h
+++ b/Source/WebCore/accessibility/AccessibilityMenuList.h
@@ -33,7 +33,7 @@ class RenderMenuList;
 
 class AccessibilityMenuList final : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityMenuList> create(RenderMenuList&);
+    static Ref<AccessibilityMenuList> create(AXID, RenderMenuList&);
 
     bool isCollapsed() const override;
     bool press() override;
@@ -41,7 +41,7 @@ public:
     void didUpdateActiveOption(int optionIndex);
 
 private:
-    explicit AccessibilityMenuList(RenderMenuList&);
+    explicit AccessibilityMenuList(AXID, RenderMenuList&);
 
     bool isMenuList() const final { return true; }
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::PopUpButton; }

--- a/Source/WebCore/accessibility/AccessibilityMenuListOption.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuListOption.cpp
@@ -37,15 +37,15 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-AccessibilityMenuListOption::AccessibilityMenuListOption(HTMLOptionElement& element)
-    : AccessibilityNodeObject(&element)
+AccessibilityMenuListOption::AccessibilityMenuListOption(AXID axID, HTMLOptionElement& element)
+    : AccessibilityNodeObject(axID, &element)
     , m_parent(nullptr)
 {
 }
 
-Ref<AccessibilityMenuListOption> AccessibilityMenuListOption::create(HTMLOptionElement& element)
+Ref<AccessibilityMenuListOption> AccessibilityMenuListOption::create(AXID axID, HTMLOptionElement& element)
 {
-    return adoptRef(*new AccessibilityMenuListOption(element));
+    return adoptRef(*new AccessibilityMenuListOption(axID, element));
 }
 
 HTMLOptionElement* AccessibilityMenuListOption::optionElement() const

--- a/Source/WebCore/accessibility/AccessibilityMenuListOption.h
+++ b/Source/WebCore/accessibility/AccessibilityMenuListOption.h
@@ -34,11 +34,11 @@ class HTMLOptionElement;
 
 class AccessibilityMenuListOption final : public AccessibilityNodeObject {
 public:
-    static Ref<AccessibilityMenuListOption> create(HTMLOptionElement&);
+    static Ref<AccessibilityMenuListOption> create(AXID, HTMLOptionElement&);
     void setParent(AccessibilityObject* parent) { m_parent = parent; }
 
 private:
-    explicit AccessibilityMenuListOption(HTMLOptionElement&);
+    explicit AccessibilityMenuListOption(AXID, HTMLOptionElement&);
 
     bool isMenuListOption() const final { return true; }
 

--- a/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
@@ -38,7 +38,8 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-AccessibilityMenuListPopup::AccessibilityMenuListPopup()
+AccessibilityMenuListPopup::AccessibilityMenuListPopup(AXID axID)
+    : AccessibilityMockObject(axID)
 {
 }
 

--- a/Source/WebCore/accessibility/AccessibilityMenuListPopup.h
+++ b/Source/WebCore/accessibility/AccessibilityMenuListPopup.h
@@ -36,7 +36,7 @@ class HTMLElement;
 class AccessibilityMenuListPopup final : public AccessibilityMockObject {
     friend class AXObjectCache;
 public:
-    static Ref<AccessibilityMenuListPopup> create() { return adoptRef(*new AccessibilityMenuListPopup); }
+    static Ref<AccessibilityMenuListPopup> create(AXID axID) { return adoptRef(*new AccessibilityMenuListPopup(axID)); }
 
     bool isEnabled() const override;
     bool isOffScreen() const override;
@@ -44,7 +44,7 @@ public:
     void didUpdateActiveOption(int optionIndex);
 
 private:
-    AccessibilityMenuListPopup();
+    explicit AccessibilityMenuListPopup(AXID);
 
     bool isMenuListPopup() const final { return true; }
 

--- a/Source/WebCore/accessibility/AccessibilityMockObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMockObject.cpp
@@ -27,9 +27,9 @@
 #include "AccessibilityMockObject.h"
 
 namespace WebCore {
-    
-AccessibilityMockObject::AccessibilityMockObject()
-    : m_parent(nullptr)
+
+AccessibilityMockObject::AccessibilityMockObject(AXID axID)
+    : AccessibilityObject(axID)
 {
 }
 

--- a/Source/WebCore/accessibility/AccessibilityMockObject.h
+++ b/Source/WebCore/accessibility/AccessibilityMockObject.h
@@ -30,9 +30,7 @@
 namespace WebCore {
     
 class AccessibilityMockObject : public AccessibilityObject {
-    
-protected:
-    AccessibilityMockObject();
+
 public:
     virtual ~AccessibilityMockObject();
     
@@ -41,6 +39,8 @@ public:
     bool isEnabled() const override { return true; }
 
 protected:
+    explicit AccessibilityMockObject(AXID);
+
     WeakPtr<AccessibilityObject> m_parent;
 
     // Must be called when the parent object clears its children.

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -98,8 +98,8 @@ using namespace HTMLNames;
 static String accessibleNameForNode(Node&, Node* labelledbyNode = nullptr);
 static void appendNameToStringBuilder(StringBuilder&, String&&, bool prependSpace = true);
 
-AccessibilityNodeObject::AccessibilityNodeObject(Node* node)
-    : AccessibilityObject()
+AccessibilityNodeObject::AccessibilityNodeObject(AXID axID, Node* node)
+    : AccessibilityObject(axID)
     , m_node(node)
 {
 }
@@ -118,9 +118,9 @@ void AccessibilityNodeObject::init()
     AccessibilityObject::init();
 }
 
-Ref<AccessibilityNodeObject> AccessibilityNodeObject::create(Node& node)
+Ref<AccessibilityNodeObject> AccessibilityNodeObject::create(AXID axID, Node& node)
 {
-    return adoptRef(*new AccessibilityNodeObject(&node));
+    return adoptRef(*new AccessibilityNodeObject(axID, &node));
 }
 
 void AccessibilityNodeObject::detachRemoteParts(AccessibilityDetachmentType detachmentType)

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -46,7 +46,7 @@ enum MouseButtonListenerResultFilter {
 
 class AccessibilityNodeObject : public AccessibilityObject {
 public:
-    static Ref<AccessibilityNodeObject> create(Node&);
+    static Ref<AccessibilityNodeObject> create(AXID, Node&);
     virtual ~AccessibilityNodeObject();
 
     void init() override;
@@ -55,6 +55,7 @@ public:
 
     bool isBusy() const override;
     bool isControl() const override;
+    bool isDetached() const override { return !m_node; }
     bool isRadioInput() const override;
     bool isFieldset() const override;
     bool isHovered() const override;
@@ -149,15 +150,13 @@ public:
 #endif
 
 protected:
-    explicit AccessibilityNodeObject(Node*);
+    explicit AccessibilityNodeObject(AXID, Node*);
     void detachRemoteParts(AccessibilityDetachmentType) override;
 
     AccessibilityRole m_ariaRole { AccessibilityRole::Unknown };
 #ifndef NDEBUG
     bool m_initialized { false };
 #endif
-
-    bool isDetached() const override { return !m_node; }
 
     AccessibilityRole determineAccessibilityRole() override;
     enum class TreatStyleFormatGroupAsInline : bool { No, Yes };

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -110,6 +110,11 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
+AccessibilityObject::AccessibilityObject(AXID axID)
+    : AXCoreObject(axID)
+{
+}
+
 AccessibilityObject::~AccessibilityObject()
 {
     ASSERT(isDetached());
@@ -136,7 +141,7 @@ String AccessibilityObject::dbg() const
 
     return makeString(
         "{role: "_s, accessibilityRoleToString(roleValue()),
-        ", ID "_s, objectID() ? objectID()->loggingString() : ""_str,
+        ", ID "_s, objectID().loggingString(),
         isIgnored() ? ", ignored"_s : emptyString(),
         backingEntityDescription,
         '}'
@@ -4094,7 +4099,7 @@ bool AccessibilityObject::isIgnored() const
         attributeCache = axObjectCache->computedObjectAttributeCache();
     
     if (attributeCache) {
-        AccessibilityObjectInclusion ignored = attributeCache->getIgnored(*objectID());
+        AccessibilityObjectInclusion ignored = attributeCache->getIgnored(objectID());
         switch (ignored) {
         case AccessibilityObjectInclusion::IgnoreObject:
             return true;
@@ -4109,7 +4114,7 @@ bool AccessibilityObject::isIgnored() const
 
     // Refetch the attribute cache in case it was enabled as part of computing isIgnored.
     if (axObjectCache && (attributeCache = axObjectCache->computedObjectAttributeCache()))
-        attributeCache->setIgnored(*objectID(), ignored ? AccessibilityObjectInclusion::IgnoreObject : AccessibilityObjectInclusion::IncludeObject);
+        attributeCache->setIgnored(objectID(), ignored ? AccessibilityObjectInclusion::IgnoreObject : AccessibilityObjectInclusion::IncludeObject);
 
     return ignored;
 }
@@ -4132,7 +4137,7 @@ bool AccessibilityObject::isIgnoredWithoutCache(AXObjectCache* cache) const
 
 #if !ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE) && ENABLE(ACCESSIBILITY_ISOLATED_TREE)
         if (becameIgnored)
-            cache->objectBecameIgnored(*objectID());
+            cache->objectBecameIgnored(objectID());
 #endif // !ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE) && ENABLE(ACCESSIBILITY_ISOLATED_TREE)
         if (becameUnignored || becameIgnored)
             cache->childrenChanged(parentObject());

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -864,7 +864,7 @@ public:
     }; // class iterator
 
 protected:
-    AccessibilityObject() = default;
+    explicit AccessibilityObject(AXID);
 
     // FIXME: Make more of these member functions private.
 

--- a/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
+++ b/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
@@ -35,15 +35,15 @@ namespace WebCore {
     
 using namespace HTMLNames;
 
-AccessibilityProgressIndicator::AccessibilityProgressIndicator(RenderObject& renderer)
-    : AccessibilityRenderObject(renderer)
+AccessibilityProgressIndicator::AccessibilityProgressIndicator(AXID axID, RenderObject& renderer)
+    : AccessibilityRenderObject(axID, renderer)
 {
     ASSERT(is<RenderProgress>(renderer) || is<RenderMeter>(renderer) || is<HTMLProgressElement>(renderer.node()) || is<HTMLMeterElement>(renderer.node()));
 }
 
-Ref<AccessibilityProgressIndicator> AccessibilityProgressIndicator::create(RenderObject& renderer)
+Ref<AccessibilityProgressIndicator> AccessibilityProgressIndicator::create(AXID axID, RenderObject& renderer)
 {
-    return adoptRef(*new AccessibilityProgressIndicator(renderer));
+    return adoptRef(*new AccessibilityProgressIndicator(axID, renderer));
 }
 
 bool AccessibilityProgressIndicator::computeIsIgnored() const

--- a/Source/WebCore/accessibility/AccessibilityProgressIndicator.h
+++ b/Source/WebCore/accessibility/AccessibilityProgressIndicator.h
@@ -32,11 +32,13 @@ class RenderProgress;
     
 class AccessibilityProgressIndicator final : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityProgressIndicator> create(RenderObject&);
+    static Ref<AccessibilityProgressIndicator> create(AXID, RenderObject&);
 
     bool isIndeterminate() const final;
 
 private:
+    explicit AccessibilityProgressIndicator(AXID, RenderObject&);
+
     AccessibilityRole determineAccessibilityRole() final;
 
     String valueDescription() const override;
@@ -45,7 +47,6 @@ private:
     float maxValueForRange() const override;
     float minValueForRange() const override;
 
-    explicit AccessibilityProgressIndicator(RenderObject&);
     HTMLProgressElement* progressElement() const;
     HTMLMeterElement* meterElement() const;
     

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -127,8 +127,8 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-AccessibilityRenderObject::AccessibilityRenderObject(RenderObject& renderer)
-    : AccessibilityNodeObject(renderer.node())
+AccessibilityRenderObject::AccessibilityRenderObject(AXID axID, RenderObject& renderer)
+    : AccessibilityNodeObject(axID, renderer.node())
     , m_renderer(renderer)
 {
 #if ASSERT_ENABLED
@@ -136,8 +136,8 @@ AccessibilityRenderObject::AccessibilityRenderObject(RenderObject& renderer)
 #endif
 }
 
-AccessibilityRenderObject::AccessibilityRenderObject(Node& node)
-    : AccessibilityNodeObject(&node)
+AccessibilityRenderObject::AccessibilityRenderObject(AXID axID, Node& node)
+    : AccessibilityNodeObject(axID, &node)
 {
     // We should only ever create an instance of this class with a node if that node has no renderer (i.e. because of display:contents).
     ASSERT(!node.renderer());
@@ -148,9 +148,9 @@ AccessibilityRenderObject::~AccessibilityRenderObject()
     ASSERT(isDetached());
 }
 
-Ref<AccessibilityRenderObject> AccessibilityRenderObject::create(RenderObject& renderer)
+Ref<AccessibilityRenderObject> AccessibilityRenderObject::create(AXID axID, RenderObject& renderer)
 {
-    return adoptRef(*new AccessibilityRenderObject(renderer));
+    return adoptRef(*new AccessibilityRenderObject(axID, renderer));
 }
 
 void AccessibilityRenderObject::detachRemoteParts(AccessibilityDetachmentType detachmentType)

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -54,13 +54,14 @@ class VisibleSelection;
 
 class AccessibilityRenderObject : public AccessibilityNodeObject {
 public:
-    static Ref<AccessibilityRenderObject> create(RenderObject&);
+    static Ref<AccessibilityRenderObject> create(AXID, RenderObject&);
     virtual ~AccessibilityRenderObject();
     
     FloatRect frameRect() const final;
     bool isNonLayerSVGObject() const override;
 
     bool isAttachment() const override;
+    bool isDetached() const final { return !m_renderer && AccessibilityNodeObject::isDetached(); }
     bool isOffScreen() const override;
     bool hasBoldFont() const override;
     bool hasItalicFont() const override;
@@ -137,14 +138,12 @@ public:
     String secureFieldValue() const override;
     void labelText(Vector<AccessibilityText>&) const override;
 protected:
-    explicit AccessibilityRenderObject(RenderObject&);
-    explicit AccessibilityRenderObject(Node&);
+    explicit AccessibilityRenderObject(AXID, RenderObject&);
+    explicit AccessibilityRenderObject(AXID, Node&);
     void detachRemoteParts(AccessibilityDetachmentType) override;
     ScrollableArea* getScrollableAreaIfScrollable() const override;
     void scrollTo(const IntPoint&) const override;
     
-    bool isDetached() const final { return !m_renderer && AccessibilityNodeObject::isDetached(); }
-
     bool shouldIgnoreAttributeRole() const override;
     AccessibilityRole determineAccessibilityRole() override;
     bool computeIsIgnored() const override;

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
@@ -44,8 +44,8 @@
 
 namespace WebCore {
 
-AccessibilitySVGObject::AccessibilitySVGObject(RenderObject& renderer, AXObjectCache* cache)
-    : AccessibilityRenderObject(renderer)
+AccessibilitySVGObject::AccessibilitySVGObject(AXID axID, RenderObject& renderer, AXObjectCache* cache)
+    : AccessibilityRenderObject(axID, renderer)
     , m_axObjectCache(cache)
 {
     ASSERT(cache);
@@ -53,9 +53,9 @@ AccessibilitySVGObject::AccessibilitySVGObject(RenderObject& renderer, AXObjectC
 
 AccessibilitySVGObject::~AccessibilitySVGObject() = default;
 
-Ref<AccessibilitySVGObject> AccessibilitySVGObject::create(RenderObject& renderer, AXObjectCache* cache)
+Ref<AccessibilitySVGObject> AccessibilitySVGObject::create(AXID axID, RenderObject& renderer, AXObjectCache* cache)
 {
-    return adoptRef(*new AccessibilitySVGObject(renderer, cache));
+    return adoptRef(*new AccessibilitySVGObject(axID, renderer, cache));
 }
 
 AccessibilityObject* AccessibilitySVGObject::targetForUseElement() const

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.h
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.h
@@ -33,11 +33,11 @@ namespace WebCore {
 
 class AccessibilitySVGObject : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilitySVGObject> create(RenderObject&, AXObjectCache*);
+    static Ref<AccessibilitySVGObject> create(AXID, RenderObject&, AXObjectCache*);
     virtual ~AccessibilitySVGObject();
 
 protected:
-    explicit AccessibilitySVGObject(RenderObject&, AXObjectCache*);
+    explicit AccessibilitySVGObject(AXID, RenderObject&, AXObjectCache*);
     AXObjectCache* axObjectCache() const override { return m_axObjectCache.get(); }
     AccessibilityRole determineAriaRoleAttribute() const final;
 

--- a/Source/WebCore/accessibility/AccessibilitySVGRoot.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGRoot.cpp
@@ -39,16 +39,16 @@
 
 namespace WebCore {
 
-AccessibilitySVGRoot::AccessibilitySVGRoot(RenderObject& renderer, AXObjectCache* cache)
-    : AccessibilitySVGObject(renderer, cache)
+AccessibilitySVGRoot::AccessibilitySVGRoot(AXID axID, RenderObject& renderer, AXObjectCache* cache)
+    : AccessibilitySVGObject(axID, renderer, cache)
 {
 }
 
 AccessibilitySVGRoot::~AccessibilitySVGRoot() = default;
 
-Ref<AccessibilitySVGRoot> AccessibilitySVGRoot::create(RenderObject& renderer, AXObjectCache* cache)
+Ref<AccessibilitySVGRoot> AccessibilitySVGRoot::create(AXID axID, RenderObject& renderer, AXObjectCache* cache)
 {
-    return adoptRef(*new AccessibilitySVGRoot(renderer, cache));
+    return adoptRef(*new AccessibilitySVGRoot(axID, renderer, cache));
 }
 
 void AccessibilitySVGRoot::setParent(AccessibilityRenderObject* parent)

--- a/Source/WebCore/accessibility/AccessibilitySVGRoot.h
+++ b/Source/WebCore/accessibility/AccessibilitySVGRoot.h
@@ -35,13 +35,13 @@ namespace WebCore {
 
 class AccessibilitySVGRoot final : public AccessibilitySVGObject {
 public:
-    static Ref<AccessibilitySVGRoot> create(RenderObject&, AXObjectCache*);
+    static Ref<AccessibilitySVGRoot> create(AXID, RenderObject&, AXObjectCache*);
     virtual ~AccessibilitySVGRoot();
 
     void setParent(AccessibilityRenderObject*);
     bool hasAccessibleContent() const;
 private:
-    explicit AccessibilitySVGRoot(RenderObject&, AXObjectCache*);
+    explicit AccessibilitySVGRoot(AXID, RenderObject&, AXObjectCache*);
 
     AccessibilityObject* parentObject() const override;
     bool isAccessibilitySVGRoot() const override { return true; }

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -38,8 +38,9 @@
 
 namespace WebCore {
     
-AccessibilityScrollView::AccessibilityScrollView(ScrollView* view)
-    : m_scrollView(view)
+AccessibilityScrollView::AccessibilityScrollView(AXID axID, ScrollView& view)
+    : AccessibilityObject(axID)
+    , m_scrollView(view)
     , m_childrenDirty(false)
 {
     if (auto* localFrameView = dynamicDowncast<LocalFrameView>(view))
@@ -68,9 +69,9 @@ void AccessibilityScrollView::detachRemoteParts(AccessibilityDetachmentType deta
     m_frameOwnerElement = nullptr;
 }
 
-Ref<AccessibilityScrollView> AccessibilityScrollView::create(ScrollView* view)
+Ref<AccessibilityScrollView> AccessibilityScrollView::create(AXID axID, ScrollView& view)
 {
-    return adoptRef(*new AccessibilityScrollView(view));
+    return adoptRef(*new AccessibilityScrollView(axID, view));
 }
 
 ScrollView* AccessibilityScrollView::currentScrollView() const

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -37,7 +37,7 @@ class ScrollView;
     
 class AccessibilityScrollView final : public AccessibilityObject {
 public:
-    static Ref<AccessibilityScrollView> create(ScrollView*);
+    static Ref<AccessibilityScrollView> create(AXID, ScrollView&);
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::ScrollArea; }
     ScrollView* scrollView() const override { return currentScrollView(); }
 
@@ -47,7 +47,7 @@ public:
     void setNeedsToUpdateChildren() override { m_childrenDirty = true; }
 
 private:
-    explicit AccessibilityScrollView(ScrollView*);
+    explicit AccessibilityScrollView(AXID, ScrollView&);
     void detachRemoteParts(AccessibilityDetachmentType) override;
 
     ScrollView* currentScrollView() const;

--- a/Source/WebCore/accessibility/AccessibilityScrollbar.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollbar.cpp
@@ -36,39 +36,31 @@
 
 namespace WebCore {
 
-AccessibilityScrollbar::AccessibilityScrollbar(Scrollbar* scrollbar)
-    : m_scrollbar(scrollbar)
+AccessibilityScrollbar::AccessibilityScrollbar(AXID axID, Scrollbar& scrollbar)
+    : AccessibilityMockObject(axID)
+    , m_scrollbar(scrollbar)
 {
-    ASSERT(scrollbar);
 }
 
-Ref<AccessibilityScrollbar> AccessibilityScrollbar::create(Scrollbar* scrollbar)
+Ref<AccessibilityScrollbar> AccessibilityScrollbar::create(AXID axID, Scrollbar& scrollbar)
 {
-    return adoptRef(*new AccessibilityScrollbar(scrollbar));
+    return adoptRef(*new AccessibilityScrollbar(axID, scrollbar));
 }
     
 LayoutRect AccessibilityScrollbar::elementRect() const
 {
-    if (!m_scrollbar)
-        return LayoutRect();
-    
     return m_scrollbar->frameRect();
 }
     
 Document* AccessibilityScrollbar::document() const
 {
-    AccessibilityObject* parent = parentObject();
-    if (!parent)
-        return nullptr;
-    return parent->document();
+    RefPtr parent = parentObject();
+    return parent ? parent->document() : nullptr;
 }
 
 AccessibilityOrientation AccessibilityScrollbar::orientation() const
 {
     // ARIA 1.1 Elements with the role scrollbar have an implicit aria-orientation value of vertical.
-    if (!m_scrollbar)
-        return AccessibilityOrientation::Vertical;
-
     if (m_scrollbar->orientation() == ScrollbarOrientation::Horizontal)
         return AccessibilityOrientation::Horizontal;
     if (m_scrollbar->orientation() == ScrollbarOrientation::Vertical)
@@ -79,24 +71,16 @@ AccessibilityOrientation AccessibilityScrollbar::orientation() const
 
 bool AccessibilityScrollbar::isEnabled() const
 {
-    if (!m_scrollbar)
-        return false;
     return m_scrollbar->enabled();
 }
     
 float AccessibilityScrollbar::valueForRange() const
 {
-    if (!m_scrollbar)
-        return 0;
-
     return m_scrollbar->currentPos() / m_scrollbar->maximum();
 }
 
 bool AccessibilityScrollbar::setValue(float value)
 {
-    if (!m_scrollbar)
-        return false;
-    
     float newValue = value * m_scrollbar->maximum();
     m_scrollbar->scrollableArea().scrollToOffsetWithoutAnimation(m_scrollbar->orientation(), newValue);
     return true;

--- a/Source/WebCore/accessibility/AccessibilityScrollbar.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollbar.h
@@ -36,12 +36,10 @@ class Scrollbar;
 
 class AccessibilityScrollbar final : public AccessibilityMockObject {
 public:
-    static Ref<AccessibilityScrollbar> create(Scrollbar*);
+    static Ref<AccessibilityScrollbar> create(AXID, Scrollbar&);
 
-    Scrollbar* scrollbar() const { return m_scrollbar.get(); }
-    
 private:
-    explicit AccessibilityScrollbar(Scrollbar*);
+    explicit AccessibilityScrollbar(AXID, Scrollbar&);
 
     bool canSetValueAttribute() const override { return true; }
 
@@ -57,7 +55,7 @@ private:
     bool setValue(float) override;
     float valueForRange() const override;
 
-    RefPtr<Scrollbar> m_scrollbar;
+    Ref<Scrollbar> m_scrollbar;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilitySlider.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySlider.cpp
@@ -42,14 +42,14 @@ namespace WebCore {
     
 using namespace HTMLNames;
 
-AccessibilitySlider::AccessibilitySlider(RenderObject& renderer)
-    : AccessibilityRenderObject(renderer)
+AccessibilitySlider::AccessibilitySlider(AXID axID, RenderObject& renderer)
+    : AccessibilityRenderObject(axID, renderer)
 {
 }
 
-Ref<AccessibilitySlider> AccessibilitySlider::create(RenderObject& renderer)
+Ref<AccessibilitySlider> AccessibilitySlider::create(AXID axID, RenderObject& renderer)
 {
-    return adoptRef(*new AccessibilitySlider(renderer));
+    return adoptRef(*new AccessibilitySlider(axID, renderer));
 }
 
 AccessibilityOrientation AccessibilitySlider::orientation() const
@@ -154,13 +154,14 @@ HTMLInputElement* AccessibilitySlider::inputElement() const
 }
 
 
-AccessibilitySliderThumb::AccessibilitySliderThumb()
+AccessibilitySliderThumb::AccessibilitySliderThumb(AXID axID)
+    : AccessibilityMockObject(axID)
 {
 }
 
-Ref<AccessibilitySliderThumb> AccessibilitySliderThumb::create()
+Ref<AccessibilitySliderThumb> AccessibilitySliderThumb::create(AXID axID)
 {
-    return adoptRef(*new AccessibilitySliderThumb());
+    return adoptRef(*new AccessibilitySliderThumb(axID));
 }
     
 LayoutRect AccessibilitySliderThumb::elementRect() const

--- a/Source/WebCore/accessibility/AccessibilitySlider.h
+++ b/Source/WebCore/accessibility/AccessibilitySlider.h
@@ -37,11 +37,11 @@ class HTMLInputElement;
 
 class AccessibilitySlider : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilitySlider> create(RenderObject&);
+    static Ref<AccessibilitySlider> create(AXID, RenderObject&);
     virtual ~AccessibilitySlider() = default;
 
 private:
-    explicit AccessibilitySlider(RenderObject&);
+    explicit AccessibilitySlider(AXID, RenderObject&);
 
     HTMLInputElement* inputElement() const;
     AccessibilityObject* elementAccessibilityHitTest(const IntPoint&) const final;
@@ -63,14 +63,14 @@ private:
 
 class AccessibilitySliderThumb final : public AccessibilityMockObject {
 public:
-    static Ref<AccessibilitySliderThumb> create();
+    static Ref<AccessibilitySliderThumb> create(AXID);
     virtual ~AccessibilitySliderThumb() = default;
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::SliderThumb; }
     LayoutRect elementRect() const override;
 
 private:
-    AccessibilitySliderThumb();
+    explicit AccessibilitySliderThumb(AXID);
 
     bool isSliderThumb() const override { return true; }
     bool computeIsIgnored() const override;

--- a/Source/WebCore/accessibility/AccessibilitySpinButton.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySpinButton.cpp
@@ -31,13 +31,14 @@
 
 namespace WebCore {
 
-Ref<AccessibilitySpinButton> AccessibilitySpinButton::create()
+Ref<AccessibilitySpinButton> AccessibilitySpinButton::create(AXID axID)
 {
-    return adoptRef(*new AccessibilitySpinButton);
+    return adoptRef(*new AccessibilitySpinButton(axID));
 }
     
-AccessibilitySpinButton::AccessibilitySpinButton()
-    : m_spinButtonElement(nullptr)
+AccessibilitySpinButton::AccessibilitySpinButton(AXID axID)
+    : AccessibilityMockObject(axID)
+    , m_spinButtonElement(nullptr)
 {
 }
 
@@ -110,14 +111,15 @@ void AccessibilitySpinButton::step(int amount)
 
 // AccessibilitySpinButtonPart 
 
-AccessibilitySpinButtonPart::AccessibilitySpinButtonPart()
-    : m_isIncrementor(false)
+AccessibilitySpinButtonPart::AccessibilitySpinButtonPart(AXID axID)
+    : AccessibilityMockObject(axID)
+    , m_isIncrementor(false)
 {
 }
     
-Ref<AccessibilitySpinButtonPart> AccessibilitySpinButtonPart::create()
+Ref<AccessibilitySpinButtonPart> AccessibilitySpinButtonPart::create(AXID axID)
 {
-    return adoptRef(*new AccessibilitySpinButtonPart);
+    return adoptRef(*new AccessibilitySpinButtonPart(axID));
 }
 
 LayoutRect AccessibilitySpinButtonPart::elementRect() const

--- a/Source/WebCore/accessibility/AccessibilitySpinButton.h
+++ b/Source/WebCore/accessibility/AccessibilitySpinButton.h
@@ -32,7 +32,7 @@ namespace WebCore {
 
 class AccessibilitySpinButton final : public AccessibilityMockObject {
 public:
-    static Ref<AccessibilitySpinButton> create();
+    static Ref<AccessibilitySpinButton> create(AXID);
     virtual ~AccessibilitySpinButton();
 
     void setSpinButtonElement(SpinButtonElement* spinButton) { m_spinButtonElement = spinButton; }
@@ -43,7 +43,7 @@ public:
     void step(int amount);
 
 private:
-    AccessibilitySpinButton();
+    explicit AccessibilitySpinButton(AXID);
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::SpinButton; }
     bool isNativeSpinButton() const override { return true; }
@@ -55,14 +55,14 @@ private:
 
 class AccessibilitySpinButtonPart final : public AccessibilityMockObject {
 public:
-    static Ref<AccessibilitySpinButtonPart> create();
+    static Ref<AccessibilitySpinButtonPart> create(AXID);
     virtual ~AccessibilitySpinButtonPart() = default;
 
     bool isIncrementor() const override { return m_isIncrementor; }
     void setIsIncrementor(bool value) { m_isIncrementor = value; }
 
 private:
-    AccessibilitySpinButtonPart();
+    explicit AccessibilitySpinButtonPart(AXID);
 
     bool press() override;
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::SpinButtonPart; }

--- a/Source/WebCore/accessibility/AccessibilityTable.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTable.cpp
@@ -56,15 +56,15 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-AccessibilityTable::AccessibilityTable(RenderObject& renderer)
-    : AccessibilityRenderObject(renderer)
+AccessibilityTable::AccessibilityTable(AXID axID, RenderObject& renderer)
+    : AccessibilityRenderObject(axID, renderer)
     , m_headerContainer(nullptr)
     , m_isExposable(true)
 {
 }
 
-AccessibilityTable::AccessibilityTable(Node& node)
-    : AccessibilityRenderObject(node)
+AccessibilityTable::AccessibilityTable(AXID axID, Node& node)
+    : AccessibilityRenderObject(axID, node)
     , m_headerContainer(nullptr)
     , m_isExposable(true)
 {
@@ -81,14 +81,14 @@ void AccessibilityTable::init()
     AccessibilityRenderObject::init();
 }
 
-Ref<AccessibilityTable> AccessibilityTable::create(RenderObject& renderer)
+Ref<AccessibilityTable> AccessibilityTable::create(AXID axID, RenderObject& renderer)
 {
-    return adoptRef(*new AccessibilityTable(renderer));
+    return adoptRef(*new AccessibilityTable(axID, renderer));
 }
 
-Ref<AccessibilityTable> AccessibilityTable::create(Node& node)
+Ref<AccessibilityTable> AccessibilityTable::create(AXID axID, Node& node)
 {
-    return adoptRef(*new AccessibilityTable(node));
+    return adoptRef(*new AccessibilityTable(axID, node));
 }
 
 bool AccessibilityTable::hasNonTableARIARole() const

--- a/Source/WebCore/accessibility/AccessibilityTable.h
+++ b/Source/WebCore/accessibility/AccessibilityTable.h
@@ -38,8 +38,8 @@ class HTMLTableElement;
 
 class AccessibilityTable : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityTable> create(RenderObject&);
-    static Ref<AccessibilityTable> create(Node&);
+    static Ref<AccessibilityTable> create(AXID, RenderObject&);
+    static Ref<AccessibilityTable> create(AXID, Node&);
     virtual ~AccessibilityTable();
 
     void init() final;
@@ -84,8 +84,8 @@ public:
     void setCellSlotsDirty();
 
 protected:
-    explicit AccessibilityTable(RenderObject&);
-    explicit AccessibilityTable(Node&);
+    explicit AccessibilityTable(AXID, RenderObject&);
+    explicit AccessibilityTable(AXID, Node&);
 
     AccessibilityChildrenVector m_rows;
     AccessibilityChildrenVector m_columns;

--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -40,26 +40,26 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-AccessibilityTableCell::AccessibilityTableCell(RenderObject& renderer)
-    : AccessibilityRenderObject(renderer)
+AccessibilityTableCell::AccessibilityTableCell(AXID axID, RenderObject& renderer)
+    : AccessibilityRenderObject(axID, renderer)
 {
 }
 
-AccessibilityTableCell::AccessibilityTableCell(Node& node)
-    : AccessibilityRenderObject(node)
+AccessibilityTableCell::AccessibilityTableCell(AXID axID, Node& node)
+    : AccessibilityRenderObject(axID, node)
 {
 }
 
 AccessibilityTableCell::~AccessibilityTableCell() = default;
 
-Ref<AccessibilityTableCell> AccessibilityTableCell::create(RenderObject& renderer)
+Ref<AccessibilityTableCell> AccessibilityTableCell::create(AXID axID, RenderObject& renderer)
 {
-    return adoptRef(*new AccessibilityTableCell(renderer));
+    return adoptRef(*new AccessibilityTableCell(axID, renderer));
 }
 
-Ref<AccessibilityTableCell> AccessibilityTableCell::create(Node& node)
+Ref<AccessibilityTableCell> AccessibilityTableCell::create(AXID axID, Node& node)
 {
-    return adoptRef(*new AccessibilityTableCell(node));
+    return adoptRef(*new AccessibilityTableCell(axID, node));
 }
 
 bool AccessibilityTableCell::computeIsIgnored() const

--- a/Source/WebCore/accessibility/AccessibilityTableCell.h
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.h
@@ -37,8 +37,8 @@ class AccessibilityTableRow;
 
 class AccessibilityTableCell : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityTableCell> create(RenderObject&);
-    static Ref<AccessibilityTableCell> create(Node&);
+    static Ref<AccessibilityTableCell> create(AXID, RenderObject&);
+    static Ref<AccessibilityTableCell> create(AXID, Node&);
     virtual ~AccessibilityTableCell();
     bool isTableCell() const final { return true; }
 
@@ -76,8 +76,8 @@ public:
 #endif
 
 protected:
-    explicit AccessibilityTableCell(RenderObject&);
-    explicit AccessibilityTableCell(Node&);
+    explicit AccessibilityTableCell(AXID, RenderObject&);
+    explicit AccessibilityTableCell(AXID, Node&);
 
     AccessibilityTableRow* parentRow() const;
     AccessibilityRole determineAccessibilityRole() final;

--- a/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
@@ -33,13 +33,16 @@
 
 namespace WebCore {
 
-AccessibilityTableColumn::AccessibilityTableColumn() = default;
+AccessibilityTableColumn::AccessibilityTableColumn(AXID axID)
+    : AccessibilityMockObject(axID)
+{
+}
 
 AccessibilityTableColumn::~AccessibilityTableColumn() = default;
 
-Ref<AccessibilityTableColumn> AccessibilityTableColumn::create()
+Ref<AccessibilityTableColumn> AccessibilityTableColumn::create(AXID axID)
 {
-    return adoptRef(*new AccessibilityTableColumn());
+    return adoptRef(*new AccessibilityTableColumn(axID));
 }
 
 void AccessibilityTableColumn::setParent(AccessibilityObject* parent)

--- a/Source/WebCore/accessibility/AccessibilityTableColumn.h
+++ b/Source/WebCore/accessibility/AccessibilityTableColumn.h
@@ -36,7 +36,7 @@ class RenderTableSection;
 
 class AccessibilityTableColumn final : public AccessibilityMockObject {
 public:
-    static Ref<AccessibilityTableColumn> create();
+    static Ref<AccessibilityTableColumn> create(AXID);
     virtual ~AccessibilityTableColumn();
 
     AXCoreObject* columnHeader() override;
@@ -52,7 +52,7 @@ public:
     LayoutRect elementRect() const override;
     
 private:
-    AccessibilityTableColumn();
+    explicit AccessibilityTableColumn(AXID);
     
     bool computeIsIgnored() const override;
     bool isTableColumn() const override { return true; }

--- a/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
@@ -34,13 +34,16 @@
 
 namespace WebCore {
 
-AccessibilityTableHeaderContainer::AccessibilityTableHeaderContainer() = default;
+AccessibilityTableHeaderContainer::AccessibilityTableHeaderContainer(AXID axID)
+    : AccessibilityMockObject(axID)
+{
+}
 
 AccessibilityTableHeaderContainer::~AccessibilityTableHeaderContainer() = default;
 
-Ref<AccessibilityTableHeaderContainer> AccessibilityTableHeaderContainer::create()
+Ref<AccessibilityTableHeaderContainer> AccessibilityTableHeaderContainer::create(AXID axID)
 {
-    return adoptRef(*new AccessibilityTableHeaderContainer());
+    return adoptRef(*new AccessibilityTableHeaderContainer(axID));
 }
     
 LayoutRect AccessibilityTableHeaderContainer::elementRect() const

--- a/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.h
+++ b/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.h
@@ -36,7 +36,7 @@ namespace WebCore {
 
 class AccessibilityTableHeaderContainer final : public AccessibilityMockObject {
 public:
-    static Ref<AccessibilityTableHeaderContainer> create();
+    static Ref<AccessibilityTableHeaderContainer> create(AXID axID);
     virtual ~AccessibilityTableHeaderContainer();
     
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::TableHeaderContainer; }
@@ -46,7 +46,7 @@ public:
     LayoutRect elementRect() const override;
     
 private:
-    AccessibilityTableHeaderContainer();
+    explicit AccessibilityTableHeaderContainer(AXID);
     
     bool computeIsIgnored() const override;
 

--- a/Source/WebCore/accessibility/AccessibilityTableRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.cpp
@@ -39,26 +39,26 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-AccessibilityTableRow::AccessibilityTableRow(RenderObject& renderer)
-    : AccessibilityRenderObject(renderer)
+AccessibilityTableRow::AccessibilityTableRow(AXID axID, RenderObject& renderer)
+    : AccessibilityRenderObject(axID, renderer)
 {
 }
 
-AccessibilityTableRow::AccessibilityTableRow(Node& node)
-    : AccessibilityRenderObject(node)
+AccessibilityTableRow::AccessibilityTableRow(AXID axID, Node& node)
+    : AccessibilityRenderObject(axID, node)
 {
 }
 
 AccessibilityTableRow::~AccessibilityTableRow() = default;
 
-Ref<AccessibilityTableRow> AccessibilityTableRow::create(RenderObject& renderer)
+Ref<AccessibilityTableRow> AccessibilityTableRow::create(AXID axID, RenderObject& renderer)
 {
-    return adoptRef(*new AccessibilityTableRow(renderer));
+    return adoptRef(*new AccessibilityTableRow(axID, renderer));
 }
 
-Ref<AccessibilityTableRow> AccessibilityTableRow::create(Node& node)
+Ref<AccessibilityTableRow> AccessibilityTableRow::create(AXID axID, Node& node)
 {
-    return adoptRef(*new AccessibilityTableRow(node));
+    return adoptRef(*new AccessibilityTableRow(axID, node));
 }
 
 AccessibilityRole AccessibilityTableRow::determineAccessibilityRole()

--- a/Source/WebCore/accessibility/AccessibilityTableRow.h
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.h
@@ -36,8 +36,8 @@ class AccessibilityTable;
 
 class AccessibilityTableRow : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityTableRow> create(RenderObject&);
-    static Ref<AccessibilityTableRow> create(Node&);
+    static Ref<AccessibilityTableRow> create(AXID, RenderObject&);
+    static Ref<AccessibilityTableRow> create(AXID, Node&);
     virtual ~AccessibilityTableRow();
 
     // retrieves the "row" header (a th tag in the rightmost column)
@@ -57,8 +57,8 @@ public:
     int axRowIndex() const override;
 
 protected:
-    explicit AccessibilityTableRow(RenderObject&);
-    explicit AccessibilityTableRow(Node&);
+    explicit AccessibilityTableRow(AXID, RenderObject&);
+    explicit AccessibilityTableRow(AXID, Node&);
 
     AccessibilityRole determineAccessibilityRole() final;
 

--- a/Source/WebCore/accessibility/AccessibilityTree.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTree.cpp
@@ -40,26 +40,26 @@ namespace WebCore {
 
 using namespace HTMLNames;
     
-AccessibilityTree::AccessibilityTree(RenderObject& renderer)
-    : AccessibilityRenderObject(renderer)
+AccessibilityTree::AccessibilityTree(AXID axID, RenderObject& renderer)
+    : AccessibilityRenderObject(axID, renderer)
 {
 }
 
-AccessibilityTree::AccessibilityTree(Node& node)
-    : AccessibilityRenderObject(node)
+AccessibilityTree::AccessibilityTree(AXID axID, Node& node)
+    : AccessibilityRenderObject(axID, node)
 {
 }
 
 AccessibilityTree::~AccessibilityTree() = default;
     
-Ref<AccessibilityTree> AccessibilityTree::create(RenderObject& renderer)
+Ref<AccessibilityTree> AccessibilityTree::create(AXID axID, RenderObject& renderer)
 {
-    return adoptRef(*new AccessibilityTree(renderer));
+    return adoptRef(*new AccessibilityTree(axID, renderer));
 }
 
-Ref<AccessibilityTree> AccessibilityTree::create(Node& node)
+Ref<AccessibilityTree> AccessibilityTree::create(AXID axID, Node& node)
 {
-    return adoptRef(*new AccessibilityTree(node));
+    return adoptRef(*new AccessibilityTree(axID, node));
 }
 
 bool AccessibilityTree::computeIsIgnored() const

--- a/Source/WebCore/accessibility/AccessibilityTree.h
+++ b/Source/WebCore/accessibility/AccessibilityTree.h
@@ -32,16 +32,18 @@
 #include "AccessibilityRenderObject.h"
 
 namespace WebCore {
-    
+
+// This class is representative of role="tree" elements, not the abstract concept
+// of the "accessibility tree".
 class AccessibilityTree final : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityTree> create(RenderObject&);
-    static Ref<AccessibilityTree> create(Node&);
+    static Ref<AccessibilityTree> create(AXID, RenderObject&);
+    static Ref<AccessibilityTree> create(AXID, Node&);
     virtual ~AccessibilityTree();
 
 private:
-    explicit AccessibilityTree(RenderObject&);
-    explicit AccessibilityTree(Node&);
+    explicit AccessibilityTree(AXID, RenderObject&);
+    explicit AccessibilityTree(AXID, Node&);
     bool computeIsIgnored() const override;
     AccessibilityRole determineAccessibilityRole() override;
     bool isTreeValid() const;

--- a/Source/WebCore/accessibility/AccessibilityTreeItem.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTreeItem.cpp
@@ -36,26 +36,26 @@ namespace WebCore {
     
 using namespace HTMLNames;
     
-AccessibilityTreeItem::AccessibilityTreeItem(RenderObject& renderer)
-    : AccessibilityRenderObject(renderer)
+AccessibilityTreeItem::AccessibilityTreeItem(AXID axID, RenderObject& renderer)
+    : AccessibilityRenderObject(axID, renderer)
 {
 }
 
-AccessibilityTreeItem::AccessibilityTreeItem(Node& node)
-    : AccessibilityRenderObject(node)
+AccessibilityTreeItem::AccessibilityTreeItem(AXID axID, Node& node)
+    : AccessibilityRenderObject(axID, node)
 {
 }
 
 AccessibilityTreeItem::~AccessibilityTreeItem() = default;
     
-Ref<AccessibilityTreeItem> AccessibilityTreeItem::create(RenderObject& renderer)
+Ref<AccessibilityTreeItem> AccessibilityTreeItem::create(AXID axID, RenderObject& renderer)
 {
-    return adoptRef(*new AccessibilityTreeItem(renderer));
+    return adoptRef(*new AccessibilityTreeItem(axID, renderer));
 }
 
-Ref<AccessibilityTreeItem> AccessibilityTreeItem::create(Node& node)
+Ref<AccessibilityTreeItem> AccessibilityTreeItem::create(AXID axID, Node& node)
 {
-    return adoptRef(*new AccessibilityTreeItem(node));
+    return adoptRef(*new AccessibilityTreeItem(axID, node));
 }
 
 bool AccessibilityTreeItem::supportsCheckedState() const

--- a/Source/WebCore/accessibility/AccessibilityTreeItem.h
+++ b/Source/WebCore/accessibility/AccessibilityTreeItem.h
@@ -34,15 +34,15 @@ namespace WebCore {
     
 class AccessibilityTreeItem final : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityTreeItem> create(RenderObject&);
-    static Ref<AccessibilityTreeItem> create(Node&);
+    static Ref<AccessibilityTreeItem> create(AXID, RenderObject&);
+    static Ref<AccessibilityTreeItem> create(AXID, Node&);
     virtual ~AccessibilityTreeItem();
 
     bool supportsCheckedState() const override;
 
 private:
-    explicit AccessibilityTreeItem(RenderObject&);
-    explicit AccessibilityTreeItem(Node&);
+    explicit AccessibilityTreeItem(AXID, RenderObject&);
+    explicit AccessibilityTreeItem(AXID, Node&);
     bool shouldIgnoreAttributeRole() const final { return !m_isTreeItemValid; }
     AccessibilityRole determineAccessibilityRole() override;
     bool m_isTreeItemValid;

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -443,7 +443,7 @@ GDBusInterfaceVTable AccessibilityObjectAtspi::s_accessibleFunctions = {
             return g_variant_new_string(atspiObject->locale().utf8().data());
         if (!g_strcmp0(propertyName, "AccessibleId")) {
             auto objectID = atspiObject->m_coreObject->objectID();
-            return g_variant_new_string(atspiObject->m_coreObject ? String::number(objectID ? objectID->toUInt64() : 0).utf8().data() : "");
+            return g_variant_new_string(atspiObject->m_coreObject ? String::number(objectID.toUInt64()).utf8().data() : "");
         }
         if (!g_strcmp0(propertyName, "Parent"))
             return atspiObject->parentReference();

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -56,7 +56,6 @@ AXIsolatedObject::AXIsolatedObject(const Ref<AccessibilityObject>& axObject, AXI
     , m_cachedTree(tree)
 {
     ASSERT(isMainThread());
-    ASSERT(objectID());
 
     if (auto* axParent = axObject->parentInCoreTree())
         m_parentID = axParent->objectID();
@@ -81,7 +80,7 @@ String AXIsolatedObject::dbg() const
 {
     return makeString(
         "{role: "_s, accessibilityRoleToString(roleValue()),
-        ", ID "_s, objectID() ? objectID()->loggingString() : ""_s, '}'
+        ", ID "_s, objectID().loggingString(), '}'
     );
 }
 
@@ -199,7 +198,7 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
     setProperty(AXPropertyName::IsNonLayerSVGObject, object.isNonLayerSVGObject());
 
     RefPtr geometryManager = tree()->geometryManager();
-    std::optional frame = geometryManager ? geometryManager->cachedRectForID(*object.objectID()) : std::nullopt;
+    std::optional frame = geometryManager ? geometryManager->cachedRectForID(object.objectID()) : std::nullopt;
     if (frame)
         setProperty(AXPropertyName::RelativeFrame, WTFMove(*frame));
     else if (object.isScrollView() || object.isWebArea() || object.isScrollbar()) {
@@ -381,7 +380,7 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
 
         auto range = object.textInputMarkedTextMarkerRange();
         if (auto characterRange = range.characterRange(); range && characterRange)
-            setProperty(AXPropertyName::TextInputMarkedTextMarkerRange, std::pair<Markable<AXID>, CharacterRange>(*range.start().objectID(), *characterRange));
+            setProperty(AXPropertyName::TextInputMarkedTextMarkerRange, std::pair<Markable<AXID>, CharacterRange>(range.start().objectID(), *characterRange));
 
         bool isNonNativeTextControl = object.isNonNativeTextControl();
         setProperty(AXPropertyName::CanBeMultilineTextField, canBeMultilineTextField(object, isNonNativeTextControl));
@@ -431,10 +430,9 @@ bool AXIsolatedObject::canBeMultilineTextField(AccessibilityObject& object, bool
 AccessibilityObject* AXIsolatedObject::associatedAXObject() const
 {
     ASSERT(isMainThread());
-    ASSERT(objectID());
 
     auto* axObjectCache = this->axObjectCache();
-    return axObjectCache ? axObjectCache->objectForID(*objectID()) : nullptr;
+    return axObjectCache ? axObjectCache->objectForID(objectID()) : nullptr;
 }
 
 void AXIsolatedObject::setMathscripts(AXPropertyName propertyName, AccessibilityObject& object)

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -98,7 +98,6 @@ private:
 
     AXIsolatedTree* tree() const { return m_cachedTree.get(); }
 
-    AXIsolatedObject() = default;
     AXIsolatedObject(const Ref<AccessibilityObject>&, AXIsolatedTree*);
     bool isAXIsolatedObjectInstance() const final { return true; }
     AccessibilityObject* associatedAXObject() const;

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -297,7 +297,7 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
 
 - (void)attachAXObject:(AccessibilityObject&)axObject
 {
-    ASSERT(!_identifier || *_identifier == axObject.objectID());
+    ASSERT(!_identifier || _identifier == axObject.objectID());
     m_axObject = axObject;
     if (!_identifier)
         _identifier = m_axObject->objectID();

--- a/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
+++ b/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
@@ -119,7 +119,7 @@ void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNoti
     ASSERT(object.objectID()->toUInt64() <= std::numeric_limits<LONG>::max());
 
     auto objectID = object.objectID();
-    NotifyWinEvent(msaaEvent, page->chrome().platformPageClient(), OBJID_CLIENT, -static_cast<LONG>(objectID ? objectID->toUInt64() : 0));
+    NotifyWinEvent(msaaEvent, page->chrome().platformPageClient(), OBJID_CLIENT, -static_cast<LONG>(objectID.toUInt64()));
 }
 
 void AXObjectCache::nodeTextChangePlatformNotification(AccessibilityObject*, AXTextChange, unsigned, const String&)


### PR DESCRIPTION
#### 5f293ca29cb7201b048dd7b3f89296b1467c1567
<pre>
AX: AXCoreObject::m_id should not be optional
<a href="https://bugs.webkit.org/show_bug.cgi?id=282788">https://bugs.webkit.org/show_bug.cgi?id=282788</a>
<a href="https://rdar.apple.com/problem/139475407">rdar://problem/139475407</a>

Reviewed by Chris Fleizach.

The only time an AXCoreObject ever has a null m_id is in the short time after it&apos;s created, and before calling
AXObjectCache::getAXID(), at which point it was set and never made null again. With this PR, we assign the ID
in tandem with creating every object. This means we never allow an object to be in an invalid state (lacking an ID).
It&apos;s also more efficient to assign the ID during construction vs. setting it post-construction.

Most importantly, this makes our code way cleaner. Prior to this commit, there were hundreds of unchecked dereferences
on our objectID() calls, all of which are removed. This also allows us to remove a few runtime if-statements checking
for null AXIDs, which are now impossible with this commit.

* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::objectID const):
(WebCore::AXCoreObject::AXCoreObject):
(WebCore::axIDs):
(WebCore::AXCoreObject::setObjectID): Deleted.
* Source/WebCore/accessibility/AXImage.cpp:
(WebCore::AXImage::AXImage):
(WebCore::AXImage::create):
* Source/WebCore/accessibility/AXImage.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
(WebCore::streamAXCoreObject):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::setIsolatedTreeFocusedObject):
(WebCore::AXObjectCache::createObjectFromRenderer):
(WebCore::AXObjectCache::createFromNode):
(WebCore::AXObjectCache::cacheAndInitializeWrapper):
(WebCore::AXObjectCache::getOrCreate):
(WebCore::AXObjectCache::create):
(WebCore::AXObjectCache::generateNewObjectID):
(WebCore::AXObjectCache::updateIsolatedTree):
(WebCore::AXObjectCache::updateIsolatedTree const):
(WebCore::AXObjectCache::addRelation):
(WebCore::AXObjectCache::removeRelation):
(WebCore::AXObjectCache::isDescendantOfRelatedNode):
(WebCore::AXObjectCache::relatedObjectIDsFor):
(WebCore::createFromNode): Deleted.
(WebCore::AXObjectCache::generateNewObjectID const): Deleted.
(WebCore::AXObjectCache::getAXID): Deleted.
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXRemoteFrame.cpp:
(WebCore::AXRemoteFrame::AXRemoteFrame):
(WebCore::AXRemoteFrame::create):
* Source/WebCore/accessibility/AXRemoteFrame.h:
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::AXSearchManager::matchForSearchKeyAtIndex):
(WebCore::AXSearchManager::findMatchingRange):
* Source/WebCore/accessibility/AccessibilityARIAGridCell.cpp:
(WebCore::AccessibilityARIAGridCell::AccessibilityARIAGridCell):
(WebCore::AccessibilityARIAGridCell::create):
* Source/WebCore/accessibility/AccessibilityARIAGridCell.h:
* Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp:
(WebCore::AccessibilityARIAGridRow::AccessibilityARIAGridRow):
(WebCore::AccessibilityARIAGridRow::create):
* Source/WebCore/accessibility/AccessibilityARIAGridRow.h:
* Source/WebCore/accessibility/AccessibilityARIATable.cpp:
(WebCore::AccessibilityARIATable::AccessibilityARIATable):
(WebCore::AccessibilityARIATable::create):
* Source/WebCore/accessibility/AccessibilityARIATable.h:
* Source/WebCore/accessibility/AccessibilityAttachment.cpp:
(WebCore::AccessibilityAttachment::AccessibilityAttachment):
(WebCore::AccessibilityAttachment::create):
* Source/WebCore/accessibility/AccessibilityAttachment.h:
* Source/WebCore/accessibility/AccessibilityImageMapLink.cpp:
(WebCore::AccessibilityImageMapLink::AccessibilityImageMapLink):
(WebCore::AccessibilityImageMapLink::create):
* Source/WebCore/accessibility/AccessibilityImageMapLink.h:
* Source/WebCore/accessibility/AccessibilityLabel.cpp:
(WebCore::AccessibilityLabel::AccessibilityLabel):
(WebCore::AccessibilityLabel::create):
* Source/WebCore/accessibility/AccessibilityLabel.h:
* Source/WebCore/accessibility/AccessibilityList.cpp:
(WebCore::AccessibilityList::AccessibilityList):
(WebCore::AccessibilityList::create):
* Source/WebCore/accessibility/AccessibilityList.h:
* Source/WebCore/accessibility/AccessibilityListBox.cpp:
(WebCore::AccessibilityListBox::AccessibilityListBox):
(WebCore::AccessibilityListBox::create):
* Source/WebCore/accessibility/AccessibilityListBox.h:
* Source/WebCore/accessibility/AccessibilityListBoxOption.cpp:
(WebCore::AccessibilityListBoxOption::AccessibilityListBoxOption):
(WebCore::AccessibilityListBoxOption::create):
* Source/WebCore/accessibility/AccessibilityListBoxOption.h:
* Source/WebCore/accessibility/AccessibilityMathMLElement.cpp:
(WebCore::AccessibilityMathMLElement::AccessibilityMathMLElement):
(WebCore::AccessibilityMathMLElement::create):
* Source/WebCore/accessibility/AccessibilityMathMLElement.h:
* Source/WebCore/accessibility/AccessibilityMediaObject.cpp:
(WebCore::AccessibilityMediaObject::AccessibilityMediaObject):
(WebCore::AccessibilityMediaObject::create):
* Source/WebCore/accessibility/AccessibilityMediaObject.h:
* Source/WebCore/accessibility/AccessibilityMenuList.cpp:
(WebCore::AccessibilityMenuList::AccessibilityMenuList):
(WebCore::AccessibilityMenuList::create):
* Source/WebCore/accessibility/AccessibilityMenuList.h:
* Source/WebCore/accessibility/AccessibilityMenuListOption.cpp:
(WebCore::AccessibilityMenuListOption::AccessibilityMenuListOption):
(WebCore::AccessibilityMenuListOption::create):
* Source/WebCore/accessibility/AccessibilityMenuListOption.h:
* Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp:
(WebCore::AccessibilityMenuListPopup::AccessibilityMenuListPopup):
* Source/WebCore/accessibility/AccessibilityMenuListPopup.h:
* Source/WebCore/accessibility/AccessibilityMockObject.cpp:
(WebCore::AccessibilityMockObject::AccessibilityMockObject):
* Source/WebCore/accessibility/AccessibilityMockObject.h:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::AccessibilityNodeObject):
(WebCore::AccessibilityNodeObject::create):
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::AccessibilityObject):
(WebCore::AccessibilityObject::dbg const):
(WebCore::AccessibilityObject::isIgnored const):
(WebCore::AccessibilityObject::isIgnoredWithoutCache const):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp:
(WebCore::AccessibilityProgressIndicator::AccessibilityProgressIndicator):
(WebCore::AccessibilityProgressIndicator::create):
* Source/WebCore/accessibility/AccessibilityProgressIndicator.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::AccessibilityRenderObject):
(WebCore::AccessibilityRenderObject::create):
* Source/WebCore/accessibility/AccessibilityRenderObject.h:
* Source/WebCore/accessibility/AccessibilitySVGObject.cpp:
(WebCore::AccessibilitySVGObject::AccessibilitySVGObject):
(WebCore::AccessibilitySVGObject::create):
* Source/WebCore/accessibility/AccessibilitySVGObject.h:
* Source/WebCore/accessibility/AccessibilitySVGRoot.cpp:
(WebCore::AccessibilitySVGRoot::AccessibilitySVGRoot):
(WebCore::AccessibilitySVGRoot::create):
* Source/WebCore/accessibility/AccessibilitySVGRoot.h:
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::AccessibilityScrollView):
(WebCore::AccessibilityScrollView::create):
* Source/WebCore/accessibility/AccessibilityScrollView.h:
* Source/WebCore/accessibility/AccessibilityScrollbar.cpp:
(WebCore::AccessibilityScrollbar::AccessibilityScrollbar):
(WebCore::AccessibilityScrollbar::create):
(WebCore::AccessibilityScrollbar::elementRect const):
(WebCore::AccessibilityScrollbar::document const):
(WebCore::AccessibilityScrollbar::orientation const):
(WebCore::AccessibilityScrollbar::isEnabled const):
(WebCore::AccessibilityScrollbar::valueForRange const):
(WebCore::AccessibilityScrollbar::setValue):
* Source/WebCore/accessibility/AccessibilityScrollbar.h:
* Source/WebCore/accessibility/AccessibilitySlider.cpp:
(WebCore::AccessibilitySlider::AccessibilitySlider):
(WebCore::AccessibilitySlider::create):
(WebCore::AccessibilitySliderThumb::AccessibilitySliderThumb):
(WebCore::AccessibilitySliderThumb::create):
* Source/WebCore/accessibility/AccessibilitySlider.h:
* Source/WebCore/accessibility/AccessibilitySpinButton.cpp:
(WebCore::AccessibilitySpinButton::create):
(WebCore::AccessibilitySpinButton::AccessibilitySpinButton):
(WebCore::AccessibilitySpinButtonPart::AccessibilitySpinButtonPart):
(WebCore::AccessibilitySpinButtonPart::create):
* Source/WebCore/accessibility/AccessibilitySpinButton.h:
* Source/WebCore/accessibility/AccessibilityTable.cpp:
(WebCore::AccessibilityTable::AccessibilityTable):
(WebCore::AccessibilityTable::create):
* Source/WebCore/accessibility/AccessibilityTable.h:
* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
(WebCore::AccessibilityTableCell::AccessibilityTableCell):
(WebCore::AccessibilityTableCell::create):
* Source/WebCore/accessibility/AccessibilityTableCell.h:
* Source/WebCore/accessibility/AccessibilityTableColumn.cpp:
(WebCore::AccessibilityTableColumn::AccessibilityTableColumn):
(WebCore::AccessibilityTableColumn::create):
* Source/WebCore/accessibility/AccessibilityTableColumn.h:
* Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp:
(WebCore::AccessibilityTableHeaderContainer::AccessibilityTableHeaderContainer):
(WebCore::AccessibilityTableHeaderContainer::create):
* Source/WebCore/accessibility/AccessibilityTableHeaderContainer.h:
* Source/WebCore/accessibility/AccessibilityTableRow.cpp:
(WebCore::AccessibilityTableRow::AccessibilityTableRow):
(WebCore::AccessibilityTableRow::create):
* Source/WebCore/accessibility/AccessibilityTableRow.h:
* Source/WebCore/accessibility/AccessibilityTree.cpp:
(WebCore::AccessibilityTree::AccessibilityTree):
(WebCore::AccessibilityTree::create):
* Source/WebCore/accessibility/AccessibilityTree.h:
* Source/WebCore/accessibility/AccessibilityTreeItem.cpp:
(WebCore::AccessibilityTreeItem::AccessibilityTreeItem):
(WebCore::AccessibilityTreeItem::create):
* Source/WebCore/accessibility/AccessibilityTreeItem.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::AXIsolatedObject):
(WebCore::AXIsolatedObject::dbg const):
(WebCore::AXIsolatedObject::initializeProperties):
(WebCore::AXIsolatedObject::associatedAXObject const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::createEmptyContent):
(WebCore::AXIsolatedTree::reportLoadingProgress):
(WebCore::AXIsolatedTree::shouldCreateNodeChange):
(WebCore::AXIsolatedTree::nodeChangeForObject):
(WebCore::AXIsolatedTree::queueChange):
(WebCore::AXIsolatedTree::addUnconnectedNode):
(WebCore::AXIsolatedTree::collectNodeChangesForSubtree):
(WebCore::AXIsolatedTree::updateNode):
(WebCore::AXIsolatedTree::updatePropertiesForSelfAndDescendants):
(WebCore::AXIsolatedTree::updateNodeProperties):
(WebCore::AXIsolatedTree::updateDependentProperties):
(WebCore::AXIsolatedTree::updateChildren):
(WebCore::AXIsolatedTree::removeNode):
(WebCore::AXIsolatedTree::removeSubtreeFromNodeMap):
(WebCore::AXIsolatedTree::relatedObjectIDsFor):
(WebCore::AXIsolatedTree::applyPendingChanges):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(-[WebAccessibilityObjectWrapperBase attachAXObject:]):

Canonical link: <a href="https://commits.webkit.org/286366@main">https://commits.webkit.org/286366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c8cf0b5ccda2b55d2830a492b17922a487f6ac0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75698 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80185 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26962 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77814 "Passed tests") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59373 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17550 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78765 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39734 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22506 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25291 "Built successfully") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81657 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3037 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67603 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3188 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66911 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16693 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10859 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9001 "Build is in progress. Recent messages:OS: Ventura (13.6.9), Xcode: 14.3") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2994 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5816 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3019 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3954 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3026 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->