### PR TITLE
Separated layers should support `border-radius`

### DIFF
--- a/LayoutTests/platform/visionos/transforms/separated-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-expected.txt
@@ -39,15 +39,12 @@
                           (sublayers
                             (
                               (layer bounds [x: 0 y: 0 width: 200 height: 200])
-                              (layer position [x: 100 y: 100])
-                              (sublayers
-                                (
-                                  (layer bounds [x: 0 y: 0 width: 200 height: 200])
-                                  (layer anchorPoint [x: 0 y: 0]))))
+                              (layer position [x: 100 y: 100]))
                             (
                               (layer bounds [x: 0 y: 0 width: 200 height: 200])
                               (layer position [x: 100 y: 100])
                               (separated 1)
+                              (layer cornerRadius 24)
                               (sublayers
                                 (
                                   (layer bounds [x: 0 y: 0 width: 200 height: 200])
@@ -55,6 +52,7 @@
                             (
                               (layer bounds [x: 0 y: 0 width: 200 height: 200])
                               (layer position [x: 100 y: 100])
+                              (layer cornerRadius 24)
                               (sublayers
                                 (
                                   (layer bounds [x: 0 y: 0 width: 200 height: 200])

--- a/LayoutTests/platform/visionos/transforms/separated.html
+++ b/LayoutTests/platform/visionos/transforms/separated.html
@@ -8,6 +8,7 @@
       height: 200px;
       background: purple;
       translate: 0 0 20px;
+      border-radius: 24px;
     }
     .separated {
       transform-style: separated;

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -3009,6 +3009,14 @@ void GraphicsLayerCA::updateContentsColorLayer()
 // roundedRect is in the coordinate space of clippingLayer.
 void GraphicsLayerCA::updateClippingStrategy(PlatformCALayer& clippingLayer, RefPtr<PlatformCALayer>& shapeMaskLayer, const FloatRoundedRect& roundedRect)
 {
+#if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
+    if (m_isSeparated && roundedRect.radii().hasEvenCorners() && clippingLayer.bounds() == roundedRect.rect()) {
+        m_layer->setCornerRadius(roundedRect.radii().topLeft().width());
+        return;
+    }
+    m_layer->setCornerRadius(0);
+#endif
+
     if (roundedRect.radii().isUniformCornerRadius() && clippingLayer.bounds() == roundedRect.rect()) {
         clippingLayer.setMaskLayer(nullptr);
         if (shapeMaskLayer) {

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3653,6 +3653,13 @@ bool RenderLayerCompositor::isCompositedPlugin(const RenderObject& renderer)
     return renderEmbeddedObject->requiresAcceleratedCompositing();
 }
 
+#if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
+bool RenderLayerCompositor::isSeparated(const RenderObject& renderer)
+{
+    return renderer.style().usedTransformStyle3D() == TransformStyle3D::Separated;
+}
+#endif
+
 // Return true if the given layer is a stacking context and has compositing child
 // layers that it needs to clip. In this case we insert a clipping GraphicsLayer
 // into the hierarchy between this layer and its children in the z-order hierarchy.

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -316,6 +316,10 @@ public:
     static bool hasCompositedWidgetContents(const RenderObject&);
     static bool isCompositedPlugin(const RenderObject&);
 
+#if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
+    static bool isSeparated(const RenderObject&);
+#endif
+
     static RenderLayerCompositor* frameContentsCompositor(RenderWidget&);
 
     struct WidgetLayerAttachment {


### PR DESCRIPTION
#### d634b453e3d6fd2b0ca50e3755f1203011a47121
<pre>
Separated layers should support `border-radius`
<a href="https://bugs.webkit.org/show_bug.cgi?id=282834">https://bugs.webkit.org/show_bug.cgi?id=282834</a>
&lt;<a href="https://rdar.apple.com/137275518">rdar://137275518</a>&gt;

Reviewed by Simon Fraser.

When using separated layers, we need to apply the corner radius to the
main layer if at all possible in order to get the expected visual effect.
Introduce a new clipping strategy for these layers.

* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateConfiguration):
Enable composited descendant clipping on separated layers.
(WebCore::RenderLayerBacking::updateContentsRects):
Generate a content clipping rect for all separated layers.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::updateClippingStrategy):
Set the corner radius on the main layer for separated layers. We also
relax the application to even corners (as opposed to uniform) since
masking won&apos;t yield the expected effect.

* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::isSeparated):
Add a helper method to test if a RenderObject requires a separated
layer.

* LayoutTests/platform/visionos/transforms/separated-expected.txt:
* LayoutTests/platform/visionos/transforms/separated.html:
Update the test to cover this by adding a `border-radius` to the
transformed elements.

Canonical link: <a href="https://commits.webkit.org/286384@main">https://commits.webkit.org/286384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef9be1c10288711b1e48b47bea524203fd75cd59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75702 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80189 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26966 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77818 "Passed tests") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2990 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59377 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17551 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78769 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39738 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22510 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25295 "Built successfully") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22846 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81661 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3041 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67604 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3192 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64999 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66912 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16704 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10863 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9003 "Build was cancelled. Recent messages:OS: Ventura (13.6.9), Xcode: 14.3") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2998 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5820 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3023 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3958 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3030 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->