### PR TITLE
Enforce enum : bool { No, Yes } order

### DIFF
--- a/Source/WTF/wtf/text/Base64.h
+++ b/Source/WTF/wtf/text/Base64.h
@@ -207,7 +207,7 @@ private:
 
 enum class Alphabet : uint8_t { Base64, Base64URL };
 enum class LastChunkHandling : uint8_t { Loose, Strict, StopBeforePartial };
-enum class FromBase64ShouldThrowError: bool { Yes, No };
+enum class FromBase64ShouldThrowError: bool { No, Yes };
 WTF_EXPORT_PRIVATE std::tuple<FromBase64ShouldThrowError, size_t, size_t> fromBase64(StringView, std::span<uint8_t>, Alphabet, LastChunkHandling);
 WTF_EXPORT_PRIVATE size_t maxLengthFromBase64(StringView);
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp
@@ -68,7 +68,7 @@ template<typename ElementType> static void complete4Sides(std::array<ElementType
 
 // MARK: - Border Radius
 
-enum class SupportWebKitBorderRadiusQuirk : bool { Yes, No };
+enum class SupportWebKitBorderRadiusQuirk : bool { No, Yes };
 
 template<SupportWebKitBorderRadiusQuirk supportQuirk> static std::optional<CSS::BorderRadius> consumeBorderRadius(CSSParserTokenRange& range, const CSSParserContext& context)
 {

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1829,7 +1829,7 @@ public:
     bool allowsAddingRenderBlockedElements() const;
     bool isRenderBlocked() const;
 
-    enum class ImplicitRenderBlocking : bool { Yes, No };
+    enum class ImplicitRenderBlocking : bool { No, Yes };
     void blockRenderingOn(Element&, ImplicitRenderBlocking = ImplicitRenderBlocking::No);
     void unblockRenderingOn(Element&);
     void processInternalResourceLinks(HTMLAnchorElement* = nullptr);
@@ -2078,7 +2078,7 @@ private:
     static constexpr OptionSet<VisualUpdatesPreventedReason> visualUpdatePreventReasonsClearedByTimer() { return { VisualUpdatesPreventedReason::ReadyState, VisualUpdatesPreventedReason::RenderBlocking }; }
     static constexpr OptionSet<VisualUpdatesPreventedReason> visualUpdatePreventRequiresLayoutMilestones() { return { VisualUpdatesPreventedReason::Client, VisualUpdatesPreventedReason::ReadyState }; }
 
-    enum class CompletePageTransition : bool { Yes, No };
+    enum class CompletePageTransition : bool { No, Yes };
     void addVisualUpdatePreventedReason(VisualUpdatesPreventedReason, CompletePageTransition = CompletePageTransition::Yes);
     void removeVisualUpdatePreventedReasons(OptionSet<VisualUpdatesPreventedReason>);
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.h
@@ -45,7 +45,7 @@ public:
     TextureMapperAnimation(TextureMapperAnimation&&) = default;
     TextureMapperAnimation& operator=(TextureMapperAnimation&&) = default;
 
-    enum class KeepInternalState : bool { Yes, No };
+    enum class KeepInternalState : bool { No, Yes };
     void apply(ApplicationResult&, MonotonicTime, KeepInternalState);
 
     void pause(Seconds);

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -711,7 +711,7 @@ void RenderTreeUpdater::tearDownRenderer(Text& text)
     invalidateRebuildRootIfNeeded(text);
 }
 
-enum class DidRepaintAndMarkContainingBlock : bool { Yes, No };
+enum class DidRepaintAndMarkContainingBlock : bool { No, Yes };
 static std::optional<DidRepaintAndMarkContainingBlock> repaintAndMarkContainingBlockDirtyBeforeTearDown(const Element& root, auto composedTreeDescendantsIterator)
 {
     auto* destroyRootRenderer = root.renderer();

--- a/Source/WebKit/Shared/ColorControlSupportsAlpha.h
+++ b/Source/WebKit/Shared/ColorControlSupportsAlpha.h
@@ -27,6 +27,6 @@
 
 namespace WebKit {
 
-enum class ColorControlSupportsAlpha : bool { Yes, No };
+enum class ColorControlSupportsAlpha : bool { No, Yes };
 
 }

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -4503,6 +4503,148 @@ class NoNonVirtualDestructorsTest(CppStyleTestBase):
                 enum Foo { FOO_ONE, FOO_TWO };''',
             '')
 
+    def test_enum_no_yes(self):
+        self.assert_multi_line_lint(
+            '''\
+                enum { No, Yes };
+                enum {
+                    No, Yes
+                };
+                enum {
+                    No,
+                    Yes
+                };
+                enum Foo { No, Yes };
+                enum Foo {
+                    No, Yes
+                };
+                enum Foo {
+                    No,
+                    Yes
+                };
+                enum class Foo { No, Yes };
+                enum class Foo {
+                    No, Yes
+                };
+                enum class Foo {
+                    No,
+                    Yes
+                };''',
+            '')
+
+        self.assert_multi_line_lint(
+            '''\
+                enum : bool { No, Yes };
+                enum : bool {
+                    No, Yes
+                };
+                enum : bool {
+                    No,
+                    Yes
+                };
+                enum Foo : bool { No, Yes };
+                enum Foo : bool {
+                    No, Yes
+                };
+                enum Foo : bool {
+                    No,
+                    Yes
+                };
+                enum class Foo : bool { No, Yes };
+                enum class Foo : bool {
+                    No, Yes
+                };
+                enum class Foo : bool {
+                    No,
+                    Yes
+                };''',
+            '')
+
+        self.assert_multi_line_lint(
+            '''\
+                enum { Yes, No };
+                enum {
+                    Yes, No
+                };
+                enum {
+                    Yes,
+                    No
+                };
+                enum Foo { Yes, No };
+                enum Foo {
+                    Yes, No
+                };
+                enum Foo {
+                    Yes,
+                    No
+                };
+                enum class Foo { Yes, No };
+                enum class Foo {
+                    Yes, No
+                };
+                enum class Foo {
+                    Yes,
+                    No
+                };''',
+            '')
+
+        self.assert_lint(
+            'enum : bool { Yes, No };',
+            'Change the order to { No, Yes }.  [readability/enum_no_yes] [5]')
+
+        self.assert_lint(
+            '''\
+                enum : bool {
+                    Yes, No
+                };''',
+            'Change the order to { No, Yes }.  [readability/enum_no_yes] [5]')
+
+        self.assert_lint(
+            '''\
+                enum : bool {
+                    Yes,
+                    No
+                };''',
+            'Change the order to { No, Yes }.  [readability/enum_no_yes] [5]')
+
+        self.assert_lint(
+            'enum Foo : bool { Yes, No };',
+            'Change the order to { No, Yes }.  [readability/enum_no_yes] [5]')
+
+        self.assert_lint(
+            '''\
+                enum Foo : bool {
+                    Yes, No
+                };''',
+            'Change the order to { No, Yes }.  [readability/enum_no_yes] [5]')
+
+        self.assert_lint(
+            '''\
+                enum Foo : bool {
+                    Yes,
+                    No
+                };''',
+            'Change the order to { No, Yes }.  [readability/enum_no_yes] [5]')
+
+        self.assert_lint(
+            'enum class Foo : bool { Yes, No };',
+            'Change the order to { No, Yes }.  [readability/enum_no_yes] [5]')
+
+        self.assert_lint(
+            '''\
+                enum class Foo : bool {
+                    Yes, No
+                };''',
+            'Change the order to { No, Yes }.  [readability/enum_no_yes] [5]')
+
+        self.assert_lint(
+            '''\
+                enum class Foo : bool {
+                    Yes,
+                    No
+                };''',
+            'Change the order to { No, Yes }.  [readability/enum_no_yes] [5]')
+
     def test_enum_trailing_semicolon(self):
         self.assert_lint(
             'enum MyEnum { Value1, Value2 };',


### PR DESCRIPTION
#### f2554a7bf3fafaf732e9ea2f5584ffa1a8a6616f
<pre>
Enforce enum : bool { No, Yes } order
<a href="https://bugs.webkit.org/show_bug.cgi?id=282674">https://bugs.webkit.org/show_bug.cgi?id=282674</a>
<a href="https://rdar.apple.com/problem/139335415">rdar://problem/139335415</a>

Reviewed by Anne van Kesteren.

This ensures that casting to/from the underlying bool matches
the expected values No==0==false and Yes==1==true.

check-webkit-style now catches unexpected {Yes,No} ordering.

A few instances were caught and fixed.

* Source/WTF/wtf/text/Base64.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp:
* Source/WebCore/dom/Document.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.h:
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
* Source/WebKit/Shared/ColorControlSupportsAlpha.h:
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(_EnumState.__init__):
(_EnumState.process_clean_line):
(_EnumState.process_clean_line.check_case_error):
(_EnumState.process_clean_line.check_case_error.is_case_error):
(_EnumState.process_clean_line.check_member_list):
(_EnumState):
(check_enum_members):
(check_style):
(CppChecker):
(_EnumState.process_clean_line.is_case_error): Deleted.
(check_enum_casing): Deleted.
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(NoNonVirtualDestructorsTest):

Canonical link: <a href="https://commits.webkit.org/286492@main">https://commits.webkit.org/286492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35f49e7776c8cedd88148466105f34454f1d418d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28817 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80417 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27186 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78036 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3243 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59527 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17686 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49407 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65202 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39887 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/75427 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46807 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22686 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25513 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69097 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67922 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81881 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75196 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2082 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67756 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67065 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16758 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11011 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9136 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97450 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3239 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6045 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21310 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3260 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4198 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3267 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->