### PR TITLE
[GTK3] Build broken in DropTarget implementation

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/DropTarget.h
+++ b/Source/WebKit/UIProcess/API/gtk/DropTarget.h
@@ -47,6 +47,16 @@ typedef struct _GtkSelectionData GtkSelectionData;
 using PlatformDropContext = GdkDragContext;
 #endif
 
+#if !USE(GTK4)
+namespace WebKit {
+class DropTarget;
+}
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<WebKit::DropTarget> : std::true_type { };
+}
+#endif
+
 namespace WebKit {
 
 class DropTarget {


### PR DESCRIPTION
#### 1e0e867470e394b400246f54c4d8e80036ea7985
<pre>
[GTK3] Build broken in DropTarget implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=282822">https://bugs.webkit.org/show_bug.cgi?id=282822</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/UIProcess/API/gtk/DropTarget.h: Add IsDeprecatedTimerSmartPointerException for GTK3 DropTarget.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e0e867470e394b400246f54c4d8e80036ea7985

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75669 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80155 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26933 "Built successfully") 
| | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59346 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17522 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78736 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/65001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39708 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25262 "Built successfully") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/22820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81628 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3008 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/1897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67578 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3159 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/64973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66885 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10832 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8982 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2965 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/5787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2990 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3925 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2997 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->