### PR TITLE
REGRESSION (265825@main): [iOS] europa.eu: Scroll position jitters when scrolling over interactive map

### DIFF
--- a/LayoutTests/fast/events/touch/ios/programmatic-scrolling-on-touchmove-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/programmatic-scrolling-on-touchmove-expected.txt
@@ -1,0 +1,10 @@
+PASS pageYOffset is > 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+To manually run this test, swipe up to scroll down; scrolling should not be jittery.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+

--- a/LayoutTests/fast/events/touch/ios/programmatic-scrolling-on-touchmove.html
+++ b/LayoutTests/fast/events/touch/ios/programmatic-scrolling-on-touchmove.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width">
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+html, body {
+    margin: 0;
+    text-align: center;
+    width: 100%;
+    font-family: system-ui;
+}
+
+.container {
+    background: linear-gradient(to bottom, red 0%, green 50%, blue 100%);
+    width: 100%;
+    height: 3000px;
+    display: inline-block;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("To manually run this test, swipe up to scroll down; scrolling should not be jittery.");
+    let scrollStartTimerID = null;
+    let startPosition = 0;
+    let scrollDeltas = [];
+    const container = document.querySelector(".container");
+    container.addEventListener("touchstart", (event) => {
+        startPosition = event.touches[0].pageY;
+        event.preventDefault();
+    });
+
+    container.addEventListener("touchmove", (event) => {
+        const position = Math.round(event.touches[0].pageY);
+        scrollTo(0, pageYOffset + startPosition - position);
+        event.preventDefault();
+    });
+
+    addEventListener("scroll", () => {
+        if (pageYOffset < 0 || pageYOffset > 1000)
+            testFailed(`Unexpected pageYOffset: ${pageYOffset}`);
+    });
+
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(100, 450)
+        .move(100, 50, 0.5)
+        .end()
+        .takeResult());
+
+    shouldBeGreaterThan("pageYOffset", "0");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <p id="description"></p>
+    <div class="container"></div>
+</body>
+</html>

--- a/Source/WebCore/dom/ios/MouseEventIOS.cpp
+++ b/Source/WebCore/dom/ios/MouseEventIOS.cpp
@@ -52,7 +52,7 @@ static AtomString mouseEventType(PlatformTouchPoint::TouchPhaseType phase)
 Ref<MouseEvent> MouseEvent::create(const PlatformTouchEvent& event, unsigned index, Ref<WindowProxy>&& view, IsCancelable cancelable)
 {
     return adoptRef(*new MouseEvent(EventInterfaceType::MouseEvent, mouseEventType(event.touchPhaseAtIndex(index)), CanBubble::Yes, cancelable, IsComposed::Yes,
-        event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, event.touchLocationAtIndex(index), event.touchLocationAtIndex(index), 0, 0,
+        event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, event.touchLocationInRootViewAtIndex(index), event.touchLocationInRootViewAtIndex(index), 0, 0,
         event.modifiers(), MouseButton::Left, 0, nullptr, 0, SyntheticClickType::NoTap, { }, { }, IsSimulated::No, IsTrusted::Yes));
 }
 

