### PR TITLE
[JSC][RISCV] Fix invalid application of 'sizeof' to an incomplete type 'JSC::OpaqueByproducts'

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -862,6 +862,8 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     jit/JITCompilationEffort.h
     jit/JITCompilationMode.h
     jit/JITMathICForwards.h
+    jit/JITOpaqueByproduct.h
+    jit/JITOpaqueByproducts.h
     jit/JITOperations.h
     jit/JITStubRoutine.h
     jit/JITThunks.h

--- a/Source/JavaScriptCore/jit/JITCompilation.cpp
+++ b/Source/JavaScriptCore/jit/JITCompilation.cpp
@@ -28,7 +28,6 @@
 
 #if ENABLE(JIT)
 
-#include "JITOpaqueByproducts.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/jit/JITCompilation.h
+++ b/Source/JavaScriptCore/jit/JITCompilation.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(JIT)
 
+#include "JITOpaqueByproducts.h"
 #include "MacroAssemblerCodeRef.h"
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
@@ -34,8 +35,6 @@
 namespace JSC {
 
 class VM;
-
-class OpaqueByproducts;
 
 // This class is a way to keep the result of a compilation alive and runnable.
 


### PR DESCRIPTION
#### a7811cbe8ba3bf74391290e8042987a1fe18a5aa
<pre>
[JSC][RISCV] Fix invalid application of &apos;sizeof&apos; to an incomplete type &apos;JSC::OpaqueByproducts&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=282677">https://bugs.webkit.org/show_bug.cgi?id=282677</a>

Reviewed by NOBODY (OOPS!).

* Source/JavaScriptCore/jit/JITCompilation.cpp:
* Source/JavaScriptCore/jit/JITCompilation.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3db0340bc8b58475f803bd1ed00eeb270566c747

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77239 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56274 "Hash 3db0340b for PR 36379 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30154 "Hash 3db0340b for PR 36379 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81806 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28521 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65422 "Hash 3db0340b for PR 36379 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4570 "Hash 3db0340b for PR 36379 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60508 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18548 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80306 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/65422 "Hash 3db0340b for PR 36379 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/30154 "Hash 3db0340b for PR 36379 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40808 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/65422 "Hash 3db0340b for PR 36379 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/30154 "Hash 3db0340b for PR 36379 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26844 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/70424 "Found 1 new JSC stress test failure: stress/get-by-val-hoist-above-structure.js.ftl-eager-no-cjit-b3o1 (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/65422 "Hash 3db0340b for PR 36379 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/30154 "Hash 3db0340b for PR 36379 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83227 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76517 "Found 4 new JSC stress test failures: stress/attribute-custom-accessor.js.dfg-eager, stress/attribute-custom-accessor.js.no-cjit-collect-continuously, stress/get-by-val-hoist-above-structure-2.js.ftl-eager-no-cjit-b3o1, wasm.yaml/wasm/modules/wasm-imports-js-exports.js.wasm-no-cjit (failure)") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4619 "Hash 3db0340b for PR 36379 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/4570 "Hash 3db0340b for PR 36379 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68780 "Found 1 new test failure: inspector/dom/getMediaStats.html (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4775 "Hash 3db0340b for PR 36379 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/30154 "Hash 3db0340b for PR 36379 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68037 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/30154 "Hash 3db0340b for PR 36379 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98770 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4566 "Hash 3db0340b for PR 36379 does not build (failure)") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21607 "Passed tests") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4585 "Hash 3db0340b for PR 36379 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8020 "Hash 3db0340b for PR 36379 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6344 "Hash 3db0340b for PR 36379 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->