### PR TITLE
[GStreamer] http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html is a permanent failure

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1168,8 +1168,11 @@ webkit.org/b/213699 imported/w3c/web-platform-tests/mediacapture-record/MediaRec
 webkit.org/b/213699 http/wpt/mediarecorder/set-srcObject-MediaStream-Blob.html [ Pass Failure ]
 webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-audio-bitrate.html [ Pass Failure ]
 webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html [ Timeout Failure ]
-webkit.org/b/282534 http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html [ Failure ]
 webkit.org/b/282911 imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-blob-timecode.https.html [ Failure Crash ]
+
+# The mp4 test here is passing but the webm test fails, matroskademux fails to seek in push mode,
+# due to missing index. GLib baselines reflect this, the Pass expectation is kept here for future reference.
+webkit.org/b/282534 http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html [ Pass ]
 
 webkit.org/b/218317 media/media-source/media-source-trackid-change.html [ Failure ]
 webkit.org/b/238201 media/media-source/media-mp4-hevc-bframes.html [ Failure ]

--- a/LayoutTests/platform/glib/http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change-expected.txt
+++ b/LayoutTests/platform/glib/http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change-expected.txt
@@ -1,0 +1,7 @@
+
+
+Harness Error (TIMEOUT), message = null
+
+PASS Recorder with sampling rate change
+TIMEOUT Recorder WebM with sampling rate change Test timed out
+

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -241,6 +241,14 @@ void GStreamerCapturer::stop()
     tearDown(false);
 }
 
+bool GStreamerCapturer::isStopped() const
+{
+    if (!m_pipeline)
+        return true;
+
+    return GST_STATE(m_pipeline.get()) == GST_STATE_NULL;
+}
+
 std::pair<GstClockTime, GstClockTime> GStreamerCapturer::queryLatency()
 {
     if (!m_sink)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
@@ -64,6 +64,7 @@ public:
     void setupPipeline();
     void start();
     void stop();
+    bool isStopped() const;
     WARN_UNUSED_RETURN GRefPtr<GstCaps> caps();
 
     std::pair<GstClockTime, GstClockTime> queryLatency();

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
@@ -153,7 +153,7 @@ void MockRealtimeAudioSourceGStreamer::render(Seconds delta)
         uint32_t bipBopCount = std::min(frameCount, bipBopRemain);
 
         // We might have stopped producing data. Break out of the loop earlier if that happens.
-        if (!m_caps)
+        if (m_capturer && m_capturer->isStopped())
             break;
 
         ASSERT(m_streamFormat);
@@ -183,6 +183,12 @@ void MockRealtimeAudioSourceGStreamer::render(Seconds delta)
         ASSERT(GST_IS_APP_SRC(m_capturer->source()));
         gst_app_src_push_sample(GST_APP_SRC_CAST(m_capturer->source()), sample.get());
     }
+}
+
+void MockRealtimeAudioSourceGStreamer::settingsDidChange(OptionSet<RealtimeMediaSourceSettings::Flag> flags)
+{
+    MockRealtimeAudioSource::settingsDidChange(flags);
+    reconfigure();
 }
 
 void MockRealtimeAudioSourceGStreamer::addHum(float amplitude, float frequency, float sampleRate, uint64_t start, float *p, uint64_t count)

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.h
@@ -46,6 +46,7 @@ public:
 
 protected:
     void render(Seconds) final;
+    void settingsDidChange(OptionSet<RealtimeMediaSourceSettings::Flag>) final;
 
 private:
     friend class MockRealtimeAudioSource;


### PR DESCRIPTION
#### 803a89518b4ee24ff61e340c94760a58a5726a89
<pre>
[GStreamer] http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html is a permanent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=282534">https://bugs.webkit.org/show_bug.cgi?id=282534</a>

Reviewed by Xabier Rodriguez-Calvar.

Reconfigure the capturer when the realtime media source settings have changed. Platform baselines
are added for this test because matroskademux fails to seek in push mode on the resulting WebM blob.
The MP4 test is passing though.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change-expected.txt: Added.
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturer::isStopped const):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp:
(WebCore::MockRealtimeAudioSourceGStreamer::render):
(WebCore::MockRealtimeAudioSourceGStreamer::settingsDidChange):
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/286528@main">https://commits.webkit.org/286528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b086b60d2f9ccae7b70eecf389204a243e2de7a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80636 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27400 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78249 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3459 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59697 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17841 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79200 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65382 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40046 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46986 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22866 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25727 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68118 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82097 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3505 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2266 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67924 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3659 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65351 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67234 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16784 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11186 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9300 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3453 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6260 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3476 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/6870 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5234 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->