### PR TITLE
[threaded-animation-resolution] use timelines for threaded animation resolution

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1902,6 +1902,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/animation/AcceleratedEffect.h
     platform/animation/AcceleratedEffectStack.h
     platform/animation/AcceleratedEffectValues.h
+    platform/animation/AcceleratedTimeline.h
     platform/animation/Animation.h
     platform/animation/AnimationList.h
     platform/animation/AnimationUtilities.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2314,6 +2314,7 @@ platform/WebCorePersistentCoders.cpp
 platform/Widget.cpp
 platform/animation/AcceleratedEffect.cpp
 platform/animation/AcceleratedEffectValues.cpp
+platform/animation/AcceleratedTimeline.cpp
 platform/animation/Animation.cpp
 platform/animation/AnimationList.cpp
 platform/animation/TimingFunction.cpp

--- a/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
+++ b/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
@@ -46,9 +46,9 @@ namespace WebCore {
 AcceleratedEffectStackUpdater::AcceleratedEffectStackUpdater(Document& document)
 {
     auto now = MonotonicTime::now();
-    m_timeOrigin = now.secondsSinceEpoch();
+    m_originTime = now.secondsSinceEpoch();
     if (RefPtr domWindow = document.domWindow())
-        m_timeOrigin -= Seconds::fromMilliseconds(domWindow->performance().relativeTimeFromTimeOriginInReducedResolution(now));
+        m_originTime -= Seconds::fromMilliseconds(domWindow->performance().relativeTimeFromTimeOriginInReducedResolution(now));
 }
 
 void AcceleratedEffectStackUpdater::updateEffectStacks()

--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -106,4 +106,20 @@ bool AnimationTimeline::animationsAreSuspended() const
     return controller() && controller()->animationsAreSuspended();
 }
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+const RefPtr<AcceleratedTimeline>& AnimationTimeline::acceleratedRepresentation()
+{
+    if (!m_acceleratedRepresentation)
+        m_acceleratedRepresentation = createAcceleratedRepresentation();
+    return m_acceleratedRepresentation;
+}
+
+Ref<AcceleratedTimeline> AnimationTimeline::createAcceleratedRepresentation()
+{
+    ASSERT_NOT_REACHED();
+    return AcceleratedTimeline::create(0_s);
+}
+
+#endif
+
 } // namespace WebCore

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -32,6 +32,10 @@
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+#include "AcceleratedTimeline.h"
+#endif
+
 namespace WebCore {
 
 class AnimationTimelinesController;
@@ -69,10 +73,24 @@ public:
 
     virtual TimelineRange defaultRange() const { return { }; }
     static void updateGlobalPosition(WebAnimation&);
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    void clearAcceleratedRepresentation() { m_acceleratedRepresentation = nullptr; }
+    const RefPtr<AcceleratedTimeline>& acceleratedRepresentation();
+#endif
+
 protected:
     AnimationTimeline(std::optional<WebAnimationTime> = std::nullopt);
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    virtual Ref<AcceleratedTimeline> createAcceleratedRepresentation();
+#endif
+
     AnimationCollection m_animations;
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    RefPtr<AcceleratedTimeline> m_acceleratedRepresentation;
+#endif
 
 private:
 

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -397,6 +397,15 @@ AcceleratedEffectStackUpdater& AnimationTimelinesController::acceleratedEffectSt
         m_acceleratedEffectStackUpdater = makeUnique<AcceleratedEffectStackUpdater>(m_document);
     return *m_acceleratedEffectStackUpdater;
 }
+
+void AnimationTimelinesController::updateAcceleratedEffectStacks()
+{
+    if (!m_acceleratedEffectStackUpdater)
+        return;
+    for (auto& timeline : m_timelines)
+        timeline.clearAcceleratedRepresentation();
+    m_acceleratedEffectStackUpdater->updateEffectStacks();
+}
 #endif
 
 } // namespace WebCore

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -79,8 +79,8 @@ public:
     AnimationTimeline* timelineForName(const AtomString&, const Element&) const;
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    AcceleratedEffectStackUpdater* existingAcceleratedEffectStackUpdater() const { return m_acceleratedEffectStackUpdater.get(); }
     AcceleratedEffectStackUpdater& acceleratedEffectStackUpdater();
