### PR TITLE
Drop IsDeprecatedTimerSmartPointerException for DownloadMonitor

### DIFF
--- a/Source/WebKit/NetworkProcess/Downloads/Download.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/Download.cpp
@@ -53,6 +53,11 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Download);
 
+Ref<Download> Download::create(DownloadManager& downloadManager, DownloadID downloadID, NetworkDataTask& download, NetworkSession& session, const String& suggestedName)
+{
+    return adoptRef(*new Download(downloadManager, downloadID, download, session, suggestedName));
+}
+
 Download::Download(DownloadManager& downloadManager, DownloadID downloadID, NetworkDataTask& download, NetworkSession& session, const String& suggestedName)
     : m_downloadManager(downloadManager)
     , m_downloadID(downloadID)
@@ -61,10 +66,15 @@ Download::Download(DownloadManager& downloadManager, DownloadID downloadID, Netw
     , m_sessionID(session.sessionID())
     , m_testSpeedMultiplier(session.testSpeedMultiplier())
 {
-    m_downloadManager->didCreateDownload();
+    downloadManager.didCreateDownload();
 }
 
 #if PLATFORM(COCOA)
+Ref<Download> Download::create(DownloadManager& downloadManager, DownloadID downloadID, NSURLSessionDownloadTask* download, NetworkSession& session, const String& suggestedName)
+{
+    return adoptRef(*new Download(downloadManager, downloadID, download, session, suggestedName));
+}
+
 Download::Download(DownloadManager& downloadManager, DownloadID downloadID, NSURLSessionDownloadTask* download, NetworkSession& session, const String& suggestedName)
     : m_downloadManager(downloadManager)
     , m_downloadID(downloadID)
@@ -73,14 +83,15 @@ Download::Download(DownloadManager& downloadManager, DownloadID downloadID, NSUR
     , m_sessionID(session.sessionID())
     , m_testSpeedMultiplier(session.testSpeedMultiplier())
 {
-    m_downloadManager->didCreateDownload();
+    downloadManager.didCreateDownload();
 }
 #endif
 
 Download::~Download()
 {
     platformDestroyDownload();
-    m_downloadManager->didDestroyDownload();
+    if (CheckedPtr downloadManager = m_downloadManager)
+        downloadManager->didDestroyDownload();
 }
 
 void Download::cancel(CompletionHandler<void(std::span<const uint8_t>)>&& completionHandler, IgnoreDidFailCallback ignoreDidFailCallback)
@@ -99,7 +110,8 @@ void Download::cancel(CompletionHandler<void(std::span<const uint8_t>)>&& comple
         DOWNLOAD_RELEASE_LOG("didCancel: (id = %" PRIu64 ")", downloadID().toUInt64());
         if (auto extension = std::exchange(m_sandboxExtension, nullptr))
             extension->revoke();
-        m_downloadManager->downloadFinished(*this);
+        if (CheckedPtr downloadManager = m_downloadManager)
+            downloadManager->downloadFinished(*this);
     };
 
     if (m_download) {
@@ -156,7 +168,8 @@ void Download::didFinish()
             m_sandboxExtension = nullptr;
         }
 
-        m_downloadManager->downloadFinished(*this);
+        if (CheckedPtr downloadManager = m_downloadManager)
+            downloadManager->downloadFinished(*this);
     });
 }
 
@@ -179,12 +192,15 @@ void Download::didFail(const ResourceError& error, std::span<const uint8_t> resu
         m_sandboxExtension->revoke();
         m_sandboxExtension = nullptr;
     }
-    m_downloadManager->downloadFinished(*this);
+    if (CheckedPtr downloadManager = m_downloadManager)
+        downloadManager->downloadFinished(*this);
 }
 
 IPC::Connection* Download::messageSenderConnection() const
 {
-    return m_downloadManager->downloadProxyConnection();
+    if (CheckedPtr downloadManager = m_downloadManager)
+        return downloadManager->downloadProxyConnection();
+    return nullptr;
 }
 
 uint64_t Download::messageSenderDestinationID() const

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
@@ -93,7 +93,7 @@ public:
     ~DownloadManager();
 
     void startDownload(PAL::SessionID, DownloadID, const WebCore::ResourceRequest&, const std::optional<WebCore::SecurityOriginData>& topOrigin, std::optional<NavigatingToAppBoundDomain>, const String& suggestedName = { }, WebCore::FromDownloadAttribute = WebCore::FromDownloadAttribute::No, std::optional<WebCore::FrameIdentifier> frameID = std::nullopt, std::optional<WebCore::PageIdentifier> = std::nullopt, std::optional<WebCore::ProcessIdentifier> = std::nullopt);
