### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebKit/WebProcess/Plugins/PDF

### DIFF
--- a/Source/WTF/wtf/cf/VectorCF.h
+++ b/Source/WTF/wtf/cf/VectorCF.h
@@ -167,6 +167,11 @@ inline std::span<const uint8_t> span(CFDataRef data)
     return { static_cast<const uint8_t*>(CFDataGetBytePtr(data)), Checked<size_t>(CFDataGetLength(data)) };
 }
 
+inline std::span<uint8_t> mutableSpan(CFMutableDataRef data)
+{
+    return { static_cast<uint8_t*>(CFDataGetMutableBytePtr(data)), Checked<size_t>(CFDataGetLength(data)) };
+}
+
 inline RetainPtr<CFDataRef> toCFData(std::span<const uint8_t> span)
 {
     return adoptCF(CFDataCreate(kCFAllocatorDefault, span.data(), span.size()));
@@ -195,6 +200,7 @@ inline std::optional<float> makeVectorElement(const float*, CFNumberRef cfNumber
 
 using WTF::createCFArray;
 using WTF::makeVector;
+using WTF::mutableSpan;
 using WTF::span;
 using WTF::toCFData;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
@@ -79,7 +79,7 @@ public:
 
     // Only public for the callbacks
     size_t dataProviderGetBytesAtPosition(std::span<uint8_t> buffer, off_t position);
-    void dataProviderGetByteRanges(CFMutableArrayRef buffers, const CFRange* ranges, size_t count);
+    void dataProviderGetByteRanges(CFMutableArrayRef buffers, std::span<const CFRange> ranges);
 
 private:
     PDFIncrementalLoader(PDFPluginBase&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -305,7 +305,7 @@ private:
     // FIXME: It would be nice to avoid having both the "copy into a buffer" and "return a pointer" ways of getting data.
     std::span<const uint8_t> dataSpanForRange(uint64_t sourcePosition, size_t count, CheckValidRanges) const;
     // Returns true only if we can satisfy all of the requests.
-    bool getByteRanges(CFMutableArrayRef, const CFRange*, size_t count) const;
+    bool getByteRanges(CFMutableArrayRef, std::span<const CFRange>) const;
 
 protected:
     explicit PDFPluginBase(WebCore::HTMLPlugInElement&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -76,8 +76,6 @@
 
 #import "PDFKitSoftLink.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit {
 using namespace WebCore;
 
@@ -308,10 +306,10 @@ std::span<const uint8_t> PDFPluginBase::dataSpanForRange(uint64_t sourcePosition
     if (!haveValidData(checkValidRanges))
         return { };
 
-    return { CFDataGetBytePtr(m_data.get()) + sourcePosition, count };
+    return span(m_data.get()).subspan(sourcePosition, count);
 }
 
-bool PDFPluginBase::getByteRanges(CFMutableArrayRef dataBuffersArray, const CFRange* ranges, size_t count) const
+bool PDFPluginBase::getByteRanges(CFMutableArrayRef dataBuffersArray, std::span<const CFRange> ranges) const
 {
     Locker locker { m_streamedDataLock };
 
@@ -335,15 +333,13 @@ bool PDFPluginBase::getByteRanges(CFMutableArrayRef dataBuffersArray, const CFRa
         return m_validRanges.contains({ rangeLocation, rangeLocation + rangeLength - 1 });
     };
 
-    for (size_t i = 0; i < count; ++i) {
-        if (!haveDataForRange(ranges[i]))
+    for (auto& range : ranges) {
+        if (!haveDataForRange(range))
             return false;
     }
 
-    for (size_t i = 0; i < count; ++i) {
-        auto range = ranges[i];
-        const uint8_t* dataPtr = CFDataGetBytePtr(m_data.get()) + range.location;
-        RetainPtr cfData = adoptCF(CFDataCreate(kCFAllocatorDefault, dataPtr, range.length));
+    for (auto& range : ranges) {
+        RetainPtr cfData = toCFData(span(m_data.get()).subspan(range.location, range.length));
         CFArrayAppendValue(dataBuffersArray, cfData.get());
     }
 
@@ -360,7 +356,7 @@ void PDFPluginBase::insertRangeRequestData(uint64_t offset, const Vector<uint8_t
     auto requiredLength = offset + requestData.size();
     ensureDataBufferLength(requiredLength);
 
-    memcpy(CFDataGetMutableBytePtr(m_data.get()) + offset, requestData.data(), requestData.size());
+    memcpySpan(mutableSpan(m_data.get()).subspan(offset), requestData.span());
 
     m_validRanges.add({ offset, offset + requestData.size() - 1 });
 }
@@ -387,7 +383,7 @@ void PDFPluginBase::streamDidReceiveData(const SharedBuffer& buffer)
 
         ensureDataBufferLength(m_streamedBytes + buffer.size());
         auto bufferSpan = buffer.span();
-        memcpy(CFDataGetMutableBytePtr(m_data.get()) + m_streamedBytes, bufferSpan.data(), bufferSpan.size());
+        memcpySpan(mutableSpan(m_data.get()).subspan(m_streamedBytes), bufferSpan);
         m_streamedBytes += buffer.size();
 
         // Keep our ranges-lookup-table compact by continuously updating its first range
@@ -1355,7 +1351,5 @@ String PDFPluginBase::annotationStyle() const
 }
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(PDF_PLUGIN)


### PR DESCRIPTION
#### a566e2e343c11bee535b6e7a47409326e7874699
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebKit/WebProcess/Plugins/PDF
<a href="https://bugs.webkit.org/show_bug.cgi?id=282894">https://bugs.webkit.org/show_bug.cgi?id=282894</a>

Reviewed by Geoffrey Garen.

* Source/WTF/wtf/cf/VectorCF.h:
(WTF::mutableSpan):
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::dataProviderGetByteRangesCallback):
(WebKit::dataProviderGetBytesAtPositionCallback):
(WebKit::PDFIncrementalLoader::dataProviderGetByteRanges):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::dataSpanForRange const):
(WebKit::PDFPluginBase::getByteRanges const):
(WebKit::PDFPluginBase::insertRangeRequestData):
(WebKit::PDFPluginBase::streamDidReceiveData):
* Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluation.mm:
(WebKit::PDFScriptEvaluation::pdfDocumentContainsPrintScript):

Canonical link: <a href="https://commits.webkit.org/286410@main">https://commits.webkit.org/286410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e72be47e85d0cdb75a792fca102e51247ce0f1a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80410 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27179 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3236 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59520 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17679 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49404 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65197 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39880 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46804 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22681 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25506 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69090 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67919 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23018 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81874 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75189 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2078 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67751 "Found 1 new test failure: inspector/dom/getMediaStats.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67059 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11007 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9131 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97443 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11739 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3232 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6038 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21308 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3253 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4191 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->