+    void updateAcceleratedEffectStacks();
 #endif
 
 private:

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -412,10 +412,8 @@ void DocumentTimeline::applyPendingAcceleratedAnimations()
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     if (m_document && m_document->settings().threadedAnimationResolutionEnabled()) {
         m_acceleratedAnimationsPendingRunningStateChange.clear();
-        if (CheckedPtr timelinesController = m_document->timelinesController()) {
-            if (auto* acceleratedEffectStackUpdater = timelinesController->existingAcceleratedEffectStackUpdater())
-                acceleratedEffectStackUpdater->updateEffectStacks();
-        }
+        if (CheckedPtr timelinesController = m_document->timelinesController())
+            timelinesController->updateAcceleratedEffectStacks();
         return;
     }
 #endif
@@ -536,5 +534,16 @@ Seconds DocumentTimeline::convertTimelineTimeToOriginRelativeTime(Seconds timeli
     // https://drafts.csswg.org/web-animations-1/#ref-for-timeline-time-to-origin-relative-time
     return timelineTime + m_originTime;
 }
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+Ref<AcceleratedTimeline> DocumentTimeline::createAcceleratedRepresentation()
+{
+    ASSERT(m_document);
+    ASSERT(m_document->timelinesController());
+    CheckedPtr timelinesController = RefPtr { m_document.get() }->timelinesController();
+    auto originTime = timelinesController->acceleratedEffectStackUpdater().originTime();
+    return AcceleratedTimeline::create(originTime);
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -92,8 +92,11 @@ private:
     DocumentTimeline(Document&, Seconds);
 
     bool isDocumentTimeline() const final { return true; }
-
     AnimationTimelinesController* controller() const override;
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    Ref<AcceleratedTimeline> createAcceleratedRepresentation() override;
+#endif
+
     void applyPendingAcceleratedAnimations();
     void scheduleInvalidationTaskIfNeeded();
     void scheduleAnimationResolution();

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -28,6 +28,7 @@
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 
 #include "AcceleratedEffectValues.h"
+#include "AcceleratedTimeline.h"
 #include "AnimationEffectTiming.h"
 #include "CompositeOperation.h"
 #include "KeyframeInterpolation.h"
@@ -74,17 +75,18 @@ public:
     };
 
     static RefPtr<AcceleratedEffect> create(const KeyframeEffect&, const IntRect&, const AcceleratedEffectValues&, OptionSet<AcceleratedEffectProperty>&);
-    WEBCORE_EXPORT static Ref<AcceleratedEffect> create(AnimationEffectTiming, Vector<Keyframe>&&, WebAnimationType, CompositeOperation, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double playbackRate, std::optional<WebAnimationTime> startTime, std::optional<WebAnimationTime> holdTime);
+    WEBCORE_EXPORT static Ref<AcceleratedEffect> create(AnimationEffectTiming, RefPtr<AcceleratedTimeline>&&, Vector<Keyframe>&&, WebAnimationType, CompositeOperation, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double playbackRate, std::optional<WebAnimationTime> startTime, std::optional<WebAnimationTime> holdTime);
 
     virtual ~AcceleratedEffect() = default;
 
     WEBCORE_EXPORT Ref<AcceleratedEffect> clone() const;
     WEBCORE_EXPORT Ref<AcceleratedEffect> copyWithProperties(OptionSet<AcceleratedEffectProperty>&) const;
 
-    WEBCORE_EXPORT void apply(WebAnimationTime, AcceleratedEffectValues&, const FloatRect&);
+    WEBCORE_EXPORT void apply(AcceleratedEffectValues&, const FloatRect&);
 
     // Encoding and decoding support
     AnimationEffectTiming timing() const { return m_timing; }
+    const RefPtr<AcceleratedTimeline>& timeline() const { return m_timeline; }
     const Vector<Keyframe>& keyframes() const { return m_keyframes; }
     WebAnimationType animationType() const { return m_animationType; }
     CompositeOperation compositeOperation() const final { return m_compositeOperation; }
@@ -101,7 +103,7 @@ public:
 
 private:
     AcceleratedEffect(const KeyframeEffect&, const IntRect&, const OptionSet<AcceleratedEffectProperty>&);
