### PR TITLE
[GTK][WPE][JSCOnly] Enable -Wunsafe-buffer-usage for the JavaScriptCore target

### DIFF
--- a/Source/JavaScriptCore/API/glib/JSCCallbackFunction.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCCallbackFunction.cpp
@@ -89,6 +89,7 @@ JSCCallbackFunction::JSCCallbackFunction(VM& vm, Structure* structure, Type type
         g_closure_set_marshal(m_closure.get(), g_cclosure_marshal_generic);
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
 JSValueRef JSCCallbackFunction::call(JSContextRef callerContext, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {
     JSLockHolder locker(toJS(callerContext));
@@ -233,6 +234,7 @@ JSObjectRef JSCCallbackFunction::construct(JSContextRef callerContext, size_t ar
     g_value_unset(&returnValue);
     return nullptr;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void JSCCallbackFunction::destroy(JSCell* cell)
 {

--- a/Source/JavaScriptCore/API/glib/JSCClass.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCClass.cpp
@@ -261,10 +261,12 @@ static void getPropertyNames(JSContextRef callerContext, JSObjectRef object, JSP
             GUniquePtr<char*> properties(enumeratePropertiesFunction(jscClass, context.get(), instance));
             if (properties) {
                 unsigned i = 0;
+                WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
                 while (const auto* name = properties.get()[i++]) {
                     JSRetainPtr<JSStringRef> propertyName(Adopt, JSStringCreateWithUTF8CString(name));
                     JSPropertyNameAccumulatorAddName(propertyNames, propertyName.get());
                 }
+                WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             }
         }
     }
@@ -646,7 +648,9 @@ JSCValue* jsc_class_add_constructorv(JSCClass* jscClass, const char* name, GCall
         name = priv->name.data();
 
     Vector<GType> parameters(parametersCount, [&](size_t i) -> GType {
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
         return parameterTypes[i];
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     });
 
     return jscClassCreateConstructor(jscClass, name ? name : priv->name.data(), callback, userData, destroyNotify, returnType, WTFMove(parameters)).leakRef();
@@ -772,7 +776,9 @@ void jsc_class_add_methodv(JSCClass* jscClass, const char* name, GCallback callb
     g_return_if_fail(jscClass->priv->context);
 
     Vector<GType> parameters(parametersCount, [&](size_t i) -> GType {
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
         return parameterTypes[i];
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     });
 
     jscClassAddMethod(jscClass, name, callback, userData, destroyNotify, returnType, WTFMove(parameters));

--- a/Source/JavaScriptCore/API/glib/JSCContext.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCContext.cpp
@@ -290,7 +290,9 @@ JSValueRef jscContextGArrayToJSArray(JSCContext* context, GPtrArray* gArray, JSV
         return JSValueMakeUndefined(priv->jsContext.get());
 
     for (unsigned i = 0; i < gArray->len; ++i) {
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
         gpointer item = g_ptr_array_index(gArray, i);
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         if (!item)
             JSObjectSetPropertyAtIndex(priv->jsContext.get(), jsArrayObject, i, JSValueMakeNull(priv->jsContext.get()), exception);
         else if (JSC_IS_VALUE(item))
@@ -383,7 +385,9 @@ GUniquePtr<char*> jscContextJSArrayToGStrv(JSCContext* context, JSValueRef jsArr
             return nullptr;
         }
 
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
         strv.get()[i] = jsc_value_to_string(jsValueItem.get());
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     return strv;
@@ -443,11 +447,13 @@ JSValueRef jscContextGValueToJSValue(JSCContext* context, const GValue* value, J
                 return jscContextGArrayToJSArray(context, static_cast<GPtrArray*>(ptr), exception);
 
             if (g_type_is_a(G_VALUE_TYPE(value), G_TYPE_STRV)) {
+                WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
                 auto** strv = static_cast<char**>(ptr);
                 auto strvLength = g_strv_length(strv);
                 GRefPtr<GPtrArray> gArray = adoptGRef(g_ptr_array_new_full(strvLength, g_object_unref));
                 for (unsigned i = 0; i < strvLength; i++)
                     g_ptr_array_add(gArray.get(), jsc_value_new_string(context, strv[i]));
+                WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                 return jscContextGArrayToJSArray(context, gArray.get(), exception);
             }
         } else

--- a/Source/JavaScriptCore/API/glib/JSCException.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCException.cpp
@@ -388,6 +388,7 @@ char* jsc_exception_report(JSCException* exception)
 
     jscExceptionEnsureProperties(exception);
     GString* report = g_string_new(nullptr);
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
     if (priv->sourceURI)
         report = g_string_append(report, priv->sourceURI.get());
     if (priv->lineNumber)
@@ -405,6 +406,7 @@ char* jsc_exception_report(JSCException* exception)
         for (unsigned i = 0; lines.get()[i]; ++i)
             g_string_append_printf(report, "  %s\n", lines.get()[i]);
     }
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     return g_string_free(report, FALSE);
 }

--- a/Source/JavaScriptCore/API/glib/JSCOptions.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCOptions.cpp
@@ -651,6 +651,7 @@ void jsc_options_foreach(JSCOptionsFunc function, gpointer userData)
 #undef VISIT_OPTION
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
 static gboolean setOptionEntry(const char* optionNameFull, const char* value, gpointer, GError** error)
 {
     const char* optionName = optionNameFull + 6; // Remove the --jsc- prefix.
@@ -661,6 +662,7 @@ static gboolean setOptionEntry(const char* optionNameFull, const char* value, gp
     }
     return TRUE;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 /**
  * jsc_options_get_option_group:
@@ -686,6 +688,7 @@ GOptionGroup* jsc_options_get_option_group(void)
     });
     g_option_group_set_translation_domain(group, GETTEXT_PACKAGE);
 
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
     GArray* entries = g_array_new(TRUE, TRUE, sizeof(GOptionEntry));
 #define REGISTER_OPTION(type_, name_, defaultValue_, availability_, description_) \
     if (Options::Availability::availability_ == Options::Availability::Normal \
@@ -703,6 +706,7 @@ GOptionGroup* jsc_options_get_option_group(void)
     Options::initialize();
     FOR_EACH_JSC_OPTION(REGISTER_OPTION)
 #undef REGISTER_OPTION
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     g_option_group_add_entries(group, reinterpret_cast<GOptionEntry*>(entries->data));
     return group;

--- a/Source/JavaScriptCore/API/glib/JSCWeakValue.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCWeakValue.cpp
@@ -59,7 +59,9 @@ struct _JSCWeakValuePrivate {
     JSC::JSWeakValue weakValueRef;
 };
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
 static guint signals[LAST_SIGNAL] = { 0, };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 WEBKIT_DEFINE_FINAL_TYPE(JSCWeakValue, jsc_weak_value, G_TYPE_OBJECT, GObject)
 
@@ -76,7 +78,9 @@ public:
     {
         auto* weakValue = JSC_WEAK_VALUE(context);
         jscWeakValueClear(weakValue);
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
         g_signal_emit(weakValue, signals[CLEARED], 0, nullptr);
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 };
 

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1459,6 +1459,13 @@ set(JavaScriptCore_INTERFACE_DEPENDENCIES
 WEBKIT_FRAMEWORK_DECLARE(JavaScriptCore)
 WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()
 
+if (PORT STREQUAL GTK OR PORT STREQUAL WPE OR PORT STREQUAL JSCOnly)
+    WEBKIT_ADD_TARGET_CXX_FLAGS(JavaScriptCore
+        -Wunsafe-buffer-usage
+        -fsafe-buffer-usage-suggestions
+    )
+endif ()
+
 if (COMPILER_IS_GCC_OR_CLANG)
     # Avoid using fused multiply-add instructions since this could give different results
     # for e.g. parseInt depending on the platform and compilation flags.

--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp
@@ -88,10 +88,12 @@ static RemoteInspector::Client::SessionCapabilities processSessionCapabilities(G
             capabilities.proxy->socksURL = String::fromUTF8(socksURL);
 
         if (GRefPtr<GVariant> ignoreAddressList = g_variant_lookup_value(proxy.get(), "ignoreAddressList", G_VARIANT_TYPE("as"))) {
+            WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
             gsize ignoreAddressListLength;
             GUniquePtr<char> ignoreAddressArray(reinterpret_cast<char*>(g_variant_get_strv(ignoreAddressList.get(), &ignoreAddressListLength)));
             for (unsigned i = 0; i < ignoreAddressListLength; ++i)
                 capabilities.proxy->ignoreAddressList.append(String::fromUTF8(reinterpret_cast<char**>(ignoreAddressArray.get())[i]));
+            WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         }
     }
 

--- a/Source/JavaScriptCore/runtime/JSCBytecodeCacheVersion.cpp
+++ b/Source/JavaScriptCore/runtime/JSCBytecodeCacheVersion.cpp
@@ -84,6 +84,7 @@ uint32_t computeJSCBytecodeCacheVersion()
             param.start = info.dli_fbase;
             if (!dl_iterate_phdr(static_cast<int(*)(struct dl_phdr_info*, size_t, void*)>(
                 [](struct dl_phdr_info* info, size_t, void* priv) -> int {
+                    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // Unix port
                     auto* data = static_cast<DLParam*>(priv);
                     void* start = nullptr;
                     for (unsigned i = 0; i < info->dlpi_phnum; ++i) {
@@ -128,6 +129,7 @@ uint32_t computeJSCBytecodeCacheVersion()
                         }
                     }
                     return 0;
+                    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                 }), &param))
                     return std::nullopt;
 


### PR DESCRIPTION
#### 1aeb02d996463ecb28a551b2b8687dad3c4948c6
<pre>
[GTK][WPE][JSCOnly] Enable -Wunsafe-buffer-usage for the JavaScriptCore target
<a href="https://bugs.webkit.org/show_bug.cgi?id=282815">https://bugs.webkit.org/show_bug.cgi?id=282815</a>

Reviewed by Justin Michaud.

Enable additional bounds safety checks from -Wunsafe-buffer-usage for
the JavaScriptCore target for the GTK, WPE, and JSCOnly ports. Add a
few needed WTF_ALLOW_UNSAFE_BUFFER_USAGE_{BEGIN,END} suppressions, to
be addressed later on.

* Source/JavaScriptCore/API/glib/JSCCallbackFunction.cpp:
* Source/JavaScriptCore/API/glib/JSCClass.cpp:
(getPropertyNames):
(jsc_class_add_constructorv):
(jsc_class_add_methodv):
* Source/JavaScriptCore/API/glib/JSCContext.cpp:
(jscContextGArrayToJSArray):
(jscContextGValueToJSValue):
* Source/JavaScriptCore/API/glib/JSCException.cpp:
(jsc_exception_report):
* Source/JavaScriptCore/API/glib/JSCOptions.cpp:
(jsc_options_get_option_group):
* Source/JavaScriptCore/API/glib/JSCValue.cpp:
(jsc_value_new_array):
(jsc_value_new_array_from_strv):
(jsc_value_object_enumerate_properties):
(jscValueCallFunction):
(jsc_value_object_invoke_methodv):
(jsc_value_new_functionv):
(jsc_value_function_callv):
(jsc_value_constructor_callv):
(jsc_value_typed_array_get_data):
* Source/JavaScriptCore/API/glib/JSCWeakValue.cpp:
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp:
(Inspector::processSessionCapabilities):
* Source/JavaScriptCore/runtime/JSCBytecodeCacheVersion.cpp:
(JSC::computeJSCBytecodeCacheVersion):

Canonical link: <a href="https://commits.webkit.org/286339@main">https://commits.webkit.org/286339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/574bc3db3578d36de7ab9327b09ee43be8d5ef2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75667 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80153 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26931 "Built successfully") 
| | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59344 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17520 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78734 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64992 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39706 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22476 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25260 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68817 "Built successfully and passed tests") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81626 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74929 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67576 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3157 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64965 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66883 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16672 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10836 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8975 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97197 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2963 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21246 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2988 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3923 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2995 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->