### PR TITLE
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in URL.cpp & URLHelpers.cpp

### DIFF
--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -37,8 +37,6 @@
 #include <wtf/IteratorRange.h>
 #include <wtf/text/WTFString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 namespace URLHelpers {
 
@@ -54,7 +52,7 @@ constexpr unsigned urlBytesBufferLength = 2048;
 constexpr auto scriptCodeLimit = static_cast<UScriptCode>(255);
 
 
-static uint32_t allowedIDNScriptBits[(scriptCodeLimit + 31) / 32];
+static std::array<uint32_t, (scriptCodeLimit + 31) / 32> allowedIDNScriptBits;
 
 #if !PLATFORM(COCOA)
 
@@ -454,8 +452,8 @@ static inline bool isSecondLevelDomainNameAllowedByTLDRules(std::span<const UCha
 
 #define CHECK_RULES_IF_SUFFIX_MATCHES(suffix, function) \
     { \
-        static const int32_t suffixLength = sizeof(suffix) / sizeof(suffix[0]); \
-        if (buffer.size() > suffixLength && !memcmp(buffer.last(suffixLength).data(), suffix, sizeof(suffix))) \
+        static constexpr size_t suffixLength = suffix.size(); \
+        if (buffer.size() > suffixLength && !memcmp(buffer.last(suffixLength).data(), suffix.data(), suffix.size())) \
             return isSecondLevelDomainNameAllowedByTLDRules(buffer.first(buffer.size() - suffixLength), function); \
     }
 
@@ -472,7 +470,7 @@ static bool allCharactersAllowedByTLDRules(std::span<const UChar> buffer)
         buffer = buffer.first(buffer.size() - 1);
 
     // http://cctld.ru/files/pdf/docs/rules_ru-rf.pdf
-    static const UChar cyrillicRF[] = {
+    static constexpr std::array<UChar, 3> cyrillicRF {
         '.',
         0x0440, // CYRILLIC SMALL LETTER ER
         0x0444, // CYRILLIC SMALL LETTER EF
@@ -480,7 +478,7 @@ static bool allCharactersAllowedByTLDRules(std::span<const UChar> buffer)
     CHECK_RULES_IF_SUFFIX_MATCHES(cyrillicRF, isRussianDomainNameCharacter);
 
     // http://rusnames.ru/rules.pl
-    static const UChar cyrillicRUS[] = {
+    static constexpr std::array<UChar, 4> cyrillicRUS {
         '.',
         0x0440, // CYRILLIC SMALL LETTER ER
         0x0443, // CYRILLIC SMALL LETTER U
@@ -489,7 +487,7 @@ static bool allCharactersAllowedByTLDRules(std::span<const UChar> buffer)
     CHECK_RULES_IF_SUFFIX_MATCHES(cyrillicRUS, isRussianDomainNameCharacter);
 
     // http://ru.faitid.org/projects/moscow/documents/moskva/idn
-    static const UChar cyrillicMOSKVA[] = {
+    static constexpr std::array<UChar, 7> cyrillicMOSKVA {
         '.',
         0x043C, // CYRILLIC SMALL LETTER EM
         0x043E, // CYRILLIC SMALL LETTER O
@@ -501,7 +499,7 @@ static bool allCharactersAllowedByTLDRules(std::span<const UChar> buffer)
     CHECK_RULES_IF_SUFFIX_MATCHES(cyrillicMOSKVA, isRussianDomainNameCharacter);
 
     // http://www.dotdeti.ru/foruser/docs/regrules.php
-    static const UChar cyrillicDETI[] = {
+    static constexpr std::array<UChar, 5> cyrillicDETI {
         '.',
         0x0434, // CYRILLIC SMALL LETTER DE
         0x0435, // CYRILLIC SMALL LETTER IE
@@ -512,7 +510,7 @@ static bool allCharactersAllowedByTLDRules(std::span<const UChar> buffer)
 
     // http://corenic.org - rules not published. The word is Russian, so only allowing Russian at this time,
     // although we may need to revise the checks if this ends up being used with other languages spoken in Russia.
-    static const UChar cyrillicONLAYN[] = {
+    static constexpr std::array<UChar, 7> cyrillicONLAYN {
         '.',
         0x043E, // CYRILLIC SMALL LETTER O
         0x043D, // CYRILLIC SMALL LETTER EN
@@ -524,7 +522,7 @@ static bool allCharactersAllowedByTLDRules(std::span<const UChar> buffer)
     CHECK_RULES_IF_SUFFIX_MATCHES(cyrillicONLAYN, isRussianDomainNameCharacter);
 
     // http://corenic.org - same as above.
-    static const UChar cyrillicSAYT[] = {
+    static constexpr std::array<UChar, 5> cyrillicSAYT {
         '.',
         0x0441, // CYRILLIC SMALL LETTER ES
         0x0430, // CYRILLIC SMALL LETTER A
@@ -536,7 +534,7 @@ static bool allCharactersAllowedByTLDRules(std::span<const UChar> buffer)
     // http://pir.org/products/opr-domain/ - rules not published. According to the registry site,
     // the intended audience is "Russian and other Slavic-speaking markets".
     // Chrome appears to only allow Russian, so sticking with that for now.
-    static const UChar cyrillicORG[] = {
+    static constexpr std::array<UChar, 4> cyrillicORG {
         '.',
         0x043E, // CYRILLIC SMALL LETTER O
         0x0440, // CYRILLIC SMALL LETTER ER
@@ -545,7 +543,7 @@ static bool allCharactersAllowedByTLDRules(std::span<const UChar> buffer)
     CHECK_RULES_IF_SUFFIX_MATCHES(cyrillicORG, isRussianDomainNameCharacter);
 
     // http://cctld.by/rules.html
-    static const UChar cyrillicBEL[] = {
+    static constexpr std::array<UChar, 4> cyrillicBEL {
         '.',
         0x0431, // CYRILLIC SMALL LETTER BE
         0x0435, // CYRILLIC SMALL LETTER IE
@@ -557,7 +555,7 @@ static bool allCharactersAllowedByTLDRules(std::span<const UChar> buffer)
     });
 
     // http://www.nic.kz/docs/poryadok_vnedreniya_kaz_ru.pdf
-    static const UChar cyrillicKAZ[] = {
+    static constexpr std::array<UChar, 4> cyrillicKAZ {
         '.',
         0x049B, // CYRILLIC SMALL LETTER KA WITH DESCENDER
         0x0430, // CYRILLIC SMALL LETTER A
@@ -569,7 +567,7 @@ static bool allCharactersAllowedByTLDRules(std::span<const UChar> buffer)
     });
 
     // http://uanic.net/docs/documents-ukr/Rules%20of%20UKR_v4.0.pdf
-    static const UChar cyrillicUKR[] = {
+    static constexpr std::array<UChar, 4> cyrillicUKR {
         '.',
         0x0443, // CYRILLIC SMALL LETTER U
         0x043A, // CYRILLIC SMALL LETTER KA
@@ -581,7 +579,7 @@ static bool allCharactersAllowedByTLDRules(std::span<const UChar> buffer)
     });
 
     // http://www.rnids.rs/data/DOKUMENTI/idn-srb-policy-termsofuse-v1.4-eng.pdf
-    static const UChar cyrillicSRB[] = {
+    static constexpr std::array<UChar, 4> cyrillicSRB {
         '.',
         0x0441, // CYRILLIC SMALL LETTER ES
         0x0440, // CYRILLIC SMALL LETTER ER
@@ -593,7 +591,7 @@ static bool allCharactersAllowedByTLDRules(std::span<const UChar> buffer)
     });
 
     // http://marnet.mk/doc/pravilnik-mk-mkd.pdf
-    static const UChar cyrillicMKD[] = {
+    static constexpr std::array<UChar, 4> cyrillicMKD {
         '.',
         0x043C, // CYRILLIC SMALL LETTER EM
         0x043A, // CYRILLIC SMALL LETTER KA
@@ -605,7 +603,7 @@ static bool allCharactersAllowedByTLDRules(std::span<const UChar> buffer)
     });
 
     // https://www.mon.mn/cs/
-    static const UChar cyrillicMON[] = {
+    static constexpr std::array<UChar, 4> cyrillicMON {
         '.',
         0x043C, // CYRILLIC SMALL LETTER EM
         0x043E, // CYRILLIC SMALL LETTER O
@@ -617,7 +615,7 @@ static bool allCharactersAllowedByTLDRules(std::span<const UChar> buffer)
     });
 
     // https://www.icann.org/sites/default/files/packages/lgr/lgr-second-level-bulgarian-30aug16-en.html
-    static const UChar cyrillicBG[] = {
+    static constexpr std::array<UChar, 3> cyrillicBG {
         '.',
         0x0431, // CYRILLIC SMALL LETTER BE
         0x0433 // CYRILLIC SMALL LETTER GHE
@@ -862,7 +860,7 @@ static String escapeUnsafeCharacters(const String& sourceBuffer)
         char32_t c = sourceBuffer.characterStartingAt(i);
         unsigned characterLength = U16_LENGTH(c);
         if (isLookalikeCharacter(previousCodePoint, c)) {
-            uint8_t utf8Buffer[4];
+            std::array<uint8_t, 4> utf8Buffer;
             size_t offset = 0;
             UBool failure = false;
             U8_APPEND(utf8Buffer, offset, 4, c, failure);
@@ -900,7 +898,7 @@ String userVisibleURL(const CString& url)
         return { };
     Vector<char, urlBytesBufferLength> after(bufferLength);
 
-    char* q = after.data();
+    size_t afterIndex = 0;
     {
         auto p = before;
         for (int i = 0; i < length; i++) {
@@ -910,23 +908,23 @@ String userVisibleURL(const CString& url)
                 auto u = toASCIIHexValue(p[i + 1], p[i + 2]);
                 if (u > 0x7f) {
                     // unescape
-                    *q++ = u;
+                    after[afterIndex++] = u;
                 } else {
                     // do not unescape
-                    *q++ = p[i];
-                    *q++ = p[i + 1];
-                    *q++ = p[i + 2];
+                    after[afterIndex++] = p[i];
+                    after[afterIndex++] = p[i + 1];
+                    after[afterIndex++] = p[i + 2];
                 }
                 i += 2;
             } else {
-                *q++ = c;
+                after[afterIndex++] = c;
                 
                 // Check for "xn--" in an efficient, non-case-sensitive, way.
-                if (c == '-' && i >= 3 && !mayNeedHostNameDecoding && (q[-4] | 0x20) == 'x' && (q[-3] | 0x20) == 'n' && q[-2] == '-')
+                if (c == '-' && i >= 3 && !mayNeedHostNameDecoding && (after[afterIndex - 4] | 0x20) == 'x' && (after[afterIndex - 3] | 0x20) == 'n' && after[afterIndex - 2] == '-')
                     mayNeedHostNameDecoding = true;
             }
         }
-        *q = '\0';
+        after[afterIndex] = '\0';
     }
     
     // Check string to see if it can be converted to display using UTF-8  
@@ -937,21 +935,21 @@ String userVisibleURL(const CString& url)
         // Shift current string to the end of the buffer
         // then we will copy back bytes to the start of the buffer 
         // as we convert.
-        int afterlength = q - after.data();
-        char* p = after.data() + bufferLength.value() - afterlength - 1;
-        memmove(p, after.data(), afterlength + 1); // copies trailing '\0'
-        char* q = after.data();
-        while (*p) {
-            unsigned char c = *p;
+        int afterlength = afterIndex;
+        auto p = after.mutableSpan().subspan(bufferLength.value() - afterlength - 1);
+        memmove(p.data(), after.data(), afterlength + 1); // copies trailing '\0'
+        afterIndex = 0;
+        while (p.front()) {
+            unsigned char c = p.front();
             if (c > 0x7f) {
-                *q++ = '%';
-                *q++ = upperNibbleToASCIIHexDigit(c);
-                *q++ = lowerNibbleToASCIIHexDigit(c);
+                after[afterIndex++] = '%';
+                after[afterIndex++] = upperNibbleToASCIIHexDigit(c);
+                after[afterIndex++] = lowerNibbleToASCIIHexDigit(c);
             } else
-                *q++ = *p;
-            p++;
+                after[afterIndex++] = p.front();
+            p = p.subspan(1);
         }
-        *q = '\0';
+        after[afterIndex] = '\0';
         // Note: after.data() points to a null-terminated, pure ASCII string.
         result = String::fromUTF8(after.data());
         ASSERT(!!result);
@@ -973,5 +971,3 @@ String userVisibleURL(const CString& url)
 
 } // namespace URLHelpers
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 591e4ca03126953946ba8fa55cd91224a0343871
<pre>
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in URL.cpp &amp; URLHelpers.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=282884">https://bugs.webkit.org/show_bug.cgi?id=282884</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/URL.cpp:
(WTF::appendEncodedHostname):
(WTF::protocolIsInternal):
* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::escapeUnsafeCharacters):
(WTF::URLHelpers::userVisibleURL):

Canonical link: <a href="https://commits.webkit.org/286395@main">https://commits.webkit.org/286395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ba232316b66beefeb6f991a0650e28a7a8b4cd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80387 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27156 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59504 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17663 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65176 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39864 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46781 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22659 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-self-collapsing-nested.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25483 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69067 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67896 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81851 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75166 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3259 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2055 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67733 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3413 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65144 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67040 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10984 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9110 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97420 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11727 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3209 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21301 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3230 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4168 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3237 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->