-    explicit AcceleratedEffect(AnimationEffectTiming, Vector<Keyframe>&&, WebAnimationType, CompositeOperation, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double playbackRate, std::optional<WebAnimationTime> startTime, std::optional<WebAnimationTime> holdTime);
+    explicit AcceleratedEffect(AnimationEffectTiming, RefPtr<AcceleratedTimeline>&&, Vector<Keyframe>&&, WebAnimationType, CompositeOperation, RefPtr<TimingFunction>&& defaultKeyframeTimingFunction, OptionSet<AcceleratedEffectProperty>&&, bool paused, double playbackRate, std::optional<WebAnimationTime> startTime, std::optional<WebAnimationTime> holdTime);
     explicit AcceleratedEffect(const AcceleratedEffect&, OptionSet<AcceleratedEffectProperty>&);
 
     void validateFilters(const AcceleratedEffectValues& baseValues, OptionSet<AcceleratedEffectProperty>&);
@@ -113,6 +115,7 @@ private:
     const TimingFunction* timingFunctionForKeyframe(const KeyframeInterpolation::Keyframe&) const final;
 
     AnimationEffectTiming m_timing;
+    RefPtr<AcceleratedTimeline> m_timeline;
     Vector<Keyframe> m_keyframes;
     WebAnimationType m_animationType { WebAnimationType::WebAnimation };
     CompositeOperation m_compositeOperation { CompositeOperation::Replace };

--- a/Source/WebCore/platform/animation/AcceleratedTimeline.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedTimeline.cpp
@@ -23,37 +23,37 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "AcceleratedTimeline.h"
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 
-#include "AcceleratedEffect.h"
-#include <wtf/HashSet.h>
-#include <wtf/Seconds.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
-class Document;
-class Element;
-struct Styleable;
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(AcceleratedTimeline);
 
-class AcceleratedEffectStackUpdater {
-    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Animation);
-public:
-    AcceleratedEffectStackUpdater(Document&);
+Ref<AcceleratedTimeline> AcceleratedTimeline::create(Seconds originTime)
+{
+    return adoptRef(*new AcceleratedTimeline(std::nullopt, originTime));
+}
 
-    void updateEffectStacks();
-    void updateEffectStackForTarget(const Styleable&);
+Ref<AcceleratedTimeline> AcceleratedTimeline::create(std::optional<WebAnimationTime>&& duration, Seconds originTime)
+{
+    return adoptRef(*new AcceleratedTimeline(WTFMove(duration), WTFMove(originTime)));
+}
 
-    Seconds originTime() const { return m_originTime; }
+AcceleratedTimeline::AcceleratedTimeline(std::optional<WebAnimationTime>&& duration, Seconds originTime)
+    : m_duration(WTFMove(duration))
+    , m_originTime(originTime)
+{
+}
 
-protected:
-
-private:
-    using HashedStyleable = std::pair<Element*, std::optional<Style::PseudoElementIdentifier>>;
-    HashSet<HashedStyleable> m_targetsPendingUpdate;
-    Seconds m_originTime;
-};
+void AcceleratedTimeline::setMonotonicTime(MonotonicTime now)
+{
+    m_currentTime = now.secondsSinceEpoch() - m_originTime;
+}
 
 } // namespace WebCore
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -160,10 +160,6 @@ header: "RemoteLayerBackingStore.h"
 #if PLATFORM(IOS_FAMILY)
     std::optional<uint64_t> m_dynamicViewportSizeUpdateID;
 #endif
-
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    Seconds m_acceleratedTimelineTimeOrigin;
-#endif
 }
 
 headers: "LayerProperties.h" "PlatformCALayerRemote.h"

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -242,11 +242,6 @@ public:
     void setDynamicViewportSizeUpdateID(DynamicViewportSizeUpdateID resizeID) { m_dynamicViewportSizeUpdateID = resizeID; }
 #endif
 
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    Seconds acceleratedTimelineTimeOrigin() const { return m_acceleratedTimelineTimeOrigin; }
-    void setAcceleratedTimelineTimeOrigin(Seconds timeOrigin) { m_acceleratedTimelineTimeOrigin = timeOrigin; }
-#endif
-
 private:
     friend struct IPC::ArgumentCoder<RemoteLayerTreeTransaction, void>;
 
@@ -296,9 +291,6 @@ private:
     std::optional<EditorState> m_editorState;
 #if PLATFORM(IOS_FAMILY)
     std::optional<DynamicViewportSizeUpdateID> m_dynamicViewportSizeUpdateID;
-#endif
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    Seconds m_acceleratedTimelineTimeOrigin;
 #endif
 };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6566,6 +6566,12 @@ struct WebCore::AnimationEffectTiming {
     WebCore::WebAnimationTime endTime;
 };
 
