### PR TITLE
[css-masonry] Update Intrinsic Sizing Rows 003 Auto Expected / Ref Test Case

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1763,7 +1763,6 @@ imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/mas
 
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/grid-placement/masonry-grid-placement-named-lines-002.html [ ImageOnlyFailure ]
 
-webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix2.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto-expected.html
@@ -8,6 +8,7 @@
   <meta charset="utf-8">
   <title>Reference: Masonry layout min-content sizing</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";
@@ -20,6 +21,7 @@ grid {
   border: 1px solid;
   padding: 1px 0 2px 0;
   vertical-align: top;
+  font-family: Ahem;
   height: min-content;
 }
 
@@ -31,6 +33,30 @@ item {
 .hidden {
   visibility: hidden;
   width: 0;
+}
+
+grid > item:nth-child(1) {
+  background-color: #89CFF0;
+}
+
+grid > item:nth-child(2) {
+  background-color: #FF6F61;
+}
+
+grid > item:nth-child(3) {
+  background-color: #FDF3E7;
+}
+
+grid > item:nth-child(4) {
+  background-color: #F4C542;
+}
+
+grid > item:nth-child(5) {
+  background-color: #333333;
+}
+
+grid > item:nth-child(6) {
+  background-color: #B2C8A5;
 }
 </style>
 
@@ -48,11 +74,11 @@ item {
 </grid>
 
 <grid>
-  <item>1</item>
+  <item style="height: 3ch">1</item>
   <item style="grid-column: span 2">2 2</item>
   <item style="grid-column: span 2">3 3</item>
   <item>4</item>
-  <item style="grid-column: span 2">5 5</item>
+  <item style="height: 2ch">5 5</item>
 
   <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
@@ -71,7 +97,7 @@ item {
 <grid>
   <item>1</item>
   <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>3 3</item>
   <item>4</item>
   <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
 
@@ -82,7 +108,7 @@ item {
 <grid>
   <item style="grid-row: 4">1</item>
   <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>3 3</item>
   <item>4</item>
   <item style="grid-area: 2/1/4/2">5 5</item>
   <item style="height:5ch; grid-area: 1/2/4/3">6</item>
@@ -95,9 +121,9 @@ item {
 <grid>
   <item style="grid-row: 4">1</item>
   <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5 5</item>
+  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
   <item style="height:5ch; grid-area: 1/2/4/3">6</item>
 
   <item class="hidden" style="grid-area: 2/1">0 0</item>
@@ -105,37 +131,29 @@ item {
 </grid>
 
 <grid>
-  <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item>4</item>
-  <item style="grid-area: 1/3/5/4">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/3">0 0</item>
-  <item class="hidden" style="grid-area: 3/3">0 0</item>
+  <item style="height: 3ch">1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item style="height: 3ch">4</item>
+  <item style="grid-column: 2; grid-row: span 4;">5 5</item>
 </grid>
 
 <grid>
-  <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item>4</item>
-  <item style="height:6ch; grid-area: 1/3/5/4">5 5</item>
+  <item style="height: 3ch">1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item style="height: 3ch">4</item>
+  <item style="grid-column: 2; grid-row: span 4; height: 6ch">5 5</item>
 
-  <item class="hidden" style="grid-area: 1/3">0 0</item>
-  <item class="hidden" style="grid-area: 4/3">0 0</item>
 </grid>
 
 <grid>
-  <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item>4</item>
-  <item style="height:6ch; grid-area: 1/3/4/4">5 5</item>
+  <item style="height: 3ch">1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item style="height: 3ch">4</item>
+  <item style="grid-column: 2; grid-row: span 3; height: 6ch">5 5</item>
 
-  <item class="hidden" style="grid-area: 1/3">0 0</item>
-  <item class="hidden" style="grid-area: 4/3">0 0</item>
-  <item class="hidden" style="height:6ch; grid-area: 2/3/5/4">0 0</item>
 </grid>
 </section>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto-ref.html
@@ -5,137 +5,155 @@
 -->
 <!-- WARNING: The interaction of writing-mode and min-content sizing seems to be a bit hazy. It's not clear if this is a correct reference. -->
 <html>
-  <meta charset="utf-8">
-  <title>Reference: Masonry layout min-content sizing</title>
-  <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
-  <style>
+<meta charset="utf-8">
+<title>Reference: Masonry layout min-content sizing</title>
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
 
-@import "support/masonry-intrinsic-sizing-visual.css";
+  @import "support/masonry-intrinsic-sizing-visual.css";
 
-grid {
-  display: inline-grid;
-  gap: 1px 2px;
-  grid-template-rows: repeat(4,auto);
-  grid-auto-flow: column;
-  border: 1px solid;
-  padding: 1px 0 2px 0;
-  vertical-align: top;
-  height: min-content;
-}
+  grid {
+    display: inline-grid;
+    gap: 1px 2px;
+    grid-template-rows: repeat(4,auto);
+    grid-auto-flow: column;
+    border: 1px solid;
+    padding: 1px 0 2px 0;
+    vertical-align: top;
+    font-family: Ahem;
+    height: min-content;
+  }
 
-item {
-  justify-self: start;
-  writing-mode: vertical-rl;
-  text-orientation: sideways;
-}
-.hidden {
-  visibility: hidden;
-  width: 0;
-}
+  item {
+    justify-self: start;
+    writing-mode: vertical-rl;
+    text-orientation: sideways;
+  }
+  .hidden {
+    visibility: hidden;
+    width: 0;
+  }
+
+  grid > item:nth-child(1) {
+    background-color: #89CFF0;
+  }
+
+  grid > item:nth-child(2) {
+    background-color: #FF6F61;
+  }
+
+  grid > item:nth-child(3) {
+    background-color: #FDF3E7;
+  }
+
+  grid > item:nth-child(4) {
+    background-color: #F4C542;
+  }
+
+  grid > item:nth-child(5) {
+    background-color: #333333;
+  }
+
+  grid > item:nth-child(6) {
+    background-color: #B2C8A5;
+  }
 </style>
 
 <body>
 
 <section>
-<grid>
-  <item style="height:2ch">1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item>4</item>
-  <item style="grid-column: span 2">5 5</item>
+  <grid>
+    <item style="height:2ch">1</item>
+    <item style="grid-column: span 2">2 2</item>
+    <item style="grid-column: span 2">3 3</item>
+    <item>4</item>
+    <item style="grid-column: span 2">5 5</item>
 
-  <item class="hidden" style="grid-area: 4/2">0 0</item>
-</grid>
+    <item class="hidden" style="grid-area: 4/2">0 0</item>
+  </grid>
 
-<grid>
-  <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item>4</item>
-  <item style="grid-column: span 2">5 5</item>
+  <grid>
+    <item style="height: 3ch">1</item>
+    <item style="grid-column: span 2">2 2</item>
+    <item style="grid-column: span 2">3 3</item>
+    <item>4</item>
+    <item style="height: 2ch">5 5</item>
 
-  <item class="hidden" style="grid-area: 4/2">0 0</item>
-</grid>
+    <item class="hidden" style="grid-area: 4/2">0 0</item>
+  </grid>
 
-<grid>
-  <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item style="grid-area: 1/2">4</item>
-  <item style="height:2ch; grid-area: 2/1/3/3">5 5</item>
+  <grid>
+    <item>1</item>
+    <item style="grid-column: span 2">2 2</item>
+    <item style="grid-column: span 2">3 3</item>
+    <item style="grid-area: 1/2">4</item>
+    <item style="height:2ch; grid-area: 2/1/3/3">5 5</item>
 
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-</grid>
+    <item class="hidden" style="grid-area: 1/2">0 0</item>
+    <item class="hidden" style="grid-area: 2/1">0 0</item>
+  </grid>
 
-<grid>
-  <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item>4</item>
-  <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
+  <grid>
+    <item>1</item>
+    <item style="grid-column: span 2">2 2</item>
+    <item>3 3</item>
+    <item>4</item>
+    <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/2">0 0</item>
-</grid>
+    <item class="hidden" style="grid-area: 2/1">0 0</item>
+    <item class="hidden" style="grid-area: 3/2">0 0</item>
+  </grid>
 
-<grid>
-  <item style="grid-row: 4">1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item>4</item>
-  <item style="grid-area: 2/1/4/2">5 5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <grid>
+    <item style="grid-row: 4">1</item>
+    <item style="grid-column: span 2">2 2</item>
+    <item>3 3</item>
+    <item>4</item>
+    <item style="grid-area: 2/1/4/2">5 5</item>
+    <item style="height:5ch; grid-area: 1/2/4/3">6</item>
 
-  <item class="hidden" style="grid-area: 3/3">0</item>
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
-</grid>
+    <item class="hidden" style="grid-area: 3/3">0</item>
+    <item class="hidden" style="grid-area: 2/1">0 0</item>
+    <item class="hidden" style="grid-area: 3/1">0 0</item>
+  </grid>
 
-<grid>
-  <item style="grid-row: 4">1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5 5</item>
-  <item style="height:5ch; grid-area: 1/2/4/3">6</item>
+  <grid>
+    <item style="grid-row: 4">1</item>
+    <item style="grid-column: span 2">2 2</item>
+    <item>3 3</item>
+    <item>4</item>
+    <item style="height:3ch; grid-area: 2/1/4/2">5</item>
+    <item style="height:5ch; grid-area: 1/2/4/3">6</item>
 
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
-</grid>
+    <item class="hidden" style="grid-area: 2/1">0 0</item>
+    <item class="hidden" style="grid-area: 3/1">0 0</item>
+  </grid>
 
-<grid>
-  <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item>4</item>
-  <item style="grid-area: 1/3/5/4">5 5</item>
+  <grid>
+    <item style="height: 3ch">1</item>
+    <item>2 2</item>
+    <item>3 3</item>
+    <item style="height: 3ch">4</item>
+    <item style="grid-column: 2; grid-row: span 4;">5 5</item>
+  </grid>
 
-  <item class="hidden" style="grid-area: 1/3">0 0</item>
-  <item class="hidden" style="grid-area: 3/3">0 0</item>
-</grid>
+  <grid>
+    <item style="height: 3ch">1</item>
+    <item>2 2</item>
+    <item>3 3</item>
+    <item style="height: 3ch">4</item>
+    <item style="grid-column: 2; grid-row: span 4; height: 6ch">5 5</item>
 
-<grid>
-  <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item>4</item>
-  <item style="height:6ch; grid-area: 1/3/5/4">5 5</item>
+  </grid>
 
-  <item class="hidden" style="grid-area: 1/3">0 0</item>
-  <item class="hidden" style="grid-area: 4/3">0 0</item>
-</grid>
+  <grid>
+    <item style="height: 3ch">1</item>
+    <item>2 2</item>
+    <item>3 3</item>
+    <item style="height: 3ch">4</item>
+    <item style="grid-column: 2; grid-row: span 3; height: 6ch">5 5</item>
 
-<grid>
-  <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item>4</item>
-  <item style="height:6ch; grid-area: 1/3/4/4">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/3">0 0</item>
-  <item class="hidden" style="grid-area: 4/3">0 0</item>
-  <item class="hidden" style="height:6ch; grid-area: 2/3/5/4">0 0</item>
-</grid>
+  </grid>
 </section>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto.html
@@ -9,6 +9,7 @@
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
   <link rel="match" href="masonry-intrinsic-sizing-rows-003-ref.html">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";
@@ -21,6 +22,7 @@ grid {
   border: 1px solid;
   padding: 1px 0 2px 0;
   vertical-align: top;
+  font-family: Ahem;
   height: min-content;
 }
 
@@ -28,6 +30,30 @@ item {
   /* allow for differing min-content and max-content sizes */
   writing-mode: vertical-rl;
   text-orientation: sideways;
+}
+
+grid > item:nth-child(1) {
+  background-color: #89CFF0;
+}
+
+grid > item:nth-child(2) {
+  background-color: #FF6F61;
+}
+
+grid > item:nth-child(3) {
+  background-color: #FDF3E7;
+}
+
+grid > item:nth-child(4) {
+  background-color: #F4C542;
+}
+
+grid > item:nth-child(5) {
+  background-color: #333333;
+}
+
+grid > item:nth-child(6) {
+  background-color: #B2C8A5;
 }
 </style>
 


### PR DESCRIPTION
#### 6522954a808415bc07e4a23ab5ab148b92f64557
<pre>
[css-masonry] Update Intrinsic Sizing Rows 003 Auto Expected / Ref Test Case
<a href="https://bugs.webkit.org/show_bug.cgi?id=282841">https://bugs.webkit.org/show_bug.cgi?id=282841</a>
<a href="https://rdar.apple.com/problem/139521637">rdar://problem/139521637</a>

Reviewed by Sammy Gill.

The 27.02px width when calculating “3 3” adds challenges for these tests. The Ahem font is more straightforward for the test cases as it results in a width of 27px.
Added colors to distinguish the individual grid items.

* Grid 2

We cannot create an invisible item, because it would add a gap at the end of the grid.

Modify 5 5 to be a height of 2ch to match the original test case.

* Grid 4

The item 3 3 should not span 2 columns, because it creates an empty column that adds a gap to the end of the grid.

* Grid 5

Same problem as grid 4.

* Grid 6

Same problem as grid 4.

Removed the extra 5 not found in the original test case.

* Grid 7-9

Creating an empty column 2 causes problems because there is now an extra grid gap that causes an extra 2px gap between the columns.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-auto.html:

Canonical link: <a href="https://commits.webkit.org/286454@main">https://commits.webkit.org/286454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6e4d0d15ee5e551ae7b8fd21e190456be7c2249

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28921 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27288 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3347 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59608 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17763 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49499 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39966 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46898 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22775 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25615 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68014 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23112 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81983 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2173 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67840 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-pseudo/marker-animate-002.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3545 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67156 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16733 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11103 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9221 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3341 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3362 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4300 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3369 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->