### PR TITLE
[GStreamer] Fix invalid AtomString usage in TrackPrivateBaseGStreamer

### DIFF
--- a/Source/WebCore/platform/graphics/TrackPrivateBase.h
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.h
@@ -111,7 +111,7 @@ protected:
     bool hasClients() const;
     bool hasOneClient() const;
     mutable Lock m_lock;
-    using ClientRecord = std::tuple<RefPtr<SharedDispatcher>, WeakPtr<TrackPrivateBaseClient>, bool>;
+    using ClientRecord = std::tuple<RefPtr<SharedDispatcher>, WeakPtr<TrackPrivateBaseClient>, bool /* is main thread */>;
     Vector<ClientRecord> m_clients WTF_GUARDED_BY_LOCK(m_lock);
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
@@ -70,6 +70,7 @@ InbandTextTrackPrivateGStreamer::InbandTextTrackPrivateGStreamer(unsigned index,
 
 void InbandTextTrackPrivateGStreamer::tagsChanged(GRefPtr<GstTagList>&& tags)
 {
+    ASSERT(isMainThread());
     if (!tags)
         return;
 


### PR DESCRIPTION
#### d6348a3fcc705423a2ca42709c2efd820a3121dd
<pre>
[GStreamer] Fix invalid AtomString usage in TrackPrivateBaseGStreamer
<a href="https://bugs.webkit.org/show_bug.cgi?id=282396">https://bugs.webkit.org/show_bug.cgi?id=282396</a>

Reviewed by Philippe Normand and Xabier Rodriguez-Calvar.

This fixes a flaky assertion crash in imported/w3c/web-platform-tests/media-source/mediasource-sequencemode-append-buffer.html

AtomString values must be always created, read, written and destroyed
from the same thread, as not only they&apos;re not thread-safe, but they also
depend on thread-local storage.

Fortunately, this is already the case for most usages I&apos;ve seen in
TrackPrivateBaseGStreamer and derived. This patch fixes the one case of
cross-thread access I was able to identify as the culprit behind the
crash.

This patch also adds a number of thread assertions and comments so that
it is more clear what functions should be called only in main thread and
which ones may be called from any thread.

* Source/WebCore/platform/graphics/TrackPrivateBase.h:
* Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp:
(WebCore::InbandTextTrackPrivateGStreamer::tagsChanged):
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
(WebCore::TrackPrivateBaseGStreamer::setPad):
(WebCore::TrackPrivateBaseGStreamer::tagsChanged):
(WebCore::TrackPrivateBaseGStreamer::notifyTrackOfTagsChanged):
(WebCore::TrackPrivateBaseGStreamer::notifyTrackOfStreamChanged):
(WebCore::TrackPrivateBaseGStreamer::updateTrackIDFromTags):

Canonical link: <a href="https://commits.webkit.org/286324@main">https://commits.webkit.org/286324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b05afdaa5828d82a5a5cb34c88e128906408b258

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75656 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80142 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26920 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77772 "Passed tests") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2944 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59334 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/17513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78723 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64985 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39697 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22469 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25249 "Built successfully") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/22805 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81615 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2995 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67566 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3146 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66873 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16665 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10824 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/8970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2952 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/2977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3912 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/2984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->