### PR TITLE
[CMake] Only override find_package on Apple targets

### DIFF
--- a/Source/cmake/WebKitFindPackage.cmake
+++ b/Source/cmake/WebKitFindPackage.cmake
@@ -11,7 +11,10 @@
 # CMake provided targets. Remove wrappers whenever the minimum version is bumped.
 #
 # ICU::<C> : need to be kept for Apple ICU
-# LibXslt::LibXslt: since 3.18
+
+if (NOT APPLE)
+    return()
+endif ()
 
 macro(find_package package)
     set(_found_package OFF)
@@ -58,22 +61,6 @@ macro(find_package package)
                 IMPORTED_LOCATION "${ICU_UC_LIBRARY}"
                 INTERFACE_INCLUDE_DIRECTORIES "${ICU_INCLUDE_DIRS}"
                 IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
-            )
-        endif ()
-    elseif ("${package}" STREQUAL "LibXslt")
-        if (LIBXSLT_FOUND AND NOT TARGET LibXslt::LibXslt)
-            add_library(LibXslt::LibXslt UNKNOWN IMPORTED)
-            set_target_properties(LibXslt::LibXslt PROPERTIES
-                IMPORTED_LOCATION "${LIBXSLT_LIBRARIES}"
-                INTERFACE_INCLUDE_DIRECTORIES "${LIBXSLT_INCLUDE_DIR}"
-                INTERFACE_COMPILE_OPTIONS "${LIBXSLT_DEFINITIONS}"
-            )
-        endif ()
-        if (LIBXSLT_EXSLT_LIBRARY AND NOT TARGET LibXslt::LibExslt)
-            add_library(LibXslt::LibExslt UNKNOWN IMPORTED)
-            set_target_properties(LibXslt::LibExslt PROPERTIES
-                IMPORTED_LOCATION "${LIBXSLT_EXSLT_LIBRARY}"
-                INTERFACE_INCLUDE_DIRECTORIES "${LIBXSLT_INCLUDE_DIR}"
             )
         endif ()
     endif ()


### PR DESCRIPTION
#### 795afa80a9cc4179efe42ae46c9d1e460c5ecd6f
<pre>
[CMake] Only override find_package on Apple targets
<a href="https://bugs.webkit.org/show_bug.cgi?id=282799">https://bugs.webkit.org/show_bug.cgi?id=282799</a>

Reviewed by Fujii Hironori.

Remove creation of `LibXslt::LibXslt` since the CMake version was bumped past
3.18. This only leaves the Apple specific detection of ICU so only include the
override when `APPLE` is set.

This is also required for `vcpkg` integration for Windows.

* Source/cmake/WebKitFindPackage.cmake:

Canonical link: <a href="https://commits.webkit.org/286337@main">https://commits.webkit.org/286337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ff2c65af1c77a34d359078237c4c92f87095bd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75621 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80103 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26885 "Built successfully") 
| | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2909 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59302 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17488 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78688 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64943 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39665 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25214 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68771 "Built successfully and passed tests") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81580 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74883 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1864 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67538 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3111 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66840 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16670 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10800 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8941 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97151 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2917 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21230 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2942 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3877 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2949 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->