### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in wtf/text/WTFString.cpp

### DIFF
--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -145,13 +145,13 @@ LinkBuffer::CodeRef<LinkBufferPtrTag> LinkBuffer::finalizeCodeWithDisassemblyImp
         size_t stringLength = vsnprintf(nullptr, 0, format, preflightArgs);
         va_end(preflightArgs);
 
-        const char prefix[] = "thunk: ";
-        char* buffer = 0;
-        size_t length = stringLength + sizeof(prefix);
+        constexpr auto prefix = "thunk: "_s;
+        std::span<char> buffer;
+        size_t length = stringLength + prefix.length() + 1;
         CString label = CString::newUninitialized(length, buffer);
-        snprintf(buffer, length, "%s", prefix);
-        vsnprintf(buffer + sizeof(prefix) - 1, stringLength + 1, format, argList);
-        out.printf("%s", buffer);
+        memcpySpan(buffer, prefix.span8());
+        vsnprintf(buffer.subspan(prefix.length()).data(), stringLength + 1, format, argList);
+        out.printf("%s", buffer.data());
 
         registerLabel(result.code().untaggedPtr(), WTFMove(label));
     } else

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp
@@ -214,14 +214,14 @@ void IndexedAbstractHeap::initialize(AbstractHeap& field, ptrdiff_t signedIndex)
         unsigned numHexlets = power >> 2;
         
         size_t stringLength = m_heapNameLength + (negative ? strlen(negSplit) : strlen(posSplit)) + numHexlets;
-        char* characters;
+        std::span<char> characters;
         m_largeIndexNames.append(CString::newUninitialized(stringLength, characters));
         
-        memcpy(characters, m_heapForAnyIndex.heapName(), m_heapNameLength);
+        memcpy(characters.data(), m_heapForAnyIndex.heapName(), m_heapNameLength);
         if (negative)
-            memcpy(characters + m_heapNameLength, negSplit, strlen(negSplit));
+            memcpy(characters.data() + m_heapNameLength, negSplit, strlen(negSplit));
         else
-            memcpy(characters + m_heapNameLength, posSplit, strlen(posSplit));
+            memcpy(characters.data() + m_heapNameLength, posSplit, strlen(posSplit));
         
         size_t accumulator = index;
         for (unsigned i = 0; i < numHexlets; ++i) {
@@ -229,7 +229,7 @@ void IndexedAbstractHeap::initialize(AbstractHeap& field, ptrdiff_t signedIndex)
             accumulator >>= 4;
         }
         
-        field.initialize(&m_heapForAnyIndex, characters, m_offset + signedIndex * m_elementSize);
+        field.initialize(&m_heapForAnyIndex, characters.data(), m_offset + signedIndex * m_elementSize);
         return;
     }
     

--- a/Source/WTF/wtf/HexNumber.h
+++ b/Source/WTF/wtf/HexNumber.h
@@ -87,12 +87,17 @@ private:
     const HexNumberBuffer& m_buffer;
 };
 
+WTF_EXPORT_PRIVATE CString toHexCString(std::span<const uint8_t>);
+WTF_EXPORT_PRIVATE String toHexString(std::span<const uint8_t>);
+
 class PrintStream;
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, HexNumberBuffer);
 
 } // namespace WTF
 
 using WTF::hex;
+using WTF::toHexCString;
+using WTF::toHexString;
 using WTF::Lowercase;
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/SHA1.cpp
+++ b/Source/WTF/wtf/SHA1.cpp
@@ -34,6 +34,7 @@
 
 #include <cstddef>
 #include <wtf/Assertions.h>
+#include <wtf/HexNumber.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 
@@ -242,14 +243,7 @@ void SHA1::addUTF8Bytes(CFStringRef string)
 
 CString SHA1::hexDigest(const Digest& digest)
 {
-    char* start = nullptr;
-    CString result = CString::newUninitialized(40, start);
-    char* buffer = start;
-    for (size_t i = 0; i < hashSize; ++i) {
-        snprintf(buffer, 3, "%02X", digest.at(i));
-        buffer += 2;
-    }
-    return result;
+    return toHexCString(digest);
 }
 
 CString SHA1::computeHexDigest()

--- a/Source/WTF/wtf/persistence/PersistentCoders.cpp
+++ b/Source/WTF/wtf/persistence/PersistentCoders.cpp
@@ -81,9 +81,9 @@ std::optional<CString> Coder<CString>::decodeForPersistence(Decoder& decoder)
     if (!decoder.bufferIsLargeEnoughToContain<char>(*length))
         return std::nullopt;
 
-    char* buffer;
+    std::span<char> buffer;
     CString string = CString::newUninitialized(*length, buffer);
