### PR TITLE
Replace comments with `[RethrowsException]` -> `[RethrowException]`

### DIFF
--- a/Source/WebCore/dom/InternalObserverEvery.cpp
+++ b/Source/WebCore/dom/InternalObserverEvery.cpp
@@ -63,7 +63,7 @@ private:
 
             // The exception is not reported, instead it is forwarded to the
             // abort signal and promise rejection.
-            // As such, PredicateCallback `[RethrowsException]` and here a
+            // As such, PredicateCallback has `[RethrowException]` and here a
             // catch scope is declared so the error can be passed to any promise
             // rejection handlers and abort handlers.
             auto scope = DECLARE_CATCH_SCOPE(vm);

--- a/Source/WebCore/dom/InternalObserverFilter.cpp
+++ b/Source/WebCore/dom/InternalObserverFilter.cpp
@@ -95,7 +95,7 @@ private:
         auto matches = false;
 
         // The exception is not reported, instead it is forwarded to the
-        // error handler. As such, PredicateCallback `[RethrowsException]`
+        // error handler. As such, PredicateCallback has `[RethrowException]`
         // and here a catch scope is declared so the error can be passed
         // to the subscription error handler.
         JSC::Exception* previousException = nullptr;

--- a/Source/WebCore/dom/InternalObserverFind.cpp
+++ b/Source/WebCore/dom/InternalObserverFind.cpp
@@ -64,7 +64,7 @@ private:
 
             // The exception is not reported, instead it is forwarded to the
             // abort signal and promise rejection.
-            // As such, PredicateCallback `[RethrowsException]` and here a
+            // As such, PredicateCallback has `[RethrowException]` and here a
             // catch scope is declared so the error can be passed to any promise
             // rejection handlers and abort handlers.
             auto scope = DECLARE_CATCH_SCOPE(vm);

--- a/Source/WebCore/dom/InternalObserverForEach.cpp
+++ b/Source/WebCore/dom/InternalObserverForEach.cpp
@@ -61,7 +61,7 @@ private:
 
             // The exception is not reported, instead it is forwarded to the
             // abort signal and promise rejection.
-            // As such, VisitorCallback `[RethrowsException]` and here a
+            // As such, VisitorCallback has `[RethrowException]` and here a
             // catch scope is declared so the error can be passed to any promise
             // rejection handlers and abort handlers.
             auto scope = DECLARE_CATCH_SCOPE(vm);

--- a/Source/WebCore/dom/InternalObserverMap.cpp
+++ b/Source/WebCore/dom/InternalObserverMap.cpp
@@ -93,7 +93,7 @@ private:
         JSC::JSLockHolder lock(vm);
 
         // The exception is not reported, instead it is forwarded to the
-        // error handler. As such, MapperCallback `[RethrowsException]`
+        // error handler. As such, MapperCallback has `[RethrowException]`
         // and here a catch scope is declared so the error can be passed
         // to the subscription error handler.
         JSC::Exception* previousException = nullptr;

--- a/Source/WebCore/dom/InternalObserverSome.cpp
+++ b/Source/WebCore/dom/InternalObserverSome.cpp
@@ -64,7 +64,7 @@ private:
 
             // The exception is not reported, instead it is forwarded to the
             // abort signal and promise rejection.
-            // As such, PredicateCallback `[RethrowsException]` and here a
+            // As such, PredicateCallback has `[RethrowException]`, and here a
             // catch scope is declared so the error can be passed to any promise
             // rejection handlers and abort handlers.
             auto scope = DECLARE_CATCH_SCOPE(vm);

--- a/Source/WebCore/dom/Observable.cpp
+++ b/Source/WebCore/dom/Observable.cpp
@@ -89,7 +89,7 @@ void Observable::subscribeInternal(ScriptExecutionContext& context, Ref<Internal
     JSC::JSLockHolder lock(vm);
 
     // The exception is not reported, instead it is forwarded to the
-    // error handler. As such, SusbcribeCallback `[RethrowsException]` and
+    // error handler. As such, SusbcribeCallback has `[RethrowException]` and
     // here a catch scope is declared so the error can be passed to the
     // subscription error handler.
     JSC::Exception* previousException = nullptr;


### PR DESCRIPTION
#### 91f64afd1f314fab49ee96caad20b3fcb17c1624
<pre>
Replace comments with `[RethrowsException]` -&gt; `[RethrowException]`
<a href="https://bugs.webkit.org/show_bug.cgi?id=282921">https://bugs.webkit.org/show_bug.cgi?id=282921</a>

Reviewed by Anne van Kesteren.

Having `[RethrowsException]` in the comments is misleading as the
annotation is `[RethrowException]`.

* Source/WebCore/dom/InternalObserverEvery.cpp:
* Source/WebCore/dom/InternalObserverFilter.cpp:
* Source/WebCore/dom/InternalObserverFind.cpp:
* Source/WebCore/dom/InternalObserverForEach.cpp:
* Source/WebCore/dom/InternalObserverMap.cpp:
* Source/WebCore/dom/InternalObserverSome.cpp:
* Source/WebCore/dom/Observable.cpp:
(WebCore::Observable::subscribeInternal):

Canonical link: <a href="https://commits.webkit.org/286431@main">https://commits.webkit.org/286431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0915f065f631e8e791047ba8d5c1ad9b9531301

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80471 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27240 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78090 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59569 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17727 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79041 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65245 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39929 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46853 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22729 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25567 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67969 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81935 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3343 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2126 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67799 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3497 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67109 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16718 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11057 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9179 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3293 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6099 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3314 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4252 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3321 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->