### PR TITLE
[iOS] Rename some member and local variables related to touch event handling

### DIFF
--- a/Source/WebKit/Shared/ios/NativeWebTouchEventIOS.mm
+++ b/Source/WebKit/Shared/ios/NativeWebTouchEventIOS.mm
@@ -92,7 +92,7 @@ static CGFloat radiusForTouchPoint(const WKTouchPoint& touchPoint)
 #if ENABLE(FIXED_IOS_TOUCH_POINT_RADIUS)
     return 12.1;
 #else
-    return touchPoint.majorRadiusInScreenCoordinates;
+    return touchPoint.majorRadiusInWindowCoordinates;
 #endif
 }
 
@@ -100,7 +100,7 @@ Vector<WebPlatformTouchPoint> NativeWebTouchEvent::extractWebTouchPoints(const W
 {
     return event.touchPoints.map([](auto& touchPoint) {
         unsigned identifier = touchPoint.identifier;
-        WebCore::IntPoint location = positionForCGPoint(touchPoint.locationInDocumentCoordinates);
+        WebCore::IntPoint location = positionForCGPoint(touchPoint.locationInRootViewCoordinates);
         WebPlatformTouchPoint::State phase = convertTouchPhase(touchPoint.phase);
         WebPlatformTouchPoint platformTouchPoint = WebPlatformTouchPoint(identifier, location, phase);
 #if ENABLE(IOS_TOUCH_EVENTS)
@@ -138,7 +138,7 @@ NativeWebTouchEvent::NativeWebTouchEvent(const WKTouchEvent& event, UIKeyModifie
         extractWebTouchPoints(event),
         extractCoalescedWebTouchEvents(event, flags),
         extractPredictedWebTouchEvents(event, flags),
-        positionForCGPoint(event.locationInDocumentCoordinates),
+        positionForCGPoint(event.locationInRootViewCoordinates),
         event.isPotentialTap,
         event.inJavaScriptGesture,
         event.scale,

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -2127,7 +2127,7 @@ typedef NS_ENUM(NSInteger, EndEditingReason) {
         return;
 
     auto& lastTouchEvent = gestureRecognizer.lastTouchEvent;
-    _lastInteractionLocation = lastTouchEvent.locationInDocumentCoordinates;
+    _lastInteractionLocation = lastTouchEvent.locationInRootViewCoordinates;
 
     if (lastTouchEvent.type == WebKit::WKTouchEventType::Begin) {
         if (!_failedTouchStartDeferringGestures)

--- a/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.h
+++ b/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.h
@@ -34,11 +34,10 @@
 namespace WebKit {
 
 struct WKTouchPoint {
-    CGPoint locationInScreenCoordinates;
-    CGPoint locationInDocumentCoordinates;
+    CGPoint locationInRootViewCoordinates;
     unsigned identifier { 0 };
     UITouchPhase phase { UITouchPhaseBegan };
-    CGFloat majorRadiusInScreenCoordinates { 0 };
+    CGFloat majorRadiusInWindowCoordinates { 0 };
     CGFloat force { 0 };
     CGFloat altitudeAngle { 0 };
     CGFloat azimuthAngle { 0 };
@@ -48,8 +47,7 @@ struct WKTouchPoint {
 struct WKTouchEvent {
     WKTouchEventType type { WKTouchEventType::Begin };
     NSTimeInterval timestamp { 0 };
-    CGPoint locationInScreenCoordinates;
-    CGPoint locationInDocumentCoordinates;
+    CGPoint locationInRootViewCoordinates;
     CGFloat scale { 0 };
     CGFloat rotation { 0 };
 

--- a/Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm
@@ -89,14 +89,11 @@ static Class touchEventsGestureRecognizerClass()
 
 namespace TestWebKitAPI {
 
-static WebKit::WKTouchPoint globalTouchPoint { CGPointZero, CGPointZero, 100, UITouchPhaseBegan, 1, 0, 0, 0, WebKit::WKTouchPointType::Direct };
-static WebKit::WKTouchEvent globalTouchEvent { WebKit::WKTouchEventType::Begin, CACurrentMediaTime(), CGPointZero, CGPointZero, 1, 0, false, { globalTouchPoint }, { }, { }, true };
+static WebKit::WKTouchPoint globalTouchPoint { CGPointZero, 100, UITouchPhaseBegan, 1, 0, 0, 0, WebKit::WKTouchPointType::Direct };
+static WebKit::WKTouchEvent globalTouchEvent { WebKit::WKTouchEventType::Begin, CACurrentMediaTime(), CGPointZero, 1, 0, false, { globalTouchPoint }, { }, { }, true };
 static void updateSimulatedTouchEvent(CGPoint location, UITouchPhase phase)
 {
-    globalTouchPoint.locationInScreenCoordinates = location;
-    globalTouchPoint.locationInDocumentCoordinates = location;
-    globalTouchEvent.locationInScreenCoordinates = location;
-    globalTouchEvent.locationInDocumentCoordinates = location;
+    globalTouchEvent.locationInRootViewCoordinates = location;
     globalTouchPoint.phase = phase;
     switch (phase) {
     case UITouchPhaseBegan:


### PR DESCRIPTION
#### d12704bb5a6630edd56b7e5707b64c9cdbaa8974
<pre>
[iOS] Rename some member and local variables related to touch event handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=282886">https://bugs.webkit.org/show_bug.cgi?id=282886</a>

Reviewed by Abrar Rahman Protyasha.

No change in behavior; see below for more details.

* Source/WebKit/Shared/ios/NativeWebTouchEventIOS.mm:
(WebKit::radiusForTouchPoint):
(WebKit::NativeWebTouchEvent::extractWebTouchPoints):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _touchEventsRecognized:]):
* Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.h:

Delete the unused `locationInScreenCoordinates` instance variable.

* Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm:
(-[WKTouchEventsGestureRecognizer reset]):
(-[WKTouchEventsGestureRecognizer _touchEventForTouch:]):
(-[WKTouchEventsGestureRecognizer _recordTouches:type:coalescedTouches:predictedTouches:]):

Rename `locationInViewport` to `locationInRootView`, to reflect the fact that this point is in the
coordinate space of the `WKContentView`, rather than the layout or visual viewport.

Rename `…InScreenCoordinates` to `…InWindowCoordinates`, to reflect the fact that these values are
in `UIWindow` coordinates, not screen coordinates.

Rename `locationInDocumentCoordinates` to `locationInRootViewCoordinates`, to clarify that this
point is always in the coordinate space of the content view (not the target document where the
touches are being dispatched).

* Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm:
(TestWebKitAPI::updateSimulatedTouchEvent):

Canonical link: <a href="https://commits.webkit.org/286418@main">https://commits.webkit.org/286418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc34eb31ca3ff7272a01204d008cb6ea83c181e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75892 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80389 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27158 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78008 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64063 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59505 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17665 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49384 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65178 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39865 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46784 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22661 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25485 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67899 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22999 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81853 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2056 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67734 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3415 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67041 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16713 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10987 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9112 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3211 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6017 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3232 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4170 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3239 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->