### PR TITLE
REGRESSION(284791@main): [ Debug ] 2x TestWebKitAPI.JavaScriptCore.Incremental* (api-tests) are constant asserts

### DIFF
--- a/Source/JavaScriptCore/API/JSContext.mm
+++ b/Source/JavaScriptCore/API/JSContext.mm
@@ -55,7 +55,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 @implementation JSContext {
     RetainPtr<JSVirtualMachine> m_virtualMachine;
     JSGlobalContextRef m_context;
-    JSC::Strong<JSC::JSObject> m_exception;
+    RetainPtr<JSValue> m_exception;
     WeakObjCPtr<id <JSModuleLoaderDelegate>> m_moduleLoaderDelegate;
 }
 
@@ -98,7 +98,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 - (void)dealloc
 {
-    m_exception.clear();
+    m_exception = nil;
     JSGlobalContextRelease(m_context);
     [_exceptionHandler release];
     [super dealloc];
@@ -193,17 +193,12 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     JSC::JSGlobalObject* globalObject = toJS(m_context);
     JSC::VM& vm = globalObject->vm();
     JSC::JSLockHolder locker(vm);
-    if (value)
-        m_exception.set(vm, toJS(JSValueToObject(m_context, valueInternalValue(value), 0)));
-    else
-        m_exception.clear();
+    m_exception = value;
 }
 
 - (JSValue *)exception
 {
-    if (!m_exception)
-        return nil;
-    return [JSValue valueWithJSValueRef:toRef(m_exception.get()) inContext:self];
+    return m_exception.get();
 }
 
 - (JSValue *)globalObject


### PR DESCRIPTION
#### 74fba0c2cf751f120626c3505c2a895032f6635d
<pre>
REGRESSION(284791@main): [ Debug ] 2x TestWebKitAPI.JavaScriptCore.Incremental* (api-tests) are constant asserts
<a href="https://bugs.webkit.org/show_bug.cgi?id=281074">https://bugs.webkit.org/show_bug.cgi?id=281074</a>
<a href="https://rdar.apple.com/137526107">rdar://137526107</a>

Reviewed by Keith Miller.

We should avoid using Strong&lt;&gt; in JSContext. The initialization of
Strong&lt;&gt; will happen before JSContext&apos;s init code runs, and this means
that we will hit Strong&lt;&gt; initialization before initializing VM. Let&apos;s
just use RetainPtr&lt;JSValue&gt; so that we do not need to run the above
code. Using RetainPtr&lt;JSValue&gt; is also natural because this m_exception
is JSValue property.

* Source/JavaScriptCore/API/JSContext.mm:
(-[JSContext dealloc]):
(-[JSContext setException:]):
(-[JSContext exception]):

Canonical link: <a href="https://commits.webkit.org/286414@main">https://commits.webkit.org/286414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2a65b780fe2fea16c14f88b42d15b2541d029fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80424 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27193 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64098 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59533 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17692 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65208 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39893 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46812 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22692 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25520 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69104 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67927 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81888 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75203 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3296 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2087 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67762 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3450 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65176 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67071 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11016 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9142 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97457 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11742 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3246 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21315 "Found 2 new JSC stress test failures: stress/json-stringify-inspector-check.js.no-llint, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3267 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4205 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->