### PR TITLE
Web Inspector: Be nice to Chromium and access Float16Array as window property to avoid ReferenceError

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/Utilities.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Utilities.js
@@ -633,7 +633,7 @@ Object.defineProperty(Array, "isTypedArray",
             || constructor === Uint8ClampedArray
             || constructor === Uint16Array
             || constructor === Uint32Array
-            || constructor === Float16Array
+            || constructor === window.Float16Array
             || constructor === Float32Array
             || constructor === Float64Array;
     }


### PR DESCRIPTION
#### 6e26b0d897468c5e8def294c7607a3fd31470580
<pre>
Web Inspector: Be nice to Chromium and access Float16Array as window property to avoid ReferenceError
<a href="https://bugs.webkit.org/show_bug.cgi?id=282924">https://bugs.webkit.org/show_bug.cgi?id=282924</a>

Reviewed by Devin Rousso.

Since implementation of Float16Array in <a href="https://commits.webkit.org/281870@main">https://commits.webkit.org/281870@main</a>
isTypedArray() in Utilities.js assumes that Float16Array exists and constructor
can be compared with it. This assumptions holds in WebKit but fails in Chromium
leading to multiple strange errors, e.g.: DOM nodes not showing up on Elements
tab without page reload, then CSS not showing up at all.

The following error can be observed in JS console:

    Main.js:33247 ReferenceError: Float16Array is not defined
        at Function.value (Main.js:775:259)
        at isArrayLike (Main.js:776:57)
        at Function.value (Main.js:777:5)
        at Function.value (Main.js:678:22)
        at DOMStorageManager._domStorageForIdentifier (Main.js:30568:62)
        at addDOMStorage (Main.js:30575:121)
        at DOMStorageManager._addDOMStorageIfNeeded (Main.js:30576:279)
        at DOMStorageManager._securityOriginDidChange (Main.js:30587:7)
        at dispatch (Main.js:293:24)
        at Frame.dispatchEventToListeners (Main.js:295:100)

To avoid the error bare Float16Array is refactored to `window.Float16Array`
which returns `undefined` if the function doesn&apos;t exist and then nicely compares
`false`, just as expected.

While Chromium need not be supported officially, HTTP WebInspector used to work
flawlessly in Chromium since introduction in 2.38 and it seems to make sense to
retain at least best-effort support for people not fortunate enough to have a
native WebKit-based browser available on their OS.

* Source/WebInspectorUI/UserInterface/Base/Utilities.js:

Canonical link: <a href="https://commits.webkit.org/286475@main">https://commits.webkit.org/286475@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57958ee9b96459d8601f400db28676daab20ec96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76038 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80536 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27304 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59616 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17773 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65296 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39973 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46906 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22780 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25631 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68022 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81999 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3407 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2179 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67845 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67154 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11108 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9227 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11774 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3357 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3378 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4934 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/4151 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->