### PR TITLE
CSS::UnevaluatedCalc template class can't be compiled in non-unified source builds

### DIFF
--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
@@ -34,6 +34,22 @@
 namespace WebCore {
 namespace CSS {
 
+BaseUnevaluatedCalc::~BaseUnevaluatedCalc() = default;
+BaseUnevaluatedCalc::BaseUnevaluatedCalc(const BaseUnevaluatedCalc&) = default;
+BaseUnevaluatedCalc::BaseUnevaluatedCalc(BaseUnevaluatedCalc&&) = default;
+BaseUnevaluatedCalc& BaseUnevaluatedCalc::operator=(const BaseUnevaluatedCalc&) = default;
+BaseUnevaluatedCalc& BaseUnevaluatedCalc::operator=(BaseUnevaluatedCalc&&) = default;
+
+BaseUnevaluatedCalc::BaseUnevaluatedCalc(Ref<CSSCalcValue>&& value)
+    : calc(WTFMove(value))
+{
+}
+
+Ref<CSSCalcValue> BaseUnevaluatedCalc::protectedCalc() const
+{
+    return calc;
+}
+
 bool unevaluatedCalcEqual(const Ref<CSSCalcValue>& a, const Ref<CSSCalcValue>& b)
 {
     return a->equals(b.get());

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
@@ -67,18 +67,30 @@ float unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const CSSToLengthConvers
 float unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>&, Calculation::Category);
 float unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>&, const CSSCalcSymbolTable&, Calculation::Category);
 
-// `UnevaluatedCalc` annotates a `CSSCalcValue` with the raw value type that it
-// will be evaluated to, allowing the processing of calc in generic code.
-template<typename T> struct UnevaluatedCalc {
-    using RawType = T;
+struct BaseUnevaluatedCalc {
     Ref<CSSCalcValue> calc;
 
-    Ref<CSSCalcValue> protectedCalc() const { return calc; }
+    BaseUnevaluatedCalc(const BaseUnevaluatedCalc&);
+    BaseUnevaluatedCalc(BaseUnevaluatedCalc&&);
+    BaseUnevaluatedCalc(Ref<CSSCalcValue>&&);
+    ~BaseUnevaluatedCalc();
+    BaseUnevaluatedCalc& operator=(const BaseUnevaluatedCalc&);
+    BaseUnevaluatedCalc& operator=(BaseUnevaluatedCalc&&);
 
-    bool operator==(const UnevaluatedCalc<T>& other) const
+    Ref<CSSCalcValue> protectedCalc() const;
+
+    bool operator==(const BaseUnevaluatedCalc& other) const
     {
         return unevaluatedCalcEqual(calc, other.calc);
     }
+};
+
+// `UnevaluatedCalc` annotates a `CSSCalcValue` with the raw value type that it
+// will be evaluated to, allowing the processing of calc in generic code.
+template<typename T> struct UnevaluatedCalc : public BaseUnevaluatedCalc {
+    using RawType = T;
+    UnevaluatedCalc(Ref<CSSCalcValue>&& value)
+        : BaseUnevaluatedCalc(WTFMove(value)) { }
 };
 
 // MARK: - Utility templates


### PR DESCRIPTION
#### 91ee8d03edf4b0eab788c07bb39879660447a168
<pre>
CSS::UnevaluatedCalc template class can&apos;t be compiled in non-unified source builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=282808">https://bugs.webkit.org/show_bug.cgi?id=282808</a>

Reviewed by Sam Weinig.

CSS::UnevaluatedCalc template class copied and destroyed an instance
of Ref&lt;CSSCalcValue&gt; class. But, CSSCalcValue was incomplete.

CSSUnevaluatedCalc.h has to include CSSCalcValue.h, but it causes a
recursive inclusion. And, definitions of UnevaluatedCalc memeber
functions can&apos;t be moved to CSSUnevaluatedCalc.cpp because it is a
template class.

Extracted BaseUnevaluatedCalc non-template class from UnevaluatedCalc.

Combined changes:
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp:
(WebCore::CSS::BaseUnevaluatedCalc::BaseUnevaluatedCalc):
(WebCore::CSS::BaseUnevaluatedCalc::protectedCalc const):
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h:
(WebCore::CSS::BaseUnevaluatedCalc::operator== const):
(WebCore::CSS::UnevaluatedCalc::UnevaluatedCalc):
(WebCore::CSS::UnevaluatedCalc::protectedCalc const): Deleted.
(WebCore::CSS::UnevaluatedCalc::operator== const): Deleted.

Canonical link: <a href="https://commits.webkit.org/286386@main">https://commits.webkit.org/286386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ce2e2e08c711639616471bf000d237e210dd8e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75640 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80124 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26904 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77756 "Passed tests") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2928 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59323 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17501 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78707 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64965 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39685 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22450 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25233 "Built successfully") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22787 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81599 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2979 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1874 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67556 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66862 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10812 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8958 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11721 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2936 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5758 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2961 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3896 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2968 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->