+[RefCounted] class WebCore::AcceleratedTimeline {
+    std::optional<WebCore::WebAnimationTime> duration();
+    Seconds originTime();
+    [NotSerialized] std::optional<WebCore::WebAnimationTime> currentTime();
+};
+
 header: <WebCore/AcceleratedEffect.h>
 [CustomHeader, Nested] class WebCore::AcceleratedEffect::Keyframe {
     double offset();
@@ -6577,6 +6583,7 @@ header: <WebCore/AcceleratedEffect.h>
 
 [RefCounted] class WebCore::AcceleratedEffect {
     WebCore::AnimationEffectTiming timing();
+    RefPtr<WebCore::AcceleratedTimeline> timeline();
     Vector<WebCore::AcceleratedEffect::Keyframe> keyframes();
     WebCore::WebAnimationType animationType();
     WebCore::CompositeOperation compositeOperation();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h
@@ -44,23 +44,23 @@ namespace WebKit {
 class RemoteAcceleratedEffectStack final : public WebCore::AcceleratedEffectStack {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RemoteAcceleratedEffectStack);
 public:
-    static Ref<RemoteAcceleratedEffectStack> create(WebCore::FloatRect, Seconds);
+    static Ref<RemoteAcceleratedEffectStack> create(WebCore::FloatRect);
 
     void setEffects(WebCore::AcceleratedEffects&&) final;
 
 #if PLATFORM(MAC)
-    void initEffectsFromMainThread(PlatformLayer*, MonotonicTime now);
-    void applyEffectsFromScrollingThread(MonotonicTime now) const;
+    void initEffectsFromMainThread(PlatformLayer*);
+    void applyEffectsFromScrollingThread() const;
 #endif
 
-    void applyEffectsFromMainThread(PlatformLayer*, MonotonicTime now, bool backdropRootIsOpaque) const;
+    void applyEffectsFromMainThread(PlatformLayer*, bool backdropRootIsOpaque) const;
 
     void clear(PlatformLayer*);
 
 private:
-    explicit RemoteAcceleratedEffectStack(WebCore::FloatRect, Seconds);
+    explicit RemoteAcceleratedEffectStack(WebCore::FloatRect);
 
-    WebCore::AcceleratedEffectValues computeValues(MonotonicTime now) const;
+    WebCore::AcceleratedEffectValues computeValues() const;
 
 #if PLATFORM(MAC)
     const WebCore::FilterOperations* longestFilterList() const;
@@ -75,7 +75,6 @@ private:
     OptionSet<LayerProperty> m_affectedLayerProperties;
 
     WebCore::FloatRect m_bounds;
-    Seconds m_acceleratedTimelineTimeOrigin;
 
 #if PLATFORM(MAC)
     RetainPtr<CAPresentationModifierGroup> m_presentationModifierGroup;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -76,10 +76,10 @@ public:
     void viewWillEndLiveResize() final;
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    void clearAnimationTimelines();
+    void setAnimationTimelinesCurrentTime(MonotonicTime);
     void animationsWereAddedToNode(RemoteLayerTreeNode&);
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
-    Seconds acceleratedTimelineTimeOrigin(WebCore::ProcessIdentifier) const;
-    MonotonicTime animationCurrentTime(WebCore::ProcessIdentifier) const;
 #endif
 
     // For testing.
@@ -104,11 +104,6 @@ protected:
         CommitLayerTreeMessageState commitLayerTreeMessageState { Idle };
         TransactionID lastLayerTreeTransactionID;
         TransactionID pendingLayerTreeTransactionID;
-
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-        Seconds acceleratedTimelineTimeOrigin;
-        MonotonicTime animationCurrentTime;
-#endif
     };
 
     ProcessState& processStateForConnection(IPC::Connection&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -338,8 +338,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
     };
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    state.acceleratedTimelineTimeOrigin = layerTreeTransaction.acceleratedTimelineTimeOrigin();
-    state.animationCurrentTime = MonotonicTime::now();
+    setAnimationTimelinesCurrentTime(MonotonicTime::now());
 #endif
 
     webPageProxy->scrollingCoordinatorProxy()->willCommitLayerAndScrollingTrees();
@@ -687,6 +686,16 @@ void RemoteLayerTreeDrawingAreaProxy::sizeToContentAutoSizeMaximumSizeDidChange(
 }
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
+void RemoteLayerTreeDrawingAreaProxy::clearAnimationTimelines()
+{
+    protectedWebPageProxy()->scrollingCoordinatorProxy()->clearAnimationTimelines();
+}
+
+void RemoteLayerTreeDrawingAreaProxy::setAnimationTimelinesCurrentTime(MonotonicTime now)
+{
+    protectedWebPageProxy()->scrollingCoordinatorProxy()->setAnimationTimelinesCurrentTime(now);
+}
+
 void RemoteLayerTreeDrawingAreaProxy::animationsWereAddedToNode(RemoteLayerTreeNode& node)
 {
     protectedWebPageProxy()->scrollingCoordinatorProxy()->animationsWereAddedToNode(node);
@@ -696,19 +705,6 @@ void RemoteLayerTreeDrawingAreaProxy::animationsWereRemovedFromNode(RemoteLayerT
 {
     protectedWebPageProxy()->scrollingCoordinatorProxy()->animationsWereRemovedFromNode(node);
 }
-
-Seconds RemoteLayerTreeDrawingAreaProxy::acceleratedTimelineTimeOrigin(WebCore::ProcessIdentifier processIdentifier) const
-{
-    const auto& state = processStateForIdentifier(processIdentifier);
-    return state.acceleratedTimelineTimeOrigin;
-}
-
-MonotonicTime RemoteLayerTreeDrawingAreaProxy::animationCurrentTime(WebCore::ProcessIdentifier processIdentifier) const
-{
-    const auto& state = processStateForIdentifier(processIdentifier);
-    return state.animationCurrentTime;
-}
-
 #endif // ENABLE(THREADED_ANIMATION_RESOLUTION)
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -96,11 +96,6 @@ public:
 
     bool cssUnprefixedBackdropFilterEnabled() const;
 
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    Seconds acceleratedTimelineTimeOrigin(WebCore::ProcessIdentifier) const;
-    MonotonicTime animationCurrentTime(WebCore::ProcessIdentifier) const;
-#endif
-
     void remotePageProcessDidTerminate(WebCore::ProcessIdentifier);
 
 private:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -294,7 +294,7 @@ void RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues(const WebCore::Acce
     if (effects.isEmpty())
         return;
 
-    m_effectStack = RemoteAcceleratedEffectStack::create(layer().bounds, host.acceleratedTimelineTimeOrigin(m_layerID.processIdentifier()));
+    m_effectStack = RemoteAcceleratedEffectStack::create(layer().bounds);
 
     auto clonedEffects = effects;
     auto clonedBaseValues = baseValues.clone();
@@ -303,9 +303,9 @@ void RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues(const WebCore::Acce
     m_effectStack->setBaseValues(WTFMove(clonedBaseValues));
 
 #if PLATFORM(IOS_FAMILY)
-    m_effectStack->applyEffectsFromMainThread(layer(), host.animationCurrentTime(m_layerID.processIdentifier()), backdropRootIsOpaque());
+    m_effectStack->applyEffectsFromMainThread(layer(), backdropRootIsOpaque());
 #else
-    m_effectStack->initEffectsFromMainThread(layer(), host.animationCurrentTime(m_layerID.processIdentifier()));
+    m_effectStack->initEffectsFromMainThread(layer());
 #endif
 
     host.animationsWereAddedToNode(*this);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -137,6 +137,8 @@ public:
     virtual void didCommitLayerAndScrollingTrees() { }
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    virtual void clearAnimationTimelines() { }
+    virtual void setAnimationTimelinesCurrentTime(MonotonicTime) { }
     virtual void animationsWereAddedToNode(RemoteLayerTreeNode&) { }
     virtual void animationsWereRemovedFromNode(RemoteLayerTreeNode&) { }
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -74,6 +74,8 @@ public:
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     void animationsWereAddedToNode(RemoteLayerTreeNode&) override WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&) override;
+    void clearAnimationTimelines() override;
+    void setAnimationTimelinesCurrentTime(MonotonicTime) override;
     void updateAnimations();
 #endif
 
@@ -104,6 +106,7 @@ private:
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     HashSet<WebCore::PlatformLayerIdentifier> m_animatedNodeLayerIDs;
+    HashSet<Ref<WebCore::AcceleratedTimeline>> m_animationTimelines;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -102,6 +102,8 @@ public:
     void animationsWereAddedToNode(RemoteLayerTreeNode&);
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
     void updateAnimations();
+    void clearAnimationTimelines();
+    void setAnimationTimelinesCurrentTime(MonotonicTime);
 #endif
 
 private:
@@ -191,6 +193,7 @@ private:
     friend class RemoteScrollingCoordinatorProxyMac;
     Lock m_effectStacksLock;
     HashMap<WebCore::PlatformLayerIdentifier, Ref<RemoteAcceleratedEffectStack>> m_effectStacks WTF_GUARDED_BY_LOCK(m_effectStacksLock);
+    HashSet<Ref<WebCore::AcceleratedTimeline>> m_animationTimelines;
 #endif
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -75,6 +75,8 @@ private:
     void willCommitLayerAndScrollingTrees() override WTF_ACQUIRES_LOCK(m_eventDispatcher->m_effectStacksLock);
     void didCommitLayerAndScrollingTrees() override WTF_RELEASES_LOCK(m_eventDispatcher->m_effectStacksLock);
 
+    void clearAnimationTimelines() override;
+    void setAnimationTimelinesCurrentTime(MonotonicTime) override;
     void animationsWereAddedToNode(RemoteLayerTreeNode&) override;
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&) override;
 #else

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -300,6 +300,16 @@ void RemoteScrollingCoordinatorProxyMac::applyScrollingTreeLayerPositionsAfterCo
 }
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
+void RemoteScrollingCoordinatorProxyMac::clearAnimationTimelines()
+{
+    m_eventDispatcher->clearAnimationTimelines();
+}
+
+void RemoteScrollingCoordinatorProxyMac::setAnimationTimelinesCurrentTime(MonotonicTime now)
+{
+    m_eventDispatcher->setAnimationTimelinesCurrentTime(now);
+}
+
 void RemoteScrollingCoordinatorProxyMac::animationsWereAddedToNode(RemoteLayerTreeNode& node)
 {
     m_eventDispatcher->animationsWereAddedToNode(node);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4856,15 +4856,6 @@ void WebPage::willCommitLayerTree(RemoteLayerTreeTransaction& layerTransaction, 
     if (!frameView)
         return;
 
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    if (auto* document = localRootFrame->document()) {
-        if (CheckedPtr timelinesController = document->timelinesController()) {
-            if (auto* acceleratedEffectStackUpdater = timelinesController->existingAcceleratedEffectStackUpdater())
-                layerTransaction.setAcceleratedTimelineTimeOrigin(acceleratedEffectStackUpdater->timeOrigin());
-        }
-    }
-#endif
-
     layerTransaction.setContentsSize(frameView->contentsSize());
     layerTransaction.setScrollOrigin(frameView->scrollOrigin());
     layerTransaction.setPageScaleFactor(corePage()->pageScaleFactor());


### PR DESCRIPTION
#### 1cda70b9c31e03d1aa642823bf564524f338fbd9
<pre>
[threaded-animation-resolution] use timelines for threaded animation resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=282833">https://bugs.webkit.org/show_bug.cgi?id=282833</a>
<a href="https://rdar.apple.com/139509143">rdar://139509143</a>

Reviewed by NOBODY (OOPS!).

Until now, we assumed all effects uploaded to the UI process for threaded animation resolution
use the same timeline. In order to support threaded animation resolution for threaded animation
resolution we will need to represent the various timelines types in the UI process.

We start this process by refactoring our currently-supported animation types, which are all
associated with a `DocumentTimeline`, to use an `AcceleratedTimeline` to compute their timing.

We add a new `acceleratedRepresentation()` on `AnimationTimeline` and allow subclasses to lazily
create it with a dedicated `createAcceleratedRepresentation()` virtual method.

The resulting `AcceleratedTimeline` objects are stored on `RemoteLayerTreeEventDispatcher` on macOS
and on `RemoteScrollingCoordinatorProxyIOS` on iOS. As the display updates, we advance the monotonic
time of the timelines by calling the `setMonotonicTime()` method which allows us to no longer call
though `RemoteLayerTreeHost` to obtain the per-process current time and pass that timestamp down to
`AcceleratedEffect::apply()`.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp:
(WebCore::AcceleratedEffectStackUpdater::AcceleratedEffectStackUpdater):
* Source/WebCore/animation/AcceleratedEffectStackUpdater.h:
(WebCore::AcceleratedEffectStackUpdater::originTime const):
(WebCore::AcceleratedEffectStackUpdater::timeOrigin const): Deleted.
* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::acceleratedRepresentation):
(WebCore::AnimationTimeline::createAcceleratedRepresentation):
* Source/WebCore/animation/AnimationTimeline.h:
(WebCore::AnimationTimeline::clearAcceleratedRepresentation):
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::updateAcceleratedEffectStacks):
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::applyPendingAcceleratedAnimations):
(WebCore::DocumentTimeline::createAcceleratedRepresentation):
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::create):
(WebCore::AcceleratedEffect::clone const):
(WebCore::AcceleratedEffect::AcceleratedEffect):
(WebCore::AcceleratedEffect::apply):
* Source/WebCore/platform/animation/AcceleratedEffect.h:
(WebCore::AcceleratedEffect::timeline const):
* Source/WebCore/platform/animation/AcceleratedTimeline.cpp: Copied from Source/WebCore/animation/AcceleratedEffectStackUpdater.h.
(WebCore::AcceleratedTimeline::create):
(WebCore::AcceleratedTimeline::AcceleratedTimeline):
(WebCore::AcceleratedTimeline::setMonotonicTime):
* Source/WebCore/platform/animation/AcceleratedTimeline.h: Copied from Source/WebCore/animation/AcceleratedEffectStackUpdater.h.
(WebCore::AcceleratedTimeline::currentTime const):
(WebCore::AcceleratedTimeline::duration const):
(WebCore::AcceleratedTimeline::originTime const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
(WebKit::RemoteLayerTreeTransaction::acceleratedTimelineTimeOrigin const): Deleted.
(WebKit::RemoteLayerTreeTransaction::setAcceleratedTimelineTimeOrigin): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm:
(WebKit::RemoteAcceleratedEffectStack::create):
(WebKit::RemoteAcceleratedEffectStack::RemoteAcceleratedEffectStack):
(WebKit::RemoteAcceleratedEffectStack::initEffectsFromMainThread):
(WebKit::RemoteAcceleratedEffectStack::applyEffectsFromScrollingThread const):
(WebKit::RemoteAcceleratedEffectStack::applyEffectsFromMainThread const):
(WebKit::RemoteAcceleratedEffectStack::computeValues const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
(WebKit::RemoteLayerTreeDrawingAreaProxy::clearAnimationTimelines):
(WebKit::RemoteLayerTreeDrawingAreaProxy::setAnimationTimelinesCurrentTime):
(WebKit::RemoteLayerTreeDrawingAreaProxy::animationsWereAddedToNode):
(WebKit::RemoteLayerTreeDrawingAreaProxy::animationsWereRemovedFromNode):
(WebKit::RemoteLayerTreeDrawingAreaProxy::acceleratedTimelineTimeOrigin const): Deleted.
(WebKit::RemoteLayerTreeDrawingAreaProxy::animationCurrentTime const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateLayerTree):
(WebKit::RemoteLayerTreeHost::animationsWereRemovedFromNode):
(WebKit::RemoteLayerTreeHost::acceleratedTimelineTimeOrigin const): Deleted.
(WebKit::RemoteLayerTreeHost::animationCurrentTime const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::clearAnimationTimelines):
(WebKit::RemoteScrollingCoordinatorProxy::setAnimationTimelinesCurrentTime):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::animationsWereAddedToNode):
(WebKit::RemoteScrollingCoordinatorProxyIOS::clearAnimationTimelines):
(WebKit::RemoteScrollingCoordinatorProxyIOS::setAnimationTimelinesCurrentTime):
(WebKit::RemoteScrollingCoordinatorProxyIOS::updateAnimations):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::startOrStopDisplayLinkOnMainThread):
(WebKit::RemoteLayerTreeEventDispatcher::animationsWereAddedToNode):
(WebKit::RemoteLayerTreeEventDispatcher::clearAnimationTimelines):
(WebKit::RemoteLayerTreeEventDispatcher::setAnimationTimelinesCurrentTime):
(WebKit::RemoteLayerTreeEventDispatcher::updateAnimations):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::clearAnimationTimelines):
(WebKit::RemoteScrollingCoordinatorProxyMac::setAnimationTimelinesCurrentTime):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::willCommitLayerTree):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cda70b9c31e03d1aa642823bf564524f338fbd9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75691 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80178 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26955 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77807 "Passed tests") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59370 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17545 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78758 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65022 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39731 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22502 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25284 "Built successfully") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22838 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81650 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3030 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1914 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67600 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3181 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66908 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10855 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8995 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2987 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5809 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3012 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3947 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3019 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->