### PR TITLE
[WGSL] Pointer operators shouldn't be constant

### DIFF
--- a/Source/WebGPU/WGSL/AttributeValidator.cpp
+++ b/Source/WebGPU/WGSL/AttributeValidator.cpp
@@ -450,7 +450,7 @@ void AttributeValidator::visit(AST::StructureMember& member)
 
             auto* type = member.type().inferredType();
             if (type && (alignmentValue % type->alignment()))
-                error(attribute.span(), "@align attribute "_s, alignmentValue, " of struct member is not a multiple of the type's alignemnt "_s, type->alignment());
+                error(attribute.span(), "@align attribute "_s, alignmentValue, " of struct member is not a multiple of the type's alignment "_s, type->alignment());
 
             update<unsigned>(attribute.span(), member.m_alignment, alignmentValue);
             continue;

--- a/Source/WebGPU/WGSL/tests/invalid/pointer-as-constant.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/pointer-as-constant.wgsl
@@ -1,0 +1,6 @@
+// RUN: %not %wgslc | %check
+
+var<storage> x: i32;
+
+// CHECK-L: cannot use runtime value in constant expression
+@id(*&x) var<storage> y: i32;

--- a/Source/WebGPU/WGSL/tests/invalid/required-alignment.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/required-alignment.wgsl
@@ -1,19 +1,19 @@
 // RUN: %not %wgslc | %check
 
 struct S1 {
-    // CHECK-L: arrays in the uniform address space must have a stride multiple of 16 bytes, but has a stride of 8 bytes
-    x: array<vec2<i32>, 2>,
-
     x1: i32,
-    // CHECK-L: offset of struct member S1::y1 must be a multiple of 16 bytes, but its offset is 20 bytes
-    @align(4) y1: array<vec4<i32>, 2>,
+
+    // CHECK-L: arrays in the uniform address space must have a stride multiple of 16 bytes, but has a stride of 4 bytes
+    // CHECK-L: offset of struct member S1::y1 must be a multiple of 16 bytes, but its offset is 4 bytes
+    @align(4) y1: array<i32, 2>,
 
     @align(16) x2: i32,
-    // CHECK-L: offset of struct member S1::y2 must be a multiple of 32 bytes, but its offset is 80 bytes
-    @align(16) y2: U,
 
     x3: i32,
+
+    // CHECK-L: offset of struct member S1::y3 must be a multiple of 16 bytes, but its offset is 24 bytes
     y3: T,
+
     // CHECK-L: uniform address space requires that the number of bytes between S1::y3 and S1::z3 must be at least 16 bytes, but it is 8 bytes
     z3: i32,
 }

--- a/Source/WebGPU/WGSL/wgslc.cpp
+++ b/Source/WebGPU/WGSL/wgslc.cpp
@@ -70,7 +70,10 @@ private:
 void CommandLine::parseArguments(int argc, char** argv)
 {
     for (int i = 1; i < argc; ++i) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
         const char* arg = argv[i];
+#pragma clang diagnostic pop
         if (!strcmp(arg, "-h") || !strcmp(arg, "--help"))
             printUsageStatement(true);
 
@@ -118,7 +121,11 @@ static int runWGSL(const CommandLine& options)
     FileSystem::closeFile(handle);
     auto source = emptyString();
     if (readResult.has_value())
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
         source = String::fromUTF8WithLatin1Fallback(std::span(readResult->data(), readResult->size()));
+#pragma clang diagnostic pop
+
     auto checkResult = WGSL::staticCheck(source, std::nullopt, configuration);
     if (auto* failedCheck = std::get_if<WGSL::FailedCheck>(&checkResult)) {
         for (const auto& error : failedCheck->errors)


### PR DESCRIPTION
#### 294fd8e4b585ca7c1c3f4fdc34d0759ae7b5f44f
<pre>
[WGSL] Pointer operators shouldn&apos;t be constant
<a href="https://bugs.webkit.org/show_bug.cgi?id=282928">https://bugs.webkit.org/show_bug.cgi?id=282928</a>
<a href="https://rdar.apple.com/139645945">rdar://139645945</a>

Reviewed by Dan Glastonbury.

The type checker did not report an error when a new expression was inferred with runtime
execution from a constant context.

* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::infer):
(WGSL::TypeChecker::check):
* Source/WebGPU/WGSL/tests/invalid/pointer-as-constant.wgsl: Added.
* Source/WebGPU/WGSL/tests/invalid/required-alignment.wgsl:
* Source/WebGPU/WGSL/wgslc.cpp:
(CommandLine::parseArguments):
(runWGSL):

Canonical link: <a href="https://commits.webkit.org/286476@main">https://commits.webkit.org/286476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9738dcb3de9d5d0e7e0065448da156e6625251c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80482 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27251 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59583 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17737 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49463 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65254 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39941 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46863 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25578 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67979 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23075 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81946 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2137 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67809 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-offscreen-child-translated.html imported/w3c/web-platform-tests/css/css-view-transitions/old-content-element-writing-modes.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65222 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67119 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16747 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11067 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9188 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3304 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3325 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4263 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3332 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->