### PR TITLE
[MediaRecorder] timecode provided in BlobEvent is incorrect

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-blob-timecode.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-blob-timecode.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS MediaRecorder Blob timecode for first chunk must be 0 and monotonically increasing
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-blob-timecode.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-blob-timecode.https.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+<head>
+  <title>MediaRecorder Blob event timecode</title>
+  <link rel="help" href="https://w3c.github.io/mediacapture-record/MediaRecorder.html#dom-mediarecorder-start">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="../mediacapture-streams/permission-helper.js"></script>
+</head>
+<body>
+
+<script>
+  promise_test(async t => {
+    await setMediaPermission();
+    const stream = await navigator.mediaDevices.getUserMedia({video:true, audio:true});
+    t.add_cleanup(() => stream.getTracks().forEach(tr => tr.stop()));
+    const recorder = new MediaRecorder(stream);
+
+    // Sets 0 timeslice will call the first chunk to be triggered immediately.
+    recorder.start(0);
+    let combinedSize = 0;
+    let previous_timecode = 0;
+    while (combinedSize < 2000) {
+      const {data, timecode} = await new Promise(r => recorder.ondataavailable = r);
+      if (combinedSize === 0) {
+        assert_equals(timecode, 0, "first chunk timecode must be 0");
+      } else {
+        assert_greater_than(timecode, previous_timecode, "timecode must increase monotonically");
+      }
+      previous_timecode = timecode;
+      combinedSize += data.size;
+    }
+    recorder.stop();
+  }, "MediaRecorder Blob timecode for first chunk must be 0 and monotonically increasing");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/w3c-import.log
@@ -17,6 +17,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/BlobEvent-constructor.html
 /LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/META.yml
 /LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-bitrate.https.html
+/LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-blob-timecode.https.html
 /LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-creation.https.html
 /LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-destroy-script-execution.html
 /LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-detached-context.html

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1166,6 +1166,7 @@ webkit.org/b/213699 http/wpt/mediarecorder/set-srcObject-MediaStream-Blob.html [
 webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-audio-bitrate.html [ Pass Failure ]
 webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html [ Timeout Failure ]
 webkit.org/b/282534 http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html [ Failure ]
+webkit.org/b/282911 imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-blob-timecode.https.html [ Failure Crash ]
 
 webkit.org/b/218317 media/media-source/media-source-trackid-change.html [ Failure ]
 webkit.org/b/238201 media/media-source/media-mp4-hevc-bframes.html [ Failure ]

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
@@ -106,6 +106,8 @@ private:
     enum class TakePrivateRecorder : bool { No, Yes };
     using FetchDataCallback = Function<void(RefPtr<FragmentedSharedBuffer>&&, const String& mimeType, double)>;
     void fetchData(FetchDataCallback&&, TakePrivateRecorder);
+    enum class ReturnDataIfEmpty : bool { No, Yes };
+    ExceptionOr<void> requestDataInternal(ReturnDataIfEmpty);
 
     // MediaStream::Observer
     void didAddTrack(MediaStreamTrackPrivate&) final { handleTrackChange(); }
@@ -130,9 +132,10 @@ private:
     std::unique_ptr<MediaRecorderPrivate> m_private;
     RecordingState m_state { RecordingState::Inactive };
     Vector<Ref<MediaStreamTrackPrivate>> m_tracks;
+    static constexpr unsigned m_mimimumTimeSlice { 100 };
     std::optional<unsigned> m_timeSlice;
     Timer m_timeSliceTimer;
-    
+
     bool m_isActive { true };
     bool m_isFetchingData { false };
     Deque<FetchDataCallback> m_pendingFetchDataTasks;


### PR DESCRIPTION
#### ced7f5e2066e77bb308efb5274a69119421cfd81
<pre>
[MediaRecorder] timecode provided in BlobEvent is incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=282320">https://bugs.webkit.org/show_bug.cgi?id=282320</a>
<a href="https://rdar.apple.com/138895100">rdar://138895100</a>

Reviewed by Anne van Kesteren.

The timecode returned was always of the time at which requestData() was called and not
&quot;For a MediaRecorder instance, the timecode in the first produced BlobEvent MUST contain 0.
Subsequent BlobEvent&apos;s timecode contain the difference of the timestamp of creation of the
first chunk in said BlobEvent and the timestamp of the first chunk of the first produced BlobEvent&quot;

imported wpt&apos;s MediaRecorder-blob-timecode.https.html to test this functionality.
The test exposed an issue in our implementation (which the test didn&apos;t deal with).
It sets a timeslice of 0 and assume that we would always get a monotonically increasing
timecode, but if we attempts to make 0ms long segment that may not always be the case.

As a workaround, and considering real-life usage, if a timeslice is set and no data was recorded at the time
the timer occurs, we will not emit `dataavailable` event. We also limit how small the timeslice can be to 100ms.

On platforms using AVFoundation, we make the minimum segment size to be 1s. Using a MP4 recorder calling requestData()
will return empty Blobs if called before 1s of data has been accumulated due to the structure of ISOBMFF (it needs to
write a complete samples table first). An AVFormatWriter will also errors with &quot;NotReady&quot; if we attempt to generate
too short segments.
With WebM data is written as received, but a new cluster will always be at least one second long.

We also hold off writing any samples until the AudioSampleBufferCompressor has started to return audible data to
ensure video and audio frames are already interleaved in monotonically increasing time order.

* LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-blob-timecode.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-blob-timecode.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/w3c-import.log:
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp:
(WebCore::MediaRecorder::MediaRecorder):
(WebCore::MediaRecorder::startRecording):
(WebCore::MediaRecorder::requestData):
(WebCore::MediaRecorder::requestDataInternal): Split method. Don&apos;t emit dataavailable event unless we actually have new data.
* Source/WebCore/Modules/mediarecorder/MediaRecorder.h: Set a minimum timeslice of 0.1s.
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::MediaRecorderPrivateEncoder::takeData):
(WebCore::MediaRecorderPrivateEncoder::enqueueCompressedAudioSampleBuffers):
(WebCore::MediaRecorderPrivateEncoder::flushToEndSegment): Return pair returnCode/time instead of setting a member variable.
Test exposed a case where we could have not written all available frames.
(WebCore::MediaRecorderPrivateEncoder::muxNextFrame):
(WebCore::MediaRecorderPrivateEncoder::fetchData):
(WebCore::MediaRecorderPrivateEncoder::flushPendingData):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h:

Canonical link: <a href="https://commits.webkit.org/286442@main">https://commits.webkit.org/286442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14773f709983a768189da0401435ec46367b8883

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75973 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55002 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80470 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27239 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3298 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59572 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17728 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79040 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49452 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39928 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46852 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22728 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25566 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67968 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81934 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3342 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2125 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67798 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3496 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65212 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67108 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16723 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11056 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9178 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3292 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6098 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3313 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4251 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3320 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->