### PR TITLE
[ARMv7] Implement OMG tail calls

### DIFF
--- a/JSTests/wasm/stress/tail-call-simple-i64.js
+++ b/JSTests/wasm/stress/tail-call-simple-i64.js
@@ -1,0 +1,72 @@
+//@ requireOptions("--useWasmTailCalls=true", "--maximumWasmCalleeSIzeForInlining=0")
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func $call_same_size (export "call_same_size") (result i64)
+      (i64.const 600000001337)
+      (return_call $callee_same_size))
+    (func $callee_same_size (param $i i64) (result i64)
+      (i64.add (local.get $i) (i64.const 42)))
+    (func $call_same_size_with_stack (export "call_same_size_with_stack") (param $i0 i64) (param $i1 i64) (param $i2 i64) (param $i3 i64) (param $i4 i64) (param $i5 i64) (param $i6 i64) (param $i7 i64) (param $i8 i64) (param $i9 i64) (result i64)
+      (i64.const 600000001337)
+      (i64.const 1)
+      (i64.const 2)
+      (i64.const 3)
+      (i64.const 4)
+      (i64.const 5)
+      (i64.const 6)
+      (i64.const 7)
+      (i64.const 8)
+      (i64.const 40000000009)
+      (return_call $callee_same_size_with_stack))
+    (func $callee_same_size_with_stack (param $i0 i64) (param $i1 i64) (param $i2 i64) (param $i3 i64) (param $i4 i64) (param $i5 i64) (param $i6 i64) (param $i7 i64) (param $i8 i64) (param $i9 i64) (result i64)
+      (i64.add (local.get $i9) (local.get $i2)))
+
+    (func $call_bigger_with_stack (export "call_bigger_with_stack") (result i64)
+      (i64.const 600000001337)
+      (i64.const 1)
+      (i64.const 2)
+      (i64.const 3)
+      (i64.const 4)
+      (i64.const 5)
+      (i64.const 6)
+      (i64.const 7)
+      (i64.const 8)
+      (i64.const 500000000090)
+      (return_call $callee_bigger_with_stack))
+    (func $callee_bigger_with_stack (param $i0 i64) (param $i1 i64) (param $i2 i64) (param $i3 i64) (param $i4 i64) (param $i5 i64) (param $i6 i64) (param $i7 i64) (param $i8 i64) (param $i9 i64) (result i64)
+      (i64.add (local.get $i9) (local.get $i2)))
+    (func $call_smaller_with_stack (export "call_smaller_with_stack") (param $i0 i64) (param $i1 i64) (param $i2 i64) (param $i3 i64) (param $i4 i64) (param $i5 i64) (param $i6 i64) (param $i7 i64) (param $i8 i64) (param $i9 i64) (param $i10 i64) (param $i11 i64) (result i64)
+      (i64.const 600000001337)
+      (i64.const 1)
+      (i64.const 2)
+      (i64.const 3)
+      (i64.const 4)
+      (i64.const 5)
+      (i64.const 6)
+      (i64.const 7)
+      (i64.const 8)
+      (i64.const 500000000090)
+      (return_call $callee_smaller_with_stack))
+    (func $callee_smaller_with_stack (param $i0 i64) (param $i1 i64) (param $i2 i64) (param $i3 i64) (param $i4 i64) (param $i5 i64) (param $i6 i64) (param $i7 i64) (param $i8 i64) (param $i9 i64) (result i64)
+      (i64.add (local.get $i9) (local.get $i2)))
+  )
+`
+let badArgs = new Array(12).fill(0xAAAAn)
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true, tail_call: true, exceptions: true })
+    const { call_same_size, call_same_size_with_stack, call_bigger_with_stack, call_smaller_with_stack } = instance.exports
+
+
+    for (let i = 0; i < 1000; ++i) {
+        assert.eq(call_same_size.apply(null, badArgs), 600000001337n + 42n)
+        assert.eq(call_same_size_with_stack.apply(null, badArgs), 40000000009n + 2n)
+        assert.eq(call_bigger_with_stack.apply(null, badArgs), 500000000090n + 2n)
+        assert.eq(call_smaller_with_stack.apply(null, badArgs), 500000000090n + 2n)
+    }
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -1393,6 +1393,17 @@ public:
         store32(dataTempRegister, dest);
     }
 
+    // Warning: not atomic.
+    void transfer64(Address src, Address dest)
+    {
+        if (src == dest)
+            return;
+        load32(src, dataTempRegister);
+        store32(dataTempRegister, dest);
+        load32(src.withOffset(sizeof(int)), dataTempRegister);
+        store32(dataTempRegister, dest.withOffset(sizeof(int)));
+    }
+
     void transferPtr(Address src, Address dest)
     {
         transfer32(src, dest);

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -45,7 +45,6 @@
 #undef LoadFence
 #undef MemoryFence
 
-#if USE(JSVALUE64)
 #include "AirBlockInsertionSet.h"
 #include "AirCCallSpecial.h"
 #include "AirCode.h"
@@ -85,6 +84,8 @@ IGNORE_RETURN_TYPE_WARNINGS_BEGIN
 #endif
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+#if USE(JSVALUE64)
 
 namespace JSC { namespace B3 {
 

--- a/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -65,6 +65,8 @@
 #if !ASSERT_ENABLED
 IGNORE_RETURN_TYPE_WARNINGS_BEGIN
 #endif
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC { namespace B3 {
 
@@ -5601,6 +5603,8 @@ void lowerToAir(Procedure& procedure)
 }
 
 } } // namespace JSC::B3
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #if !ASSERT_ENABLED
 IGNORE_RETURN_TYPE_WARNINGS_END

--- a/Source/JavaScriptCore/b3/B3MoveConstants.cpp
+++ b/Source/JavaScriptCore/b3/B3MoveConstants.cpp
@@ -340,6 +340,12 @@ private:
                     if (child->type().isVector())
                         continue;
 
+                    // BigImms don't work reliably for 32-bit, so this is the most reliable.
+                    if constexpr (is32Bit()) {
+                        if (child->hasDouble() && !WTF::isIdentical(child->asDouble(), 0.0))
+                            continue;
+                    }
+
                     ValueKey key = child->key();
                     child = m_insertionSet.insertValue(
                         valueIndex, key.materialize(m_proc, value->origin()));

--- a/Source/JavaScriptCore/disassembler/CapstoneDisassembler.cpp
+++ b/Source/JavaScriptCore/disassembler/CapstoneDisassembler.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 
 #if ENABLE(DISASSEMBLER) && USE(CAPSTONE)
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #include "MacroAssemblerCodeRef.h"
 #include "Options.h"
@@ -78,4 +79,5 @@ bool tryToDisassemble(const CodePtr<DisassemblyPtrTag>& codePtr, size_t size, vo
 
 } // namespace JSC
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif // ENABLE(DISASSEMBLER) && USE(CAPSTONE)

--- a/Source/JavaScriptCore/jit/Width.h
+++ b/Source/JavaScriptCore/jit/Width.h
@@ -44,6 +44,12 @@ static constexpr Width Width32 = Width::Width32;
 static constexpr Width Width64 = Width::Width64;
 static constexpr Width Width128 = Width::Width128;
 
+#if USE(JSVALUE64)
+static constexpr Width WidthPtr = Width::Width64;
+#else
+static constexpr Width WidthPtr = Width::Width32;
+#endif
+
 enum class PreservedWidth : uint8_t {
     PreservesNothing = 0,
     Preserves64 = 1,

--- a/Source/JavaScriptCore/runtime/JSCJSValue.cpp
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.cpp
@@ -270,12 +270,14 @@ void JSValue::dumpInContextAssumingStructure(
 #if USE(JSVALUE64)
         out.printf("Double: %lld, %lf", (long long)reinterpretDoubleToInt64(asDouble()), asDouble());
 #else
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         union {
             double asDouble;
             uint32_t asTwoInt32s[2];
         } u;
         u.asDouble = asDouble();
         out.printf("Double: %08x:%08x, %lf", u.asTwoInt32s[1], u.asTwoInt32s[0], asDouble());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
     } else if (isCell()) {
         if (structure->classInfoForCells()->isSubClassOf(JSString::info())) {

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -96,6 +96,12 @@ namespace JSC { namespace Wasm {
 using namespace B3;
 
 namespace {
+#if USE(JSVALUE32_64)
+using ConstIntPtrValue = Const32Value;
+#else
+using ConstIntPtrValue = Const64Value;
+#endif
+
 namespace WasmOMGIRGeneratorInternal {
 static constexpr bool verbose = false;
 static constexpr bool verboseInlining = false;
@@ -120,6 +126,7 @@ public:
     using ArgumentList = Vector<ExpressionType, 8>;
     using CallType = CallLinkInfo::CallType;
     using CallPatchpointData = std::tuple<B3::PatchpointValue*, Box<PatchpointExceptionHandle>, RefPtr<B3::StackmapGenerator>>;
+    using WasmConstRefValue = Const64Value;
 
     static constexpr bool shouldFuseBranchCompare = false;
     static constexpr bool tierSupportsSIMD = true;
@@ -737,9 +744,12 @@ public:
     PartialResult WARN_UNUSED_RETURN addCallRef(const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
     PartialResult WARN_UNUSED_RETURN addUnreachable();
     PartialResult WARN_UNUSED_RETURN addCrash();
+    void fillCallResults(Value* callResult, const TypeDefinition& signature, ResultList& results);
     PartialResult WARN_UNUSED_RETURN emitIndirectCall(Value* calleeInstance, Value* calleeCode, Value* boxedCalleeCallee, const TypeDefinition&, const ArgumentList& args, ResultList&, CallType = CallType::Call);
-    auto createCallPatchpoint(BasicBlock*, B3::Type, const CallInformation&, const ArgumentList& tmpArgs) -> CallPatchpointData;
-    auto createTailCallPatchpoint(BasicBlock*, CallInformation wasmCallerInfoAsCallee, CallInformation wasmCalleeInfoAsCallee, const ArgumentList& tmpArgSourceLocations, Vector<B3::ConstrainedValue> patchArgs) -> CallPatchpointData;
+
+    Vector<ConstrainedValue> createCallConstrainedArgs(BasicBlock*, const CallInformation& wasmCalleeInfo, const ArgumentList&);
+    auto createCallPatchpoint(BasicBlock*, const TypeDefinition&, const CallInformation&, const ArgumentList& tmpArgs) -> CallPatchpointData;
+    auto createTailCallPatchpoint(BasicBlock*, const TypeDefinition&, const CallInformation& wasmCallerInfoAsCallee, const CallInformation& wasmCalleeInfoAsCallee, const ArgumentList& tmpArgSourceLocations, Vector<B3::ConstrainedValue> patchArgs) -> CallPatchpointData;
 
     bool canInline(FunctionSpaceIndex functionIndexSpace) const;
     PartialResult WARN_UNUSED_RETURN emitInlineDirectCall(FunctionCodeIndex calleeIndex, const TypeDefinition&, ArgumentList& args, ResultList& results);
@@ -1753,7 +1763,7 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
         const TypeDefinition& callerTypeDefinition = TypeInformation::get(callerTypeIndex).expand();
         CallInformation wasmCallerInfoAsCallee = callingConvention.callInformationFor(callerTypeDefinition, CallRole::Callee);
 
-        auto [patchpoint, _, prepareForCall] = createTailCallPatchpoint(m_currentBlock, wasmCallerInfoAsCallee, wasmCalleeInfoAsCallee, args, { { calleeCode, ValueRep(GPRInfo::wasmScratchGPR0) } });
+        auto [patchpoint, _, prepareForCall] = createTailCallPatchpoint(m_currentBlock, signature, wasmCallerInfoAsCallee, wasmCalleeInfoAsCallee, args, { { calleeCode, ValueRep(GPRInfo::wasmScratchGPR0) } });
         unsigned patchArgsIndex = patchpoint->reps().size();
         patchpoint->append(calleeCode, ValueRep(GPRInfo::nonPreservedNonArgumentGPR0));
         patchpoint->append(boxedCalleeCallee, ValueRep::SomeRegister);
@@ -1768,7 +1778,7 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
     }
 
     B3::Type returnType = toB3ResultType(&signature);
-    auto [patchpoint, handle, prepareForCall] = createCallPatchpoint(m_currentBlock, returnType, wasmCalleeInfo, args);
+    auto [patchpoint, handle, prepareForCall] = createCallPatchpoint(m_currentBlock, signature, wasmCalleeInfo, args);
     // We need to clobber all potential pinned registers since we might be leaving the instance.
     // We pessimistically assume we're always calling something that is bounds checking so
     // because the wasm->wasm thunk unconditionally overrides the size registers.
@@ -4763,12 +4773,23 @@ auto OMGIRGenerator::addEndToUnreachable(ControlEntry& entry, const Stack& expre
     return { };
 }
 
-
-auto OMGIRGenerator::createCallPatchpoint(BasicBlock* block, B3::Type returnType, const CallInformation& wasmCalleeInfo, const ArgumentList& tmpArgs) -> CallPatchpointData
+Vector<ConstrainedValue> OMGIRGenerator::createCallConstrainedArgs(BasicBlock* block, const CallInformation& wasmCalleeInfo, const ArgumentList& tmpArgs)
 {
-    Vector<B3::ConstrainedValue> constrainedPatchArgs;
-    for (unsigned i = 0; i < tmpArgs.size(); ++i)
-        constrainedPatchArgs.append(B3::ConstrainedValue(get(block, tmpArgs[i]), wasmCalleeInfo.params[i]));
+    Vector<ConstrainedValue> constrainedPatchArgs;
+    for (unsigned i = 0; i < tmpArgs.size(); ++i) {
+        auto dstLocation = wasmCalleeInfo.params[i];
+        constrainedPatchArgs.append(B3::ConstrainedValue(get(block, tmpArgs[i]), dstLocation));
+    }
+
+    return constrainedPatchArgs;
+}
+
+
+auto OMGIRGenerator::createCallPatchpoint(BasicBlock* block, const TypeDefinition& signature, const CallInformation& wasmCalleeInfo, const ArgumentList& tmpArgs) -> CallPatchpointData
+{
+    auto returnType = toB3ResultType(&signature);
+
+    auto constrainedPatchArgs = createCallConstrainedArgs(block, wasmCalleeInfo, tmpArgs);
 
     Box<PatchpointExceptionHandle> exceptionHandle = Box<PatchpointExceptionHandle>::create(m_hasExceptionHandlers, callSiteIndex());
 
@@ -4792,9 +4813,10 @@ auto OMGIRGenerator::createCallPatchpoint(BasicBlock* block, B3::Type returnType
     return { patchpoint, exceptionHandle, nullptr };
 }
 
-// See emitTailCallPatchpoint for the setup before this.
-static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& jit, const B3::StackmapGenerationParams& params, CallInformation wasmCallerInfoAsCallee, CallInformation wasmCalleeInfoAsCallee, unsigned firstPatchArg, unsigned lastPatchArg, int32_t newFPOffsetFromFP)
+// See createTailCallPatchpoint for the setup before this.
+static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& jit, const B3::StackmapGenerationParams& params, const TypeDefinition& signature, const CallInformation& wasmCallerInfoAsCallee, const CallInformation& wasmCalleeInfoAsCallee, unsigned firstPatchArg, unsigned lastPatchArg, int32_t newFPOffsetFromFP)
 {
+    auto& functionSignature = *signature.as<FunctionSignature>();
     const Checked<int32_t> offsetOfFirstSlotFromFP = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(wasmCallerInfoAsCallee.headerAndArgumentStackSizeInBytes);
     JIT_COMMENT(jit, "Set up tail call, new FP offset from FP: ", newFPOffsetFromFP);
     AllowMacroScratchRegisterUsage allowScratch(jit);
@@ -4823,6 +4845,17 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
         }
     }
 
+    ASSERT(!calleeSaves.find(tmp));
+
+#if ASSERT_ENABLED
+    // Let's make sure we never rely on these slots, so we can use them for scratch in the future.
+    // ARMv7 does currently use them.
+    jit.storePtr(MacroAssembler::TrustedImmPtr(0xBEEFAAAA),
+        CCallHelpers::Address(MacroAssembler::framePointerRegister, CallFrameSlot::thisArgument * sizeof(Register)));
+    jit.storePtr(MacroAssembler::TrustedImmPtr(0xBEEFAAAA),
+        CCallHelpers::Address(MacroAssembler::framePointerRegister, CallFrameSlot::argumentCountIncludingThis * sizeof(Register)));
+#endif
+
     const unsigned frameSize = params.code().frameSize();
     ASSERT(WTF::roundUpToMultipleOf<stackAlignmentBytes()>(frameSize) == frameSize);
     ASSERT(WTF::roundUpToMultipleOf<stackAlignmentBytes()>(std::abs(newFPOffsetFromFP)) == static_cast<size_t>(std::abs(newFPOffsetFromFP)));
@@ -4833,17 +4866,18 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
 
     JIT_COMMENT(jit, "Let's use the caller's frame, so that we always have a valid frame.");
     if (WasmOMGIRGeneratorInternal::verboseTailCalls) {
-        jit.probeDebugSIMD([frameSize, fpOffsetToSPOffset, newFPOffsetFromFP, wasmCalleeInfoAsCallee, firstPatchArg, params, functionIndex] (Probe::Context& context) {
-            uint64_t sp = context.gpr<uint64_t>(MacroAssembler::stackPointerRegister);
-            uint64_t fp = context.gpr<uint64_t>(GPRInfo::callFrameRegister);
+        jit.probeDebugSIMD([frameSize, fpOffsetToSPOffset, newFPOffsetFromFP, signature = Ref<const TypeDefinition>(signature), wasmCalleeInfoAsCallee, firstPatchArg, lastPatchArg, params, functionIndex] (Probe::Context& context) {
+            auto& functionSignature = *signature->as<FunctionSignature>();
+            auto sp = context.gpr<uintptr_t>(MacroAssembler::stackPointerRegister);
+            auto fp = context.gpr<uintptr_t>(GPRInfo::callFrameRegister);
             dataLogLn("Before tail call in function ", functionIndex, " before changing anything: FP: ", RawHex(fp), " SP: ", RawHex(sp));
             dataLogLn("New FP will be at ", RawHex(sp + fpOffsetToSPOffset(newFPOffsetFromFP)));
             CallFrame* fpp = context.gpr<CallFrame*>(GPRInfo::callFrameRegister);
             dataLogLn("callee original: ", RawPointer(fpp->callee().rawPtr()));
-            auto& wasmCallee = context.gpr<uint64_t*>(GPRInfo::callFrameRegister)[CallFrameSlot::callee * 1];
+            auto& wasmCallee = context.gpr<uintptr_t*>(GPRInfo::callFrameRegister)[CallFrameSlot::callee * 1];
             dataLogLn("callee original: ", RawHex(wasmCallee), " at ", RawPointer(&wasmCallee));
             dataLogLn("retPC original: ", RawPointer(fpp->rawReturnPCForInspection()));
-            auto& retPC = context.gpr<uint64_t*>(GPRInfo::callFrameRegister)[CallFrame::returnPCOffset() / sizeof(uint64_t)];
+            auto& retPC = context.gpr<uintptr_t*>(GPRInfo::callFrameRegister)[CallFrame::returnPCOffset() / sizeof(uintptr_t)];
             dataLogLn("retPC original: ", RawHex(retPC), " at ", RawPointer(&retPC));
             dataLogLn("callerFrame original: ", RawPointer(fpp->callerFrame()));
             ASSERT_UNUSED(frameSize, sp + frameSize == fp);
@@ -4851,30 +4885,37 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
             auto fpl = context.gpr<uint64_t*>(GPRInfo::callFrameRegister);
             auto fpi = context.gpr<uint32_t*>(GPRInfo::callFrameRegister);
 
-            for (unsigned i = 0; i < wasmCalleeInfoAsCallee.params.size(); ++i) {
-                auto src = params[firstPatchArg + i];
-                auto dst = wasmCalleeInfoAsCallee.params[i].location;
-                auto width = wasmCalleeInfoAsCallee.params[i].width;
-                dataLog("Arg source ", i, " located at ", src, " = ");
+            unsigned currentPatchArg = firstPatchArg;
+            auto dumpSrc = [&context, fpl, fpi, fpp] (ValueRep src, Width width) {
+                dataLog(src, " = ");
                 if (src.isGPR())
                     dataLog(context.gpr(src.gpr()), " / ", (int) context.gpr(src.gpr()));
-                else if (src.isFPR() && width <= Width::Width64)
+                else if (src.isFPR() && width <= Width64)
                     dataLog(context.fpr(src.fpr(), SavedFPWidth::SaveVectors));
                 else if (src.isFPR())
                     dataLog(context.vector(src.fpr()));
                 else if (src.isConstant())
                     dataLog(src.value(), " / ", src.doubleValue());
                 else
-                    dataLog(fpl[src.offsetFromFP() / sizeof(uint64_t)], " / ", fpi[src.offsetFromFP() / sizeof(uint32_t)], " / ", std::bit_cast<double>(fpl[src.offsetFromFP() / sizeof(uint64_t)]), " at ", RawPointer(&fpp[src.offsetFromFP() / sizeof(uint64_t)]));
-                dataLogLn(" -> ", dst);
+                dataLog(fpl[src.offsetFromFP() / sizeof(*fpl)], " / ", fpi[src.offsetFromFP() / sizeof(*fpi)], " / ", std::bit_cast<double>(fpl[src.offsetFromFP() / sizeof(*fpl)]), " at ", RawPointer(&fpp[src.offsetFromFP() / sizeof(*fpp)]));
+            };
+
+            for (unsigned i = 0; i < functionSignature.argumentCount(); ++i) {
+                auto width = functionSignature.argumentType(i).width();
+                ASSERT(wasmCalleeInfoAsCallee.params[i].width >= width);
+                dataLog("Arg source ", i, " located at ");
+                ASSERT_UNUSED(lastPatchArg, currentPatchArg < lastPatchArg);
+                dumpSrc(params[currentPatchArg++], width);
+
+                dataLogLn(" ->(final) ", wasmCalleeInfoAsCallee.params[i].location);
             }
         });
     }
     jit.loadPtr(CCallHelpers::Address(MacroAssembler::framePointerRegister, CallFrame::callerFrameOffset()), MacroAssembler::framePointerRegister);
     if (WasmOMGIRGeneratorInternal::verboseTailCalls) {
         jit.probeDebugSIMD([] (Probe::Context& context) {
-            uint64_t sp = context.gpr<uint64_t>(MacroAssembler::stackPointerRegister);
-            uint64_t fp = context.gpr<uint64_t>(GPRInfo::callFrameRegister);
+            auto sp = context.gpr<uintptr_t>(MacroAssembler::stackPointerRegister);
+            auto fp = context.gpr<uintptr_t>(GPRInfo::callFrameRegister);
             dataLogLn("In the new expanded frame, including F's caller: FP: ", RawHex(fp), " SP: ", RawHex(sp));
         });
     }
@@ -4904,7 +4945,7 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
         return offset;
     };
 
-    auto doMove = [&] (int srcOffset, int dstOffset, Width width) {
+    auto doMove = [&jit, tmp] (int srcOffset, int dstOffset, Width width) {
         JIT_COMMENT(jit, "Do move ", srcOffset, " -> ", dstOffset);
         auto src = CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset);
         auto dst = CCallHelpers::Address(MacroAssembler::stackPointerRegister, dstOffset);
@@ -4918,8 +4959,8 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
         }
         if (WasmOMGIRGeneratorInternal::verboseTailCalls) {
             jit.probeDebugSIMD([tmp, srcOffset, dstOffset, width] (Probe::Context& context) {
-                uint64_t val = context.gpr<uint64_t>(tmp);
-                uint64_t sp = context.gpr<uint64_t>(MacroAssembler::stackPointerRegister);
+                auto val = context.gpr<uintptr_t>(tmp);
+                auto sp = context.gpr<uintptr_t>(MacroAssembler::stackPointerRegister);
                 dataLogLn("Move value ", val, " / ", RawHex(val), " at ", RawHex(sp + srcOffset), " -> ", RawHex(sp + dstOffset), " width ", width);
             });
         }
@@ -4947,58 +4988,75 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
     argsToMove.reserveInitialCapacity(wasmCalleeInfoAsCallee.params.size() + 1);
 
     if (clobbersTmp) {
-        tmpSpill = allocateSpill(Width::Width64);
+        tmpSpill = allocateSpill(WidthPtr);
         jit.storePtr(tmp, CCallHelpers::Address(MacroAssembler::stackPointerRegister, tmpSpill));
     }
 
     // We will complete those moves who's source is closest to the danger frontier first.
     // That will move the danger frontier.
-
-    for (unsigned i = 0; i < wasmCalleeInfoAsCallee.params.size(); ++i) {
+    unsigned currentPatchArg = firstPatchArg;
+    for (unsigned i = 0; i < functionSignature.argumentCount(); ++i) {
         auto dst = wasmCalleeInfoAsCallee.params[i];
+        auto dstType = functionSignature.argumentType(i);
+        ASSERT(dst.width <= Width::Width64);
+        ASSERT(dst.width >= dstType.width());
         if (dst.location.isGPR()) {
             ASSERT(!calleeSaves.find(dst.location.jsr().payloadGPR()));
+            currentPatchArg++;
             continue;
         }
         if (dst.location.isFPR()) {
             ASSERT(!calleeSaves.find(dst.location.fpr()));
+            currentPatchArg++;
             continue;
         }
-        auto src = params[firstPatchArg + i];
-        ASSERT_UNUSED(lastPatchArg, firstPatchArg + i < lastPatchArg);
 
-        intptr_t srcOffset = -1;
+        auto saveSrc = [tmp, dstType, &allocateSpill, &jit, &fpOffsetToSPOffset](ValueRep src) -> std::tuple<int, Width> {
+            int srcOffset = 0;
+            if (src.isGPR()) {
+                srcOffset = allocateSpill(WidthPtr);
+                jit.storePtr(src.gpr(), CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
+            } else if (src.isFPR()) {
+                srcOffset = allocateSpill(dstType.width());
+                if (dstType.width() <= Width::Width64)
+                    jit.storeDouble(src.fpr(), CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
+                else
+                    jit.storeVector(src.fpr(), CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
+            } else if (src.isConstant()) {
+                if (toB3Type(dstType).kind() == Float) {
+                    srcOffset = allocateSpill(Width32);
+                    jit.move(MacroAssembler::TrustedImm32(src.value()), tmp);
+                    jit.store32(tmp, CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
+                } else if (toB3Type(dstType).kind() == Double) {
+                    srcOffset = allocateSpill(Width64);
+                    jit.move(MacroAssembler::TrustedImmPtr(src.value()), tmp);
+                    jit.storePtr(tmp, CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
+                } else {
+                    srcOffset = allocateSpill(WidthPtr);
+                    jit.move(MacroAssembler::TrustedImmPtr(src.value()), tmp);
+                    jit.storePtr(tmp, CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
+                }
+            } else {
+                ASSERT(src.isStack());
+                srcOffset = fpOffsetToSPOffset(src.offsetFromFP());
+            }
 
-        if (src.isGPR()) {
-            ASSERT(dst.width <= Width::Width64);
-            srcOffset = allocateSpill(dst.width);
-            jit.storePtr(src.gpr(), CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
-        } else if (src.isFPR()) {
-            srcOffset = allocateSpill(dst.width);
-            if (dst.width <= Width::Width64)
-                jit.storeDouble(src.fpr(), CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
-            else
-                jit.storeVector(src.fpr(), CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
-        } else if (src.isConstant()) {
-            srcOffset = allocateSpill(dst.width);
-            ASSERT(dst.width <= Width::Width64);
-            jit.move(MacroAssembler::TrustedImm64(src.value()), tmp);
-            jit.store64(tmp, CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
-        } else {
-            ASSERT(src.isStack());
-            srcOffset = fpOffsetToSPOffset(src.offsetFromFP());
-        }
+            return { srcOffset, dstType.width() };
+        };
+
+        ASSERT_UNUSED(lastPatchArg, currentPatchArg < lastPatchArg);
+        auto [srcOffset, srcWidth] = saveSrc(params[currentPatchArg++]);
         intptr_t dstOffset = fpOffsetToSPOffset(checkedSum<int32_t>(dst.location.offsetFromFP(), newFPOffsetFromFP).value());
         ASSERT(srcOffset >= 0);
         ASSERT(dstOffset >= 0);
         JIT_COMMENT(jit, "Arg ", i, " has srcOffset ", srcOffset, " dstOffset ", dstOffset);
-        argsToMove.append({ srcOffset, dstOffset, dst.width });
+        argsToMove.append({ srcOffset, dstOffset, srcWidth });
     }
 
     argsToMove.append({
         fpOffsetToSPOffset(CallFrame::returnPCOffset()),
         newReturnPCOffset,
-        Width::Width64
+        WidthPtr
     });
     JIT_COMMENT(jit, "ReturnPC has srcOffset ", fpOffsetToSPOffset(CallFrame::returnPCOffset()), " dstOffset ", newReturnPCOffset);
 
@@ -5061,11 +5119,11 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
 
 #if CPU(ARM) || CPU(ARM64) || CPU(RISCV64)
     JIT_COMMENT(jit, "Load the return pointer from its saved location.");
-    jit.load64(CCallHelpers::Address(MacroAssembler::stackPointerRegister, newFPOffsetFromSP + OBJECT_OFFSETOF(CallerFrameAndPC, returnPC)), tmp);
+    jit.loadPtr(CCallHelpers::Address(MacroAssembler::stackPointerRegister, newFPOffsetFromSP + OBJECT_OFFSETOF(CallerFrameAndPC, returnPC)), tmp);
     jit.move(tmp, MacroAssembler::linkRegister);
     if (WasmOMGIRGeneratorInternal::verboseTailCalls) {
         jit.probeDebugSIMD([] (Probe::Context& context) {
-            dataLogLn("tagged return pc: ", RawHex(context.gpr<uint64_t>(MacroAssembler::linkRegister)));
+            dataLogLn("tagged return pc: ", RawHex(context.gpr<uintptr_t>(MacroAssembler::linkRegister)));
         });
     }
 #if CPU(ARM64E)
@@ -5074,7 +5132,7 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
     jit.untagPtr(tmp, MacroAssembler::linkRegister);
     if (WasmOMGIRGeneratorInternal::verboseTailCalls) {
         jit.probeDebugSIMD([] (Probe::Context& context) {
-            dataLogLn("untagged return pc: ", RawHex(context.gpr<uint64_t>(MacroAssembler::linkRegister)));
+            dataLogLn("untagged return pc: ", RawHex(context.gpr<uintptr_t>(MacroAssembler::linkRegister)));
         });
     }
     jit.validateUntaggedPtr(MacroAssembler::linkRegister);
@@ -5086,7 +5144,7 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
 #if CPU(X86_64)
     if (WasmOMGIRGeneratorInternal::verboseTailCalls) {
         jit.probeDebugSIMD([] (Probe::Context& context) {
-            dataLogLn("return pc on the top of the stack: ", RawHex(*context.gpr<uint64_t*>(MacroAssembler::stackPointerRegister)), " at ", RawHex(context.gpr<uint64_t>(MacroAssembler::stackPointerRegister)));
+            dataLogLn("return pc on the top of the stack: ", RawHex(*context.gpr<uintptr_t*>(MacroAssembler::stackPointerRegister)), " at ", RawHex(context.gpr<uintptr_t>(MacroAssembler::stackPointerRegister)));
         });
     }
 #endif
@@ -5094,31 +5152,31 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
 #if ASSERT_ENABLED
     for (unsigned i = 2; i < 50; ++i) {
         // Everthing after sp might be overwritten anyway.
-        jit.store64(MacroAssembler::TrustedImm32(0xBFFF), CCallHelpers::Address(MacroAssembler::stackPointerRegister, -i * sizeof(uint64_t)));
+        jit.storePtr(MacroAssembler::TrustedImm32(0xBFFF), CCallHelpers::Address(MacroAssembler::stackPointerRegister, -i * sizeof(uintptr_t)));
     }
 #endif
 
     JIT_COMMENT(jit, "OK, now we can jump.");
     if (WasmOMGIRGeneratorInternal::verboseTailCalls) {
         jit.probeDebugSIMD([wasmCalleeInfoAsCallee] (Probe::Context& context) {
-            dataLogLn("Can now jump: FP: ", RawHex(context.gpr<uint64_t>(GPRInfo::callFrameRegister)), " SP: ", RawHex(context.gpr<uint64_t>(MacroAssembler::stackPointerRegister)));
-            auto* newFP = context.gpr<uint64_t*>(MacroAssembler::stackPointerRegister) - prologueStackPointerDelta() / sizeof(uint64_t);
+            dataLogLn("Can now jump: FP: ", RawHex(context.gpr<uintptr_t>(GPRInfo::callFrameRegister)), " SP: ", RawHex(context.gpr<uintptr_t>(MacroAssembler::stackPointerRegister)));
+            auto* newFP = context.gpr<uintptr_t*>(MacroAssembler::stackPointerRegister) - prologueStackPointerDelta() / sizeof(uintptr_t);
             dataLogLn("New (callee) FP at prologue will be at ", RawPointer(newFP));
-            auto fpl = static_cast<uint64_t*>(newFP);
-            auto fpi = reinterpret_cast<uint32_t*>(newFP);
+            auto fpl = std::bit_cast<uint64_t*>(newFP);
+            auto fpi = std::bit_cast<uint32_t*>(newFP);
 
             for (unsigned i = 0; i < wasmCalleeInfoAsCallee.params.size(); ++i) {
                 auto arg = wasmCalleeInfoAsCallee.params[i];
                 auto src = arg.location;
                 dataLog("Arg ", i, " located at ", arg.location, " = ");
                 if (arg.location.isGPR())
-                    dataLog(context.gpr(arg.location.jsr().gpr()), " / ", (int) context.gpr(arg.location.jsr().gpr()));
+                    dataLog(context.gpr(arg.location.jsr().payloadGPR()), " / ", (int) context.gpr(arg.location.jsr().payloadGPR()));
                 else if (arg.location.isFPR() && arg.width <= Width::Width64)
                     dataLog(context.fpr(arg.location.fpr(), SavedFPWidth::SaveVectors));
                 else if (arg.location.isFPR())
                     dataLog(context.vector(arg.location.fpr()));
                 else
-                    dataLog(fpl[src.offsetFromFP() / sizeof(uint64_t)], " / ", fpi[src.offsetFromFP() / sizeof(uint32_t)],  " / ", RawHex(fpi[src.offsetFromFP() / sizeof(uint32_t)]), " / ", std::bit_cast<double>(fpl[src.offsetFromFP() / sizeof(uint64_t)]), " at ", RawPointer(&fpi[src.offsetFromFP() / sizeof(uint32_t)]));
+                    dataLog(fpl[src.offsetFromFP() / sizeof(*fpl)], " / ", fpi[src.offsetFromFP() / sizeof(*fpi)],  " / ", RawHex(fpi[src.offsetFromFP() / sizeof(*fpi)]), " / ", std::bit_cast<double>(fpl[src.offsetFromFP() / sizeof(*fpl)]), " at ", RawPointer(&fpi[src.offsetFromFP() / sizeof(*fpi)]));
                 dataLogLn();
             }
         });
@@ -5129,7 +5187,7 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
 }
 
 // See also: https://leaningtech.com/fantastic-tail-calls-and-how-to-implement-them/, a blog post about contributing this feature.
-auto OMGIRGenerator::createTailCallPatchpoint(BasicBlock* block, CallInformation wasmCallerInfoAsCallee, CallInformation wasmCalleeInfoAsCallee, const ArgumentList& tmpArgSourceLocations, Vector<B3::ConstrainedValue> patchArgs) -> CallPatchpointData
+auto OMGIRGenerator::createTailCallPatchpoint(BasicBlock* block, const TypeDefinition& signature, const CallInformation& wasmCallerInfoAsCallee, const CallInformation& wasmCalleeInfoAsCallee, const ArgumentList& tmpArgSourceLocations, Vector<B3::ConstrainedValue> patchArgs) -> CallPatchpointData
 {
     m_makesTailCalls = true;
     // Our args are placed in argument registers or locals.
@@ -5199,20 +5257,20 @@ auto OMGIRGenerator::createTailCallPatchpoint(BasicBlock* block, CallInformation
     ASSERT(wasmCalleeInfoAsCallee.params.size() == tmpArgSourceLocations.size());
     unsigned firstPatchArg = patchArgs.size();
 
-    for (unsigned i = 0; i < tmpArgSourceLocations.size(); ++i) {
-        auto src = get(block, tmpArgSourceLocations[i]);
-        auto dst = wasmCalleeInfoAsCallee.params[i];
-        ASSERT(dst.location.isStack() || dst.location.isFPR() || dst.location.isGPR());
-        ASSERT(dst.width >= src->resultWidth());
-        if (!dst.location.isStack()) {
+    auto constrainedArgPatchArgs = createCallConstrainedArgs(block, wasmCalleeInfoAsCallee, tmpArgSourceLocations);
+
+    for (unsigned i = 0; i < constrainedArgPatchArgs.size(); ++i) {
+        auto src = constrainedArgPatchArgs[i].value();
+        auto dst = constrainedArgPatchArgs[i].rep();
+        ASSERT(dst.isStack() || dst.isFPR() || dst.isGPR());
+        if (!dst.isStack()) {
             // We will restore callee saves before jumping to the callee.
             // The calling convention should guarantee this anyway, but let's document it just in case.
-            ASSERT_UNUSED(forbiddenArgumentRegisters, !forbiddenArgumentRegisters.contains(dst.location.isGPR() ? Reg(dst.location.jsr().gpr()) : Reg(dst.location.fpr()), IgnoreVectors));
-            patchArgs.append(ConstrainedValue(src, dst));
+            ASSERT_UNUSED(forbiddenArgumentRegisters, !forbiddenArgumentRegisters.contains(dst.isGPR() ? Reg(dst.gpr()) : Reg(dst.fpr()), IgnoreVectors));
+            patchArgs.append(constrainedArgPatchArgs[i]);
             continue;
         }
-        ASSERT(dst.width >= Width64);
-        patchArgs.append(src);
+        patchArgs.append(ConstrainedValue(src, ValueRep::LateColdAny));
     }
     unsigned lastPatchArg = patchArgs.size();
 
@@ -5233,9 +5291,9 @@ auto OMGIRGenerator::createTailCallPatchpoint(BasicBlock* block, CallInformation
     firstPatchArg += m_proc.resultCount(patchpoint->type());
     lastPatchArg += m_proc.resultCount(patchpoint->type());
 
-    auto prepareForCall = createSharedTask<B3::StackmapGeneratorFunction>([wasmCalleeInfoAsCallee, wasmCallerInfoAsCallee, newFPOffsetFromFP, firstPatchArg, lastPatchArg, functionIndex = m_functionIndex](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
+    auto prepareForCall = createSharedTask<B3::StackmapGeneratorFunction>([signature = Ref<const TypeDefinition>(signature), wasmCalleeInfoAsCallee, wasmCallerInfoAsCallee, newFPOffsetFromFP, firstPatchArg, lastPatchArg, functionIndex = m_functionIndex](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
         ASSERT(newFPOffsetFromFP >= 0 || params.code().frameSize() >= static_cast<uint32_t>(-newFPOffsetFromFP));
-        prepareForTailCallImpl(functionIndex, jit, params, wasmCallerInfoAsCallee, wasmCalleeInfoAsCallee, firstPatchArg, lastPatchArg, newFPOffsetFromFP);
+        prepareForTailCallImpl(functionIndex, jit, params, signature, wasmCallerInfoAsCallee, wasmCalleeInfoAsCallee, firstPatchArg, lastPatchArg, newFPOffsetFromFP);
     });
 
     return { patchpoint, nullptr, WTFMove(prepareForCall) };
@@ -5405,6 +5463,7 @@ auto OMGIRGenerator::addCall(FunctionSpaceIndex functionIndexSpace, const TypeDe
                 AllowMacroScratchRegisterUsage allowScratch(jit);
                 if (prepareForCall)
                     prepareForCall->run(jit, params);
+                ASSERT(!isTailCall || !handle);
                 if (handle)
                     handle->generate(jit, params, this);
                 if (isTailCall)
@@ -5426,12 +5485,12 @@ auto OMGIRGenerator::addCall(FunctionSpaceIndex functionIndexSpace, const TypeDe
         jumpDestination = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfImportFunctionStub(functionIndexSpace)));
 
         if (isTailCall) {
-            auto [patchpoint, handle, prepareForCall] = createTailCallPatchpoint(m_currentBlock, wasmCallerInfoAsCallee, wasmCalleeInfoAsCallee, args, { });
+            auto [patchpoint, handle, prepareForCall] = createTailCallPatchpoint(m_currentBlock, signature, wasmCallerInfoAsCallee, wasmCalleeInfoAsCallee, args, { });
             emitCallToImport(patchpoint, handle, prepareForCall);
             return { };
         }
 
-        auto [patchpoint, handle, prepareForCall] = createCallPatchpoint(m_currentBlock, returnType, wasmCalleeInfo, args);
+        auto [patchpoint, handle, prepareForCall] = createCallPatchpoint(m_currentBlock, signature, wasmCalleeInfo, args);
         emitCallToImport(patchpoint, handle, prepareForCall);
 
         if (returnType != B3::Void)
@@ -5472,7 +5531,7 @@ auto OMGIRGenerator::addCall(FunctionSpaceIndex functionIndexSpace, const TypeDe
     };
 
     if (isTailCall) {
-        auto [patchpoint, handle, prepareForCall] = createTailCallPatchpoint(m_currentBlock, wasmCallerInfoAsCallee, wasmCalleeInfoAsCallee, args, { });
+        auto [patchpoint, handle, prepareForCall] = createTailCallPatchpoint(m_currentBlock, signature, wasmCallerInfoAsCallee, wasmCalleeInfoAsCallee, args, { });
         emitUnlinkedWasmToWasmCall(patchpoint, handle, prepareForCall);
         return { };
     }
@@ -5488,7 +5547,7 @@ auto OMGIRGenerator::addCall(FunctionSpaceIndex functionIndexSpace, const TypeDe
     // 1. It is not tail-call. So this does not clobber the arguments of this function.
     // 2. We are not changing instance. Thus, |this| of this function's arguments are the same and OK.
 
-    auto [patchpoint, handle, prepareForCall] = createCallPatchpoint(m_currentBlock, returnType, wasmCalleeInfo, args);
+    auto [patchpoint, handle, prepareForCall] = createCallPatchpoint(m_currentBlock, signature, wasmCalleeInfo, args);
     emitUnlinkedWasmToWasmCall(patchpoint, handle, prepareForCall);
     // We need to clobber the size register since the LLInt always bounds checks
     if (useSignalingMemory() || m_info.memory.isShared())

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -861,8 +861,10 @@ public:
     PartialResult WARN_UNUSED_RETURN addCrash();
     void fillCallResults(Value* callResult, const TypeDefinition& signature, ResultList& results);
     PartialResult WARN_UNUSED_RETURN emitIndirectCall(Value* calleeInstance, Value* calleeCode, Value* boxedCalleeCallee, const TypeDefinition&, const ArgumentList& args, ResultList&, CallType = CallType::Call);
+
+    Vector<ConstrainedValue> createCallConstrainedArgs(BasicBlock*, const CallInformation& wasmCalleeInfo, const ArgumentList&);
     auto createCallPatchpoint(BasicBlock*, const TypeDefinition&, const CallInformation&, const ArgumentList& tmpArgs) -> CallPatchpointData;
-    auto createTailCallPatchpoint(BasicBlock*, CallInformation wasmCallerInfoAsCallee, CallInformation wasmCalleeInfoAsCallee, const ArgumentList& tmpArgSourceLocations, Vector<B3::ConstrainedValue> patchArgs) -> CallPatchpointData;
+    auto createTailCallPatchpoint(BasicBlock*, const TypeDefinition&, const CallInformation& wasmCallerInfoAsCallee, const CallInformation& wasmCalleeInfoAsCallee, const ArgumentList& tmpArgSourceLocations, Vector<B3::ConstrainedValue> patchArgs) -> CallPatchpointData;
 
     bool canInline(FunctionSpaceIndex functionIndexSpace) const;
     PartialResult WARN_UNUSED_RETURN emitInlineDirectCall(FunctionCodeIndex calleeIndex, const TypeDefinition&, ArgumentList& args, ResultList& results);
@@ -1750,7 +1752,7 @@ auto OMGIRGenerator::addArguments(const TypeDefinition& signature) -> PartialRes
         patch->effects.writes = HeapRange::top();
         m_currentBlock->append(patch);
         patch->setGenerator([functionIndex = m_functionIndex, signature = signature.as<FunctionSignature>(), wasmCallInfo] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
-            jit.probeDebugSIMD([functionIndex, signature, wasmCallInfo] (Probe::Context& context) {
+            jit.probeDebug([functionIndex, signature, wasmCallInfo] (Probe::Context& context) {
                 dataLogLn(" General Add arguments, fucntion ", functionIndex, " FP: ", RawHex(context.gpr<uint64_t>(GPRInfo::callFrameRegister)), " SP: ", RawHex(context.gpr<uint64_t>(MacroAssembler::stackPointerRegister)));
 
                 auto fpl = context.gpr<uint64_t*>(GPRInfo::callFrameRegister);
@@ -1762,10 +1764,12 @@ auto OMGIRGenerator::addArguments(const TypeDefinition& signature) -> PartialRes
                     auto width = rep.width;
                     dataLog("     Arg source ", i, " located at ", src, " = ");
 
-                    if (src.isGPR())
+                    if (src.isGPR()) {
                         dataLog(context.gpr(src.jsr().payloadGPR()), " / ", (int) context.gpr(src.jsr().payloadGPR()));
-                    else if (src.isFPR() && width <= Width::Width64)
-                        dataLog(context.fpr(src.fpr(), SavedFPWidth::SaveVectors));
+                        if (src.jsr().tagGPR())
+                            dataLog(" Upper bits: ", context.gpr(src.jsr().tagGPR()), " / ", (int) context.gpr(src.jsr().tagGPR()));
+                    } else if (src.isFPR() && width <= Width::Width64)
+                        dataLog(context.fpr(src.fpr(), SavedFPWidth::DontSaveVectors));
                     else if (src.isFPR())
                         RELEASE_ASSERT_NOT_REACHED();
                     else
@@ -1996,6 +2000,10 @@ auto OMGIRGenerator::addCrash() -> PartialResult
     return { };
 }
 
+
+static constexpr int tailCallPatchpointScratchOffsets[] = { CallFrameSlot::thisArgument * sizeof(Register), CallFrameSlot::argumentCountIncludingThis * sizeof(Register) };
+static constexpr int tailCallPatchpointScratchCount = sizeof(tailCallPatchpointScratchOffsets) / sizeof(tailCallPatchpointScratchOffsets[0]);
+
 void OMGIRGenerator::fillCallResults(Value* callResult, const TypeDefinition& signature, ResultList& results)
 {
     B3::Type returnType = toB3ResultType(&signature);
@@ -2096,16 +2104,38 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
         const TypeDefinition& callerTypeDefinition = TypeInformation::get(callerTypeIndex).expand();
         CallInformation wasmCallerInfoAsCallee = callingConvention.callInformationFor(callerTypeDefinition, CallRole::Callee);
 
-        auto [patchpoint, _, prepareForCall] = createTailCallPatchpoint(m_currentBlock, wasmCallerInfoAsCallee, wasmCalleeInfoAsCallee, args, { { calleeCode, ValueRep(GPRInfo::wasmScratchGPR0) } });
+        auto [patchpoint, _, prepareForCall] = createTailCallPatchpoint(m_currentBlock, signature, wasmCallerInfoAsCallee, wasmCalleeInfoAsCallee, args, { });
         unsigned patchArgsIndex = patchpoint->reps().size();
-        patchpoint->append(calleeCode, ValueRep(GPRInfo::nonPreservedNonArgumentGPR0));
-        patchpoint->append(boxedCalleeCallee, ValueRep::SomeRegister);
+        if (is32Bit()) {
+            patchpoint->append(calleeCode, ValueRep::stackArgument(0));
+            patchpoint->append(boxedCalleeCallee, ValueRep::stackArgument(8));
+        } else {
+            patchpoint->append(calleeCode, ValueRep(GPRInfo::nonPreservedNonArgumentGPR0));
+            patchpoint->append(boxedCalleeCallee, ValueRep::SomeRegister);
+        }
         patchArgsIndex += m_proc.resultCount(patchpoint->type());
         patchpoint->setGenerator([prepareForCall = prepareForCall, patchArgsIndex](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
             AllowMacroScratchRegisterUsage allowScratch(jit);
             prepareForCall->run(jit, params);
-            jit.storeWasmCalleeCallee(params[patchArgsIndex + 1].gpr(), sizeof(CallerFrameAndPC) - prologueStackPointerDelta());
-            jit.farJump(params[patchArgsIndex].gpr(), WasmEntryPtrTag);
+            GPRReg callTarget;
+            GPRReg callee;
+            if (is32Bit() && params[patchArgsIndex + 1].isStack()) {
+                callee = MacroAssembler::addressTempRegister;
+                jit.loadPtr(CCallHelpers::Address(MacroAssembler::stackPointerRegister,
+                    tailCallPatchpointScratchOffsets[1] - sizeof(CallerFrameAndPC)), callee);
+            } else
+                callee = params[patchArgsIndex + 1].gpr();
+
+            jit.storeWasmCalleeCallee(callee, sizeof(CallerFrameAndPC) - prologueStackPointerDelta());
+
+            if (is32Bit() && params[patchArgsIndex].isStack()) {
+                callTarget = MacroAssembler::addressTempRegister;
+                jit.loadPtr(CCallHelpers::Address(MacroAssembler::stackPointerRegister,
+                    tailCallPatchpointScratchOffsets[0] - sizeof(CallerFrameAndPC)), callTarget);
+            } else
+                callTarget = params[patchArgsIndex].gpr();
+
+            jit.farJump(callTarget, WasmEntryPtrTag);
         });
         return { };
     }
@@ -5095,25 +5125,48 @@ auto OMGIRGenerator::addEndToUnreachable(ControlEntry& entry, const Stack& expre
     return { };
 }
 
+Vector<ConstrainedValue> OMGIRGenerator::createCallConstrainedArgs(BasicBlock* block, const CallInformation& wasmCalleeInfo, const ArgumentList& tmpArgs)
+{
+    Vector<ConstrainedValue> constrainedPatchArgs;
+    for (unsigned i = 0; i < tmpArgs.size(); ++i) {
+        auto dstLocation = wasmCalleeInfo.params[i];
+        if (tmpArgs[i]->type() == Int64 && dstLocation.location.isGPR()) {
+            auto int64 = get(block, tmpArgs[i]);
+            auto hi = append<ExtractValue>(block, m_proc, origin(), Int32, int64, ExtractValue::s_int64HighBits);
+            auto lo = append<ExtractValue>(block, m_proc, origin(), Int32, int64, ExtractValue::s_int64LowBits);
+            constrainedPatchArgs.append(B3::ConstrainedValue(lo, ValueRep::reg(dstLocation.location.jsr().payloadGPR())));
+            constrainedPatchArgs.append(B3::ConstrainedValue(hi, ValueRep::reg(dstLocation.location.jsr().tagGPR())));
+            continue;
+        }
+
+        if (tmpArgs[i]->type() == Int64) {
+            auto int64 = get(block, tmpArgs[i]);
+            auto hi = append<ExtractValue>(block, m_proc, origin(), Int32, int64, ExtractValue::s_int64HighBits);
+            auto lo = append<ExtractValue>(block, m_proc, origin(), Int32, int64, ExtractValue::s_int64LowBits);
+
+            if (dstLocation.location.isStack()) {
+                constrainedPatchArgs.append(B3::ConstrainedValue(lo, ValueRep::stack(dstLocation.location.offsetFromFP())));
+                constrainedPatchArgs.append(B3::ConstrainedValue(hi, ValueRep::stack(dstLocation.location.offsetFromFP() + sizeof(int))));
+            } else {
+                ASSERT(dstLocation.location.isStackArgument());
+                constrainedPatchArgs.append(B3::ConstrainedValue(lo, ValueRep::stackArgument(dstLocation.location.offsetFromSP())));
+                constrainedPatchArgs.append(B3::ConstrainedValue(hi, ValueRep::stackArgument(dstLocation.location.offsetFromSP() + sizeof(int))));
+            }
+            continue;
+        }
+        constrainedPatchArgs.append(B3::ConstrainedValue(get(block, tmpArgs[i]), dstLocation));
+    }
+
+    return constrainedPatchArgs;
+}
+
 
 auto OMGIRGenerator::createCallPatchpoint(BasicBlock* block, const TypeDefinition& signature, const CallInformation& wasmCalleeInfo, const ArgumentList& tmpArgs) -> CallPatchpointData
 {
     auto& functionSignature = *signature.as<FunctionSignature>();
     auto returnType = toB3ResultType(&signature);
 
-    Vector<B3::ConstrainedValue> constrainedPatchArgs;
-    Vector<B3::ConstrainedValue> constrainedPatchArgsHighBits;
-    for (unsigned i = 0; i < tmpArgs.size(); ++i) {
-        if (tmpArgs[i]->type() == Int64) {
-            auto int64 = get(block, tmpArgs[i]);
-            auto hi = append<ExtractValue>(m_proc, origin(), Int32, int64, ExtractValue::s_int64HighBits);
-            auto lo = append<ExtractValue>(m_proc, origin(), Int32, int64, ExtractValue::s_int64LowBits);
-            constrainedPatchArgs.append(B3::ConstrainedValue(lo, ValueRep::reg(wasmCalleeInfo.params[i].location.jsr().payloadGPR())));
-            constrainedPatchArgsHighBits.append(B3::ConstrainedValue(hi, ValueRep::reg(wasmCalleeInfo.params[i].location.jsr().tagGPR())));
-            continue;
-        }
-        constrainedPatchArgs.append(B3::ConstrainedValue(get(block, tmpArgs[i]), wasmCalleeInfo.params[i]));
-    }
+    auto constrainedPatchArgs = createCallConstrainedArgs(block, wasmCalleeInfo, tmpArgs);
 
     Box<PatchpointExceptionHandle> exceptionHandle = Box<PatchpointExceptionHandle>::create(m_hasExceptionHandlers, callSiteIndex());
 
@@ -5123,7 +5176,6 @@ auto OMGIRGenerator::createCallPatchpoint(BasicBlock* block, const TypeDefinitio
     patchpoint->clobberEarly(RegisterSetBuilder::macroClobberedGPRs());
     patchpoint->clobberLate(RegisterSetBuilder::registersToSaveForJSCall(m_proc.usesSIMD() ? RegisterSetBuilder::allRegisters() : RegisterSetBuilder::allScalarRegisters()));
     patchpoint->appendVector(constrainedPatchArgs);
-    patchpoint->appendVector(constrainedPatchArgsHighBits);
 
     *exceptionHandle = preparePatchpointForExceptions(block, patchpoint);
 
@@ -5173,9 +5225,10 @@ auto OMGIRGenerator::createCallPatchpoint(BasicBlock* block, const TypeDefinitio
     return { patchpoint, exceptionHandle, nullptr };
 }
 
-// See emitTailCallPatchpoint for the setup before this.
-static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& jit, const B3::StackmapGenerationParams& params, CallInformation wasmCallerInfoAsCallee, CallInformation wasmCalleeInfoAsCallee, unsigned firstPatchArg, unsigned lastPatchArg, int32_t newFPOffsetFromFP)
+// See createTailCallPatchpoint for the setup before this.
+static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& jit, const B3::StackmapGenerationParams& params, const TypeDefinition& signature, const CallInformation& wasmCallerInfoAsCallee, const CallInformation& wasmCalleeInfoAsCallee, unsigned firstPatchArg, unsigned lastPatchArg, int32_t newFPOffsetFromFP)
 {
+    auto& functionSignature = *signature.as<FunctionSignature>();
     const Checked<int32_t> offsetOfFirstSlotFromFP = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(wasmCallerInfoAsCallee.headerAndArgumentStackSizeInBytes);
     JIT_COMMENT(jit, "Set up tail call, new FP offset from FP: ", newFPOffsetFromFP);
     AllowMacroScratchRegisterUsage allowScratch(jit);
@@ -5185,6 +5238,10 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
     bool clobbersTmp = false;
     auto tmp = jit.scratchRegister();
     int tmpSpill = 0;
+
+    // If we pass a stack location to the patchpoint in arugmentCountIncludingThis, preserve it here.
+    bool stackPatchArg[tailCallPatchpointScratchCount] = { false, false };
+    int stackPatchArgSpill[tailCallPatchpointScratchCount] = { 0, 0 };
 
     // Set up a valid frame so that we can clobber this one.
     RegisterAtOffsetList calleeSaves = params.code().calleeSaveRegisterAtOffsetList();
@@ -5204,9 +5261,44 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
         }
     }
 
+    for (unsigned i = lastPatchArg; i < params.size(); ++i) {
+        auto arg = params[i];
+        if (arg.isStack()) {
+            unsigned scratch = -1;
+            for (unsigned i = 0; i < tailCallPatchpointScratchCount; ++i) {
+                if (!stackPatchArg[i]) {
+                    scratch = i;
+                    break;
+                }
+            }
+            ASSERT(scratch >= 0 && !stackPatchArg[scratch]);
+            stackPatchArg[scratch] = true;
+            if (WasmOMGIRGeneratorInternal::verboseTailCalls) {
+                jit.probeDebug([arg] (Probe::Context& context) {
+                    dataLogLn("patch arg spill: ", RawHex(context.gpr<uintptr_t*>(MacroAssembler::framePointerRegister)[arg.offsetFromFP() / sizeof(uintptr_t)]));
+                });
+            }
+            // A convinent and save place to stash it.
+            jit.transferPtr(CCallHelpers::Address(MacroAssembler::framePointerRegister, arg.offsetFromFP()),
+                CCallHelpers::Address(MacroAssembler::framePointerRegister, tailCallPatchpointScratchOffsets[scratch]));
+        } else
+            ASSERT(arg.isGPR() || arg.isFPR());
+    }
+
+#if ASSERT_ENABLED
+    // Let's make sure we never rely on these slots, since they may be used for scratch.
+    for (unsigned i = 0; i < tailCallPatchpointScratchCount; ++i) {
+        if (!stackPatchArg[i]) {
+            jit.storePtr(MacroAssembler::TrustedImmPtr(0xBEEFAAAA),
+                CCallHelpers::Address(MacroAssembler::framePointerRegister, tailCallPatchpointScratchOffsets[i]));
+        }
+    }
+#endif
+
+    ASSERT(!calleeSaves.find(tmp) || !clobbersTmp);
+
     const unsigned frameSize = params.code().frameSize();
-    ASSERT(WTF::roundUpToMultipleOf<stackAlignmentBytes()>(frameSize) == frameSize);
-    ASSERT(WTF::roundUpToMultipleOf<stackAlignmentBytes()>(std::abs(newFPOffsetFromFP)) == static_cast<size_t>(std::abs(newFPOffsetFromFP)));
+    ASSERT(WTF::roundUpToMultipleOf<stackAlignmentBytes()>(frameSize + sizeof(CallerFrameAndPC)) == frameSize + sizeof(CallerFrameAndPC));
 
     auto fpOffsetToSPOffset = [frameSize](int32_t offset) {
         return checkedSum<int>(safeCast<int>(frameSize), offset).value();
@@ -5214,17 +5306,18 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
 
     JIT_COMMENT(jit, "Let's use the caller's frame, so that we always have a valid frame.");
     if (WasmOMGIRGeneratorInternal::verboseTailCalls) {
-        jit.probeDebugSIMD([frameSize, fpOffsetToSPOffset, newFPOffsetFromFP, wasmCalleeInfoAsCallee, firstPatchArg, params, functionIndex] (Probe::Context& context) {
-            uint64_t sp = context.gpr<uint64_t>(MacroAssembler::stackPointerRegister);
-            uint64_t fp = context.gpr<uint64_t>(GPRInfo::callFrameRegister);
+        jit.probeDebug([frameSize, fpOffsetToSPOffset, newFPOffsetFromFP, signature = Ref<const TypeDefinition>(signature), wasmCalleeInfoAsCallee, firstPatchArg, lastPatchArg, params, functionIndex] (Probe::Context& context) {
+            auto& functionSignature = *signature->as<FunctionSignature>();
+            auto sp = context.gpr<uintptr_t>(MacroAssembler::stackPointerRegister);
+            auto fp = context.gpr<uintptr_t>(GPRInfo::callFrameRegister);
             dataLogLn("Before tail call in function ", functionIndex, " before changing anything: FP: ", RawHex(fp), " SP: ", RawHex(sp));
             dataLogLn("New FP will be at ", RawHex(sp + fpOffsetToSPOffset(newFPOffsetFromFP)));
             CallFrame* fpp = context.gpr<CallFrame*>(GPRInfo::callFrameRegister);
             dataLogLn("callee original: ", RawPointer(fpp->callee().rawPtr()));
-            auto& wasmCallee = context.gpr<uint64_t*>(GPRInfo::callFrameRegister)[CallFrameSlot::callee * 1];
+            auto& wasmCallee = context.gpr<uintptr_t*>(GPRInfo::callFrameRegister)[CallFrameSlot::callee * 1];
             dataLogLn("callee original: ", RawHex(wasmCallee), " at ", RawPointer(&wasmCallee));
             dataLogLn("retPC original: ", RawPointer(fpp->rawReturnPCForInspection()));
-            auto& retPC = context.gpr<uint64_t*>(GPRInfo::callFrameRegister)[CallFrame::returnPCOffset() / sizeof(uint64_t)];
+            auto& retPC = context.gpr<uintptr_t*>(GPRInfo::callFrameRegister)[CallFrame::returnPCOffset() / sizeof(uintptr_t)];
             dataLogLn("retPC original: ", RawHex(retPC), " at ", RawPointer(&retPC));
             dataLogLn("callerFrame original: ", RawPointer(fpp->callerFrame()));
             ASSERT_UNUSED(frameSize, sp + frameSize == fp);
@@ -5232,30 +5325,43 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
             auto fpl = context.gpr<uint64_t*>(GPRInfo::callFrameRegister);
             auto fpi = context.gpr<uint32_t*>(GPRInfo::callFrameRegister);
 
-            for (unsigned i = 0; i < wasmCalleeInfoAsCallee.params.size(); ++i) {
-                auto src = params[firstPatchArg + i];
-                auto dst = wasmCalleeInfoAsCallee.params[i].location;
-                auto width = wasmCalleeInfoAsCallee.params[i].width;
-                dataLog("Arg source ", i, " located at ", src, " = ");
+            unsigned currentPatchArg = firstPatchArg;
+            auto dumpSrc = [&context, fpl, fpi, fpp] (ValueRep src, Width width) {
+                dataLog(src, " = ");
                 if (src.isGPR())
                     dataLog(context.gpr(src.gpr()), " / ", (int) context.gpr(src.gpr()));
-                else if (src.isFPR() && width <= Width::Width64)
-                    dataLog(context.fpr(src.fpr(), SavedFPWidth::SaveVectors));
+                else if (src.isFPR() && width <= Width64)
+                    dataLog(context.fpr(src.fpr(), SavedFPWidth::DontSaveVectors));
                 else if (src.isFPR())
                     RELEASE_ASSERT_NOT_REACHED();
                 else if (src.isConstant())
                     dataLog(src.value(), " / ", src.doubleValue());
                 else
-                    dataLog(fpl[src.offsetFromFP() / sizeof(uint64_t)], " / ", fpi[src.offsetFromFP() / sizeof(uint32_t)], " / ", std::bit_cast<double>(fpl[src.offsetFromFP() / sizeof(uint64_t)]), " at ", RawPointer(&fpp[src.offsetFromFP() / sizeof(uint64_t)]));
-                dataLogLn(" -> ", dst);
+                    dataLog(fpl[src.offsetFromFP() / sizeof(*fpl)], " / ", fpi[src.offsetFromFP() / sizeof(*fpi)], " / ", std::bit_cast<double>(fpl[src.offsetFromFP() / sizeof(*fpl)]), " at ", RawPointer(&fpp[src.offsetFromFP() / sizeof(*fpp)]));
+            };
+
+            for (unsigned i = 0; i < functionSignature.argumentCount(); ++i) {
+                auto width = functionSignature.argumentType(i).width();
+                ASSERT(wasmCalleeInfoAsCallee.params[i].width >= width);
+                dataLog("Arg source ", i, " located at ");
+                ASSERT_UNUSED(lastPatchArg, currentPatchArg < lastPatchArg);
+                dumpSrc(params[currentPatchArg++], width);
+                if (is32Bit() && functionSignature.argumentType(i).isI64()) {
+                    dataLog(" (Upper bits: ");
+                    ASSERT_UNUSED(lastPatchArg, currentPatchArg < lastPatchArg);
+                    dumpSrc(params[currentPatchArg++], width);
+                    dataLog(")");
+                }
+
+                dataLogLn(" ->(final) ", wasmCalleeInfoAsCallee.params[i].location);
             }
         });
     }
     jit.loadPtr(CCallHelpers::Address(MacroAssembler::framePointerRegister, CallFrame::callerFrameOffset()), MacroAssembler::framePointerRegister);
     if (WasmOMGIRGeneratorInternal::verboseTailCalls) {
         jit.probeDebugSIMD([] (Probe::Context& context) {
-            uint64_t sp = context.gpr<uint64_t>(MacroAssembler::stackPointerRegister);
-            uint64_t fp = context.gpr<uint64_t>(GPRInfo::callFrameRegister);
+            auto sp = context.gpr<uintptr_t>(MacroAssembler::stackPointerRegister);
+            auto fp = context.gpr<uintptr_t>(GPRInfo::callFrameRegister);
             dataLogLn("In the new expanded frame, including F's caller: FP: ", RawHex(fp), " SP: ", RawHex(sp));
         });
     }
@@ -5285,25 +5391,30 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
         return offset;
     };
 
-    auto doMove = [&] (int srcOffset, int dstOffset, Width width) {
+    auto doMove = [&jit, tmp] (int srcOffset, int dstOffset, Width width) {
         JIT_COMMENT(jit, "Do move ", srcOffset, " -> ", dstOffset);
         auto src = CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset);
         auto dst = CCallHelpers::Address(MacroAssembler::stackPointerRegister, dstOffset);
         if (width <= Width32)
             jit.transfer32(src, dst);
-        else
-            RELEASE_ASSERT_NOT_REACHED();
+        else if (width <= Width64)
+            jit.transfer64(src, dst);
+        else {
+            jit.transfer64(src, dst);
+            jit.transfer64(src.withOffset(bytesForWidth(Width::Width64)), dst.withOffset(bytesForWidth(Width::Width64)));
+        }
         if (WasmOMGIRGeneratorInternal::verboseTailCalls) {
-            jit.probeDebugSIMD([tmp, srcOffset, dstOffset, width] (Probe::Context& context) {
-                uint64_t val = context.gpr<uint64_t>(tmp);
-                uint64_t sp = context.gpr<uint64_t>(MacroAssembler::stackPointerRegister);
+            jit.loadPtr(dst, tmp);
+            jit.probeDebug([tmp, srcOffset, dstOffset, width] (Probe::Context& context) {
+                auto val = context.gpr<uintptr_t>(tmp);
+                auto sp = context.gpr<uintptr_t>(MacroAssembler::stackPointerRegister);
                 dataLogLn("Move value ", val, " / ", RawHex(val), " at ", RawHex(sp + srcOffset), " -> ", RawHex(sp + dstOffset), " width ", width);
             });
         }
     };
 
     // This should grow down towards SP (towards 0) as we move stuff out of the way.
-    int safeAreaLowerBound = fpOffsetToSPOffset(CallFrameSlot::codeBlock * sizeof(Register));
+    int safeAreaLowerBound = fpOffsetToSPOffset(CallFrameSlot::firstArgument * sizeof(Register));
     const int stackUpperBound = fpOffsetToSPOffset(offsetOfFirstSlotFromFP); // ArgN in the stack diagram
     ASSERT(safeAreaLowerBound > 0);
     ASSERT(safeAreaLowerBound < stackUpperBound);
@@ -5324,60 +5435,105 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
     argsToMove.reserveInitialCapacity(wasmCalleeInfoAsCallee.params.size() + 1);
 
     if (clobbersTmp) {
-        tmpSpill = allocateSpill(Width::Width64);
+        tmpSpill = allocateSpill(WidthPtr);
         jit.storePtr(tmp, CCallHelpers::Address(MacroAssembler::stackPointerRegister, tmpSpill));
+    }
+
+
+    for (unsigned i = 0; i < tailCallPatchpointScratchCount; ++i) {
+        if (stackPatchArg[i]) {
+            stackPatchArgSpill[i] = allocateSpill(WidthPtr);
+            jit.transferPtr(CCallHelpers::Address(MacroAssembler::stackPointerRegister, fpOffsetToSPOffset(tailCallPatchpointScratchOffsets[i])), CCallHelpers::Address(MacroAssembler::stackPointerRegister, stackPatchArgSpill[i]));
+        }
     }
 
     // We will complete those moves who's source is closest to the danger frontier first.
     // That will move the danger frontier.
-
-    for (unsigned i = 0; i < wasmCalleeInfoAsCallee.params.size(); ++i) {
+    unsigned currentPatchArg = firstPatchArg;
+    for (unsigned i = 0; i < functionSignature.argumentCount(); ++i) {
         auto dst = wasmCalleeInfoAsCallee.params[i];
+        auto dstType = functionSignature.argumentType(i);
+        ASSERT(dst.width <= Width::Width64);
+        ASSERT(dst.width >= dstType.width());
         if (dst.location.isGPR()) {
             ASSERT(!calleeSaves.find(dst.location.jsr().payloadGPR()));
+            currentPatchArg += dstType.width() == Width64 ? 2 : 1;
             continue;
         }
         if (dst.location.isFPR()) {
             ASSERT(!calleeSaves.find(dst.location.fpr()));
+            currentPatchArg++;
             continue;
         }
-        auto src = params[firstPatchArg + i];
-        ASSERT_UNUSED(lastPatchArg, firstPatchArg + i < lastPatchArg);
 
-        intptr_t srcOffset = -1;
+        auto saveSrc = [tmp, dstType, &allocateSpill, &jit, &fpOffsetToSPOffset](ValueRep src) -> std::tuple<int, Width> {
+            int srcOffset = 0;
+            if (src.isGPR()) {
+                srcOffset = allocateSpill(WidthPtr);
+                jit.storePtr(src.gpr(), CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
+                return { srcOffset, WidthPtr };
+            }
+            if (src.isFPR()) {
+                srcOffset = allocateSpill(dstType.width());
+                if (dstType.width() <= Width::Width64)
+                    jit.storeDouble(src.fpr(), CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
+                else
+                    jit.storeVector(src.fpr(), CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
+            } else if (src.isConstant()) {
+                if (toB3Type(dstType).kind() == Float) {
+                    srcOffset = allocateSpill(Width32);
+                    jit.move(MacroAssembler::TrustedImm32(src.value()), tmp);
+                    jit.store32(tmp, CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
+                } else if (toB3Type(dstType).kind() == Double) {
+                    srcOffset = allocateSpill(Width64);
+                    jit.move(MacroAssembler::TrustedImmPtr(src.value()), tmp);
+                    jit.storePtr(tmp, CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
+                    jit.move(MacroAssembler::TrustedImmPtr(src.value() >> 32), tmp);
+                    jit.storePtr(tmp, CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset + sizeof(int)));
+                } else {
+                    srcOffset = allocateSpill(WidthPtr);
+                    jit.move(MacroAssembler::TrustedImmPtr(src.value()), tmp);
+                    jit.storePtr(tmp, CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
+                    return { srcOffset, WidthPtr };
+                }
+            } else {
+                ASSERT(src.isStack());
+                srcOffset = fpOffsetToSPOffset(src.offsetFromFP());
 
-        if (src.isGPR()) {
-            ASSERT(dst.width <= Width::Width32);
-            srcOffset = allocateSpill(dst.width);
-            jit.storePtr(src.gpr(), CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
-        } else if (src.isFPR()) {
-            srcOffset = allocateSpill(dst.width);
-            if (dst.width <= Width::Width64)
-                jit.storeDouble(src.fpr(), CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
-            else
-                jit.storeVector(src.fpr(), CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
-        } else if (src.isConstant()) {
-            srcOffset = allocateSpill(dst.width);
-            ASSERT(dst.width <= Width::Width32);
-            jit.move(MacroAssembler::TrustedImmPtr(src.value()), tmp);
-            jit.storePtr(tmp, CCallHelpers::Address(MacroAssembler::stackPointerRegister, srcOffset));
-        } else {
-            ASSERT(src.isStack());
-            srcOffset = fpOffsetToSPOffset(src.offsetFromFP());
-        }
+                if (is32Bit() && toB3Type(dstType).kind() == Int64)
+                    return { srcOffset, WidthPtr };
+            }
+
+            return { srcOffset, dstType.width() };
+        };
+
+        ASSERT_UNUSED(lastPatchArg, currentPatchArg < lastPatchArg);
+        auto [srcOffset, srcWidth] = saveSrc(params[currentPatchArg++]);
         intptr_t dstOffset = fpOffsetToSPOffset(checkedSum<int32_t>(dst.location.offsetFromFP(), newFPOffsetFromFP).value());
         ASSERT(srcOffset >= 0);
         ASSERT(dstOffset >= 0);
         JIT_COMMENT(jit, "Arg ", i, " has srcOffset ", srcOffset, " dstOffset ", dstOffset);
-        argsToMove.append({ srcOffset, dstOffset, dst.width });
+        argsToMove.append({ srcOffset, dstOffset, srcWidth });
+
+        if (is32Bit() && srcWidth < dstType.width()) {
+            ASSERT_UNUSED(lastPatchArg, currentPatchArg < lastPatchArg);
+            auto [srcOffsetUpperBits, srcWidthUpperBits] = saveSrc(params[currentPatchArg++]);
+            ASSERT(srcWidthUpperBits == WidthPtr);
+            argsToMove.append({ srcOffsetUpperBits, dstOffset + sizeof(int), srcWidthUpperBits });
+        }
     }
 
     argsToMove.append({
         fpOffsetToSPOffset(CallFrame::returnPCOffset()),
         newReturnPCOffset,
-        Width::Width64
+        WidthPtr
     });
     JIT_COMMENT(jit, "ReturnPC has srcOffset ", fpOffsetToSPOffset(CallFrame::returnPCOffset()), " dstOffset ", newReturnPCOffset);
+
+    for (unsigned i = 0; i < tailCallPatchpointScratchCount; ++i) {
+        if (stackPatchArg[i])
+            argsToMove.append({ stackPatchArgSpill[i], fpOffsetToSPOffset(tailCallPatchpointScratchOffsets[i] + newFPOffsetFromFP), WidthPtr });
+    }
 
     std::sort(
         argsToMove.begin(), argsToMove.end(),
@@ -5429,7 +5585,7 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
     // Also pop callee.
     auto newFPOffsetFromSP = fpOffsetToSPOffset(newFPOffsetFromFP);
     ASSERT(newFPOffsetFromSP > 0);
-    ASSERT(WTF::roundUpToMultipleOf<stackAlignmentBytes()>(std::abs(newFPOffsetFromSP)) == static_cast<size_t>(std::abs(newFPOffsetFromSP)));
+    ASSERT(WTF::roundUpToMultipleOf<stackAlignmentBytes()>(std::abs(newFPOffsetFromSP) + sizeof(CallerFrameAndPC)) == static_cast<size_t>(std::abs(newFPOffsetFromSP) + sizeof(CallerFrameAndPC)));
 
     auto newSPAtPrologueOffsetFromSP = newFPOffsetFromSP + prologueStackPointerDelta();
 
@@ -5442,7 +5598,7 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
     jit.move(tmp, MacroAssembler::linkRegister);
     if (WasmOMGIRGeneratorInternal::verboseTailCalls) {
         jit.probeDebugSIMD([] (Probe::Context& context) {
-            dataLogLn("tagged return pc: ", RawHex(context.gpr<uint64_t>(MacroAssembler::linkRegister)));
+            dataLogLn("tagged return pc: ", RawHex(context.gpr<uintptr_t>(MacroAssembler::linkRegister)));
         });
     }
 #if CPU(ARM64E)
@@ -5451,7 +5607,7 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
     jit.untagPtr(tmp, MacroAssembler::linkRegister);
     if (WasmOMGIRGeneratorInternal::verboseTailCalls) {
         jit.probeDebugSIMD([] (Probe::Context& context) {
-            dataLogLn("untagged return pc: ", RawHex(context.gpr<uint64_t>(MacroAssembler::linkRegister)));
+            dataLogLn("untagged return pc: ", RawHex(context.gpr<uintptr_t>(MacroAssembler::linkRegister)));
         });
     }
     jit.validateUntaggedPtr(MacroAssembler::linkRegister);
@@ -5463,7 +5619,7 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
 #if CPU(X86_64)
     if (WasmOMGIRGeneratorInternal::verboseTailCalls) {
         jit.probeDebugSIMD([] (Probe::Context& context) {
-            dataLogLn("return pc on the top of the stack: ", RawHex(*context.gpr<uint64_t*>(MacroAssembler::stackPointerRegister)), " at ", RawHex(context.gpr<uint64_t>(MacroAssembler::stackPointerRegister)));
+            dataLogLn("return pc on the top of the stack: ", RawHex(*context.gpr<uintptr_t*>(MacroAssembler::stackPointerRegister)), " at ", RawHex(context.gpr<uintptr_t>(MacroAssembler::stackPointerRegister)));
         });
     }
 #endif
@@ -5471,31 +5627,33 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
 #if ASSERT_ENABLED
     for (unsigned i = 2; i < 50; ++i) {
         // Everthing after sp might be overwritten anyway.
-        jit.storePtr(MacroAssembler::TrustedImm32(0xBFFF), CCallHelpers::Address(MacroAssembler::stackPointerRegister, -i * sizeof(uint64_t)));
+        jit.storePtr(MacroAssembler::TrustedImm32(0xBFFF), CCallHelpers::Address(MacroAssembler::stackPointerRegister, -i * sizeof(uintptr_t)));
     }
 #endif
 
     JIT_COMMENT(jit, "OK, now we can jump.");
     if (WasmOMGIRGeneratorInternal::verboseTailCalls) {
-        jit.probeDebugSIMD([wasmCalleeInfoAsCallee] (Probe::Context& context) {
-            dataLogLn("Can now jump: FP: ", RawHex(context.gpr<uint64_t>(GPRInfo::callFrameRegister)), " SP: ", RawHex(context.gpr<uint64_t>(MacroAssembler::stackPointerRegister)));
-            auto* newFP = context.gpr<uint64_t*>(MacroAssembler::stackPointerRegister) - prologueStackPointerDelta() / sizeof(uint64_t);
+        jit.probeDebug([wasmCalleeInfoAsCallee] (Probe::Context& context) {
+            dataLogLn("Can now jump: FP: ", RawHex(context.gpr<uintptr_t>(GPRInfo::callFrameRegister)), " SP: ", RawHex(context.gpr<uintptr_t>(MacroAssembler::stackPointerRegister)));
+            auto* newFP = context.gpr<uintptr_t*>(MacroAssembler::stackPointerRegister) - prologueStackPointerDelta() / sizeof(uintptr_t);
             dataLogLn("New (callee) FP at prologue will be at ", RawPointer(newFP));
-            auto fpl = static_cast<uint64_t*>(newFP);
-            auto fpi = reinterpret_cast<uint32_t*>(newFP);
+            auto fpl = std::bit_cast<uint64_t*>(newFP);
+            auto fpi = std::bit_cast<uint32_t*>(newFP);
 
             for (unsigned i = 0; i < wasmCalleeInfoAsCallee.params.size(); ++i) {
                 auto arg = wasmCalleeInfoAsCallee.params[i];
                 auto src = arg.location;
                 dataLog("Arg ", i, " located at ", arg.location, " = ");
-                if (arg.location.isGPR())
+                if (arg.location.isGPR()) {
                     dataLog(context.gpr(arg.location.jsr().payloadGPR()), " / ", (int) context.gpr(arg.location.jsr().payloadGPR()));
-                else if (arg.location.isFPR() && arg.width <= Width::Width64)
-                    dataLog(context.fpr(arg.location.fpr(), SavedFPWidth::SaveVectors));
+                    if (src.jsr().tagGPR())
+                        dataLog(" Upper bits: ", context.gpr(src.jsr().tagGPR()), " / ", (int) context.gpr(src.jsr().tagGPR()));
+                } else if (arg.location.isFPR() && arg.width <= Width::Width64)
+                    dataLog(context.fpr(arg.location.fpr(), SavedFPWidth::DontSaveVectors));
                 else if (arg.location.isFPR())
                     RELEASE_ASSERT_NOT_REACHED();
                 else
-                    dataLog(fpl[src.offsetFromFP() / sizeof(uint64_t)], " / ", fpi[src.offsetFromFP() / sizeof(uint32_t)],  " / ", RawHex(fpi[src.offsetFromFP() / sizeof(uint32_t)]), " / ", std::bit_cast<double>(fpl[src.offsetFromFP() / sizeof(uint64_t)]), " at ", RawPointer(&fpi[src.offsetFromFP() / sizeof(uint32_t)]));
+                    dataLog(fpl[src.offsetFromFP() / sizeof(*fpl)], " / ", fpi[src.offsetFromFP() / sizeof(*fpi)],  " / ", RawHex(fpi[src.offsetFromFP() / sizeof(*fpi)]), " / ", std::bit_cast<double>(fpl[src.offsetFromFP() / sizeof(*fpl)]), " at ", RawPointer(&fpi[src.offsetFromFP() / sizeof(*fpi)]));
                 dataLogLn();
             }
         });
@@ -5506,7 +5664,7 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
 }
 
 // See also: https://leaningtech.com/fantastic-tail-calls-and-how-to-implement-them/, a blog post about contributing this feature.
-auto OMGIRGenerator::createTailCallPatchpoint(BasicBlock* block, CallInformation wasmCallerInfoAsCallee, CallInformation wasmCalleeInfoAsCallee, const ArgumentList& tmpArgSourceLocations, Vector<B3::ConstrainedValue> patchArgs) -> CallPatchpointData
+auto OMGIRGenerator::createTailCallPatchpoint(BasicBlock* block, const TypeDefinition& signature, const CallInformation& wasmCallerInfoAsCallee, const CallInformation& wasmCalleeInfoAsCallee, const ArgumentList& tmpArgSourceLocations, Vector<B3::ConstrainedValue> patchArgs) -> CallPatchpointData
 {
     m_makesTailCalls = true;
     // Our args are placed in argument registers or locals.
@@ -5515,7 +5673,6 @@ auto OMGIRGenerator::createTailCallPatchpoint(BasicBlock* block, CallInformation
     // - Restore and re-sign lr
     // - Restore our caller's FP so that the stack area we write to is always valid
     // - Move stack args from our stack to their final resting spots. Note that they might overlap.
-    // - Move argumentCountIncludingThis (a.k.a. callSiteIndex) to its final spot, since WASM uses it for exceptions.
     // Layout of stack right now, and after this patchpoint.
     //
     //
@@ -5568,28 +5725,31 @@ auto OMGIRGenerator::createTailCallPatchpoint(BasicBlock* block, CallInformation
 #if ASSERT_ENABLED
     for (unsigned i = 0; i < patchArgs.size(); ++i) {
         // We will clobber our stack, so we shouldn't be reading any special extra patch args from it after this point.
-        ASSERT(patchArgs[i].rep().isReg() || patchArgs[i].rep().isConstant());
-        ASSERT(!scratchRegisters.contains(patchArgs[i].rep().reg(), IgnoreVectors));
+        // If we do need a stack arg, we can only save one.
+        ASSERT(patchArgs[i].rep().isReg()
+            || patchArgs[i].rep().isConstant()
+            || (patchArgs[i].rep().isStackArgument() && patchArgs.size() == 1));
+        ASSERT(!patchArgs[i].rep().isReg() || !scratchRegisters.contains(patchArgs[i].rep().reg(), IgnoreVectors));
     }
 #endif
 
     ASSERT(wasmCalleeInfoAsCallee.params.size() == tmpArgSourceLocations.size());
     unsigned firstPatchArg = patchArgs.size();
 
-    for (unsigned i = 0; i < tmpArgSourceLocations.size(); ++i) {
-        auto src = get(block, tmpArgSourceLocations[i]);
-        auto dst = wasmCalleeInfoAsCallee.params[i];
-        ASSERT(dst.location.isStack() || dst.location.isFPR() || dst.location.isGPR());
-        ASSERT(dst.width >= src->resultWidth());
-        if (!dst.location.isStack()) {
+    auto constrainedArgPatchArgs = createCallConstrainedArgs(block, wasmCalleeInfoAsCallee, tmpArgSourceLocations);
+
+    for (unsigned i = 0; i < constrainedArgPatchArgs.size(); ++i) {
+        auto src = constrainedArgPatchArgs[i].value();
+        auto dst = constrainedArgPatchArgs[i].rep();
+        ASSERT(dst.isStack() || dst.isFPR() || dst.isGPR());
+        if (!dst.isStack()) {
             // We will restore callee saves before jumping to the callee.
             // The calling convention should guarantee this anyway, but let's document it just in case.
-            ASSERT_UNUSED(forbiddenArgumentRegisters, !forbiddenArgumentRegisters.contains(dst.location.isGPR() ? Reg(dst.location.jsr().payloadGPR()) : Reg(dst.location.fpr()), IgnoreVectors));
-            patchArgs.append(ConstrainedValue(src, dst));
+            ASSERT_UNUSED(forbiddenArgumentRegisters, !forbiddenArgumentRegisters.contains(dst.isGPR() ? Reg(dst.gpr()) : Reg(dst.fpr()), IgnoreVectors));
+            patchArgs.append(constrainedArgPatchArgs[i]);
             continue;
         }
-        ASSERT(dst.width >= Width64);
-        patchArgs.append(src);
+        patchArgs.append(ConstrainedValue(src, ValueRep::LateColdAny));
     }
     unsigned lastPatchArg = patchArgs.size();
 
@@ -5610,9 +5770,9 @@ auto OMGIRGenerator::createTailCallPatchpoint(BasicBlock* block, CallInformation
     firstPatchArg += m_proc.resultCount(patchpoint->type());
     lastPatchArg += m_proc.resultCount(patchpoint->type());
 
-    auto prepareForCall = createSharedTask<B3::StackmapGeneratorFunction>([wasmCalleeInfoAsCallee, wasmCallerInfoAsCallee, newFPOffsetFromFP, firstPatchArg, lastPatchArg, functionIndex = m_functionIndex](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
+    auto prepareForCall = createSharedTask<B3::StackmapGeneratorFunction>([signature = Ref<const TypeDefinition>(signature), wasmCalleeInfoAsCallee, wasmCallerInfoAsCallee, newFPOffsetFromFP, firstPatchArg, lastPatchArg, functionIndex = m_functionIndex](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
         ASSERT(newFPOffsetFromFP >= 0 || params.code().frameSize() >= static_cast<uint32_t>(-newFPOffsetFromFP));
-        prepareForTailCallImpl(functionIndex, jit, params, wasmCallerInfoAsCallee, wasmCalleeInfoAsCallee, firstPatchArg, lastPatchArg, newFPOffsetFromFP);
+        prepareForTailCallImpl(functionIndex, jit, params, signature, wasmCallerInfoAsCallee, wasmCalleeInfoAsCallee, firstPatchArg, lastPatchArg, newFPOffsetFromFP);
     });
 
     return { patchpoint, nullptr, WTFMove(prepareForCall) };
@@ -5746,12 +5906,15 @@ auto OMGIRGenerator::addCall(FunctionSpaceIndex functionIndexSpace, const TypeDe
     if (isTailCall || isTailCallInlineCaller)
         m_makesTailCalls = true;
 
-    m_proc.requestCallArgAreaSizeInBytes(calleeStackSize);
+    m_proc.requestCallArgAreaSizeInBytes(calleeStackSize + sizeof(Register));
 
     if (m_info.isImportedFunctionFromFunctionIndexSpace(functionIndexSpace)) {
         auto emitCallToImport = [&, this](PatchpointValue* patchpoint, Box<PatchpointExceptionHandle> handle, RefPtr<B3::StackmapGenerator> prepareForCall) -> void {
             unsigned patchArgsIndex = patchpoint->reps().size();
-            patchpoint->append(jumpDestination, ValueRep(GPRInfo::nonPreservedNonArgumentGPR0));
+            if (is32Bit() && isTailCall)
+                patchpoint->append(jumpDestination, ValueRep::stackArgument(0));
+            else
+                patchpoint->append(jumpDestination, ValueRep(GPRInfo::nonPreservedNonArgumentGPR0));
             // We need to clobber all potential pinned registers since we might be leaving the instance.
             // We pessimistically assume we could be calling to something that is bounds checking.
             // FIXME: We shouldn't have to do this: https://bugs.webkit.org/show_bug.cgi?id=172181
@@ -5761,10 +5924,24 @@ auto OMGIRGenerator::addCall(FunctionSpaceIndex functionIndexSpace, const TypeDe
                 AllowMacroScratchRegisterUsage allowScratch(jit);
                 if (prepareForCall)
                     prepareForCall->run(jit, params);
+                ASSERT(!isTailCall || !handle);
                 if (handle)
                     handle->generate(jit, params, this);
-                if (isTailCall)
-                    jit.farJump(params[patchArgsIndex].gpr(), WasmEntryPtrTag);
+                if (isTailCall) {
+                    GPRReg callTarget;
+                    if (is32Bit() && params[patchArgsIndex].isStack()) {
+                        callTarget = MacroAssembler::addressTempRegister;
+                        jit.loadPtr(CCallHelpers::Address(MacroAssembler::stackPointerRegister,
+                            tailCallPatchpointScratchOffsets[0] - sizeof(CallerFrameAndPC)), callTarget);
+                    } else
+                        callTarget = params[patchArgsIndex].gpr();
+                    if (WasmOMGIRGeneratorInternal::verboseTailCalls) {
+                        jit.probeDebug([callTarget] (Probe::Context& context) {
+                            dataLogLn("Can now jump: ", RawHex(context.gpr<uintptr_t>(callTarget)));
+                        });
+                    }
+                    jit.farJump(callTarget, WasmEntryPtrTag);
+                }
                 else {
                     jit.call(params[patchArgsIndex].gpr(), WasmEntryPtrTag);
                     // Restore the stack pointer since it may have been lowered if our callee did a tail call.
@@ -5782,7 +5959,7 @@ auto OMGIRGenerator::addCall(FunctionSpaceIndex functionIndexSpace, const TypeDe
         jumpDestination = append<MemoryValue>(heapImports(), m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfImportFunctionStub(functionIndexSpace)));
 
         if (isTailCall) {
-            auto [patchpoint, handle, prepareForCall] = createTailCallPatchpoint(m_currentBlock, wasmCallerInfoAsCallee, wasmCalleeInfoAsCallee, args, { });
+            auto [patchpoint, handle, prepareForCall] = createTailCallPatchpoint(m_currentBlock, signature, wasmCallerInfoAsCallee, wasmCalleeInfoAsCallee, args, { });
             emitCallToImport(patchpoint, handle, prepareForCall);
             return { };
         }
@@ -5828,7 +6005,7 @@ auto OMGIRGenerator::addCall(FunctionSpaceIndex functionIndexSpace, const TypeDe
     };
 
     if (isTailCall) {
-        auto [patchpoint, handle, prepareForCall] = createTailCallPatchpoint(m_currentBlock, wasmCallerInfoAsCallee, wasmCalleeInfoAsCallee, args, { });
+        auto [patchpoint, handle, prepareForCall] = createTailCallPatchpoint(m_currentBlock, signature, wasmCallerInfoAsCallee, wasmCalleeInfoAsCallee, args, { });
         emitUnlinkedWasmToWasmCall(patchpoint, handle, prepareForCall);
         return { };
     }


### PR DESCRIPTION
#### da8e66a4fd1c8a97a7e7ec9b02c07cfb3dbb7c6d
<pre>
[ARMv7] Implement OMG tail calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=282870">https://bugs.webkit.org/show_bug.cgi?id=282870</a>

Reviewed by David Degazio.

Implement OMG tail calls. The big difference from 64-bit is that Int64
args (but not double args) need to be split when entering into the patchpoint.

We also have no non-callee-save registers to pass into the tail call patchpoint,
so we re-purpose some unused slots on the stack.

We also fix a handfull of simple build issues.

* JSTests/wasm/stress/tail-call-simple-i64.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.call_same_size.export.string_appeared_here.result.i64.i64.const.600000001337.return_call.callee_same_size.func.callee_same_size.param.i.i64.result.i64.i64.add.local.i.i64.const.42.func.call_same_size_with_stack.export.string_appeared_here.param.i0.i64.param.i1.i64.param.i2.i64.param.i3.i64.param.i4.i64.param.i5.i64.param.i6.i64.param.i7.i64.param.i8.i64.param.i9.i64.result.i64.i64.const.600000001337.i64.const.1.i64.const.2.i64.const.3.i64.const.4.i64.const.5.i64.const.6.i64.const.7.i64.const.8.i64.const.40000000009.return_call.callee_same_size_with_stack.func.callee_same_size_with_stack.param.i0.i64.param.i1.i64.param.i2.i64.param.i3.i64.param.i4.i64.param.i5.i64.param.i6.i64.param.i7.i64.param.i8.i64.param.i9.i64.result.i64.i64.add.local.i9.local.i2.func.call_bigger_with_stack.export.string_appeared_here.result.i64.i64.const.600000001337.i64.const.1.i64.const.2.i64.const.3.i64.const.4.i64.const.5.i64.const.6.i64.const.7.i64.const.8.i64.const.500000000090.return_call.callee_bigger_with_stack.func.callee_bigger_with_stack.param.i0.i64.param.i1.i64.param.i2.i64.param.i3.i64.param.i4.i64.param.i5.i64.param.i6.i64.param.i7.i64.param.i8.i64.param.i9.i64.result.i64.i64.add.local.i9.local.i2.func.call_smaller_with_stack.export.string_appeared_here.param.i0.i64.param.i1.i64.param.i2.i64.param.i3.i64.param.i4.i64.param.i5.i64.param.i6.i64.param.i7.i64.param.i8.i64.param.i9.i64.param.i10.i64.param.i11.i64.result.i64.i64.const.600000001337.i64.const.1.i64.const.2.i64.const.3.i64.const.4.i64.const.5.i64.const.6.i64.const.7.i64.const.8.i64.const.500000000090.return_call.callee_smaller_with_stack.func.callee_smaller_with_stack.param.i0.i64.param.i1.i64.param.i2.i64.param.i3.i64.param.i4.i64.param.i5.i64.param.i6.i64.param.i7.i64.param.i8.i64.param.i9.i64.result.i64.i64.add.local.i9.local.i2.let.badArgs.new.Array.12.fill.0xAAAAn.async test):
* Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h:
(JSC::MacroAssemblerARMv7::transfer64):
* Source/JavaScriptCore/jit/Width.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::addArguments):
(JSC::Wasm::OMGIRGenerator::emitIndirectCall):
(JSC::Wasm::OMGIRGenerator::createCallConstrainedArgs):
(JSC::Wasm::OMGIRGenerator::createCallPatchpoint):
(JSC::Wasm::prepareForTailCallImpl):
(JSC::Wasm::OMGIRGenerator::createTailCallPatchpoint):

Canonical link: <a href="https://commits.webkit.org/287649@main">https://commits.webkit.org/287649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8eda977db7786d00ead0d5d04448f9010041b01d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83208 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29812 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61528 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19445 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51536 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69789 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41839 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48882 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25369 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28149 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71693 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69982 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84574 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77784 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4049 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69752 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6073 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69006 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17523 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13023 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11469 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/100093 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5859 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21864 "Found 2 new JSC stress test failures: stress/json-stringify-inspector-check.js.no-llint, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5847 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9281 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7634 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->