-    if (!decoder.decodeFixedLengthData({ byteCast<uint8_t>(buffer), *length }))
+    if (!decoder.decodeFixedLengthData(byteCast<uint8_t>(buffer)))
         return std::nullopt;
 
     return string;

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -54,6 +54,8 @@ private:
 
     CStringBuffer(size_t length) : m_length(length) { }
     char* mutableData() { return reinterpret_cast_ptr<char*>(this + 1); }
+    std::span<char> mutableSpan() { return unsafeMakeSpan(mutableData(), m_length); }
+    std::span<char> mutableSpanIncludingNullCharacter() { return unsafeMakeSpan(mutableData(), m_length + 1); }
 
     const size_t m_length;
 };
@@ -69,7 +71,7 @@ public:
     CString(std::span<const uint8_t>);
     CString(std::span<const char8_t> characters) : CString(byteCast<uint8_t>(characters)) { }
     CString(CStringBuffer* buffer) : m_buffer(buffer) { }
-    WTF_EXPORT_PRIVATE static CString newUninitialized(size_t length, char*& characterBuffer);
+    WTF_EXPORT_PRIVATE static CString newUninitialized(size_t length, std::span<char>& characterBuffer);
     CString(HashTableDeletedValueType) : m_buffer(HashTableDeletedValue) { }
 
     const char* data() const;

--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -118,10 +118,10 @@ CString fileSystemRepresentation(const String& path)
     auto characters = StringView(path).upconvertedCharacters();
     int size = WideCharToMultiByte(CP_ACP, 0, wcharFrom(characters), path.length(), 0, 0, 0, 0);
 
-    char* buffer;
+    std::span<char> buffer;
     CString string = CString::newUninitialized(size, buffer);
 
-    WideCharToMultiByte(CP_ACP, 0, wcharFrom(characters), path.length(), buffer, size, 0, 0);
+    WideCharToMultiByte(CP_ACP, 0, wcharFrom(characters), path.length(), buffer.data(), buffer.size(), 0, 0);
 
     return string;
 }

--- a/Source/WebCore/PAL/pal/crypto/CryptoDigest.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoDigest.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/HexNumber.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
@@ -50,11 +51,16 @@ public:
 
     PAL_EXPORT void addBytes(std::span<const uint8_t>);
     PAL_EXPORT Vector<uint8_t> computeHash();
-    PAL_EXPORT String toHexString();
+    String toHexString();
     PAL_EXPORT CryptoDigest();
 
 private:
     std::unique_ptr<CryptoDigestContext> m_context;
 };
+
+inline String CryptoDigest::toHexString()
+{
+    return WTF::toHexString(computeHash());
+}
 
 } // namespace PAL

--- a/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
+++ b/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
@@ -217,21 +217,6 @@ Vector<uint8_t> CryptoDigest::computeHash()
     return result;
 }
 
-String CryptoDigest::toHexString()
-{
-    auto hash = computeHash();
-
-    char* start = 0;
-    unsigned hashLength = hash.size();
-    CString result = CString::newUninitialized(hashLength * 2, start);
-    char* buffer = start;
-    for (size_t i = 0; i < hashLength; ++i) {
-        snprintf(buffer, 3, "%02X", hash.at(i));
-        buffer += 2;
-    }
-    return String::fromUTF8(result.span());
-}
-
 } // namespace PAL
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/win/TextCodecWin.cpp
+++ b/Source/WebCore/PAL/pal/text/win/TextCodecWin.cpp
@@ -285,10 +285,10 @@ CString TextCodecWin::encode(const UChar* characters, size_t length, Unencodable
     if (resultLength <= 0)
         return "?";
 
-    char* characterBuffer;
+    std::span<char> characterBuffer;
     CString result = CString::newUninitialized(resultLength, characterBuffer);
 
-    WideCharToMultiByte(m_codePage, WC_COMPOSITECHECK, characters, length, characterBuffer, resultLength, 0, 0);
+    WideCharToMultiByte(m_codePage, WC_COMPOSITECHECK, characters, length, characterBuffer.data(), characterBuffer.size(), 0, 0);
 
     return result;
 }

--- a/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
+++ b/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
@@ -37,6 +37,7 @@
 #include <pal/crypto/CryptoDigest.h>
 #include <sqlite3.h>
 #include <wtf/FileSystem.h>
+#include <wtf/HexNumber.h>
 #include <wtf/text/MakeString.h>
 
 #if PLATFORM(COCOA)
@@ -47,15 +48,11 @@
 #include <sys/xattr.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 static constexpr std::array<ASCIILiteral, 3> databaseFileSuffixes { ""_s, "-shm"_s, "-wal"_s };
 
