### PR TITLE
[WPE] Use a std::span to iterate over configure event states

### DIFF
--- a/Tools/wpe/backends/fdo/WindowViewBackend.cpp
+++ b/Tools/wpe/backends/fdo/WindowViewBackend.cpp
@@ -25,11 +25,13 @@
 
 #include "WindowViewBackend.h"
 
+#include <cassert>
 #include <cstdio>
 #include <cstring>
 #include <linux/input.h>
 #include <memory>
 #include <mutex>
+#include <span>
 #include <sys/mman.h>
 #include <unistd.h>
 
@@ -552,12 +554,10 @@ const struct xdg_toplevel_listener WindowViewBackend::XDGStable::s_toplevelListe
         // wl_array_for_each, but at the time of writing it relies on
         // GCC specific extension to work properly:
         // https://gitlab.freedesktop.org/wayland/wayland/issues/34
-        uint32_t* pos = static_cast<uint32_t*>(states->data);
-        uint32_t* end = static_cast<uint32_t*>(states->data) + states->size;
 
-        for (; pos < end; pos++) {
-            uint32_t state = *pos;
-
+        assert(!(states->size % sizeof(uint32_t)));
+        auto statesSpan = std::span(static_cast<uint32_t*>(states->data), states->size / sizeof(uint32_t));
+        for (auto state : statesSpan) {
             switch (state) {
             case XDG_TOPLEVEL_STATE_ACTIVATED:
                 isFocused = true;
@@ -617,12 +617,9 @@ const struct zxdg_toplevel_v6_listener WindowViewBackend::XDGUnstable::s_topleve
         // wl_array_for_each, but at the time of writing it relies on
         // GCC specific extension to work properly:
         // https://gitlab.freedesktop.org/wayland/wayland/issues/34
-        uint32_t* pos = static_cast<uint32_t*>(states->data);
-        uint32_t* end = static_cast<uint32_t*>(states->data) + states->size;
-
-        for (; pos < end; pos++) {
-            uint32_t state = *pos;
-
+        assert(!(states->size % sizeof(uint32_t)));
+        auto statesSpan = std::span(static_cast<uint32_t*>(states->data), states->size / sizeof(uint32_t));
+        for (auto state : statesSpan) {
             switch (state) {
             case ZXDG_TOPLEVEL_V6_STATE_ACTIVATED:
                 isFocused = true;


### PR DESCRIPTION
#### 43d66a1783e96b01e3f6b75beb5b217d2301cdda
<pre>
[WPE] Use a std::span to iterate over configure event states
<a href="https://bugs.webkit.org/show_bug.cgi?id=282922">https://bugs.webkit.org/show_bug.cgi?id=282922</a>

Reviewed by Adrian Perez de Castro.

Instead of doing pointer aritmetic use a std::span to
iterate configure event states.

* Tools/wpe/backends/fdo/WindowViewBackend.cpp:

Canonical link: <a href="https://commits.webkit.org/286426@main">https://commits.webkit.org/286426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d6228397e634817c766d04e004751843186977c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80473 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27242 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78092 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3301 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59571 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17730 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79043 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49455 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39931 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46855 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22731 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25569 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67971 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/23068 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81937 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3345 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2128 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/67801 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3499 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67111 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11059 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9181 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11749 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3295 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3316 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4254 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3323 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->