### PR TITLE
Unreviewed build fix for Windows Debug builds after 286366@main

### DIFF
--- a/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
+++ b/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
@@ -115,8 +115,8 @@ void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNoti
     // negate the AXID so we know that the caller is passing the ID of an
     // element, not the index of a child element.
 
-    ASSERT(object.objectID()->toUInt64() >= 1);
-    ASSERT(object.objectID()->toUInt64() <= std::numeric_limits<LONG>::max());
+    ASSERT(object.objectID().toUInt64() >= 1);
+    ASSERT(object.objectID().toUInt64() <= std::numeric_limits<LONG>::max());
 
     auto objectID = object.objectID();
     NotifyWinEvent(msaaEvent, page->chrome().platformPageClient(), OBJID_CLIENT, -static_cast<LONG>(objectID.toUInt64()));


### PR DESCRIPTION
#### 5ac097a2fd2b5e9363ec7156b1984f101b499add
<pre>
Unreviewed build fix for Windows Debug builds after 286366@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=282788">https://bugs.webkit.org/show_bug.cgi?id=282788</a>

&gt; Source\WebCore\accessibility\win\AXObjectCacheWin.cpp(118,29): error: member reference type &apos;AXID&apos; (aka &apos;ObjectIdentifierGeneric&lt;WebCore::AXIDType, ObjectIdentifierMainThreadAccessTraits&lt;unsigned long long&gt;, unsigned long long&gt;&apos;) is not a pointer; did you mean to use &apos;.&apos;?
&gt;   118 |     ASSERT(object.objectID()-&gt;toUInt64() &gt;= 1);
&gt;       |            ~~~~~~~~~~~~~~~~~^~

* Source/WebCore/accessibility/win/AXObjectCacheWin.cpp:
(WebCore::AXObjectCache::postPlatformNotification):

Canonical link: <a href="https://commits.webkit.org/286376@main">https://commits.webkit.org/286376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbf33c1503517aa122eaa78e11c864411535a203

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80352 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27121 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59479 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17638 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65147 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39839 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46751 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22630 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25448 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67866 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81816 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3224 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67708 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65115 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67014 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10956 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9082 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11717 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3174 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5980 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3195 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4133 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3202 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->