### PR TITLE
Stop using IsDeprecatedTimerSmartPointerException in WebKit/NetworkProcess

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -307,7 +307,7 @@ void NetworkResourceLoader::retrieveCacheEntry(const ResourceRequest& request)
     if (isMainFrameLoad()) {
         ASSERT(m_parameters.options.mode == FetchOptions::Mode::Navigate);
         if (auto* session = protectedConnectionToWebProcess()->protectedNetworkProcess()->networkSession(sessionID())) {
-            if (auto entry = session->prefetchCache().take(request.url())) {
+            if (auto entry = session->checkedPrefetchCache()->take(request.url())) {
                 LOADER_RELEASE_LOG("retrieveCacheEntry: retrieved an entry from the prefetch cache (isRedirect=%d)", !entry->redirectRequest.isNull());
                 if (!entry->redirectRequest.isNull()) {
                     auto cacheEntry = cache->makeRedirectEntry(request, entry->response, entry->redirectRequest);
@@ -1369,7 +1369,7 @@ void NetworkResourceLoader::didFinishWithRedirectResponse(WebCore::ResourceReque
     if (!isCrossOriginPrefetch())
         didReceiveResponse(WTFMove(redirectResponse), PrivateRelayed::No, [] (auto) { });
     else if (auto* session = protectedConnectionToWebProcess()->protectedNetworkProcess()->networkSession(sessionID()))
-        session->prefetchCache().storeRedirect(request.url(), WTFMove(redirectResponse), WTFMove(redirectRequest));
+        session->checkedPrefetchCache()->storeRedirect(request.url(), WTFMove(redirectResponse), WTFMove(redirectRequest));
 
     WebCore::NetworkLoadMetrics networkLoadMetrics;
     networkLoadMetrics.markComplete();
@@ -1586,7 +1586,7 @@ void NetworkResourceLoader::tryStoreAsCacheEntry()
     if (isCrossOriginPrefetch()) {
         if (auto* session = protectedConnectionToWebProcess()->protectedNetworkProcess()->networkSession(sessionID())) {
             LOADER_RELEASE_LOG("tryStoreAsCacheEntry: Storing entry in prefetch cache");
-            session->prefetchCache().store(m_networkLoad->currentRequest().url(), WTFMove(m_response), m_privateRelayed, m_bufferedDataForCache.take());
+            session->checkedPrefetchCache()->store(m_networkLoad->currentRequest().url(), WTFMove(m_response), m_privateRelayed, m_bufferedDataForCache.take());
         }
         return;
     }

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -557,6 +557,11 @@ void NetworkSession::removeKeptAliveLoad(NetworkResourceLoader& loader)
     m_keptAliveLoads.remove(loader);
 }
 
+Ref<NetworkSession::CachedNetworkResourceLoader> NetworkSession::CachedNetworkResourceLoader::create(Ref<NetworkResourceLoader>&& loader)
+{
+    return adoptRef(*new NetworkSession::CachedNetworkResourceLoader(WTFMove(loader)));
+}
+
 NetworkSession::CachedNetworkResourceLoader::CachedNetworkResourceLoader(Ref<NetworkResourceLoader>&& loader)
     : m_expirationTimer(*this, &CachedNetworkResourceLoader::expirationTimerFired)
     , m_loader(WTFMove(loader))
@@ -584,7 +589,7 @@ void NetworkSession::addLoaderAwaitingWebProcessTransfer(Ref<NetworkResourceLoad
     ASSERT(m_sessionID == loader->sessionID());
     auto identifier = loader->identifier();
     ASSERT(!m_loadersAwaitingWebProcessTransfer.contains(identifier));
-    m_loadersAwaitingWebProcessTransfer.add(identifier, makeUnique<CachedNetworkResourceLoader>(WTFMove(loader)));
+    m_loadersAwaitingWebProcessTransfer.add(identifier, CachedNetworkResourceLoader::create(WTFMove(loader)));
 }
 
 RefPtr<NetworkResourceLoader> NetworkSession::takeLoaderAwaitingWebProcessTransfer(NetworkResourceLoadIdentifier identifier)
@@ -881,6 +886,11 @@ void NetworkSession::setPersistedDomains(HashSet<WebCore::RegistrableDomain>&& d
 
     if (m_resourceLoadStatistics)
         m_resourceLoadStatistics->setPersistedDomains(m_persistedDomains);
+}
+
+CheckedRef<PrefetchCache> NetworkSession::checkedPrefetchCache()
+{
+    return m_prefetchCache;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/cache/PrefetchCache.h
+++ b/Source/WebKit/NetworkProcess/cache/PrefetchCache.h
@@ -30,6 +30,7 @@
 #include <WebCore/ResourceResponse.h>
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/Timer.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/Deque.h>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
@@ -37,18 +38,10 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
-class PrefetchCache;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebKit::PrefetchCache> : std::true_type { };
-}
-
-namespace WebKit {
-
-class PrefetchCache {
+class PrefetchCache final : public CanMakeCheckedPtr<PrefetchCache> {
     WTF_MAKE_TZONE_ALLOCATED(PrefetchCache);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PrefetchCache);
     WTF_MAKE_NONCOPYABLE(PrefetchCache);
 public:
     PrefetchCache();

--- a/Source/WebKit/NetworkProcess/glib/DNSCache.cpp
+++ b/Source/WebKit/NetworkProcess/glib/DNSCache.cpp
@@ -33,6 +33,11 @@ namespace WebKit {
 static const Seconds expireInterval = 60_s;
 static const unsigned maxCacheSize = 400;
 
+Ref<DNSCache> DNSCache::create()
+{
+    return adoptRef(*new DNSCache);
+}
+
 DNSCache::DNSCache()
     : m_expiredTimer(RunLoop::main(), this, &DNSCache::removeExpiredResponsesFired)
 {

--- a/Source/WebKit/NetworkProcess/glib/DNSCache.h
+++ b/Source/WebKit/NetworkProcess/glib/DNSCache.h
@@ -28,6 +28,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/RefCounted.h>
 #include <wtf/RunLoop.h>
 #include <wtf/Vector.h>
 #include <wtf/glib/GRefPtr.h>
@@ -36,19 +37,10 @@
 typedef struct _GInetAddress GInetAddress;
 
 namespace WebKit {
-class DNSCache;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebKit::DNSCache> : std::true_type { };
-}
-
-namespace WebKit {
-
-class DNSCache {
+class DNSCache : public RefCounted<DNSCache> {
 public:
-    DNSCache();
+    static Ref<DNSCache> create();
     ~DNSCache() = default;
 
     enum class Type { Default, IPv4Only, IPv6Only };
@@ -57,6 +49,8 @@ public:
     void clear();
 
 private:
+    DNSCache();
+
     struct CachedResponse {
         Vector<GRefPtr<GInetAddress>> addressList;
         MonotonicTime expirationTime;


### PR DESCRIPTION
#### e5251715c351a5e775065a94321579b97b664f02
<pre>
Stop using IsDeprecatedTimerSmartPointerException in WebKit/NetworkProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=282885">https://bugs.webkit.org/show_bug.cgi?id=282885</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::CachedNetworkResourceLoader::create):
(WebKit::NetworkSession::addLoaderAwaitingWebProcessTransfer):
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/cache/PrefetchCache.h:
(WebKit::PrefetchCache::Entry::releaseBuffer): Deleted.
* Source/WebKit/NetworkProcess/glib/DNSCache.cpp:
(WebKit::DNSCache::create):
* Source/WebKit/NetworkProcess/glib/DNSCache.h:
* Source/WebKit/NetworkProcess/glib/WebKitCachedResolver.cpp:

Canonical link: <a href="https://commits.webkit.org/286416@main">https://commits.webkit.org/286416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d5a169b045e4c875800307e3d84da7f4d0940f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80432 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27201 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3260 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59539 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17699 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79002 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/49416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65210 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39899 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46816 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25528 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67931 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23031 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81896 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3304 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/2091 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67767 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3458 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65178 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67076 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16711 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11023 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9144 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3254 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6060 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3275 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4213 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3282 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->