### PR TITLE
[ANGLE] Fix leaks in NewMetalLibraryFromMetallib() on every call

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_library_cache.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_library_cache.mm
@@ -110,7 +110,11 @@ AutoObjCPtr<id<MTLLibrary>> NewMetalLibraryFromMetallib(id<MTLDevice> metalDevic
                                              DISPATCH_DATA_DESTRUCTOR_DEFAULT);
 
         NSError *nsError = nil;
-        return [metalDevice newLibraryWithData:mtl_data error:&nsError];
+        auto library = adoptObjCObj([metalDevice newLibraryWithData:mtl_data error:&nsError]);
+
+        dispatch_release(mtl_data);
+
+        return library;
     }
 }
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.mm
@@ -1063,16 +1063,15 @@ AutoObjCPtr<id<MTLLibrary>> CreateShaderLibraryFromBinary(id<MTLDevice> metalDev
         NSError *nsError = nil;
         auto shaderSourceData =
             dispatch_data_create(binarySource, binarySourceLen, dispatch_get_main_queue(),
-                                 ^{
-                                 });
+                                 DISPATCH_DATA_DESTRUCTOR_DEFAULT);
 
-        auto library = [metalDevice newLibraryWithData:shaderSourceData error:&nsError];
+        auto library = adoptObjCObj([metalDevice newLibraryWithData:shaderSourceData error:&nsError]);
 
         dispatch_release(shaderSourceData);
 
         *errorOut = std::move(nsError);
 
-        return [library ANGLE_MTL_AUTORELEASE];
+        return library;
     }
 }
 


### PR DESCRIPTION
#### 8826887be8c67b88382cbe64ac62b45e35c689eb
<pre>
[ANGLE] Fix leaks in NewMetalLibraryFromMetallib() on every call
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=282890">https://bugs.webkit.org/show_bug.cgi?id=282890</a>&gt;
&lt;<a href="https://rdar.apple.com/139586222">rdar://139586222</a>&gt;

Reviewed by Kimmo Kinnunen.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_library_cache.mm:
(rx::(anonymous)::NewMetalLibraryFromMetallib):
- Use adoptObjCObj() to fix leak of id&lt;MTLLibrary&gt;.
- Call dispatch_release() to fix leak of dispatch_data_t.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.mm:
(rx::mtl::CreateShaderLibraryFromBinary):
- Use DISPATCH_DATA_DESTRUCTOR_DEFAULT instead of empty block.
- Replace ANGLE_MTL_AUTORELEASE with adoptObjCObj() to avoid unneeded
  autorelease of id&lt;MTLLibrary&gt; object.

Canonical link: <a href="https://commits.webkit.org/286425@main">https://commits.webkit.org/286425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ffcf83fa4fcc68b7e2e2a632ce8ee246cf46672

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28812 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80412 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27181 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3238 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59523 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17680 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49402 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39883 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46802 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22683 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25508 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67917 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81876 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3284 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2079 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67754 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67064 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16715 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11008 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9133 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3234 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3255 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4193 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3262 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->