-    void dataTaskBecameDownloadTask(DownloadID, std::unique_ptr<Download>&&);
+    void dataTaskBecameDownloadTask(DownloadID, Ref<Download>&&);
     void convertNetworkLoadToDownload(DownloadID, Ref<NetworkLoad>&&, ResponseCompletionHandler&&,  Vector<RefPtr<WebCore::BlobDataFileReference>>&&, const WebCore::ResourceRequest&, const WebCore::ResourceResponse&);
     void downloadDestinationDecided(DownloadID, Ref<NetworkDataTask>&&);
 
@@ -108,7 +108,7 @@ public:
 #endif
 #endif
     
-    Download* download(DownloadID downloadID) { return m_downloads.get(downloadID); }
+    Download* download(DownloadID);
 
     void downloadFinished(Download&);
     bool isDownloading() const { return !m_downloads.isEmpty(); }

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMap.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMap.h
@@ -32,6 +32,6 @@ namespace WebKit {
 
 class Download;
 
-using DownloadMap = HashMap<DownloadID, std::unique_ptr<Download>>;
+using DownloadMap = HashMap<DownloadID, Ref<Download>>;
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp
@@ -69,6 +69,16 @@ DownloadMonitor::DownloadMonitor(Download& download)
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DownloadMonitor);
 
+void DownloadMonitor::ref() const
+{
+    m_download->ref();
+}
+
+void DownloadMonitor::deref() const
+{
+    m_download->deref();
+}
+
 double DownloadMonitor::measuredThroughputRate() const
 {
     uint64_t bytes { 0 };
@@ -120,7 +130,7 @@ void DownloadMonitor::timerFired()
     RELEASE_ASSERT(m_interval < std::size(throughputIntervals));
     if (measuredThroughputRate() < throughputIntervals[m_interval].bytesPerSecond) {
         DOWNLOAD_MONITOR_RELEASE_LOG("timerFired: cancelling download (id = %" PRIu64 ")", m_download->downloadID().toUInt64());
-        m_download->cancel([](auto) { }, Download::IgnoreDidFailCallback::No);
+        Ref { m_download.get() }->cancel([](auto) { }, Download::IgnoreDidFailCallback::No);
     } else if (m_interval + 1 < std::size(throughputIntervals)) {
         DOWNLOAD_MONITOR_RELEASE_LOG("timerFired: sufficient throughput rate (id = %" PRIu64 ")", m_download->downloadID().toUInt64());
         m_timer.startOneShot(timeUntilNextInterval(m_interval++) / testSpeedMultiplier());

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h
@@ -26,18 +26,9 @@
 #pragma once
 
 #include <WebCore/Timer.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/Deque.h>
 #include <wtf/TZoneMalloc.h>
-
-namespace WebKit {
-class DownloadMonitor;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebKit::DownloadMonitor> : std::true_type { };
-}
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
@@ -54,8 +45,11 @@ public:
     void downloadReceivedBytes(uint64_t);
     void timerFired();
 
+    void ref() const;
+    void deref() const;
+
 private:
-    CheckedRef<Download> m_download;
+    WeakRef<Download> m_download;
 
     double measuredThroughputRate() const;
     uint32_t testSpeedMultiplier() const;

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
@@ -124,14 +124,14 @@ void PendingDownload::publishProgress(const URL& url, SandboxExtension::Handle&&
 }
 #endif
 
-void PendingDownload::didBecomeDownload(const std::unique_ptr<Download>& download)
+void PendingDownload::didBecomeDownload(Download& download)
 {
     if (!m_progressURL.isValid())
         return;
 #if HAVE(MODERN_DOWNLOADPROGRESS)
-    download->publishProgress(m_progressURL, m_bookmarkData, m_useDownloadPlaceholder, m_activityAccessToken);
+    download.publishProgress(m_progressURL, m_bookmarkData, m_useDownloadPlaceholder, m_activityAccessToken);
 #else
-    download->publishProgress(m_progressURL, WTFMove(m_progressSandboxExtension));
+    download.publishProgress(m_progressURL, WTFMove(m_progressSandboxExtension));
 #endif
 }
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
@@ -74,7 +74,7 @@ public:
 #else
     void publishProgress(const URL&, SandboxExtension::Handle&&);
 #endif
-    void didBecomeDownload(const std::unique_ptr<Download>&);
+    void didBecomeDownload(Download&);
 #endif
 
 private:    

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -451,10 +451,9 @@ void NetworkDataTaskBlob::download()
     }
 
     auto& downloadManager = m_networkProcess->downloadManager();
-    auto download = makeUnique<Download>(downloadManager, *m_pendingDownloadID, *this, *m_session, suggestedFilename());
-    auto* downloadPtr = download.get();
-    downloadManager.dataTaskBecameDownloadTask(*m_pendingDownloadID, WTFMove(download));
-    downloadPtr->didCreateDestination(m_pendingDownloadLocation);
+    Ref download = Download::create(downloadManager, *m_pendingDownloadID, *this, *m_session, suggestedFilename());
+    downloadManager.dataTaskBecameDownloadTask(*m_pendingDownloadID, download.copyRef());
+    download->didCreateDestination(m_pendingDownloadLocation);
 
     ASSERT(!m_client);
 
@@ -472,7 +471,7 @@ bool NetworkDataTaskBlob::writeDownload(std::span<const uint8_t> data)
     }
 
     m_downloadBytesWritten += bytesWritten;
