### PR TITLE
Drop IsDeprecatedTimerSmartPointerException use in the UIProcess

### DIFF
--- a/Source/WebKit/UIProcess/API/APINavigation.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigation.cpp
@@ -50,7 +50,7 @@ SubstituteData::SubstituteData(Vector<uint8_t>&& content, const ResourceResponse
 Navigation::Navigation(WebCore::ProcessIdentifier processID)
     : m_navigationID(WebCore::NavigationIdentifier::generate())
     , m_processID(processID)
-    , m_clientNavigationActivity(navigationActivityTimeout)
+    , m_clientNavigationActivity(ProcessThrottler::TimedActivity::create(navigationActivityTimeout))
 {
 }
 
@@ -58,7 +58,7 @@ Navigation::Navigation(WebCore::ProcessIdentifier processID, RefPtr<WebBackForwa
     : m_navigationID(WebCore::NavigationIdentifier::generate())
     , m_processID(processID)
     , m_reloadItem(WTFMove(currentAndTargetItem))
-    , m_clientNavigationActivity(navigationActivityTimeout)
+    , m_clientNavigationActivity(ProcessThrottler::TimedActivity::create(navigationActivityTimeout))
 {
 }
 
@@ -69,7 +69,7 @@ Navigation::Navigation(WebCore::ProcessIdentifier processID, WebCore::ResourceRe
     , m_currentRequest(m_originalRequest)
     , m_redirectChain { m_originalRequest.url() }
     , m_fromItem(WTFMove(fromItem))
-    , m_clientNavigationActivity(navigationActivityTimeout)
+    , m_clientNavigationActivity(ProcessThrottler::TimedActivity::create(navigationActivityTimeout))
 {
 }
 
@@ -81,7 +81,7 @@ Navigation::Navigation(WebCore::ProcessIdentifier processID, Ref<WebBackForwardL
     , m_targetItem(WTFMove(targetItem))
     , m_fromItem(WTFMove(fromItem))
     , m_backForwardFrameLoadType(backForwardFrameLoadType)
-    , m_clientNavigationActivity(navigationActivityTimeout)
+    , m_clientNavigationActivity(ProcessThrottler::TimedActivity::create(navigationActivityTimeout))
 {
 }
 

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -157,7 +157,7 @@ public:
 
     const std::optional<WebCore::PrivateClickMeasurement>& privateClickMeasurement() const { return m_lastNavigationAction.privateClickMeasurement; }
 
-    void setClientNavigationActivity(RefPtr<WebKit::ProcessThrottler::Activity>&& activity) { m_clientNavigationActivity = WTFMove(activity); }
+    void setClientNavigationActivity(RefPtr<WebKit::ProcessThrottler::Activity>&& activity) { Ref { m_clientNavigationActivity }->setActivity(WTFMove(activity)); }
 
     void setIsLoadedWithNavigationShared(bool value) { m_isLoadedWithNavigationShared = value; }
     bool isLoadedWithNavigationShared() const { return m_isLoadedWithNavigationShared; }
@@ -197,7 +197,7 @@ private:
     WebCore::SecurityOriginData m_destinationFrameSecurityOrigin;
     bool m_userContentExtensionsEnabled { true };
     WebKit::WebContentMode m_effectiveContentMode { WebKit::WebContentMode::Recommended };
-    WebKit::ProcessThrottler::TimedActivity m_clientNavigationActivity;
+    Ref<WebKit::ProcessThrottler::TimedActivity> m_clientNavigationActivity;
     bool m_isLoadedWithNavigationShared { false };
     RefPtr<API::WebsitePolicies> m_websitePolicies;
     std::optional<OptionSet<WebCore::AdvancedPrivacyProtections>> m_originatorAdvancedPrivacyProtections;

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -474,7 +474,7 @@ bool AuxiliaryProcessProxy::platformIsBeingDebugged() const
 
 void AuxiliaryProcessProxy::stopResponsivenessTimer()
 {
-    responsivenessTimer().stop();
+    checkedResponsivenessTimer()->stop();
 }
 
 void AuxiliaryProcessProxy::beginResponsivenessChecks()
@@ -493,9 +493,9 @@ void AuxiliaryProcessProxy::startResponsivenessTimer(UseLazyStop useLazyStop)
     }
 
     if (useLazyStop == UseLazyStop::Yes)
-        responsivenessTimer().startWithLazyStop();
+        checkedResponsivenessTimer()->startWithLazyStop();
     else
-        responsivenessTimer().start();
+        checkedResponsivenessTimer()->start();
 }
 
 bool AuxiliaryProcessProxy::mayBecomeUnresponsive()

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -205,6 +205,8 @@ public:
 
     ResponsivenessTimer& responsivenessTimer() { return m_responsivenessTimer; }
     const ResponsivenessTimer& responsivenessTimer() const { return m_responsivenessTimer; }
+    CheckedRef<ResponsivenessTimer> checkedResponsivenessTimer() { return m_responsivenessTimer; }
+    CheckedRef<const ResponsivenessTimer> checkedResponsivenessTimer() const { return m_responsivenessTimer; }
 
     void ref() const final { ThreadSafeRefCounted::ref(); }
     void deref() const final { ThreadSafeRefCounted::deref(); }

--- a/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h
+++ b/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h
@@ -26,23 +26,17 @@
 #pragma once
 
 #include "ResponsivenessTimer.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/WeakRef.h>
-
-namespace WebKit {
-class BackgroundProcessResponsivenessTimer;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebKit::BackgroundProcessResponsivenessTimer> : std::true_type { };
-}
 
 namespace WebKit {
 
 class WebProcessProxy;
 
-class BackgroundProcessResponsivenessTimer {
+class BackgroundProcessResponsivenessTimer : public CanMakeCheckedPtr<BackgroundProcessResponsivenessTimer> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(BackgroundProcessResponsivenessTimer);
 public:
     explicit BackgroundProcessResponsivenessTimer(WebProcessProxy&);
     ~BackgroundProcessResponsivenessTimer();

--- a/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp
+++ b/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp
@@ -49,8 +49,16 @@ PerActivityStateCPUUsageSampler::PerActivityStateCPUUsageSampler(WebProcessPool&
     m_loggingTimer.startRepeating(loggingInterval);
 }
 
-PerActivityStateCPUUsageSampler::~PerActivityStateCPUUsageSampler()
+PerActivityStateCPUUsageSampler::~PerActivityStateCPUUsageSampler() = default;
+
+void PerActivityStateCPUUsageSampler::ref() const
 {
+    m_processPool->ref();
+}
+
+void PerActivityStateCPUUsageSampler::deref() const
+{
+    m_processPool->deref();
 }
 
 void PerActivityStateCPUUsageSampler::reportWebContentCPUTime(Seconds cpuTime, ActivityStateForCPUSampling activityState)

--- a/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h
+++ b/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h
@@ -31,15 +31,6 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
-class PerActivityStateCPUUsageSampler;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebKit::PerActivityStateCPUUsageSampler> : std::true_type { };
-}
-
-namespace WebKit {
 
 class WebPageProxy;
 class WebProcessPool;
@@ -49,6 +40,9 @@ class PerActivityStateCPUUsageSampler {
 public:
     explicit PerActivityStateCPUUsageSampler(WebProcessPool&);
     ~PerActivityStateCPUUsageSampler();
+
+    void ref() const;
+    void deref() const;
 
     void reportWebContentCPUTime(Seconds cpuTime, WebCore::ActivityStateForCPUSampling);
 

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -35,15 +35,8 @@
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
 
-namespace WebKit {
-class ProcessThrottlerTimedActivity;
-}
-
 namespace WTF {
 class TextStream;
-
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebKit::ProcessThrottlerTimedActivity> : std::true_type { };
 }
 
 namespace WebKit {
@@ -94,17 +87,20 @@ private:
     IsQuietActivity m_isQuietActivity;
 };
 
-class ProcessThrottlerTimedActivity {
+class ProcessThrottlerTimedActivity : public RefCounted<ProcessThrottlerTimedActivity> {
     WTF_MAKE_TZONE_ALLOCATED(ProcessThrottlerTimedActivity);
     WTF_MAKE_NONCOPYABLE(ProcessThrottlerTimedActivity);
     using Activity = ProcessThrottlerActivity;
 public:
-    explicit ProcessThrottlerTimedActivity(Seconds, RefPtr<Activity>&& = nullptr);
-    ProcessThrottlerTimedActivity& operator=(RefPtr<Activity>&&);
+    static Ref<ProcessThrottlerTimedActivity> create(Seconds, RefPtr<Activity>&& = nullptr);
     const RefPtr<Activity> activity() const { return m_activity; }
     void setTimeout(Seconds);
 
+    void setActivity(RefPtr<Activity>&&);
+
 private:
+    explicit ProcessThrottlerTimedActivity(Seconds, RefPtr<Activity>&&);
+
     void activityTimedOut();
     void updateTimer();
 

--- a/Source/WebKit/UIProcess/ResponsivenessTimer.h
+++ b/Source/WebKit/UIProcess/ResponsivenessTimer.h
@@ -27,21 +27,15 @@
 #define ResponsivenessTimer_h
 
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/WeakRef.h>
 
 namespace WebKit {
-class ResponsivenessTimer;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebKit::ResponsivenessTimer> : std::true_type { };
-}
-
-namespace WebKit {
-
-class ResponsivenessTimer {
+class ResponsivenessTimer : public CanMakeCheckedPtr<ResponsivenessTimer> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ResponsivenessTimer);
 public:
     class Client : public AbstractRefCountedAndCanMakeWeakPtr<Client> {
     public:

--- a/Source/WebKit/UIProcess/WebProcessActivityState.h
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.h
@@ -75,7 +75,7 @@ private:
 
     RefPtr<ProcessThrottlerActivity> m_isVisibleActivity;
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
-    UniqueRef<ProcessThrottlerTimedActivity> m_wasRecentlyVisibleActivity;
+    Ref<ProcessThrottlerTimedActivity> m_wasRecentlyVisibleActivity;
 #endif
     RefPtr<ProcessThrottlerActivity> m_isAudibleActivity;
     RefPtr<ProcessThrottlerActivity> m_isCapturingActivity;

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -243,7 +243,7 @@ WebProcessPool::WebProcessPool(API::ProcessPoolConfiguration& configuration)
     , m_historyClient(makeUnique<API::LegacyContextHistoryClient>())
     , m_visitedLinkStore(VisitedLinkStore::create())
 #if PLATFORM(MAC)
-    , m_perActivityStateCPUUsageSampler(makeUnique<PerActivityStateCPUUsageSampler>(*this))
+    , m_perActivityStateCPUUsageSampler(makeUniqueRefWithoutRefCountedCheck<PerActivityStateCPUUsageSampler>(*this))
 #endif
     , m_alwaysRunsAtBackgroundPriority(m_configuration->alwaysRunsAtBackgroundPriority())
     , m_shouldTakeUIBackgroundAssertion(m_configuration->shouldTakeUIBackgroundAssertion())
@@ -1882,8 +1882,7 @@ void WebProcessPool::updateHiddenPageThrottlingAutoIncreaseLimit()
 void WebProcessPool::reportWebContentCPUTime(Seconds cpuTime, uint64_t activityState)
 {
 #if PLATFORM(MAC)
-    if (m_perActivityStateCPUUsageSampler)
-        m_perActivityStateCPUUsageSampler->reportWebContentCPUTime(cpuTime, static_cast<WebCore::ActivityStateForCPUSampling>(activityState));
+    Ref { m_perActivityStateCPUUsageSampler.get() }->reportWebContentCPUTime(cpuTime, static_cast<WebCore::ActivityStateForCPUSampling>(activityState));
 #else
     UNUSED_PARAM(cpuTime);
     UNUSED_PARAM(activityState);

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -802,7 +802,7 @@ private:
     RetainPtr<NSObject> m_deactivationObserver;
     RetainPtr<WKWebInspectorPreferenceObserver> m_webInspectorPreferenceObserver;
 
-    std::unique_ptr<PerActivityStateCPUUsageSampler> m_perActivityStateCPUUsageSampler;
+    UniqueRef<PerActivityStateCPUUsageSampler> m_perActivityStateCPUUsageSampler;
 #endif
 
 #if PLATFORM(COCOA)


### PR DESCRIPTION
#### 002cc01fab1b0d4d0f1f709eb4d6a3133c79c1be
<pre>
Drop IsDeprecatedTimerSmartPointerException use in the UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=282913">https://bugs.webkit.org/show_bug.cgi?id=282913</a>

Reviewed by Darin Adler.

* Source/WebKit/UIProcess/API/APINavigation.cpp:
(API::Navigation::Navigation):
(API::m_clientNavigationActivity):
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::setClientNavigationActivity):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::stopResponsivenessTimer):
(WebKit::AuxiliaryProcessProxy::startResponsivenessTimer):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::checkedResponsivenessTimer):
(WebKit::AuxiliaryProcessProxy::checkedResponsivenessTimer const):
* Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h:
* Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h:
* Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.mm:
(WebKit::XPCConnectionTerminationWatchdog::startConnectionTerminationWatchdog):
(WebKit::XPCConnectionTerminationWatchdog::XPCConnectionTerminationWatchdog):
(WebKit::XPCConnectionTerminationWatchdog::terminateProcess):
(WebKit::XPCConnectionTerminationWatchdog::watchdogTimerFired): Deleted.
* Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp:
(WebKit::PerActivityStateCPUUsageSampler::ref const):
(WebKit::PerActivityStateCPUUsageSampler::deref const):
(WebKit::PerActivityStateCPUUsageSampler::~PerActivityStateCPUUsageSampler): Deleted.
* Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h:
* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottlerTimedActivity::create):
(WebKit::ProcessThrottlerTimedActivity::setActivity):
(WebKit::ProcessThrottlerTimedActivity::operator=): Deleted.
* Source/WebKit/UIProcess/ProcessThrottler.h:
* Source/WebKit/UIProcess/ResponsivenessTimer.h:
* Source/WebKit/UIProcess/WebProcessActivityState.cpp:
(WebKit::WebProcessActivityState::WebProcessActivityState):
(WebKit::WebProcessActivityState::takeVisibleActivity):
(WebKit::WebProcessActivityState::reset):
(WebKit::WebProcessActivityState::dropVisibleActivity):
* Source/WebKit/UIProcess/WebProcessActivityState.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::WebProcessPool):
(WebKit::WebProcessPool::reportWebContentCPUTime):
* Source/WebKit/UIProcess/WebProcessPool.h:

Canonical link: <a href="https://commits.webkit.org/286437@main">https://commits.webkit.org/286437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f90e8bbb61ee9c8eb6b63420474a4a2b653eaa92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80459 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27228 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3287 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59561 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17720 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39921 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46841 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25555 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67956 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23053 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81923 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3331 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2114 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67789 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65200 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67098 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11045 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9166 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11757 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3281 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6087 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3302 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4240 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3309 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->