### PR TITLE
[build.webkit.org] lldb-webkit-test should report to results database

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1101,6 +1101,12 @@ class RunLLDBWebKitTests(RunPythonTests):
         "--verbose",
         "--no-build",
         WithProperties("--%(configuration)s"),
+        "--suite", "lldb-webkit-test",
+        "--buildbot-master", DNS_NAME,
+        "--builder-name", WithProperties("%(buildername)s"),
+        "--build-number", WithProperties("%(buildnumber)s"),
+        "--buildbot-worker", WithProperties("%(workername)s"),
+        "--report", RESULTS_WEBKIT_URL,
     ]
     failedTestsFormatString = "%d lldb test%s failed"
 

--- a/Tools/CISupport/build-webkit-org/steps_unittest.py
+++ b/Tools/CISupport/build-webkit-org/steps_unittest.py
@@ -726,48 +726,90 @@ class TestRunWebKitPyTests(BuildStepMixinAdditions, unittest.TestCase):
 class TestRunLLDBWebKitTests(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):
         self.longMessage = True
+        os.environ['RESULTS_SERVER_API_KEY'] = 'test-api-key'
         return self.setUpBuildStep()
 
     def tearDown(self):
+        del os.environ['RESULTS_SERVER_API_KEY']
         return self.tearDownBuildStep()
 
-    def test_success(self):
+    def configureStep(self):
         self.setupStep(RunLLDBWebKitTests())
         self.setProperty('configuration', 'release')
+        self.setProperty('buildername', 'LLDBWebKit-Tests-EWS')
+        self.setProperty('buildnumber', '101')
+        self.setProperty('workername', 'ews100')
+
+    def test_success(self):
+        self.configureStep()
         self.expectRemoteCommands(
             ExpectShell(
                 workdir='wkdir',
                 timeout=1200,
                 logEnviron=True,
-                command=['python3', 'Tools/Scripts/test-lldb-webkit', '--verbose', '--no-build', '--release'],
+                command=[
+                    'python3',
+                    'Tools/Scripts/test-lldb-webkit',
+                    '--verbose',
+                    '--no-build',
+                    '--release',
+                    '--suite', 'lldb-webkit-test',
+                    '--buildbot-master', DNS_NAME,
+                    '--builder-name', 'LLDBWebKit-Tests-EWS',
+                    '--build-number', '101',
+                    '--buildbot-worker', 'ews100',
+                    '--report', RESULTS_WEBKIT_URL,
+                ],
             ) + 0,
         )
         self.expectOutcome(result=SUCCESS, state_string='lldb-webkit-test')
         return self.runStep()
 
     def test_unexpected_failure(self):
-        self.setupStep(RunLLDBWebKitTests())
-        self.setProperty('configuration', 'release')
+        self.configureStep()
         self.expectRemoteCommands(
             ExpectShell(
                 workdir='wkdir',
                 timeout=1200,
                 logEnviron=True,
-                command=['python3', 'Tools/Scripts/test-lldb-webkit', '--verbose', '--no-build', '--release'],
+                command=[
+                    'python3',
+                    'Tools/Scripts/test-lldb-webkit',
+                    '--verbose',
+                    '--no-build',
+                    '--release',
+                    '--suite', 'lldb-webkit-test',
+                    '--buildbot-master', DNS_NAME,
+                    '--builder-name', 'LLDBWebKit-Tests-EWS',
+                    '--build-number', '101',
+                    '--buildbot-worker', 'ews100',
+                    '--report', RESULTS_WEBKIT_URL,
+                ],
             ) + 2,
         )
         self.expectOutcome(result=FAILURE, state_string='lldb-webkit-test (failure)')
         return self.runStep()
 
     def test_failure(self):
