### PR TITLE
Use checked_objc_cast in checkedObjCCast

### DIFF
--- a/Source/WebKit/Shared/API/c/mac/WKObjCTypeWrapperRef.mm
+++ b/Source/WebKit/Shared/API/c/mac/WKObjCTypeWrapperRef.mm
@@ -33,7 +33,9 @@
 
 id WKObjCTypeWrapperGetObject(WKObjCTypeWrapperRef wrapperRef)
 {
-    if (wrapperRef && WKGetTypeID(wrapperRef) == WKDataGetTypeID())
-        return WebKit::wrapper(WebKit::toImpl((WKDataRef)wrapperRef));
+    if (wrapperRef && WKGetTypeID(wrapperRef) == WKDataGetTypeID()) {
+        RefPtr impl = WebKit::toImpl((WKDataRef)wrapperRef);
+        return WebKit::wrapper(impl.get());
+    }
     return nil;
 }

--- a/Source/WebKit/Shared/Cocoa/WKObject.h
+++ b/Source/WebKit/Shared/Cocoa/WKObject.h
@@ -60,8 +60,7 @@ template<typename WrappedObjectClass> struct WrapperTraits;
 
 template<typename DestinationClass, typename SourceClass> inline DestinationClass *checkedObjCCast(SourceClass *source)
 {
-    ASSERT([source isKindOfClass:[DestinationClass class]]);
-    return (DestinationClass *)source;
+    return checked_objc_cast<DestinationClass>(source);
 }
 
 template<typename ObjectClass> inline typename WrapperTraits<ObjectClass>::WrapperClass *wrapper(ObjectClass& object)

--- a/Source/WebKit/UIProcess/API/APINavigationResponse.h
+++ b/Source/WebKit/UIProcess/API/APINavigationResponse.h
@@ -42,6 +42,7 @@ public:
     }
 
     FrameInfo& frame() { return m_frame.get(); }
+    Ref<FrameInfo> protectedFrame() { return m_frame.get(); }
 
     const WebCore::ResourceRequest& request() const { return m_request; }
     const WebCore::ResourceResponse& response() const { return m_response; }

