### PR TITLE
Reduce use of IsDeprecatedTimerSmartPointerException in WebKit/UIProcess

### DIFF
--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -173,12 +173,19 @@ void WebBackForwardListItem::wasRemovedFromBackForwardList()
 
 void WebBackForwardListItem::removeFromBackForwardCache()
 {
-    if (m_backForwardCacheEntry)
-        m_backForwardCacheEntry->backForwardCache().removeEntry(*this);
+    if (RefPtr backForwardCacheEntry = m_backForwardCacheEntry) {
+        if (RefPtr backForwardCache = backForwardCacheEntry->backForwardCache())
+            backForwardCache->removeEntry(*this);
+    }
     ASSERT(!m_backForwardCacheEntry);
 }
 
-void WebBackForwardListItem::setBackForwardCacheEntry(std::unique_ptr<WebBackForwardCacheEntry>&& backForwardCacheEntry)
+RefPtr<WebBackForwardCacheEntry> WebBackForwardListItem::protectedBackForwardCacheEntry() const
+{
+    return m_backForwardCacheEntry;
+}
+
+void WebBackForwardListItem::setBackForwardCacheEntry(RefPtr<WebBackForwardCacheEntry>&& backForwardCacheEntry)
 {
     m_backForwardCacheEntry = WTFMove(backForwardCacheEntry);
 }

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -88,6 +88,8 @@ public:
     void wasRemovedFromBackForwardList();
 
     WebBackForwardCacheEntry* backForwardCacheEntry() const { return m_backForwardCacheEntry.get(); }
+    RefPtr<WebBackForwardCacheEntry> protectedBackForwardCacheEntry() const;
+
     SuspendedPageProxy* suspendedPage() const;
 
     void setNavigatedFrameID(WebCore::FrameIdentifier frameID) { m_navigatedFrameID = frameID; }
@@ -115,7 +117,7 @@ private:
 
     // WebBackForwardCache.
     friend class WebBackForwardCache;
-    void setBackForwardCacheEntry(std::unique_ptr<WebBackForwardCacheEntry>&&);
+    void setBackForwardCacheEntry(RefPtr<WebBackForwardCacheEntry>&&);
 
     RefPtr<WebsiteDataStore> m_dataStoreForWebArchive;
 
@@ -124,7 +126,7 @@ private:
     WebPageProxyIdentifier m_pageID;
     WebCore::ProcessIdentifier m_lastProcessIdentifier;
     Markable<WebCore::FrameIdentifier> m_navigatedFrameID;
-    std::unique_ptr<WebBackForwardCacheEntry> m_backForwardCacheEntry;
+    RefPtr<WebBackForwardCacheEntry> m_backForwardCacheEntry;
 #if PLATFORM(COCOA) || PLATFORM(GTK)
     RefPtr<ViewSnapshot> m_snapshot;
 #endif

--- a/Source/WebKit/UIProcess/WebBackForwardCache.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.h
@@ -27,10 +27,10 @@
 
 #include <WebCore/ProcessIdentifier.h>
 #include <pal/SessionID.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakListHashSet.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebKit {
 
@@ -41,12 +41,14 @@ class WebPageProxy;
 class WebProcessPool;
 class WebProcessProxy;
 
-class WebBackForwardCache final : public CanMakeCheckedPtr<WebBackForwardCache> {
+class WebBackForwardCache final : public CanMakeWeakPtr<WebBackForwardCache> {
     WTF_MAKE_TZONE_ALLOCATED(WebBackForwardCache);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebBackForwardCache);
 public:
-    explicit WebBackForwardCache();
+    explicit WebBackForwardCache(WebProcessPool&);
     ~WebBackForwardCache();
+
+    void ref() const;
+    void deref() const;
 
     void setCapacity(WebProcessPool&, unsigned);
     unsigned capacity() const { return m_capacity; }
@@ -70,8 +72,9 @@ private:
 
     void removeOldestEntry();
     void removeEntriesMatching(const Function<bool(WebBackForwardListItem&)>&);
-    void addEntry(WebBackForwardListItem&, std::unique_ptr<WebBackForwardCacheEntry>&&);
+    void addEntry(WebBackForwardListItem&, Ref<WebBackForwardCacheEntry>&&);
 
+    WeakRef<WebProcessPool> m_processPool;
     unsigned m_capacity { 0 };
     WeakListHashSet<WebBackForwardListItem> m_itemsWithCachedPage;
 };

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp
@@ -39,6 +39,11 @@ static const Seconds expirationDelay { 30_min };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebBackForwardCacheEntry);
 