-        self.setupStep(RunLLDBWebKitTests())
-        self.setProperty('configuration', 'release')
+        self.configureStep()
         self.expectRemoteCommands(
             ExpectShell(
                 workdir='wkdir',
                 timeout=1200,
                 logEnviron=True,
-                command=['python3', 'Tools/Scripts/test-lldb-webkit', '--verbose', '--no-build', '--release'],
+                command=[
+                    'python3',
+                    'Tools/Scripts/test-lldb-webkit',
+                    '--verbose',
+                    '--no-build',
+                    '--release',
+                    '--suite', 'lldb-webkit-test',
+                    '--buildbot-master', DNS_NAME,
+                    '--builder-name', 'LLDBWebKit-Tests-EWS',
+                    '--build-number', '101',
+                    '--buildbot-worker', 'ews100',
+                    '--report', RESULTS_WEBKIT_URL,
+                ],
             ) + 2
             + ExpectShell.log('stdio', stdout='FAILED (failures=2, errors=0)'),
         )
@@ -775,14 +817,25 @@ class TestRunLLDBWebKitTests(BuildStepMixinAdditions, unittest.TestCase):
         return self.runStep()
 
     def test_errors(self):
-        self.setupStep(RunLLDBWebKitTests())
-        self.setProperty('configuration', 'release')
+        self.configureStep()
         self.expectRemoteCommands(
             ExpectShell(
                 workdir='wkdir',
                 timeout=1200,
                 logEnviron=True,
-                command=['python3', 'Tools/Scripts/test-lldb-webkit', '--verbose', '--no-build', '--release'],
+                command=[
+                    'python3',
+                    'Tools/Scripts/test-lldb-webkit',
+                    '--verbose',
+                    '--no-build',
+                    '--release',
+                    '--suite', 'lldb-webkit-test',
+                    '--buildbot-master', DNS_NAME,
+                    '--builder-name', 'LLDBWebKit-Tests-EWS',
+                    '--build-number', '101',
+                    '--buildbot-worker', 'ews100',
+                    '--report', RESULTS_WEBKIT_URL,
+                ],
             ) + 2
             + ExpectShell.log('stdio', stdout='FAILED (failures=0, errors=2)'),
         )
@@ -790,14 +843,25 @@ class TestRunLLDBWebKitTests(BuildStepMixinAdditions, unittest.TestCase):
         return self.runStep()
 
     def test_lot_of_failures(self):
-        self.setupStep(RunLLDBWebKitTests())
-        self.setProperty('configuration', 'release')
+        self.configureStep()
         self.expectRemoteCommands(
             ExpectShell(
                 workdir='wkdir',
                 timeout=1200,
                 logEnviron=True,
-                command=['python3', 'Tools/Scripts/test-lldb-webkit', '--verbose', '--no-build', '--release'],
+                command=[
+                    'python3',
+                    'Tools/Scripts/test-lldb-webkit',
+                    '--verbose',
+                    '--no-build',
+                    '--release',
+                    '--suite', 'lldb-webkit-test',
+                    '--buildbot-master', DNS_NAME,
+                    '--builder-name', 'LLDBWebKit-Tests-EWS',
+                    '--build-number', '101',
+                    '--buildbot-worker', 'ews100',
+                    '--report', RESULTS_WEBKIT_URL,
+                ],
             ) + 2
             + ExpectShell.log('stdio', stdout='FAILED (failures=30, errors=2)'),
         )


### PR DESCRIPTION
#### 2ddeb64eb38c
<pre>
[build.webkit.org] lldb-webkit-test should report to results database
<a href="https://bugs.webkit.org/show_bug.cgi?id=282872">https://bugs.webkit.org/show_bug.cgi?id=282872</a>

Reviewed by NOBODY (OOPS!).

* Tools/CISupport/build-webkit-org/steps.py:
(RunLLDBWebKitTests): Modelled on RunWebKitPyTests, with --suite.
* Tools/CISupport/build-webkit-org/steps_unittest.py:
(TestRunLLDBWebKitTests): Modelled on TestRunWebKitPyTests, albeit
using DNS_NAME to match the actual steps (see bug 282903).
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ddeb64eb38cff5a82413a004219e93842087a8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80435 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27204 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78054 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59541 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17698 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79005 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49420 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65213 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39901 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46820 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22697 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25531 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67935 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23034 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81899 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2094 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67768 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/75615 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3461 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65181 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67077 "Found 1 new API test failure: /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11020 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9147 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3257 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3278 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4216 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3285 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->