--- a/Source/WebCore/dom/ios/PointerEventIOS.cpp
+++ b/Source/WebCore/dom/ios/PointerEventIOS.cpp
@@ -72,7 +72,7 @@ Ref<PointerEvent> PointerEvent::create(const AtomString& type, const PlatformTou
 
 PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
     : MouseEvent(EventInterfaceType::PointerEvent, type, canBubble, isCancelable, typeIsComposed(type), event.timestamp().approximateMonotonicTime(), WTFMove(view), 0,
-        event.touchLocationAtIndex(index), event.touchLocationAtIndex(index), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, { }, { }, IsSimulated::No, IsTrusted::Yes)
+        event.touchLocationInRootViewAtIndex(index), event.touchLocationInRootViewAtIndex(index), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, { }, { }, IsSimulated::No, IsTrusted::Yes)
     , m_pointerId(event.touchIdentifierAtIndex(index))
     , m_width(2 * event.radiusXAtIndex(index))
     , m_height(2 * event.radiusYAtIndex(index))

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -327,7 +327,7 @@ void PointerCaptureController::dispatchEventForTouchAtIndex(EventTarget& target,
 
 #if PLATFORM(IOS_FAMILY)
     if (pointerEvent->type() == eventNames().pointercancelEvent) {
-        cancelPointer(pointerEvent->pointerId(), platformTouchEvent.touchLocationAtIndex(index), pointerEvent.ptr());
+        cancelPointer(pointerEvent->pointerId(), platformTouchEvent.touchLocationInRootViewAtIndex(index), pointerEvent.ptr());
         return;
     }
 #endif

--- a/Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm
@@ -590,8 +590,8 @@ static PlatformTouchPoint::TouchPhaseType touchPhaseFromPlatformEventType(Platfo
 
 class PlatformTouchPointBuilder : public PlatformTouchPoint {
 public:
-    PlatformTouchPointBuilder(unsigned identifier, const IntPoint& location, TouchPhaseType phase)
-        : PlatformTouchPoint(identifier, location, phase)
+    PlatformTouchPointBuilder(unsigned identifier, const IntPoint& locationInRootView, std::optional<IntPoint>&& locationInViewport, TouchPhaseType phase)
+        : PlatformTouchPoint(identifier, locationInRootView, WTFMove(locationInViewport), phase)
     {
     }
 };
@@ -615,7 +615,7 @@ public:
             unsigned identifier = [(NSNumber *)[event.touchIdentifiers objectAtIndex:i] unsignedIntValue];
             IntPoint location = IntPoint([(NSValue *)[event.touchLocations objectAtIndex:i] pointValue]);
             PlatformTouchPoint::TouchPhaseType touchPhase = convertTouchPhase([event.touchPhases objectAtIndex:i]);
-            return PlatformTouchPointBuilder(identifier, location, touchPhase);
+            return PlatformTouchPointBuilder(identifier, location, std::nullopt, touchPhase);
         });
     }
     
@@ -631,7 +631,7 @@ public:
         m_globalPosition = location;
         m_isPotentialTap = true;
         
-        m_touchPoints = Vector<PlatformTouchPoint>({ PlatformTouchPointBuilder(1, location, touchPhaseFromPlatformEventType(type)) });
+        m_touchPoints = Vector<PlatformTouchPoint>({ PlatformTouchPointBuilder(1, location, std::nullopt, touchPhaseFromPlatformEventType(type)) });
     }
 };
 

