### PR TITLE
check-webkit-style --filter now accepts "-*" or "+*" wildcard

### DIFF
--- a/Tools/Scripts/webkitpy/style/filter.py
+++ b/Tools/Scripts/webkitpy/style/filter.py
@@ -45,6 +45,9 @@ def validate_filter_rules(filter_rules, all_categories):
             raise ValueError('Invalid filter rule "%s": every rule '
                              "must start with + or -." % rule)
 
+        if rule[1:] == "*":
+            break
+
         for category in all_categories:
             if category.startswith(rule[1:]):
                 break
@@ -102,8 +105,8 @@ class _CategoryFilter(object):
 
         A filter rule applies to a category if the string after the
         leading plus/minus (+/-) matches the beginning of the category
-        name.  A plus (+) means the category should be checked, while a
-        minus (-) means the category should not be checked.
+        name or is "*".  A plus (+) means the category should be checked,
+        while a minus (-) means the category should not be checked.
 
         """
         if category in self._should_check_category:
@@ -111,7 +114,7 @@ class _CategoryFilter(object):
 
         should_check = True  # All categories checked by default.
         for rule in self._filter_rules:
-            if not category.startswith(rule[1:]):
+            if not category.startswith(rule[1:]) and rule[1:] != "*":
                 continue
             should_check = rule.startswith('+')
         self._should_check_category[category] = should_check  # Update cache.

--- a/Tools/Scripts/webkitpy/style/optparser.py
+++ b/Tools/Scripts/webkitpy/style/optparser.py
@@ -272,7 +272,7 @@ class ArgumentParser(object):
         filter_help = ('set a filter to control what categories of style '
                        'errors to report.  Specify a filter using a comma-'
                        'delimited list of boolean filter rules, for example '
-                       '"--filter -whitespace,+whitespace/braces".  To display '
+                       '"--filter +*,-whitespace,+whitespace/braces".  To display '
                        'all categories and which are enabled by default, pass '
                        """no value (e.g. '-f ""' or '--filter=').""")
         parser.add_option("-f", "--filter-rules", metavar="RULES",


### PR DESCRIPTION
#### c330e6e64e9b733f1b44243ce45d339e86bf0daa
<pre>
check-webkit-style --filter now accepts &quot;-*&quot; or &quot;+*&quot; wildcard
<a href="https://bugs.webkit.org/show_bug.cgi?id=282858">https://bugs.webkit.org/show_bug.cgi?id=282858</a>
<a href="https://rdar.apple.com/problem/139542830">rdar://problem/139542830</a>

Reviewed by NOBODY (OOPS!).

This overrides all previous filter rules.
&quot;-*&quot; will not check any category, &quot;+*&quot; will check all categories.

This is most useful to test only specific categories, regardless of
the default rules, e.g.:
`check-webkit-style --filter &quot;-*,+readability&quot;`

* Tools/Scripts/webkitpy/style/filter.py:
(validate_filter_rules):
(_CategoryFilter.should_check):
* Tools/Scripts/webkitpy/style/optparser.py:
(ArgumentParser._create_option_parser):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c330e6e64e9b733f1b44243ce45d339e86bf0daa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80303 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27078 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77928 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59442 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17610 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49320 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65112 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39801 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/75319 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22595 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25405 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67836 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22933 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81773 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3181 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1992 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67672 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66977 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10921 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9052 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3131 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3152 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4090 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3159 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->