-    auto* download = m_networkProcess->downloadManager().download(*m_pendingDownloadID);
+    RefPtr download = m_networkProcess->downloadManager().download(*m_pendingDownloadID);
     ASSERT(download);
     download->didReceiveData(bytesWritten, m_downloadBytesWritten, m_totalSize);
     return true;
@@ -502,7 +501,7 @@ void NetworkDataTaskBlob::didFailDownload(const ResourceError& error)
     if (m_client)
         m_client->didCompleteWithError(error);
     else {
-        auto* download = m_networkProcess->downloadManager().download(*m_pendingDownloadID);
+        RefPtr download = m_networkProcess->downloadManager().download(*m_pendingDownloadID);
         ASSERT(download);
         download->didFail(error, { });
     }
@@ -524,7 +523,7 @@ void NetworkDataTaskBlob::didFinishDownload()
 #endif
 
     clearStream();
-    auto* download = m_networkProcess->downloadManager().download(*m_pendingDownloadID);
+    RefPtr download = m_networkProcess->downloadManager().download(*m_pendingDownloadID);
     ASSERT(download);
 
 #if HAVE(MODERN_DOWNLOADPROGRESS)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1185,8 +1185,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     Ref<NetworkDataTaskCocoa> protectedNetworkDataTask(*networkDataTask);
     auto downloadID = *networkDataTask->pendingDownloadID();
     auto& downloadManager = sessionCocoa->networkProcess().downloadManager();
-    auto download = makeUnique<WebKit::Download>(downloadManager, downloadID, downloadTask, *sessionCocoa, networkDataTask->suggestedFilename());
-    networkDataTask->transferSandboxExtensionToDownload(*download);
+    Ref download = WebKit::Download::create(downloadManager, downloadID, downloadTask, *sessionCocoa, networkDataTask->suggestedFilename());
+    networkDataTask->transferSandboxExtensionToDownload(download);
     ASSERT(FileSystem::fileExists(networkDataTask->pendingDownloadLocation()));
     download->didCreateDestination(networkDataTask->pendingDownloadLocation());
     downloadManager.dataTaskBecameDownloadTask(downloadID, WTFMove(download));

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -318,10 +318,9 @@ void NetworkDataTaskCurl::invokeDidReceiveResponse()
             }
 
             auto& downloadManager = m_session->networkProcess().downloadManager();
