### PR TITLE
[GTK][WPE][Skia] Avoid temporary copies in getImageData()

### DIFF
--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -160,15 +160,33 @@ void ImageBufferSkiaAcceleratedBackend::getPixelBuffer(const IntRect& srcRect, P
     if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
         return;
 
-    auto info = m_surface->imageInfo();
-    auto data = SkData::MakeUninitialized(info.computeMinByteSize());
-    auto* pixels = static_cast<uint8_t*>(data->writable_data());
-    size_t rowBytes = static_cast<size_t>(info.minRowBytes64());
+    const IntRect backendRect { { }, size() };
+    const auto sourceRectClipped = intersection(backendRect, srcRect);
+    IntRect destinationRect { IntPoint::zero(), sourceRectClipped.size() };
 
-    // Create a SkImageInfo so the readPixels call will convert the RGBA pixels from the surface into BGRA.
-    SkImageInfo imageInfo = SkImageInfo::Make(info.width(), info.height(), SkColorType::kBGRA_8888_SkColorType, SkAlphaType::kPremul_SkAlphaType, colorSpace().platformColorSpace());
-    if (m_surface->readPixels(imageInfo, pixels, rowBytes, 0, 0))
-        ImageBufferBackend::getPixelBuffer(srcRect, pixels, destination);
+    if (srcRect.x() < 0)
+        destinationRect.setX(destinationRect.x() - srcRect.x());
+    if (srcRect.y() < 0)
+        destinationRect.setY(destinationRect.y() - srcRect.y());
+
+    if (destination.size() != sourceRectClipped.size())
+        destination.zeroFill();
+
+    const auto destinationColorType = (destination.format().pixelFormat == PixelFormat::RGBA8)
+        ? SkColorType::kRGBA_8888_SkColorType : SkColorType::kBGRA_8888_SkColorType;
+
+    const auto destinationAlphaType = (destination.format().alphaFormat == AlphaPremultiplication::Premultiplied)
+        ? SkAlphaType::kPremul_SkAlphaType : SkAlphaType::kUnpremul_SkAlphaType;
+
+    auto destinationInfo = SkImageInfo::Make(destination.size().width(), destination.size().height(),
+        destinationColorType, destinationAlphaType, destination.format().colorSpace.platformColorSpace());
+    SkPixmap pixmap(destinationInfo, destination.bytes().data(), destination.size().width() * 4);
+
+    SkPixmap dstPixmap;
+    if (UNLIKELY(!pixmap.extractSubset(&dstPixmap, destinationRect)))
+        return;
+
+    m_surface->readPixels(dstPixmap, sourceRectClipped.x(), sourceRectClipped.y());
 }
 
 void ImageBufferSkiaAcceleratedBackend::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat)


### PR DESCRIPTION
#### 3ca14e7517d743ab5bca0ed6fd7579799aa85aec
<pre>
[GTK][WPE][Skia] Avoid temporary copies in getImageData()
<a href="https://bugs.webkit.org/show_bug.cgi?id=282915">https://bugs.webkit.org/show_bug.cgi?id=282915</a>

Reviewed by Carlos Garcia Campos.

Change ImageBufferSkiaAcceleratedBackend::getPixelBuffer() to avoid
making a temporary scratch buffer with the same size as the canvas
backing SkSurface on each canvas.getImageData() invocation.

As in 285116@main, avoid using the ImageBufferBackend::getPixelBuffer()
helper on a temporary buffer, bring inline the needed calculations for
the source/destination areas, and wrap the PixelBuffer with a SkPixmap
that then gets passed directly to Skia. This way we can always let Skia
do the needed pixel format and alpha component type conversions.

On top of reducing memory usage, this makes the MotionMark Canvas
put/get Image Data test ~10x faster.

Covered by existing layout tests.

* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::getPixelBuffer):

Canonical link: <a href="https://commits.webkit.org/286795@main">https://commits.webkit.org/286795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6052b34dc464f8ffc0c7024e2ba17753bbbf8908

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54987 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80455 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27224 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64129 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59558 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17718 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65231 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39918 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46838 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22715 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25551 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67953 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81919 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2134 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67787 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3481 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65199 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67096 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11042 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9165 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11934 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3277 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6083 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3298 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4236 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3305 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->