### PR TITLE
Radial gradients stopping at 100% are broken

### DIFF
--- a/LayoutTests/fast/gradients/radial-two-stops-at-one-expected.html
+++ b/LayoutTests/fast/gradients/radial-two-stops-at-one-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        div {
+            margin: 10px;
+            width: 300px;
+            height: 300px;
+        }
+
+        .radial {
+            background: radial-gradient(farthest-side at 0 0, transparent 99.99999%, green 100%);
+        }
+    </style>
+</head>
+<body>
+    <p>You should see some green below</p>
+    <div class="radial"></div>
+</body>
+</html>

--- a/LayoutTests/fast/gradients/radial-two-stops-at-one.html
+++ b/LayoutTests/fast/gradients/radial-two-stops-at-one.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-100" />
+    <style>
+        div {
+            margin: 10px;
+            width: 300px;
+            height: 300px;
+        }
+
+        .radial {
+            background: radial-gradient(farthest-side at 0 0, transparent 100%, green 100.001%);
+        }
+    </style>
+</head>
+<body>
+    <p>You should see some green below</p>
+    <div class="radial"></div>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -572,8 +572,8 @@ void FillRectWithGradient::apply(GraphicsContext& context) const
 
 void FillRectWithGradient::dump(TextStream& ts, OptionSet<AsTextFlag>) const
 {
-    // FIXME: log gradient.
     ts.dumpProperty("rect", rect());
+    ts.dumpProperty("gradient", m_gradient);
 }
 
 FillRectWithGradientAndSpaceTransform::FillRectWithGradientAndSpaceTransform(const FloatRect& rect, Gradient& gradient, const AffineTransform& gradientSpaceTransform, GraphicsContext::RequiresClipToRect requiresClipToRect)


### PR DESCRIPTION
#### 737f793f8647abfcc27f5b392da5ac955dd10fef
<pre>
Radial gradients stopping at 100% are broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=282584">https://bugs.webkit.org/show_bug.cgi?id=282584</a>
<a href="https://rdar.apple.com/139369366">rdar://139369366</a>

Reviewed by Sam Weinig.

If a gradient has two color stops at 100%, CoreGraphics has a bug where the last
color fails to extend; this is visible in radial gradients.

Work around this by replicating the last color stop.

* LayoutTests/fast/gradients/radial-two-stops-at-one-expected.html: Added.
* LayoutTests/fast/gradients/radial-two-stops-at-one.html: Added.
* Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp:
(WebCore::GradientRendererCG::makeGradient const):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::FillRectWithGradient::dump const):

Canonical link: <a href="https://commits.webkit.org/286413@main">https://commits.webkit.org/286413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8043161d653abbfce8d83badb6fb24a3412d489

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80419 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27188 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3245 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59528 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17689 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49409 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65204 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39888 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46809 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22688 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25515 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67924 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23025 "Found 1 new test failure: media/media-vp8-webm-with-poster.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81883 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3291 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2084 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67759 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3445 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67068 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16710 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11013 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9138 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3241 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6047 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3262 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4200 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->