--- a/Source/WebCore/platform/ios/ScrollAnimatorIOS.mm
+++ b/Source/WebCore/platform/ios/ScrollAnimatorIOS.mm
@@ -60,7 +60,7 @@ ScrollAnimatorIOS::~ScrollAnimatorIOS()
 bool ScrollAnimatorIOS::handleTouchEvent(const PlatformTouchEvent& touchEvent)
 {
     if (touchEvent.type() == PlatformEvent::Type::TouchStart && touchEvent.touchCount() == 1) {
-        m_firstTouchPoint = touchEvent.touchLocationAtIndex(0);
+        m_firstTouchPoint = touchEvent.touchLocationInRootViewAtIndex(0);
         m_lastTouchPoint = m_firstTouchPoint;
         m_inTouchSequence = true;
         m_committedToScrollAxis = false;
@@ -91,7 +91,7 @@ bool ScrollAnimatorIOS::handleTouchEvent(const PlatformTouchEvent& touchEvent)
         return false;
     }
     
-    IntPoint currentPoint = touchEvent.touchLocationAtIndex(0);
+    IntPoint currentPoint = touchEvent.touchLocationInRootViewAtIndex(0);
 
     IntSize touchDelta = m_lastTouchPoint - currentPoint;
     m_lastTouchPoint = currentPoint;

--- a/Source/WebKit/Shared/WebEvent.serialization.in
+++ b/Source/WebKit/Shared/WebEvent.serialization.in
@@ -123,7 +123,8 @@ class WebKit::WebTouchEvent : WebKit::WebEvent {
 [CustomHeader] class WebKit::WebPlatformTouchPoint {
 #if PLATFORM(IOS_FAMILY)
     unsigned identifier()
-    WebCore::IntPoint location()
+    WebCore::IntPoint locationInRootView()
+    WebCore::IntPoint locationInViewport()
     WebKit::WebPlatformTouchPoint::State phase()
 #endif
 #if PLATFORM(IOS_FAMILY) && ENABLE(IOS_TOUCH_EVENTS)

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -284,7 +284,7 @@ static WebCore::PlatformTouchPoint::TouchType webPlatformTouchTypeToPlatform(con
 class WebKit2PlatformTouchPoint : public WebCore::PlatformTouchPoint {
 public:
 WebKit2PlatformTouchPoint(const WebPlatformTouchPoint& webTouchPoint)
-    : PlatformTouchPoint(webTouchPoint.identifier(), webTouchPoint.location(), touchEventType(webTouchPoint)
+    : PlatformTouchPoint(webTouchPoint.identifier(), webTouchPoint.locationInRootView(), webTouchPoint.locationInViewport(), touchEventType(webTouchPoint)
 #if ENABLE(IOS_TOUCH_EVENTS)
         , webTouchPoint.radiusX(), webTouchPoint.radiusY(), webTouchPoint.rotationAngle(), webTouchPoint.force(), webTouchPoint.altitudeAngle(), webTouchPoint.azimuthAngle(), webPlatformTouchTypeToPlatform(webTouchPoint.touchType())
 #endif

--- a/Source/WebKit/Shared/WebTouchEvent.h
+++ b/Source/WebKit/Shared/WebTouchEvent.h
@@ -52,16 +52,18 @@ public:
     };
 
     WebPlatformTouchPoint() = default;
-    WebPlatformTouchPoint(unsigned identifier, WebCore::IntPoint location, State phase)
+    WebPlatformTouchPoint(unsigned identifier, WebCore::IntPoint locationInRootView, WebCore::IntPoint locationInViewport, State phase)
         : m_identifier(identifier)
-        , m_location(location)
+        , m_locationInRootView(locationInRootView)
+        , m_locationInViewport(locationInViewport)
         , m_phase(phase)
     {
     }
 #if ENABLE(IOS_TOUCH_EVENTS)
-    WebPlatformTouchPoint(unsigned identifier, WebCore::IntPoint location, State phase, double radiusX, double radiusY, double rotationAngle, double force, double altitudeAngle, double azimuthAngle, TouchType touchType)
+    WebPlatformTouchPoint(unsigned identifier, WebCore::IntPoint locationInRootView, WebCore::IntPoint locationInViewport, State phase, double radiusX, double radiusY, double rotationAngle, double force, double altitudeAngle, double azimuthAngle, TouchType touchType)
         : m_identifier(identifier)
-        , m_location(location)
+        , m_locationInRootView(locationInRootView)
+        , m_locationInViewport(locationInViewport)
         , m_phase(phase)
         , m_radiusX(radiusX)
         , m_radiusY(radiusY)
@@ -75,7 +77,8 @@ public:
 #endif
 
     unsigned identifier() const { return m_identifier; }
-    WebCore::IntPoint location() const { return m_location; }
+    WebCore::IntPoint locationInRootView() const { return m_locationInRootView; }
+    WebCore::IntPoint locationInViewport() const { return m_locationInViewport; }
     State phase() const { return m_phase; }
     State state() const { return phase(); }
 
@@ -99,7 +102,8 @@ public:
 
 private:
     unsigned m_identifier { 0 };
-    WebCore::IntPoint m_location;
+    WebCore::IntPoint m_locationInRootView;
+    WebCore::IntPoint m_locationInViewport;
     State m_phase { State::Released };
 #if ENABLE(IOS_TOUCH_EVENTS)
     double m_radiusX { 0 };

--- a/Source/WebKit/Shared/ios/NativeWebTouchEventIOS.mm
+++ b/Source/WebKit/Shared/ios/NativeWebTouchEventIOS.mm
@@ -100,9 +100,10 @@ Vector<WebPlatformTouchPoint> NativeWebTouchEvent::extractWebTouchPoints(const W
 {
     return event.touchPoints.map([](auto& touchPoint) {
         unsigned identifier = touchPoint.identifier;
-        WebCore::IntPoint location = positionForCGPoint(touchPoint.locationInRootViewCoordinates);
+        auto locationInRootView = positionForCGPoint(touchPoint.locationInRootViewCoordinates);
+        auto locationInViewport = positionForCGPoint(touchPoint.locationInViewport);
         WebPlatformTouchPoint::State phase = convertTouchPhase(touchPoint.phase);
-        WebPlatformTouchPoint platformTouchPoint = WebPlatformTouchPoint(identifier, location, phase);
+        WebPlatformTouchPoint platformTouchPoint = WebPlatformTouchPoint(identifier, locationInRootView, locationInViewport, phase);
 #if ENABLE(IOS_TOUCH_EVENTS)
         auto radius = radiusForTouchPoint(touchPoint);
         platformTouchPoint.setRadiusX(radius);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4184,7 +4184,7 @@ void WebPageProxy::updateTouchEventTracking(const WebTouchEvent& touchStartEvent
 {
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(COCOA)
     for (auto& touchPoint : touchStartEvent.touchPoints()) {
-        auto location = touchPoint.location();
+        auto location = touchPoint.locationInRootView();
         auto update = [this, location](TrackingType& trackingType, EventTrackingRegions::EventType eventType) {
             if (trackingType == TrackingType::Synchronous)
                 return;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -619,7 +619,7 @@ struct ImageAnalysisContextMenuActionData {
 
 @end
 
-@interface WKContentView (WKInteraction) <UIGestureRecognizerDelegate, UITextInput, WKFormAccessoryViewDelegate, WKTouchEventsGestureRecognizerDelegate, WKActionSheetAssistantDelegate, WKFileUploadPanelDelegate, WKKeyboardScrollViewAnimatorDelegate, WKDeferringGestureRecognizerDelegate
+@interface WKContentView (WKInteraction) <UIGestureRecognizerDelegate, UITextInput, WKFormAccessoryViewDelegate, WKActionSheetAssistantDelegate, WKFileUploadPanelDelegate, WKKeyboardScrollViewAnimatorDelegate, WKDeferringGestureRecognizerDelegate
 #if HAVE(CONTACTSUI)
     , WKContactPickerDelegate
 #endif
@@ -910,6 +910,9 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 
 - (BOOL)_tryToHandlePressesEvent:(UIPressesEvent *)event;
 - (void)_closeCurrentTypingCommand;
+
+- (BOOL)_shouldIgnoreTouchEvent:(UIEvent *)event;
+- (void)_touchEventsRecognized;
 
 @property (nonatomic, readonly) BOOL shouldUseAsyncInteractions;
 @property (nonatomic, readonly) BOOL selectionHonorsOverflowScrolling;

--- a/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.h
+++ b/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.h
@@ -31,10 +31,13 @@
 #import <UIKit/UIKit.h>
 #import <wtf/Vector.h>
 
+@class WKContentView;
+
 namespace WebKit {
 
 struct WKTouchPoint {
     CGPoint locationInRootViewCoordinates;
+    CGPoint locationInViewport;
     unsigned identifier { 0 };
     UITouchPhase phase { UITouchPhaseBegan };
     CGFloat majorRadiusInWindowCoordinates { 0 };
@@ -61,17 +64,8 @@ struct WKTouchEvent {
 
 } // namespace WebKit
 
-@class WKTouchEventsGestureRecognizer;
-
-@protocol WKTouchEventsGestureRecognizerDelegate <NSObject>
-- (BOOL)isAnyTouchOverActiveArea:(NSSet *)touches;
-@optional
-- (BOOL)shouldIgnoreTouchEvent;
-- (BOOL)gestureRecognizer:(WKTouchEventsGestureRecognizer *)gestureRecognizer shouldIgnoreTouchEvent:(UIEvent *)event;
-@end
-
 @interface WKTouchEventsGestureRecognizer : UIGestureRecognizer
-- (id)initWithTarget:(id)target action:(SEL)action touchDelegate:(id<WKTouchEventsGestureRecognizerDelegate>)delegate;
+- (instancetype)initWithContentView:(WKContentView *)view;
 - (void)cancel;
 
 @property (nonatomic, getter=isDefaultPrevented) BOOL defaultPrevented;
@@ -79,6 +73,7 @@ struct WKTouchEvent {
 @property (nonatomic, readonly) const WebKit::WKTouchEvent& lastTouchEvent;
 @property (nonatomic, readonly, getter=isDispatchingTouchEvents) BOOL dispatchingTouchEvents;
 @property (nonatomic, readonly) NSMapTable<NSNumber *, UITouch *> *activeTouchesByIdentifier;
+@property (nonatomic, readonly, weak) WKContentView *contentView;
 
 @end
 

--- a/Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm
@@ -89,7 +89,7 @@ static Class touchEventsGestureRecognizerClass()
 
 namespace TestWebKitAPI {
 
-static WebKit::WKTouchPoint globalTouchPoint { CGPointZero, 100, UITouchPhaseBegan, 1, 0, 0, 0, WebKit::WKTouchPointType::Direct };
+static WebKit::WKTouchPoint globalTouchPoint { CGPointZero, CGPointZero, 100, UITouchPhaseBegan, 1, 0, 0, 0, WebKit::WKTouchPointType::Direct };
 static WebKit::WKTouchEvent globalTouchEvent { WebKit::WKTouchEventType::Begin, CACurrentMediaTime(), CGPointZero, 1, 0, false, { globalTouchPoint }, { }, { }, true };
 static void updateSimulatedTouchEvent(CGPoint location, UITouchPhase phase)
 {


### PR DESCRIPTION
#### 8612f9f7a3cda362a6280a9ef0e0e687f4d360c1
<pre>
REGRESSION (265825@main): [iOS] europa.eu: Scroll position jitters when scrolling over interactive map
<a href="https://bugs.webkit.org/show_bug.cgi?id=282933">https://bugs.webkit.org/show_bug.cgi?id=282933</a>
<a href="https://rdar.apple.com/112427506">rdar://112427506</a>

Reviewed by Abrar Rahman Protyasha.

The changes in 265825@main exacerbated an existing bug, regarding how our touch event handling logic
propagates the location of the user&apos;s touches from the UI process to the web process; this results
in scrolling on the immigration portal on europa.eu becoming extremely jittery (bouncing between the
minimum and maximum scroll positions in the main document) as the user performs an upwards swipe
over the interactive map to scroll down.

The interactive map on europa.eu intercepts and prevents all `touchstart` and `touchmove` events
that are dispatched over it. When the user attempts to scroll the page by swiping over the element
and `touchmove` is dispatched, their script attempts to adjust `pageYOffset` such that the location
of the user&apos;s touch relative to the document remains the same, before and after handling the
`touchmove` delta. In other words, the `touchmove` event listener simulates scrolling by keeping a
point in content coordinates fixed underneath the user&apos;s finger as they pan.

However, this doesn&apos;t quite work well in practice, especially after the changes in 265825@main
elided an extra CA commit that would otherwise more aggressively sync programmatic scrolling to UI-
side scroll content offset. That&apos;s because touch locations are computed in `WKContentView`
coordinates in the UI process (when receiving gesture recognizer subclass method calls from UIKit),
and then dispatched to the web process where they&apos;re asynchronously queued and delivered to event
listeners for processing. Throughout this process, the root view location of the touch remains
unchanged since it was computed in the UI process, which means that it ignores any changes to the
scroll position of the page that happened after the gesture was recognized. This is particularly
disastrous when combined with europa.eu&apos;s touch event handling logic, which constantly shifts the
scroll position when receiving `touchmove` events — the result is that the page can be scrolled
programmatically, but the root view coordinates of subsequent `touchmove` touch locations don&apos;t
reflect this scrolling at all, causing the event listener to try and move the `pageYOffset` in the
*opposite* direction to compensate. This error then compounds very quickly, causing the scroll
position to jump between min and max scroll positions on the page.

To fix this, we make some adjustments to propagate the user&apos;s touch location relative to the
viewport (unobscured content rect), and only map from the viewport back to root view coordinates at
the last possible moment before dispatching the event by shifting the touch delta back up, using the
main frame&apos;s current `contentsScrollPosition()`.

See below for more details.

* LayoutTests/fast/events/touch/ios/programmatic-scrolling-on-touchmove-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/programmatic-scrolling-on-touchmove.html: Added.

Add a layout test to exercise the change, by swiping up in a reduced test case that emulates
europa.eu&apos;s logic for scrolling in response to `touchmove`, and verifying that the scroll position
always stays within reasonable limits. Without the fixes in this bug, the `pageYOffset` ends up
bouncing between negative values and values of up to 2000-3000.

* Source/WebCore/dom/ios/MouseEventIOS.cpp:
(WebCore::MouseEvent::create):
* Source/WebCore/dom/ios/PointerEventIOS.cpp:
(WebCore::PointerEvent::PointerEvent):
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::dispatchEventForTouchAtIndex):
* Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm:
(WebCore::PlatformTouchPointBuilder::PlatformTouchPointBuilder):
(WebCore::PlatformTouchEventBuilder::PlatformTouchEventBuilder):

Pass `locationInViewport` through to `PlatformTouchPoint` on construction. This is optional since
we currently don&apos;t compute this for `UIWebView` (WebKitLegacy).

* Source/WebCore/platform/ios/ScrollAnimatorIOS.mm:

Adjust call sites, since `touchLocationAtIndex` is now renamed to `touchLocationInRootViewAtIndex`.

(WebCore::ScrollAnimatorIOS::handleTouchEvent):
* Source/WebKit/Shared/WebEvent.serialization.in:
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::WebKit2PlatformTouchPoint::WebKit2PlatformTouchPoint):
* Source/WebKit/Shared/WebTouchEvent.h:
(WebKit::WebPlatformTouchPoint::WebPlatformTouchPoint):
(WebKit::WebPlatformTouchPoint::locationInRootView const):
(WebKit::WebPlatformTouchPoint::locationInViewport const):
(WebKit::WebPlatformTouchPoint::location const): Deleted.

Rename `location` to `locationInRootView` (along with other related members), and plumb a new
`locationInViewport` point alongside the touch point.

* Source/WebKit/Shared/ios/NativeWebTouchEventIOS.mm:
(WebKit::NativeWebTouchEvent::extractWebTouchPoints):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::updateTouchEventTracking):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:

Refactor `WKTouchEventsGestureRecognizer` to just directly take a `WKContentView`. Now that the
touch events gesture no longer needs to be generic for both WebKitLegacy and modern WebKit, there&apos;s
no benefit to maintaining a separate, WebKit-internal `WKTouchEventsGestureRecognizerDelegate` that
is only implemented by the content view.

This allows us to remove some unused code and unnecessary logic (such as the touch target and action
selector, as well as `-isAnyTouchOverActiveArea:`), but importantly allows us to call into the web
view to compute the unobscured content offset when determining the viewport-relative location for
each `WKTouchPoint`.

(-[WKContentView setUpInteraction]):
(-[WKContentView _touchEventsRecognized]):
(-[WKContentView _handleTouchActionsForTouchEvent:]):
(-[WKContentView _shouldIgnoreTouchEvent:]):
(-[WKContentView _touchEventsRecognized:]): Deleted.
(-[WKContentView gestureRecognizer:shouldIgnoreTouchEvent:]): Deleted.
(-[WKContentView isAnyTouchOverActiveArea:]): Deleted.
* Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.h:
* Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm:
(-[WKTouchEventsGestureRecognizer initWithContentView:]):
(mapRootViewToViewport):

Add a helper function to unadjust the given point in root view coordinates by the current unobscured
content offset.

(-[WKTouchEventsGestureRecognizer _touchEventForTouch:]):
(-[WKTouchEventsGestureRecognizer _recordTouches:type:coalescedTouches:predictedTouches:]):

Populate the new `locationInViewport` member on each touch point.

(-[WKTouchEventsGestureRecognizer performAction]):
(-[WKTouchEventsGestureRecognizer touchesBegan:withEvent:]):
(-[WKTouchEventsGestureRecognizer initWithTarget:action:touchDelegate:]): Deleted.
* Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm:

Canonical link: <a href="https://commits.webkit.org/286448@main">https://commits.webkit.org/286448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6471a2cbe019fd75f43a39906ac57c1fdd28dc43

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80508 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27277 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78127 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59598 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17759 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39956 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46886 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22766 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25604 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68002 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81972 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2162 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67829 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3534 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65250 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67138 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16727 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11091 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9213 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3330 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6136 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3351 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4289 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3358 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->