### PR TITLE
[WGSL] Pointer rewriting should preserve inferred types

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTExpression.h
@@ -34,6 +34,7 @@ namespace WGSL {
 class BoundsCheckVisitor;
 class ConstantRewriter;
 class EntryPointRewriter;
+class PointerRewriter;
 class RewriteGlobalVariables;
 class TypeChecker;
 struct Type;
@@ -45,6 +46,7 @@ class Expression : public Node {
     friend BoundsCheckVisitor;
     friend ConstantRewriter;
     friend EntryPointRewriter;
+    friend PointerRewriter;
     friend RewriteGlobalVariables;
     friend TypeChecker;
 

--- a/Source/WebGPU/WGSL/PointerRewriter.cpp
+++ b/Source/WebGPU/WGSL/PointerRewriter.cpp
@@ -160,7 +160,12 @@ void PointerRewriter::visit(AST::UnaryExpression& unary)
     if (!nestedUnary || nestedUnary->operation() != AST::UnaryOperation::AddressOf)
         return;
 
-    m_shaderModule.replace(unary, nestedUnary->expression());
+    auto& identity = m_shaderModule.astBuilder().construct<AST::IdentityExpression>(
+        unary.span(),
+        nestedUnary->expression()
+    );
+    identity.m_inferredType = unary.m_inferredType;
+    m_shaderModule.replace(unary, identity);
 }
 
 void rewritePointers(ShaderModule& shaderModule)

--- a/Source/WebGPU/WGSL/tests/valid/pointer-rewriting-concrete-type.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/pointer-rewriting-concrete-type.wgsl
@@ -1,0 +1,9 @@
+// RUN: %metal-compile main
+// RUN: %metal main | %check
+
+@fragment
+fn main() {
+  var h = vec2f();
+  // CHECK-L: length(local0)
+  _ = length(*&h);
+}


### PR DESCRIPTION
#### a3b1e68032f3396cc6667831d984d628dbd35b8e
<pre>
[WGSL] Pointer rewriting should preserve inferred types
<a href="https://bugs.webkit.org/show_bug.cgi?id=282931">https://bugs.webkit.org/show_bug.cgi?id=282931</a>
<a href="https://rdar.apple.com/139647710">rdar://139647710</a>

Reviewed by Dan Glastonbury.

When replacing `*&amp;x` with `x` we need to update the type of `x`, since that might
have been concretized during type checking.

* Source/WebGPU/WGSL/AST/ASTExpression.h:
* Source/WebGPU/WGSL/PointerRewriter.cpp:
(WGSL::PointerRewriter::visit):
* Source/WebGPU/WGSL/tests/valid/pointer-rewriting-concrete-type.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/286478@main">https://commits.webkit.org/286478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5562c8ac9b3f1f635ea5e998791c297e2bb88a1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80624 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27256 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3315 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59687 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17741 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65257 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40039 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46865 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25583 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23078 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81951 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3359 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67813 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3513 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65225 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67123 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16749 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11072 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9191 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3309 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3330 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4268 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3337 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->