### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in more places in WebKit/

### DIFF
--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h
@@ -57,7 +57,7 @@ public:
 
     WEBCORE_EXPORT size_t storageSize() const;
 
-    WEBCORE_EXPORT RetainPtr<CVPixelBufferRef> createPixelBufferFromMemory(const uint8_t* data, CVPixelBufferPoolRef = nullptr);
+    WEBCORE_EXPORT RetainPtr<CVPixelBufferRef> createPixelBufferFromMemory(std::span<const uint8_t> data, CVPixelBufferPoolRef = nullptr);
 
     WEBCORE_EXPORT bool isReadWriteSupported() const;
     WEBCORE_EXPORT RetainPtr<CVPixelBufferPoolRef> createCompatibleBufferPool() const;

--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
@@ -169,19 +169,19 @@ std::optional<SharedVideoFrameInfo> SharedVideoFrameInfo::decode(std::span<const
     return info;
 }
 
-static const uint8_t* copyToCVPixelBufferPlane(CVPixelBufferRef pixelBuffer, size_t planeIndex, const uint8_t* source, size_t height, uint32_t bytesPerRowSource)
+static std::span<const uint8_t> copyToCVPixelBufferPlane(CVPixelBufferRef pixelBuffer, size_t planeIndex, std::span<const uint8_t> source, size_t height, uint32_t bytesPerRowSource)
 {
     auto* destination = static_cast<uint8_t*>(CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, planeIndex));
     uint32_t bytesPerRowDestination = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, planeIndex);
     for (unsigned i = 0; i < height; ++i) {
-        std::memcpy(destination, source, std::min(bytesPerRowSource, bytesPerRowDestination));
-        source += bytesPerRowSource;
+        std::memcpy(destination, source.data(), std::min(bytesPerRowSource, bytesPerRowDestination));
+        source = source.subspan(bytesPerRowSource);
         destination += bytesPerRowDestination;
     }
     return source;
 }
 
