### PR TITLE
Reduce use of IsDeprecatedTimerSmartPointerException in WebCore

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2012,6 +2012,7 @@ private:
     ScriptModuleLoader& ensureModuleLoader();
     WEBCORE_EXPORT FullscreenManager& ensureFullscreenManager();
     inline DocumentFontLoader& fontLoader();
+    Ref<DocumentFontLoader> protectedFontLoader();
     DocumentFontLoader& ensureFontLoader();
     CSSFontSelector& ensureFontSelector();
     UndoManager& ensureUndoManager();

--- a/Source/WebCore/dom/DocumentFontLoader.cpp
+++ b/Source/WebCore/dom/DocumentFontLoader.cpp
@@ -54,6 +54,16 @@ DocumentFontLoader::~DocumentFontLoader()
     stopLoadingAndClearFonts();
 }
 
+void DocumentFontLoader::ref() const
+{
+    m_document->ref();
+}
+
+void DocumentFontLoader::deref() const
+{
+    m_document->deref();
+}
+
 CachedFont* DocumentFontLoader::cachedFont(URL&& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource loadedFromOpaqueSource)
 {
     ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();

--- a/Source/WebCore/dom/DocumentFontLoader.h
+++ b/Source/WebCore/dom/DocumentFontLoader.h
@@ -34,15 +34,6 @@
 #include <wtf/WeakRef.h>
 
 namespace WebCore {
-class DocumentFontLoader;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::DocumentFontLoader> : std::true_type { };
-}
-
-namespace WebCore {
 
 class CachedFont;
 
@@ -51,6 +42,9 @@ class DocumentFontLoader {
 public:
     DocumentFontLoader(Document&);
     ~DocumentFontLoader();
+
+    void ref() const;
+    void deref() const;
 
     CachedFont* cachedFont(URL&&, bool, bool, LoadedFromOpaqueSource);
     void beginLoadingFontSoon(CachedFont&);

--- a/Source/WebCore/dom/EventSender.h
+++ b/Source/WebCore/dom/EventSender.h
@@ -26,28 +26,19 @@
 #pragma once
 
 #include "Timer.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
-
-namespace WebCore {
-template<typename T, typename WeakPtrImpl> class EventSender;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-
-template<typename U, typename WeakPtrImpl>
-struct IsDeprecatedTimerSmartPointerException<WebCore::EventSender<U, WeakPtrImpl>> : std::true_type { };
-}
 
 namespace WebCore {
 
 class Page;
 class WeakPtrImplWithEventTargetData;
 
-template<typename T, typename WeakPtrImpl> class EventSender {
+template<typename T, typename WeakPtrImpl> class EventSender : public CanMakeCheckedPtr<EventSender<T, WeakPtrImpl>> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(EventSender);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EventSender);
     WTF_MAKE_NONCOPYABLE(EventSender);
 public:
     EventSender();

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -107,7 +107,7 @@ void ValidatedFormListedElement::updateVisibleValidationMessage(Ref<HTMLElement>
     if (element.renderer() && willValidate())
         message = validationMessage().trim(deprecatedIsSpaceOrNewline);
     if (!m_validationMessage)
-        m_validationMessage = makeUnique<ValidationMessage>(validationAnchor);
+        m_validationMessage = ValidationMessage::create(validationAnchor);
     m_validationMessage->updateValidationMessage(validationAnchor, message);
 }
 

--- a/Source/WebCore/html/ValidatedFormListedElement.h
+++ b/Source/WebCore/html/ValidatedFormListedElement.h
@@ -128,7 +128,7 @@ private:
     void startDelayingUpdateValidity() { ++m_delayedUpdateValidityCount; }
     void endDelayingUpdateValidity();
 
-    std::unique_ptr<ValidationMessage> m_validationMessage;
+    RefPtr<ValidationMessage> m_validationMessage;
 
     // Cache of validity()->valid().
     // But "candidate for constraint validation" doesn't affect isValid.

--- a/Source/WebCore/html/ValidationMessage.cpp
+++ b/Source/WebCore/html/ValidationMessage.cpp
@@ -58,6 +58,11 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ValidationMessage);
 
 using namespace HTMLNames;
 
+Ref<ValidationMessage> ValidationMessage::create(HTMLElement& element)
+{
+    return adoptRef(*new ValidationMessage(element));
+}
+
 ValidationMessage::ValidationMessage(HTMLElement& element)
     : m_element(element)
 {

--- a/Source/WebCore/html/ValidationMessage.h
+++ b/Source/WebCore/html/ValidationMessage.h
@@ -33,22 +33,11 @@
 #include "Timer.h"
 #include <memory>
 #include <wtf/Noncopyable.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
-
-namespace WebCore {
-class ValidationMessage;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::ValidationMessage> : std::true_type { };
-
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::ValidationMessage> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -59,11 +48,11 @@ class ValidationMessageClient;
 
 // FIXME: We should remove the code for !validationMessageClient() when all
 // ports supporting interactive validation switch to ValidationMessageClient.
-class ValidationMessage : public CanMakeWeakPtr<ValidationMessage> {
+class ValidationMessage : public RefCountedAndCanMakeWeakPtr<ValidationMessage> {
     WTF_MAKE_TZONE_ALLOCATED(ValidationMessage);
     WTF_MAKE_NONCOPYABLE(ValidationMessage);
 public:
-    explicit ValidationMessage(HTMLElement&);
+    static Ref<ValidationMessage> create(HTMLElement&);
     ~ValidationMessage();
 
     void updateValidationMessage(HTMLElement&, const String&);
@@ -73,6 +62,8 @@ public:
     void adjustBubblePosition();
 
 private:
+    explicit ValidationMessage(HTMLElement&);
+
     ValidationMessageClient* validationMessageClient() const;
     void setMessage(const String&);
     void setMessageDOMAndStartTimer();


### PR DESCRIPTION
#### 234f9f0aac39990e9dc80ca6eb11aee1dd7b0447
<pre>
Reduce use of IsDeprecatedTimerSmartPointerException in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=282916">https://bugs.webkit.org/show_bug.cgi?id=282916</a>

Reviewed by Darin Adler.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::~Document):
(WebCore::Document::removedLastRef):
(WebCore::Document::protectedFontLoader):
(WebCore::Document::ensureFontLoader):
(WebCore::Document::resolveStyle):
(WebCore::Document::suspendFontLoading):
(WebCore::Document::fontLoadRequest):
(WebCore::Document::beginLoadingFontSoon):
(WebCore::Document::suspend):
(WebCore::Document::resume):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentFontLoader.cpp:
(WebCore::DocumentFontLoader::ref const):
(WebCore::DocumentFontLoader::deref const):
* Source/WebCore/dom/DocumentFontLoader.h:
* Source/WebCore/dom/EventSender.h:
(): Deleted.
* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::ValidatedFormListedElement::updateVisibleValidationMessage):
* Source/WebCore/html/ValidatedFormListedElement.h:
* Source/WebCore/html/ValidationMessage.cpp:
(WebCore::ValidationMessage::create):
* Source/WebCore/html/ValidationMessage.h:

Canonical link: <a href="https://commits.webkit.org/286452@main">https://commits.webkit.org/286452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cdab520e79f91df5db42bace924e75999752c32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28866 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80464 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27233 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78083 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3292 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59562 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17722 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65237 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39922 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46845 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22721 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25560 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81928 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2120 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67793 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3490 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65205 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67102 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11050 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9171 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11765 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3286 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6092 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3307 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4245 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->