### PR TITLE
AX: Two new AccessibilitySpinButtonParts are created and never cleaned up for every clearChildren-addChildren cycle of AccessibilitySpinButton, causing a memory leak

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -29,5 +29,11 @@ accessibility/element-reflection-ariaactivedescendant.html [ Failure ]
 # Used to be a timeout until https://github.com/WebKit/WebKit/commit/c69e4c0caaf5368db791652eee3a057ed2751144, now is a text failure.
 accessibility/frame-disconnect-textmarker-cache-crash.html [ Failure ]
 
+# Crashes
+accessibility/mac/apple-pay-labels.html  [ Crash ]
+
+# Flaky timeouts
+accessibility/datetime/input-date-field-labels-and-value-changes.html [ Pass Timeout ]
+
 # When ENABLE(AX_THREAD_TEXT_APIS) is on by default, un-comment this.
 # accessibility/ax-thread-text-apis [ Pass ]

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -470,7 +470,6 @@ accessibility/AccessibilitySVGObject.cpp
 accessibility/AccessibilitySVGRoot.cpp
 accessibility/AccessibilityScrollView.cpp
 accessibility/AccessibilitySlider.cpp
-accessibility/AccessibilitySpinButton.cpp
 accessibility/AccessibilityTable.cpp
 accessibility/AccessibilityTableCell.cpp
 accessibility/AccessibilityTableColumn.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -575,6 +575,7 @@ accessibility/AccessibilityScrollView.cpp
 accessibility/AccessibilityScrollbar.cpp
 accessibility/AccessibilitySlider.cpp
 accessibility/AccessibilitySpinButton.cpp
+accessibility/AccessibilitySpinButtonPart.cpp
 accessibility/AccessibilityTable.cpp
 accessibility/AccessibilityTableCell.cpp
 accessibility/AccessibilityTableColumn.cpp

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1107,7 +1107,7 @@ AccessibilityObject* AXObjectCache::create(AccessibilityRole role)
         object = AccessibilityMenuListPopup::create(generateNewObjectID());
         break;
     case AccessibilityRole::SpinButton:
-        object = AccessibilitySpinButton::create(generateNewObjectID());
+        object = AccessibilitySpinButton::create(generateNewObjectID(), *this);
         break;
     case AccessibilityRole::SpinButtonPart:
         object = AccessibilitySpinButtonPart::create(generateNewObjectID());

--- a/Source/WebCore/accessibility/AccessibilitySpinButton.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySpinButton.cpp
@@ -31,125 +31,71 @@
 
 namespace WebCore {
 
-Ref<AccessibilitySpinButton> AccessibilitySpinButton::create(AXID axID)
+Ref<AccessibilitySpinButton> AccessibilitySpinButton::create(AXID axID, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilitySpinButton(axID));
+    return adoptRef(*new AccessibilitySpinButton(axID, cache));
 }
     
-AccessibilitySpinButton::AccessibilitySpinButton(AXID axID)
+AccessibilitySpinButton::AccessibilitySpinButton(AXID axID, AXObjectCache& cache)
     : AccessibilityMockObject(axID)
     , m_spinButtonElement(nullptr)
