### PR TITLE
Enhance checked_objc_cast/dynamic_objc_cast and add is_objc

### DIFF
--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -385,17 +385,6 @@ inline CFHashCode safeCFHash(CFTypeRef a)
     return a ? CFHash(a) : 0;
 }
 
-#ifdef __OBJC__
-// FIXME: Move to TypeCastsCocoa.h once all clients include that header.
-template<typename T> T *dynamic_objc_cast(id object, Class theClass = [T class])
-{
-    if (![object isKindOfClass:theClass])
-        return nullptr;
-
-    return reinterpret_cast<T*>(object);
-}
-#endif
-
 } // namespace WTF
 
 using WTF::RetainPtr;
@@ -406,7 +395,6 @@ using WTF::safeCFHash;
 
 #ifdef __OBJC__
 using WTF::adoptNS;
-using WTF::dynamic_objc_cast;
 #endif
 
 #endif // USE(CF) || defined(__OBJC__)

--- a/Source/WTF/wtf/cocoa/UUIDCocoa.mm
+++ b/Source/WTF/wtf/cocoa/UUIDCocoa.mm
@@ -27,6 +27,7 @@
 #import "UUID.h"
 
 #import "RetainPtr.h"
+#import "TypeCastsCocoa.h"
 
 namespace WTF {
 

--- a/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
@@ -29,6 +29,7 @@
 
 #import <AVFoundation/AVFoundation.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 SOFT_LINK_FRAMEWORK_FOR_HEADER(PAL, AVFoundation)
 
@@ -420,5 +421,9 @@ SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(PAL, AVFoundation, AVSampleBufferDisplayL
 
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, AVFoundation, AVSampleBufferAttachContentKey, BOOL, (CMSampleBufferRef sbuf, AVContentKey *contentKey, NSError **outError), (sbuf, contentKey, outError))
 #define AVSampleBufferAttachContentKey PAL::softLink_AVFoundation_AVSampleBufferAttachContentKey
+
+SPECIALIZE_OBJC_TYPE_TRAITS(AVSampleBufferAudioRenderer, PAL::getAVSampleBufferAudioRendererClass())
+SPECIALIZE_OBJC_TYPE_TRAITS(AVSampleBufferDisplayLayer, PAL::getAVSampleBufferDisplayLayerClass())
+SPECIALIZE_OBJC_TYPE_TRAITS(AVSampleBufferVideoRenderer, PAL::getAVSampleBufferVideoRendererClass())
 
 #endif // USE(AVFOUNDATION)

--- a/Source/WebCore/bridge/objc/objc_utility.mm
+++ b/Source/WebCore/bridge/objc/objc_utility.mm
@@ -33,6 +33,7 @@
 #import <JavaScriptCore/JSGlobalObjectInlines.h>
 #import <JavaScriptCore/JSLock.h>
 #import <wtf/Assertions.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -195,8 +196,8 @@ JSValue convertObjcValueToValue(JSGlobalObject* lexicalGlobalObject, void* buffe
     switch (type) {
         case ObjcObjectType: {
             id obj = *(const id*)buffer;
-            if ([obj isKindOfClass:[NSString class]])
-                return convertNSStringToString(lexicalGlobalObject, (NSString *)obj);
+            if (auto *str = dynamic_objc_cast<NSString>(obj))
+                return convertNSStringToString(lexicalGlobalObject, str);
             if ([obj isKindOfClass:webUndefinedClass()])
                 return jsUndefined();
             if ((__bridge CFBooleanRef)obj == kCFBooleanTrue)

--- a/Source/WebCore/editing/mac/EditorMac.mm
+++ b/Source/WebCore/editing/mac/EditorMac.mm
@@ -63,6 +63,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/RuntimeApplicationChecks.h>
 #import <wtf/cocoa/NSURLExtras.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm
+++ b/Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm
@@ -27,6 +27,7 @@
 #import "SerializedPlatformDataCueValue.h"
 
 #import <AVFoundation/AVMetadataItem.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -76,14 +77,14 @@ SerializedPlatformDataCueValue::SerializedPlatformDataCueValue(AVMetadataItem *i
     if (item.locale)
         m_data->locale = item.locale;
 
-    if ([item.value isKindOfClass:NSString.class])
-        m_data->value = (NSString *)item.value;
-    else if ([item.value isKindOfClass:NSData.class])
-        m_data->value = (NSData *)item.value;
-    else if ([item.value isKindOfClass:NSDate.class])
-        m_data->value = (NSDate *)item.value;
-    else if ([item.value isKindOfClass:NSNumber.class])
-        m_data->value = (NSNumber *)item.value;
+    if (auto *str = dynamic_objc_cast<NSString>(item.value))
+        m_data->value = str;
+    else if (auto *data = dynamic_objc_cast<NSData>(item.value))
+        m_data->value = data;
+    else if (auto *date = dynamic_objc_cast<NSDate>(item.value))
+        m_data->value = date;
+    else if (auto *number = dynamic_objc_cast<NSNumber>(item.value))
+        m_data->value = number;
 }
 
 RetainPtr<NSDictionary> SerializedPlatformDataCueValue::toNSDictionary() const

--- a/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm
@@ -56,11 +56,11 @@ static void* outputObscuredDueToInsufficientExternalProtectionContext = &outputO
 namespace WebCore {
 static bool isSampleBufferVideoRenderer(id object)
 {
-    if (dynamic_objc_cast<AVSampleBufferDisplayLayer>(object, PAL::getAVSampleBufferDisplayLayerClass()))
+    if (dynamic_objc_cast<AVSampleBufferDisplayLayer>(object))
         return true;
 
 #if HAVE(AVSAMPLEBUFFERVIDEORENDERER)
-    if (dynamic_objc_cast<AVSampleBufferVideoRenderer>(object, PAL::getAVSampleBufferVideoRendererClass()))
+    if (dynamic_objc_cast<AVSampleBufferVideoRenderer>(object))
         return true;
 #endif
 
@@ -254,7 +254,7 @@ static bool isSampleBufferVideoRenderer(id object)
 #if HAVE(AVSAMPLEBUFFERDISPLAYLAYER_READYFORDISPLAY)
 - (void)layerReadyForDisplayChanged:(NSNotification *)notification
 {
-    RetainPtr layer = dynamic_objc_cast<AVSampleBufferDisplayLayer>(notification.object, PAL::getAVSampleBufferDisplayLayerClass());
+    RetainPtr layer = dynamic_objc_cast<AVSampleBufferDisplayLayer>(notification.object);
     if (!layer)
         return;
 
@@ -271,7 +271,7 @@ static bool isSampleBufferVideoRenderer(id object)
 
 - (void)audioRendererWasAutomaticallyFlushed:(NSNotification *)notification
 {
-    RetainPtr renderer = dynamic_objc_cast<AVSampleBufferAudioRenderer>(notification.object, PAL::getAVSampleBufferAudioRendererClass());
+    RetainPtr renderer = dynamic_objc_cast<AVSampleBufferAudioRenderer>(notification.object);
     CMTime flushTime = [[notification.userInfo valueForKey:AVSampleBufferAudioRendererFlushTimeKey] CMTimeValue];
 
     ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTFMove(renderer), flushTime] {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMFairPlayStreamingAVFObjC.mm
@@ -32,15 +32,16 @@
 #import <pal/spi/cocoa/AVFoundationSPI.h>
 #import <wtf/Ref.h>
 #import <wtf/Vector.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebCore {
 
 Vector<Ref<SharedBuffer>> CDMPrivateFairPlayStreaming::keyIDsForRequest(AVContentKeyRequest *request)
 {
-    if ([request.identifier isKindOfClass:NSString.class])
-        return { SharedBuffer::create([(NSString *)request.identifier dataUsingEncoding:NSUTF8StringEncoding]) };
-    if ([request.identifier isKindOfClass:NSData.class])
-        return { SharedBuffer::create((NSData *)request.identifier) };
+    if (auto *identiferStr = dynamic_objc_cast<NSString>(request.identifier))
+        return { SharedBuffer::create([identiferStr dataUsingEncoding:NSUTF8StringEncoding]) };
+    if (auto *identifierData = dynamic_objc_cast<NSData>(request.identifier))
+        return { SharedBuffer::create(identifierData) };
     if (request.initializationData) {
         if (auto sinfKeyIDs = CDMPrivateFairPlayStreaming::extractKeyIDsSinf(SharedBuffer::create(request.initializationData)))
             return WTFMove(sinfKeyIDs.value());

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
@@ -32,6 +32,7 @@
 #import <QuartzCore/QuartzCore.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/BlockObjCExceptions.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/MakeString.h>
 
@@ -326,7 +327,7 @@ void PlatformCAFilters::setFiltersOnLayer(PlatformLayer* layer, const FilterOper
             const auto& blurOperation = downcast<BlurFilterOperation>(filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterGaussianBlur];
             [filter setValue:[NSNumber numberWithFloat:floatValueForLength(blurOperation.stdDeviation(), 0)] forKey:@"inputRadius"];
-            if ([layer isKindOfClass:[CABackdropLayer class]]) {
+            if (is_objc<CABackdropLayer>(layer)) {
 #if PLATFORM(VISION)
                 // FIXME: https://bugs.webkit.org/show_bug.cgi?id=275965
                 UNUSED_PARAM(backdropIsOpaque);

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -1326,8 +1326,8 @@ AVPlayerLayer *PlatformCALayerCocoa::avPlayerLayer() const
     if ([platformLayer() isKindOfClass:PAL::getAVPlayerLayerClass()])
         return static_cast<AVPlayerLayer *>(platformLayer());
 
-    if ([platformLayer() isKindOfClass:WebVideoContainerLayer.class])
-        return static_cast<WebVideoContainerLayer *>(platformLayer()).playerLayer;
+    if (auto *layer = dynamic_objc_cast<WebVideoContainerLayer>(platformLayer()))
+        return layer.playerLayer;
 
     ASSERT_NOT_REACHED();
     return nil;

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -54,9 +54,9 @@ static constexpr CMItemCount CompressedSampleQueueLowWaterMark = 15;
 VideoMediaSampleRenderer::VideoMediaSampleRenderer(WebSampleBufferVideoRendering *renderering)
     : m_workQueue(WorkQueue::create("VideoMediaSampleRenderer Queue"_s))
 {
-    if (auto *displayLayer = dynamic_objc_cast<AVSampleBufferDisplayLayer>(renderering, PAL::getAVSampleBufferDisplayLayerClass()))
+    if (auto *displayLayer = dynamic_objc_cast<AVSampleBufferDisplayLayer>(renderering))
         m_displayLayer = displayLayer;
-    else if (auto *renderer = dynamic_objc_cast<AVSampleBufferVideoRenderer>(renderering, PAL::getAVSampleBufferVideoRendererClass()))
+    else if (auto *renderer = dynamic_objc_cast<AVSampleBufferVideoRenderer>(renderering))
         m_renderer = renderer;
 }
 

--- a/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
@@ -46,6 +46,7 @@
 #import <wtf/RuntimeApplicationChecks.h>
 #import <wtf/URL.h>
 #import <wtf/cocoa/NSURLExtras.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/StringHash.h>
 

--- a/Source/WebCore/platform/ios/WidgetIOS.mm
+++ b/Source/WebCore/platform/ios/WidgetIOS.mm
@@ -43,6 +43,7 @@
 #import "WebCoreFrameView.h"
 #import "WebCoreView.h"
 #import <wtf/BlockObjCExceptions.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 @interface NSView (WebSetSelectedMethods)
 - (void)setIsSelected:(BOOL)isSelected;
@@ -194,8 +195,7 @@ IntRect Widget::convertFromRootToContainingWindow(const Widget* rootWidget, cons
         return rect;
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    ASSERT([rootWidget->platformWidget() isKindOfClass:[NSScrollView class]]);
-    WAKScrollView *view = static_cast<WAKScrollView *>(rootWidget->platformWidget());
+    WAKScrollView *view = checked_objc_cast<WAKScrollView>(rootWidget->platformWidget());
     if (WAKView *documentView = [view documentView])
         return enclosingIntRect([documentView convertRect:rect toView:nil]);
     return enclosingIntRect([view convertRect:rect toView:nil]);
@@ -210,8 +210,7 @@ IntRect Widget::convertFromContainingWindowToRoot(const Widget* rootWidget, cons
         return rect;
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    ASSERT([rootWidget->platformWidget() isKindOfClass:[NSScrollView class]]);
-    WAKScrollView *view = static_cast<WAKScrollView *>(rootWidget->platformWidget());
+    WAKScrollView *view = checked_objc_cast<WAKScrollView>(rootWidget->platformWidget());
     if (WAKView *documentView = [view documentView])
         return enclosingIntRect([documentView convertRect:rect fromView:nil]);
     return enclosingIntRect([view convertRect:rect fromView:nil]);
@@ -226,8 +225,7 @@ IntPoint Widget::convertFromRootToContainingWindow(const Widget* rootWidget, con
         return point;
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    ASSERT([rootWidget->platformWidget() isKindOfClass:[NSScrollView class]]);
-    WAKScrollView *view = static_cast<WAKScrollView *>(rootWidget->platformWidget());
+    WAKScrollView *view = checked_objc_cast<WAKScrollView>(rootWidget->platformWidget());
     NSPoint convertedPoint;
     if (WAKView *documentView = [view documentView])
         convertedPoint = [documentView convertPoint:point toView:nil];
@@ -245,8 +243,7 @@ IntPoint Widget::convertFromContainingWindowToRoot(const Widget* rootWidget, con
         return point;
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    ASSERT([rootWidget->platformWidget() isKindOfClass:[NSScrollView class]]);
-    WAKScrollView *view = static_cast<WAKScrollView *>(rootWidget->platformWidget());
+    WAKScrollView *view = checked_objc_cast<WAKScrollView>(rootWidget->platformWidget());
     NSPoint convertedPoint;
     if (WAKView *documentView = [view documentView])
         convertedPoint = IntPoint([documentView convertPoint:point fromView:nil]);

--- a/Source/WebCore/platform/mac/WidgetMac.mm
+++ b/Source/WebCore/platform/mac/WidgetMac.mm
@@ -65,8 +65,8 @@ static void safeRemoveFromSuperview(NSView *view)
     // If the view is the first responder, then set the window's first responder to nil so
     // we don't leave the window pointing to a view that's no longer in it.
     NSWindow *window = [view window];
-    NSResponder *firstResponder = [window firstResponder];
-    if ([firstResponder isKindOfClass:[NSView class]] && [(NSView *)firstResponder isDescendantOf:view])
+    auto *firstResponderView = dynamic_objc_cast<NSView>([window firstResponder]);
+    if ([firstResponderView isDescendantOf:view])
         [window makeFirstResponder:nil];
 
     // Suppress the resetting of drag margins since we know we can't affect them.
@@ -219,8 +219,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     NSView *innerView = platformWidget();
     NSScrollView *scrollView = 0;
     if ([innerView conformsToProtocol:@protocol(WebCoreFrameScrollView)]) {
-        ASSERT([innerView isKindOfClass:[NSScrollView class]]);
-        NSScrollView *scrollView = static_cast<NSScrollView *>(innerView);
+        NSScrollView *scrollView = checked_objc_cast<NSScrollView>(innerView);
         // -copiesOnScroll will return NO whenever the content view is not fully opaque.
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         if ([scrollView drawsBackground] && ![[scrollView contentView] copiesOnScroll])

--- a/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
@@ -25,6 +25,7 @@
 
 #import "config.h"
 #import "Cookie.h"
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 // FIXME: Remove NS_ASSUME_NONNULL_BEGIN/END and all _Nullable annotations once we remove the NSHTTPCookie forward declaration below.
 NS_ASSUME_NONNULL_BEGIN
@@ -62,11 +63,11 @@ static double cookieCreated(NSHTTPCookie *cookie)
         return 1000.0 * (referenceFormat + NSTimeIntervalSince1970);
     };
 
-    if ([value isKindOfClass:[NSNumber class]])
-        return toCanonicalFormat(((NSNumber *)value).doubleValue);
+    if (auto *number = dynamic_objc_cast<NSNumber>(value))
+        return toCanonicalFormat(number.doubleValue);
 
-    if ([value isKindOfClass:[NSString class]])
-        return toCanonicalFormat(((NSString *)value).doubleValue);
+    if (auto *string = dynamic_objc_cast<NSString>(value))
+        return toCanonicalFormat(string.doubleValue);
 
     return 0;
 }

--- a/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
@@ -37,6 +37,7 @@
 #import <wtf/StdLibExtras.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/cf/TypeCastsCF.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/text/StringView.h>
 
 WTF_DECLARE_CF_TYPE_TRAIT(SecTrust);
@@ -164,7 +165,8 @@ void ResourceResponse::platformLazyInit(InitLevel initLevel)
     
     @autoreleasepool {
 
-        auto messageRef = [m_nsResponse isKindOfClass:[NSHTTPURLResponse class]] ? CFURLResponseGetHTTPResponse([ (NSHTTPURLResponse *)m_nsResponse.get() _CFURLResponse]) : nullptr;
+        RetainPtr urlResponse = dynamic_objc_cast<NSHTTPURLResponse>(m_nsResponse.get());
+        RetainPtr messageRef = urlResponse ? CFURLResponseGetHTTPResponse([urlResponse _CFURLResponse]) : nullptr;
 
         if (m_initLevel < CommonFieldsOnly) {
             m_url = [m_nsResponse URL];
@@ -172,13 +174,13 @@ void ResourceResponse::platformLazyInit(InitLevel initLevel)
             m_expectedContentLength = [m_nsResponse expectedContentLength];
             // Stripping double quotes as a workaround for <rdar://problem/8757088>, can be removed once that is fixed.
             m_textEncodingName = stripLeadingAndTrailingDoubleQuote([m_nsResponse textEncodingName]);
-            m_httpStatusCode = messageRef ? CFHTTPMessageGetResponseStatusCode(messageRef) : 0;
+            m_httpStatusCode = messageRef ? CFHTTPMessageGetResponseStatusCode(messageRef.get()) : 0;
             if (messageRef)
-                m_httpHeaderFields = initializeHTTPHeaders(messageRef);
+                m_httpHeaderFields = initializeHTTPHeaders(messageRef.get());
         }
         if (messageRef && initLevel == AllFields) {
-            m_httpStatusText = extractHTTPStatusText(messageRef);
-            m_httpVersion = AtomString { String(adoptCF(CFHTTPMessageCopyVersion(messageRef)).get()).convertToASCIIUppercase() };
+            m_httpStatusText = extractHTTPStatusText(messageRef.get());
+            m_httpVersion = AtomString { String(adoptCF(CFHTTPMessageCopyVersion(messageRef.get())).get()).convertToASCIIUppercase() };
         }
     }
 

--- a/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
@@ -32,6 +32,7 @@
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/URL.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/text/WTFString.h>
 
 @interface NSError (WebExtras)

--- a/Source/WebCore/rendering/AttachmentLayout.mm
+++ b/Source/WebCore/rendering/AttachmentLayout.mm
@@ -35,6 +35,7 @@
 #include "GeometryUtilities.h"
 #include "RenderTheme.h"
 #include <pal/spi/cf/CoreTextSPI.h>
+#include <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebCore {
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1074,8 +1074,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 // FIXME: Remove when rdar://108002223 can be resolved.
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task _didReceiveInformationalResponse:(NSURLResponse *)response
 {
-    if ([response isKindOfClass:[NSHTTPURLResponse class]])
-        [self URLSession:session task:task didReceiveInformationalResponse:(NSHTTPURLResponse *)response];
+    if (auto *httpResponse = dynamic_objc_cast<NSHTTPURLResponse>(response))
+        [self URLSession:session task:task didReceiveInformationalResponse:httpResponse];
 }
 
 - (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSessionResponseDisposition disposition))completionHandler
@@ -1103,9 +1103,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         ALLOW_DEPRECATED_DECLARATIONS_END
 
         // Avoid MIME type sniffing if the response comes back as 304 Not Modified.
-        auto isNSHTTPURLResponseClass = [response isKindOfClass:NSHTTPURLResponse.class];
-        int statusCode = isNSHTTPURLResponseClass ? [(NSHTTPURLResponse *)response statusCode] : 0;
-        NSString *xContentTypeOptions = isNSHTTPURLResponseClass ? [(NSHTTPURLResponse *)response valueForHTTPHeaderField:@"X-Content-Type-Options"] : nil;
+        auto httpResponse = dynamic_objc_cast<NSHTTPURLResponse>(response);
+        int statusCode = httpResponse ? [httpResponse statusCode] : 0;
+        NSString *xContentTypeOptions = httpResponse ? [httpResponse valueForHTTPHeaderField:@"X-Content-Type-Options"] : nil;
         bool isNoSniff = xContentTypeOptions && [xContentTypeOptions caseInsensitiveCompare:@"nosniff"] == NSOrderedSame;
         if (statusCode != httpStatus304NotModified) {
             bool isMainResourceLoad = networkDataTask->firstRequest().requester() == WebCore::ResourceRequestRequester::Main;

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
@@ -123,8 +123,8 @@ void WebSocketTask::didConnect(const String& protocol)
 {
     String extensionsValue;
     auto response = [m_task response];
-    if ([response isKindOfClass:[NSHTTPURLResponse class]])
-        extensionsValue = [(NSHTTPURLResponse *)response valueForHTTPHeaderField:@"Sec-WebSocket-Extensions"];
+    if (auto *httpResponse  = dynamic_objc_cast<NSHTTPURLResponse>(response))
+        extensionsValue = [httpResponse  valueForHTTPHeaderField:@"Sec-WebSocket-Extensions"];
 
     m_receivedDidConnect = true;
     RefPtr channel = m_channel.get();

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -30,6 +30,7 @@
 #import <wtf/URLHash.h>
 #import <wtf/UUID.h>
 #import <wtf/WallTime.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/text/StringHash.h>
 
 OBJC_CLASS NSArray;

--- a/Source/WebKit/Platform/mac/MenuUtilities.mm
+++ b/Source/WebKit/Platform/mac/MenuUtilities.mm
@@ -93,8 +93,8 @@ static DDMacAction *actionForMenuItem(NSMenuItem *item)
 static DDAction *actionForMenuItem(NSMenuItem *item)
 #endif
 {
-    NSDictionary *representedObject = item.representedObject;
-    if (![representedObject isKindOfClass:[NSDictionary class]])
+    auto *representedObject = dynamic_objc_cast<NSDictionary>(item.representedObject);
+    if (!representedObject)
         return nil;
 
     id action = [representedObject objectForKey:@"DDAction"];

--- a/Source/WebKit/Shared/API/Cocoa/_WKFrameHandle.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKFrameHandle.mm
@@ -46,10 +46,11 @@
     if (object == self)
         return YES;
 
-    if (![object isKindOfClass:[_WKFrameHandle class]])
+    auto *handle = dynamic_objc_cast<_WKFrameHandle>(object);
+    if (!handle)
         return NO;
 
-    return _frameHandle->frameID() == ((_WKFrameHandle *)object)->_frameHandle->frameID();
+    return _frameHandle->frameID() == handle->_frameHandle->frameID();
 }
 
 - (NSUInteger)hash

--- a/Source/WebKit/Shared/Cocoa/WKNSDictionary.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSDictionary.mm
@@ -61,11 +61,12 @@ using namespace WebKit;
 
 - (id)objectForKey:(id)key
 {
-    if (![key isKindOfClass:[NSString class]])
+    auto *str = dynamic_objc_cast<NSString>(key);
+    if (!str)
         return nil;
 
     bool exists;
-    RefPtr value = _dictionary->get((NSString *)key, exists);
+    RefPtr value = _dictionary->get(str, exists);
     if (!exists)
         return nil;
 

--- a/Source/WebKit/Shared/Cocoa/WKObject.h
+++ b/Source/WebKit/Shared/Cocoa/WKObject.h
@@ -32,6 +32,7 @@
 #import <wtf/RefPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/spi/cocoa/objcSPI.h>
 
 namespace API {

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.mm
@@ -165,12 +165,12 @@ using namespace WebKit;
     for (NSString *key in localizedDictionary.allKeys) {
         id value = localizedDictionary[key];
 
-        if ([value isKindOfClass:NSString.class])
-            localizedDictionary[key] = [self localizedStringForString:(NSString *)value];
-        else if ([value isKindOfClass:NSArray.class])
-            localizedDictionary[key] = [self _localizedArrayForArray:(NSArray *)value];
-        else if ([value isKindOfClass:NSDictionary.class])
-            localizedDictionary[key] = [self localizedDictionaryForDictionary:(NSDictionary *)value];
+        if (auto *str = dynamic_objc_cast<NSString>(value))
+            localizedDictionary[key] = [self localizedStringForString:str];
+        else if (auto *arr = dynamic_objc_cast<NSArray>(value))
+            localizedDictionary[key] = [self _localizedArrayForArray:arr];
+        else if (auto* dict = dynamic_objc_cast<NSDictionary>(value))
+            localizedDictionary[key] = [self localizedDictionaryForDictionary:dict];
     }
 
     return localizedDictionary;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextInputContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextInputContext.mm
@@ -64,10 +64,9 @@
     if (self == otherObject)
         return YES;
 
-    if (![otherObject isKindOfClass:[_WKTextInputContext class]])
+    auto *other = dynamic_objc_cast<_WKTextInputContext>(otherObject);
+    if (!other)
         return NO;
-
-    _WKTextInputContext *other = (_WKTextInputContext *)otherObject;
 
     return _textInputContext == other->_textInputContext;
 }

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1212,8 +1212,8 @@ static void configureScrollViewWithOverlayRegionsIDs(WKBaseScrollView* scrollVie
         HashSet<UIView *> overlayAncestorsChain;
         for (UIView *overlayAncestor = (UIView *)overlayView; overlayAncestor; overlayAncestor = [overlayAncestor superview]) {
             overlayAncestorsChain.add(overlayAncestor);
-            if ([overlayAncestor isKindOfClass:[WKBaseScrollView class]]) {
-                enclosingScrollView = (WKBaseScrollView *)overlayAncestor;
+            if (auto *layer = dynamic_objc_cast<WKBaseScrollView>(overlayAncestor)) {
+                enclosingScrollView = layer;
                 break;
             }
         }

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -306,8 +306,7 @@ static NSString * const _WKARQLWebsiteURLParameterKey = @"ARQLWebsiteURLParamete
 
 - (void)dataTask:(_WKDataTask *)dataTask didReceiveResponse:(NSURLResponse *)response decisionHandler:(void (^)(_WKDataTaskResponsePolicy))decisionHandler
 {
-    if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
-        NSHTTPURLResponse *HTTPResponse = (NSHTTPURLResponse *)response;
+    if (auto *HTTPResponse = dynamic_objc_cast<NSHTTPURLResponse>(response)) {
         if ([NSHTTPURLResponse isErrorStatusCode:HTTPResponse.statusCode]) {
             RELEASE_LOG(SystemPreview, "cancelling subresource load due to error status code: %ld", (long)HTTPResponse.statusCode);
             decisionHandler(_WKDataTaskResponsePolicyCancel);

--- a/Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm
@@ -50,10 +50,11 @@ bool WebPreferences::platformGetStringUserValueForKey(const String& key, String&
     id object = [[NSUserDefaults standardUserDefaults] objectForKey:makeKey(m_identifier, m_keyPrefix, key)];
     if (!object)
         return false;
-    if (![object isKindOfClass:[NSString class]])
+    auto *str = dynamic_objc_cast<NSString>(object);
+    if (!str)
         return false;
 
-    userValue = (NSString *)object;
+    userValue = str;
     return true;
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm
+++ b/Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm
@@ -113,8 +113,7 @@ static WebCore::CocoaFont *fontOfSize(WarningTextSize size)
 
 static WebCore::CocoaColor *colorForItem(WarningItem item, ViewType *warning)
 {
-    ASSERT([warning isKindOfClass:[_WKWarningView class]]);
-    _WKWarningView *warningView = (_WKWarningView *)warning;
+    auto *warningView = checked_objc_cast<_WKWarningView>(warning);
 #if PLATFORM(MAC)
 
     auto colorNamed = [] (NSString *name) -> WebCore::CocoaColor * {

--- a/Source/WebKit/UIProcess/Gamepad/ios/UIGamepadProviderIOS.mm
+++ b/Source/WebKit/UIProcess/Gamepad/ios/UIGamepadProviderIOS.mm
@@ -40,8 +40,8 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     auto firstResponder = [[[UIApplication sharedApplication] keyWindow] firstResponder];
 ALLOW_DEPRECATED_DECLARATIONS_END
 
-    if ([firstResponder isKindOfClass:[WKContentView class]])
-        return ((WKContentView *)firstResponder).page;
+    if (auto *view = dynamic_objc_cast<WKContentView>(firstResponder))
+        return view.page;
 
 #if ENABLE(WEBXR) && !USE(OPENXR)
     if (auto page = WebProcessProxy::webPageWithActiveXRSession())

--- a/Source/WebKit/UIProcess/Gamepad/mac/UIGamepadProviderMac.mm
+++ b/Source/WebKit/UIProcess/Gamepad/mac/UIGamepadProviderMac.mm
@@ -41,12 +41,12 @@ WebPageProxy* UIGamepadProvider::platformWebPageProxyForGamepadInput()
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
     auto responder = [[NSApp keyWindow] firstResponder];
 
-    if ([responder isKindOfClass:[WKWebView class]])
-        return ((WKWebView *)responder)->_page.get();
+    if (auto *view = dynamic_objc_cast<WKWebView>(responder))
+        return view->_page.get();
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if ([responder isKindOfClass:[WKView class]])
-        return toImpl(((WKView *)responder).pageRef);
+    if (auto *view = dynamic_objc_cast<WKView>(responder))
+        return toImpl(view.pageRef);
 ALLOW_DEPRECATED_DECLARATIONS_END
 
     return nullptr;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
@@ -41,6 +41,7 @@
 #import <WebCore/WebCoreCALayerExtras.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 namespace WTF {

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1051,7 +1051,7 @@ inline static NSString *textRelativeToSelectionStart(WKRelativeTextRange *range,
 
 static WKDragSessionContext *existingLocalDragSessionContext(id <UIDragSession> session)
 {
-    return [session.localContext isKindOfClass:[WKDragSessionContext class]] ? (WKDragSessionContext *)session.localContext : nil;
+    return dynamic_objc_cast<WKDragSessionContext>(session.localContext);
 }
 
 static WKDragSessionContext *ensureLocalDragSessionContext(id <UIDragSession> session)
@@ -1065,7 +1065,7 @@ static WKDragSessionContext *ensureLocalDragSessionContext(id <UIDragSession> se
     }
 
     session.localContext = adoptNS([[WKDragSessionContext alloc] init]).get();
-    return (WKDragSessionContext *)session.localContext;
+    return existingLocalDragSessionContext(session);
 }
 
 #endif // ENABLE(DRAG_SUPPORT)

--- a/Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm
@@ -30,6 +30,7 @@
 
 #import <pal/system/ios/UserInterfaceIdiom.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebKit {
 

--- a/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
@@ -174,8 +174,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)selectColor:(UIColor *)color
 {
-    if ([self.control isKindOfClass:WKColorPicker.class])
-        [(WKColorPicker *)self.control selectColor:color];
+    if (auto *picker = dynamic_objc_cast<WKColorPicker>(self.control))
+        [picker selectColor:color];
 }
 
 @end

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.mm
@@ -108,9 +108,9 @@ CGFloat adjustedFontSize(CGFloat textWidth, UIFont *font, CGFloat initialFontSiz
 
 - (NSString *)selectFormPopoverTitle
 {
-    if (![self.control isKindOfClass:[WKSelectPopover class]])
-        return nil;
-    return [(WKSelectPopover *)self.control tableViewController].title;
+    if (auto *popover = dynamic_objc_cast<WKSelectPopover>(self.control))
+        return [popover tableViewController].title;
+    return nil;
 }
 
 - (BOOL)selectFormAccessoryHasCheckedItemAtRow:(long)rowIndex

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -84,7 +84,7 @@ static NSRect convertRectToScreen(NSWindow *window, NSRect rect)
 
 static void makeResponderFirstResponderIfDescendantOfView(NSWindow *window, NSResponder *responder, NSView *view)
 {
-    if ([responder isKindOfClass:[NSView class]] && [(NSView *)responder isDescendantOf:view])
+    if (auto *responderView = dynamic_objc_cast<NSView>(responder); responderView && [responderView isDescendantOf:view])
         [window makeFirstResponder:responder];
 }
 

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm
@@ -35,6 +35,7 @@
 #import "WebExtensionUtilities.h"
 #import <WebKit/WebNSURLExtras.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 using namespace WebKit;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -44,6 +44,8 @@
 #include "PasteboardTypes.h"
 #include "PluginView.h"
 #include "WKAccessibilityPDFDocumentObject.h"
+#include "WKAccessibilityWebPageObjectIOS.h"
+#include "WKAccessibilityWebPageObjectMac.h"
 #include "WebEventConversion.h"
 #include "WebEventModifier.h"
 #include "WebEventType.h"
@@ -98,6 +100,7 @@
 #include <wtf/Algorithms.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/cocoa/TypeCastsCocoa.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/TextStream.h>
@@ -173,7 +176,7 @@ UnifiedPDFPlugin::UnifiedPDFPlugin(HTMLPlugInElement& element)
     m_accessibilityDocumentObject = adoptNS([[WKAccessibilityPDFDocumentObject alloc] initWithPDFDocument:m_pdfDocument andElement:&element]);
     [m_accessibilityDocumentObject setPDFPlugin:this];
     if (this->isFullFramePlugin() && m_frame && m_frame->page() && m_frame->isMainFrame())
-        [m_accessibilityDocumentObject setParent:dynamic_objc_cast<NSObject>(m_frame->protectedPage()->accessibilityRemoteObject())];
+        [m_accessibilityDocumentObject setParent:m_frame->protectedPage()->accessibilityRemoteObject()];
 #endif
 
     if (m_presentationController->wantsWheelEvents())

--- a/Tools/DumpRenderTree/mac/TestRunnerMac.mm
+++ b/Tools/DumpRenderTree/mac/TestRunnerMac.mm
@@ -78,6 +78,7 @@
 #import <wtf/HashMap.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/WallTime.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import "UIKitSPIForTesting.h"

--- a/Tools/DumpRenderTree/mac/UIScriptControllerMac.mm
+++ b/Tools/DumpRenderTree/mac/UIScriptControllerMac.mm
@@ -41,6 +41,7 @@
 #import <mach/mach_time.h>
 #import <pal/spi/mac/NSTextInputContextSPI.h>
 #import <wtf/WorkQueue.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WTR {
 

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
@@ -162,7 +162,8 @@ TEST(TypeCastsCocoa, checked_objc_cast)
 
 TEST(TypeCastsCocoa, dynamic_objc_cast)
 {
-    EXPECT_EQ(nil, dynamic_objc_cast<NSString>(nil));
+    NSObject *obj = nil;
+    EXPECT_EQ(nil, dynamic_objc_cast<NSString>(obj));
 
     @autoreleasepool {
         auto objectNS = adoptNS<id>([[NSString alloc] initWithFormat:@"%s", helloWorldCString]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
@@ -47,6 +47,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/text/MakeString.h>
 
 #if PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm
@@ -37,6 +37,7 @@
 #import <pal/spi/ios/BrowserEngineKitSPI.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/Vector.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/text/MakeString.h>
 
 static constexpr auto longTextString = "Here's to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. "

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm
@@ -29,6 +29,7 @@
 
 #import "WebExtensionUtilities.h"
 #import <WebKit/WKWebExtensionCommandPrivate.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 #if USE(APPKIT)
 #import <Carbon/Carbon.h>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
@@ -33,6 +33,7 @@
 #import "TestWebExtensionsDelegate.h"
 #import "WebExtensionUtilities.h"
 #import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace TestWebKitAPI {
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
@@ -35,6 +35,7 @@
 #import <WebKit/WKWebExtensionMatchPatternPrivate.h>
 #import <WebKit/WKWebExtensionPermission.h>
 #import <WebKit/WKWebExtensionPrivate.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import <UIKit/UIKit.h>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -52,6 +52,7 @@
 #import <pal/spi/cocoa/WritingToolsUISPI.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/unicode/CharacterNames.h>
 
 #if PLATFORM(MAC)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
@@ -44,6 +44,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/MonotonicTime.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 #if HAVE(MOUSE_DEVICE_OBSERVATION)
 

--- a/Tools/TestWebKitAPI/Tests/mac/MouseEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/MouseEventTests.mm
@@ -36,6 +36,7 @@
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <wtf/RunLoop.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/text/MakeString.h>
 
 namespace TestWebKitAPI {

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -47,6 +47,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/Deque.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 #if PLATFORM(MAC)
 #import <AppKit/AppKit.h>

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -38,6 +38,7 @@
 #import <WebKit/WKWebExtensionWindowConfiguration.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 @interface TestWebExtensionManager () <WKWebExtensionControllerDelegatePrivate>
 @end

--- a/Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm
+++ b/Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm
@@ -41,6 +41,7 @@
 #import <WebKit/_WKFormInputSession.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 #if USE(BROWSERENGINEKIT)
 #import <BrowserEngineKit/BrowserEngineKit.h>

--- a/Tools/TestWebKitAPI/ios/IOSMouseEventTestHarness.mm
+++ b/Tools/TestWebKitAPI/ios/IOSMouseEventTestHarness.mm
@@ -27,6 +27,7 @@
 #import "IOSMouseEventTestHarness.h"
 
 #import <wtf/MonotonicTime.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 #if PLATFORM(IOS) || PLATFORM(MACCATALYST) || PLATFORM(VISION)
 

--- a/Tools/TestWebKitAPI/ios/TestUIMenuBuilder.mm
+++ b/Tools/TestWebKitAPI/ios/TestUIMenuBuilder.mm
@@ -27,6 +27,7 @@
 #import "TestUIMenuBuilder.h"
 
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 #if PLATFORM(IOS_FAMILY)
 

--- a/Tools/TestWebKitAPI/mac/TestDraggingInfo.mm
+++ b/Tools/TestWebKitAPI/mac/TestDraggingInfo.mm
@@ -32,6 +32,7 @@
 #import "DragAndDropSimulator.h"
 #import "TestFilePromiseReceiver.h"
 #import <wtf/WeakObjCPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 @implementation TestDraggingInfo {
     WeakObjCPtr<id> _source;

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -36,6 +36,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import "UIKitSPIForTesting.h"

--- a/Tools/WebKitTestRunner/ios/UIPasteboardConsistencyEnforcer.mm
+++ b/Tools/WebKitTestRunner/ios/UIPasteboardConsistencyEnforcer.mm
@@ -30,6 +30,7 @@
 
 #import <UIKit/UIKit.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 @implementation UIPasteboardConsistencyEnforcer {
     RetainPtr<UIPasteboard> _pasteboardToReset;

--- a/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
@@ -49,6 +49,7 @@
 #import <pal/spi/mac/NSSpellCheckerSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/WorkQueue.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WTR {
 


### PR DESCRIPTION
#### 1b87bf876b4f36380addf41137a13c7aaeb4b04e
<pre>
Enhance checked_objc_cast/dynamic_objc_cast and add is_objc
<a href="https://bugs.webkit.org/show_bug.cgi?id=282811">https://bugs.webkit.org/show_bug.cgi?id=282811</a>

Reviewed by David Kilzer and Timothy Hatcher.

This PR improves checked_objc_cast and dynamic_objc_cast by adding the support for converting U* to T*
and adds is_objc&lt;T&gt;, which like is&lt;T&gt; for Objective-C objects.

Deploy these new functions throughout WebKit codebase.

* Source/WTF/wtf/RetainPtr.h:
(WTF::dynamic_objc_cast): Deleted.
* Source/WTF/wtf/cocoa/TypeCastsCocoa.h:
(WTF::ObjCTypeCastTraits::isType):
(WTF::is_objc):
(WTF::checked_objc_cast):
(WTF::dynamic_objc_cast):
* Source/WTF/wtf/cocoa/UUIDCocoa.mm:
* Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h:
* Source/WebCore/bridge/objc/objc_utility.mm:
(JSC::Bindings::convertObjcValueToValue):
* Source/WebCore/editing/mac/EditorMac.mm:
* Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm:
(WebCore::SerializedPlatformDataCueValue::SerializedPlatformDataCueValue):
* Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm:
(WebCore::isSampleBufferVideoRenderer):
(-[WebAVSampleBufferListenerPrivate layerReadyForDisplayChanged:]):
(-[WebAVSampleBufferListenerPrivate audioRendererWasAutomaticallyFlushed:]):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMFairPlayStreamingAVFObjC.mm:
(WebCore::CDMPrivateFairPlayStreaming::keyIDsForRequest):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm:
(WebCore::PlatformCAFilters::setFiltersOnLayer):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::avPlayerLayer const):
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::VideoMediaSampleRenderer):
* Source/WebCore/platform/ios/PlatformPasteboardIOS.mm:
* Source/WebCore/platform/ios/WidgetIOS.mm:
(WebCore::Widget::convertFromRootToContainingWindow):
(WebCore::Widget::convertFromContainingWindowToRoot):
* Source/WebCore/platform/mac/WidgetMac.mm:
(WebCore::safeRemoveFromSuperview):
(WebCore::Widget::paint):
* Source/WebCore/platform/network/cocoa/CookieCocoa.mm:
(WebCore::cookieCreated):
* Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm:
(WebCore::ResourceResponse::platformLazyInit):
* Source/WebCore/platform/network/mac/ResourceErrorMac.mm:
* Source/WebCore/rendering/AttachmentLayout.mm:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(-[WKNetworkSessionDelegate URLSession:task:_didReceiveInformationalResponse:]):
(-[WKNetworkSessionDelegate URLSession:dataTask:didReceiveResponse:completionHandler:]):
* Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm:
(WebKit::WebSocketTask::didConnect):
* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::actionForMenuItem):
* Source/WebKit/Shared/API/Cocoa/_WKFrameHandle.mm:
(-[_WKFrameHandle isEqual:]):
* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::fromNSObject):
* Source/WebKit/Shared/Cocoa/WKNSDictionary.mm:
(-[WKNSDictionary objectForKey:]):
* Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.mm:
(-[_WKWebExtensionLocalization localizedDictionaryForDictionary:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextInputContext.mm:
(-[_WKTextInputContext isEqual:]):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(configureScrollViewWithOverlayRegionsIDs):
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm:
(WebKit::WebPreferences::platformGetStringUserValueForKey):
* Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm:
(colorForItem):
* Source/WebKit/UIProcess/Gamepad/ios/UIGamepadProviderIOS.mm:
(WebKit::UIGamepadProvider::platformWebPageProxyForGamepadInput):
* Source/WebKit/UIProcess/Gamepad/mac/UIGamepadProviderMac.mm:
(WebKit::UIGamepadProvider::platformWebPageProxyForGamepadInput):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(existingLocalDragSessionContext):
(ensureLocalDragSessionContext):
* Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm:
* Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm:
(-[WKFormColorControl selectColor:]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.mm:
(-[WKFormSelectControl selectFormPopoverTitle]):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(makeResponderFirstResponderIfDescendantOfView):
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
* Tools/DumpRenderTree/mac/TestRunnerMac.mm:
* Tools/DumpRenderTree/mac/UIScriptControllerMac.mm:
* Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm:
(TestWebKitAPI::TEST(TypeCastsCocoa, dynamic_objc_cast)):
* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm:
* Tools/TestWebKitAPI/Tests/mac/MouseEventTests.mm:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
* Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm:
* Tools/TestWebKitAPI/ios/IOSMouseEventTestHarness.mm:
* Tools/TestWebKitAPI/ios/TestUIMenuBuilder.mm:
* Tools/TestWebKitAPI/mac/TestDraggingInfo.mm:
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
* Tools/WebKitTestRunner/ios/UIPasteboardConsistencyEnforcer.mm:
* Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm:

Canonical link: <a href="https://commits.webkit.org/286415@main">https://commits.webkit.org/286415@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60b4b91e34042aff9b441a4659fc821047c1406c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80431 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27200 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78050 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59537 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17700 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65211 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39897 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46818 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22695 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25527 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69111 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67933 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23032 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81895 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75210 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67764 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3457 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65179 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67073 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11021 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9145 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97464 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11743 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3253 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6059 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21319 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3274 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4212 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->