-SQLiteFileSystem::SQLiteFileSystem()
-{
-}
+SQLiteFileSystem::SQLiteFileSystem() = default;
 
 String SQLiteFileSystem::appendDatabaseFileNameToPath(StringView path, StringView fileName)
 {
@@ -154,20 +151,7 @@ String SQLiteFileSystem::computeHashForFileName(StringView fileName)
     auto cryptoDigest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     auto utf8FileName = fileName.utf8();
     cryptoDigest->addBytes(utf8FileName.span());
-    auto digest = cryptoDigest->computeHash();
-    
-    // Convert digest to hex.
-    char* start = 0;
-    unsigned digestLength = digest.size();
-    CString result = CString::newUninitialized(digestLength * 2, start);
-    char* buffer = start;
-    for (size_t i = 0; i < digestLength; ++i) {
-        snprintf(buffer, 3, "%02X", digest.at(i));
-        buffer += 2;
-    }
-    return String::fromUTF8(result.span());
+    return cryptoDigest->toHexString();
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -496,7 +496,9 @@ static bool tryApplyCachedSandbox(const SandboxInfo& info)
     profile.builtin = nullptr;
     profile.size = cachedSandboxHeader.dataSize;
     if (haveBuiltin) {
-        builtin = CString::newUninitialized(cachedSandboxHeader.builtinSize, profile.builtin);
+        std::span<char> cstringBuffer;
+        builtin = CString::newUninitialized(cachedSandboxHeader.builtinSize, cstringBuffer);
+        profile.builtin = cstringBuffer.data();
         if (builtin.isNull())
             return false;
         memcpy(profile.builtin, sandboxBuiltin.data(), cachedSandboxHeader.builtinSize);

--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
@@ -114,11 +114,11 @@ static void wpe_settings_class_init(WPESettingsClass* settingsClass)
 
 static CString makeKeyPath(const char* group, const char* key)
 {
-    char* buffer;
+    std::span<char> buffer;
     size_t length = strlen(group) + strlen(key) + 3;
 
     CString path = CString::newUninitialized(length - 1, buffer);
-    g_snprintf(buffer, length, "/%s/%s", group, key);
+    g_snprintf(buffer.data(), length, "/%s/%s", group, key);
 
     return path;
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/CString.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CString.cpp
@@ -77,16 +77,16 @@ TEST(WTF, CStringEmptyRegularConstructor)
 
 TEST(WTF, CStringUninitializedConstructor)
 {
-    char* buffer;
+    std::span<char> buffer;
     CString emptyString = CString::newUninitialized(0, buffer);
     ASSERT_FALSE(emptyString.isNull());
-    ASSERT_EQ(buffer, emptyString.data());
+    ASSERT_EQ(buffer.data(), emptyString.data());
     ASSERT_EQ(buffer[0], 0);
 
     const size_t length = 25;
     CString uninitializedString = CString::newUninitialized(length, buffer);
     ASSERT_FALSE(uninitializedString.isNull());
-    ASSERT_EQ(buffer, uninitializedString.data());
+    ASSERT_EQ(buffer.data(), uninitializedString.data());
     ASSERT_EQ(uninitializedString.data()[length], 0);
 }
 


### PR DESCRIPTION
#### 4c227b3c248ed64abc1561bfc143c9172f5770a5
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in wtf/text/WTFString.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=282909">https://bugs.webkit.org/show_bug.cgi?id=282909</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/assembler/LinkBuffer.cpp:
(JSC::LinkBuffer::finalizeCodeWithDisassemblyImpl):
* Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp:
(JSC::FTL::IndexedAbstractHeap::initialize):
* Source/WTF/wtf/SHA1.cpp:
(WTF::SHA1::hexDigest):
* Source/WTF/wtf/SafeStrerror.cpp:
(WTF::safeStrerror):
* Source/WTF/wtf/persistence/PersistentCoders.cpp:
(WTF::Persistence::Coder&lt;CString&gt;::decodeForPersistence):
* Source/WTF/wtf/text/CString.cpp:
(WTF::CString::newUninitialized):
* Source/WTF/wtf/text/CString.h:
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::ascii const):
(WTF::String::latin1 const):
(WTF::String::fromCodePoint):
* Source/WTF/wtf/win/FileSystemWin.cpp:
(WTF::FileSystemImpl::fileSystemRepresentation):
* Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp:
(PAL::CryptoDigest::toHexString):
* Source/WebCore/PAL/pal/text/win/TextCodecWin.cpp:
(PAL::TextCodecWin::encode):
* Source/WebCore/platform/sql/SQLiteFileSystem.cpp:
(WebCore::SQLiteFileSystem::computeHashForFileName):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::tryApplyCachedSandbox):
* Tools/TestWebKitAPI/Tests/WTF/CString.cpp:
(TEST(WTF, CStringUninitializedConstructor)):

Canonical link: <a href="https://commits.webkit.org/286466@main">https://commits.webkit.org/286466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f10ad433585c10875be533e056c696b2079cf1ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80557 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27323 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78173 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64228 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59640 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17788 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65317 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39997 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22802 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25650 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69234 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/68037 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82018 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75333 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3426 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67869 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3580 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65285 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67180 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11125 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97587 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11771 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3376 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6182 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21347 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3397 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/4936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/4178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->