+    , m_incrementor(downcast<AccessibilitySpinButtonPart>(*cache.create(AccessibilityRole::SpinButtonPart)))
+    , m_decrementor(downcast<AccessibilitySpinButtonPart>(*cache.create(AccessibilityRole::SpinButtonPart)))
 {
+    m_incrementor->setIsIncrementor(true);
+    m_incrementor->setParent(this);
+
+    m_decrementor->setIsIncrementor(false);
+    m_decrementor->setParent(this);
+
+    addChild(m_incrementor.ptr());
+    addChild(m_decrementor.ptr());
+    m_childrenInitialized = true;
 }
 
 AccessibilitySpinButton::~AccessibilitySpinButton() = default;
     
 AXCoreObject* AccessibilitySpinButton::incrementButton()
 {
-    if (!m_childrenInitialized)
-        addChildren();
-    if (!m_childrenInitialized)
-        return nullptr;
-
-    ASSERT(m_children.size() == 2);
-
+    ASSERT(m_childrenInitialized);
+    RELEASE_ASSERT(m_children.size() == 2);
     return m_children[0].get();
 }
    
 AXCoreObject* AccessibilitySpinButton::decrementButton()
 {
-    if (!m_childrenInitialized)
-        addChildren();
-    if (!m_childrenInitialized)
-        return nullptr;
-    
-    ASSERT(m_children.size() == 2);
-    
-    return m_children[1].get();    
+    ASSERT(m_childrenInitialized);
+    RELEASE_ASSERT(m_children.size() == 2);
+    return m_children[1].get();
 }
     
 LayoutRect AccessibilitySpinButton::elementRect() const
 {
     ASSERT(m_spinButtonElement);
     
-    if (!m_spinButtonElement || !m_spinButtonElement->renderer())
-        return LayoutRect();
-    
-    Vector<FloatQuad> quads;
-    m_spinButtonElement->renderer()->absoluteFocusRingQuads(quads);
+    CheckedPtr renderer = m_spinButtonElement ? m_spinButtonElement->renderer() : nullptr;
+    if (!renderer)
+        return { };
 
-    return boundingBoxForQuads(m_spinButtonElement->renderer(), quads);
+    Vector<FloatQuad> quads;
+    renderer->absoluteFocusRingQuads(quads);
+    return boundingBoxForQuads(renderer.get(), quads);
 }
 
 void AccessibilitySpinButton::addChildren()
 {
-    AXObjectCache* cache = axObjectCache();
-    if (!cache)
-        return;
-    
-    m_childrenInitialized = true;
-    
-    auto& incrementor = downcast<AccessibilitySpinButtonPart>(*cache->create(AccessibilityRole::SpinButtonPart));
-    incrementor.setIsIncrementor(true);
-    incrementor.setParent(this);
-    addChild(&incrementor);
-
-    auto& decrementor = downcast<AccessibilitySpinButtonPart>(*cache->create(AccessibilityRole::SpinButtonPart));
-    decrementor.setIsIncrementor(false);
-    decrementor.setParent(this);
-    addChild(&decrementor);
+    // This class sets its children once in the constructor, and should never
+    // have dirty or uninitialized children afterwards.
+    ASSERT(m_childrenInitialized);
+    ASSERT(!m_subtreeDirty);
+    ASSERT(!m_childrenDirty);
 }
     
 void AccessibilitySpinButton::step(int amount)
 {
     ASSERT(m_spinButtonElement);
-    if (!m_spinButtonElement)
-        return;
-    
-    m_spinButtonElement->step(amount);
-}
-
-// AccessibilitySpinButtonPart 
-
-AccessibilitySpinButtonPart::AccessibilitySpinButtonPart(AXID axID)
-    : AccessibilityMockObject(axID)
-    , m_isIncrementor(false)
-{
-}
-    
-Ref<AccessibilitySpinButtonPart> AccessibilitySpinButtonPart::create(AXID axID)
-{
-    return adoptRef(*new AccessibilitySpinButtonPart(axID));
-}
-
-LayoutRect AccessibilitySpinButtonPart::elementRect() const
-{
-    // FIXME: This logic should exist in the render tree or elsewhere, but there is no
-    // relationship that exists that can be queried.
-    
-    LayoutRect parentRect = parentObject()->elementRect();
-    if (m_isIncrementor)
-        parentRect.setHeight(parentRect.height() / 2);
-    else {
-        parentRect.setY(parentRect.y() + parentRect.height() / 2);        
-        parentRect.setHeight(parentRect.height() / 2);        
-    }
-        
-    return parentRect;
-}
-
-bool AccessibilitySpinButtonPart::press()
-{
-    auto* spinButton = dynamicDowncast<AccessibilitySpinButton>(m_parent.get());
-    if (!spinButton)
-        return false;
-
-    if (m_isIncrementor)
-        spinButton->step(1);
-    else
-        spinButton->step(-1);
-
-    return true;
+    if (m_spinButtonElement)
+        m_spinButtonElement->step(amount);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilitySpinButton.h
+++ b/Source/WebCore/accessibility/AccessibilitySpinButton.h
@@ -26,58 +26,40 @@
 #pragma once
 
 #include "AccessibilityMockObject.h"
+#include "AccessibilitySpinButtonPart.h"
 #include "SpinButtonElement.h"
 
 namespace WebCore {
 
+// Currently only represents native spinbuttons (i.e. <input type="number">) and not role="spinbutton" elements.
 class AccessibilitySpinButton final : public AccessibilityMockObject {
 public:
-    static Ref<AccessibilitySpinButton> create(AXID);
+    static Ref<AccessibilitySpinButton> create(AXID, AXObjectCache&);
     virtual ~AccessibilitySpinButton();
 
     void setSpinButtonElement(SpinButtonElement* spinButton) { m_spinButtonElement = spinButton; }
 
-    AXCoreObject* incrementButton() override;
-    AXCoreObject* decrementButton() override;
+    AXCoreObject* incrementButton() final;
+    AXCoreObject* decrementButton() final;
 
     void step(int amount);
 
 private:
-    explicit AccessibilitySpinButton(AXID);
+    explicit AccessibilitySpinButton(AXID, AXObjectCache&);
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::SpinButton; }
     bool isNativeSpinButton() const override { return true; }
-    void addChildren() override;
+    void clearChildren() final { };
+    void addChildren() final;
     LayoutRect elementRect() const override;
 
     WeakPtr<SpinButtonElement, WeakPtrImplWithEventTargetData> m_spinButtonElement;
-}; 
-
-class AccessibilitySpinButtonPart final : public AccessibilityMockObject {
-public:
-    static Ref<AccessibilitySpinButtonPart> create(AXID);
-    virtual ~AccessibilitySpinButtonPart() = default;
-
-    bool isIncrementor() const override { return m_isIncrementor; }
-    void setIsIncrementor(bool value) { m_isIncrementor = value; }
-
-private:
-    explicit AccessibilitySpinButtonPart(AXID);
-
-    bool press() override;
-    AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::SpinButtonPart; }
-    bool isSpinButtonPart() const override { return true; }
-    LayoutRect elementRect() const override;
-
-    bool m_isIncrementor { true };
+    Ref<AccessibilitySpinButtonPart> m_incrementor;
+    Ref<AccessibilitySpinButtonPart> m_decrementor;
 };
 
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AccessibilitySpinButton) \
     static bool isType(const WebCore::AccessibilityObject& object) { return object.isNativeSpinButton(); } \