-RetainPtr<CVPixelBufferRef> SharedVideoFrameInfo::createPixelBufferFromMemory(const uint8_t* data, CVPixelBufferPoolRef bufferPool)
+RetainPtr<CVPixelBufferRef> SharedVideoFrameInfo::createPixelBufferFromMemory(std::span<const uint8_t> data, CVPixelBufferPoolRef bufferPool)
 {
     ASSERT(isReadWriteSupported());
     CVPixelBufferRef rawPixelBuffer = nullptr;

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -63,14 +63,13 @@
 #include <WebCore/LocalFrame.h>
 #include <WebCore/LocalFrameView.h>
 #include <WebCore/RenderElement.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/UUID.h>
 
 #if ENABLE(DATALIST_ELEMENT)
 #include <WebCore/HTMLDataListElement.h>
 #endif
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebKit {
 
@@ -191,13 +190,16 @@ static JSValueRef createUUID(JSContextRef context, JSObjectRef function, JSObjec
     return toJSValue(context, createVersion4UUIDString().convertToASCIIUppercase());
 }
 
-static JSValueRef evaluateJavaScriptCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+static JSValueRef evaluateJavaScriptCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
 {
-    ASSERT_ARG(argumentCount, argumentCount == 4);
-    ASSERT_ARG(arguments, JSValueIsNumber(context, arguments[0]));
-    ASSERT_ARG(arguments, JSValueIsNumber(context, arguments[1]));
-    ASSERT_ARG(arguments, JSValueIsNumber(context, arguments[2]));
-    ASSERT_ARG(arguments, JSValueIsObject(context, arguments[3]) || JSValueIsString(context, arguments[3]));
+    // This is using the JSC C API so we cannot take a std::span in argument directly.
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
+
+    ASSERT(arguments.size() == 4);
+    ASSERT(JSValueIsNumber(context, arguments[0]));
+    ASSERT(JSValueIsNumber(context, arguments[1]));
+    ASSERT(JSValueIsNumber(context, arguments[2]));
+    ASSERT(JSValueIsObject(context, arguments[3]) || JSValueIsString(context, arguments[3]));
 
     auto automationSessionProxy = WebProcess::singleton().automationSessionProxy();
     if (!automationSessionProxy)
@@ -1069,5 +1071,3 @@ void WebAutomationSessionProxy::deleteCookie(WebCore::PageIdentifier pageID, std
 }
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
@@ -39,8 +39,6 @@
 #import <WebCore/PlatformCALayer.h>
 #import <WebCore/PlatformCALayerDelegatedContents.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebKit {
 
 namespace {
@@ -152,7 +150,7 @@ private:
     void addNewFence(Ref<DisplayBufferFence> newFence);
     static constexpr size_t maxPendingFences = 3;
     size_t m_oldestFenceIndex { 0 };
-    RefPtr<DisplayBufferFence> m_frameCompletionFences[maxPendingFences];
+    std::array<RefPtr<DisplayBufferFence>, maxPendingFences> m_frameCompletionFences;
 
     Ref<DisplayBufferDisplayDelegate> m_layerContentsDisplayDelegate;
     friend class RemoteGraphicsContextGLProxy;
@@ -202,7 +200,5 @@ Ref<RemoteGraphicsContextGLProxy> RemoteGraphicsContextGLProxy::platformCreate(c
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
@@ -37,6 +37,7 @@
 #include <WebCore/AudioUtilities.h>
 #include <WebCore/SharedMemory.h>
 #include <algorithm>
+#include <wtf/StdLibExtras.h>
 
 #if PLATFORM(COCOA)
 #include <WebCore/AudioUtilitiesCocoa.h>
@@ -44,8 +45,6 @@
 #include <WebCore/WebAudioBufferList.h>
 #include <mach/mach_time.h>
 #endif
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebKit {
 
@@ -82,7 +81,7 @@ RemoteAudioDestinationProxy::RemoteAudioDestinationProxy(AudioIOCallback& callba
 uint32_t RemoteAudioDestinationProxy::totalFrameCount() const
 {
     RELEASE_ASSERT(m_frameCount->size() == sizeof(std::atomic<uint32_t>));
-    return WTF::atomicLoad(reinterpret_cast<uint32_t*>(m_frameCount->mutableSpan().data()));
+    return WTF::atomicLoad(&spanReinterpretCast<uint32_t>(m_frameCount->mutableSpan())[0]);
 }
 
 void RemoteAudioDestinationProxy::startRenderingThread()
@@ -242,8 +241,9 @@ void RemoteAudioDestinationProxy::renderAudio(unsigned frameCount)
         frameCount -= numberOfFrames;
         auto* ioData = m_audioBufferList->list();
 
-        auto* buffers = ioData->mBuffers;
+
         auto numberOfBuffers = std::min<UInt32>(ioData->mNumberBuffers, m_outputBus->numberOfChannels());
+        auto buffers = unsafeMakeSpan(ioData->mBuffers, numberOfBuffers);
 
         // Associate the destination data array with the output bus then fill the FIFO.
         for (UInt32 i = 0; i < numberOfBuffers; ++i) {
@@ -270,7 +270,5 @@ void RemoteAudioDestinationProxy::gpuProcessConnectionDidClose(GPUProcessConnect
 }
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(GPU_PROCESS) && ENABLE(WEB_AUDIO)

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
@@ -39,8 +39,6 @@
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 #if USE(LIBWEBRTC)
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
@@ -237,7 +235,7 @@ RetainPtr<CVPixelBufferRef> SharedVideoFrameReader::readBufferFromSharedMemory()
         return { };
     }
 
-    auto result = info->createPixelBufferFromMemory(data.data() + SharedVideoFrameInfoEncodingLength, pixelBufferPool(*info));
+    auto result = info->createPixelBufferFromMemory(data.subspan(SharedVideoFrameInfoEncodingLength), pixelBufferPool(*info));
     if (result && m_resourceOwner && m_useIOSurfaceBufferPool == UseIOSurfaceBufferPool::Yes)
         setOwnershipIdentityForCVPixelBuffer(result.get(), m_resourceOwner);
     return result;
@@ -312,7 +310,5 @@ bool SharedVideoFrameReader::setSharedMemory(SharedMemory::Handle&& handle)
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
@@ -38,9 +38,8 @@
 #include <WebCore/SharedBuffer.h>
 #include <wtf/Function.h>
 #include <wtf/MainThread.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebKit {
 
@@ -122,7 +121,7 @@ int LibWebRTCSocket::SendTo(const void *value, size_t size, const rtc::SocketAdd
     if (m_isSuspended)
         return size;
 
-    std::span data(static_cast<const uint8_t*>(value), size);
+    auto data = unsafeMakeSpan(static_cast<const uint8_t*>(value), size);
     connection->send(Messages::NetworkRTCProvider::SendToSocket { identifier(), data, RTCNetwork::SocketAddress { address }, RTCPacketOptions { options } }, 0);
 
     return size;
@@ -181,7 +180,5 @@ void LibWebRTCSocket::suspend()
 }
 
 } // namespace WebKit
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(LIBWEBRTC)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
@@ -98,7 +98,7 @@ private:
     State m_state { STATE_BINDING };
 
     static const unsigned MAX_SOCKET_OPTION { rtc::Socket::OPT_RTP_SENDTIME_EXTN_ID + 1 };
-    std::optional<int> m_options[MAX_SOCKET_OPTION];
+    std::array<std::optional<int>, MAX_SOCKET_OPTION> m_options;
 
     bool m_isSuspended { false };
     WebCore::ScriptExecutionContextIdentifier m_contextIdentifier;


### PR DESCRIPTION
#### 87d9743a24bdcc47640e86ffd06fb72c4f402bbb
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in more places in WebKit/
<a href="https://bugs.webkit.org/show_bug.cgi?id=282895">https://bugs.webkit.org/show_bug.cgi?id=282895</a>

Reviewed by Brady Eidson.

* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::evaluateJavaScriptCallback):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
(WebKit::RemoteAudioDestinationProxy::totalFrameCount const):
(WebKit::RemoteAudioDestinationProxy::renderAudio):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::decodeVideoFrame):
(WebKit::LibWebRTCCodecs::completedEncoding):
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp:
(WebKit::SharedVideoFrameReader::readBufferFromSharedMemory):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp:
(WebKit::LibWebRTCSocket::SendTo):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h:

Canonical link: <a href="https://commits.webkit.org/286422@main">https://commits.webkit.org/286422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/850d7f6b808360fb8838a03297859119f9468211

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28816 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80416 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27185 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78035 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3242 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59525 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17684 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39885 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46806 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22685 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25512 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67921 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23022 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81880 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2081 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67753 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3442 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67061 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11010 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9135 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11747 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3238 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6044 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3259 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4197 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3266 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->