### PR TITLE
Cloning capture MediaStreamTrack should preserve muted/interrupted flags

### DIFF
--- a/LayoutTests/fast/mediastream/mediastreamtrack-clone-muted-expected.txt
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-clone-muted-expected.txt
@@ -1,0 +1,7 @@
+
+
+PASS Video clone during interruption
+PASS Video clone during muting
+PASS Audio clone during interruption
+PASS Audio clone during muting
+

--- a/LayoutTests/fast/mediastream/mediastreamtrack-clone-muted.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-clone-muted.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+    <video id=video autoplay playsinline></video>
+    <script>
+promise_test(async (t) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    const track = stream.getTracks()[0];
+
+    if (!window.testRunner)
+        return;
+
+    testRunner.setMockCaptureDevicesInterrupted(true, false);
+
+    await new Promise(resolve => track.onmute = resolve);
+
+    const cloneTrack = track.clone();
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    assert_true(track.muted, "track muted");
+    assert_true(cloneTrack.muted, "cloneTrack muted");
+
+    testRunner.setMockCaptureDevicesInterrupted(false, false);
+
+    await new Promise(resolve => track.onunmute = resolve);
+    if (cloneTrack.muted)
+        await new Promise(resolve => cloneTrack.onunmute = resolve);
+
+    video.srcObject = new MediaStream([cloneTrack]);
+    await video.play();
+    video.srcObject = null;
+}, "Video clone during interruption");
+
+promise_test(async (t) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    const track = stream.getTracks()[0];
+
+    if (!window.internals)
+        return;
+
+    internals.setPageMuted("capturedevices");
+
+    await new Promise(resolve => track.onmute = resolve);
+
+    const cloneTrack = track.clone();
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    assert_true(track.muted, "track muted");
+    assert_true(cloneTrack.muted, "cloneTrack muted");
+
+    internals.setPageMuted("");
+
+    await new Promise(resolve => track.onunmute = resolve);
+    if (cloneTrack.muted)
+        await new Promise(resolve => cloneTrack.onunmute = resolve);
+
+    video.srcObject = new MediaStream([cloneTrack]);
+    await video.play();
+    video.srcObject = null;
+}, "Video clone during muting");
+
+promise_test(async (t) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const track = stream.getTracks()[0];
+
+    if (!window.testRunner)
+        return;
+
+    testRunner.setMockCaptureDevicesInterrupted(false, true);
+
+    await new Promise(resolve => track.onmute = resolve);
+
+    const cloneTrack = track.clone();
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    assert_true(track.muted, "track muted");
+    assert_true(cloneTrack.muted, "cloneTrack muted");
+
+    testRunner.setMockCaptureDevicesInterrupted(false, false);
+
+    await new Promise(resolve => track.onunmute = resolve);
+    if (cloneTrack.muted)
+        await new Promise(resolve => cloneTrack.onunmute = resolve);
+
+
+    video.srcObject = new MediaStream([cloneTrack]);
+    await video.play();
+    video.srcObject = null;
+}, "Audio clone during interruption");
+
+promise_test(async (t) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const track = stream.getTracks()[0];
+
+    if (!window.internals)
+        return;
+
+    internals.setPageMuted("capturedevices");
+
+    await new Promise(resolve => track.onmute = resolve);
+
+    const cloneTrack = track.clone();
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    assert_true(track.muted, "track muted");
+    assert_true(cloneTrack.muted, "cloneTrack muted");
+
+    internals.setPageMuted("");
+
+    await new Promise(resolve => track.onunmute = resolve);
+    if (cloneTrack.muted)
+        await new Promise(resolve => cloneTrack.onunmute = resolve);
+
+    video.srcObject = new MediaStream([cloneTrack]);
+    await video.play();
+    video.srcObject = null;
+}, "Audio clone during muting");
+
+    </script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2460,6 +2460,9 @@ http/tests/webrtc/muted-video-mediastream-invisible-autoplay.html [ Failure Time
 
 webkit.org/b/280117 webrtc/audio-muted-stats.html [ Failure ]
 
+# Crashing since introduced
+fast/mediastream/mediastreamtrack-clone-muted.html [ Skip ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of WebRTC-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -493,7 +493,7 @@ Ref<MediaStreamTrackPrivate> MediaStreamTrackPrivate::clone()
     clonedMediaStreamTrackPrivate->m_captureDidFail = this->m_captureDidFail;
     clonedMediaStreamTrackPrivate->updateReadyState();
 
-    if (m_isProducingData)
+    if (m_isProducingData && !m_isMuted && !m_isInterrupted)
         clonedMediaStreamTrackPrivate->startProducingData();
 
     return clonedMediaStreamTrackPrivate;

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
@@ -98,7 +98,12 @@ void RemoteRealtimeMediaSourceProxy::createRemoteMediaSource(const MediaDeviceHa
 
 RemoteRealtimeMediaSourceProxy RemoteRealtimeMediaSourceProxy::clone()
 {
-    return { RealtimeMediaSourceIdentifier::generate(), m_device, m_shouldCaptureInGPUProcess, &m_constraints };
+    RemoteRealtimeMediaSourceProxy clone = { RealtimeMediaSourceIdentifier::generate(), m_device, m_shouldCaptureInGPUProcess, &m_constraints };
+
+    clone.m_interrupted = m_interrupted;
+    clone.m_isEnded = m_isEnded;
+
+    return clone;
 }
 
 void RemoteRealtimeMediaSourceProxy::createRemoteCloneSource(WebCore::RealtimeMediaSourceIdentifier cloneIdentifier, WebCore::PageIdentifier pageIdentifier)

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
@@ -82,6 +82,7 @@ Ref<RealtimeMediaSource> RemoteRealtimeVideoSource::clone()
         clone->m_registerOwnerCallback = m_registerOwnerCallback;
         clone->setSettings(RealtimeMediaSourceSettings { settings() });
         clone->setCapabilities(RealtimeMediaSourceCapabilities { capabilities() });
+        clone->setMuted(muted());
 
         manager().addSource(*clone);
         manager().remoteCaptureSampleManager().addSource(*clone);


### PR DESCRIPTION
#### 782d2a89a9b1338e940e13a4d16340ef973ee168
<pre>
Cloning capture MediaStreamTrack should preserve muted/interrupted flags
<a href="https://rdar.apple.com/139563413">rdar://139563413</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=282874">https://bugs.webkit.org/show_bug.cgi?id=282874</a>

Reviewed by Eric Carlson.

When cloning a track, we would ask the source to start producing data if the track producing data flag is set.
This is incorrect when the source is muted/interrupted, as the source producing data flag in that case is false but the track flag is true.
We should probably rename MediaStreamTrackPrivate::m_isProducingData in a follow-up.

Also, for video source clones, we would not copy the muted/interrupted states, which would make the MediaStreamTrackPrivate and its source out of sync.

Covered by added test.

* LayoutTests/fast/mediastream/mediastreamtrack-clone-muted-expected.txt: Added.
* LayoutTests/fast/mediastream/mediastreamtrack-clone-muted.html: Added.
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp:
(WebCore::MediaStreamTrackPrivate::clone):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp:
(WebKit::RemoteRealtimeMediaSourceProxy::clone):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp:
(WebKit::RemoteRealtimeVideoSource::clone):

Canonical link: <a href="https://commits.webkit.org/286477@main">https://commits.webkit.org/286477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b76278e36699bcfd6cd0ed01b0b040f1314a16dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80353 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27122 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59480 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17640 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65148 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39840 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46753 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22631 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25449 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67868 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81817 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3225 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2025 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67709 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3379 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65116 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67015 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16748 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10957 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9083 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3175 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5981 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3196 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4134 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3203 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->