-SPECIALIZE_TYPE_TRAITS_END()
-
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AccessibilitySpinButtonPart) \
-    static bool isType(const WebCore::AccessibilityObject& object) { return object.isSpinButtonPart(); } \
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/accessibility/AccessibilitySpinButtonPart.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySpinButtonPart.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AccessibilitySpinButtonPart.h"
+
+#include "AccessibilitySpinButton.h"
+
+namespace WebCore {
+
+AccessibilitySpinButtonPart::AccessibilitySpinButtonPart(AXID axID)
+    : AccessibilityMockObject(axID)
+    , m_isIncrementor(false)
+{
+}
+
+Ref<AccessibilitySpinButtonPart> AccessibilitySpinButtonPart::create(AXID axID)
+{
+    return adoptRef(*new AccessibilitySpinButtonPart(axID));
+}
+
+LayoutRect AccessibilitySpinButtonPart::elementRect() const
+{
+    // FIXME: This logic should exist in the render tree or elsewhere, but there is no
+    // relationship that exists that can be queried.
+
+    RefPtr parent = parentObject();
+    if (!parent)
+        return { };
+
+    LayoutRect parentRect = parent->elementRect();
+    if (m_isIncrementor)
+        parentRect.setHeight(parentRect.height() / 2);
+    else {
+        parentRect.setY(parentRect.y() + parentRect.height() / 2);
+        parentRect.setHeight(parentRect.height() / 2);
+    }
+
+    return parentRect;
+}
+
+bool AccessibilitySpinButtonPart::press()
+{
+    RefPtr spinButton = dynamicDowncast<AccessibilitySpinButton>(m_parent.get());
+    if (!spinButton)
+        return false;
+
+    if (m_isIncrementor)
+        spinButton->step(1);
+    else
+        spinButton->step(-1);
+
+    return true;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilitySpinButtonPart.h
+++ b/Source/WebCore/accessibility/AccessibilitySpinButtonPart.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "AccessibilityMockObject.h"
+
+namespace WebCore {
+
+class AccessibilitySpinButtonPart final : public AccessibilityMockObject {
+public:
+    static Ref<AccessibilitySpinButtonPart> create(AXID);
+    virtual ~AccessibilitySpinButtonPart() = default;
+
+    bool isIncrementor() const final { return m_isIncrementor; }
+    void setIsIncrementor(bool value) { m_isIncrementor = value; }
+
+private:
+    explicit AccessibilitySpinButtonPart(AXID);
+
+    bool press() final;
+    AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::SpinButtonPart; }
+    bool isSpinButtonPart() const final { return true; }
+    LayoutRect elementRect() const final;
+
+    bool m_isIncrementor { true };
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AccessibilitySpinButtonPart) \
+    static bool isType(const WebCore::AccessibilityObject& object) { return object.isSpinButtonPart(); } \
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -297,7 +297,6 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
     }
 
     if (object.isSpinButton()) {
-        // FIXME: These properties get out of date every time AccessibilitySpinButton::{clearChildren, addChildren} is called. We should probably just not cache these properties.
         setObjectProperty(AXPropertyName::DecrementButton, object.decrementButton());
         setObjectProperty(AXPropertyName::IncrementButton, object.incrementButton());
     }


### PR DESCRIPTION
#### a4221ebed1c01347b5862a53f4f0ab5d303058b6
<pre>
AX: Two new AccessibilitySpinButtonParts are created and never cleaned up for every clearChildren-addChildren cycle of AccessibilitySpinButton, causing a memory leak
<a href="https://bugs.webkit.org/show_bug.cgi?id=282879">https://bugs.webkit.org/show_bug.cgi?id=282879</a>
<a href="https://rdar.apple.com/139572476">rdar://139572476</a>

Reviewed by Chris Fleizach.

Prior to this commit, every time an AccessibilitySpinButton calls clearChildren() and addChildren(), we would create
two brand new AccessibilitySpinButtonPart objects with associated object wrappers, without cleaning up the spin button
parts or wrappers from the last cycle, leaking them.

With this commit, we now create the increment and decrementer spin button parts up-front in the AccessibilitySpinButton
constructor, and maintain them between clearChildren-addChildren cycles. This is also better because it keeps UI elements
more stable for ATs, i.e. we are no longer at risk of sending a notification with a spin button part, then calling
clearChildren, effectively detaching the spin button part the AT has a reference to, making it useless.

This commit also includes unrelated changes to garden some test expectations for ITM.

* LayoutTests/accessibility-isolated-tree/TestExpectations:
* Source/WTF/wtf/PlatformEnable.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::create):
* Source/WebCore/accessibility/AccessibilitySpinButton.cpp:
(WebCore::AccessibilitySpinButton::create):
(WebCore::AccessibilitySpinButton::AccessibilitySpinButton):
(WebCore::AccessibilitySpinButton::incrementButton):
(WebCore::AccessibilitySpinButton::decrementButton):
(WebCore::AccessibilitySpinButton::elementRect const):
(WebCore::AccessibilitySpinButton::addChildren):
(WebCore::AccessibilitySpinButton::step):
(WebCore::AccessibilitySpinButtonPart::AccessibilitySpinButtonPart): Deleted.
(WebCore::AccessibilitySpinButtonPart::create): Deleted.
(WebCore::AccessibilitySpinButtonPart::elementRect const): Deleted.
(WebCore::AccessibilitySpinButtonPart::press): Deleted.
* Source/WebCore/accessibility/AccessibilitySpinButton.h:
* Source/WebCore/accessibility/AccessibilitySpinButtonPart.cpp: Added.
(WebCore::AccessibilitySpinButtonPart::AccessibilitySpinButtonPart):
(WebCore::AccessibilitySpinButtonPart::create):
(WebCore::AccessibilitySpinButtonPart::elementRect const):
(WebCore::AccessibilitySpinButtonPart::press):
* Source/WebCore/accessibility/AccessibilitySpinButtonPart.h: Added.
(isType):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):

Canonical link: <a href="https://commits.webkit.org/286453@main">https://commits.webkit.org/286453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27a5268e1f9117e81c86f24b6b862f66f693b5cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80382 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27151 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78001 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3208 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59501 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17659 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78952 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65172 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39861 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46778 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22655 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25478 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67893 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81846 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3254 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2052 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67728 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3408 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65140 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67035 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16732 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10978 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9106 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3204 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6010 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3225 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4163 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3232 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->