### PR TITLE
Lock is no longer necessary around LibWebRTCVPXInternalVideoDecoder::createPixelBuffer

### DIFF
--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h
@@ -35,7 +35,7 @@ namespace WebCore {
 
 class LibWebRTCVPXInternalVideoDecoder;
 
-class LibWebRTCVPXVideoDecoder : public VideoDecoder {
+class LibWebRTCVPXVideoDecoder final : public VideoDecoder {
     WTF_MAKE_TZONE_ALLOCATED(LibWebRTCVPXVideoDecoder);
 public:
     enum class Type {


### PR DESCRIPTION
#### f836b19c42aad06fa7f3352ebcdc9791ac5a5ed6
<pre>
Lock is no longer necessary around LibWebRTCVPXInternalVideoDecoder::createPixelBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=282813">https://bugs.webkit.org/show_bug.cgi?id=282813</a>
<a href="https://rdar.apple.com/139491094">rdar://139491094</a>

Reviewed by NOBODY (OOPS!).

Access to the pixelBufferPool is now only ever done on the decoder&apos;s WorkQueue.
Fly-By:
- Make m_isClosed atomic as there could be concurrent access to it.
- Make eligible members const.

* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp:
(WebCore::LibWebRTCVPXInternalVideoDecoder::WTF_GUARDED_BY_CAPABILITY):
(WebCore::LibWebRTCVPXVideoDecoder::flush):
(WebCore::LibWebRTCVPXInternalVideoDecoder::LibWebRTCVPXInternalVideoDecoder):
(WebCore::LibWebRTCVPXInternalVideoDecoder::pixelBufferPool):
(WebCore::LibWebRTCVPXInternalVideoDecoder::createPixelBuffer):
(WebCore::LibWebRTCVPXInternalVideoDecoder::Decoded):
(WebCore::LibWebRTCVPXVideoDecoder::~LibWebRTCVPXVideoDecoder): Deleted.
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h: Make class final.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f836b19c42aad06fa7f3352ebcdc9791ac5a5ed6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80323 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27097 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77947 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3154 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59454 "Found 1 new test failure: compositing/repaint/repaint-on-layer-grouping-change.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17619 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49330 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65128 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39813 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46729 "Found 8 new test failures: imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?av1 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?vp8 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?vp9 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.worker.html?av1 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.worker.html?vp8 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.worker.html?vp9 imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any.html imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any.worker.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22611 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25424 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67846 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22949 "Found 6 new test failures: imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?av1 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?vp8 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?vp9 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.worker.html?av1 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.worker.html?vp8 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.worker.html?vp9 (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81792 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3200 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2006 "Found 15 new test failures: http/wpt/webcodecs/copyTo-same-decoder.html imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?av1 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?vp8 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?vp9_p0 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?vp9_p2 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?av1 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?vp8 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?vp9_p0 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?vp9_p2 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?av1 ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67685 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3354 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66990 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10941 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9064 "Found 6 new test failures: imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?av1 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?vp8 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?vp9 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.worker.html?av1 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.worker.html?vp8 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.worker.html?vp9 (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3150 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5956 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3171 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4109 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3178 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->