### PR TITLE
Generate text preview snapshots at 3x scale for visionOS

### DIFF
--- a/Source/WebCore/page/FrameSnapshotting.cpp
+++ b/Source/WebCore/page/FrameSnapshotting.cpp
@@ -116,6 +116,8 @@ RefPtr<ImageBuffer> snapshotFrameRectWithClip(LocalFrame& frame, const IntRect& 
     frame.view()->setPaintBehavior(paintBehavior);
 
     float scaleFactor = frame.page()->deviceScaleFactor();
+    if (options.flags.contains(SnapshotFlags::PaintWith3xBaseScale))
+        scaleFactor = 3;
 
     if (frame.page()->delegatesScaling())
         scaleFactor *= frame.page()->pageScaleFactor();

--- a/Source/WebCore/page/FrameSnapshotting.h
+++ b/Source/WebCore/page/FrameSnapshotting.h
@@ -55,6 +55,7 @@ enum class SnapshotFlags : uint16_t {
     Shareable = 1 << 7,
     Accelerated = 1 << 8,
     ExcludeReplacedContent = 1 << 9,
+    PaintWith3xBaseScale = 1 << 10,
 };
 
 struct SnapshotOptions {

--- a/Source/WebCore/page/IntelligenceTextEffectsSupport.cpp
+++ b/Source/WebCore/page/IntelligenceTextEffectsSupport.cpp
@@ -85,6 +85,9 @@ std::optional<TextIndicatorData> textPreviewDataForRange(Document&, const Simple
         TextIndicatorOption::SkipReplacedContent,
         TextIndicatorOption::RespectTextColor,
         TextIndicatorOption::DoNotClipToVisibleRect,
+#if PLATFORM(VISION)
+        TextIndicatorOption::SnapshotContentAt3xBaseScale,
+#endif
     };
 
     RefPtr textIndicator = WebCore::TextIndicator::createWithRange(resolvedRange, textIndicatorOptions, WebCore::TextIndicatorPresentationTransition::None, { });

--- a/Source/WebCore/page/TextIndicator.h
+++ b/Source/WebCore/page/TextIndicator.h
@@ -123,6 +123,9 @@ enum class TextIndicatorOption : uint16_t {
 
     // If this option is set, exclude all content that is replaced by a separate render pass, like images, media, etc.
     SkipReplacedContent = 1 << 13,
+
+    // If this option is set, perform the snapshot with 3x as the base scale, rather than the device scale factor
+    SnapshotContentAt3xBaseScale = 1 << 14,
 };
 
 struct TextIndicatorData {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6238,6 +6238,7 @@ enum class WebCore::TextIndicatorPresentationTransition : uint8_t {
     ComputeEstimatedBackgroundColor,
     UseUserSelectAllCommonAncestor,
     SkipReplacedContent,
+    SnapshotContentAt3xBaseScale,
 };
 
 using WebCore::IDBConnectionIdentifier = WebCore::ProcessIdentifier;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
@@ -383,7 +383,10 @@ std::optional<WebCore::TextIndicatorData> TextAnimationController::createTextInd
         WebCore::TextIndicatorOption::IncludeSnapshotOfAllVisibleContentWithoutSelection,
         WebCore::TextIndicatorOption::ExpandClipBeyondVisibleRect,
         WebCore::TextIndicatorOption::SkipReplacedContent,
-        WebCore::TextIndicatorOption::RespectTextColor
+        WebCore::TextIndicatorOption::RespectTextColor,
+#if PLATFORM(VISION)
+        WebCore::TextIndicatorOption::SnapshotContentAt3xBaseScale,
+#endif
     };
 
     if (auto textIndicator = WebCore::TextIndicator::createWithRange(range, textIndicatorOptions, WebCore::TextIndicatorPresentationTransition::None, { }))

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -1152,7 +1152,10 @@ void WebPage::createTextIndicatorForElementWithID(const String& elementID, Compl
         WebCore::TextIndicatorOption::IncludeSnapshotOfAllVisibleContentWithoutSelection,
         WebCore::TextIndicatorOption::ExpandClipBeyondVisibleRect,
         WebCore::TextIndicatorOption::SkipReplacedContent,
-        WebCore::TextIndicatorOption::RespectTextColor
+        WebCore::TextIndicatorOption::RespectTextColor,
+#if PLATFORM(VISION)
+        WebCore::TextIndicatorOption::SnapshotContentAt3xBaseScale,
+#endif
     };
 
     RefPtr textIndicator = WebCore::TextIndicator::createWithRange(elementRange, textIndicatorOptions, WebCore::TextIndicatorPresentationTransition::None, { });


### PR DESCRIPTION
#### fc074a37881360cff2fbeab286b0499586097b16
<pre>
Generate text preview snapshots at 3x scale for visionOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=282817">https://bugs.webkit.org/show_bug.cgi?id=282817</a>
<a href="https://rdar.apple.com/139098078">rdar://139098078</a>

Reviewed by Richard Robinson.

On visionOS, render some snapshots with higher quality by using a higher scale factor.

* Source/WebCore/page/FrameSnapshotting.cpp:
(WebCore::snapshotFrameRectWithClip):
* Source/WebCore/page/FrameSnapshotting.h:
* Source/WebCore/page/IntelligenceTextEffectsSupport.cpp:
(WebCore::IntelligenceTextEffectsSupport::textPreviewDataForRange):
* Source/WebCore/page/TextIndicator.cpp:
(WebCore::snapshotOptionsForTextIndicatorOptions):
(WebCore::takeSnapshots):
* Source/WebCore/page/TextIndicator.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm:
(WebKit::TextAnimationController::createTextIndicatorForRange):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::createTextIndicatorForElementWithID):

Canonical link: <a href="https://commits.webkit.org/286648@main">https://commits.webkit.org/286648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97b5437b84ffb3e2cc4606dced04ed1eb5b42d83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80241 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27018 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77868 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59415 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17582 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78819 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39770 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46707 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22550 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25345 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22889 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81712 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3092 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1959 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67641 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/new-content-object-view-box-clip-path-reference.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3245 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65035 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66947 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16865 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10894 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9027 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3050 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5876 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3075 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4011 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3082 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->