### PR TITLE
Introduce WebSWServerToContextConnection::sendToParentProcess to make code more readable

### DIFF
--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -101,6 +101,9 @@ private:
 
     RefPtr<NetworkConnectionToWebProcess> protectedConnection() const;
 
+    template<typename T> void sendToParentProcess(T&&);
+    template<typename T, typename C> void sendWithAsyncReplyToParentProcess(T&&, C&&);
+
     // IPC::MessageSender
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final;


### PR DESCRIPTION
#### f9563db71bf9c2da12b1d5c52413eb1b99abc94d
<pre>
Introduce WebSWServerToContextConnection::sendToParentProcess to make code more readable
<a href="https://rdar.apple.com/139502899">rdar://139502899</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=282826">https://bugs.webkit.org/show_bug.cgi?id=282826</a>

Reviewed by Chris Dumez.

No change of behavior.

* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::sendToParentProcess):
(WebKit::WebSWServerToContextConnection::sendWithAsyncReplyToParentProcess):
(WebKit::WebSWServerToContextConnection::firePushEvent):
(WebKit::WebSWServerToContextConnection::fireNotificationEvent):
(WebKit::WebSWServerToContextConnection::fireBackgroundFetchEvent):
(WebKit::WebSWServerToContextConnection::fireBackgroundFetchClickEvent):
(WebKit::WebSWServerToContextConnection::openWindow):
(WebKit::WebSWServerToContextConnection::reportConsoleMessage):
(WebKit::WebSWServerToContextConnection::navigate):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:

Canonical link: <a href="https://commits.webkit.org/286500@main">https://commits.webkit.org/286500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4828f0d310e3319451ae6a9da261a519c54416e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75674 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80160 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26938 "Built successfully") 
| | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2962 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59351 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17527 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78741 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65000 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39713 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25267 "Built successfully") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81633 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1902 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67582 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3164 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66889 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16766 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10838 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8981 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2970 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5792 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2995 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3930 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3002 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->