### PR TITLE
[WebDriver] Assertion failure when starting a second session after the first one exits

### DIFF
--- a/Source/WebDriver/SessionHost.cpp
+++ b/Source/WebDriver/SessionHost.cpp
@@ -117,6 +117,11 @@ void SessionHost::addBrowserTerminatedObserver(const BrowserTerminatedObserver& 
     ASSERT(!browserTerminatedObservers().contains(observer));
     browserTerminatedObservers().add(observer);
 }
+
+void SessionHost::removeBrowserTerminatedObserver(const BrowserTerminatedObserver& observer)
+{
+    browserTerminatedObservers().remove(observer);
+}
 #endif
 
 } // namespace WebDriver

--- a/Source/WebDriver/SessionHost.h
+++ b/Source/WebDriver/SessionHost.h
@@ -60,7 +60,8 @@ public:
 
 #if ENABLE(WEBDRIVER_BIDI)
     using BrowserTerminatedObserver = WTF::Observer<void(const String&)>;
-    void addBrowserTerminatedObserver(const BrowserTerminatedObserver&);
+    static void addBrowserTerminatedObserver(const BrowserTerminatedObserver&);
+    static void removeBrowserTerminatedObserver(const BrowserTerminatedObserver&);
 #endif
 
     void setHostAddress(const String& ip, uint16_t port) { m_targetIp = ip; m_targetPort = port; }

--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -61,6 +61,16 @@ WebDriverService::WebDriverService()
     , m_browserTerminatedObserver([this](const String& sessionID) { onBrowserTerminated(sessionID); })
 #endif
 {
+#if ENABLE(WEBDRIVER_BIDI)
+    SessionHost::addBrowserTerminatedObserver(m_browserTerminatedObserver);
+#endif
+}
+
+WebDriverService::~WebDriverService()
+{
+#if ENABLE(WEBDRIVER_BIDI)
+    SessionHost::removeBrowserTerminatedObserver(m_browserTerminatedObserver);
+#endif
 }
 
 static void printUsageStatement(const char* programName)
@@ -1019,9 +1029,6 @@ void WebDriverService::connectToBrowser(Vector<Capabilities>&& capabilitiesList,
     }
 
     auto sessionHost = makeUnique<SessionHost>(capabilitiesList.takeLast());
-#if ENABLE(WEBDRIVER_BIDI)
-    sessionHost->addBrowserTerminatedObserver(m_browserTerminatedObserver);
-#endif
     auto* sessionHostPtr = sessionHost.get();
     sessionHostPtr->setHostAddress(m_targetAddress, m_targetPort);
     sessionHostPtr->connectToBrowser([this, capabilitiesList = WTFMove(capabilitiesList), sessionHost = WTFMove(sessionHost), completionHandler = WTFMove(completionHandler)](std::optional<String> error) mutable {

--- a/Source/WebDriver/WebDriverService.h
+++ b/Source/WebDriver/WebDriverService.h
@@ -49,7 +49,7 @@ class WebDriverService final : public HTTPRequestHandler
 {
 public:
     WebDriverService();
-    ~WebDriverService() = default;
+    ~WebDriverService();
 
     int run(int argc, char** argv);
 


### PR DESCRIPTION
#### 1b3d1149f0fe66e926d915128316c5f76d6956df
<pre>
[WebDriver] Assertion failure when starting a second session after the first one exits
<a href="https://bugs.webkit.org/show_bug.cgi?id=282790">https://bugs.webkit.org/show_bug.cgi?id=282790</a>

Reviewed by Carlos Garcia Campos.

285374@main added the BrowserTerminatedObserver to allow the
WebDriverService to disconnect the WebSocket connection to the WebDriver
client when the browser is terminated. But it was adding the same observer
for each new session created, instead of adding it only once, as in each
call we are given the required session id.

This commit changes the related observer methods to be static on the
SessionHost and moves the WebDriverService call to them into its
constructor, so we add the observer only once. For completeness, a
cleanup method on the WebDriverService destructor was added.

* Source/WebDriver/SessionHost.cpp:
(WebDriver::SessionHost::removeBrowserTerminatedObserver):
* Source/WebDriver/SessionHost.h:
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::WebDriverService::~WebDriverService):
(WebDriver::WebDriverService::connectToBrowser):
* Source/WebDriver/WebDriverService.h:

Canonical link: <a href="https://commits.webkit.org/286371@main">https://commits.webkit.org/286371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/048ab38b99700ebffc99e5d3843d30c78b64b390

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75745 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80234 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27010 "Built successfully") 
| | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/3033 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59413 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17572 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78812 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65064 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39760 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/22545 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25338 "Built successfully") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22885 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81705 "Build is in progress. Recent messages:Printed configuration") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/3084 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/3033 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/81705 "Build is in progress. Recent messages:Printed configuration") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/3235 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/65030 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/81705 "Build is in progress. Recent messages:Printed configuration") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16696 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9024 "Passed tests") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/3041 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3068 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4005 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3075 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->