### PR TITLE
Re-import dom/abort WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/AbortSignal.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/AbortSignal.any-expected.txt
@@ -1,7 +1,4 @@
 
 PASS the AbortSignal.abort() static returns an already aborted signal
 PASS signal returned by AbortSignal.abort() should not fire abort event
-PASS AbortSignal.timeout() returns a non-aborted signal
-PASS Signal returned by AbortSignal.timeout() times out
-PASS AbortSignal timeouts fire in order
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/AbortSignal.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/AbortSignal.any.js
@@ -1,3 +1,5 @@
+// META: global=window,dedicatedworker,shadowrealm
+
 test(t => {
   const signal = AbortSignal.abort();
   assert_true(signal instanceof AbortSignal, "returned object is an AbortSignal");
@@ -10,31 +12,3 @@ async_test(t => {
   s.onabort = t.unreached_func("abort event handler called");
   t.step_timeout(() => { t.done(); }, 2000);
 }, "signal returned by AbortSignal.abort() should not fire abort event");
-
-test(t => {
-  const signal = AbortSignal.timeout(0);
-  assert_true(signal instanceof AbortSignal, "returned object is an AbortSignal");
-  assert_false(signal.aborted, "returned signal is not already aborted");
-}, "AbortSignal.timeout() returns a non-aborted signal");
-
-async_test(t => {
-  const signal = AbortSignal.timeout(5);
-  signal.onabort = t.step_func_done(() => {
-    assert_true(signal.aborted, "signal is aborted");
-    assert_true(signal.reason instanceof DOMException, "signal.reason is a DOMException");
-    assert_equals(signal.reason.name, "TimeoutError", "signal.reason is a TimeoutError");
-  });
-}, "Signal returned by AbortSignal.timeout() times out");
-
-async_test(t => {
-  let result = "";
-  for (const value of ["1", "2", "3"]) {
-    const signal = AbortSignal.timeout(5);
-    signal.onabort = t.step_func(() => { result += value; });
-  }
-
-  const signal = AbortSignal.timeout(5);
-  signal.onabort = t.step_func_done(() => {
-    assert_equals(result, "123", "Timeout order should be 123");
-  });
-}, "AbortSignal timeouts fire in order");

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/AbortSignal.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/AbortSignal.any.worker-expected.txt
@@ -1,7 +1,4 @@
 
 PASS the AbortSignal.abort() static returns an already aborted signal
 PASS signal returned by AbortSignal.abort() should not fire abort event
-PASS AbortSignal.timeout() returns a non-aborted signal
-PASS Signal returned by AbortSignal.timeout() times out
-PASS AbortSignal timeouts fire in order
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/WEB_FEATURES.yml
@@ -1,0 +1,6 @@
+features:
+- name: aborting
+  files: "**"
+- name: abortsignal-any
+  files:
+  - abort-signal-any.any.js

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any-crash.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html class=test-wait>
+  <head>
+    <title>AbortSignal::Any when source signal was garbage collected</title>
+    <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1908466">
+    <link rel="author" title="Vincent Hilla" href="mailto:vhilla@mozilla.com">
+    <script src="/common/gc.js"></script>
+  </head>
+  <body>
+    <p>Test passes if the browser does not crash.</p>
+    <script>
+        async function test() {
+            let controller = new AbortController();
+            let signal = AbortSignal.any([controller.signal]);
+            controller = undefined;
+            await garbageCollect();
+            AbortSignal.any([signal]);
+            document.documentElement.classList.remove('test-wait');
+        }
+        test();
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any.any-expected.txt
@@ -11,4 +11,6 @@ PASS AbortSignal.any() works with intermediate signals (using AbortController)
 PASS Abort events for AbortSignal.any() signals fire in the right order (using AbortController)
 PASS Dependent signals for AbortSignal.any() are marked aborted before abort events fire (using AbortController)
 PASS Dependent signals for AbortSignal.any() are aborted correctly for reentrant aborts (using AbortController)
+PASS Dependent signals for AbortSignal.any() should use the same DOMException instance from the already aborted source signal (using AbortController)
+PASS Dependent signals for AbortSignal.any() should use the same DOMException instance from the source signal being aborted later (using AbortController)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any.any.worker-expected.txt
@@ -11,4 +11,6 @@ PASS AbortSignal.any() works with intermediate signals (using AbortController)
 PASS Abort events for AbortSignal.any() signals fire in the right order (using AbortController)
 PASS Dependent signals for AbortSignal.any() are marked aborted before abort events fire (using AbortController)
 PASS Dependent signals for AbortSignal.any() are aborted correctly for reentrant aborts (using AbortController)
+PASS Dependent signals for AbortSignal.any() should use the same DOMException instance from the already aborted source signal (using AbortController)
+PASS Dependent signals for AbortSignal.any() should use the same DOMException instance from the source signal being aborted later (using AbortController)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/crashtests/any-on-abort.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/crashtests/any-on-abort.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script>
+  let b;
+  window.addEventListener("DOMContentLoaded", () => {
+    let a = new AbortController()
+    b = AbortSignal.any([a.signal])
+    a.signal.addEventListener("abort", () => { AbortSignal.any([b]) }, { })
+    a.abort(undefined)
+  })
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/crashtests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/crashtests/w3c-import.log
@@ -14,4 +14,5 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/dom/abort/crashtests/any-on-abort.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/abort/crashtests/timeout-close.html

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/event.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/event.any.js
@@ -1,3 +1,5 @@
+// META: global=window,dedicatedworker,shadowrealm
+
 test(t => {
   const c = new AbortController(),
         s = c.signal;

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/resources/abort-signal-any-tests.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/resources/abort-signal-any-tests.js
@@ -221,4 +221,20 @@ function abortSignalAnyTests(signalInterface, controllerInterface) {
     assert_true(signal.aborted);
     assert_equals(signal.reason, "reason 1");
   }, `Dependent signals for ${desc} are aborted correctly for reentrant aborts ${suffix}`);
+
+  test(t => {
+    const source = signalInterface.abort();
+    const dependent = signalInterface.any([source]);
+    assert_true(source.reason instanceof DOMException);
+    assert_equals(source.reason, dependent.reason);
+  }, `Dependent signals for ${desc} should use the same DOMException instance from the already aborted source signal ${suffix}`);
+
+  test(t => {
+    const controller = new controllerInterface();
+    const source = controller.signal;
+    const dependent = signalInterface.any([source]);
+    controller.abort();
+    assert_true(source.reason instanceof DOMException);
+    assert_equals(source.reason, dependent.reason);
+  }, `Dependent signals for ${desc} should use the same DOMException instance from the source signal being aborted later ${suffix}`);
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/timeout.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/timeout.any-expected.txt
@@ -1,0 +1,5 @@
+
+PASS AbortSignal.timeout() returns a non-aborted signal
+PASS Signal returned by AbortSignal.timeout() times out
+PASS AbortSignal timeouts fire in order
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/timeout.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/timeout.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/timeout.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/timeout.any.js
@@ -1,0 +1,29 @@
+// META: global=window,dedicatedworker
+
+test(t => {
+  const signal = AbortSignal.timeout(0);
+  assert_true(signal instanceof AbortSignal, "returned object is an AbortSignal");
+  assert_false(signal.aborted, "returned signal is not already aborted");
+}, "AbortSignal.timeout() returns a non-aborted signal");
+
+async_test(t => {
+  const signal = AbortSignal.timeout(5);
+  signal.onabort = t.step_func_done(() => {
+    assert_true(signal.aborted, "signal is aborted");
+    assert_true(signal.reason instanceof DOMException, "signal.reason is a DOMException");
+    assert_equals(signal.reason.name, "TimeoutError", "signal.reason is a TimeoutError");
+  });
+}, "Signal returned by AbortSignal.timeout() times out");
+
+async_test(t => {
+  let result = "";
+  for (const value of ["1", "2", "3"]) {
+    const signal = AbortSignal.timeout(5);
+    signal.onabort = t.step_func(() => { result += value; });
+  }
+
+  const signal = AbortSignal.timeout(5);
+  signal.onabort = t.step_func_done(() => {
+    assert_equals(result, "123", "Timeout order should be 123");
+  });
+}, "AbortSignal timeouts fire in order");

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/timeout.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/timeout.any.worker-expected.txt
@@ -1,0 +1,5 @@
+
+PASS AbortSignal.timeout() returns a non-aborted signal
+PASS Signal returned by AbortSignal.timeout() times out
+PASS AbortSignal timeouts fire in order
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/timeout.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/timeout.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/w3c-import.log
@@ -15,7 +15,10 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/dom/abort/AbortSignal.any.js
+/LayoutTests/imported/w3c/web-platform-tests/dom/abort/WEB_FEATURES.yml
+/LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any.any.js
 /LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-timeout.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/abort/event.any.js
 /LayoutTests/imported/w3c/web-platform-tests/dom/abort/reason-constructor.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/abort/timeout.any.js


### PR DESCRIPTION
#### b378219597dd4fea868f798f490858a2d831bf80
<pre>
Re-import dom/abort WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=282823">https://bugs.webkit.org/show_bug.cgi?id=282823</a>

Reviewed by Anne van Kesteren.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/c6e7febe9c5f8cca44c4e6e110104b4e12097fdf">https://github.com/web-platform-tests/wpt/commit/c6e7febe9c5f8cca44c4e6e110104b4e12097fdf</a>

* LayoutTests/imported/w3c/web-platform-tests/dom/abort/AbortSignal.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/abort/AbortSignal.any.js:
* LayoutTests/imported/w3c/web-platform-tests/dom/abort/AbortSignal.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/abort/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/abort/crashtests/any-on-abort.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/abort/crashtests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/dom/abort/event.any.js:
* LayoutTests/imported/w3c/web-platform-tests/dom/abort/resources/abort-signal-any-tests.js:
* LayoutTests/imported/w3c/web-platform-tests/dom/abort/timeout.any-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/dom/abort/AbortSignal.any-expected.txt.
* LayoutTests/imported/w3c/web-platform-tests/dom/abort/timeout.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/abort/timeout.any.js: Copied from LayoutTests/imported/w3c/web-platform-tests/dom/abort/AbortSignal.any.js.
* LayoutTests/imported/w3c/web-platform-tests/dom/abort/timeout.any.worker-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/dom/abort/AbortSignal.any-expected.txt.
* LayoutTests/imported/w3c/web-platform-tests/dom/abort/timeout.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/abort/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/286402@main">https://commits.webkit.org/286402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20bbed98e2b484691bb71af8d5aaa32d009096ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80380 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27149 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3206 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59499 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17655 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49377 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65169 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39859 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46777 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22652 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25476 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67892 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22990 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81844 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67725 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65137 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67032 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10981 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9103 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11732 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3202 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4161 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3230 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->