### PR TITLE
Service Worker can't correctly redirect relative URLs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/navigation-redirect.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/navigation-redirect.https-expected.txt
@@ -13,7 +13,7 @@ PASS SW-fallbacked redirect to other-origin out-scope.
 PASS SW-fallbacked redirect to other-origin in-scope.
 PASS SW-fallbacked redirect to other-origin and back to same-origin.
 PASS SW-generated redirect to same-origin out-scope.
-FAIL SW-generated redirect to same-origin out-scope with a hash fragment. assert_equals: Last URL should match. expected "https://localhost:9443/service-workers/service-worker/resources/navigation-redirect-out-scope.py?#ref" but got "https://localhost:9443/service-workers/service-worker/resources/navigation-redirect-out-scope.py?"
+PASS SW-generated redirect to same-origin out-scope with a hash fragment.
 PASS SW-generated redirect to same-origin out-scope with different hash fragments.
 PASS SW-generated redirect to same-origin same-scope.
 PASS SW-generated redirect to same-origin other-scope.

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/navigation-redirect.https_client-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/navigation-redirect.https_client-expected.txt
@@ -13,7 +13,7 @@ FAIL SW-fallbacked redirect to other-origin out-scope. assert_true: crossOriginW
 FAIL SW-fallbacked redirect to other-origin in-scope. assert_equals: crossOriginWorker client tag matches expected "x" but got "a"
 FAIL SW-fallbacked redirect to other-origin and back to same-origin. assert_equals: worker0 client tag matches expected "x" but got "a"
 PASS SW-generated redirect to same-origin out-scope.
-FAIL SW-generated redirect to same-origin out-scope with a hash fragment. assert_equals: worker0 client url expected "https://localhost:9443/service-workers/service-worker/resources/navigation-redirect-out-scope.py?#ref" but got "https://localhost:9443/service-workers/service-worker/resources/navigation-redirect-out-scope.py?"
+PASS SW-generated redirect to same-origin out-scope with a hash fragment.
 PASS SW-generated redirect to same-origin out-scope with different hash fragments.
 PASS SW-generated redirect to same-origin same-scope.
 PASS SW-generated redirect to same-origin other-scope.

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https-expected.txt
@@ -17,7 +17,7 @@ PASS mode: "manual", generated redirect response
 PASS mode: "follow", manually-generated redirect response
 PASS mode: "error", manually-generated redirect response
 PASS mode: "manual", manually-generated redirect response
-PASS mode: "follow", generated relative redirect response
+FAIL mode: "follow", generated relative redirect response assert_unreached: Should have rejected: Following the generated redirect response from the service worker should result fail. Reached unreachable code
 PASS mode: "error", generated relative redirect response
 PASS mode: "manual", generated relative redirect response
 PASS Fetch should follow the redirect response 20 times

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
@@ -104,6 +104,10 @@ static void processResponse(Ref<Client>&& client, Expected<Ref<FetchResponse>, s
         return;
     }
 
+    // As per https://fetch.spec.whatwg.org/#main-fetch step 9, copy request's url list in response's url list if empty.
+    if (resourceResponse.url().isNull())
+        resourceResponse.setURL(requestURL);
+
     if (resourceResponse.isRedirection() && resourceResponse.httpHeaderFields().contains(HTTPHeaderName::Location)) {
         client->didReceiveRedirection(resourceResponse);
         return;
@@ -120,10 +124,6 @@ static void processResponse(Ref<Client>&& client, Expected<Ref<FetchResponse>, s
         if (!resourceResponse.certificateInfo())
             resourceResponse.setCertificateInfo(WTFMove(certificateInfo));
     }
-
-    // As per https://fetch.spec.whatwg.org/#main-fetch step 9, copy request's url list in response's url list if empty.
-    if (resourceResponse.url().isNull())
-        resourceResponse.setURL(requestURL);
 
     client->didReceiveResponse(resourceResponse);
 


### PR DESCRIPTION
#### 8aeae6caf5398bb8369bc280e2acab4b8554c0af
<pre>
Service Worker can&apos;t correctly redirect relative URLs
<a href="https://rdar.apple.com/139498279">rdar://139498279</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=282427">https://bugs.webkit.org/show_bug.cgi?id=282427</a>

Reviewed by Per Arne Vollan.

Set the URL of the service worker response slightly before so that it is taken into account for redirections.
One of the WPT test is changing from PASS to FAIL, which aligns with Chrome and Firefox.
This WPT test should probably be fixed or removed upstream.

* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/navigation-redirect.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/navigation-redirect.https_client-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https-expected.txt:
* Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp:
(WebCore::ServiceWorkerFetch::processResponse):

Canonical link: <a href="https://commits.webkit.org/286470@main">https://commits.webkit.org/286470@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/887c902f6c44e2ea33af35dced2cc33706eb8c56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75694 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80181 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26958 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77810 "Passed tests") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2982 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59369 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17543 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78761 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65021 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39730 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22501 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25287 "Built successfully") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22837 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81653 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3033 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1916 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67599 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/navigation-redirect.https.html?client (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3184 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66907 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16741 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10856 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8994 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2990 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5812 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3015 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3950 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3022 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->