+Ref<WebBackForwardCacheEntry> WebBackForwardCacheEntry::create(WebBackForwardCache& backForwardCache, WebCore::BackForwardItemIdentifier backForwardItemID, WebCore::ProcessIdentifier processIdentifier, std::unique_ptr<SuspendedPageProxy>&& suspendedPage)
+{
+    return adoptRef(*new WebBackForwardCacheEntry(backForwardCache, backForwardItemID, processIdentifier, WTFMove(suspendedPage)));
+}
+
 WebBackForwardCacheEntry::WebBackForwardCacheEntry(WebBackForwardCache& backForwardCache, WebCore::BackForwardItemIdentifier backForwardItemID, WebCore::ProcessIdentifier processIdentifier, std::unique_ptr<SuspendedPageProxy>&& suspendedPage)
     : m_backForwardCache(backForwardCache)
     , m_processIdentifier(processIdentifier)
@@ -57,7 +62,7 @@ WebBackForwardCacheEntry::~WebBackForwardCacheEntry()
     }
 }
 
-WebBackForwardCache& WebBackForwardCacheEntry::backForwardCache() const
+WebBackForwardCache* WebBackForwardCacheEntry::backForwardCache() const
 {
     return m_backForwardCache.get();
 }
@@ -84,7 +89,8 @@ void WebBackForwardCacheEntry::expirationTimerFired()
     RELEASE_LOG(BackForwardCache, "%p - WebBackForwardCacheEntry::expirationTimerFired backForwardItemID=%s, hasSuspendedPage=%d", this, m_backForwardItemID->toString().utf8().data(), !!m_suspendedPage);
     auto* item = WebBackForwardListItem::itemForID(*m_backForwardItemID);
     ASSERT(item);
-    m_backForwardCache->removeEntry(*item); // Will destroy |this|.
+    if (RefPtr backForwardCache = m_backForwardCache.get())
+        backForwardCache->removeEntry(*item);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
@@ -29,17 +29,9 @@
 #include <WebCore/ProcessIdentifier.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