--- a/Source/WebKit/UIProcess/API/C/mac/WKWebsiteDataStoreRefPrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKWebsiteDataStoreRefPrivateMac.mm
@@ -31,5 +31,8 @@
 
 WKWebsiteDataStore *WKWebsiteDataStoreGetDataStore(WKWebsiteDataStoreRef dataStore)
 {
-    return dataStore ? wrapper(WebKit::toImpl(dataStore)) : nil;
+    if (!dataStore)
+        return nil;
+    RefPtr impl = WebKit::toImpl(dataStore);
+    return wrapper(impl);
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
@@ -76,7 +76,8 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (WKFrameInfo *)_frame
 {
-    return wrapper(_navigationResponse->frame());
+    // FIXME: This RefPtr should not be necessary. Remove it once clang static analyzer is fixed.
+    return wrapper(RefPtr { _navigationResponse.get() }->protectedFrame().get());
 }
 
 - (NSURLRequest *)_request

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.mm
@@ -181,7 +181,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionControllerConfiguration, Web
 
 - (WKWebsiteDataStore *)defaultWebsiteDataStore
 {
-    return wrapper(self._protectedWebExtensionControllerConfiguration->defaultWebsiteDataStore());
+    return wrapper(self._protectedWebExtensionControllerConfiguration->protectedDefaultWebsiteDataStore().get());
 }
 
 - (void)setDefaultWebsiteDataStore:(WKWebsiteDataStore *)dataStore

--- a/Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.h
+++ b/Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.h
@@ -47,6 +47,8 @@ public:
     void deref() const final;
 
 private:
+    RefPtr<API::WebsitePolicies> protectedPolicies();
+
     void willChangeLockdownMode() final;
     void didChangeLockdownMode() final;
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.mm
@@ -48,9 +48,14 @@ WebPagePreferencesLockdownModeObserver::~WebPagePreferencesLockdownModeObserver(
     removeLockdownModeObserver(*this);
 }
 
+RefPtr<API::WebsitePolicies> WebPagePreferencesLockdownModeObserver::protectedPolicies()
+{
+    return m_policies.get();
+}
+
 void WebPagePreferencesLockdownModeObserver::willChangeLockdownMode()
 {
-    if (auto preferences = wrapper(m_policies.get())) {
+    if (auto preferences = wrapper(protectedPolicies().get())) {
         [preferences willChangeValueForKey:@"_captivePortalModeEnabled"];
         [preferences willChangeValueForKey:@"lockdownModeEnabled"];
     }
@@ -58,7 +63,7 @@ void WebPagePreferencesLockdownModeObserver::willChangeLockdownMode()
 
 void WebPagePreferencesLockdownModeObserver::didChangeLockdownMode()
 {
-    if (auto preferences = wrapper(m_policies.get())) {
+    if (auto preferences = wrapper(protectedPolicies().get())) {
         [preferences didChangeValueForKey:@"_captivePortalModeEnabled"];
         [preferences didChangeValueForKey:@"lockdownModeEnabled"];
     }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
@@ -69,6 +69,7 @@ public:
     void setWebViewConfiguration(WKWebViewConfiguration *configuration) { m_webViewConfiguration = configuration; }
 
     WebsiteDataStore& defaultWebsiteDataStore() const;
+    Ref<WebsiteDataStore> protectedDefaultWebsiteDataStore() const { return defaultWebsiteDataStore(); }
     void setDefaultWebsiteDataStore(WebsiteDataStore* dataStore) { m_defaultWebsiteDataStore = dataStore; }
 
     bool operator==(const WebExtensionControllerConfiguration&) const;


### PR DESCRIPTION
#### 45e5e706cfe35f6153430749e4b9d63b765c2282
<pre>
Use checked_objc_cast in checkedObjCCast
<a href="https://bugs.webkit.org/show_bug.cgi?id=282906">https://bugs.webkit.org/show_bug.cgi?id=282906</a>

Reviewed by Timothy Hatcher.

Convert the debug only assertion in checkedObjCCast to a release assert by using checked_objc_cast.

* Source/WebKit/Shared/API/c/mac/WKObjCTypeWrapperRef.mm:
(WKObjCTypeWrapperGetObject):
* Source/WebKit/Shared/Cocoa/WKObject.h:
(WebKit::checkedObjCCast):
* Source/WebKit/UIProcess/API/APINavigationResponse.h:
* Source/WebKit/UIProcess/API/C/mac/WKWebsiteDataStoreRefPrivateMac.mm:
(WKWebsiteDataStoreGetDataStore):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm:
(-[WKNavigationResponse _frame]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.mm:
(-[WKWebExtensionControllerConfiguration defaultWebsiteDataStore]):
* Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.h:
* Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.mm:
(WebKit::WebPagePreferencesLockdownModeObserver::protectedPolicies):
(WebKit::WebPagePreferencesLockdownModeObserver::willChangeLockdownMode):
(WebKit::WebPagePreferencesLockdownModeObserver::didChangeLockdownMode):
* Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h:
(WebKit::WebExtensionControllerConfiguration::protectedDefaultWebsiteDataStore const):

Canonical link: <a href="https://commits.webkit.org/286462@main">https://commits.webkit.org/286462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/616881ab46493c01770e831f7f501324110896e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80467 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27236 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3295 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59565 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17724 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49449 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65241 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39925 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46849 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25563 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67964 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23062 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81931 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3339 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2122 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67794 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/new-content-object-view-box-clip-path.html imported/w3c/web-platform-tests/css/css-view-transitions/old-content-captures-different-size.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3493 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65209 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67104 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11052 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9175 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11769 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3289 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6095 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3310 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4248 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3317 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->