### PR TITLE
Rename WKBundleRangeHandleDocumentFrame to WKBundleRangeHandleCopyDocumentFrame

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleRangeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleRangeHandle.cpp
@@ -57,7 +57,7 @@ WKImageRef WKBundleRangeHandleCopySnapshotWithOptions(WKBundleRangeHandleRef ran
     return toAPI(image.leakRef());
 }
 
-WKBundleFrameRef WKBundleRangeHandleDocumentFrame(WKBundleRangeHandleRef rangeHandleRef)
+WKBundleFrameRef WKBundleRangeHandleCopyDocumentFrame(WKBundleRangeHandleRef rangeHandleRef)
 {
     RefPtr frame = WebKit::toImpl(rangeHandleRef)->document()->documentFrame();
     return toAPI(frame.leakRef());

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleRangeHandlePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleRangeHandlePrivate.h
@@ -39,7 +39,7 @@ WK_EXPORT WKBundleRangeHandleRef WKBundleRangeHandleCreate(JSContextRef context,
 
 WK_EXPORT WKRect WKBundleRangeHandleGetBoundingRectInWindowCoordinates(WKBundleRangeHandleRef rangeHandle);
 WK_EXPORT WKImageRef WKBundleRangeHandleCopySnapshotWithOptions(WKBundleRangeHandleRef rangeHandle, WKSnapshotOptions options);
-WK_EXPORT WKBundleFrameRef WKBundleRangeHandleDocumentFrame(WKBundleRangeHandleRef);
+WK_EXPORT WKBundleFrameRef WKBundleRangeHandleCopyDocumentFrame(WKBundleRangeHandleRef);
 
 #ifdef __cplusplus
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -127,7 +127,7 @@ static WTF::String string(WKBundleScriptWorldRef world, WKBundleRangeHandleRef r
     if (!rangeRef)
         return "(null)"_s;
 
-    auto frame = adoptWK(WKBundleRangeHandleDocumentFrame(rangeRef));
+    auto frame = adoptWK(WKBundleRangeHandleCopyDocumentFrame(rangeRef));
     auto context = WKBundleFrameGetJavaScriptContextForWorld(frame.get(), world);
     auto rangeValue = WKBundleFrameGetJavaScriptWrapperForRangeForWorld(frame.get(), rangeRef, world);
     ASSERT(JSValueIsObject(context, rangeValue));


### PR DESCRIPTION
#### 6b918bd68aa5b2414a83be927d8b102964c4ffd6
<pre>
Rename WKBundleRangeHandleDocumentFrame to WKBundleRangeHandleCopyDocumentFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=282869">https://bugs.webkit.org/show_bug.cgi?id=282869</a>
<a href="https://rdar.apple.com/139551935">rdar://139551935</a>

Reviewed by Wenson Hsieh.

* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleRangeHandle.cpp:
(WKBundleRangeHandleCopyDocumentFrame):
(WKBundleRangeHandleDocumentFrame): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleRangeHandlePrivate.h:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::string):

Canonical link: <a href="https://commits.webkit.org/286373@main">https://commits.webkit.org/286373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8948f71294023896686bd2b3c515ab8a7215edbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28738 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80335 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27107 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77957 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59462 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17626 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39822 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46747 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22617 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25434 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67862 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22955 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81802 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67694 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67000 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10942 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9070 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11711 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3160 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5966 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3181 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4119 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3188 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->