+#include <wtf/RefCounted.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
-
-namespace WebKit {
-class WebBackForwardCacheEntry;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebKit::WebBackForwardCacheEntry> : std::true_type { };
-}
 
 namespace WebKit {
 
@@ -47,13 +39,13 @@ class SuspendedPageProxy;
 class WebBackForwardCache;
 class WebProcessProxy;
 
-class WebBackForwardCacheEntry {
+class WebBackForwardCacheEntry : public RefCounted<WebBackForwardCacheEntry> {
     WTF_MAKE_TZONE_ALLOCATED(WebBackForwardCacheEntry);
 public:
-    WebBackForwardCacheEntry(WebBackForwardCache&, WebCore::BackForwardItemIdentifier, WebCore::ProcessIdentifier, std::unique_ptr<SuspendedPageProxy>&&);
+    static Ref<WebBackForwardCacheEntry> create(WebBackForwardCache&, WebCore::BackForwardItemIdentifier, WebCore::ProcessIdentifier, std::unique_ptr<SuspendedPageProxy>&&);
     ~WebBackForwardCacheEntry();
 
-    WebBackForwardCache& backForwardCache() const;
+    WebBackForwardCache* backForwardCache() const;
 
     SuspendedPageProxy* suspendedPage() const { return m_suspendedPage.get(); }
     std::unique_ptr<SuspendedPageProxy> takeSuspendedPage();
@@ -61,9 +53,11 @@ public:
     RefPtr<WebProcessProxy> process() const;
 
 private:
+    WebBackForwardCacheEntry(WebBackForwardCache&, WebCore::BackForwardItemIdentifier, WebCore::ProcessIdentifier, std::unique_ptr<SuspendedPageProxy>&&);
+
     void expirationTimerFired();
 
-    CheckedRef<WebBackForwardCache> m_backForwardCache;
+    WeakPtr<WebBackForwardCache> m_backForwardCache;
     WebCore::ProcessIdentifier m_processIdentifier;
     Markable<WebCore::BackForwardItemIdentifier> m_backForwardItemID;
     std::unique_ptr<SuspendedPageProxy> m_suspendedPage;

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -197,7 +197,7 @@ public:
     void removeMessageReceiver(IPC::ReceiverName, uint64_t destinationID);
 
     WebBackForwardCache& backForwardCache() { return m_backForwardCache.get(); }
-    CheckedRef<WebBackForwardCache> checkedBackForwardCache();
+    Ref<WebBackForwardCache> protectedBackForwardCache();
     
     template<typename RawValue>
     void addMessageReceiver(IPC::ReceiverName messageReceiverName, const ObjectIdentifierGenericBase<RawValue>& destinationID, IPC::MessageReceiver& receiver)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1128,9 +1128,9 @@ void WebProcessProxy::updateBackForwardItem(Ref<FrameState>&& frameState)
 
     if (!!item->backForwardCacheEntry() != frameState->hasCachedPage) {
         if (frameState->hasCachedPage)
-            protectedProcessPool()->checkedBackForwardCache()->addEntry(*item, coreProcessIdentifier());
+            protectedProcessPool()->protectedBackForwardCache()->addEntry(*item, coreProcessIdentifier());
         else if (!item->suspendedPage())
-            protectedProcessPool()->checkedBackForwardCache()->removeEntry(*item);
+            protectedProcessPool()->protectedBackForwardCache()->removeEntry(*item);
     }
 
     frameItem->setFrameState(WTFMove(frameState));

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -846,7 +846,7 @@ void WebsiteDataStore::removeData(OptionSet<WebsiteDataType> dataTypes, WallTime
         for (RefPtr processPool : processPools()) {
             // Clear back/forward cache first as processes removed from the back/forward cache will likely
             // be added to the WebProcess cache.
-            processPool->checkedBackForwardCache()->removeEntriesForSession(sessionID());
+            processPool->protectedBackForwardCache()->removeEntriesForSession(sessionID());
             processPool->checkedWebProcessCache()->clearAllProcessesForSession(sessionID());
         }
 


### PR DESCRIPTION
#### 67b72bbf80cda513ef4785e6f51e1c965aa1f14b
<pre>
Reduce use of IsDeprecatedTimerSmartPointerException in WebKit/UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=282887">https://bugs.webkit.org/show_bug.cgi?id=282887</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::setBackForwardCacheEntry):
* Source/WebKit/Shared/WebBackForwardListItem.h:
* Source/WebKit/UIProcess/WebBackForwardCache.cpp:
(WebKit::WebBackForwardCache::create):
(WebKit::WebBackForwardCache::WebBackForwardCache):
(WebKit::WebBackForwardCache::ref const):
(WebKit::WebBackForwardCache::deref const):
(WebKit::WebBackForwardCache::addEntry):
* Source/WebKit/UIProcess/WebBackForwardCache.h:
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp:
(WebKit::WebBackForwardCacheEntry::create):
(WebKit::WebBackForwardCacheEntry::backForwardCache const):
(WebKit::WebBackForwardCacheEntry::expirationTimerFired):
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.h:
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::addProcessIfPossible):
(WebKit::WebProcessCache::addProcess):
(WebKit::WebProcessCache::removeProcess):
(WebKit::WebProcessCache::CachedProcess::create):
* Source/WebKit/UIProcess/WebProcessCache.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::disconnectProcess):
(WebKit::WebProcessPool::handleMemoryPressureWarning):
(WebKit::WebProcessPool::updateBackForwardCacheCapacity):
(WebKit::WebProcessPool::protectedBackForwardCache):
(WebKit::WebProcessPool::checkedBackForwardCache): Deleted.
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::updateBackForwardItem):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::removeData):

Canonical link: <a href="https://commits.webkit.org/286399@main">https://commits.webkit.org/286399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cda746d3e7ceb02b56b3b471d2da0cd3b3d7f1ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80400 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27169 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59512 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17672 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49394 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65188 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39872 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46794 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25496 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67909 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23009 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81864 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67741 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3426 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67049 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10997 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9122 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11730 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3222 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6028 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3243 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4181 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3250 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->