-            auto download = makeUnique<Download>(downloadManager, *m_pendingDownloadID, *this, *m_session, suggestedFilename());
-            auto* downloadPtr = download.get();
-            downloadManager.dataTaskBecameDownloadTask(*m_pendingDownloadID, WTFMove(download));
-            downloadPtr->didCreateDestination(m_pendingDownloadLocation);
+            Ref download = Download::create(downloadManager, *m_pendingDownloadID, *this, *m_session, suggestedFilename());
+            downloadManager.dataTaskBecameDownloadTask(*m_pendingDownloadID, download.copyRef());
+            download->didCreateDestination(m_pendingDownloadLocation);
             if (m_curlRequest)
                 m_curlRequest->completeDidReceiveResponse();
             break;

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -1396,10 +1396,9 @@ void NetworkDataTaskSoup::download()
     m_downloadOutputStream = adoptGRef(G_OUTPUT_STREAM(outputStream.leakRef()));
 
     auto& downloadManager = m_session->networkProcess().downloadManager();
-    auto download = makeUnique<Download>(downloadManager, *m_pendingDownloadID, *this, *m_session, suggestedFilename());
-    auto* downloadPtr = download.get();
-    downloadManager.dataTaskBecameDownloadTask(*m_pendingDownloadID, WTFMove(download));
-    downloadPtr->didCreateDestination(m_pendingDownloadLocation);
+    Ref download = Download::create(downloadManager, *m_pendingDownloadID, *this, *m_session, suggestedFilename());
+    downloadManager.dataTaskBecameDownloadTask(*m_pendingDownloadID, download.copyRef());
+    download->didCreateDestination(m_pendingDownloadLocation);
 
     ASSERT(!m_client);
     read();


### PR DESCRIPTION
#### d9c794d8639b3df98dab9f285aba5a8e004d72a0
<pre>
Drop IsDeprecatedTimerSmartPointerException for DownloadMonitor
<a href="https://bugs.webkit.org/show_bug.cgi?id=282839">https://bugs.webkit.org/show_bug.cgi?id=282839</a>

Reviewed by Darin Adler.

* Source/WebKit/NetworkProcess/Downloads/Download.cpp:
(WebKit::Download::create):
(WebKit::Download::Download):
(WebKit::Download::~Download):
(WebKit::Download::cancel):
(WebKit::Download::didFinish):
(WebKit::Download::didFail):
(WebKit::Download::messageSenderConnection const):
* Source/WebKit/NetworkProcess/Downloads/Download.h:
(WebKit::Download::Download): Deleted.
(WebKit::Download::downloadID const): Deleted.
(WebKit::Download::sessionID const): Deleted.
(WebKit::Download::setSandboxExtension): Deleted.
(WebKit::Download::applicationDidEnterBackground): Deleted.
(WebKit::Download::applicationWillEnterForeground): Deleted.
(WebKit::Download::manager const): Deleted.
(WebKit::Download::testSpeedMultiplier const): Deleted.
* Source/WebKit/NetworkProcess/Downloads/DownloadManager.cpp:
(WebKit::DownloadManager::dataTaskBecameDownloadTask):
(WebKit::DownloadManager::resumeDownload):
(WebKit::DownloadManager::cancelDownload):
(WebKit::DownloadManager::download):
(WebKit::DownloadManager::publishDownloadProgress):
(WebKit::DownloadManager::downloadFinished):
(WebKit::DownloadManager::applicationDidEnterBackground):
(WebKit::DownloadManager::applicationWillEnterForeground):
* Source/WebKit/NetworkProcess/Downloads/DownloadManager.h:
(WebKit::DownloadManager::download): Deleted.
* Source/WebKit/NetworkProcess/Downloads/DownloadMap.h:
* Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp:
(WebKit::DownloadMonitor::ref const):
(WebKit::DownloadMonitor::deref const):
(WebKit::DownloadMonitor::timerFired):
* Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h:
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::download):
* Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.cpp:
(WebKit::NetworkDataTaskDataURL::downloadDecodedData):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp:
(WebKit::ServiceWorkerDownloadTask::start):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(-[WKNetworkSessionDelegate URLSession:dataTask:didBecomeDownloadTask:]):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::invokeDidReceiveResponse):
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::download):

Canonical link: <a href="https://commits.webkit.org/286385@main">https://commits.webkit.org/286385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5324dc3e81bf12b32949c017ceda052c7ec8e4fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80348 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27117 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3174 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59475 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17635 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39835 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46748 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25444 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67863 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81812 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2020 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67704 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3374 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65110 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67010 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10952 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9078 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11720 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3170 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5976 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3191 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4129 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3198 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->