### PR TITLE
[WebGPU] Make it explicit that __wgslMin is only called on uint parameters

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-282937-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-282937-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-282937.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-282937.html
@@ -1,0 +1,25110 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = globalThis.$vm?.print ?? console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  label: '\u1f1b\uf236\u06a6\u0ae8\ua453\u{1fc53}\ucd8a',
+  defaultQueue: {label: '\u8cd1\ued29\u07cf\u{1f8b9}\u96c8'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 4,
+    maxDynamicUniformBuffersPerPipelineLayout: 8,
+    minStorageBufferOffsetAlignment: 256,
+    maxUniformBufferBindingSize: 62928294,
+    maxStorageBufferBindingSize: 159659193,
+  },
+});
+let commandEncoder0 = device0.createCommandEncoder();
+let texture0 = device0.createTexture({
+  size: {width: 220, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'etc2-rgb8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let buffer0 = device0.createBuffer({size: 247, usage: GPUBufferUsage.MAP_WRITE});
+let buffer1 = device0.createBuffer({
+  label: '\u3f96\u{1f730}\ufe66\ud48d\u{1fe04}\u0eda\u0bbc\u02cc',
+  size: 1531,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder1 = device0.createCommandEncoder();
+let texture1 = device0.createTexture({size: [36, 1, 1], format: 'rgba16sint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder0 = commandEncoder1.beginComputePass({});
+let buffer2 = device0.createBuffer({
+  label: '\u5e63\u03a8\u9f84\u092a\u18a7\ua069\uad9f\u52a7\ucc77',
+  size: 8433,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+buffer2.unmap();
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 103,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 176,
+      visibility: 0,
+      storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let commandEncoder2 = device0.createCommandEncoder({});
+let texture2 = device0.createTexture({
+  size: {width: 560, height: 582, depthOrArrayLayers: 7},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView0 = texture2.createView({dimension: '3d'});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint'], sampleCount: 1, stencilReadOnly: true});
+let sampler0 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 63.40,
+});
+try {
+renderBundleEncoder0.setIndexBuffer(buffer1, 'uint16', 968, 4);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(7, buffer2, 0);
+} catch {}
+let texture3 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 262},
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView1 = texture0.createView({dimension: '2d-array', aspect: 'all', mipLevelCount: 1});
+let renderBundle0 = renderBundleEncoder0.finish();
+try {
+globalThis.someLabel = device0.label;
+} catch {}
+let pipelineLayout0 = device0.createPipelineLayout({label: '\u042b\uf445\u0434\ua17a\uff5c\u{1fd6f}\u06cb', bindGroupLayouts: [bindGroupLayout0]});
+let texture4 = device0.createTexture({
+  label: '\uf16a\u2e93\u{1fea1}\ud00a\u{1fdae}\u9da7\uf4e6\ubdf5',
+  size: {width: 70, height: 72, depthOrArrayLayers: 20},
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView2 = texture0.createView({dimension: '2d-array', aspect: 'all', mipLevelCount: 1});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  label: '\u{1ffa5}\u04be',
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(103) var st0: texture_storage_3d<rgba8unorm, write>;
+
+@group(0) @binding(176) var st1: texture_storage_3d<rgba16uint, write>;
+
+struct T0 {
+  @align(64) @size(64) f0: mat2x2h,
+  @size(320) f1: array<vec2i, 1>,
+  f2: array<vec2i, 40>,
+}
+
+struct T1 {
+  f0: f32,
+  @size(144) f1: array<vec4f>,
+}
+
+struct S0 {
+  @location(4) f0: vec2f,
+}
+
+struct VertexOutput0 {
+  @builtin(position) f0: vec4f,
+  @location(4) @interpolate(flat, sample) f1: vec4u,
+  @location(10) f2: f32,
+  @location(0) f3: f32,
+  @location(8) @interpolate(linear, sample) f4: vec4f,
+  @location(5) @interpolate(linear) f5: vec2h,
+  @location(15) f6: vec2u,
+  @location(14) f7: i32,
+}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4i,
+}
+
+override override0: bool;
+
+override override1: u32 = 25;
+
+var<workgroup> vw0: mat4x3f;
+
+var<workgroup> vw1: S0;
+
+var<workgroup> vw2: S0;
+
+var<workgroup> vw3: mat3x4h;
+
+var<workgroup> vw4: mat2x3h;
+
+var<private> vp0: S0 = S0();
+
+@vertex
+fn vertex0(@location(11) a0: u32, @location(9) @interpolate(flat, center) a1: vec4u, a2: S0, @location(3) a3: vec2i) -> VertexOutput0 {
+  var out: VertexOutput0;
+  out.f3 -= vec2f(firstLeadingBit(vec2i(unconst_i32(84), unconst_i32(-538)))).r;
+  let vf0: vec3f = inverseSqrt(vec3f(unconst_f32(0.05185), unconst_f32(0.3398), unconst_f32(0.1379)));
+  var vf1: S0 = a2;
+  out.f6 -= vec2u(override1);
+  out.f5 *= vec2h(unpack4xI8(u32(unconst_u32(83))).gr);
+  out.f2 = vp0.f0.y;
+  out.f6 += vec2u(countOneBits(vec4i(unconst_i32(103), unconst_i32(554), unconst_i32(85), unconst_i32(-228))).bb);
+  let vf2: bool = override0;
+  out.f4 += vec4f(f32(any(bool(unconst_bool(false)))));
+  out.f1 *= bitcast<vec4u>(unpack4xI8(pack4xI8Clamp(unpack4xI8(u32(unconst_u32(14))))));
+  out.f7 = i32(determinant(mat3x3h(vec3h(unpack2x16float(u32(unconst_u32(385))).xxy), vec3h(unpack2x16float(u32(unconst_u32(385))).rgg), vec3h(unpack2x16float(u32(unconst_u32(385))).rrg))));
+  var vf3: vec2f = a2.f0;
+  let vf4: f16 = determinant(mat3x3h(f16(vf3[u32(unconst_u32(53))]), f16(vf3[u32(unconst_u32(53))]), f16(vf3[u32(unconst_u32(53))]), f16(vf3[u32(unconst_u32(53))]), f16(vf3[u32(unconst_u32(53))]), f16(vf3[u32(unconst_u32(53))]), f16(vf3[u32(unconst_u32(53))]), f16(vf3[u32(unconst_u32(53))]), f16(vf3[u32(unconst_u32(53))])));
+  let vf5: vec4h = degrees(vec4h(unconst_f16(21347.6), unconst_f16(12805.4), unconst_f16(195.6), unconst_f16(3855.6)));
+  let vf6: vec4i = countOneBits(vec4i(unconst_i32(364), unconst_i32(331), unconst_i32(131), unconst_i32(49)));
+  vp0.f0 += unpack2x16snorm(a1[u32(unconst_u32(9))]);
+  var vf7: bool = any(bool(unconst_bool(false)));
+  out.f2 = f32(pack4xU8(vec4u(unconst_u32(42), unconst_u32(425), unconst_u32(178), unconst_u32(117))));
+  let ptr0: ptr<private, S0> = &vp0;
+  out.f4 -= vp0.f0.gggr;
+  out.f4 += vec4f(f32(vf5[u32(unconst_u32(87))]));
+  return out;
+  _ = override0;
+  _ = override1;
+}
+
+@fragment
+fn fragment0(@location(8) a0: vec4f, @location(4) a1: vec4u) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  let vf8: vec3f = tan(vec3f(unconst_f32(0.4395), unconst_f32(0.1132), unconst_f32(0.2976)));
+  var vf9: vec4h = normalize(vec4h(unconst_f16(-7661.0), unconst_f16(988.7), unconst_f16(786.0), unconst_f16(2880.2)));
+  out.f1 -= vec4i(a0);
+  let vf10: vec3f = tan(vec3f(unconst_f32(0.2049), unconst_f32(0.05386), unconst_f32(0.1620)));
+  let ptr1: ptr<private, S0> = &vp0;
+  out = FragmentOutput0(pack2x16unorm(vp0.f0), bitcast<vec4i>(vp0.f0.rgrg));
+  var vf11: f32 = a0[override1];
+  out.f0 |= u32((*ptr1).f0[u32(unconst_u32(121))]);
+  out.f0 <<= bitcast<u32>(tan(vec3f(unconst_f32(0.3263), unconst_f32(0.03503), unconst_f32(0.2125))).x);
+  vp0.f0 = vp0.f0;
+  out.f1 |= vec4i(i32(override0));
+  return out;
+  _ = override1;
+  _ = override0;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  var vf12: f16 = vw4[u32(unconst_u32(56))][u32(unconst_u32(101))];
+  let ptr2: ptr<workgroup, vec2f> = &vw2.f0;
+  let vf13: mat4x3f = workgroupUniformLoad(&vw0);
+  var vf14: f32 = exp(f32(unconst_f32(0.08708)));
+  vw2.f0 += vec2f(tan(vec3h(unconst_f16(11870.7), unconst_f16(3528.5), unconst_f16(3064.0))).gb);
+  vw4 -= mat2x3h(f16(exp(f32(unconst_f32(0.00705)))), f16(exp(f32(unconst_f32(0.00705)))), f16(exp(f32(unconst_f32(0.00705)))), f16(exp(f32(unconst_f32(0.00705)))), f16(exp(f32(unconst_f32(0.00705)))), f16(exp(f32(unconst_f32(0.00705)))));
+  vw4 = mat2x3h(vec3h((*&vw2).f0.rrg), vec3h((*&vw2).f0.xyx));
+  vf12 -= f16(override0);
+  _ = override0;
+}`,
+  sourceMap: {},
+});
+let texture5 = device0.createTexture({
+  size: {width: 73, height: 1, depthOrArrayLayers: 54},
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture6 = device0.createTexture({
+  size: [96, 1, 1],
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView3 = texture5.createView({});
+try {
+  await buffer0.mapAsync(GPUMapMode.WRITE, 0, 24);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 107},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 6},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+commandEncoder2.insertDebugMarker('\u31a5');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+requires pointer_composite_access;
+
+requires packed_4x8_integer_dot_product;
+
+requires packed_4x8_integer_dot_product;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(103) var st2: texture_storage_3d<rgba8unorm, write>;
+
+@group(0) @binding(176) var st3: texture_storage_3d<rgba16uint, write>;
+
+struct T0 {
+  f0: mat2x4h,
+  @align(16) @size(16) f1: vec2i,
+  @size(624) f2: array<array<array<array<atomic<u32>, 1>, 1>, 6>>,
+}
+
+struct S1 {
+  @location(15) f0: f32,
+  @builtin(instance_index) f1: u32,
+  @location(10) f2: vec2f,
+  @location(0) f3: vec4f,
+  @location(7) @interpolate(flat, sample) f4: vec2i,
+}
+
+struct S2 {
+  @location(13) @interpolate(linear, center) f0: vec4f,
+  @location(9) @interpolate(flat, center) f1: vec4i,
+}
+
+struct VertexOutput1 {
+  @location(2) f8: vec2i,
+  @location(12) @interpolate(linear, centroid) f9: f16,
+  @builtin(position) f10: vec4f,
+}
+
+override override2 = 0.1127;
+
+fn fn0() -> array<S2, 1> {
+  var out: array<S2, 1>;
+  var vf15: vec4h = asin(vec4h(unconst_f16(939.1), unconst_f16(45897.9), unconst_f16(5480.5), unconst_f16(3341.5)));
+  let vf16: i32 = dot4I8Packed(u32(unconst_u32(125)), u32(unconst_u32(404)));
+  vf15 = vec4h(vf15[u32(unconst_u32(22))]);
+  vf15 -= vec4h(f16(override2));
+  var vf17: f16 = vf15[u32(unconst_u32(220))];
+  vf17 += dot(vec2h(unconst_f16(14421.5), unconst_f16(8077.8)), vec2h(unconst_f16(11659.0), unconst_f16(933.1)));
+  vf17 = vf15.g;
+  var vf18: vec2f = cosh(vec2f(unconst_f32(0.1709), unconst_f32(0.2085)));
+  out[u32(dot(vec2h(unconst_f16(31755.3), unconst_f16(-17544.9)), vec2h(unconst_f16(9057.5), unconst_f16(21069.4))))] = S2(vec4f(f32(length(vec2h(unconst_f16(8092.1), unconst_f16(409.9))))), vec4i(i32(length(vec2h(unconst_f16(8092.1), unconst_f16(409.9))))));
+  vf15 += bitcast<vec4h>(vf18);
+  let vf19: vec2f = cosh(vec2f(unconst_f32(-0.04846), unconst_f32(-0.07237)));
+  var vf20: bool = any(bool(unconst_bool(false)));
+  var vf21: f16 = vf15[u32(unconst_u32(475))];
+  out[u32(unconst_u32(271))].f1 = vec4i(vf16);
+  var vf22: vec2h = round(vec2h(unconst_f16(132.8), unconst_f16(1180.0)));
+  let vf23: f32 = vf19[u32(unconst_u32(159))];
+  var vf24: f32 = vf23;
+  vf24 -= refract(vec4f(unconst_f32(0.1515), unconst_f32(0.02979), unconst_f32(-0.05912), unconst_f32(0.3204)), vec4f(unconst_f32(0.1218), unconst_f32(-0.2674), unconst_f32(0.00204), unconst_f32(0.3202)), f32(unconst_f32(0.1880))).g;
+  vf21 = f16(any(bool(round(vec2h(unconst_f16(37794.2), unconst_f16(2555.7)))[0])));
+  var vf25: f32 = vf18[u32(unconst_u32(198))];
+  vf22 -= bitcast<vec2h>(vf23);
+  vf20 = bool(vf21);
+  vf15 *= vec4h(f16(pack4x8snorm(vec4f(unconst_f32(0.3399), unconst_f32(0.2771), unconst_f32(0.00742), unconst_f32(0.00935)))));
+  vf15 = vf15;
+  let ptr3: ptr<function, f32> = &vf24;
+  return out;
+  _ = override2;
+}
+
+var<workgroup> vw5: vec4<bool>;
+
+var<workgroup> vw6: vec4h;
+
+var<workgroup> vw7: vec2h;
+
+var<workgroup> vw8: mat2x4f;
+
+var<workgroup> vw9: array<array<S2, 1>, 1>;
+
+var<workgroup> vw10: atomic<i32>;
+
+var<workgroup> vw11: S2;
+
+@vertex
+fn vertex1(a0: S1, a1: S2) -> VertexOutput1 {
+  var out: VertexOutput1;
+  out.f9 = cos(vec3h(f16(override2))).r;
+  out.f10 -= a0.f3;
+  var vf26 = fn0();
+  vf26[0] = S2(transpose(mat2x3f(unconst_f32(0.05471), unconst_f32(-0.00654), unconst_f32(0.3878), unconst_f32(0.1215), unconst_f32(0.09587), unconst_f32(-0.4084)))[unconst_i32(1)].rrgg, vec4i(transpose(mat2x3f(unconst_f32(0.05471), unconst_f32(-0.00654), unconst_f32(0.3878), unconst_f32(0.1215), unconst_f32(0.09587), unconst_f32(-0.4084)))[unconst_i32(2)].gggg));
+  out.f10 = vec4f(f32(determinant(mat2x2h())));
+  fn0();
+  vf26[pack4xI8Clamp(vf26[0].f1)].f0 = vec4f(atanh(vec2h(a1.f0.ar)).rrgr);
+  fn0();
+  vf26[u32(unconst_u32(3))].f1 = bitcast<vec4i>(vf26[u32(unconst_u32(611))].f0);
+  vf26[u32(unconst_u32(96))] = S2(vec4f(f32(all(vec2<bool>(unconst_bool(false), unconst_bool(true))))), vec4i(i32(all(vec2<bool>(unconst_bool(false), unconst_bool(true))))));
+  vf26[pack4xI8Clamp(a1.f1)] = vf26[u32(unconst_u32(350))];
+  return out;
+  _ = override2;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute1() {
+  vw6 = vec4h((*&vw9)[u32(unconst_u32(124))][u32(unconst_u32(315))].f1);
+  atomicCompareExchangeWeak(&vw10, unconst_i32(29), unconst_i32(248));
+  vw5 = vec4<bool>(vw9[0][0].f0);
+  textureStore(st2, vec3i(unconst_i32(397), unconst_i32(1), unconst_i32(215)), vec4f(vec4f(unconst_f32(0.2742), unconst_f32(0.1447), unconst_f32(0.2709), unconst_f32(0.04326))));
+  let ptr4: ptr<workgroup, vec4i> = &vw9[0][0].f1;
+  var vf27: i32 = atomicExchange(&vw10, i32(vw5[u32(unconst_u32(42))]));
+  let ptr5: ptr<workgroup, vec4i> = &vw9[u32(unconst_u32(231))][0].f1;
+  vf27 *= bitcast<i32>((*&vw8)[unconst_i32(1)].b);
+  let ptr6: ptr<workgroup, vec4i> = &(*&vw9)[u32(unconst_u32(58))][0].f1;
+  let ptr7: ptr<workgroup, vec4i> = &vw9[bitcast<vec4u>((*&vw9)[u32(unconst_u32(583))][0].f1).r][0].f1;
+  let ptr8: ptr<workgroup, vec4i> = &(*ptr6);
+  atomicMax(&vw10, i32(unconst_i32(734)));
+  vf27 = atomicExchange(&vw10, i32(unconst_i32(-144)));
+  let vf28: f32 = override2;
+  vw7 = bitcast<vec2h>((*ptr4)[u32(unconst_u32(26))]);
+  atomicStore(&vw10, i32(unconst_i32(11)));
+  let ptr9: ptr<workgroup, vec4i> = &vw11.f1;
+  _ = override2;
+}`,
+  sourceMap: {},
+});
+let bindGroup0 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 176, resource: textureView0}, {binding: 103, resource: textureView3}],
+});
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: []});
+let texture7 = device0.createTexture({
+  size: [36, 1, 202],
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let bindGroup1 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 103, resource: textureView3}, {binding: 176, resource: textureView0}],
+});
+let textureView4 = texture7.createView({label: '\u1989\ub645\u683d'});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup0, new Uint32Array(918), 79, 0);
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer1, 276, 116);
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 103, resource: textureView3}, {binding: 176, resource: textureView0}],
+});
+let buffer3 = device0.createBuffer({
+  label: '\ud851\u7ef0\u89fc\ua334\u{1f9a2}',
+  size: 619,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder3 = device0.createCommandEncoder({});
+let texture8 = device0.createTexture({
+  label: '\u{1f813}\u7590\u{1fe62}\u1d39\u34a3\u2296\u0ccf',
+  size: {width: 73, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView5 = texture6.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 0});
+let computePassEncoder1 = commandEncoder3.beginComputePass({});
+let renderPassEncoder0 = commandEncoder0.beginRenderPass({colorAttachments: [{view: textureView5, loadOp: 'clear', storeOp: 'store'}]});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup2, new Uint32Array(1466), 480, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(buffer3, 288, buffer2, 3412, 116);
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer3, 196, 28);
+} catch {}
+let commandEncoder4 = device0.createCommandEncoder({});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup0, new Uint32Array(308), 41, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint16', 108, 169);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(buffer3, 40, buffer1, 180, 84);
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout({entries: [{binding: 277, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }}]});
+let sampler1 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 98.24,
+  lodMaxClamp: 98.32,
+  maxAnisotropy: 3,
+});
+let computePassEncoder2 = commandEncoder4.beginComputePass({});
+let renderPassEncoder1 = commandEncoder2.beginRenderPass({
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 173,
+  clearValue: { r: -798.4, g: 620.9, b: -350.2, a: 220.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let arrayBuffer0 = buffer0.getMappedRange(8, 0);
+try {
+renderBundle0.label = '\uc3af\u068f\u01b4\u0f08\u0ae0\uf682\u0a04\uce24';
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+  label: '\u{1fd63}\u7511\ud2ef\u{1faff}\u22fa\ub430\u{1ffd2}\u{1f9e5}\u{1fbca}\u{1f79b}',
+  layout: bindGroupLayout0,
+  entries: [{binding: 103, resource: textureView3}, {binding: 176, resource: textureView0}],
+});
+let commandEncoder5 = device0.createCommandEncoder({});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint16', 200, 110);
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: []});
+let computePassEncoder3 = commandEncoder5.beginComputePass({});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup3, new Uint32Array(1169), 13, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 12},
+  aspect: 'all',
+}, new Uint8Array(2_112).fill(36), /* required buffer size: 2_112 */
+{offset: 267, bytesPerRow: 123, rowsPerImage: 1}, {width: 29, height: 0, depthOrArrayLayers: 16});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let bindGroup4 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 277, resource: sampler1}]});
+let buffer4 = device0.createBuffer({
+  size: 27964,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder6 = device0.createCommandEncoder({label: '\u1ac3\u0e22\u{1f940}\ue7b9\ubb20\uf204\u{1fe8f}\ua5c2\u1bec'});
+let renderPassEncoder2 = commandEncoder6.beginRenderPass({
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 136,
+  clearValue: { r: -408.2, g: 708.6, b: 595.9, a: -7.452, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup1, new Uint32Array(1462), 736, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer3, 132, 12);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 5},
+  aspect: 'all',
+}, new Uint8Array(268_352).fill(157), /* required buffer size: 268_352 */
+{offset: 32, bytesPerRow: 40, rowsPerImage: 86}, {width: 1, height: 0, depthOrArrayLayers: 79});
+} catch {}
+await gc();
+let buffer5 = device0.createBuffer({size: 27075, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder7 = device0.createCommandEncoder({});
+let textureView6 = texture6.createView({label: '\u0ac0\u3246\u5dbe\u{1f755}\ucd1b\u0763', dimension: '2d', baseMipLevel: 0});
+let texture9 = device0.createTexture({
+  label: '\u035e\ueb5d\u06b2',
+  size: [73, 1, 1],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder4 = commandEncoder7.beginComputePass({label: '\u0c91\ud0ba\uaa4d\u031d\u0694'});
+try {
+renderPassEncoder0.setIndexBuffer(buffer4, 'uint16', 2_828, 2_138);
+} catch {}
+let bindGroup5 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 277, resource: sampler1}]});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup2, new Uint32Array(2289), 1_180, 0);
+} catch {}
+await gc();
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 94,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 567,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 132,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 243,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 398,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 42,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 999,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 35,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 421,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup6 = device0.createBindGroup({
+  label: '\u682d\ua11a\u4afa\u15ac\u5455\uf2c6',
+  layout: bindGroupLayout0,
+  entries: [{binding: 176, resource: textureView0}, {binding: 103, resource: textureView3}],
+});
+let texture10 = device0.createTexture({
+  size: [110, 10, 1],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture11 = device0.createTexture({
+  size: [36, 1, 534],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView7 = texture3.createView({});
+let sampler2 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.80,
+  lodMaxClamp: 98.57,
+  maxAnisotropy: 10,
+});
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer2, 1_168);
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 225,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 58,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture12 = device0.createTexture({
+  label: '\u0e12\u{1fddf}\u0388',
+  size: [70, 72, 1],
+  mipLevelCount: 1,
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup1, new Uint32Array(575), 33, 0);
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({});
+let texture13 = device0.createTexture({
+  size: [147],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture14 = device0.createTexture({
+  label: '\u0038\u03e0',
+  size: [96, 1, 36],
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder5 = commandEncoder8.beginComputePass({});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup0, new Uint32Array(651), 139, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+computePassEncoder4.label = '\u{1f7bc}\u05c3\u2820\u579e\u{1f922}';
+} catch {}
+let buffer6 = device0.createBuffer({size: 2238, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let texture15 = device0.createTexture({
+  size: {width: 73},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup6, new Uint32Array(2394), 2_164, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint32', 156, 479);
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+  label: '\u0ac8\u72fe\u{1fc77}\u30bf',
+  layout: bindGroupLayout0,
+  entries: [{binding: 103, resource: textureView3}, {binding: 176, resource: textureView0}],
+});
+let buffer7 = device0.createBuffer({size: 31115, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder9 = device0.createCommandEncoder({});
+let textureView8 = texture2.createView({});
+let textureView9 = texture10.createView({dimension: '2d-array', aspect: 'stencil-only', format: 'stencil8', mipLevelCount: 1});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup5, new Uint32Array(115), 1, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer1, 'uint16', 24, 464);
+} catch {}
+try {
+globalThis.someLabel = sampler1.label;
+} catch {}
+let texture16 = device0.createTexture({
+  size: [64, 64, 22],
+  mipLevelCount: 2,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture17 = device0.createTexture({
+  label: '\u396f\u2d02\u9810\uab34\u7937\u{1f7e3}',
+  size: [192, 1, 262],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder6 = commandEncoder9.beginComputePass({});
+try {
+renderPassEncoder0.setIndexBuffer(buffer4, 'uint32', 11_428, 7_089);
+} catch {}
+let textureView10 = texture15.createView({});
+let texture18 = device0.createTexture({
+  size: {width: 96, height: 1, depthOrArrayLayers: 131},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView11 = texture13.createView({label: '\u0b57\u{1ff60}\u681f\u661a\u1f28\u07cc'});
+let sampler3 = device0.createSampler({
+  label: '\u0618\u20de\u{1f8d5}\ua3ed\u7f10',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+});
+try {
+renderPassEncoder1.setVertexBuffer(4, undefined, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let bindGroup8 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 103, resource: textureView3}, {binding: 176, resource: textureView8}],
+});
+let commandEncoder10 = device0.createCommandEncoder({label: '\u0abd\u7b04\uf099\u3f88\u{1fd7a}\u04d4\uf2c1\ucddc\u4820\u3e71'});
+let textureView12 = texture10.createView({dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 2});
+let renderPassEncoder3 = commandEncoder10.beginRenderPass({
+  colorAttachments: [{
+  view: textureView6,
+  clearValue: { r: -393.8, g: 434.2, b: -186.8, a: -390.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let promise0 = device0.queue.onSubmittedWorkDone();
+let buffer8 = device0.createBuffer({
+  label: '\u0951\u1e8e\u8ac2',
+  size: 2758,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 227});
+let textureView13 = texture10.createView({
+  label: '\uf46e\u02f2\u0d09\uec98\u0ba7',
+  format: 'depth24plus-stencil8',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup3, new Uint32Array(1782), 21, 0);
+} catch {}
+let imageData0 = new ImageData(32, 116);
+let bindGroup9 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 176, resource: textureView0}, {binding: 103, resource: textureView7}],
+});
+let texture19 = device0.createTexture({
+  size: [140, 145, 1],
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup9, new Uint32Array(702), 232, 0);
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 511,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup10 = device0.createBindGroup({
+  label: '\u{1f662}\u2449\u{1f9b6}\u0dd6',
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 225, resource: textureView13},
+    {binding: 58, resource: {buffer: buffer4, offset: 256, size: 8346}},
+  ],
+});
+let buffer9 = device0.createBuffer({size: 9435, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let texture20 = device0.createTexture({
+  size: [110, 10, 51],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView14 = texture19.createView({});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer3, 28);
+} catch {}
+let arrayBuffer1 = buffer0.getMappedRange(16, 0);
+try {
+sampler3.label = '\u{1fd38}\u140a\u0afe\u{1fb8e}\u{1ff93}';
+} catch {}
+let bindGroup11 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 277, resource: sampler2}]});
+let texture21 = device0.createTexture({
+  label: '\u{1fc98}\u378a\uabea\u7dc8\u{1fbe7}\ua49c\u05d7\u07ef\u1da6\u0c40\u{1f8f8}',
+  size: [96, 1, 24],
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture22 = device0.createTexture({
+  label: '\ua858\u2f02\u07f3\u0155\u0c95',
+  size: {width: 295, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup10, new Uint32Array(1254), 4, 0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(7, buffer8);
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder({label: '\u94ed\u025d'});
+let textureView15 = texture6.createView({dimension: '2d-array'});
+let renderPassEncoder4 = commandEncoder11.beginRenderPass({
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 137,
+  clearValue: { r: -53.83, g: 202.0, b: -940.1, a: 473.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 241155204,
+});
+try {
+renderPassEncoder4.executeBundles([renderBundle0]);
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  label: '\u0a7c\u{1ffa1}\u08b6\u3621\u02ef\u0496',
+  entries: [
+    {
+      binding: 211,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 62,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 86,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let texture23 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 207},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture24 = device0.createTexture({
+  label: '\u6840\ubc94\u{1f644}\ucc50\u{1fc7f}\u0a64',
+  size: {width: 220},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView16 = texture14.createView({dimension: '2d', baseArrayLayer: 8});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup10, new Uint32Array(149), 6, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer1, 'uint32', 192, 529);
+} catch {}
+let buffer10 = device0.createBuffer({
+  size: 16926,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder12 = device0.createCommandEncoder({});
+let texture25 = device0.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 524},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture26 = device0.createTexture({
+  size: [70, 72, 1],
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder7 = commandEncoder12.beginComputePass({});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup8, new Uint32Array(3000), 650, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let textureView17 = texture25.createView({mipLevelCount: 1});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup7, new Uint32Array(2465), 108, 0);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -366.0, g: 54.19, b: -77.26, a: -87.93, });
+} catch {}
+let imageData1 = new ImageData(108, 8);
+let buffer11 = device0.createBuffer({
+  size: 13055,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder13 = device0.createCommandEncoder({});
+let computePassEncoder8 = commandEncoder13.beginComputePass({});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup1, new Uint32Array(3583), 2_583, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder2.setViewport(26.02835255080396, 0.6839984790346014, 7.8317143952165775, 0.06855447020665686, 0.9425023575430436, 0.9797368762746984);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer10, 'uint32', 3_256, 796);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  code: `
+enable f16;
+
+enable f16;
+
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(103) var st4: texture_storage_3d<rgba8unorm, write>;
+
+@group(0) @binding(176) var st5: texture_storage_3d<rgba16uint, write>;
+
+struct T0 {
+  @align(16) @size(80) f0: array<u32>,
+}
+
+struct T1 {
+  @align(128) @size(640) f0: array<u32>,
+}
+
+struct T2 {
+  @align(64) @size(384) f0: array<array<atomic<u32>, 1>>,
+}
+
+struct T3 {
+  f0: f32,
+}
+
+struct S3 {
+  @location(7) @interpolate(flat) f0: f32,
+}
+
+struct S4 {
+  @builtin(instance_index) f0: u32,
+}
+
+struct VertexOutput2 {
+  @builtin(position) f11: vec4f,
+}
+
+struct FragmentOutput1 {
+  @location(0) @interpolate(flat, centroid) f0: vec4i,
+}
+
+alias vec3b = vec3<bool>;
+
+fn fn0() {
+  var vf29: vec2u = insertBits(vec2u(unconst_u32(38), unconst_u32(304)), vec2u(unconst_u32(69), unconst_u32(49)), insertBits(vec2u(unconst_u32(44), unconst_u32(83)), vec2u(unconst_u32(148), unconst_u32(169)), u32(unconst_u32(59)), bitcast<u32>(sqrt(vec3f(unconst_f32(-0.1676), unconst_f32(0.2897), unconst_f32(0.00003))).b)).y, u32(unconst_u32(33)));
+  let ptr10: ptr<function, vec2u> = &vf29;
+  vf29 <<= vec2u(sqrt(vec3f(unconst_f32(0.02282), unconst_f32(0.09096), unconst_f32(0.03228))).zy);
+  let ptr11: ptr<function, vec2u> = &(*ptr10);
+  let ptr12: ptr<function, vec2u> = &vf29;
+  vf29 ^= bitcast<vec2u>(sqrt(vec3f(unconst_f32(0.1685), unconst_f32(0.1318), unconst_f32(0.06017))).bb);
+  var vf30: vec3f = log2(vec3f(unconst_f32(0.1118), unconst_f32(-0.2218), unconst_f32(0.02198)));
+  let vf31: vec3f = sqrt(vec3f(f32((*ptr10)[u32(unconst_u32(87))])));
+  vf29 ^= vec2u(bitcast<u32>(vf30[u32(unconst_u32(68))]));
+  let ptr13: ptr<function, vec2u> = &vf29;
+}
+
+fn fn1(a0: array<FragmentOutput1, 1>) -> array<vec4i, 1> {
+  var out: array<vec4i, 1>;
+  let vf32: i32 = a0[pack4xI8(unpack4xI8(u32(unconst_u32(210))))].f0[u32(unconst_u32(59))];
+  out[0] = vec4i(i32(any(bool(unconst_bool(true)))));
+  var vf33: vec2h = log(vec2h(unconst_f16(24126.7), unconst_f16(846.7)));
+  vf33 = vec2h(a0[0].f0.rb);
+  let vf34: vec4i = a0[0].f0;
+  var vf35: u32 = pack4xU8Clamp(vec4u(unconst_u32(207), unconst_u32(106), unconst_u32(50), unconst_u32(25)));
+  var vf36: vec3h = radians(vec3h(unconst_f16(11335.2), unconst_f16(29059.7), unconst_f16(2589.2)));
+  var vf37: f32 = tan(f32(unconst_f32(0.07821)));
+  var vf38: vec4i = a0[0].f0;
+  vf37 += vec3f(exp(vec3h(unconst_f16(6744.2), unconst_f16(18593.5), unconst_f16(5.480)))).z;
+  vf37 -= f32(a0[0].f0[u32(unconst_u32(207))]);
+  vf33 += vec2h(a0[0].f0.xz);
+  vf38 &= bitcast<vec4i>(exp(vec2f(unconst_f32(0.2595), unconst_f32(0.1600))).grgg);
+  out[u32(unconst_u32(118))] &= vf38;
+  let vf39: array<FragmentOutput1, 1> = a0;
+  var vf40: vec4i = unpack4xI8(u32(unconst_u32(238)));
+  out[u32(unconst_u32(194))] ^= vec4i(i32(pack4x8unorm(vec4f(f32(vf40[u32(unconst_u32(25))])))));
+  out[0] *= vf34;
+  let vf41: FragmentOutput1 = a0[0];
+  vf36 = vec3h(f16(any(bool(unconst_bool(false)))));
+  vf38 *= a0[0].f0;
+  let vf42: i32 = sign(i32(unconst_i32(137)));
+  let ptr14: ptr<function, vec4i> = &vf40;
+  var vf43: u32 = dot4U8Packed(u32((*ptr14)[u32(unconst_u32(574))]), u32(unconst_u32(690)));
+  return out;
+}
+
+var<workgroup> vw12: VertexOutput2;
+
+var<workgroup> vw13: VertexOutput2;
+
+var<workgroup> vw14: VertexOutput2;
+
+var<workgroup> vw15: S3;
+
+var<workgroup> vw16: VertexOutput2;
+
+var<workgroup> vw17: S4;
+
+var<workgroup> vw18: S3;
+
+@vertex @must_use
+fn vertex2(@location(9) @interpolate(flat) a0: vec4u, @location(1) @interpolate(flat) a1: vec2u, a2: S3, a3: S4) -> VertexOutput2 {
+  var out: VertexOutput2;
+  out.f11 -= fract(vec2f(unconst_f32(-0.1969), unconst_f32(0.08946))).yyyy;
+  out = VertexOutput2(vec4f(a1.rgrr));
+  var vf44 = fn1(array<FragmentOutput1, 1>(FragmentOutput1()));
+  let ptr15: ptr<function, vec4i> = &vf44[0];
+  var vf45 = fn1(array<FragmentOutput1, 1>(FragmentOutput1(vec4i(i32(a2.f0)))));
+  out.f11 += vec4f(bitcast<f32>(vf44[0][u32(unconst_u32(330))]));
+  var vf46: u32 = pack4xI8Clamp(vec4i(fract(vec2f(unconst_f32(0.03817), unconst_f32(0.00828))).ggrg));
+  out = VertexOutput2(fract(vec2f(unconst_f32(0.1417), unconst_f32(0.5319))).xyyy);
+  out.f11 = vec4f(insertBits(vec4u(unconst_u32(34), unconst_u32(581), unconst_u32(71), unconst_u32(131)), vec4u(unconst_u32(80), unconst_u32(326), unconst_u32(56), unconst_u32(230)), u32(unconst_u32(160)), u32(unconst_u32(147))));
+  let ptr16: ptr<function, vec4i> = &vf45[0];
+  vf44[u32(unconst_u32(877))] ^= vec4i(bitcast<i32>(vf46));
+  return out;
+}
+
+@fragment
+fn fragment1(@builtin(sample_mask) a0: u32, @invariant @builtin(position) a1: vec4f) -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  out.f0 = vec4i(i32(acos(f16(unconst_f16(4117.6)))));
+  discard;
+  out = FragmentOutput1(vec4i(faceForward(vec3f(unconst_f32(-0.1062), unconst_f32(0.09335), unconst_f32(0.06871)), vec3f(unconst_f32(0.2243), unconst_f32(0.01310), unconst_f32(0.5064)), vec3f(unconst_f32(0.1255), unconst_f32(1.000), unconst_f32(0.2007))).xzyx));
+  let vf47: u32 = pack4xI8Clamp(vec4i(unconst_i32(0), unconst_i32(49), unconst_i32(179), unconst_i32(48)));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute2() {
+  let ptr17: ptr<workgroup, VertexOutput2> = &vw14;
+  vw14 = VertexOutput2(vec4f(f32(pack4xI8(vec4i(unconst_i32(54), unconst_i32(56), unconst_i32(114), unconst_i32(52))))));
+  let vf48: f16 = acos(f16(unconst_f16(7502.1)));
+  let ptr18: ptr<workgroup, f32> = &vw18.f0;
+  textureStore(st4, vec3i(i32(vf48)), vec4f(vec4f(unconst_f32(0.05117), unconst_f32(0.1385), unconst_f32(0.08572), unconst_f32(0.00274))));
+  var vf49: f32 = (*&vw12).f11[u32(unconst_u32(114))];
+  let ptr19: ptr<workgroup, f32> = &vw15.f0;
+}`,
+});
+let buffer12 = device0.createBuffer({
+  size: 988,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder14 = device0.createCommandEncoder({});
+let textureView18 = texture14.createView({label: '\u95b5\u{1ff8f}\u{1fbee}', baseMipLevel: 0, arrayLayerCount: 1});
+let computePassEncoder9 = commandEncoder14.beginComputePass({});
+try {
+computePassEncoder2.setBindGroup(2, bindGroup0, new Uint32Array(1947), 280, 0);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+let buffer13 = device0.createBuffer({size: 12116, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let textureView19 = texture11.createView({label: '\u06ca\u04c9\u{1fcfa}\u0f3d\u{1fbc1}'});
+let sampler4 = device0.createSampler({
+  label: '\uf163\u1899\ub617\uc414\u0747\u703e',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 19.20,
+  lodMaxClamp: 39.83,
+});
+try {
+renderPassEncoder4.beginOcclusionQuery(65);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(0, bindGroup10, new Uint32Array(2544), 188, 0);
+} catch {}
+let arrayBuffer2 = buffer0.getMappedRange(0, 0);
+try {
+  await promise0;
+} catch {}
+let buffer14 = device0.createBuffer({
+  label: '\u{1f677}\u7d69\u63cf\u2251',
+  size: 5744,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder15 = device0.createCommandEncoder({});
+let textureView20 = texture6.createView({label: '\u005f\u4603\u31b4\uc8df\ud3a8\u{1f92b}', arrayLayerCount: 1});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup3, new Uint32Array(1402), 182, 0);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 288, new DataView(new ArrayBuffer(14178)), 992, 108);
+} catch {}
+let imageData2 = new ImageData(76, 28);
+try {
+renderPassEncoder4.setIndexBuffer(buffer1, 'uint32', 416, 79);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, buffer12, 56);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 54}
+*/
+{
+  source: imageData2,
+  origin: { x: 2, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 9},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  label: '\udad1\uf309\u{1f9a8}',
+  entries: [
+    {
+      binding: 11,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 660, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder16 = device0.createCommandEncoder({});
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 406});
+let textureView21 = texture20.createView({label: '\u9757\u0fb2\u{1f60d}\u5da3', mipLevelCount: 1, baseArrayLayer: 4, arrayLayerCount: 7});
+let computePassEncoder10 = commandEncoder16.beginComputePass({});
+try {
+renderPassEncoder3.setBlendConstant({ r: -722.8, g: -469.1, b: 888.4, a: 231.7, });
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(1172);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer13, 'uint32', 5_076, 4_838);
+} catch {}
+let computePassEncoder11 = commandEncoder15.beginComputePass({label: '\u9b5c\u0188\u{1fed4}\u1bde\ua07d'});
+try {
+renderPassEncoder3.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer1, 'uint16', 130, 17);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(0, buffer8);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 54}
+*/
+{
+  source: imageData0,
+  origin: { x: 2, y: 18 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 33},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup12 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 277, resource: sampler2}]});
+let commandEncoder17 = device0.createCommandEncoder({});
+let texture27 = device0.createTexture({
+  size: [295, 1, 1],
+  mipLevelCount: 4,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder5 = commandEncoder17.beginRenderPass({
+  label: '\u{1fdc1}\ud112\u{1f6c4}',
+  colorAttachments: [{
+  view: textureView16,
+  clearValue: { r: -918.5, g: -8.116, b: 826.2, a: -797.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder5.setIndexBuffer(buffer10, 'uint32', 452, 3_634);
+} catch {}
+let bindGroup13 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 225, resource: textureView13},
+    {binding: 58, resource: {buffer: buffer10, offset: 768, size: 4680}},
+  ],
+});
+let texture28 = device0.createTexture({
+  size: {width: 70, height: 72, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler5 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 83.08,
+  lodMaxClamp: 85.71,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(0, bindGroup4, new Uint32Array(1136), 456, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer13, 'uint32', 6_100, 3_873);
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+  label: '\u50cb\u46fe\u505d\u07c2\u5383\u0b39\u{1fbf7}\u{1f911}\ucdcb',
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 58, resource: {buffer: buffer11, offset: 0, size: 8693}},
+    {binding: 225, resource: textureView13},
+  ],
+});
+let buffer15 = device0.createBuffer({
+  label: '\uf87d\uab18\u0442\ua1d8\u78c7\u{1f9a4}\u3204\u042f',
+  size: 9092,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView22 = texture20.createView({
+  label: '\u7e2b\u045e\u0429\u01c7\u5512\u{1fd8a}\u068a\u{1f9cf}\u{1fef3}\u0d69',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 1,
+});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup7, new Uint32Array(1172), 202, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer1, 'uint16', 2, 147);
+} catch {}
+let textureView23 = texture18.createView({baseMipLevel: 0, baseArrayLayer: 0});
+let texture29 = device0.createTexture({
+  label: '\u79de\u0d60\u2bc2\u0441\u019d\u65fc\u8668\u979e',
+  size: {width: 280},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler6 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 44.83,
+  lodMaxClamp: 71.69,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer10, 0, 453);
+} catch {}
+await gc();
+let bindGroup15 = device0.createBindGroup({
+  label: '\u{1fb6f}\ud1aa\ud401\u06a5\u{1f723}\u421c\u{1fa76}',
+  layout: bindGroupLayout6,
+  entries: [{binding: 11, resource: {buffer: buffer15, offset: 1792}}],
+});
+let commandEncoder18 = device0.createCommandEncoder({});
+let commandBuffer0 = commandEncoder4.finish();
+let texture30 = device0.createTexture({
+  size: {width: 560, height: 582, depthOrArrayLayers: 1},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba16sint'],
+});
+let computePassEncoder12 = commandEncoder18.beginComputePass({});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup10, []);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(2);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData3 = new ImageData(44, 28);
+let commandEncoder19 = device0.createCommandEncoder({label: '\u4d39\u4b2e\uf6d5\u0bca'});
+let texture31 = device0.createTexture({
+  size: {width: 48, height: 1, depthOrArrayLayers: 47},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView24 = texture29.createView({});
+let computePassEncoder13 = commandEncoder19.beginComputePass({});
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle0]);
+} catch {}
+try {
+commandEncoder1.copyBufferToBuffer(buffer7, 8940, buffer5, 4384, 3240);
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(20, 21);
+let buffer16 = device0.createBuffer({
+  label: '\ub3e4\ubfd2\ucdbe\u0430\u{1fa74}\ud009\u636c\ueab5\u{1f74c}\u{1fe20}',
+  size: 11156,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView25 = texture7.createView({});
+try {
+renderPassEncoder2.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer4, 'uint32', 19_380, 56);
+} catch {}
+try {
+commandEncoder1.copyBufferToTexture({
+  /* bytesInLastRow: 136 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 200 */
+  offset: 200,
+  bytesPerRow: 32000,
+  rowsPerImage: 247,
+  buffer: buffer7,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 54}
+*/
+{
+  source: imageData3,
+  origin: { x: 12, y: 9 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder({});
+let texture32 = device0.createTexture({
+  size: {width: 73, height: 1, depthOrArrayLayers: 1},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup5, new Uint32Array(688), 144, 0);
+} catch {}
+try {
+commandEncoder20.copyBufferToTexture({
+  /* bytesInLastRow: 72 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 600 */
+  offset: 600,
+  bytesPerRow: 25088,
+  buffer: buffer7,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder1.clearBuffer(buffer11, 2080, 760);
+} catch {}
+let buffer17 = device0.createBuffer({size: 2938, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture33 = device0.createTexture({
+  size: [560, 582, 1],
+  format: 'depth32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture34 = device0.createTexture({
+  size: {width: 295, height: 1, depthOrArrayLayers: 17},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder14 = commandEncoder1.beginComputePass({label: '\uc59f\u9858\u9e96\u{1fdd3}\u90e0'});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup8, new Uint32Array(2000), 109, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(878_948).fill(128), /* required buffer size: 878_948 */
+{offset: 26, bytesPerRow: 66, rowsPerImage: 193}, {width: 12, height: 0, depthOrArrayLayers: 70});
+} catch {}
+let bindGroup16 = device0.createBindGroup({
+  label: '\u350e\u1369\u9a5c\u06bb',
+  layout: bindGroupLayout0,
+  entries: [{binding: 176, resource: textureView8}, {binding: 103, resource: textureView3}],
+});
+let commandEncoder21 = device0.createCommandEncoder();
+try {
+computePassEncoder12.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+computePassEncoder3.setBindGroup(1, bindGroup6, new Uint32Array(180), 155, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup5, new Uint32Array(775), 55, 0);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer12);
+} catch {}
+try {
+commandEncoder20.clearBuffer(buffer3, 120, 24);
+} catch {}
+try {
+commandEncoder20.resolveQuerySet(querySet0, 29, 42, buffer6, 0);
+} catch {}
+let buffer18 = device0.createBuffer({
+  size: 5719,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView26 = texture34.createView({aspect: 'all', arrayLayerCount: 1});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true});
+let renderBundle1 = renderBundleEncoder1.finish({});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer8);
+} catch {}
+try {
+commandEncoder20.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 144 */
+  offset: 144,
+  bytesPerRow: 12544,
+  buffer: buffer3,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+let buffer19 = device0.createBuffer({size: 9888, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let textureView27 = texture22.createView({});
+let computePassEncoder15 = commandEncoder21.beginComputePass({});
+let sampler7 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 70.08,
+  lodMaxClamp: 73.68,
+});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup7, new Uint32Array(129), 23, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer12);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 280, new Float32Array(12639), 121, 156);
+} catch {}
+await gc();
+let buffer20 = device0.createBuffer({size: 635, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let commandEncoder22 = device0.createCommandEncoder({label: '\u3462\udaf1\u0b97\u7bbd\u{1ff92}\u0f58\u0ca8'});
+let computePassEncoder16 = commandEncoder20.beginComputePass();
+let renderPassEncoder6 = commandEncoder22.beginRenderPass({
+  colorAttachments: [{
+  view: textureView5,
+  clearValue: { r: -875.6, g: -367.5, b: -56.20, a: 64.03, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer10, 'uint32', 3_524, 752);
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder({});
+let texture35 = gpuCanvasContext0.getCurrentTexture();
+let textureView28 = texture3.createView({aspect: 'all'});
+let renderPassEncoder7 = commandEncoder23.beginRenderPass({
+  colorAttachments: [{
+  view: textureView19,
+  depthSlice: 293,
+  clearValue: { r: -996.6, g: -819.4, b: 659.1, a: -201.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer6, 0, 502);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+try {
+computePassEncoder10.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup6, new Uint32Array(951), 2, 0);
+} catch {}
+let buffer21 = device0.createBuffer({
+  size: 13170,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder24 = device0.createCommandEncoder();
+let computePassEncoder17 = commandEncoder24.beginComputePass({});
+let sampler8 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 81.44,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer21, 'uint16', 11_190, 32);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer10, 0, 2_880);
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(103) var st6: texture_storage_3d<rgba8unorm, write>;
+
+@group(0) @binding(176) var st7: texture_storage_3d<rgba16uint, write>;
+
+struct T0 {
+  @align(16) @size(16) f0: array<array<atomic<u32>, 1>>,
+}
+
+struct T1 {
+  @size(128) f0: array<array<array<array<atomic<i32>, 1>, 1>, 1>>,
+}
+
+struct T2 {
+  @align(64) @size(448) f0: array<atomic<i32>>,
+}
+
+struct T3 {
+  @size(8) f0: array<u32>,
+}
+
+struct FragmentOutput2 {
+  @location(0) f0: vec4i,
+  @location(5) @interpolate(perspective, sample) f1: vec2f,
+  @builtin(sample_mask) f2: u32,
+  @location(4) f3: vec4f,
+}
+
+var<workgroup> vw19: array<atomic<i32>, 1>;
+
+var<workgroup> vw20: FragmentOutput2;
+
+var<workgroup> vw21: FragmentOutput2;
+
+var<private> vp1 = array(modf(f16(2628.8)), modf(f16(1164.1)), modf(f16(8341.4)), modf(f16(16079.8)), modf(f16(10205.6)), modf(f16(2010.2)), modf(f16(10410.1)), modf(f16(8688.9)), modf(f16(2858.1)), modf(f16(4805.4)), modf(f16(23514.1)), modf(f16(9922.7)), modf(f16(3082.1)), modf(f16(184.0)), modf(f16(26471.5)), modf(f16(1592.3)), modf(f16(18645.6)), modf(f16(-26209.4)), modf(f16(1536.3)), modf(f16(17110.9)), modf(f16(2083.9)), modf(f16(10535.7)), modf(f16(28160.3)), modf(f16(3099.7)), modf(f16(-17931.9)), modf(f16(2097.9)), modf(f16(5539.1)), modf(f16(835.0)), modf(f16(290.1)), modf(f16(11590.5)), modf(f16(4862.1)), modf(f16(3396.8)), modf(f16(-15859.7)), modf(f16(3637.2)), modf(f16(5239.3)), modf(f16(4573.7)), modf(f16(-3050.5)), modf(f16(13568.2)), modf(f16(2290.6)), modf(f16(-23701.7)));
+
+@fragment
+fn fragment2() -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  out.f0 = bitcast<vec4i>(pow(vec2f(unconst_f32(0.09710), unconst_f32(0.3528)), vec2f(unconst_f32(0.04970), unconst_f32(0.01549))).ggrr);
+  let vf50: vec4h = cosh(vec4h(unconst_f16(15814.8), unconst_f16(665.7), unconst_f16(981.0), unconst_f16(-3240.3)));
+  let vf51: vec4h = vf50;
+  out.f1 = vec2f(f32(vp1[39].whole));
+  out.f2 -= u32(vp1[39].whole);
+  out.f3 = vec4f(f32(vp1[39].fract));
+  let ptr20 = &vp1[39];
+  let vf52: vec4h = vf50;
+  out.f2 *= u32(vp1[39].fract);
+  let ptr21 = &(*ptr20);
+  let vf53: f16 = vf50[u32(unconst_u32(188))];
+  let ptr22: ptr<private, f16> = &vp1[u32(unconst_u32(408))].fract;
+  let ptr23: ptr<private, f16> = &(*ptr20).whole;
+  let vf54: vec4f = log(vec4f(unconst_f32(0.1841), unconst_f32(0.1240), unconst_f32(0.2457), unconst_f32(0.02834)));
+  return out;
+}
+
+@compute @workgroup_size(4, 1, 1)
+fn compute3(@builtin(num_workgroups) a0: vec3u) {
+  vw21.f3 += unpack4x8snorm(pack4xI8(vec4i(unconst_i32(61), unconst_i32(121), unconst_i32(48), unconst_i32(387))));
+  vw20.f3 -= vw21.f3;
+  let vf55: f32 = (*&vw20).f3[u32(unconst_u32(238))];
+  let vf56: vec2f = unpack2x16float(u32(unconst_u32(456)));
+  let ptr24: ptr<workgroup, FragmentOutput2> = &vw21;
+  vw21.f0 = vec4i(bitcast<i32>(vw20.f1[u32(unconst_u32(202))]));
+  vw20 = FragmentOutput2(vec4i(vw21.f0[u32(unconst_u32(22))]), vec2f(f32(vw21.f0[u32(unconst_u32(22))])), bitcast<u32>(vw21.f0[u32(unconst_u32(22))]), vec4f(f32(vw21.f0[u32(unconst_u32(22))])));
+  let ptr25: ptr<workgroup, vec4i> = &vw20.f0;
+  let vf57: vec3u = a0;
+  vp1[u32(unconst_u32(29))] = modf(normalize(vec4h(unconst_f16(18620.9), unconst_f16(8754.8), unconst_f16(1582.6), unconst_f16(32423.9))).y);
+  let ptr26: ptr<workgroup, vec4i> = &vw20.f0;
+  let vf58: vec2h = abs(vec2h(unconst_f16(4460.1), unconst_f16(11625.8)));
+  let ptr27: ptr<workgroup, vec4i> = &(*ptr25);
+  let ptr28: ptr<workgroup, vec4f> = &(*&vw21).f3;
+  var vf59: vec2h = vf58;
+  let ptr29: ptr<workgroup, u32> = &(*ptr24).f2;
+  let ptr30: ptr<workgroup, vec4i> = &(*&vw21).f0;
+  var vf60: f32 = (*&vw20).f1[u32(unconst_u32(232))];
+  vf59 = bitcast<vec2h>((*&vw21).f1[u32(unconst_u32(83))]);
+  var vf61: u32 = pack2x16float(vec2f(unconst_f32(0.03597), unconst_f32(-0.2529)));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup3, new Uint32Array(53), 12, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup12, new Uint32Array(6558), 1_660, 0);
+} catch {}
+let texture36 = device0.createTexture({
+  size: {width: 36, height: 1, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer21, 'uint32', 1_708, 399);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, buffer15, 0);
+} catch {}
+let buffer22 = device0.createBuffer({
+  size: 2340,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let texture37 = device0.createTexture({
+  label: '\u10e1\u0cc4',
+  size: {width: 440},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView29 = texture7.createView({});
+let bindGroup17 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [{binding: 511, resource: {buffer: buffer21, offset: 2304, size: 840}}],
+});
+let buffer23 = device0.createBuffer({
+  size: 22704,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(176);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer8);
+} catch {}
+let img0 = await imageWithData(93, 18, '#10101010', '#20202020');
+let commandEncoder25 = device0.createCommandEncoder({});
+let texture38 = device0.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler9 = device0.createSampler({
+  label: '\ua8b5\u{1f89e}\u8d82\u7ed8\u0809\u2229\u0217\u7238\u{1ff09}',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 53.78,
+  lodMaxClamp: 90.46,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer6, 644);
+} catch {}
+try {
+device0.queue.label = '\u01ad\ua518\u00f7\u{1f78f}\u02cc\u{1f74a}\u0779';
+} catch {}
+let querySet2 = device0.createQuerySet({
+  label: '\uec8b\u920d\u8bb6\u{1f920}\u97b7\ud5a0\uae97\u251b\uf880\ubaba',
+  type: 'occlusion',
+  count: 1004,
+});
+let textureView30 = texture12.createView({});
+let computePassEncoder18 = commandEncoder25.beginComputePass({});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup14, new Uint32Array(243), 11, 0);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: 785.5, g: -448.8, b: 534.2, a: -684.6, });
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(1, buffer4, 0);
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(img0);
+let textureView31 = texture6.createView({dimension: '2d-array', baseMipLevel: 0});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+computePassEncoder11.setBindGroup(2, bindGroup4, []);
+} catch {}
+try {
+computePassEncoder17.setBindGroup(2, bindGroup4, new Uint32Array(3047), 562, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer8);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder({});
+let texture39 = device0.createTexture({
+  size: {width: 295, height: 1, depthOrArrayLayers: 1},
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture40 = device0.createTexture({
+  size: {width: 73, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder19 = commandEncoder26.beginComputePass();
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup8, new Uint32Array(2263), 31, 0);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(213);
+} catch {}
+let sampler10 = device0.createSampler({
+  label: '\ua0f8\u076b',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 18.51,
+  lodMaxClamp: 86.49,
+  compare: 'greater',
+});
+let texture41 = device0.createTexture({
+  size: [192, 1, 5],
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup14, new Uint32Array(613), 89, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 236, new Float32Array(441), 31, 0);
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  label: '\u04d1\u522a',
+  entries: [
+    {
+      binding: 54,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {binding: 53, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder27 = device0.createCommandEncoder({});
+let textureView32 = texture11.createView({arrayLayerCount: 1});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup8, new Uint32Array(1433), 1_012, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer21, 'uint16', 2_502, 148);
+} catch {}
+let textureView33 = texture21.createView({arrayLayerCount: 12});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer13, 'uint32', 404, 1_390);
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+  /* bytesInLastRow: 240 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2272 */
+  offset: 2272,
+  buffer: buffer23,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder27.clearBuffer(buffer6, 228, 152);
+} catch {}
+let buffer24 = device0.createBuffer({
+  size: 5033,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder28 = device0.createCommandEncoder({});
+let texture42 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 262},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView34 = texture29.createView({dimension: '1d', aspect: 'all'});
+let renderPassEncoder8 = commandEncoder28.beginRenderPass({
+  label: '\u072d\u075d\u0133\u5373\u2df3\u0f9d',
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 182,
+  clearValue: { r: -523.9, g: -589.3, b: 948.6, a: 225.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 53331445,
+});
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup0, new Uint32Array(272), 51, 0);
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 152 */
+  offset: 152,
+  bytesPerRow: 1280,
+  buffer: buffer11,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 55, y: 152, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 67, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder29 = device0.createCommandEncoder({});
+let texture43 = device0.createTexture({
+  label: '\uf688\u{1f6cc}\u5d41',
+  size: {width: 70, height: 72, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder6.executeBundles([renderBundle0, renderBundle0, renderBundle0]);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+computePassEncoder18.pushDebugGroup('\u8214');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 1, y: 15, z: 0},
+  aspect: 'all',
+}, new Uint8Array(63).fill(239), /* required buffer size: 63 */
+{offset: 63, bytesPerRow: 147, rowsPerImage: 32}, {width: 25, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let textureView35 = texture9.createView({mipLevelCount: 1});
+let computePassEncoder20 = commandEncoder29.beginComputePass({});
+let renderPassEncoder9 = commandEncoder27.beginRenderPass({colorAttachments: [{view: textureView20, loadOp: 'clear', storeOp: 'store'}]});
+let sampler11 = device0.createSampler({
+  label: '\u{1f725}\ua633\u0681\u7d3d\u0a94\ub24d',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 24.85,
+  lodMaxClamp: 83.62,
+  maxAnisotropy: 20,
+});
+try {
+renderPassEncoder6.setIndexBuffer(buffer21, 'uint32', 3_792, 2_504);
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 11, resource: {buffer: buffer21, offset: 768, size: 1668}}],
+});
+let commandEncoder30 = device0.createCommandEncoder();
+let textureView36 = texture26.createView({dimension: '2d-array', aspect: 'all'});
+let computePassEncoder21 = commandEncoder30.beginComputePass();
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup7, new Uint32Array(1657), 74, 0);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+computePassEncoder6.setBindGroup(2, bindGroup10, new Uint32Array(1142), 50, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup10, new Uint32Array(414), 50, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer18, 0, 289);
+} catch {}
+try {
+computePassEncoder10.pushDebugGroup('\u{1ff60}');
+} catch {}
+let buffer25 = device0.createBuffer({size: 17662, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT});
+let textureView37 = texture17.createView({mipLevelCount: 1});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup4, new Uint32Array(1419), 164, 0);
+} catch {}
+try {
+computePassEncoder18.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'smpte170m', transfer: 'unspecified'} });
+try {
+commandEncoder6.label = '\u{1ff56}\u{1f6ec}\ud67c\u58e3\ua096\u{1fa57}\uc12d\u{1fd92}';
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder({});
+let texture44 = device0.createTexture({
+  label: '\uf25f\u0be0\u{1f73d}\ubd30',
+  size: [295, 1, 57],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder22 = commandEncoder31.beginComputePass({});
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup13, new Uint32Array(903), 114, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 112, new Float32Array(4738), 156, 48);
+} catch {}
+let textureView38 = texture43.createView({});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\u0cc6\u3bd6\ub822\uf155\u079d\ued42\u746b',
+  colorFormats: ['rgb10a2uint'],
+  depthReadOnly: true,
+});
+let renderBundle2 = renderBundleEncoder2.finish({});
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer4, 'uint32', 4_620, 2_448);
+} catch {}
+try {
+device0.queue.label = '\u{1f997}\u2610\u4fae';
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  label: '\u{1fe3b}\u53a6\u{1ff16}\u7885',
+  entries: [
+    {
+      binding: 27,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup1, new Uint32Array(203), 60, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer13, 'uint32', 5_860, 370);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer4);
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+try {
+globalThis.someLabel = textureView23.label;
+} catch {}
+let bindGroup19 = device0.createBindGroup({
+  label: '\u{1ff9f}\u0d9e\u0427\u{1f8c1}\ufd88',
+  layout: bindGroupLayout4,
+  entries: [{binding: 511, resource: {buffer: buffer24, offset: 256, size: 564}}],
+});
+let commandEncoder32 = device0.createCommandEncoder({});
+let texture45 = device0.createTexture({
+  size: {width: 140, height: 145, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder23 = commandEncoder32.beginComputePass({});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup7, []);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(193).fill(240), /* required buffer size: 193 */
+{offset: 193}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let bindGroup20 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [{binding: 511, resource: {buffer: buffer12, offset: 0, size: 268}}],
+});
+let textureView39 = texture16.createView({dimension: '2d', aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 4});
+let sampler12 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 61.86,
+  lodMaxClamp: 83.92,
+});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup7, new Uint32Array(4161), 2_255, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup3);
+} catch {}
+let commandEncoder33 = device0.createCommandEncoder();
+let texture46 = device0.createTexture({
+  size: [280, 291, 1],
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture47 = device0.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder24 = commandEncoder33.beginComputePass({});
+let sampler13 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 99.58,
+  lodMaxClamp: 99.68,
+  compare: 'never',
+  maxAnisotropy: 1,
+});
+try {
+buffer12.unmap();
+} catch {}
+let buffer26 = device0.createBuffer({
+  size: 3113,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder34 = device0.createCommandEncoder({});
+let computePassEncoder25 = commandEncoder34.beginComputePass({});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer23, 'uint16', 1_230, 827);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let textureView40 = texture22.createView({});
+let texture48 = device0.createTexture({
+  size: {width: 440},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup13, new Uint32Array(1428), 274, 0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(1, buffer18, 0);
+} catch {}
+try {
+computePassEncoder10.popDebugGroup();
+} catch {}
+try {
+  await promise2;
+} catch {}
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'bt470m', transfer: 'smpte170m'} });
+let bindGroup21 = device0.createBindGroup({
+  label: '\uc82a\u{1f9fc}\u{1f885}\u{1f674}\u8177',
+  layout: bindGroupLayout3,
+  entries: [{binding: 225, resource: textureView13}, {binding: 58, resource: {buffer: buffer16, offset: 512}}],
+});
+let buffer27 = device0.createBuffer({
+  size: 1824,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView41 = texture42.createView({mipLevelCount: 1});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: imageData0,
+  origin: { x: 4, y: 35 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 17},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let texture49 = device0.createTexture({
+  size: {width: 384},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup7, new Uint32Array(3120), 139, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer15);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let shaderModule4 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(103) var st8: texture_storage_3d<rgba8unorm, write>;
+
+@group(0) @binding(176) var st9: texture_storage_3d<rgba16uint, write>;
+
+struct T0 {
+  @size(128) f0: array<array<atomic<u32>, 5>, 1>,
+  @size(1216) f1: array<array<array<array<atomic<i32>, 1>, 1>, 1>>,
+}
+
+struct T1 {
+  @align(64) @size(448) f0: array<u32>,
+}
+
+struct T2 {
+  @align(32) @size(1280) f0: array<atomic<i32>>,
+}
+
+struct S5 {
+  @location(15) f0: f32,
+  @location(10) f1: vec4u,
+  @location(9) @interpolate(flat, centroid) f2: vec2u,
+  @location(13) @interpolate(flat, sample) f3: vec2i,
+  @location(3) @interpolate(flat) f4: vec4i,
+  @location(12) @interpolate(flat, centroid) f5: vec4i,
+  @location(1) f6: vec4f,
+  @location(0) f7: vec2i,
+}
+
+struct S6 {
+  @location(11) @interpolate(flat) f0: vec4i,
+  @location(2) @interpolate(flat, sample) f1: u32,
+}
+
+struct S7 {
+  @location(5) f0: vec2h,
+}
+
+struct VertexOutput3 {
+  @builtin(position) f12: vec4f,
+  @location(10) @interpolate(flat, sample) f13: vec4u,
+  @location(11) @interpolate(flat, centroid) f14: vec4u,
+  @location(14) @interpolate(flat, center) f15: vec4u,
+  @location(8) @interpolate(flat, centroid) f16: vec2u,
+  @location(9) f17: f16,
+}
+
+struct FragmentOutput3 {
+  @location(0) f0: vec4i,
+  @location(7) f1: f32,
+}
+
+struct FragmentOutput4 {
+  @location(1) @interpolate(flat) f0: i32,
+  @location(3) @interpolate(flat) f1: vec4i,
+  @location(0) f2: vec4u,
+}
+
+alias vec3b = vec3<bool>;
+
+fn fn0() -> mat3x3h {
+  var out: mat3x3h;
+  let vf62: vec4f = asin(vec4f(unconst_f32(0.04794), unconst_f32(0.09500), unconst_f32(0.08847), unconst_f32(0.09376)));
+  var vf63: vec3f = sin(vec3f(unconst_f32(0.06197), unconst_f32(-0.3807), unconst_f32(0.1705)));
+  out = mat3x3h(f16(pack4xU8Clamp(vec4u(unconst_u32(78), unconst_u32(3), unconst_u32(121), unconst_u32(151)))), f16(pack4xU8Clamp(vec4u(unconst_u32(78), unconst_u32(3), unconst_u32(121), unconst_u32(151)))), f16(pack4xU8Clamp(vec4u(unconst_u32(78), unconst_u32(3), unconst_u32(121), unconst_u32(151)))), f16(pack4xU8Clamp(vec4u(unconst_u32(78), unconst_u32(3), unconst_u32(121), unconst_u32(151)))), f16(pack4xU8Clamp(vec4u(unconst_u32(78), unconst_u32(3), unconst_u32(121), unconst_u32(151)))), f16(pack4xU8Clamp(vec4u(unconst_u32(78), unconst_u32(3), unconst_u32(121), unconst_u32(151)))), f16(pack4xU8Clamp(vec4u(unconst_u32(78), unconst_u32(3), unconst_u32(121), unconst_u32(151)))), f16(pack4xU8Clamp(vec4u(unconst_u32(78), unconst_u32(3), unconst_u32(121), unconst_u32(151)))), f16(pack4xU8Clamp(vec4u(unconst_u32(78), unconst_u32(3), unconst_u32(121), unconst_u32(151)))));
+  let vf64: vec3h = mix(vec3h(asin(vec4f(unconst_f32(0.04242), unconst_f32(0.1437), unconst_f32(0.07283), unconst_f32(0.02475))).zyy), vec3h(unconst_f16(24526.7), unconst_f16(13408.7), unconst_f16(4117.5)), vec3h(unconst_f16(3019.2), unconst_f16(176.6), unconst_f16(20660.2)));
+  var vf65: vec2f = unpack2x16unorm(u32(unconst_u32(374)));
+  let vf66: vec3h = vf64;
+  vf63 = vec3f(firstTrailingBit(vec2i(unconst_i32(82), unconst_i32(373))).grr);
+  vf63 -= vec3f(vf63[u32(unconst_u32(39))]);
+  let vf67: vec4f = vf62;
+  vf65 = vf67.bg;
+  var vf68: vec4f = vf62;
+  let vf69: f32 = vf68[u32(unconst_u32(123))];
+  vf63 -= vec3f(mix(vec3h(unconst_f16(13105.0), unconst_f16(4302.1), unconst_f16(4596.7)), vec3h(unconst_f16(85.65), unconst_f16(1187.4), unconst_f16(2308.2)), vec3h(unconst_f16(52.82), unconst_f16(36536.9), unconst_f16(17793.1))));
+  out = mat3x3h(vec3h(vf62.brb), vec3h(vf62.aaa), vec3h(vf62.xyz));
+  let vf70: f32 = vf67[u32(unconst_u32(128))];
+  var vf71: f16 = vf64[u32(unconst_u32(205))];
+  return out;
+}
+
+fn fn1() -> mat3x2f {
+  var out: mat3x2f;
+  let vf72: vec4i = insertBits(vec4i(unconst_i32(568), unconst_i32(406), unconst_i32(199), unconst_i32(154)), vec4i(i32(distance(vec3h(unconst_f16(5649.1), unconst_f16(13164.3), unconst_f16(5953.7)), vec3h(unconst_f16(15390.8), unconst_f16(13504.1), unconst_f16(12919.6))))), u32(unconst_u32(16)), u32(unconst_u32(56)));
+  out = mat3x2f(bitcast<vec2f>(countOneBits(vec2u(tan(vec2h(unconst_f16(16068.8), unconst_f16(1239.5)))))), vec2f(countOneBits(vec2u(tan(vec2h(unconst_f16(16068.8), unconst_f16(1239.5)))))), bitcast<vec2f>(countOneBits(vec2u(tan(vec2h(unconst_f16(16068.8), unconst_f16(1239.5)))))));
+  out = mat3x2f(f32(pack4xU8Clamp(vec4u(unconst_u32(74), unconst_u32(15), unconst_u32(208), unconst_u32(47)))), bitcast<f32>(pack4xU8Clamp(vec4u(unconst_u32(74), unconst_u32(15), unconst_u32(208), unconst_u32(47)))), f32(pack4xU8Clamp(vec4u(unconst_u32(74), unconst_u32(15), unconst_u32(208), unconst_u32(47)))), f32(pack4xU8Clamp(vec4u(unconst_u32(74), unconst_u32(15), unconst_u32(208), unconst_u32(47)))), f32(pack4xU8Clamp(vec4u(unconst_u32(74), unconst_u32(15), unconst_u32(208), unconst_u32(47)))), bitcast<f32>(pack4xU8Clamp(vec4u(unconst_u32(74), unconst_u32(15), unconst_u32(208), unconst_u32(47)))));
+  out = mat3x2f(fma(vec4f(unconst_f32(-0.1352), unconst_f32(0.2386), unconst_f32(0.1366), unconst_f32(-0.3942)), vec4f(unconst_f32(0.05106), unconst_f32(0.1597), unconst_f32(0.02934), unconst_f32(0.07998)), vec4f(unconst_f32(0.03112), unconst_f32(0.04883), unconst_f32(0.00852), unconst_f32(0.1949))).zy, fma(vec4f(unconst_f32(-0.1352), unconst_f32(0.2386), unconst_f32(0.1366), unconst_f32(-0.3942)), vec4f(unconst_f32(0.05106), unconst_f32(0.1597), unconst_f32(0.02934), unconst_f32(0.07998)), vec4f(unconst_f32(0.03112), unconst_f32(0.04883), unconst_f32(0.00852), unconst_f32(0.1949))).xy, fma(vec4f(unconst_f32(-0.1352), unconst_f32(0.2386), unconst_f32(0.1366), unconst_f32(-0.3942)), vec4f(unconst_f32(0.05106), unconst_f32(0.1597), unconst_f32(0.02934), unconst_f32(0.07998)), vec4f(unconst_f32(0.03112), unconst_f32(0.04883), unconst_f32(0.00852), unconst_f32(0.1949))).zw);
+  var vf73: u32 = pack4xU8Clamp(vec4u(unconst_u32(770), unconst_u32(105), unconst_u32(415), unconst_u32(176)));
+  var vf74: u32 = pack4xU8Clamp(vec4u(unconst_u32(49), unconst_u32(108), unconst_u32(136), unconst_u32(49)));
+  let vf75: vec4i = insertBits(vec4i(unconst_i32(207), unconst_i32(769), unconst_i32(27), unconst_i32(72)), vec4i(unconst_i32(4), unconst_i32(20), unconst_i32(8), unconst_i32(-67)), u32(unconst_u32(518)), u32(unconst_u32(104)));
+  var vf76: vec3f = acosh(vec3f(unconst_f32(0.1097), unconst_f32(0.07716), unconst_f32(0.1612)));
+  let vf77: vec3h = sqrt(vec3h(unconst_f16(12582.9), unconst_f16(7266.4), unconst_f16(5594.7)));
+  let vf78: vec4f = fma(vec4f(unconst_f32(0.3194), unconst_f32(0.07576), unconst_f32(0.06474), unconst_f32(-0.6655)), vec4f(unconst_f32(0.01362), unconst_f32(0.2505), unconst_f32(0.2713), unconst_f32(0.1063)), vec4f(unconst_f32(0.08233), unconst_f32(0.04981), unconst_f32(0.2091), unconst_f32(0.3599)));
+  let ptr31: ptr<function, vec3f> = &vf76;
+  let ptr32: ptr<function, u32> = &vf74;
+  var vf79: f16 = distance(vec3h(unconst_f16(3607.3), unconst_f16(3010.2), unconst_f16(10483.3)), vec3h(unconst_f16(13906.7), unconst_f16(3756.0), unconst_f16(2273.9)));
+  return out;
+}
+
+var<workgroup> vw22: vec2f;
+
+var<workgroup> vw23: array<atomic<u32>, 3>;
+
+var<workgroup> vw24: atomic<i32>;
+
+var<workgroup> vw25: array<array<atomic<i32>, 1>, 58>;
+
+var<workgroup> vw26: atomic<u32>;
+
+var<workgroup> vw27: mat3x2f;
+
+@vertex
+fn vertex3(@location(7) @interpolate(flat) a0: vec4h, @location(6) @interpolate(perspective, centroid) a1: vec4f, @location(4) @interpolate(flat) a2: vec2u, @location(14) @interpolate(flat, centroid) a3: f16, a4: S5, a5: S6, a6: S7, @location(8) a7: f32, @builtin(instance_index) a8: u32) -> VertexOutput3 {
+  var out: VertexOutput3;
+  var vf80 = fn1();
+  var vf81 = fn0();
+  return out;
+}
+
+@fragment
+fn fragment3(@location(15) a0: vec2u, @location(14) @interpolate(flat, centroid) a1: i32) -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  var vf82 = fn1();
+  let vf83: bool = any(bool(unconst_bool(true)));
+  out.f0 |= vec4i(i32(any(vec4<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(true), unconst_bool(false)))));
+  var vf84 = fn1();
+  fn1();
+  var vf85 = fn1();
+  fn1();
+  var vf86: bool = any(bool(unconst_bool(true)));
+  fn1();
+  vf86 = bool(saturate(vec4h(unconst_f16(7245.7), unconst_f16(15715.4), unconst_f16(7858.3), unconst_f16(16044.8))).y);
+  let ptr33: ptr<function, bool> = &vf86;
+  var vf87: vec4f = log2(vec4f(unconst_f32(0.1987), unconst_f32(0.1409), unconst_f32(0.2786), unconst_f32(0.03715)));
+  var vf88 = fn1();
+  let vf89: vec2u = a0;
+  fn1();
+  vf88 = mat3x2f(bitcast<vec2f>(radians(vec4h(unconst_f16(966.1), unconst_f16(15657.5), unconst_f16(1825.0), unconst_f16(11847.8)))), bitcast<vec2f>(radians(vec4h(unconst_f16(966.1), unconst_f16(15657.5), unconst_f16(1825.0), unconst_f16(11847.8)))), bitcast<vec2f>(radians(vec4h(unconst_f16(966.1), unconst_f16(15657.5), unconst_f16(1825.0), unconst_f16(11847.8)))));
+  var vf90: vec4f = log2(vec4f(unconst_f32(0.09000), unconst_f32(-0.1741), unconst_f32(0.4234), unconst_f32(0.4815)));
+  var vf91 = fn1();
+  let vf92: f32 = vf91[u32(unconst_u32(127))][u32(unconst_u32(178))];
+  vf91 = mat3x2f(bitcast<f32>(a1), f32(a1), f32(a1), bitcast<f32>(a1), bitcast<f32>(a1), bitcast<f32>(a1));
+  return out;
+}
+
+@fragment
+fn fragment4() -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  out.f0 = bitcast<i32>(unpack4x8snorm(u32(unconst_u32(95)))[2]);
+  let vf93: f32 = log(f32(unconst_f32(0.7861)));
+  var vf94: vec4f = unpack4x8snorm(u32(unconst_u32(191)));
+  let vf95: vec4f = unpack4x8snorm(u32(unconst_u32(17)));
+  let vf96: vec4f = cosh(vec4f(unconst_f32(0.2417), unconst_f32(0.03778), unconst_f32(0.4769), unconst_f32(0.01684)));
+  var vf97: f32 = vf94[u32(unconst_u32(167))];
+  let vf98: f32 = vf93;
+  let vf99: vec4f = vf95;
+  fn1();
+  return out;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute4() {
+  let ptr34: ptr<workgroup, atomic<i32>> = &(*&vw24);
+  fn0();
+  let vf100: u32 = countLeadingZeros(u32(unconst_u32(328)));
+  var vf101: u32 = pack4xU8(vec4u(unconst_u32(162), unconst_u32(77), unconst_u32(33), unconst_u32(908)));
+  atomicSub(&vw25[u32(unconst_u32(35))][u32(unconst_u32(36))], i32(unconst_i32(217)));
+  let ptr35: ptr<workgroup, vec2f> = &vw22;
+  var vf102 = fn0();
+  vf102 = mat3x3h(f16(vf101), f16(vf101), f16(vf101), f16(vf101), f16(vf101), f16(vf101), f16(vf101), f16(vf101), f16(vf101));
+  vf101 = bitcast<u32>(reflect(vec2h(unconst_f16(5217.7), unconst_f16(9327.4)), vec2h(unconst_f16(13838.3), unconst_f16(19559.5))));
+  var vf103 = fn0();
+  atomicMax(&vw24, i32(unconst_i32(274)));
+  textureStore(st8, vec3i(unconst_i32(9), unconst_i32(17), unconst_i32(309)), vec4f(vec4f(unconst_f32(-0.2632), unconst_f32(0.2698), unconst_f32(0.05573), unconst_f32(0.2452))));
+  var vf104 = fn1();
+  fn0();
+  let ptr36: ptr<workgroup, atomic<i32>> = &(*&vw25)[u32(unconst_u32(339))][0];
+  fn1();
+  atomicMax(&vw24, i32(unconst_i32(106)));
+  var vf105: i32 = atomicLoad(&(*ptr36));
+  var vf106 = fn1();
+  let ptr37: ptr<workgroup, array<atomic<u32>, 3>> = &(*&vw23);
+  let vf107: vec2u = firstTrailingBit(vec2u(unconst_u32(268), unconst_u32(17)));
+  fn0();
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer28 = device0.createBuffer({
+  size: 5775,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder35 = device0.createCommandEncoder({});
+let texture50 = device0.createTexture({
+  size: {width: 110, height: 10, depthOrArrayLayers: 78},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup2, new Uint32Array(696), 18, 0);
+} catch {}
+try {
+commandEncoder35.copyBufferToBuffer(buffer4, 22360, buffer11, 6472, 2964);
+} catch {}
+await gc();
+let buffer29 = device0.createBuffer({size: 2780, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let commandEncoder36 = device0.createCommandEncoder({});
+let texture51 = device0.createTexture({
+  label: '\uc8cf\u75b3\u{1fadd}\u6213\u0627\ue685\u632d',
+  size: {width: 560},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder26 = commandEncoder36.beginComputePass();
+try {
+renderPassEncoder3.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer4, 'uint16', 6_748, 6_140);
+} catch {}
+try {
+commandEncoder35.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1316 */
+  offset: 1316,
+  bytesPerRow: 2304,
+  rowsPerImage: 549,
+  buffer: buffer4,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 9},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let buffer30 = device0.createBuffer({size: 58, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let computePassEncoder27 = commandEncoder35.beginComputePass({label: '\u1ef3\u2cf7\u0073\u1750\u{1fe43}\u7a3a\u04a3'});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderPassEncoder7.insertDebugMarker('\u0f8c');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 54}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer31 = device0.createBuffer({size: 1755, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView42 = texture27.createView({label: '\u{1f738}\u0162', aspect: 'stencil-only', mipLevelCount: 2});
+let sampler14 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.47,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder16.setBindGroup(3, bindGroup16, new Uint32Array(606), 10, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup12, new Uint32Array(755), 64, 0);
+} catch {}
+document.body.append(img0);
+try {
+renderPassEncoder0.executeBundles([renderBundle0]);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(11).fill(183), /* required buffer size: 11 */
+{offset: 11}, {width: 32, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 54}
+*/
+{
+  source: imageData2,
+  origin: { x: 15, y: 2 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup22 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 27, resource: {buffer: buffer16, offset: 0}}]});
+let buffer32 = device0.createBuffer({size: 9070, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let sampler15 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 96.80,
+  lodMaxClamp: 99.98,
+});
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer10, 0, 271);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 1896, new BigUint64Array(21079), 4685, 72);
+} catch {}
+let img1 = await imageWithData(43, 46, '#10101010', '#20202020');
+let buffer33 = device0.createBuffer({size: 24679, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder37 = device0.createCommandEncoder({label: '\u05af\uf332\u9a40\u{1fe76}\u8635\u{1fe1d}\u06c4\u009b\u0e38'});
+let textureView43 = texture8.createView({dimension: '2d-array', baseMipLevel: 0});
+let externalTexture0 = device0.importExternalTexture({label: '\uf7b5\u00a5', source: videoFrame0});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer21, 'uint16', 1_420, 6_820);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+commandEncoder37.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1792 */
+  offset: 1792,
+  bytesPerRow: 55808,
+  buffer: buffer7,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder37.copyTextureToBuffer({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 19, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 70 widthInBlocks: 70 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 184 */
+  offset: 184,
+  buffer: buffer26,
+}, {width: 70, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(192).fill(149), /* required buffer size: 192 */
+{offset: 192, rowsPerImage: 9}, {width: 42, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer34 = device0.createBuffer({size: 9615, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let renderPassEncoder10 = commandEncoder37.beginRenderPass({colorAttachments: [{view: textureView38, loadOp: 'load', storeOp: 'store'}]});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup11, new Uint32Array(2528), 588, 0);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(2, 10, 5, 20);
+} catch {}
+let texture52 = device0.createTexture({size: [140], sampleCount: 1, dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_DST});
+let textureView44 = texture4.createView({baseArrayLayer: 0});
+let sampler16 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeW: 'clamp-to-edge', magFilter: 'nearest', lodMaxClamp: 75.45});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+computePassEncoder21.setBindGroup(2, bindGroup19, new Uint32Array(192), 66, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder({});
+let commandBuffer1 = commandEncoder38.finish();
+let sampler17 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 57.98,
+  lodMaxClamp: 97.63,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup6, new Uint32Array(6134), 5_019, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup8, new Uint32Array(3866), 884, 0);
+} catch {}
+try {
+renderPassEncoder4.setViewport(22.475898138163537, 0.9371507246081682, 8.661867426964486, 0.027844123909638693, 0.6326354053367029, 0.7065691887287074);
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(img0);
+await gc();
+let imageData4 = new ImageData(8, 24);
+let commandEncoder39 = device0.createCommandEncoder({});
+let texture53 = device0.createTexture({
+  size: {width: 36, height: 1, depthOrArrayLayers: 46},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder28 = commandEncoder39.beginComputePass();
+try {
+computePassEncoder18.setBindGroup(0, bindGroup2, new Uint32Array(195), 58, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle0, renderBundle0, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer2, 1_748);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let buffer35 = device0.createBuffer({size: 29881, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder40 = device0.createCommandEncoder({});
+let renderPassEncoder11 = commandEncoder40.beginRenderPass({
+  colorAttachments: [{
+  view: textureView38,
+  clearValue: { r: 321.1, g: 682.2, b: 406.5, a: -727.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 36510126,
+});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup7);
+} catch {}
+let commandEncoder41 = device0.createCommandEncoder({});
+let computePassEncoder29 = commandEncoder41.beginComputePass();
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup19, new Uint32Array(5403), 157, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let textureView45 = texture17.createView({mipLevelCount: 1});
+try {
+renderPassEncoder5.executeBundles([renderBundle0]);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let commandEncoder42 = device0.createCommandEncoder({label: '\u{1f66b}\uc894\u9ca5\u04cd\uc112\u{1fbf4}\u555d'});
+try {
+computePassEncoder1.insertDebugMarker('\ue002');
+} catch {}
+let buffer36 = device0.createBuffer({size: 4447, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder43 = device0.createCommandEncoder({});
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 146});
+let computePassEncoder30 = commandEncoder43.beginComputePass({});
+try {
+computePassEncoder29.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer21, 'uint16', 3_776, 4_858);
+} catch {}
+try {
+  await promise1;
+} catch {}
+let bindGroup23 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 103, resource: textureView3}, {binding: 176, resource: textureView8}],
+});
+let buffer37 = device0.createBuffer({size: 3455, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder44 = device0.createCommandEncoder({});
+let textureView46 = texture28.createView({dimension: '2d', aspect: 'stencil-only'});
+let computePassEncoder31 = commandEncoder44.beginComputePass({});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup12, new Uint32Array(687), 32, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup0, new Uint32Array(311), 12, 0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer3);
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+let commandEncoder45 = device0.createCommandEncoder({});
+let sampler18 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 14.97,
+  lodMaxClamp: 46.50,
+});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(10, 0, 8, 0);
+} catch {}
+try {
+commandEncoder42.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 13, y: 21, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 25},
+  aspect: 'all',
+},
+{width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+document.body.prepend(img1);
+let shaderModule5 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(103) var st10: texture_storage_3d<rgba8unorm, write>;
+
+@group(0) @binding(176) var st11: texture_storage_3d<rgba16uint, write>;
+
+struct T0 {
+  @align(8) @size(40) f0: array<u32>,
+}
+
+struct S8 {
+  @location(14) @interpolate(flat) f0: vec2i,
+  @location(4) @interpolate(flat) f1: vec2i,
+}
+
+struct VertexOutput4 {
+  @builtin(position) f18: vec4f,
+  @location(5) f19: f16,
+  @location(11) @interpolate(flat, centroid) f20: vec4u,
+  @location(3) f21: vec2h,
+  @location(6) @interpolate(flat, centroid) f22: vec2i,
+  @location(7) @interpolate(flat, sample) f23: i32,
+}
+
+alias vec3b = vec3<bool>;
+
+fn fn0(a0: ptr<storage, array<S8>, read>) -> vec2u {
+  var out: vec2u;
+  let ptr38: ptr<private, S8> = &vp2[u32(unconst_u32(346))];
+  vp2[u32(unconst_u32(204))].f0 |= vp2[bitcast<vec2u>((*ptr38).f1).g].f1;
+  vp2[u32(unconst_u32(438))].f1 = bitcast<vec2i>(vp3[0][0]);
+  let ptr39: ptr<storage, S8, read> = &(*a0)[i32(unconst_i32(40))];
+  var vf108: u32 = vp3[u32(unconst_u32(17))][u32(unconst_u32(162))][u32(unconst_u32(62))];
+  var vf109: i32 = (*ptr39).f0[bitcast<u32>((*ptr38).f0[u32(unconst_u32(793))])];
+  let ptr40: ptr<storage, vec2i, read> = &(*ptr39).f0;
+  vf108 |= u32((*ptr38).f0[1]);
+  return out;
+}
+
+fn fn1() {
+  let ptr41: ptr<private, vec2u> = &vp3[0][u32(unconst_u32(8))];
+  vp3[u32(unconst_u32(307))][0] = vp3[0][0];
+  let ptr42: ptr<private, vec2u> = &(*ptr41);
+  let ptr43: ptr<private, vec2u> = &vp3[0][u32(unconst_u32(66))];
+}
+
+fn fn2() -> array<array<array<array<array<vec2h, 1>, 1>, 42>, 1>, 1> {
+  var out: array<array<array<array<array<vec2h, 1>, 1>, 42>, 1>, 1>;
+  vp2[u32(unconst_u32(21))] = S8(vec2i(sign(vec4f(unconst_f32(-0.07538), unconst_f32(0.00993), unconst_f32(0.02765), unconst_f32(0.3565))).wz), bitcast<vec2i>(sign(vec4f(unconst_f32(-0.07538), unconst_f32(0.00993), unconst_f32(0.02765), unconst_f32(0.3565))).gr));
+  let ptr44: ptr<private, vec2i> = &vp2[u32(unconst_u32(84))].f1;
+  let vf110: vec4u = countTrailingZeros(vp3[0][0].yxxx);
+  out[u32(unconst_u32(24))][u32(unconst_u32(177))][u32(unconst_u32(109))][u32(unconst_u32(494))][u32(unconst_u32(292))] *= bitcast<vec2h>(vp3[u32(unconst_u32(233))][0][u32(unconst_u32(153))]);
+  let ptr45: ptr<private, vec2i> = &vp2[0].f1;
+  vp2[u32(unconst_u32(147))].f0 |= vec2i(i32(pack4x8snorm(vec4f(unconst_f32(0.4613), unconst_f32(0.00191), unconst_f32(0.04739), unconst_f32(0.2163)))));
+  let ptr46: ptr<private, vec2u> = &vp3[bitcast<u32>(vp2[u32(unconst_u32(12))].f1.r)][u32(unconst_u32(42))];
+  var vf111: vec3h = log2(vec3h(unconst_f16(-1184.2), unconst_f16(6996.6), unconst_f16(4325.9)));
+  vf111 -= vec3h(f16(vf110[u32(unconst_u32(238))]));
+  vp2[u32(unconst_u32(136))].f0 -= vec2i(floor(vec2f(unconst_f32(0.02629), unconst_f32(0.6027))));
+  var vf112: vec4u = unpack4xU8(u32(unconst_u32(66)));
+  vp3[u32(unconst_u32(158))][u32(unconst_u32(408))] = vec2u(u32(vp2[0].f0[u32(unconst_u32(441))]));
+  vp3[u32(unconst_u32(130))][u32(unconst_u32(256))] >>= vec2u((*ptr44));
+  let ptr47: ptr<private, vec2u> = &vp3[u32(unconst_u32(90))][0];
+  out[vp3[u32(unconst_u32(47))][0].g][u32(unconst_u32(295))][u32(unconst_u32(455))][u32(unconst_u32(20))][u32(unconst_u32(63))] = vec2h(acos(vec3f(unconst_f32(0.06152), unconst_f32(0.03587), unconst_f32(0.03940))).yz);
+  return out;
+}
+
+var<workgroup> vw28: array<atomic<u32>, 1>;
+
+var<workgroup> vw29: S8;
+
+var<workgroup> vw30: array<S8, 2>;
+
+var<private> vp2: array<S8, 1> = array<S8, 1>(S8(vec2i(203, 29), vec2i(187, 95)));
+
+var<private> vp3: array<array<vec2u, 1>, 1> = array<array<vec2u, 1>, 1>(array(vec2u(260, 111)));
+
+@vertex
+fn vertex4(a0: S8, @location(13) a1: vec4i, @location(6) a2: vec4u) -> VertexOutput4 {
+  var out: VertexOutput4;
+  vp3[u32(exp(f16(unconst_f16(5041.6))))][0] <<= a2.ww;
+  fn1();
+  out.f20 += vp3[0][0].rrgg;
+  fn1();
+  fn1();
+  let ptr48: ptr<private, vec2i> = &vp2[0].f1;
+  out.f21 = vec2h(vp3[0][0]);
+  var vf113: i32 = vp2[0].f1[u32(unconst_u32(565))];
+  let vf114: u32 = pack4x8unorm(vec4f(unconst_f32(0.1596), unconst_f32(0.3442), unconst_f32(0.2455), unconst_f32(-0.02050)));
+  let ptr49: ptr<private, vec2u> = &vp3[0][u32(unconst_u32(128))];
+  fn1();
+  var vf115: u32 = vp3[u32(unconst_u32(172))][0][u32(unconst_u32(117))];
+  let vf116: u32 = pack2x16unorm(vec2f(unconst_f32(0.05855), unconst_f32(-0.5275)));
+  out.f20 *= unpack4xU8(u32(exp(f16(unconst_f16(14144.7)))));
+  fn1();
+  fn1();
+  fn1();
+  fn1();
+  fn1();
+  out.f21 = vec2h((*ptr48));
+  let ptr50: ptr<private, array<S8, 1>> = &vp2;
+  out.f18 += vec4f(vp3[u32(unconst_u32(145))][u32(unconst_u32(49))].xyxy);
+  fn1();
+  fn1();
+  vf115 *= vec2u(vp2[0].f1)[0];
+  return out;
+}
+
+@fragment
+fn fragment5() -> @location(200) @interpolate(linear, center) vec4u {
+  var out: vec4u;
+  vp2[0] = S8(vp2[0].f1, vp2[0].f1);
+  fn2();
+  out &= unpack4xU8(bitcast<u32>(vp2[u32(unconst_u32(228))].f0[u32(unconst_u32(122))]));
+  vp2[u32(unconst_u32(3))] = S8(vec2i(vp2[0].f1[u32(unconst_u32(131))]), vec2i(vp2[0].f1[u32(unconst_u32(131))]));
+  var vf117 = fn2();
+  vp3[u32(unconst_u32(101))][0] = vec2u(u32(vf117[bitcast<u32>(vf117[u32(unconst_u32(49))][0][u32(unconst_u32(94))][0][0])][0][41][u32(unconst_u32(31))][bitcast<u32>(vf117[u32(unconst_u32(64))][u32(unconst_u32(90))][u32(unconst_u32(201))][u32(unconst_u32(45))][0])][u32(unconst_u32(9))]));
+  let ptr51: ptr<function, vec2h> = &vf117[u32(unconst_u32(64))][0][41][u32(unconst_u32(42))][u32(unconst_u32(33))];
+  vp2[u32(unconst_u32(42))] = S8(vec2i(bitcast<i32>(floor(f32(unconst_f32(0.2505))))), vec2i(bitcast<i32>(floor(f32(unconst_f32(0.2505))))));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute5(@builtin(num_workgroups) a0: vec3u, @builtin(local_invocation_index) a1: u32) {
+  var vf118 = fn2();
+  let ptr52: ptr<workgroup, atomic<u32>> = &(*&vw28)[0];
+  var vf119: f16 = vf118[u32(unconst_u32(479))][u32(unconst_u32(293))][41][u32(unconst_u32(72))][u32(unconst_u32(83))][u32(unconst_u32(84))];
+  let ptr53: ptr<function, vec2h> = &vf118[u32(unconst_u32(5))][0][bitcast<u32>(vf118[0][0][u32(unconst_u32(137))][u32(unconst_u32(724))][u32(unconst_u32(68))])][0][u32(unconst_u32(57))];
+  fn2();
+  let ptr54: ptr<function, array<vec2h, 1>> = &vf118[0][0][u32(unconst_u32(3))][u32(unconst_u32(40))];
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer38 = device0.createBuffer({size: 12982, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let commandEncoder46 = device0.createCommandEncoder();
+let computePassEncoder32 = commandEncoder46.beginComputePass({});
+let renderPassEncoder12 = commandEncoder42.beginRenderPass({
+  colorAttachments: [{
+  view: textureView6,
+  clearValue: { r: 507.9, g: 397.9, b: 7.328, a: -568.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 341703515,
+});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+commandEncoder45.clearBuffer(buffer26, 148, 688);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer25, 540, new Int16Array(6236), 712, 2504);
+} catch {}
+let bindGroup24 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 225, resource: textureView39},
+    {binding: 58, resource: {buffer: buffer10, offset: 2560, size: 4417}},
+  ],
+});
+let textureView47 = texture23.createView({dimension: '3d', baseMipLevel: 1, mipLevelCount: 1});
+let computePassEncoder33 = commandEncoder45.beginComputePass({label: '\uf2d6\u09e1\ucb09\u0284\u{1fe87}\u2f12\u0c27\u08a3\u{1ff3c}\u264f\u3d59'});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup4, new Uint32Array(1332), 605, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup5, new Uint32Array(314), 10, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer12, 40, 121);
+} catch {}
+let bindGroup25 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 11, resource: {buffer: buffer37, offset: 0, size: 912}}],
+});
+let buffer39 = device0.createBuffer({size: 21921, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder47 = device0.createCommandEncoder();
+let texture54 = device0.createTexture({
+  size: {width: 140, height: 145, depthOrArrayLayers: 2},
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView48 = texture20.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 5});
+let computePassEncoder34 = commandEncoder47.beginComputePass({});
+let sampler19 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 43.55,
+  lodMaxClamp: 61.43,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup2, new Uint32Array(1269), 85, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup20, new Uint32Array(625), 38, 0);
+} catch {}
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'bt709', transfer: 'pq'} });
+let commandEncoder48 = device0.createCommandEncoder();
+let renderPassEncoder13 = commandEncoder48.beginRenderPass({
+  colorAttachments: [{
+  view: textureView20,
+  clearValue: { r: 233.0, g: -381.1, b: -625.6, a: -355.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder6.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(5, buffer24, 0, 115);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup26 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 11, resource: {buffer: buffer28, offset: 1280, size: 1012}}],
+});
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 703});
+let texture55 = device0.createTexture({
+  size: {width: 560, height: 582, depthOrArrayLayers: 1},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup8, new Uint32Array(548), 44, 0);
+} catch {}
+try {
+  await promise5;
+} catch {}
+let commandEncoder49 = device0.createCommandEncoder({});
+let textureView49 = texture31.createView({label: '\u084d\u0a22\u{1fe1a}\u{1fa09}\u88ac', dimension: '2d', mipLevelCount: 1});
+let renderPassEncoder14 = commandEncoder49.beginRenderPass({colorAttachments: [{view: textureView38, loadOp: 'load', storeOp: 'store'}]});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup7, new Uint32Array(3428), 630, 0);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(3);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer20, 'uint32', 0, 70);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 50},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup27 = device0.createBindGroup({
+  label: '\u1e04\ud416\u{1ff21}\u3e36\u09ea\uba48\u0482',
+  layout: bindGroupLayout1,
+  entries: [{binding: 277, resource: sampler8}],
+});
+let texture56 = device0.createTexture({
+  label: '\u2cff\ud382\ub529\ud44b\u28e8\uefaa\u{1f957}\ua92e\u{1fbd4}\u0cf7',
+  size: [440, 40, 62],
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView50 = texture31.createView({baseArrayLayer: 4, arrayLayerCount: 2});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup23, new Uint32Array(454), 2, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer18, 544, 1_276);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let buffer40 = device0.createBuffer({size: 65536, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM, mappedAtCreation: false});
+let textureView51 = texture2.createView({aspect: 'all', mipLevelCount: 1});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+computePassEncoder28.setBindGroup(2, bindGroup6, new Uint32Array(445), 99, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let buffer41 = device0.createBuffer({size: 6425, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder50 = device0.createCommandEncoder({});
+let computePassEncoder35 = commandEncoder50.beginComputePass({});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup5, new Uint32Array(2152), 364, 0);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer15, 'uint32', 560, 4_414);
+} catch {}
+document.body.append(img0);
+await gc();
+let buffer42 = device0.createBuffer({
+  size: 1841,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let texture57 = device0.createTexture({
+  size: [560, 582, 1],
+  mipLevelCount: 3,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder7.beginOcclusionQuery(142);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer20, 'uint32', 108, 64);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let bindGroup28 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 225, resource: textureView13},
+    {binding: 58, resource: {buffer: buffer23, offset: 1024, size: 7889}},
+  ],
+});
+try {
+buffer5.unmap();
+} catch {}
+try {
+  await promise4;
+} catch {}
+let commandEncoder51 = device0.createCommandEncoder();
+let textureView52 = texture43.createView({dimension: '2d-array'});
+let computePassEncoder36 = commandEncoder51.beginComputePass({});
+try {
+computePassEncoder31.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder29.setBindGroup(1, bindGroup9, new Uint32Array(2903), 486, 0);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup0, new Uint32Array(611), 69, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline0 = await device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule3}});
+let commandEncoder52 = device0.createCommandEncoder({});
+let querySet5 = device0.createQuerySet({label: '\u9c8a\uce74\u{1ff9b}', type: 'occlusion', count: 65});
+let computePassEncoder37 = commandEncoder52.beginComputePass({});
+let sampler20 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 8.898,
+  lodMaxClamp: 94.63,
+});
+try {
+computePassEncoder29.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer23, 1196, new DataView(new ArrayBuffer(535)), 3);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture58 = device0.createTexture({
+  size: [220, 20, 1],
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer20, 'uint32', 172, 5);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(3, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 2632, new Int16Array(4536), 66, 404);
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder();
+let renderPassEncoder15 = commandEncoder53.beginRenderPass({
+  colorAttachments: [{view: textureView38, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet5,
+});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer13, 'uint32', 592, 8_835);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData5 = new ImageData(40, 88);
+let bindGroup29 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 86, resource: textureView47},
+    {binding: 62, resource: textureView39},
+    {binding: 211, resource: sampler18},
+  ],
+});
+let commandEncoder54 = device0.createCommandEncoder({});
+let texture59 = device0.createTexture({
+  size: [147, 1, 1],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView53 = texture16.createView({dimension: 'cube-array', mipLevelCount: 1, arrayLayerCount: 6});
+let computePassEncoder38 = commandEncoder54.beginComputePass({});
+let sampler21 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 68.22,
+  lodMaxClamp: 80.07,
+});
+try {
+computePassEncoder27.setBindGroup(1, bindGroup18, new Uint32Array(1076), 449, 0);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer6, 60, 155);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 940, new DataView(new ArrayBuffer(4095)), 1614, 240);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: imageData3,
+  origin: { x: 0, y: 8 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 9},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup30 = device0.createBindGroup({
+  label: '\ue0eb\u2916\uc9e4\u05ab\u{1fe99}\u{1fce8}\u{1fbae}\ue78a\u{1ff53}\u38ce\u{1f7b0}',
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 54, resource: {buffer: buffer19, offset: 256, size: 2788}},
+    {binding: 53, resource: externalTexture0},
+  ],
+});
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 169});
+let texture60 = device0.createTexture({
+  size: [280, 291, 1],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+await gc();
+let textureView54 = texture33.createView({dimension: '2d-array'});
+try {
+computePassEncoder29.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(1671);
+} catch {}
+let commandEncoder55 = device0.createCommandEncoder({});
+let commandBuffer2 = commandEncoder55.finish();
+let textureView55 = texture16.createView({
+  label: '\u0a15\u{1fe97}',
+  dimension: 'cube-array',
+  aspect: 'all',
+  mipLevelCount: 1,
+  baseArrayLayer: 1,
+  arrayLayerCount: 6,
+});
+try {
+renderPassEncoder3.executeBundles([renderBundle0, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer4);
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 2148, new BigUint64Array(6187), 349, 8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 9, y: 105, z: 0},
+  aspect: 'all',
+}, new Uint8Array(112).fill(220), /* required buffer size: 112 */
+{offset: 112, bytesPerRow: 76}, {width: 6, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let buffer43 = device0.createBuffer({
+  label: '\ua104\u010d\ud69a',
+  size: 5311,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder56 = device0.createCommandEncoder({});
+let texture61 = device0.createTexture({size: [48], dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder39 = commandEncoder56.beginComputePass({});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(7, buffer12, 40, 4);
+} catch {}
+let textureView56 = texture14.createView({label: '\ub444\u3593\u04eb\u{1fe2d}', format: 'rgba16sint', baseArrayLayer: 1, arrayLayerCount: 6});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer28, 'uint16', 6, 1_654);
+} catch {}
+let commandEncoder57 = device0.createCommandEncoder({label: '\uc819\ue42a\ucdd3\u{1fe77}\u075e\uc931\u917a\u{1f908}\u0889'});
+let textureView57 = texture10.createView({aspect: 'depth-only', baseMipLevel: 1, mipLevelCount: 1});
+let computePassEncoder40 = commandEncoder57.beginComputePass({});
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup10, new Uint32Array(1023), 272, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer28, 0, 942);
+} catch {}
+let buffer44 = device0.createBuffer({
+  size: 19274,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let sampler22 = device0.createSampler({
+  label: '\u{1fcfc}\u7ee7\u4eee\u{1fb9a}\u{1fd70}\u5e37\ue88f\u22e1\u9045\u0e69',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 34.86,
+  lodMaxClamp: 55.12,
+});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup5, new Uint32Array(1617), 17, 0);
+} catch {}
+try {
+computePassEncoder28.end();
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup31 = device0.createBindGroup({
+  label: '\u2028\u94eb',
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 999, resource: textureView31},
+    {binding: 35, resource: textureView10},
+    {binding: 42, resource: externalTexture0},
+    {binding: 421, resource: {buffer: buffer8, offset: 768, size: 52}},
+    {binding: 243, resource: textureView13},
+    {binding: 398, resource: textureView57},
+    {binding: 567, resource: textureView30},
+    {binding: 94, resource: textureView12},
+    {binding: 132, resource: textureView35},
+  ],
+});
+let textureView58 = texture29.createView({label: '\u9475\uc84a\u{1feb0}\u0b96\u483f'});
+let renderPassEncoder16 = commandEncoder39.beginRenderPass({
+  label: '\u{1fb19}\u6e63\u329d\u7782\u{1f951}',
+  colorAttachments: [{view: textureView4, depthSlice: 162, loadOp: 'load', storeOp: 'store'}],
+});
+try {
+computePassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup22, new Uint32Array(1321), 33, 0);
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(37, 0, 10, 0);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(3, bindGroup10);
+} catch {}
+let textureView59 = texture5.createView({
+  label: '\u3887\u0518\u0955\u0ff1\u0805\uf819\u{1f7e3}\u{1f65b}\ub9b9\u0971',
+  dimension: '3d',
+  format: 'rgba8unorm',
+});
+try {
+computePassEncoder25.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(4, buffer28, 164, 1_018);
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let buffer45 = device0.createBuffer({size: 20431, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT});
+let commandEncoder58 = device0.createCommandEncoder({});
+let computePassEncoder41 = commandEncoder2.beginComputePass({});
+let renderPassEncoder17 = commandEncoder58.beginRenderPass({
+  label: '\u01a9\u0876\u0bef\u1869\u0026\u5b3c\u609d\u7570\ue309',
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: -0.9335, g: 142.3, b: -792.2, a: -131.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet3,
+});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup4, new Uint32Array(577), 81, 0);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(4, buffer4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 24, new Float32Array(492), 38, 0);
+} catch {}
+let commandEncoder59 = device0.createCommandEncoder({label: '\u{1f885}\u{1f90b}\u0b7a\u97a3\u0472\u{1fa75}\uc339\u65f3\u{1ffd4}\u8746'});
+let commandBuffer3 = commandEncoder59.finish({label: '\ubcee\ub86f\u{1fa69}'});
+try {
+computePassEncoder34.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+computePassEncoder30.setBindGroup(3, bindGroup24, new Uint32Array(717), 32, 0);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup27);
+} catch {}
+let buffer46 = device0.createBuffer({size: 10795, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let textureView60 = texture59.createView({dimension: '2d-array', aspect: 'depth-only'});
+try {
+computePassEncoder35.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: -551.2, g: -212.2, b: 163.7, a: 467.2, });
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer24, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 81},
+  aspect: 'all',
+}, new Uint8Array(14_334).fill(73), /* required buffer size: 14_334 */
+{offset: 78, bytesPerRow: 36, rowsPerImage: 44}, {width: 1, height: 0, depthOrArrayLayers: 10});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer47 = device0.createBuffer({size: 8242, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let sampler23 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 61.04,
+  lodMaxClamp: 64.24,
+});
+try {
+computePassEncoder30.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer8);
+} catch {}
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'bt709', transfer: 'bt1361ExtendedColourGamut'} });
+let commandEncoder60 = device0.createCommandEncoder({});
+let texture62 = device0.createTexture({
+  size: {width: 48},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView61 = texture33.createView({dimension: '2d-array', arrayLayerCount: 1});
+let computePassEncoder42 = commandEncoder60.beginComputePass();
+let sampler24 = device0.createSampler({
+  label: '\u9285\u{1f70d}\ud6b1\u073c\u8d8a\uaaec\u{1f8e0}\u6b43\u0347\ud7c5',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 17.10,
+  lodMaxClamp: 85.70,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder21.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup1, new Uint32Array(3587), 52, 0);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(42);
+} catch {}
+try {
+  await promise3;
+} catch {}
+let texture63 = device0.createTexture({
+  size: [110, 10, 1],
+  mipLevelCount: 1,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler25 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 86.63,
+  lodMaxClamp: 91.63,
+});
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(17).fill(137), /* required buffer size: 17 */
+{offset: 17, rowsPerImage: 80}, {width: 171, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+await gc();
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup28, new Uint32Array(125), 62, 0);
+} catch {}
+let buffer48 = device0.createBuffer({label: '\uad95\u69c0\uc554', size: 4757, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder61 = device0.createCommandEncoder();
+let texture64 = device0.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 4},
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder43 = commandEncoder61.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroupsIndirect(buffer8, 264); };
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup24, new Uint32Array(2037), 348, 0);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(858).fill(76), /* required buffer size: 858 */
+{offset: 858, rowsPerImage: 87}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData6 = new ImageData(60, 24);
+let bindGroup32 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 11, resource: {buffer: buffer12, offset: 0}}]});
+let buffer49 = device0.createBuffer({
+  size: 1732,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture65 = device0.createTexture({
+  size: {width: 73, height: 1, depthOrArrayLayers: 24},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline0);
+} catch {}
+let commandEncoder62 = device0.createCommandEncoder({});
+let texture66 = device0.createTexture({
+  label: '\u7f85\uf0a2\ua319\u081e\ubaf6\u5490\u{1faa4}\u003a\u{1ffcb}\u8a0e',
+  size: [560, 582, 1],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder44 = commandEncoder62.beginComputePass({label: '\uc78a\u62b9\u0033\u86fc\ud0e1\u2ee0\u0c57\u0e15\u0b3c\u65ff\u7240'});
+try {
+computePassEncoder37.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(131).fill(155), /* required buffer size: 131 */
+{offset: 131}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture67 = device0.createTexture({
+  label: '\u0bfb\uf703\u{1f916}\u3318\u{1fbc0}\u{1fbc3}',
+  size: {width: 36, height: 1, depthOrArrayLayers: 11},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16sint'],
+});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup11, new Uint32Array(934), 111, 0);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup6, new Uint32Array(1415), 186, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup33 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 277, resource: sampler7}]});
+let buffer50 = device0.createBuffer({
+  size: 1490,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder63 = device0.createCommandEncoder();
+let computePassEncoder45 = commandEncoder63.beginComputePass();
+let sampler26 = device0.createSampler({
+  label: '\ud406\u2a56\u{1fffb}\u0f3d\u{1ffb2}\u3092\uef4b\u02de',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 99.12,
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup8, new Uint32Array(455), 1, 0);
+} catch {}
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(0, buffer3, 88, 176);
+} catch {}
+try {
+  await promise6;
+} catch {}
+let computePassEncoder46 = commandEncoder3.beginComputePass({});
+try {
+computePassEncoder43.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup31, new Uint32Array(4675), 102, 0);
+} catch {}
+try {
+renderPassEncoder17.setViewport(90.25700842093102, 0.08292614958652778, 3.6823953367973252, 0.03180822545249983, 0.5753112786032316, 0.7666719561514712);
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer51 = device0.createBuffer({
+  label: '\uaffc\u5eb4\u{1faae}\u0eb1\u07eb',
+  size: 3176,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let externalTexture1 = device0.importExternalTexture({source: videoFrame2});
+try {
+computePassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(7, buffer6);
+} catch {}
+try {
+computePassEncoder11.pushDebugGroup('\u0c41');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 6, y: 1 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 18},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let buffer52 = device0.createBuffer({size: 1684, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX, mappedAtCreation: false});
+let commandEncoder64 = device0.createCommandEncoder();
+let textureView62 = texture46.createView({dimension: '2d-array', aspect: 'depth-only'});
+let renderPassEncoder18 = commandEncoder64.beginRenderPass({colorAttachments: [{view: textureView36, loadOp: 'clear', storeOp: 'store'}]});
+let sampler27 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 10.93,
+  lodMaxClamp: 58.42,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder34.setBindGroup(2, bindGroup19, new Uint32Array(1436), 150, 0);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup0, new Uint32Array(4830), 679, 0);
+} catch {}
+document.body.append(img1);
+let buffer53 = device0.createBuffer({
+  size: 7273,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let sampler28 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 72.68,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+computePassEncoder32.setBindGroup(0, bindGroup25, new Uint32Array(502), 94, 0);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup8, new Uint32Array(2038), 428, 0);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(3, buffer10);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let texture68 = device0.createTexture({
+  size: {width: 36, height: 1, depthOrArrayLayers: 24},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup8, new Uint32Array(1824), 561, 0);
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer4, 'uint16', 610, 7_146);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(3, bindGroup1, new Uint32Array(815), 424, 0);
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+  label: '\u0c62\u126a',
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(176) var st12: texture_storage_3d<rgba16uint, write>;
+
+struct T0 {
+  @align(32) @size(224) f0: array<array<array<f16, 1>, 14>>,
+}
+
+struct T1 {
+  @size(248) f0: array<vec2i>,
+}
+
+struct T2 {
+  @align(32) @size(64) f0: atomic<u32>,
+  @size(4096) f1: array<u32>,
+}
+
+struct T3 {
+  @align(16) @size(48) f0: array<array<mat4x4h, 1>, 1>,
+}
+
+struct VertexOutput5 {
+  @location(15) @interpolate(flat, centroid) f24: vec4i,
+  @builtin(position) f25: vec4f,
+  @location(4) @interpolate(flat, sample) f26: f16,
+}
+
+struct FragmentOutput5 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4i,
+}
+
+alias vec3b = vec3<bool>;
+
+var<workgroup> vw31: mat3x4h;
+
+var<workgroup> vw32: FragmentOutput5;
+
+var<workgroup> vw33: FragmentOutput5;
+
+var<workgroup> vw34: array<FragmentOutput5, 1>;
+
+var<private> vp4: VertexOutput5 = VertexOutput5(vec4i(123, 11, 8, -89), vec4f(0.2610, -0.05641, 0.00933, 0.2370), f16(4444.8));
+
+var<private> vp5: FragmentOutput5 = FragmentOutput5();
+
+@vertex
+fn vertex5(@location(7) @interpolate(flat, centroid) a0: vec2i, @location(0) a1: vec2i) -> VertexOutput5 {
+  var out: VertexOutput5;
+  out.f24 += vec4i(i32(vp4.f26));
+  let ptr55: ptr<private, f16> = &vp4.f26;
+  var vf120: f32 = vp4.f25[vec3u(saturate(vec3f(unconst_f32(0.4408), unconst_f32(0.1741), unconst_f32(0.08870))))[0]];
+  out.f24 *= vec4i(floor(vec4h(unconst_f16(7988.0), unconst_f16(5838.3), unconst_f16(3534.9), unconst_f16(3089.9))));
+  var vf121: vec4u = max(vec4u(unconst_u32(117), unconst_u32(7), unconst_u32(148), unconst_u32(86)), vec4u(unconst_u32(267), unconst_u32(107), unconst_u32(1000), unconst_u32(161)));
+  var vf122: u32 = vf121[u32(unconst_u32(304))];
+  out.f24 = a1.yxyy;
+  vp4.f25 = unpack4x8snorm(vp5.f0);
+  out.f25 = acosh(vec4f(unconst_f32(0.01233), unconst_f32(-0.3400), unconst_f32(0.08932), unconst_f32(0.3074)));
+  let vf123: i32 = a0[u32(unconst_u32(42))];
+  let vf124: u32 = pack4xI8(vec4i(unconst_i32(11), unconst_i32(145), unconst_i32(36), unconst_i32(70)));
+  var vf125: vec2i = a1;
+  out.f26 = f16(vp5.f0);
+  let ptr56: ptr<private, vec4i> = &vp5.f1;
+  let ptr57: ptr<function, f32> = &vf120;
+  vp5.f0 *= u32((*ptr57));
+  var vf126: u32 = pack4xI8(vec4i(unconst_i32(130), unconst_i32(239), unconst_i32(135), unconst_i32(98)));
+  out = VertexOutput5(vec4i(i32(vf126)), vec4f(bitcast<f32>(vf126)), f16(vf126));
+  let vf127: vec2i = a0;
+  var vf128: i32 = vf125[u32(unconst_u32(30))];
+  let vf129: vec4f = step(vec4f(unconst_f32(0.2225), unconst_f32(0.00236), unconst_f32(0.2676), unconst_f32(0.02082)), vec4f(f32((*ptr56)[u32(unconst_u32(209))])));
+  let ptr58: ptr<function, vec4u> = &vf121;
+  return out;
+}
+
+@fragment
+fn fragment6() -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  out.f0 = countTrailingZeros(vec3u(unpack2x16snorm(u32(unconst_u32(90))).xyx)).r;
+  let ptr59: ptr<private, f16> = &vp4.f26;
+  var vf130: vec2f = log(vec2f(unconst_f32(0.1184), unconst_f32(0.1955)));
+  let ptr60: ptr<private, FragmentOutput5> = &vp5;
+  let vf131: vec2f = smoothstep(vec2f(unconst_f32(0.2379), unconst_f32(0.05978)), vec2f(unconst_f32(0.6442), unconst_f32(0.08395)), vec2f(unconst_f32(0.05456), unconst_f32(0.3774)));
+  out.f1 *= vec4i(firstLeadingBit(i32(unconst_i32(438))));
+  out.f1 ^= vec4i(i32(vp4.f26));
+  out = FragmentOutput5(insertBits(vec2u(unconst_u32(163), unconst_u32(66)), vec2u(unconst_u32(79), unconst_u32(6)), u32(unconst_u32(21)), u32(unconst_u32(155)))[0], bitcast<vec4i>(insertBits(vec2u(unconst_u32(163), unconst_u32(66)), vec2u(unconst_u32(79), unconst_u32(6)), u32(unconst_u32(21)), u32(unconst_u32(155))).xyxy));
+  vp5.f1 = unpack4xI8(pack4x8snorm(vec4f(unconst_f32(0.01959), unconst_f32(-0.1335), unconst_f32(-0.3388), unconst_f32(0.1872))));
+  let ptr61: ptr<private, vec4i> = &vp4.f24;
+  var vf132: vec2f = vf131;
+  out.f1 *= vec4i(insertBits(vec2u(unconst_u32(739), unconst_u32(305)), vec2u(unconst_u32(75), unconst_u32(324)), u32(unconst_u32(1000)), u32(unconst_u32(208))).xxxx);
+  let ptr62: ptr<private, FragmentOutput5> = &vp5;
+  let ptr63: ptr<function, vec2f> = &vf132;
+  let vf133: f32 = vf131[u32(unconst_u32(314))];
+  let ptr64: ptr<private, u32> = &(*ptr62).f0;
+  var vf134: vec3h = cross(vec3h(unconst_f16(6121.9), unconst_f16(2749.9), unconst_f16(20207.2)), vec3h(unconst_f16(18748.4), unconst_f16(42426.6), unconst_f16(12552.3)));
+  let ptr65: ptr<private, FragmentOutput5> = &vp5;
+  let vf135: i32 = (*ptr60).f1[u32(unconst_u32(263))];
+  var vf136: i32 = (*ptr62).f1[u32(unconst_u32(304))];
+  vf130 = bitcast<vec2f>((*ptr65).f1.ab);
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer54 = device0.createBuffer({
+  label: '\u6a19\u06da\u04be\u7247\uf928\u{1fe15}\ub122',
+  size: 11252,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder65 = device0.createCommandEncoder();
+let renderPassEncoder19 = commandEncoder65.beginRenderPass({
+  label: '\u07a6\u{1f67f}\u3a24\u0528\ud2cd\u{1fcc6}\uc4c6\u225a\ueb71\u9d22',
+  colorAttachments: [{
+  view: textureView16,
+  clearValue: { r: 11.37, g: -87.86, b: 80.10, a: 29.25, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup7, new Uint32Array(2802), 399, 0);
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer10, 'uint32', 292, 5_312);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(6, buffer10, 5_380);
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 107, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(175).fill(120), /* required buffer size: 175 */
+{offset: 175}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: imageData5,
+  origin: { x: 6, y: 19 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer55 = device0.createBuffer({size: 32162, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView63 = texture10.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 1});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup12, new Uint32Array(596), 291, 0);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(3, bindGroup22, new Uint32Array(1624), 36, 0);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer42, 'uint32', 4, 575);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(6, buffer3, 0, 137);
+} catch {}
+try {
+computePassEncoder3.insertDebugMarker('\ua07f');
+} catch {}
+try {
+renderBundleEncoder3.insertDebugMarker('\u01de');
+} catch {}
+let bindGroup34 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [{binding: 27, resource: {buffer: buffer8, offset: 0, size: 358}}],
+});
+let renderBundle3 = renderBundleEncoder3.finish({});
+let sampler29 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 39.27,
+  lodMaxClamp: 50.06,
+});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+computePassEncoder4.dispatchWorkgroupsIndirect(buffer26, 44);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer44, 'uint16', 2_966, 3_849);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(3, buffer12, 24, 3);
+} catch {}
+let commandEncoder66 = device0.createCommandEncoder({label: '\u04fd\u{1fd33}\u0851\ua978\u{1fdf3}'});
+let texture69 = device0.createTexture({
+  size: {width: 192},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder20 = commandEncoder66.beginRenderPass({
+  colorAttachments: [{
+  view: textureView52,
+  clearValue: { r: 747.4, g: -827.3, b: -795.7, a: -689.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler30 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 67.86,
+  maxAnisotropy: 8,
+});
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup17, new Uint32Array(1556), 291, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer50, 'uint16', 118, 315);
+} catch {}
+let canvas0 = document.createElement('canvas');
+let sampler31 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 66.80,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup34, new Uint32Array(1505), 271, 0);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle0]);
+} catch {}
+let sampler32 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 87.18,
+  compare: 'less',
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+computePassEncoder26.setBindGroup(0, bindGroup7, new Uint32Array(354), 227, 0);
+} catch {}
+try {
+computePassEncoder44.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(20);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(5, buffer50, 220, 436);
+} catch {}
+try {
+renderPassEncoder9.insertDebugMarker('\u3090');
+} catch {}
+let commandEncoder67 = device0.createCommandEncoder({});
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 274});
+let computePassEncoder47 = commandEncoder67.beginComputePass({});
+let sampler33 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 85.58,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder6.setViewport(63.175236927911186, 0.5447279634374392, 15.792586307660072, 0.3681254983202363, 0.9564349314816643, 0.9909721520638055);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer30, 'uint16', 2, 17);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer56 = device0.createBuffer({
+  label: '\u{1fb3a}\u4430\u00ae\u3a86',
+  size: 21544,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView64 = texture20.createView({dimension: '2d', format: 'rgba32sint', mipLevelCount: 1, baseArrayLayer: 1});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(2, bindGroup26, new Uint32Array(821), 57, 0);
+} catch {}
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup24, []);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup4, new Uint32Array(1509), 47, 0);
+} catch {}
+document.body.prepend(canvas0);
+let buffer57 = device0.createBuffer({
+  size: 3811,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView65 = texture26.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder48 = commandEncoder7.beginComputePass({});
+try {
+computePassEncoder11.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer54, 'uint32', 8_348, 213);
+} catch {}
+try {
+computePassEncoder11.popDebugGroup();
+} catch {}
+let bindGroup35 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 277, resource: sampler14}]});
+let buffer58 = device0.createBuffer({size: 2236, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder68 = device0.createCommandEncoder({});
+try {
+computePassEncoder46.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder10); computePassEncoder10.dispatchWorkgroupsIndirect(buffer50, 356); };
+} catch {}
+try {
+computePassEncoder48.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup22, new Uint32Array(707), 291, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer15, 'uint32', 924, 144);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer8, 524);
+} catch {}
+let imageData7 = new ImageData(36, 4);
+let bindGroup36 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 35, resource: textureView11},
+    {binding: 398, resource: textureView13},
+    {binding: 999, resource: textureView65},
+    {binding: 94, resource: textureView12},
+    {binding: 421, resource: {buffer: buffer58, offset: 0, size: 948}},
+    {binding: 243, resource: textureView39},
+    {binding: 567, resource: textureView14},
+    {binding: 42, resource: externalTexture0},
+    {binding: 132, resource: textureView48},
+  ],
+});
+let commandEncoder69 = device0.createCommandEncoder();
+let texture70 = device0.createTexture({
+  size: [73],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler34 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 0.8019,
+  lodMaxClamp: 45.14,
+  maxAnisotropy: 9,
+});
+let externalTexture2 = device0.importExternalTexture({
+  label: '\u{1f968}\u{1f80f}\u7d75\udd31\uc002\u0b52\ubab9\u0b61\u0ad8',
+  source: videoFrame1,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup27);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer8, 0, 31);
+} catch {}
+try {
+buffer25.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.append(canvas0);
+let bindGroup37 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 103, resource: textureView28}, {binding: 176, resource: textureView8}],
+});
+let texture71 = device0.createTexture({
+  size: [55, 5, 1],
+  mipLevelCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgb10a2uint'],
+});
+let textureView66 = texture1.createView({});
+let computePassEncoder49 = commandEncoder69.beginComputePass({label: '\uf922\u{1fbb1}\u07c7\uc926\u1f93\u{1f637}\u08f4'});
+try {
+computePassEncoder34.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+computePassEncoder45.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup10, new Uint32Array(751), 2, 0);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer21, 'uint16', 96, 3_967);
+} catch {}
+try {
+commandEncoder68.copyBufferToTexture({
+  /* bytesInLastRow: 52 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1016 */
+  offset: 1016,
+  buffer: buffer27,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 5},
+  aspect: 'all',
+}, {width: 13, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let textureView67 = texture39.createView({dimension: '2d-array', mipLevelCount: 1});
+let sampler35 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 18.34,
+  lodMaxClamp: 99.06,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup16, new Uint32Array(1136), 542, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle3, renderBundle0, renderBundle0]);
+} catch {}
+try {
+buffer50.unmap();
+} catch {}
+let computePassEncoder50 = commandEncoder16.beginComputePass({});
+try {
+computePassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup10, new Uint32Array(572), 128, 0);
+} catch {}
+try {
+commandEncoder68.resolveQuerySet(querySet0, 0, 10, buffer51, 512);
+} catch {}
+let buffer59 = device0.createBuffer({
+  size: 2193,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder70 = device0.createCommandEncoder({});
+let sampler36 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 7.759,
+  lodMaxClamp: 61.87,
+});
+try {
+computePassEncoder22.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder68.copyBufferToTexture({
+  /* bytesInLastRow: 328 widthInBlocks: 82 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 240 */
+  offset: 240,
+  rowsPerImage: 123,
+  buffer: buffer27,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 5},
+  aspect: 'all',
+}, {width: 82, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+globalThis.someLabel = textureView25.label;
+} catch {}
+let bindGroup38 = device0.createBindGroup({
+  label: '\u690a\uf79d',
+  layout: bindGroupLayout6,
+  entries: [{binding: 11, resource: {buffer: buffer40, offset: 28416}}],
+});
+let computePassEncoder51 = commandEncoder70.beginComputePass({label: '\u{1f858}\u{1fbba}\uf657\u4044\ufb22\u0441'});
+let renderPassEncoder21 = commandEncoder68.beginRenderPass({
+  colorAttachments: [{
+  view: textureView6,
+  clearValue: { r: 576.1, g: -828.3, b: 914.9, a: 850.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler37 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 10.35,
+  lodMaxClamp: 16.56,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup13, new Uint32Array(1195), 205, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup30, new Uint32Array(3521), 527, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle2, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer13, 'uint32', 940, 3_245);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(74).fill(144), /* required buffer size: 74 */
+{offset: 74}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup39 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 11, resource: {buffer: buffer50, offset: 0, size: 980}}],
+});
+let commandEncoder71 = device0.createCommandEncoder({});
+let computePassEncoder52 = commandEncoder71.beginComputePass({});
+try {
+computePassEncoder50.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 14},
+  aspect: 'all',
+}, new Uint8Array(27).fill(26), /* required buffer size: 27 */
+{offset: 27, rowsPerImage: 69}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder72 = device0.createCommandEncoder({});
+let renderPassEncoder22 = commandEncoder72.beginRenderPass({
+  colorAttachments: [{
+  view: textureView38,
+  clearValue: { r: 729.5, g: -331.5, b: -810.3, a: 269.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler38 = device0.createSampler({
+  label: '\u4658\uf8ff\u0800\u{1fbc3}\u05f1',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 54.35,
+  lodMaxClamp: 75.96,
+});
+try {
+computePassEncoder43.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+computePassEncoder47.setBindGroup(2, bindGroup8, new Uint32Array(4423), 610, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder18); computePassEncoder18.dispatchWorkgroupsIndirect(buffer3, 340); };
+} catch {}
+try {
+computePassEncoder26.end();
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer21, 'uint32', 2_408, 281);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 54}
+*/
+{
+  source: imageData7,
+  origin: { x: 4, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 70, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer60 = device0.createBuffer({size: 1432, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE});
+let commandEncoder73 = device0.createCommandEncoder({});
+let texture72 = device0.createTexture({
+  size: {width: 70, height: 72, depthOrArrayLayers: 276},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder53 = commandEncoder73.beginComputePass({});
+let sampler39 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 23.04,
+  lodMaxClamp: 48.50,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder18); computePassEncoder18.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer10);
+} catch {}
+try {
+commandEncoder36.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3808 */
+  offset: 3808,
+  rowsPerImage: 1830,
+  buffer: buffer11,
+}, {
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 43, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 38, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(57).fill(129), /* required buffer size: 57 */
+{offset: 57, rowsPerImage: 3}, {width: 113, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder54 = commandEncoder36.beginComputePass();
+try {
+computePassEncoder43.setBindGroup(2, bindGroup4, new Uint32Array(1109), 185, 0);
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(28, 13, 10, 2);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer27, 'uint32', 740, 322);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 54}
+*/
+{
+  source: imageData6,
+  origin: { x: 0, y: 10 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let imageData8 = new ImageData(8, 24);
+let commandEncoder74 = device0.createCommandEncoder({});
+let texture73 = device0.createTexture({
+  size: [55, 5, 41],
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView68 = texture62.createView({});
+let renderPassEncoder23 = commandEncoder74.beginRenderPass({
+  colorAttachments: [{
+  view: textureView36,
+  clearValue: { r: -316.9, g: 865.7, b: 599.1, a: -647.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet3,
+  maxDrawCount: 336395403,
+});
+let sampler40 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 4.366,
+  lodMaxClamp: 93.54,
+});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup9, new Uint32Array(53), 2, 0);
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup28, new Uint32Array(2083), 64, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer10, 'uint32', 2_700, 7_853);
+} catch {}
+document.body.append(canvas0);
+let commandEncoder75 = device0.createCommandEncoder({});
+let texture74 = device0.createTexture({
+  size: {width: 73, height: 1, depthOrArrayLayers: 35},
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder24 = commandEncoder75.beginRenderPass({colorAttachments: [{view: textureView52, loadOp: 'load', storeOp: 'store'}]});
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setViewport(17.586159251107347, 51.20227765667542, 1.3113871328753293, 15.370376167385334, 0.9417810292882771, 0.9606309683538449);
+} catch {}
+await gc();
+let commandEncoder76 = device0.createCommandEncoder({});
+let renderPassEncoder25 = commandEncoder76.beginRenderPass({
+  colorAttachments: [{
+  view: textureView5,
+  clearValue: { r: -339.8, g: -349.1, b: 34.54, a: 280.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder12.beginOcclusionQuery(32);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: 432.6, g: 275.0, b: -214.2, a: 480.0, });
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer18, 0, 179);
+} catch {}
+let commandEncoder77 = device0.createCommandEncoder({label: '\u54f8\u8cfa\uadc4\u{1fb1c}\u5b14\u36d5\u0a66'});
+try {
+{ clearResourceUsages(device0, computePassEncoder18); computePassEncoder18.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder77.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext1 = canvas0.getContext('webgpu');
+let bindGroup40 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 225, resource: textureView57},
+    {binding: 58, resource: {buffer: buffer37, offset: 0, size: 3333}},
+  ],
+});
+let commandEncoder78 = device0.createCommandEncoder({});
+let textureView69 = texture37.createView({});
+let renderPassEncoder26 = commandEncoder78.beginRenderPass({colorAttachments: [{view: textureView52, loadOp: 'clear', storeOp: 'store'}]});
+try {
+computePassEncoder12.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup29, []);
+} catch {}
+try {
+commandEncoder77.copyBufferToTexture({
+  /* bytesInLastRow: 64 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 5680 */
+  offset: 5680,
+  bytesPerRow: 1792,
+  rowsPerImage: 0,
+  buffer: buffer23,
+}, {
+  texture: texture20,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 33});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer46, 1252, new DataView(new ArrayBuffer(33200)), 2643, 1396);
+} catch {}
+let bindGroup41 = device0.createBindGroup({
+  label: '\u5ae4\u0134\u68da\u0808\u9a3c\u{1f740}\u{1fab1}\u{1fbc5}\u{1fa16}\u96c2\u7e9f',
+  layout: bindGroupLayout8,
+  entries: [{binding: 27, resource: {buffer: buffer27, offset: 256, size: 212}}],
+});
+let commandEncoder79 = device0.createCommandEncoder({label: '\ufc0b\u0fc5\u{1f815}\uc4ea\u2f7d\u0149\u9ca6'});
+let computePassEncoder55 = commandEncoder79.beginComputePass({});
+let renderPassEncoder27 = commandEncoder77.beginRenderPass({
+  colorAttachments: [{
+  view: textureView52,
+  clearValue: { r: 654.8, g: 56.36, b: 795.3, a: 304.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 91560532,
+});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(5, buffer12);
+} catch {}
+try {
+renderPassEncoder9.insertDebugMarker('\u8dc5');
+} catch {}
+await gc();
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'smpte170m', transfer: 'unspecified'} });
+try {
+computePassEncoder53.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle0, renderBundle3, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer10, 'uint16', 2_852, 9);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 257, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(310).fill(135), /* required buffer size: 310 */
+{offset: 310}, {width: 50, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder3.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(1, buffer3, 0);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let commandEncoder80 = device0.createCommandEncoder({label: '\u00ff\u{1ffe0}\u00ec\u971d\u0044\u92c6\u{1f6f5}'});
+let textureView70 = texture15.createView({baseMipLevel: 0});
+let computePassEncoder56 = commandEncoder80.beginComputePass({});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+computePassEncoder18.end();
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup10, new Uint32Array(2076), 381, 0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer15, 'uint16', 412, 1_045);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(0, buffer6, 376);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer23, 2880, new Float32Array(12418), 132, 12);
+} catch {}
+let imageData9 = new ImageData(12, 48);
+let videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'smpte432', transfer: 'log'} });
+try {
+adapter0.label = '\ue5e1\u5e4d\u5237\u0d3e';
+} catch {}
+let bindGroup42 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 42, resource: externalTexture2},
+    {binding: 132, resource: textureView22},
+    {binding: 94, resource: textureView54},
+    {binding: 398, resource: textureView39},
+    {binding: 35, resource: textureView11},
+    {binding: 999, resource: textureView36},
+    {binding: 421, resource: {buffer: buffer19, offset: 0, size: 468}},
+    {binding: 567, resource: textureView30},
+    {binding: 243, resource: textureView39},
+  ],
+});
+let computePassEncoder57 = commandEncoder25.beginComputePass({});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup22, new Uint32Array(463), 31, 0);
+} catch {}
+try {
+computePassEncoder44.end();
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(16, 37, 9, 9);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer4, 'uint16', 16_400, 459);
+} catch {}
+try {
+commandEncoder62.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1708 */
+  offset: 1708,
+  bytesPerRow: 20224,
+  rowsPerImage: 9,
+  buffer: buffer41,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup43 = device0.createBindGroup({
+  label: '\u7406\u04c2\u0579\u{1fe06}\u{1fac7}\u{1f7e5}',
+  layout: bindGroupLayout1,
+  entries: [{binding: 277, resource: sampler26}],
+});
+let buffer61 = device0.createBuffer({size: 3084, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let sampler41 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 76.83,
+  lodMaxClamp: 82.30,
+});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup36, new Uint32Array(2899), 133, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder12); computePassEncoder12.dispatchWorkgroupsIndirect(buffer3, 264); };
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer28, 'uint32', 1_548, 321);
+} catch {}
+let pipeline1 = await device0.createRenderPipelineAsync({
+  label: '\u9e5a\uc93e\uabd9\udb58\u951e\ueed9\u{1f85f}\u0e4e',
+  layout: pipelineLayout0,
+  multisample: {},
+  fragment: {
+  module: shaderModule5,
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule2,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 84,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint8x4', offset: 4, shaderLocation: 1},
+          {format: 'uint32x2', offset: 4, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 0, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+});
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpte240m', transfer: 'bt2020_12bit'} });
+let buffer62 = device0.createBuffer({
+  size: 26892,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder81 = device0.createCommandEncoder({});
+let commandBuffer4 = commandEncoder62.finish();
+let renderPassEncoder28 = commandEncoder81.beginRenderPass({colorAttachments: [{view: textureView52, loadOp: 'load', storeOp: 'store'}]});
+let sampler42 = device0.createSampler({
+  label: '\u5065\u1ce3\u0ea7\u5490',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 76.28,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup27, new Uint32Array(114), 7, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroups(5); };
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup28, new Uint32Array(386), 23, 0);
+} catch {}
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'smpteRp431', transfer: 'gamma28curve'} });
+let textureView71 = texture37.createView({aspect: 'all'});
+let sampler43 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+});
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup16, new Uint32Array(159), 13, 0);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer56, 0);
+} catch {}
+try {
+renderPassEncoder19.pushDebugGroup('\u8ec4');
+} catch {}
+try {
+renderPassEncoder19.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 2964, new Int16Array(28051), 1969, 1660);
+} catch {}
+let textureView72 = texture19.createView({label: '\u86f6\u0aed\u4515\u7c22\u0592\u{1fba9}\uc3ab\ue32a\u1429\u{1fd2c}\u{1f9ff}', aspect: 'all'});
+let texture75 = device0.createTexture({
+  size: {width: 140, height: 145, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler44 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 40.05,
+  lodMaxClamp: 63.96,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer4, 'uint32', 6_324, 13_520);
+} catch {}
+let bindGroup44 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 86, resource: textureView17},
+    {binding: 211, resource: sampler31},
+    {binding: 62, resource: textureView13},
+  ],
+});
+let commandEncoder82 = device0.createCommandEncoder({});
+let texture76 = device0.createTexture({
+  label: '\u08f6\u013b\uc5a1\u05b8\u6e07',
+  size: {width: 64, height: 64, depthOrArrayLayers: 22},
+  mipLevelCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder58 = commandEncoder82.beginComputePass({});
+try {
+computePassEncoder43.setBindGroup(2, bindGroup30, new Uint32Array(3317), 1_396, 0);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(13, 0, 20, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer42, 'uint16', 248, 224);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(2, buffer3);
+} catch {}
+try {
+  await buffer41.mapAsync(GPUMapMode.WRITE, 24, 144);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder20.insertDebugMarker('\u3187');
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+document.body.prepend(img0);
+let texture77 = device0.createTexture({
+  size: {width: 73},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder55.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle3, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(7, buffer62, 8_320, 120);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+await gc();
+try {
+computePassEncoder24.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(7, buffer59, 0, 507);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+document.body.append(img0);
+let buffer63 = device0.createBuffer({
+  size: 20249,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder25.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup43, new Uint32Array(422), 12, 0);
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant({ r: -828.0, g: -340.6, b: 164.8, a: 54.44, });
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(0, 0, 14, 0);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer57, 'uint32', 1_716, 52);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline1);
+} catch {}
+document.body.append(canvas0);
+let sampler45 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 79.85,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroupsIndirect(buffer45, 4_460); };
+} catch {}
+try {
+computePassEncoder46.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer10, 'uint32', 5_564, 1_195);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: imageData0,
+  origin: { x: 1, y: 15 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  label: '\ua606\u8933\u6970\u{1f96d}\u0e8a\ub4b6\u00ce\u53ea\u09ab\u314f',
+  entries: [
+    {
+      binding: 96,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 127,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 113,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let commandEncoder83 = device0.createCommandEncoder();
+let textureView73 = texture40.createView({dimension: '2d-array'});
+let computePassEncoder59 = commandEncoder83.beginComputePass({});
+let sampler46 = device0.createSampler({
+  label: '\u0a44\u0b68\u0978\u{1f85b}\u{1fc00}\u4577\ufd66\u0101\u0510\u8841\ue268',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 8.264,
+  lodMaxClamp: 45.59,
+});
+try {
+renderPassEncoder10.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(7, buffer43, 836, 105);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 148, new DataView(new ArrayBuffer(19732)), 183, 300);
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(103) var st13: texture_storage_3d<rgba8unorm, write>;
+
+@group(0) @binding(176) var st14: texture_storage_3d<rgba16uint, write>;
+
+struct T0 {
+  @size(16) f0: array<atomic<u32>, 1>,
+  @size(4) f1: f16,
+}
+
+struct VertexOutput6 {
+  @builtin(position) f27: vec4f,
+  @location(5) @interpolate(flat, center) f28: u32,
+  @location(11) @interpolate(flat, centroid) f29: vec4u,
+  @location(14) @interpolate(flat) f30: vec4i,
+  @location(4) @interpolate(flat, center) f31: vec4u,
+}
+
+struct FragmentOutput6 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4i,
+}
+
+fn fn0(a0: array<mat3x3f, 1>) -> VertexOutput6 {
+  var out: VertexOutput6;
+  let vf137: f32 = inverseSqrt(f32(unconst_f32(0.02485)));
+  var vf138: i32 = insertBits(i32(unconst_i32(68)), i32(unconst_i32(259)), insertBits(vec3u(unconst_u32(151), unconst_u32(3), unconst_u32(371)), vec3u(cosh(vec3f(unconst_f32(0.1696), unconst_f32(0.2278), unconst_f32(0.08995)))), u32(unconst_u32(169)), u32(unconst_u32(263))).b, u32(unconst_u32(47)));
+  out.f30 -= vp6.f1;
+  var vf139: mat2x4f = transpose(mat4x2f(unconst_f32(0.1381), unconst_f32(0.3233), unconst_f32(0.00822), unconst_f32(0.07840), unconst_f32(0.1308), unconst_f32(0.3194), unconst_f32(0.3896), unconst_f32(0.3217)));
+  var vf140: f32 = a0[u32(unconst_u32(137))][u32(unconst_u32(174))][u32(unconst_u32(716))];
+  let vf141: vec2h = radians(vec2h(unconst_f16(9485.9), unconst_f16(5009.0)));
+  out.f29 &= vec4u(bitcast<u32>(inverseSqrt(f32(unconst_f32(0.05802)))));
+  out.f27 = vec4f(f32(all(vec3<bool>(unconst_bool(false), unconst_bool(true), unconst_bool(true)))));
+  var vf142: f32 = min(f32(unpack4xU8(u32(unconst_u32(208))).b), f32(unconst_f32(0.01462)));
+  var vf143: vec3f = cosh(vec3f(unconst_f32(0.2942), unconst_f32(0.1615), unconst_f32(0.02495)));
+  let ptr66: ptr<private, u32> = &vp6.f0;
+  let vf144: u32 = pack4xU8(vec4u(unconst_u32(70), unconst_u32(222), unconst_u32(12), unconst_u32(381)));
+  let vf145: u32 = vf144;
+  out.f31 <<= vec4u(fract(vec2h(unconst_f16(6757.5), unconst_f16(1596.7))).yxxx);
+  out.f30 = vec4i(vp6.f1[countTrailingZeros(vec2u(unconst_u32(198), unconst_u32(162)))[0]]);
+  out.f27 += a0[0][unconst_i32(0)].xyyz;
+  var vf146: bool = all(vec3<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(false)));
+  out.f31 |= vec4u(bitcast<u32>(vf143[u32(unconst_u32(717))]));
+  let vf147: mat3x3f = a0[(*ptr66)];
+  let vf148: vec2h = vf141;
+  return out;
+}
+
+var<workgroup> vw35: atomic<i32>;
+
+var<private> vp6: FragmentOutput6 = FragmentOutput6(u32(10), vec4i(331, 9, 237, 46));
+
+@vertex @must_use
+fn vertex6(@location(13) a0: vec4f, @location(8) a1: vec4u, @location(9) a2: vec2u) -> VertexOutput6 {
+  var out: VertexOutput6;
+  vp6 = FragmentOutput6(pack2x16unorm(acos(vec2f(unconst_f32(0.07900), unconst_f32(0.4495)))), bitcast<vec4i>(acos(vec2f(unconst_f32(0.07900), unconst_f32(0.4495))).xxyy));
+  return out;
+}
+
+@fragment
+fn fragment7(@location(15) @interpolate(flat, center) a0: vec4i) -> FragmentOutput6 {
+  var out: FragmentOutput6;
+  var vf149: i32 = vp6.f1[u32(unconst_u32(58))];
+  var vf150: f16 = ldexp(f16(unconst_f16(305.1)), i32(unconst_i32(51)));
+  var vf151: vec4i = a0;
+  var vf152: vec2f = radians(vec2f(unconst_f32(0.03723), unconst_f32(0.2875)));
+  vf152 = vec2f(f32(vf150));
+  var vf153: f32 = vf152[u32(unconst_u32(127))];
+  out.f1 = vec4i(vf152.ggrg);
+  out = FragmentOutput6(u32(vp6.f1.y), vp6.f1);
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute6() {
+  var vf154 = fn0(array<mat3x3f, 1>(mat3x3f(unconst_f32(0.2777), unconst_f32(0.2941), unconst_f32(0.1098), unconst_f32(0.1346), unconst_f32(0.4172), unconst_f32(0.1203), unconst_f32(0.2888), unconst_f32(0.03180), unconst_f32(0.2428))));
+  fn0(array<mat3x3f, 1>(mat3x3f(f32(countOneBits(u32(unconst_u32(300)))), f32(countOneBits(u32(unconst_u32(300)))), bitcast<f32>(countOneBits(u32(unconst_u32(300)))), f32(countOneBits(u32(unconst_u32(300)))), f32(countOneBits(u32(unconst_u32(300)))), bitcast<f32>(countOneBits(u32(unconst_u32(300)))), bitcast<f32>(countOneBits(u32(unconst_u32(300)))), bitcast<f32>(countOneBits(u32(unconst_u32(300)))), f32(countOneBits(u32(unconst_u32(300)))))));
+  textureStore(st13, vec3i(unconst_i32(246), unconst_i32(354), unconst_i32(240)), vec4f(vec4f(unconst_f32(0.02391), unconst_f32(0.3128), unconst_f32(0.2820), unconst_f32(0.2335))));
+  var vf155: vec4f = step(vec4f(unconst_f32(0.02543), unconst_f32(0.1070), unconst_f32(0.06531), unconst_f32(0.1308)), vec4f(unconst_f32(0.4046), unconst_f32(0.1547), unconst_f32(-0.02784), unconst_f32(0.01303)));
+  vf155 += vec4f(f32(vp6.f0));
+  workgroupBarrier();
+  atomicAnd(&vw35, i32(unconst_i32(-385)));
+  let ptr67: ptr<private, vec4i> = &vp6.f1;
+  vf155 += vec4f(f32(vf154.f28));
+  let ptr68: ptr<function, vec4i> = &vf154.f30;
+  atomicCompareExchangeWeak(&vw35, unconst_i32(8), unconst_i32(532));
+  let ptr69: ptr<function, VertexOutput6> = &vf154;
+  let ptr70: ptr<private, u32> = &vp6.f0;
+  let ptr71: ptr<private, FragmentOutput6> = &vp6;
+  fn0(array<mat3x3f, 1>(mat3x3f(vec3f(reflect(vec4h(f16(pack2x16unorm(vec2f(unconst_f32(0.1608), unconst_f32(0.4268))))), vec4h(unconst_f16(1558.2), unconst_f16(23028.6), unconst_f16(280.9), unconst_f16(15346.4))).xyz), vec3f(reflect(vec4h(f16(pack2x16unorm(vec2f(unconst_f32(0.1608), unconst_f32(0.4268))))), vec4h(unconst_f16(1558.2), unconst_f16(23028.6), unconst_f16(280.9), unconst_f16(15346.4))).xxy), vec3f(reflect(vec4h(f16(pack2x16unorm(vec2f(unconst_f32(0.1608), unconst_f32(0.4268))))), vec4h(unconst_f16(1558.2), unconst_f16(23028.6), unconst_f16(280.9), unconst_f16(15346.4))).xzy))));
+  vf154.f28 <<= u32(sign(f16(unconst_f16(9963.3))));
+  fn0(array<mat3x3f, 1>(mat3x3f(bitcast<f32>(vp6.f1[u32(unconst_u32(30))]), f32(vp6.f1[u32(unconst_u32(30))]), bitcast<f32>(vp6.f1[u32(unconst_u32(30))]), f32(vp6.f1[u32(unconst_u32(30))]), f32(vp6.f1[u32(unconst_u32(30))]), f32(vp6.f1[u32(unconst_u32(30))]), f32(vp6.f1[u32(unconst_u32(30))]), bitcast<f32>(vp6.f1[u32(unconst_u32(30))]), f32(vp6.f1[u32(unconst_u32(30))]))));
+  vf154.f30 = vec4i((*ptr69).f31);
+  let vf156: vec4i = unpack4xI8(u32(unconst_u32(434)));
+  var vf157: i32 = (*ptr68)[u32(unconst_u32(1))];
+  textureStore(st13, vec3i(unconst_i32(579), unconst_i32(85), unconst_i32(86)), vec4f(vec4f(vf154.f29)));
+}`,
+  sourceMap: {},
+});
+let commandEncoder84 = device0.createCommandEncoder({});
+let texture78 = device0.createTexture({
+  size: {width: 280, height: 291, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderPassEncoder29 = commandEncoder84.beginRenderPass({
+  colorAttachments: [{
+  view: textureView6,
+  clearValue: { r: 718.4, g: 674.1, b: -683.7, a: -177.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet4,
+});
+let buffer64 = device0.createBuffer({
+  size: 7976,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder85 = device0.createCommandEncoder({});
+let computePassEncoder60 = commandEncoder85.beginComputePass();
+try {
+renderPassEncoder29.beginOcclusionQuery(5);
+} catch {}
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let sampler47 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 34.53,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder59.setBindGroup(3, bindGroup7, new Uint32Array(1592), 501, 0);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(7, buffer15, 1_116, 678);
+} catch {}
+let videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'bt709', transfer: 'linear'} });
+let bindGroup45 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [{binding: 511, resource: {buffer: buffer11, offset: 5120, size: 4700}}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder8); computePassEncoder8.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: 122.8, g: -846.5, b: -431.1, a: 138.8, });
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer10, 'uint32', 280, 855);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 10},
+  aspect: 'all',
+}, new Uint8Array(20_082).fill(115), /* required buffer size: 20_082 */
+{offset: 362, bytesPerRow: 145, rowsPerImage: 68}, {width: 20, height: 0, depthOrArrayLayers: 3});
+} catch {}
+await gc();
+let bindGroup46 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 27, resource: {buffer: buffer15, offset: 256}}]});
+let commandEncoder86 = device0.createCommandEncoder({});
+let computePassEncoder61 = commandEncoder86.beginComputePass({label: '\u07e2\u0775\u1fa3\uc76a\u{1fefe}\u{1ff54}\u031e\u0433'});
+let sampler48 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 22.77,
+  lodMaxClamp: 75.98,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder58.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline1);
+} catch {}
+document.body.append(img0);
+let textureView74 = texture72.createView({});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame6, colorSpace: 'srgb'});
+try {
+computePassEncoder53.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+computePassEncoder36.setBindGroup(1, bindGroup29, new Uint32Array(57), 15, 0);
+} catch {}
+try {
+computePassEncoder24.pushDebugGroup('\u0587');
+} catch {}
+try {
+computePassEncoder24.popDebugGroup();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let textureView75 = texture37.createView({});
+try {
+computePassEncoder53.setBindGroup(0, bindGroup8, new Uint32Array(3539), 60, 0);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let commandEncoder87 = device0.createCommandEncoder();
+let texture79 = device0.createTexture({
+  size: [280, 291, 1],
+  mipLevelCount: 3,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder62 = commandEncoder87.beginComputePass();
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], stencilReadOnly: false});
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup36, new Uint32Array(3725), 11, 0);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer44, 'uint32', 3_584, 2_218);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline1);
+} catch {}
+document.body.prepend(canvas0);
+let buffer65 = device0.createBuffer({
+  label: '\u08ff\ueecf\u8359\u0da2\u25df\u8b58',
+  size: 1220,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let querySet8 = device0.createQuerySet({
+  label: '\u8a24\u8df3\u{1f8c3}\u{1f76d}\u8886\u{1f887}\u5788\u0d3c\uf34f\u{1fe8c}\uf75c',
+  type: 'occlusion',
+  count: 361,
+});
+let renderBundle4 = renderBundleEncoder4.finish({label: '\ufcd5\ue461\ucacf\ue8ef\u8de6\u7ca3\u031e\u08b6\u0f13\u0ae1\uc4a8'});
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup26, new Uint32Array(3010), 1_316, 0);
+} catch {}
+try {
+buffer50.unmap();
+} catch {}
+try {
+  await buffer35.mapAsync(GPUMapMode.READ, 0, 4756);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer42, 52, new BigUint64Array(12897), 1799, 20);
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let buffer66 = device0.createBuffer({size: 22324, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder88 = device0.createCommandEncoder({label: '\u{1fef0}\u0f14\u0cea\u6a26\u03f1\u37a4\uef88'});
+let renderPassEncoder30 = commandEncoder88.beginRenderPass({
+  colorAttachments: [{
+  view: textureView73,
+  clearValue: { r: -372.3, g: 795.7, b: -268.6, a: -809.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet6,
+});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer27, 'uint16', 498, 115);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder14.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3084 */
+  offset: 3084,
+  rowsPerImage: 482,
+  buffer: buffer48,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder89 = device0.createCommandEncoder({});
+let textureView76 = texture65.createView({label: '\u0c72\u10b0', baseArrayLayer: 5, arrayLayerCount: 4});
+let computePassEncoder63 = commandEncoder89.beginComputePass({});
+let externalTexture4 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder32.setBindGroup(1, bindGroup22, new Uint32Array(318), 86, 0);
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(5, buffer12, 0, 42);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer50, 328, new DataView(new ArrayBuffer(6355)), 45, 196);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: imageData2,
+  origin: { x: 20, y: 0 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 37},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup47 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 398, resource: textureView13},
+    {binding: 421, resource: {buffer: buffer63, offset: 7168, size: 2492}},
+    {binding: 94, resource: textureView61},
+    {binding: 132, resource: textureView35},
+    {binding: 999, resource: textureView36},
+    {binding: 35, resource: textureView11},
+    {binding: 243, resource: textureView13},
+    {binding: 42, resource: externalTexture2},
+    {binding: 567, resource: textureView72},
+  ],
+});
+let textureView77 = texture10.createView({dimension: '2d-array', aspect: 'depth-only', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder64 = commandEncoder14.beginComputePass({label: '\u{1ff98}\u0877\u98f4\ub06f'});
+try {
+computePassEncoder46.setBindGroup(3, bindGroup42);
+} catch {}
+try {
+computePassEncoder22.end();
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup47, new Uint32Array(827), 132, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 420, new DataView(new ArrayBuffer(6399)), 915, 24);
+} catch {}
+let videoFrame9 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpte240m', transfer: 'linear'} });
+try {
+externalTexture2.label = '\u0ef3\ua17d\u01ee\u0cf6\u0c63\u09bc\u1f8d';
+} catch {}
+let texture80 = device0.createTexture({
+  size: [64, 64, 22],
+  mipLevelCount: 6,
+  format: 'astc-8x8-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder65 = commandEncoder31.beginComputePass({});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder57.setBindGroup(0, bindGroup11, new Uint32Array(543), 14, 0);
+} catch {}
+try {
+computePassEncoder52.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(6, buffer6, 0, 938);
+} catch {}
+let commandEncoder90 = device0.createCommandEncoder();
+let computePassEncoder66 = commandEncoder90.beginComputePass({});
+try {
+renderPassEncoder21.setScissorRect(16, 0, 21, 0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(4, buffer6, 0, 59);
+} catch {}
+let buffer67 = device0.createBuffer({
+  label: '\ua1ec\u0c4e\ud0d2\u0c45\u0919\u{1ff88}\u{1fb2f}\ucac1\u57e4',
+  size: 3305,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup29);
+} catch {}
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup42);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup12, new Uint32Array(763), 67, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer54, 'uint16', 7_170, 653);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 54, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(66).fill(75), /* required buffer size: 66 */
+{offset: 66, bytesPerRow: 85}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'bt470bg', transfer: 'iec6196624'} });
+try {
+adapter0.label = '\u0988\u01ea\u2430';
+} catch {}
+let buffer68 = device0.createBuffer({
+  size: 542,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let texture81 = device0.createTexture({
+  label: '\u3e17\u1574\ud5a3\u{1fc8f}',
+  size: {width: 295, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  dimension: '2d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView78 = texture23.createView({mipLevelCount: 1});
+let renderPassEncoder31 = commandEncoder13.beginRenderPass({colorAttachments: [{view: textureView73, loadOp: 'load', storeOp: 'store'}]});
+try {
+computePassEncoder41.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer64, 'uint16', 7_534, 17);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer24, 148, 331);
+} catch {}
+try {
+  await promise7;
+} catch {}
+document.body.append(canvas0);
+let commandEncoder91 = device0.createCommandEncoder({label: '\u0afc\u{1fcfe}\u95a4\u0a35\u0ebd\u{1ff2a}\u{1f9dc}\ue456\u{1fb93}\u5616'});
+let computePassEncoder67 = commandEncoder91.beginComputePass({label: '\u00a6\u6ccb\ue906\u{1fbb7}\u0e91\uf006\u9ec8\u{1ff64}\uca46\u{1fe68}'});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup36);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder92 = device0.createCommandEncoder();
+try {
+computePassEncoder39.setBindGroup(3, bindGroup19, new Uint32Array(241), 25, 0);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: 337.9, g: 869.7, b: 246.2, a: -371.4, });
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(0, buffer67, 448, 176);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+buffer41.unmap();
+} catch {}
+try {
+commandEncoder92.copyBufferToBuffer(buffer41, 1916, buffer59, 72, 172);
+} catch {}
+try {
+commandEncoder92.copyTextureToBuffer({
+  texture: texture47,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 288 widthInBlocks: 72 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1604 */
+  offset: 1604,
+  bytesPerRow: 19968,
+  buffer: buffer51,
+}, {width: 72, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = externalTexture2.label;
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+  code: `
+enable f16;
+
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(176) var st15: texture_storage_3d<rgba16uint, write>;
+
+struct T0 {
+  @align(16) @size(320) f0: array<mat2x4h>,
+}
+
+struct VertexOutput7 {
+  @location(3) f32: vec4h,
+  @builtin(position) f33: vec4f,
+}
+
+var<workgroup> vw36: array<vec2i, 1>;
+
+var<private> vp7 = frexp(vec3h(7260.3, -33957.7, 935.2));
+
+var<private> vp8: VertexOutput7 = VertexOutput7();
+
+@vertex
+fn vertex7(@location(8) a0: vec2u, @location(15) a1: u32) -> @builtin(position) vec4f {
+  var out: vec4f;
+  let vf158: vec2h = sin(vec2h(unconst_f16(29781.0), unconst_f16(3815.5)));
+  var vf159: f32 = vp8.f33[u32(unconst_u32(78))];
+  vp7 = frexp(sin(vec2h(unconst_f16(563.7), unconst_f16(7201.4))).xyx);
+  let vf160: f16 = vf158[u32(unconst_u32(121))];
+  vp7 = frexp(vp8.f32.wyz);
+  var vf161: u32 = a0[u32(unconst_u32(152))];
+  vp8.f33 *= vec4f(f32(vf158[u32(unconst_u32(96))]));
+  var vf162: vec2h = vf158;
+  vp8 = VertexOutput7(vp7.fract.yxxx, vec4f(vp7.fract.yzyx));
+  let vf163: vec2f = radians(vec2f(unconst_f32(0.07121), unconst_f32(0.03270)));
+  var vf164: u32 = a1;
+  var vf165: vec2h = abs(vp8.f32.ba);
+  var vf166: f16 = vf165[bitcast<u32>(sin(vec2h(unconst_f16(4539.9), unconst_f16(2179.8))))];
+  return out;
+}
+
+@vertex @must_use
+fn vertex8(@location(15) a0: i32, @location(12) @interpolate(flat) a1: vec2f, @location(4) a2: vec4f) -> VertexOutput7 {
+  var out: VertexOutput7;
+  var vf167: vec4i = unpack4xI8(u32(unconst_u32(224)));
+  out.f32 = vec4h(vp8.f33);
+  out.f32 = cross(vec3h(unconst_f16(4331.4), unconst_f16(2315.1), unconst_f16(620.6)), vec3h(unconst_f16(8764.1), unconst_f16(-14591.0), unconst_f16(6691.1))).zxxx;
+  let vf168: f16 = length(vec4h(unconst_f16(2893.6), unconst_f16(9937.7), unconst_f16(11087.1), unconst_f16(6506.4)));
+  vf167 = vec4i(i32(a1[bitcast<u32>(reflect(vec3f(unconst_f32(0.06941), unconst_f32(0.1859), unconst_f32(0.1929)), vec3f(unconst_f32(0.2299), unconst_f32(0.06723), unconst_f32(0.09090)))[2])]));
+  var vf169: vec4f = a2;
+  var vf170: vec4f = fma(vec4f(unconst_f32(0.04527), unconst_f32(0.01571), unconst_f32(0.05583), unconst_f32(0.1202)), vec4f(unconst_f32(-0.09779), unconst_f32(0.09675), unconst_f32(0.1079), unconst_f32(0.1898)), vec4f(unconst_f32(0.4194), unconst_f32(0.1206), unconst_f32(0.3295), unconst_f32(0.1862)));
+  var vf171: f32 = vp8.f33[u32(vp8.f32[u32(unconst_u32(87))])];
+  let vf172: vec3f = sign(vec3f(unconst_f32(0.3830), unconst_f32(0.04410), unconst_f32(0.03823)));
+  let vf173: vec2u = firstLeadingBit(vec2u(unconst_u32(345), unconst_u32(26)));
+  let ptr72: ptr<private, vec4f> = &vp8.f33;
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute7() {
+  vw36[u32(unconst_u32(12))] = vec2i(sin(vec2h(unconst_f16(8578.9), unconst_f16(11784.4))));
+  var vf174: vec2f = acos(vec2f(unconst_f32(0.6671), unconst_f32(0.1985)));
+  vw36[0] = vp7.exp.rg;
+  vp8.f32 = atan(vec3h(unconst_f16(2559.4), unconst_f16(3846.3), unconst_f16(7774.9))).rggr;
+}`,
+  sourceMap: {},
+});
+let commandEncoder93 = device0.createCommandEncoder({});
+let textureView79 = texture26.createView({dimension: '2d-array', arrayLayerCount: 1});
+try {
+computePassEncoder20.setBindGroup(1, bindGroup41, new Uint32Array(4368), 803, 0);
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder13.setViewport(91.68703716164704, 0.8203603926484702, 2.12503740968694, 0.09664570661214122, 0.3075201304721641, 0.5558685057961178);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer28, 'uint32', 1_600, 536);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(0, buffer2, 0);
+} catch {}
+try {
+buffer44.unmap();
+} catch {}
+let renderPassEncoder32 = commandEncoder92.beginRenderPass({
+  label: '\u{1ffdb}\u0506',
+  colorAttachments: [{
+  view: textureView5,
+  clearValue: { r: 806.6, g: 281.2, b: -307.4, a: -600.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 273241393,
+});
+try {
+computePassEncoder40.setBindGroup(2, bindGroup18, new Uint32Array(993), 73, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder53); computePassEncoder53.dispatchWorkgroups(2, 2); };
+} catch {}
+let bindGroup48 = device0.createBindGroup({
+  label: '\udbce\u{1ffae}\u{1f965}\u0451\u090d\u6262\u7339\u2cbd',
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 58, resource: {buffer: buffer10, offset: 2560, size: 6500}},
+    {binding: 225, resource: textureView13},
+  ],
+});
+let commandEncoder94 = device0.createCommandEncoder({});
+let sampler49 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 54.03,
+  lodMaxClamp: 70.90,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline1);
+} catch {}
+try {
+buffer56.unmap();
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(buffer34, 1712, buffer55, 300, 2888);
+} catch {}
+try {
+commandEncoder18.copyBufferToTexture({
+  /* bytesInLastRow: 472 widthInBlocks: 118 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 224 */
+  offset: 224,
+  bytesPerRow: 8704,
+  buffer: buffer49,
+}, {
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 99, y: 101, z: 0},
+  aspect: 'all',
+}, {width: 118, height: 97, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder94.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 163, y: 36, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 40 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1624 */
+  offset: 1624,
+  bytesPerRow: 13568,
+  rowsPerImage: 736,
+  buffer: buffer23,
+}, {width: 5, height: 298, depthOrArrayLayers: 0});
+} catch {}
+try {
+textureView42.label = '\u08cd\u7b5f\u0c14\u2399\u{1f902}\u255c\u06b3\u0cfe';
+} catch {}
+let textureView80 = texture0.createView({label: '\ua280\u3f04', dimension: '2d-array', mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder68 = commandEncoder94.beginComputePass({});
+let sampler50 = device0.createSampler({
+  label: '\u160c\u{1f81f}\u002e\u03df\u1768\uf1ef\u6da7\u9ec2\u4e6b\u{1f925}\u0499',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 90.03,
+  lodMaxClamp: 97.32,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder53); computePassEncoder53.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroupsIndirect(buffer24, 136); };
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer54, 'uint16', 3_294, 769);
+} catch {}
+document.body.append(canvas0);
+let bindGroup49 = device0.createBindGroup({layout: bindGroupLayout8, entries: [{binding: 27, resource: {buffer: buffer58, offset: 0}}]});
+let texture82 = device0.createTexture({
+  size: {width: 440, height: 40, depthOrArrayLayers: 24},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView81 = texture41.createView({
+  label: '\u740d\u019b\u{1f99c}\u{1febf}\u0fc8\u6bd2\u{1f85e}\u56b0\u054f\u37d5\u04b5',
+  baseArrayLayer: 0,
+  arrayLayerCount: 1,
+});
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer28, 1_268, 1_719);
+} catch {}
+try {
+commandEncoder93.copyBufferToTexture({
+  /* bytesInLastRow: 176 widthInBlocks: 44 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 644 */
+  offset: 644,
+  bytesPerRow: 2304,
+  buffer: buffer28,
+}, {
+  texture: texture79,
+  mipLevel: 1,
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 44, height: 22, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder18.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture81,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup50 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [{binding: 511, resource: {buffer: buffer50, offset: 256, size: 284}}],
+});
+let computePassEncoder69 = commandEncoder93.beginComputePass();
+try {
+computePassEncoder3.setBindGroup(3, bindGroup36);
+} catch {}
+try {
+renderPassEncoder27.setStencilReference(804);
+} catch {}
+try {
+renderPassEncoder28.setViewport(45.755126203254044, 55.96459691185869, 12.096748006965782, 0.022405052872582144, 0.3546890453591003, 0.45275867612049836);
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer69 = device0.createBuffer({size: 12469, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture83 = device0.createTexture({size: [64, 64, 22], dimension: '2d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_DST});
+let renderPassEncoder33 = commandEncoder18.beginRenderPass({
+  colorAttachments: [{
+  view: textureView32,
+  depthSlice: 18,
+  clearValue: { r: -53.42, g: 642.9, b: 916.0, a: 941.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 342672468,
+});
+try {
+computePassEncoder56.setBindGroup(2, bindGroup9, new Uint32Array(145), 6, 0);
+} catch {}
+let textureView82 = texture67.createView({dimension: '3d', arrayLayerCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(0, buffer67, 20);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup51 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [
+    {binding: 96, resource: {buffer: buffer63, offset: 2560, size: 3324}},
+    {binding: 127, resource: sampler15},
+    {binding: 113, resource: sampler42},
+  ],
+});
+let texture84 = device0.createTexture({
+  size: [220, 20, 1],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView83 = texture20.createView({label: '\ue38d\u3272\u151e\ufe4d\u04db', mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 3});
+try {
+{ clearResourceUsages(device0, computePassEncoder53); computePassEncoder53.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline0);
+} catch {}
+let buffer70 = device0.createBuffer({size: 10629, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let commandEncoder95 = device0.createCommandEncoder({});
+let texture85 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 262},
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let renderPassEncoder34 = commandEncoder95.beginRenderPass({
+  colorAttachments: [{
+  view: textureView32,
+  depthSlice: 149,
+  clearValue: { r: 710.1, g: 116.4, b: -664.4, a: -515.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder34.setBindGroup(2, bindGroup43);
+} catch {}
+try {
+computePassEncoder65.setBindGroup(1, bindGroup23, new Uint32Array(77), 7, 0);
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setViewport(58.58347340095297, 66.7628049618577, 9.797146580905313, 3.533177817285342, 0.6618308771676491, 0.7825195218023538);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: imageData4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let buffer71 = device0.createBuffer({size: 23759, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let texture86 = device0.createTexture({
+  size: {width: 280, height: 291, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup3, new Uint32Array(1103), 13, 0);
+} catch {}
+try {
+renderPassEncoder8.setViewport(32.81439388308239, 0.2869181006256122, 1.6166643841375266, 0.24513148008411323, 0.4994465387658973, 0.6316555079539039);
+} catch {}
+let bindGroup52 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 58, resource: {buffer: buffer57, offset: 0, size: 3444}},
+    {binding: 225, resource: textureView13},
+  ],
+});
+let commandEncoder96 = device0.createCommandEncoder({});
+let computePassEncoder70 = commandEncoder96.beginComputePass({});
+try {
+computePassEncoder16.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup52, new Uint32Array(411), 113, 0);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer42, 'uint32', 688, 217);
+} catch {}
+let textureView84 = texture37.createView({dimension: '1d'});
+try {
+computePassEncoder68.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup52, new Uint32Array(577), 36, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(399).fill(209), /* required buffer size: 399 */
+{offset: 49, bytesPerRow: 35, rowsPerImage: 5}, {width: 3, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let commandEncoder97 = device0.createCommandEncoder();
+let textureView85 = texture3.createView({});
+let computePassEncoder71 = commandEncoder97.beginComputePass({});
+let renderPassEncoder35 = commandEncoder5.beginRenderPass({
+  colorAttachments: [{view: textureView16, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet1,
+});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup16, new Uint32Array(197), 27, 0);
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup6, []);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 13},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let buffer72 = device0.createBuffer({
+  label: '\u38a0\ud95d\uc3bf\u7391\uda0f\u84e6\u2b7e',
+  size: 19840,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView86 = texture79.createView({label: '\ud69c\u1be3\u{1f896}\u070c\u049a\u9a90\u7d56\u3b33', dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder53.dispatchWorkgroupsIndirect(buffer8, 40);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle3, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(794);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer26, 'uint32', 1_904, 249);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline1);
+} catch {}
+let bindGroup53 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [{binding: 54, resource: {buffer: buffer27, offset: 0}}, {binding: 53, resource: externalTexture3}],
+});
+let sampler51 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.571,
+  lodMaxClamp: 98.87,
+  compare: 'always',
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder69.setBindGroup(3, bindGroup42, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder53); computePassEncoder53.dispatchWorkgroupsIndirect(buffer22, 212); };
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer51, 'uint16', 62, 118);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(5, buffer12);
+} catch {}
+let textureView87 = texture18.createView({baseMipLevel: 0});
+try {
+computePassEncoder47.setBindGroup(2, bindGroup22, []);
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup53, new Uint32Array(612), 350, 0);
+} catch {}
+let imageData10 = new ImageData(20, 20);
+let buffer73 = device0.createBuffer({
+  label: '\u8abc\ucf9d\u008b\u03f7\u5cdb\u{1fd91}\u{1f8a8}\u{1ff7b}\u6a99\u0f39\u34bc',
+  size: 31166,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder98 = device0.createCommandEncoder({label: '\u4844\ufc7c\u0a6f\ufffe\u{1f6a1}\u04ee\u5e91\u{1f681}'});
+let texture87 = device0.createTexture({
+  size: [220, 20, 156],
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler52 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.97,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder25.setBindGroup(3, bindGroup41);
+} catch {}
+try {
+renderPassEncoder35.beginOcclusionQuery(52);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer70, 'uint32', 368, 633);
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+let shaderModule9 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(103) var st16: texture_storage_3d<rgba8unorm, write>;
+
+@group(0) @binding(176) var st17: texture_storage_3d<rgba16uint, write>;
+
+struct T0 {
+  @align(16) @size(16) f0: array<u32>,
+}
+
+struct T1 {
+  @align(16) @size(896) f0: array<mat4x3h, 4>,
+  @align(64) @size(128) f1: array<atomic<u32>, 1>,
+  @align(64) @size(1152) f2: atomic<u32>,
+  @align(8) @size(2816) f3: array<array<atomic<u32>, 80>>,
+}
+
+struct T2 {
+  @size(224) f0: array<u32>,
+}
+
+struct S9 {
+  @location(4) f0: f16,
+  @location(14) f1: vec4i,
+}
+
+struct VertexOutput8 {
+  @builtin(position) f34: vec4f,
+}
+
+fn fn0() {
+  vp10 = bitcast<u32>(pow(f32(unconst_f32(0.05921)), f32(unconst_f32(0.3468))));
+  vp9 = S9(vec4h(vp9.f1).y, vp9.f1);
+  vp9.f1 *= vec4i(bitcast<i32>(pow(bitcast<f32>(fma(vec2h(unconst_f16(1579.3), unconst_f16(-5721.1)), vec2h(unconst_f16(1847.8), unconst_f16(-5518.7)), vec2h(unconst_f16(5813.2), unconst_f16(1960.2)))), f32(unconst_f32(0.5570)))));
+  vp9 = S9(f16(unpack4x8snorm(u32(unconst_u32(162)))[0]), vec4i(unpack4x8snorm(u32(unconst_u32(162)))));
+  let ptr73: ptr<private, vec4f> = &vp11[u32(unconst_u32(29))].f34;
+  let vf175: f32 = pow(f32(unconst_f32(0.5171)), f32(unconst_f32(0.08916)));
+  let ptr74: ptr<private, VertexOutput8> = &vp11[9];
+  var vf176: vec3h = cross(vec3h(unconst_f16(440.8), unconst_f16(2476.4), unconst_f16(19689.3)), vec3h(unconst_f16(4410.3), unconst_f16(29780.3), unconst_f16(32387.0)));
+  vp11[u32(unconst_u32(9))].f34 -= saturate(vec3f(unconst_f32(0.00495), unconst_f32(0.5651), unconst_f32(0.05611))).zxzx;
+  let ptr75: ptr<private, u32> = &vp10;
+}
+
+fn fn1(a0: array<i32, 4>) {
+  let vf177: i32 = a0[u32(unconst_u32(106))];
+  let ptr76: ptr<private, vec4f> = &vp11[u32(unconst_u32(250))].f34;
+  vp10 |= bitcast<u32>(vp9.f1[3]);
+  let vf178: vec4f = faceForward(vec4f(unconst_f32(0.07808), unconst_f32(0.07483), unconst_f32(0.2867), unconst_f32(0.2702)), vec4f(unconst_f32(0.1020), unconst_f32(0.04246), unconst_f32(0.1351), unconst_f32(0.2677)), vec4f(unconst_f32(0.1322), unconst_f32(0.00220), unconst_f32(0.01970), unconst_f32(-0.3912)));
+  let ptr77: ptr<private, VertexOutput8> = &vp11[u32(unconst_u32(173))];
+  let vf179: vec3h = smoothstep(vec3h(unconst_f16(-539.0), unconst_f16(14870.0), unconst_f16(1558.9)), vec3h(unconst_f16(15772.6), unconst_f16(5182.2), unconst_f16(10763.4)), vec3h(unconst_f16(8476.0), unconst_f16(14536.8), unconst_f16(48278.0)));
+}
+
+fn fn2() -> array<VertexOutput8, 1> {
+  var out: array<VertexOutput8, 1>;
+  fn1(array<i32, 4>(bitcast<i32>(vp11[u32(unconst_u32(32))].f34.y), vec4i(vp11[u32(unconst_u32(32))].f34)[2], bitcast<vec4i>(vp11[u32(unconst_u32(32))].f34)[0], bitcast<vec4i>(vp11[u32(unconst_u32(32))].f34)[3]));
+  vp9.f1 += bitcast<vec4i>(unpack2x16snorm(u32(unconst_u32(2))).yxyy);
+  vp9.f1 = vec4i(vp11[u32(unconst_u32(195))].f34);
+  var vf180: f32 = ceil(f32(unconst_f32(0.1058)));
+  fn1(array<i32, 4>(i32(vp9.f0), i32(vp9.f0), i32(vp9.f0), i32(vp9.f0)));
+  let vf181: vec3f = quantizeToF16(vec3f(unconst_f32(0.02993), unconst_f32(0.1157), unconst_f32(0.2194)));
+  var vf182: vec2f = unpack2x16unorm(u32(unconst_u32(567)));
+  fn1(array<i32, 4>(bitcast<i32>(vf181[u32(unconst_u32(136))]), bitcast<i32>(vf181[u32(unconst_u32(136))]), bitcast<i32>(vf181[u32(unconst_u32(136))]), i32(vf181[u32(unconst_u32(136))])));
+  fn1(array<i32, 4>(vec2i(unpack2x16unorm(u32(unconst_u32(54))))[1], bitcast<vec2i>(unpack2x16unorm(u32(unconst_u32(54)))).y, i32(unpack2x16unorm(u32(unconst_u32(54))).r), i32(unpack2x16unorm(u32(unconst_u32(54))).x)));
+  vp10 *= bitcast<u32>(vp11[u32(unconst_u32(519))].f34.b);
+  vp10 = bitcast<u32>(vp11[u32(unconst_u32(355))].f34[u32(unconst_u32(42))]);
+  return out;
+}
+
+var<workgroup> vw37: array<atomic<i32>, 21>;
+
+var<workgroup> vw38: vec4<bool>;
+
+var<workgroup> vw39: S9;
+
+var<workgroup> vw40: VertexOutput8;
+
+var<workgroup> vw41: S9;
+
+var<workgroup> vw42: array<VertexOutput8, 1>;
+
+var<workgroup> vw43: atomic<u32>;
+
+var<private> vp9: S9 = S9();
+
+var<private> vp10: u32 = u32(137);
+
+var<private> vp11: array<VertexOutput8, 10> = array(VertexOutput8(vec4f(0.2049, 0.02493, 0.00388, 0.1816)), VertexOutput8(vec4f(0.06921, 0.5519, 0.1122, 0.4268)), VertexOutput8(), VertexOutput8(vec4f(0.1428, 0.4054, 0.1027, -0.03782)), VertexOutput8(), VertexOutput8(), VertexOutput8(vec4f(0.00109, 0.06991, 0.1564, 0.4761)), VertexOutput8(), VertexOutput8(), VertexOutput8());
+
+@vertex
+fn vertex9(@location(11) a0: i32, @location(0) @interpolate(flat) a1: f32, a2: S9, @location(7) @interpolate(flat, sample) a3: u32, @builtin(vertex_index) a4: u32, @location(10) a5: vec2h, @location(8) a6: i32, @location(6) a7: vec4f, @location(9) @interpolate(flat, center) a8: u32, @location(2) a9: vec2i, @builtin(instance_index) a10: u32, @location(13) @interpolate(flat, centroid) a11: i32) -> VertexOutput8 {
+  var out: VertexOutput8;
+  fn1(array<i32, 4>(i32(unconst_i32(89)), i32(unconst_i32(30)), i32(unconst_i32(33)), i32(unconst_i32(175))));
+  fn1(array<i32, 4>(i32(unconst_i32(4)), i32(unconst_i32(17)), i32(unconst_i32(97)), i32(unconst_i32(229))));
+  out.f34 = vec4f(vp11[9].f34[u32(degrees(f32(unconst_f32(0.08271))))]);
+  vp11[u32(unconst_u32(232))].f34 -= bitcast<vec4f>(vp9.f1);
+  vp9.f0 += f16(vp11[9].f34.w);
+  let ptr78: ptr<private, VertexOutput8> = &vp11[9];
+  fn2();
+  vp9 = S9(a2.f0, vec4i(i32(a2.f0)));
+  vp11[u32(unconst_u32(55))] = VertexOutput8(vec4f(saturate(vec2h(unconst_f16(866.2), unconst_f16(2838.1))).grgr));
+  fn1(array<i32, 4>(i32(unconst_i32(264)), i32(unconst_i32(4)), i32(unconst_i32(134)), i32(unconst_i32(80))));
+  out.f34 = a7;
+  fn1(array<i32, 4>(vec4i(vp11[9].f34)[3], i32(vp11[9].f34[3]), vec4i(vp11[9].f34).w, i32(vp11[9].f34[1])));
+  var vf183 = fn2();
+  vf183[u32(unconst_u32(49))] = vf183[0];
+  let ptr79: ptr<function, VertexOutput8> = &vf183[0];
+  fn1(array<i32, 4>(bitcast<i32>(unpack2x16snorm(u32(unconst_u32(9))).y), bitcast<vec2i>(unpack2x16snorm(u32(unconst_u32(9))))[0], bitcast<vec2i>(unpack2x16snorm(u32(unconst_u32(9)))).r, bitcast<i32>(unpack2x16snorm(u32(unconst_u32(9))).y)));
+  var vf184: vec2h = a5;
+  out.f34 += (*ptr78).f34;
+  vf183[u32(unconst_u32(294))].f34 = (*ptr79).f34;
+  vp11[u32(unconst_u32(25))].f34 = vec4f(f32(a5[u32(unconst_u32(50))]));
+  out.f34 = vp11[9].f34;
+  fn1(array<i32, 4>(bitcast<i32>(pack4xU8Clamp(vec4u(unconst_u32(71), unconst_u32(478), unconst_u32(228), unconst_u32(206)))), i32(pack4xU8Clamp(vec4u(unconst_u32(71), unconst_u32(478), unconst_u32(228), unconst_u32(206)))), i32(pack4xU8Clamp(vec4u(unconst_u32(71), unconst_u32(478), unconst_u32(228), unconst_u32(206)))), i32(pack4xU8Clamp(vec4u(unconst_u32(71), unconst_u32(478), unconst_u32(228), unconst_u32(206))))));
+  fn1(array<i32, 4>(i32((*ptr78).f34[u32(unconst_u32(38))]), i32((*ptr78).f34[u32(unconst_u32(38))]), bitcast<i32>((*ptr78).f34[u32(unconst_u32(38))]), i32((*ptr78).f34[u32(unconst_u32(38))])));
+  let ptr80: ptr<private, vec4i> = &vp9.f1;
+  return out;
+}
+
+@compute @workgroup_size(1, 2, 1)
+fn compute8() {
+  fn0();
+  vw38 = vec4<bool>(bool(atomicLoad(&(*&vw37)[20])));
+  vw41.f0 += f16(atomicLoad(&vw37[pack4x8snorm(vw42[u32(vw39.f1[u32(unconst_u32(119))])].f34)]));
+  vp10 = u32(vw42[0].f34[3]);
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let commandBuffer5 = commandEncoder98.finish();
+try {
+computePassEncoder70.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder35.endOcclusionQuery();
+} catch {}
+let texture88 = device0.createTexture({
+  size: [140, 145, 1],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+buffer33.unmap();
+} catch {}
+let videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'bt2020', transfer: 'bt2020_12bit'} });
+try {
+computePassEncoder66.setBindGroup(1, bindGroup1, new Uint32Array(34), 1, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle3, renderBundle3, renderBundle3]);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+document.body.prepend(canvas0);
+let texture89 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 31},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle3, renderBundle3, renderBundle0]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: img1,
+  origin: { x: 11, y: 10 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 19},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture90 = device0.createTexture({
+  size: [560, 582, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView88 = texture51.createView({label: '\u1fa5\u003c\u4d83\u{1fa14}\u6d46', dimension: '1d'});
+try {
+computePassEncoder46.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline0);
+} catch {}
+let bindGroup54 = device0.createBindGroup({
+  label: '\u29c7\u{1f8ea}\uac06\u440d',
+  layout: bindGroupLayout0,
+  entries: [{binding: 176, resource: textureView8}, {binding: 103, resource: textureView3}],
+});
+let commandEncoder99 = device0.createCommandEncoder({label: '\udf3e\u04e4\u535a\u4e5e\udf14\u9e9f'});
+let renderPassEncoder36 = commandEncoder99.beginRenderPass({
+  label: '\u091d\u047d\u03b9\u04b5',
+  colorAttachments: [{view: textureView38, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 257680737,
+});
+let sampler53 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 45.89,
+  lodMaxClamp: 94.73,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup27);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer57, 'uint16', 2, 129);
+} catch {}
+await gc();
+try {
+computePassEncoder20.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup52, new Uint32Array(1515), 128, 0);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(6, buffer6);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+try {
+computePassEncoder38.setBindGroup(2, bindGroup40);
+} catch {}
+try {
+computePassEncoder63.setBindGroup(1, bindGroup33, new Uint32Array(200), 10, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder53); computePassEncoder53.dispatchWorkgroupsIndirect(buffer15, 5_820); };
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer43, 'uint32', 176, 579);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(7, buffer4, 0);
+} catch {}
+let shaderModule10 = device0.createShaderModule({
+  code: `
+enable f16;
+
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(103) var st18: texture_storage_3d<rgba8unorm, write>;
+
+@group(0) @binding(176) var st19: texture_storage_3d<rgba16uint, write>;
+
+struct T0 {
+  @align(8) @size(1088) f0: array<atomic<i32>>,
+}
+
+struct T1 {
+  f0: vec4i,
+  @align(16) @size(16) f1: vec2f,
+  @align(16) @size(304) f2: mat2x2f,
+  @align(16) @size(864) f3: array<mat4x4h, 2>,
+}
+
+struct T2 {
+  @align(16) @size(16) f0: array<array<atomic<u32>, 1>>,
+}
+
+struct T3 {
+  @size(2944) f0: array<i32>,
+}
+
+struct VertexOutput9 {
+  @builtin(position) f35: vec4f,
+}
+
+struct FragmentOutput7 {
+  @location(3) @interpolate(linear) f0: f32,
+  @location(0) @interpolate(flat, center) f1: vec4u,
+  @location(6) f2: vec4u,
+}
+
+alias vec3b = vec3<bool>;
+
+override override3: i32;
+
+fn fn0() -> VertexOutput9 {
+  var out: VertexOutput9;
+  let vf185: vec4f = quantizeToF16(vec4f(unconst_f32(-0.02473), unconst_f32(0.2391), unconst_f32(-0.00355), unconst_f32(0.05767)));
+  out = VertexOutput9(vf185);
+  var vf186: vec4f = vf185;
+  out.f35 = quantizeToF16(vec4f(unconst_f32(0.00253), unconst_f32(0.00581), unconst_f32(0.03095), unconst_f32(0.1295)));
+  return out;
+}
+
+fn fn1() -> array<VertexOutput9, 1> {
+  var out: array<VertexOutput9, 1>;
+  out[u32(unconst_u32(378))] = VertexOutput9(saturate(vec2f(unconst_f32(-0.01898), unconst_f32(0.1512))).rrrg);
+  out[u32(unconst_u32(10))] = VertexOutput9(vec4f(countLeadingZeros(vec3u(unconst_u32(168), unconst_u32(347), unconst_u32(4))).yzzx));
+  fn0();
+  let vf187: f32 = asinh(f32(unconst_f32(0.00311)));
+  out[u32(unconst_u32(184))].f35 += saturate(vec2f(unconst_f32(0.2640), unconst_f32(0.08649))).rrrr;
+  out[u32(unconst_u32(144))].f35 = bitcast<vec4f>(countLeadingZeros(vec3u(unconst_u32(46), unconst_u32(229), unconst_u32(166))).xzyx);
+  out[u32(unconst_u32(168))] = VertexOutput9(vec4f(f32(asinh(f16(unconst_f16(12680.8))))));
+  out[u32(unconst_u32(17))] = VertexOutput9(vec4f(asinh(f32(unconst_f32(0.01640)))));
+  let vf188: i32 = override3;
+  var vf189 = fn0();
+  var vf190: i32 = override3;
+  return out;
+  _ = override3;
+}
+
+var<workgroup> vw44: atomic<u32>;
+
+var<workgroup> vw45: array<VertexOutput9, 3>;
+
+@vertex
+fn vertex10() -> VertexOutput9 {
+  var out: VertexOutput9;
+  out = VertexOutput9(vec4f(f32(dot4I8Packed(u32(unconst_u32(23)), u32(unconst_u32(44))))));
+  out.f35 = faceForward(vec2f(unconst_f32(0.04221), unconst_f32(0.1726)), fma(vec3f(unconst_f32(0.1477), unconst_f32(0.1042), unconst_f32(0.1685)), vec3f(f32(pack4xU8Clamp(vec4u(unconst_u32(72), unconst_u32(244), unconst_u32(101), unconst_u32(23))))), log(vec2f(unconst_f32(0.00609), unconst_f32(0.3018))).ggr).br, vec2f(unconst_f32(0.09662), unconst_f32(0.3441))).xyyx;
+  out.f35 = faceForward(vec2f(unconst_f32(0.09074), unconst_f32(0.3308)), vec2f(unconst_f32(0.01877), unconst_f32(0.09188)), vec2f(unconst_f32(0.07924), unconst_f32(0.2704))).rggg;
+  var vf191: i32 = override3;
+  var vf192 = fn0();
+  var vf193: vec3f = sqrt(vec3f(unconst_f32(0.4294), unconst_f32(-0.6491), unconst_f32(0.1035)));
+  out.f35 = unpack4x8snorm(pack4xU8Clamp(bitcast<vec4u>(vf192.f35)));
+  fn0();
+  out.f35 = vec4f(f32(sqrt(f16(unconst_f16(15047.2)))));
+  let vf194: vec2f = pow(vec2f(unconst_f32(0.1251), unconst_f32(0.01698)), vec2f(unconst_f32(0.3009), unconst_f32(0.07460)));
+  out.f35 -= vf193.brrr;
+  fn1();
+  let vf195: bool = any(vec4<bool>(unconst_bool(true), unconst_bool(false), unconst_bool(false), unconst_bool(false)));
+  var vf196 = fn1();
+  out.f35 *= vf193.bbgr;
+  vf193 -= bitcast<vec3f>(abs(vec4i(unconst_i32(160), unconst_i32(-198), unconst_i32(278), unconst_i32(404))).zyy);
+  let vf197: i32 = dot4I8Packed(u32(unconst_u32(90)), u32(unconst_u32(19)));
+  let vf198: vec3f = sqrt(vec3f(f32(pack4xU8Clamp(vec4u(unconst_u32(122), unconst_u32(82), unconst_u32(28), unconst_u32(63))))));
+  vf191 *= dot4I8Packed(u32(unconst_u32(53)), u32(unconst_u32(459)));
+  vf196[u32(unconst_u32(137))] = VertexOutput9(vec4f(vf196[u32(unconst_u32(542))].f35[u32(unconst_u32(57))]));
+  vf193 = bitcast<vec3f>(abs(vec4i(unconst_i32(304), unconst_i32(421), unconst_i32(64), unconst_i32(60))).rrb);
+  fn0();
+  return out;
+  _ = override3;
+}
+
+@fragment
+fn fragment8(@location(2) a0: vec2i, @location(12) a1: f16) -> FragmentOutput7 {
+  var out: FragmentOutput7;
+  var vf199: vec2i = a0;
+  fn0();
+  vf199 += vec2i(i32(determinant(mat2x2f(unconst_f32(-0.1032), unconst_f32(0.06426), unconst_f32(0.04717), unconst_f32(0.09675)))));
+  out.f1 <<= vec4u(tanh(vec2h(unconst_f16(23825.7), unconst_f16(3241.4))).yxxy);
+  var vf200: f32 = determinant(mat2x2f(unconst_f32(0.1714), unconst_f32(0.07874), unconst_f32(0.2536), unconst_f32(0.01299)));
+  vf200 = f32(clamp(u32(unconst_u32(19)), u32(unconst_u32(70)), u32(unconst_u32(315))));
+  let ptr81: ptr<function, f32> = &vf200;
+  let vf201: i32 = insertBits(i32(unconst_i32(28)), i32(unconst_i32(63)), u32(unconst_u32(30)), u32(unconst_u32(12)));
+  out.f0 = f32(a1);
+  out.f2 -= unpack4xU8(bitcast<u32>(vf201));
+  out.f0 = f32(pack4xI8Clamp(vec4i(unconst_i32(72), unconst_i32(2), unconst_i32(21), unconst_i32(1))));
+  out.f2 *= vec4u(bitcast<u32>(vf201));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute9(@builtin(workgroup_id) a0: vec3u) {
+  let vf202: u32 = atomicExchange(&vw44, u32(unconst_u32(11)));
+  let vf203: u32 = atomicLoad(&(*&vw44));
+  let ptr82: ptr<workgroup, atomic<u32>> = &(*&vw44);
+  var vf204 = fn1();
+  atomicCompareExchangeWeak(&vw44, unconst_u32(6), unconst_u32(392));
+  vw45[pack4xU8Clamp(vec4u(vf204[u32(unconst_u32(506))].f35))] = VertexOutput9(unpack4x8snorm(atomicLoad(&(*ptr82))));
+  let vf205: array<VertexOutput9, 3> = workgroupUniformLoad(&vw45);
+  fn1();
+  _ = override3;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer74 = device0.createBuffer({
+  label: '\u241f\uec56\ud970\u0632\uee78\u22db\u0f1e\u{1fc8c}',
+  size: 5039,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder100 = device0.createCommandEncoder();
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 99});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup47);
+} catch {}
+try {
+computePassEncoder38.setBindGroup(0, bindGroup2, new Uint32Array(3861), 139, 0);
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle0, renderBundle0, renderBundle3, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer16, 'uint16', 482, 255);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(6, buffer72, 0);
+} catch {}
+try {
+commandEncoder100.copyBufferToBuffer(buffer42, 236, buffer22, 40, 392);
+} catch {}
+try {
+commandEncoder100.copyBufferToTexture({
+  /* bytesInLastRow: 72 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2688 */
+  offset: 2688,
+  bytesPerRow: 28672,
+  buffer: buffer51,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 16, y: 32, z: 0},
+  aspect: 'all',
+}, {width: 18, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+let buffer75 = device0.createBuffer({size: 5762, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView89 = texture51.createView({aspect: 'all'});
+let texture91 = device0.createTexture({
+  size: {width: 110, height: 10, depthOrArrayLayers: 1},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView90 = texture78.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder72 = commandEncoder100.beginComputePass();
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint'], depthReadOnly: true});
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let buffer76 = device0.createBuffer({
+  size: 38812,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder101 = device0.createCommandEncoder({});
+let textureView91 = texture39.createView({dimension: '2d', aspect: 'all'});
+let computePassEncoder73 = commandEncoder101.beginComputePass({});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup17, new Uint32Array(921), 47, 0);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup9, new Uint32Array(2349), 201, 0);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(6, buffer56);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 2656, new BigUint64Array(1318), 53, 64);
+} catch {}
+let buffer77 = device0.createBuffer({
+  label: '\u7afb\u{1fbb3}\u0dcd\u{1f693}',
+  size: 6018,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup8, new Uint32Array(1379), 235, 0);
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder29.setViewport(45.76208559116681, 0.4833706511646809, 45.46785964863729, 0.04919451053929141, 0.3169837851481946, 0.8133929864013272);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer42, 'uint32', 120, 827);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer57, 'uint16', 622, 1);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(7, buffer62, 0, 3_951);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture({
+  /* bytesInLastRow: 56 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 320 */
+  offset: 320,
+  rowsPerImage: 1266,
+  buffer: buffer51,
+}, {
+  texture: texture81,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 31, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer54, 360, new Int16Array(3945), 244, 216);
+} catch {}
+canvas0.width = 675;
+let buffer78 = device0.createBuffer({size: 2652, usage: GPUBufferUsage.INDIRECT, mappedAtCreation: false});
+let texture92 = device0.createTexture({
+  label: '\ub927\ufa24\u188b\ue860',
+  size: [220, 20, 1],
+  sampleCount: 1,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder56.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup6, new Uint32Array(1240), 529, 0);
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture({
+  /* bytesInLastRow: 240 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 160 */
+  offset: 160,
+  buffer: buffer75,
+}, {
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'smpte240m', transfer: 'hlg'} });
+let bindGroup55 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 277, resource: sampler48}]});
+let texture93 = device0.createTexture({
+  size: [55, 5, 1],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder74 = commandEncoder21.beginComputePass({});
+try {
+renderBundleEncoder5.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer54, 'uint16', 2_788, 292);
+} catch {}
+let externalTexture5 = device0.importExternalTexture({source: videoFrame9});
+try {
+computePassEncoder43.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+computePassEncoder57.setBindGroup(2, bindGroup50, new Uint32Array(713), 287, 0);
+} catch {}
+try {
+computePassEncoder74.setPipeline(pipeline0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let buffer79 = device0.createBuffer({size: 4383, usage: GPUBufferUsage.INDEX});
+try {
+computePassEncoder42.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+computePassEncoder73.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder10.setViewport(28.662741173277034, 33.7862170978539, 10.379756806058513, 11.636311393024773, 0.3722126658934751, 0.39069421066259746);
+} catch {}
+try {
+renderBundleEncoder5.insertDebugMarker('\u{1fad8}');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let bindGroup56 = device0.createBindGroup({
+  label: '\u{1fe95}\uadae\u0a35',
+  layout: bindGroupLayout9,
+  entries: [
+    {binding: 113, resource: sampler38},
+    {binding: 127, resource: sampler46},
+    {binding: 96, resource: {buffer: buffer50, offset: 0, size: 236}},
+  ],
+});
+let textureView92 = texture77.createView({aspect: 'all'});
+let renderBundle5 = renderBundleEncoder5.finish({});
+try {
+computePassEncoder31.setBindGroup(1, bindGroup54);
+} catch {}
+try {
+computePassEncoder53.end();
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer71, 'uint32', 1_436, 4_882);
+} catch {}
+try {
+commandEncoder73.copyTextureToBuffer({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 19, y: 11, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 64 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 448 */
+  offset: 448,
+  rowsPerImage: 198,
+  buffer: buffer44,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder73.clearBuffer(buffer53, 216, 316);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: canvas0,
+  origin: { x: 28, y: 77 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 41},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 55, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 52,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 57,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let sampler54 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 15.95,
+  lodMaxClamp: 60.47,
+});
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup49, new Uint32Array(447), 18, 0);
+} catch {}
+let imageData11 = new ImageData(32, 4);
+let texture94 = device0.createTexture({
+  size: {width: 55, height: 5, depthOrArrayLayers: 6},
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView93 = texture61.createView({baseMipLevel: 0, arrayLayerCount: 1});
+let computePassEncoder75 = commandEncoder73.beginComputePass();
+try {
+computePassEncoder68.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle5, renderBundle3, renderBundle0, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer77, 'uint16', 1_902, 640);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: imageData11,
+  origin: { x: 4, y: 0 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 27},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 335});
+let sampler55 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 39.74,
+  lodMaxClamp: 98.79,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder49.setBindGroup(1, bindGroup4, new Uint32Array(1663), 16, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder6); computePassEncoder6.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(0, bindGroup49);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup35, new Uint32Array(1660), 228, 0);
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(43);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline1);
+} catch {}
+try {
+querySet3.destroy();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let sampler56 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 10.91,
+  lodMaxClamp: 34.96,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder72.setBindGroup(0, bindGroup40);
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: -604.9, g: -593.3, b: -31.49, a: -815.2, });
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(7, buffer65, 0);
+} catch {}
+try {
+renderPassEncoder3.insertDebugMarker('\ub7d2');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder102 = device0.createCommandEncoder({});
+let texture95 = device0.createTexture({
+  size: [55, 5, 39],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder76 = commandEncoder102.beginComputePass({});
+try {
+computePassEncoder76.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+computePassEncoder45.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_SRC, alphaMode: 'premultiplied'});
+} catch {}
+let bindGroup57 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [
+    {binding: 113, resource: sampler25},
+    {binding: 127, resource: sampler35},
+    {binding: 96, resource: {buffer: buffer50, offset: 256, size: 120}},
+  ],
+});
+let commandEncoder103 = device0.createCommandEncoder({});
+let computePassEncoder77 = commandEncoder9.beginComputePass({});
+let renderPassEncoder37 = commandEncoder103.beginRenderPass({
+  colorAttachments: [{view: textureView8, depthSlice: 0, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 240569899,
+});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer76, 'uint32', 540, 3_705);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(3, buffer50);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline2 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule5}});
+let promise8 = device0.createRenderPipelineAsync({
+  label: '\ua0fd\u242c\u095c\u{1ff01}\u089a\ufc02',
+  layout: pipelineLayout0,
+  multisample: {mask: 0x4dc67973},
+  fragment: {
+  module: shaderModule3,
+  constants: {},
+  targets: [{format: 'rgba16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule10, constants: {override3: 0}, buffers: []},
+  primitive: {topology: 'point-list', cullMode: 'front', unclippedDepth: false},
+});
+let img2 = await imageWithData(15, 54, '#10101010', '#20202020');
+try {
+computePassEncoder77.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(0, buffer62, 0, 9_452);
+} catch {}
+try {
+buffer59.unmap();
+} catch {}
+let buffer80 = device0.createBuffer({size: 23351, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let sampler57 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 82.11,
+  lodMaxClamp: 91.55,
+});
+try {
+computePassEncoder67.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer62, 796, 1_968);
+} catch {}
+await gc();
+let commandEncoder104 = device0.createCommandEncoder({});
+let computePassEncoder78 = commandEncoder104.beginComputePass({});
+let sampler58 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 47.96,
+  lodMaxClamp: 89.92,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder55.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup39);
+} catch {}
+try {
+renderPassEncoder24.setStencilReference(185);
+} catch {}
+try {
+renderPassEncoder20.setViewport(41.378700977712946, 6.49761849464134, 23.296775326624726, 42.22117714635374, 0.35819460018002225, 0.9546759883358251);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let textureView94 = texture71.createView({baseMipLevel: 0});
+try {
+renderPassEncoder23.setVertexBuffer(3, buffer42);
+} catch {}
+let commandEncoder105 = device0.createCommandEncoder();
+let textureView95 = texture16.createView({
+  label: '\u0579\u9ead\u{1f673}\u03aa\ue315\u807a\ua13e\u{1fae0}',
+  dimension: 'cube-array',
+  mipLevelCount: 1,
+  baseArrayLayer: 1,
+  arrayLayerCount: 6,
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], stencilReadOnly: true});
+try {
+computePassEncoder45.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+computePassEncoder30.setBindGroup(1, bindGroup20, new Uint32Array(664), 50, 0);
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(17);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer54, 'uint32', 1_956, 5_239);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer80, 'uint16', 8_162, 662);
+} catch {}
+let texture96 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder79 = commandEncoder105.beginComputePass({});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup48, new Uint32Array(4596), 2_125, 0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer20, 'uint32', 72, 17);
+} catch {}
+let bindGroup58 = device0.createBindGroup({
+  label: '\ud4cd\u07ad\u050c\u31a6\u0477\ub20a\uc6fd\u069e\u{1f7d3}\u{1fdf1}',
+  layout: bindGroupLayout6,
+  entries: [{binding: 11, resource: {buffer: buffer12, offset: 0, size: 672}}],
+});
+let commandEncoder106 = device0.createCommandEncoder();
+let computePassEncoder80 = commandEncoder106.beginComputePass({label: '\u23cb\uf1b8\u6b92\u{1fc3d}\u99a8\u0acc\uaac2\u2599'});
+let renderBundle6 = renderBundleEncoder6.finish({});
+try {
+computePassEncoder61.setBindGroup(0, bindGroup35, new Uint32Array(469), 264, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder46); computePassEncoder46.dispatchWorkgroupsIndirect(buffer24, 348); };
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer15, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let commandEncoder107 = device0.createCommandEncoder({});
+let texture97 = device0.createTexture({
+  size: [384, 1, 524],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder38 = commandEncoder107.beginRenderPass({
+  colorAttachments: [{
+  view: textureView51,
+  depthSlice: 5,
+  clearValue: { r: 313.6, g: 807.9, b: -842.4, a: -831.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 138148182,
+});
+try {
+computePassEncoder34.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(2022);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer59, 'uint32', 312, 766);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 3504, new DataView(new ArrayBuffer(2220)), 835, 160);
+} catch {}
+let commandEncoder108 = device0.createCommandEncoder();
+let texture98 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 22},
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder46.end();
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup40, new Uint32Array(1093), 422, 0);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle5, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(0, buffer59);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture93,
+  mipLevel: 0,
+  origin: {x: 15, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(159).fill(90), /* required buffer size: 159 */
+{offset: 159, bytesPerRow: 121}, {width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup59 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [{binding: 54, resource: {buffer: buffer72, offset: 1536}}, {binding: 53, resource: externalTexture0}],
+});
+let buffer81 = device0.createBuffer({
+  label: '\u0cdf\u01b3\u{1f9b1}\u0c64\u{1f9e3}\u0054',
+  size: 5956,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let computePassEncoder81 = commandEncoder108.beginComputePass();
+let renderPassEncoder39 = commandEncoder3.beginRenderPass({
+  colorAttachments: [{
+  view: textureView16,
+  clearValue: { r: 805.5, g: -857.0, b: 703.4, a: 460.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler59 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 30.97,
+});
+try {
+computePassEncoder72.setBindGroup(3, bindGroup47);
+} catch {}
+try {
+computePassEncoder72.end();
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup20, new Uint32Array(3170), 386, 0);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder37.setScissorRect(159, 9, 68, 147);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer42, 'uint16', 368, 426);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(0, buffer67);
+} catch {}
+let bindGroup60 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 86, resource: textureView78},
+    {binding: 211, resource: sampler20},
+    {binding: 62, resource: textureView39},
+  ],
+});
+let buffer82 = device0.createBuffer({
+  size: 1101,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture99 = device0.createTexture({
+  size: [73, 1, 1],
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderPassEncoder40 = commandEncoder100.beginRenderPass({
+  colorAttachments: [{view: textureView25, depthSlice: 125, loadOp: 'load', storeOp: 'store'}],
+  maxDrawCount: 343140706,
+});
+try {
+renderPassEncoder28.setBindGroup(1, bindGroup49);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 400, new DataView(new ArrayBuffer(9015)), 124, 652);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let sampler60 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 66.78,
+  lodMaxClamp: 87.01,
+});
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle0, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer20, 'uint16', 42, 75);
+} catch {}
+document.body.append(canvas0);
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint'], stencilReadOnly: true});
+try {
+computePassEncoder59.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer51, 'uint16', 216, 1_012);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(7, buffer3, 20);
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(img2);
+let buffer83 = device0.createBuffer({
+  size: 17091,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let renderBundle7 = renderBundleEncoder7.finish();
+let sampler61 = device0.createSampler({
+  label: '\u0704\u{1ff85}\u267c',
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 66.96,
+  lodMaxClamp: 79.62,
+  compare: 'never',
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder71.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer44, 'uint16', 2_762, 2_365);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline1);
+} catch {}
+let arrayBuffer3 = buffer35.getMappedRange(520, 116);
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup61 = device0.createBindGroup({
+  label: '\u0830\ua071\u968a\u20e0\u4a9f\u0077',
+  layout: bindGroupLayout6,
+  entries: [{binding: 11, resource: {buffer: buffer63, offset: 256, size: 4252}}],
+});
+try {
+computePassEncoder76.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup41, new Uint32Array(2020), 11, 0);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder26.insertDebugMarker('\u0f6b');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 54}
+*/
+{
+  source: imageData3,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder109 = device0.createCommandEncoder({});
+let texture100 = device0.createTexture({
+  label: '\ucd6c\u{1fa62}',
+  size: {width: 64, height: 64, depthOrArrayLayers: 22},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder57.setBindGroup(2, bindGroup31);
+} catch {}
+try {
+computePassEncoder67.setBindGroup(2, bindGroup58, new Uint32Array(3818), 112, 0);
+} catch {}
+try {
+computePassEncoder76.setPipeline(pipeline2);
+} catch {}
+let commandEncoder110 = device0.createCommandEncoder({});
+try {
+computePassEncoder73.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+computePassEncoder61.setBindGroup(3, bindGroup48, new Uint32Array(2706), 226, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(2, buffer12);
+} catch {}
+try {
+commandEncoder109.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture60,
+  mipLevel: 1,
+  origin: {x: 16, y: 24, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder109.resolveQuerySet(querySet7, 8, 69, buffer46, 512);
+} catch {}
+let videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'bt2020', transfer: 'smpte170m'} });
+let commandEncoder111 = device0.createCommandEncoder({});
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 1532});
+let textureView96 = texture63.createView({dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder82 = commandEncoder110.beginComputePass();
+try {
+renderPassEncoder31.setIndexBuffer(buffer70, 'uint32', 780, 2_396);
+} catch {}
+try {
+commandEncoder111.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 276 */
+  offset: 276,
+  bytesPerRow: 12544,
+  buffer: buffer11,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder111.resolveQuerySet(querySet9, 22, 5, buffer64, 512);
+} catch {}
+await gc();
+let commandEncoder112 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder11); computePassEncoder11.dispatchWorkgroupsIndirect(buffer81, 976); };
+} catch {}
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+computePassEncoder81.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup28, new Uint32Array(2580), 50, 0);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline1);
+} catch {}
+let arrayBuffer4 = buffer35.getMappedRange(0, 28);
+let commandEncoder113 = device0.createCommandEncoder();
+let renderPassEncoder41 = commandEncoder111.beginRenderPass({
+  colorAttachments: [{
+  view: textureView8,
+  depthSlice: 1,
+  clearValue: { r: -472.8, g: 308.1, b: -803.9, a: -461.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder50.setBindGroup(0, bindGroup2, new Uint32Array(53), 14, 0);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle5]);
+} catch {}
+let commandEncoder114 = device0.createCommandEncoder();
+let textureView97 = texture47.createView({
+  label: '\u09f3\u0860\u5db2\u08cf\u96b3\u6760\u{1f669}\u05ee\u{1fadc}',
+  dimension: '2d-array',
+  format: 'rgb10a2uint',
+  mipLevelCount: 1,
+});
+let renderPassEncoder42 = commandEncoder114.beginRenderPass({
+  colorAttachments: [{
+  view: textureView73,
+  clearValue: { r: -254.5, g: -978.0, b: -115.7, a: 450.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+try {
+globalThis.someLabel = commandEncoder4.label;
+} catch {}
+let buffer84 = device0.createBuffer({
+  size: 27762,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView98 = texture91.createView({label: '\u068c\u460c\u0bfe\udef6\u1813\ud0a7\ua6cd\u7704\u300d\u3ae8', format: 'rgba16uint'});
+let computePassEncoder83 = commandEncoder15.beginComputePass({});
+try {
+computePassEncoder29.setBindGroup(1, bindGroup57, new Uint32Array(751), 110, 0);
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle2, renderBundle1]);
+} catch {}
+let computePassEncoder84 = commandEncoder112.beginComputePass({});
+try {
+computePassEncoder59.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder59); computePassEncoder59.dispatchWorkgroupsIndirect(buffer78, 432); };
+} catch {}
+try {
+computePassEncoder59.end();
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer30, 'uint32', 4, 4);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(3, buffer8, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: img1,
+  origin: { x: 6, y: 4 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 32},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let offscreenCanvas1 = new OffscreenCanvas(380, 156);
+let imageData12 = new ImageData(32, 12);
+let commandEncoder115 = device0.createCommandEncoder({label: '\u{1ffb2}\u0aab\u0722\u0f8f\u032c\ubfef\u316c\u{1f8ea}\u0409\ubd14\u001b'});
+let texture101 = device0.createTexture({
+  size: [64],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder85 = commandEncoder109.beginComputePass({});
+let renderPassEncoder43 = commandEncoder83.beginRenderPass({
+  colorAttachments: [{
+  view: textureView38,
+  clearValue: { r: -978.9, g: 678.3, b: -523.1, a: -840.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 42765863,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder50); computePassEncoder50.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder78.setPipeline(pipeline2);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer54, 960, new DataView(new ArrayBuffer(16916)), 1395, 1808);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+offscreenCanvas1.getContext('2d');
+} catch {}
+let bindGroup62 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 57, resource: textureView48}, {binding: 52, resource: textureView47}],
+});
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer85 = device0.createBuffer({
+  label: '\u07f7\u4bf4\u086a',
+  size: 17742,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView99 = texture2.createView({});
+let renderPassEncoder44 = commandEncoder115.beginRenderPass({
+  colorAttachments: [{view: textureView98, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 84849259,
+});
+let sampler62 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 69.44,
+  lodMaxClamp: 93.08,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder61.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+computePassEncoder62.setBindGroup(2, bindGroup52, new Uint32Array(3391), 57, 0);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(2, bindGroup41);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup50, new Uint32Array(5014), 730, 0);
+} catch {}
+try {
+renderPassEncoder17.setScissorRect(2, 0, 11, 0);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline1);
+} catch {}
+let arrayBuffer5 = buffer35.getMappedRange(32, 8);
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 71, y: 98, z: 0},
+  aspect: 'all',
+}, new Uint8Array(122).fill(135), /* required buffer size: 122 */
+{offset: 122, bytesPerRow: 632}, {width: 68, height: 34, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 39,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+  ],
+});
+let buffer86 = device0.createBuffer({
+  label: '\u8460\u034b\u0f09\u2b77\u6dd2\uf4f5\u2528',
+  size: 3728,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder116 = device0.createCommandEncoder({});
+let texture102 = device0.createTexture({
+  label: '\u2c1e\u0100\u0b0c\u01dc\u{1fe85}\u{1fe82}\u7bae\u0b3e',
+  size: {width: 73, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView100 = texture30.createView({format: 'rgba16sint', arrayLayerCount: 1});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup16, new Uint32Array(3454), 85, 0);
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup34, new Uint32Array(1201), 220, 0);
+} catch {}
+try {
+renderPassEncoder14.setViewport(8.106110482023922, 52.85146264733003, 46.647254449198606, 0.8845238629239057, 0.9396636089550949, 0.9468029626430029);
+} catch {}
+try {
+commandEncoder116.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 208 */
+  offset: 208,
+  bytesPerRow: 17152,
+  rowsPerImage: 172,
+  buffer: buffer41,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 27},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+document.body.append(canvas0);
+let commandEncoder117 = device0.createCommandEncoder({});
+let textureView101 = texture102.createView({dimension: '2d'});
+let textureView102 = texture59.createView({});
+let sampler63 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 42.58,
+  lodMaxClamp: 74.33,
+  compare: 'greater',
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup54);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer20, 'uint16', 428, 5);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(2, buffer59);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+let bindGroup63 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 11, resource: {buffer: buffer62, offset: 768}}]});
+let sampler64 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 92.11,
+  lodMaxClamp: 98.97,
+});
+try {
+renderPassEncoder4.executeBundles([renderBundle3, renderBundle7]);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder118 = device0.createCommandEncoder({});
+let computePassEncoder86 = commandEncoder117.beginComputePass({});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup48);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle1]);
+} catch {}
+try {
+buffer51.unmap();
+} catch {}
+let buffer87 = device0.createBuffer({
+  size: 8579,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder119 = device0.createCommandEncoder({});
+let renderPassEncoder45 = commandEncoder119.beginRenderPass({
+  label: '\u0cd7\u0ebf\u0eef\u0166\u17bb',
+  colorAttachments: [{
+  view: textureView79,
+  clearValue: { r: -625.7, g: -762.9, b: 373.0, a: 926.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet10,
+});
+try {
+computePassEncoder85.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup52);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer84, 'uint32', 440, 1_780);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(7, buffer83, 0, 1_353);
+} catch {}
+try {
+commandEncoder113.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 308 */
+  offset: 308,
+  buffer: buffer86,
+}, {
+  texture: texture76,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline3 = await device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule4}});
+try {
+adapter0.label = '\u4a64\udaa1\u07c8\uefac\u{1fd72}\u0e49\u{1fbf7}\u9246\uecc2\u4440';
+} catch {}
+let commandEncoder120 = device0.createCommandEncoder();
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 483});
+let computePassEncoder87 = commandEncoder120.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder34); computePassEncoder34.dispatchWorkgroupsIndirect(buffer81, 604); };
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup18, new Uint32Array(20), 4, 0);
+} catch {}
+try {
+commandEncoder118.copyBufferToTexture({
+  /* bytesInLastRow: 36 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1764 */
+  offset: 1764,
+  rowsPerImage: 791,
+  buffer: buffer69,
+}, {
+  texture: texture93,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder15.insertDebugMarker('\uc0bf');
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  label: '\ud0f5\u0ff0\ue979\ua61b\ud351\u13e6\u07d7\u592d\u63cc\u622b\u07e2',
+  entries: [
+    {binding: 272, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+  ],
+});
+let texture103 = device0.createTexture({
+  size: [73, 1, 22],
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder88 = commandEncoder116.beginComputePass({});
+let sampler65 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 41.22,
+  lodMaxClamp: 98.31,
+});
+try {
+computePassEncoder73.setBindGroup(3, bindGroup58);
+} catch {}
+try {
+computePassEncoder17.setBindGroup(0, bindGroup3, new Uint32Array(745), 473, 0);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(4, buffer50, 0);
+} catch {}
+try {
+commandEncoder118.copyBufferToBuffer(buffer83, 2956, buffer62, 4660, 1472);
+} catch {}
+let canvas1 = document.createElement('canvas');
+let computePassEncoder89 = commandEncoder118.beginComputePass({});
+let renderPassEncoder46 = commandEncoder113.beginRenderPass({
+  label: '\u5ed1\u0894\u24f2\u0e5c\u0450\uc30b\u{1ffe6}',
+  colorAttachments: [{view: textureView82, depthSlice: 7, loadOp: 'clear', storeOp: 'discard'}],
+});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup44, new Uint32Array(1861), 526, 0);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder40.insertDebugMarker('\uf04f');
+} catch {}
+let bindGroup64 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 62, resource: textureView102},
+    {binding: 211, resource: sampler41},
+    {binding: 86, resource: textureView17},
+  ],
+});
+let commandEncoder121 = device0.createCommandEncoder();
+let textureView103 = texture102.createView({baseMipLevel: 0});
+let textureView104 = texture23.createView({aspect: 'all', mipLevelCount: 1});
+let renderPassEncoder47 = commandEncoder121.beginRenderPass({
+  colorAttachments: [{view: textureView5, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet12,
+  maxDrawCount: 125031860,
+});
+try {
+computePassEncoder45.setBindGroup(3, bindGroup58, new Uint32Array(26), 0, 0);
+} catch {}
+try {
+computePassEncoder87.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: img1,
+  origin: { x: 7, y: 17 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 41, y: 0, z: 34},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+canvas1.getContext('2d');
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup55, new Uint32Array(2242), 787, 0);
+} catch {}
+try {
+renderPassEncoder35.beginOcclusionQuery(144);
+} catch {}
+try {
+renderPassEncoder35.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline1);
+} catch {}
+let bindGroup65 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [{binding: 511, resource: {buffer: buffer50, offset: 256, size: 396}}],
+});
+let commandEncoder122 = device0.createCommandEncoder({});
+let computePassEncoder90 = commandEncoder122.beginComputePass({});
+let sampler66 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 28.04,
+  maxAnisotropy: 7,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 102},
+  aspect: 'all',
+}, new Uint8Array(2_941).fill(64), /* required buffer size: 2_941 */
+{offset: 81, bytesPerRow: 130, rowsPerImage: 1}, {width: 7, height: 0, depthOrArrayLayers: 23});
+} catch {}
+let bindGroup66 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [
+    {binding: 127, resource: sampler64},
+    {binding: 96, resource: {buffer: buffer12, offset: 0}},
+    {binding: 113, resource: sampler22},
+  ],
+});
+let commandEncoder123 = device0.createCommandEncoder({label: '\u{1ff8a}\u0e9b\u0b2c\u2215\ufea0\u5e77\u{1fc46}\u{1f9db}\u{1fcfd}'});
+let computePassEncoder91 = commandEncoder123.beginComputePass({label: '\u6068\u{1fa39}\ue857\u96c7'});
+let sampler67 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 43.91,
+});
+try {
+renderPassEncoder35.setVertexBuffer(4, buffer24, 0, 171);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+computePassEncoder90.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup54);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(2, bindGroup44, new Uint32Array(483), 36, 0);
+} catch {}
+let textureView105 = texture22.createView({
+  label: '\u890f\u0596\u0322\ucf37\u{1f680}\u06d4\u{1f8d3}\u{1fdb7}\u{1f992}\u{1f96c}',
+  aspect: 'all',
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder89.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup0, new Uint32Array(810), 73, 0);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle2]);
+} catch {}
+let arrayBuffer6 = buffer35.getMappedRange(40, 12);
+try {
+  await buffer36.mapAsync(GPUMapMode.WRITE, 256, 444);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 328, new Float32Array(1408), 629, 92);
+} catch {}
+await gc();
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  label: '\u0e5c\u0214\u7dbb',
+  entries: [
+    {
+      binding: 172,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 57,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 153,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 462,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 264,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 9,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 51,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 8,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 67,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let querySet13 = device0.createQuerySet({label: '\u{1fc39}\u{1ff0d}\u3e83\u9553\u0a00\u559a', type: 'occlusion', count: 328});
+let texture104 = device0.createTexture({
+  size: [64],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture6 = device0.importExternalTexture({label: '\u0661\u455b\u01aa\u155c', source: videoFrame7});
+try {
+computePassEncoder71.setBindGroup(0, bindGroup54, new Uint32Array(547), 22, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder50); computePassEncoder50.dispatchWorkgroupsIndirect(buffer50, 128); };
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup41);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle4, renderBundle2, renderBundle2, renderBundle1, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer82, 'uint16', 352, 16);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 19, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(391).fill(136), /* required buffer size: 391 */
+{offset: 223, bytesPerRow: 4, rowsPerImage: 37}, {width: 1, height: 5, depthOrArrayLayers: 2});
+} catch {}
+try {
+adapter0.label = '\u{1faf5}\u96de\u037d\u5793\u3348\u0d2f\u{1f630}\u5f7d\u7aa1\u784e\u0f44';
+} catch {}
+let texture105 = device0.createTexture({
+  label: '\ud419\u6823\u06b3\u0489\u016a\u{1f914}',
+  size: [36, 1, 18],
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView106 = texture77.createView({label: '\u2a9e\u07e6\u376b\u0447\u3154', arrayLayerCount: 1});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup13, new Uint32Array(772), 455, 0);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline1);
+} catch {}
+let textureView107 = texture105.createView({aspect: 'all'});
+try {
+{ clearResourceUsages(device0, computePassEncoder73); computePassEncoder73.dispatchWorkgroupsIndirect(buffer42, 652); };
+} catch {}
+try {
+device0.queue.writeBuffer(buffer82, 24, new DataView(new ArrayBuffer(8597)), 373, 284);
+} catch {}
+document.body.append(img1);
+let bindGroup67 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [{binding: 511, resource: {buffer: buffer11, offset: 1536, size: 8676}}],
+});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup10, new Uint32Array(3487), 1_097, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup48);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: -883.5, g: -799.6, b: -355.9, a: -247.0, });
+} catch {}
+try {
+renderPassEncoder8.setViewport(2.001624356202766, 0.5402923408959516, 0.2707699341761901, 0.09136486904618263, 0.3554263047514914, 0.6216146109017195);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(6_297).fill(170), /* required buffer size: 6_297 */
+{offset: 73, bytesPerRow: 389, rowsPerImage: 8}, {width: 18, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let bindGroup68 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 53, resource: externalTexture6},
+    {binding: 54, resource: {buffer: buffer2, offset: 0, size: 1192}},
+  ],
+});
+try {
+computePassEncoder79.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(99);
+} catch {}
+let commandEncoder124 = device0.createCommandEncoder();
+try {
+computePassEncoder74.setBindGroup(0, bindGroup47, new Uint32Array(1248), 70, 0);
+} catch {}
+try {
+computePassEncoder91.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(3, bindGroup41, new Uint32Array(1808), 1_490, 0);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer26, 'uint32', 204, 627);
+} catch {}
+try {
+commandEncoder124.copyBufferToBuffer(buffer10, 4316, buffer53, 388, 376);
+} catch {}
+try {
+commandEncoder124.copyBufferToTexture({
+  /* bytesInLastRow: 348 widthInBlocks: 87 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2968 */
+  offset: 2968,
+  bytesPerRow: 19456,
+  rowsPerImage: 2195,
+  buffer: buffer10,
+}, {
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 203, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 87, height: 63, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise9;
+} catch {}
+let commandEncoder125 = device0.createCommandEncoder();
+try {
+computePassEncoder86.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(5, buffer56, 0, 5_759);
+} catch {}
+try {
+commandEncoder124.copyBufferToBuffer(buffer51, 308, buffer11, 3624, 8);
+} catch {}
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {
+  fullRange: true,
+  matrix: 'bt709',
+  primaries: 'jedecP22Phosphors',
+  transfer: 'bt1361ExtendedColourGamut',
+} });
+let commandEncoder126 = device0.createCommandEncoder({});
+let texture106 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 22},
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView108 = texture46.createView({});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup5, new Uint32Array(2454), 139, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer6, 0);
+} catch {}
+try {
+commandEncoder125.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 80 */
+  offset: 80,
+  bytesPerRow: 256,
+  rowsPerImage: 265,
+  buffer: buffer47,
+}, {
+  texture: texture94,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView109 = texture105.createView({aspect: 'all'});
+let texture107 = gpuCanvasContext1.getCurrentTexture();
+let textureView110 = texture0.createView({dimension: '2d', aspect: 'all', mipLevelCount: 1});
+let renderPassEncoder48 = commandEncoder125.beginRenderPass({
+  colorAttachments: [{
+  view: textureView65,
+  clearValue: { r: 905.8, g: -913.3, b: -197.5, a: 513.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder50.setBindGroup(2, bindGroup66, []);
+} catch {}
+try {
+computePassEncoder88.setPipeline(pipeline2);
+} catch {}
+let texture108 = device0.createTexture({
+  size: {width: 295, height: 1, depthOrArrayLayers: 123},
+  sampleCount: 1,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup23, new Uint32Array(452), 170, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup49);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(3, bindGroup13, new Uint32Array(860), 83, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img2);
+let commandEncoder127 = device0.createCommandEncoder({});
+let computePassEncoder92 = commandEncoder127.beginComputePass();
+let sampler68 = device0.createSampler({
+  label: '\u0f63\u05b8\udaf2\u{1fd4a}\ub08f\u{1fa34}',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 15.70,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup42, new Uint32Array(4595), 1_427, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder36); computePassEncoder36.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup28, new Uint32Array(278), 3, 0);
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(0, 0, 17, 0);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(2, buffer51, 16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer54, 2576, new Int16Array(4114));
+} catch {}
+let buffer88 = device0.createBuffer({size: 14067, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let texture109 = device0.createTexture({
+  size: {width: 440},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler69 = device0.createSampler({
+  label: '\ue96a\u0b92\u{1f72f}\ufa45\u0cce\u3e34\u003d\u01d4\u{1fc47}\u0c0d',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 54.27,
+  lodMaxClamp: 54.76,
+});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame14});
+try {
+computePassEncoder75.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer86, 'uint16', 868, 62);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(2, buffer67, 0);
+} catch {}
+try {
+  await shaderModule4.getCompilationInfo();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: imageData3,
+  origin: { x: 10, y: 6 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder128 = device0.createCommandEncoder({});
+let texture110 = device0.createTexture({
+  size: [295, 1, 19],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder93 = commandEncoder128.beginComputePass({});
+let renderPassEncoder49 = commandEncoder126.beginRenderPass({
+  colorAttachments: [{
+  view: textureView5,
+  clearValue: { r: 975.3, g: -343.2, b: 272.8, a: 388.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 61360249,
+});
+try {
+computePassEncoder92.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer70, 'uint16', 2_248, 4_135);
+} catch {}
+try {
+commandEncoder124.copyBufferToTexture({
+  /* bytesInLastRow: 1024 widthInBlocks: 128 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 440 */
+  offset: 440,
+  buffer: buffer34,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 128, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 54}
+*/
+{
+  source: videoFrame13,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 13},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let videoFrame15 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'bt470bg', transfer: 'linear'} });
+let commandEncoder129 = device0.createCommandEncoder({});
+let computePassEncoder94 = commandEncoder129.beginComputePass();
+let renderPassEncoder50 = commandEncoder124.beginRenderPass({
+  colorAttachments: [{
+  view: textureView74,
+  depthSlice: 173,
+  clearValue: { r: 449.7, g: -522.6, b: -477.7, a: 456.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder75.setBindGroup(1, bindGroup19, new Uint32Array(154), 37, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder50); computePassEncoder50.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup68);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap0 = await createImageBitmap(imageData8);
+let commandEncoder130 = device0.createCommandEncoder({});
+let textureView111 = texture88.createView({label: '\ua34e\u{1f622}\u02ac\u{1fd60}\u3f76\u8c17\u1388', dimension: '2d-array'});
+try {
+computePassEncoder81.setBindGroup(2, bindGroup49);
+} catch {}
+try {
+computePassEncoder37.setBindGroup(0, bindGroup55, new Uint32Array(3313), 382, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder38); computePassEncoder38.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder93.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup5, new Uint32Array(2070), 11, 0);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(5, buffer10, 1_320, 1_975);
+} catch {}
+try {
+computePassEncoder94.pushDebugGroup('\u0c9f');
+} catch {}
+try {
+computePassEncoder71.insertDebugMarker('\ua8b9');
+} catch {}
+let texture111 = gpuCanvasContext1.getCurrentTexture();
+let textureView112 = texture30.createView({format: 'rgba16sint', mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder95 = commandEncoder130.beginComputePass();
+try {
+computePassEncoder85.setBindGroup(1, bindGroup35);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup61);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 295, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture112 = device0.createTexture({
+  size: {width: 48, height: 1, depthOrArrayLayers: 22},
+  dimension: '2d',
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView113 = texture45.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder71.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder30); computePassEncoder30.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder36); computePassEncoder36.dispatchWorkgroupsIndirect(buffer15, 3_360); };
+} catch {}
+try {
+computePassEncoder82.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer15, 'uint16', 286, 185);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(5, buffer62, 2_384);
+} catch {}
+let bindGroup69 = device0.createBindGroup({
+  label: '\u0739\uaa34\uf8d1\u6217\u0477\u0abf\u{1ff60}\u4fd0\u7aa8\u05a6\ud439',
+  layout: bindGroupLayout13,
+  entries: [{binding: 272, resource: {buffer: buffer64, offset: 512, size: 192}}],
+});
+try {
+computePassEncoder16.setBindGroup(3, bindGroup66, new Uint32Array(2333), 1_160, 0);
+} catch {}
+try {
+computePassEncoder95.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup24, []);
+} catch {}
+document.body.prepend(img1);
+let bindGroup70 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 39, resource: textureView103}]});
+let pipelineLayout6 = device0.createPipelineLayout({label: '\ue5e9\u0ded', bindGroupLayouts: [bindGroupLayout3]});
+let sampler70 = device0.createSampler({
+  label: '\u{1f6bc}\u{1fede}\udf20\uf8d1\u3c1c\ucff7\u0fe6\u043f',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 29.57,
+});
+try {
+renderPassEncoder4.beginOcclusionQuery(32);
+} catch {}
+try {
+buffer26.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder131 = device0.createCommandEncoder();
+let texture113 = device0.createTexture({
+  size: [64],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder96 = commandEncoder131.beginComputePass({label: '\u{1ffe2}\uc5df\u{1faa6}\u0f82\u0164\uc92a\u3191\u0ab6\u94a3\u8fb7'});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder61); computePassEncoder61.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder34); computePassEncoder34.dispatchWorkgroupsIndirect(buffer64, 260); };
+} catch {}
+try {
+computePassEncoder94.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer82, 'uint16', 0, 102);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer87, 560, 484);
+} catch {}
+try {
+buffer83.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(143).fill(115), /* required buffer size: 143 */
+{offset: 143}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+bindGroup61.label = '\u0c7d\u0d3d\u68e1';
+} catch {}
+let bindGroup71 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 5, resource: sampler32}]});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer15, 'uint16', 6_948, 994);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer52, 124, new BigUint64Array(1951), 224, 48);
+} catch {}
+let bindGroup72 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 225, resource: textureView39},
+    {binding: 58, resource: {buffer: buffer44, offset: 0, size: 6001}},
+  ],
+});
+let commandEncoder132 = device0.createCommandEncoder({});
+let computePassEncoder97 = commandEncoder132.beginComputePass({label: '\u0152\u90a8\u016d\u{1f65e}\ub71c\u3386\u{1fbe6}\u6455'});
+try {
+computePassEncoder40.setBindGroup(3, bindGroup52);
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(1, buffer8, 92, 295);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 920, new Float32Array(308));
+} catch {}
+let sampler71 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 93.68,
+  lodMaxClamp: 97.71,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder80.setBindGroup(2, bindGroup4, new Uint32Array(5279), 539, 0);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(2, buffer51);
+} catch {}
+let arrayBuffer7 = buffer35.getMappedRange(56, 52);
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+let textureView114 = texture63.createView({dimension: '2d-array'});
+let sampler72 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup47);
+} catch {}
+try {
+computePassEncoder47.setBindGroup(0, bindGroup16, new Uint32Array(2313), 205, 0);
+} catch {}
+try {
+renderPassEncoder47.beginOcclusionQuery(40);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer81, 436, new Int16Array(2032));
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(375).fill(80), /* required buffer size: 375 */
+{offset: 375}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup73 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 58, resource: {buffer: buffer81, offset: 512, size: 4363}},
+    {binding: 225, resource: textureView108},
+  ],
+});
+let commandEncoder133 = device0.createCommandEncoder({});
+let externalTexture8 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder73.end();
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup65);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup54, new Uint32Array(2303), 55, 0);
+} catch {}
+try {
+renderPassEncoder47.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle2, renderBundle1, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer82, 'uint16', 532, 50);
+} catch {}
+document.body.prepend(canvas1);
+let renderPassEncoder51 = commandEncoder101.beginRenderPass({
+  label: '\u0984\u{1ffde}\u07d7',
+  colorAttachments: [{
+  view: textureView98,
+  clearValue: { r: 242.7, g: 606.4, b: 510.5, a: 425.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 1234567890,
+});
+let sampler73 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 93.17,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup60);
+} catch {}
+try {
+computePassEncoder38.end();
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup39);
+} catch {}
+try {
+renderPassEncoder7.setViewport(26.28884470204025, 0.1542674133054449, 6.686596033944005, 0.11837418827153506, 0.40984960444539853, 0.9403904667974389);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer23, 'uint16', 4_748, 2_119);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let buffer89 = device0.createBuffer({
+  size: 2246,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder134 = device0.createCommandEncoder({});
+let commandBuffer6 = commandEncoder54.finish();
+let textureView115 = texture45.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder98 = commandEncoder133.beginComputePass();
+let renderPassEncoder52 = commandEncoder134.beginRenderPass({
+  colorAttachments: [{
+  view: textureView52,
+  clearValue: { r: 213.5, g: -46.41, b: 181.3, a: -637.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet11,
+});
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup52);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(101);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer62, 'uint16', 320, 878);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageBitmap1 = await createImageBitmap(videoFrame14);
+let bindGroup74 = device0.createBindGroup({
+  label: '\u{1f600}\ucf3b\u0e9d\u09f6\u03f6\u161a',
+  layout: bindGroupLayout0,
+  entries: [{binding: 103, resource: textureView59}, {binding: 176, resource: textureView99}],
+});
+let buffer90 = device0.createBuffer({
+  size: 2054,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let texture114 = device0.createTexture({
+  size: {width: 73},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler74 = device0.createSampler({
+  label: '\u0dd6\u{1f9fc}\u6771\u2353\ucf81\ubcaa',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 5.891,
+  lodMaxClamp: 21.52,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder62.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+computePassEncoder98.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup49);
+} catch {}
+try {
+renderPassEncoder50.executeBundles([renderBundle5, renderBundle3, renderBundle0, renderBundle5, renderBundle5]);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+computePassEncoder94.popDebugGroup();
+} catch {}
+let videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'bt2020', transfer: 'unspecified'} });
+let commandEncoder135 = device0.createCommandEncoder({});
+let texture115 = device0.createTexture({
+  size: {width: 295, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder96.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(2, bindGroup31, new Uint32Array(142), 28, 0);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(6, buffer59, 480, 295);
+} catch {}
+let arrayBuffer8 = buffer36.getMappedRange(256, 120);
+try {
+commandEncoder135.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture78,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder135.clearBuffer(buffer18, 1480, 240);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(200).fill(79), /* required buffer size: 200 */
+{offset: 200, bytesPerRow: 311}, {width: 38, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup75 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 277, resource: sampler58}]});
+let textureView116 = texture28.createView({dimension: '2d-array', aspect: 'stencil-only', baseMipLevel: 0});
+let computePassEncoder99 = commandEncoder135.beginComputePass({});
+try {
+computePassEncoder99.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(4, buffer56, 0);
+} catch {}
+let videoFrame17 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'smpte170m', transfer: 'log'} });
+let bindGroup76 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [{binding: 272, resource: {buffer: buffer82, offset: 0, size: 358}}],
+});
+let buffer91 = device0.createBuffer({
+  size: 15459,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder136 = device0.createCommandEncoder({label: '\udd70\u087a\u02e1'});
+let textureView117 = texture65.createView({label: '\u0660\u07cc\u6451\uea8f', format: 'rgb10a2uint', baseArrayLayer: 5, arrayLayerCount: 6});
+let sampler75 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 26.33,
+  maxAnisotropy: 5,
+});
+let externalTexture9 = device0.importExternalTexture({source: videoFrame5});
+try {
+renderPassEncoder38.setBindGroup(2, bindGroup45);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(7, buffer87, 1_156, 459);
+} catch {}
+try {
+commandEncoder136.resolveQuerySet(querySet6, 17, 7, buffer24, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 420, new DataView(new ArrayBuffer(12935)), 3086, 1144);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup77 = device0.createBindGroup({
+  label: '\u773b\u0b85\u8629\ucd51\u032d\u{1f7a8}\u4553',
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 462, resource: {buffer: buffer64, offset: 512}},
+    {binding: 172, resource: textureView110},
+    {binding: 51, resource: {buffer: buffer76, offset: 3584}},
+    {binding: 9, resource: textureView14},
+    {binding: 67, resource: textureView10},
+    {binding: 264, resource: sampler71},
+    {binding: 153, resource: {buffer: buffer12, offset: 0}},
+    {binding: 8, resource: textureView107},
+    {binding: 57, resource: textureView91},
+  ],
+});
+let computePassEncoder100 = commandEncoder136.beginComputePass({});
+let promise13 = device0.queue.onSubmittedWorkDone();
+let commandEncoder137 = device0.createCommandEncoder({});
+let renderPassEncoder53 = commandEncoder137.beginRenderPass({
+  colorAttachments: [{
+  view: textureView31,
+  clearValue: { r: 77.30, g: -133.6, b: -617.6, a: 164.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let externalTexture10 = device0.importExternalTexture({
+  label: '\u6775\u8e70\u34b7\u7801\u8133\ud1c5\u0136\u{1fc2c}\u096f\u7d74',
+  source: videoFrame10,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder74.setBindGroup(2, bindGroup12, new Uint32Array(4886), 296, 0);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer43, 'uint16', 600, 573);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let bindGroup78 = device0.createBindGroup({
+  label: '\ud640\ub2d3\u0426\u{1f858}\ue5ff\u{1fc22}\u{1fcaf}',
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 264, resource: sampler9},
+    {binding: 51, resource: {buffer: buffer15, offset: 512}},
+    {binding: 153, resource: {buffer: buffer15, offset: 1024}},
+    {binding: 8, resource: textureView109},
+    {binding: 9, resource: textureView14},
+    {binding: 57, resource: textureView14},
+    {binding: 172, resource: textureView30},
+    {binding: 462, resource: {buffer: buffer87, offset: 0, size: 2932}},
+    {binding: 67, resource: textureView11},
+  ],
+});
+let buffer92 = device0.createBuffer({
+  size: 5397,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder83.setBindGroup(3, bindGroup55);
+} catch {}
+try {
+computePassEncoder100.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(0, bindGroup11, new Uint32Array(2026), 444, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer2);
+} catch {}
+document.body.prepend(img0);
+await gc();
+let commandEncoder138 = device0.createCommandEncoder({});
+try {
+computePassEncoder97.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer84, 'uint16', 1_784, 1_350);
+} catch {}
+try {
+commandEncoder138.copyTextureToBuffer({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 8, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 188 widthInBlocks: 47 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4476 */
+  offset: 4476,
+  bytesPerRow: 17152,
+  buffer: buffer76,
+}, {width: 47, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let buffer93 = device0.createBuffer({size: 6333, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM});
+let texture116 = device0.createTexture({
+  size: [192, 1, 30],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView118 = texture13.createView({});
+let computePassEncoder101 = commandEncoder138.beginComputePass({});
+let sampler76 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 85.38,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder31.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+computePassEncoder90.setBindGroup(0, bindGroup39, new Uint32Array(680), 52, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup47, new Uint32Array(970), 10, 0);
+} catch {}
+try {
+computePassEncoder17.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+computePassEncoder101.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(7, buffer83, 6_944);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 54}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup79 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 103, resource: textureView3}, {binding: 176, resource: textureView8}],
+});
+let commandEncoder139 = device0.createCommandEncoder({});
+let textureView119 = texture34.createView({baseArrayLayer: 1, arrayLayerCount: 7});
+try {
+computePassEncoder36.setBindGroup(1, bindGroup35, new Uint32Array(1319), 285, 0);
+} catch {}
+try {
+  await promise11;
+} catch {}
+await gc();
+let imageData13 = new ImageData(48, 68);
+let buffer94 = device0.createBuffer({
+  label: '\u089e\u83d3\u6d6c\u07bf\u033a',
+  size: 2557,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture117 = device0.createTexture({
+  size: [73],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder102 = commandEncoder139.beginComputePass({label: '\ubd5f\u0b77\u8d1d\u0034\ua700\u3d3a\u{1fd80}\u5bf2\ucf1e\u678d\u{1fa1c}'});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder102.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer81, 'uint32', 804, 948);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup74);
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  entries: [{binding: 44, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let textureView120 = texture40.createView({dimension: '2d-array'});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup27);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer62, 'uint32', 7_268, 4_493);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 54}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(img1);
+try {
+adapter0.label = '\u7fe3\u73c6\uc5b5\u83de\u5ef8\uee55\uf9e4';
+} catch {}
+let sampler77 = device0.createSampler({
+  label: '\u{1fae2}\u9f2e\u92f6\u{1fb66}\u0f42\udc3d\u{1f73d}\udbae\udb26\ubda3',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.41,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder87.setBindGroup(2, bindGroup73);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(2, bindGroup69, []);
+} catch {}
+let bindGroup80 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 11, resource: {buffer: buffer76, offset: 6912}}]});
+let sampler78 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 45.80,
+  lodMaxClamp: 76.30,
+  maxAnisotropy: 10,
+});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: videoFrame16,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder140 = device0.createCommandEncoder({label: '\u{1f9a4}\u3563\u0be6\ud55d\u{1f93f}\u0632\u0014\u{1f917}\u{1f8a1}'});
+let texture118 = device0.createTexture({
+  size: [110, 10, 26],
+  mipLevelCount: 2,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder103 = commandEncoder140.beginComputePass({});
+try {
+computePassEncoder100.setBindGroup(0, bindGroup8, new Uint32Array(397), 31, 0);
+} catch {}
+try {
+computePassEncoder103.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup18, new Uint32Array(139), 9, 0);
+} catch {}
+try {
+renderPassEncoder18.setViewport(11.721937547712768, 4.254930791749911, 14.858393419905648, 41.75300153661143, 0.4697011585202099, 0.7269280835744327);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer21, 'uint16', 4_366, 45);
+} catch {}
+try {
+  await promise13;
+} catch {}
+let texture119 = device0.createTexture({
+  size: [147, 1, 16],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder98.setBindGroup(2, bindGroup68);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup75, new Uint32Array(3052), 1_982, 0);
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer80, 'uint32', 1_076, 10_696);
+} catch {}
+try {
+  await promise10;
+} catch {}
+let bindGroup81 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 57, resource: textureView22}, {binding: 52, resource: textureView17}],
+});
+let commandEncoder141 = device0.createCommandEncoder({});
+let renderPassEncoder54 = commandEncoder141.beginRenderPass({
+  colorAttachments: [{
+  view: textureView94,
+  clearValue: { r: 600.0, g: 23.14, b: -184.8, a: -709.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet13,
+});
+let sampler79 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 0.7821,
+  lodMaxClamp: 46.20,
+  compare: 'less',
+});
+try {
+computePassEncoder30.end();
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(1, bindGroup37);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder43.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 688 */
+  offset: 688,
+  bytesPerRow: 3584,
+  rowsPerImage: 1542,
+  buffer: buffer4,
+}, {
+  texture: texture20,
+  mipLevel: 2,
+  origin: {x: 7, y: 0, z: 8},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder43.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 64 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1624 */
+  offset: 1624,
+  bytesPerRow: 8448,
+  buffer: buffer92,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer95 = device0.createBuffer({
+  size: 20654,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup51);
+} catch {}
+try {
+commandEncoder43.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 80 */
+  offset: 80,
+  bytesPerRow: 9728,
+  buffer: buffer95,
+}, {
+  texture: texture79,
+  mipLevel: 2,
+  origin: {x: 5, y: 6, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 20, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder104 = commandEncoder43.beginComputePass({});
+try {
+computePassEncoder29.setBindGroup(3, bindGroup44, new Uint32Array(713), 4, 0);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle1]);
+} catch {}
+try {
+  await promise12;
+} catch {}
+let bindGroup82 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 5, resource: sampler61}]});
+let commandEncoder142 = device0.createCommandEncoder({});
+let renderPassEncoder55 = commandEncoder142.beginRenderPass({
+  colorAttachments: [{
+  view: textureView99,
+  depthSlice: 1,
+  clearValue: { r: -844.5, g: 741.0, b: -202.9, a: 38.24, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 32962157,
+});
+try {
+computePassEncoder104.setPipeline(pipeline2);
+} catch {}
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 0, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let buffer96 = device0.createBuffer({size: 19798, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture120 = device0.createTexture({
+  size: {width: 140, height: 145, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder78.setBindGroup(0, bindGroup58, new Uint32Array(1699), 1_072, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder34); computePassEncoder34.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(15);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([renderBundle6, renderBundle6, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(0, buffer6);
+} catch {}
+try {
+renderPassEncoder54.setBlendConstant({ r: 348.5, g: -990.4, b: 2.658, a: -196.0, });
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer84, 'uint16', 10_466, 3_308);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(2, buffer43, 1_152, 101);
+} catch {}
+let pipeline4 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule5, constants: {}}});
+let imageData14 = new ImageData(4, 8);
+let bindGroup83 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 999, resource: textureView79},
+    {binding: 132, resource: textureView48},
+    {binding: 567, resource: textureView30},
+    {binding: 243, resource: textureView57},
+    {binding: 94, resource: textureView60},
+    {binding: 421, resource: {buffer: buffer76, offset: 9472}},
+    {binding: 398, resource: textureView57},
+    {binding: 42, resource: externalTexture1},
+    {binding: 35, resource: textureView10},
+  ],
+});
+let commandEncoder143 = device0.createCommandEncoder({});
+let sampler80 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 99.20,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder61); computePassEncoder61.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer91, 'uint16', 1_810, 2_157);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline1);
+} catch {}
+let bindGroup84 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 176, resource: textureView99}, {binding: 103, resource: textureView44}],
+});
+let commandEncoder144 = device0.createCommandEncoder();
+try {
+computePassEncoder78.setBindGroup(2, bindGroup41);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+computePassEncoder58.insertDebugMarker('\u0c22');
+} catch {}
+let shaderModule11 = device0.createShaderModule({
+  code: `
+enable f16;
+
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(103) var st20: texture_storage_3d<rgba8unorm, write>;
+
+@group(0) @binding(176) var st21: texture_storage_3d<rgba16uint, write>;
+
+struct T0 {
+  @align(256) @size(1024) f0: atomic<u32>,
+}
+
+struct T1 {
+  @align(8) @size(8) f0: array<u32>,
+}
+
+struct T2 {
+  @align(16) @size(16) f0: array<atomic<u32>>,
+}
+
+struct T3 {
+  @size(8) f0: atomic<i32>,
+}
+
+struct VertexOutput10 {
+  @builtin(position) f36: vec4f,
+}
+
+override override4 = 0.3008;
+
+override override5 = true;
+
+override override6 = true;
+
+var<workgroup> vw46: T3;
+
+var<workgroup> vw47: atomic<u32>;
+
+var<workgroup> vw48: atomic<i32>;
+
+var<workgroup> vw49: atomic<u32>;
+
+var<private> vp12 = frexp(vec2f(0.03212, -0.00775));
+
+var<private> vp13 = frexp(f16(13505.7));
+
+@vertex
+fn vertex11() -> VertexOutput10 {
+  var out: VertexOutput10;
+  vp12.exp = vec2i(inverseSqrt(vec4f(unconst_f32(0.1385), unconst_f32(0.1174), unconst_f32(0.2165), unconst_f32(0.00192))).ra);
+  let vf206: u32 = pack2x16snorm(vec2f(unconst_f32(0.05382), unconst_f32(0.01739)));
+  vp13 = frexp(f16(pow(vec3f(unconst_f32(-0.08490), unconst_f32(0.02883), unconst_f32(-0.07836)), vec3f(unconst_f32(0.2919), unconst_f32(0.06211), unconst_f32(0.1246))).y));
+  out.f36 = vec4f(pow(vec3h(pow(vec3f(unconst_f32(0.01135), unconst_f32(0.1670), unconst_f32(0.09860)), vec3f(unconst_f32(0.01704), unconst_f32(0.1490), unconst_f32(0.2933)))), vec3h(f16(pack4xU8(vec4u(unconst_u32(670), unconst_u32(172), unconst_u32(98), unconst_u32(293)))))).brbb);
+  vp12.exp = vec2i(i32(pack4xU8(unpack4xU8(u32(override5)))));
+  let vf207: vec3f = pow(vec3f(unconst_f32(0.4839), unconst_f32(0.00615), unconst_f32(0.1891)), vec3f(unconst_f32(0.1452), unconst_f32(-0.6357), unconst_f32(0.06832)));
+  var vf208: u32 = pack2x16snorm(vec2f(unconst_f32(0.05199), unconst_f32(0.05463)));
+  out.f36 -= vec4f(mix(vec2h(unconst_f16(4833.6), unconst_f16(4672.7)), vec2h(unconst_f16(18861.7), unconst_f16(9219.2)), vec2h(unconst_f16(45883.1), unconst_f16(3438.3))).rgrr);
+  out = VertexOutput10(inverseSqrt(vec4f(unconst_f32(0.09193), unconst_f32(0.3293), unconst_f32(0.06277), unconst_f32(0.3062))));
+  vp12.exp = vec2i(vp13.exp);
+  let ptr83: ptr<private, i32> = &vp13.exp;
+  vf208 &= u32(pow(vec3f(unconst_f32(0.2183), unconst_f32(0.1391), unconst_f32(0.04610)), vec3f(unconst_f32(0.00135), unconst_f32(0.00358), unconst_f32(0.03856))).b);
+  vp12 = frexp(radians(vec2f(unconst_f32(0.07077), unconst_f32(-0.06785))));
+  out.f36 = vec4f(f32(override5));
+  return out;
+  _ = override5;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute10(@builtin(local_invocation_id) a0: vec3u) {
+  vp13 = frexp(abs(vec3h(vp12.fract.yxx)).r);
+  var vf209: f32 = smoothstep(f32(unconst_f32(0.04582)), f32(unconst_f32(-0.06231)), f32(unconst_f32(0.03230)));
+  var vf210: vec3f = normalize(vec3f(bitcast<f32>(pack2x16unorm(vec2f(unconst_f32(0.04964), unconst_f32(0.01100))))));
+  vp12.fract -= vec2f(f32(vp13.fract));
+  var vf211: i32 = atomicLoad(&vw46.f0);
+  let ptr84: ptr<workgroup, T3> = &vw46;
+  var vf212: i32 = atomicLoad(&vw46.f0);
+  var vf213: vec4u = unpack4xU8(u32(unconst_u32(49)));
+  let vf214: f16 = acosh(f16(unconst_f16(4717.2)));
+  let ptr85: ptr<workgroup, T3> = &vw46;
+  vf210 = vec3f(f32(atomicLoad(&(*&vw46).f0)));
+}`,
+  hints: {},
+});
+let bindGroupLayout17 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 78, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 113,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let buffer97 = device0.createBuffer({size: 12231, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let renderPassEncoder56 = commandEncoder144.beginRenderPass({
+  colorAttachments: [{
+  view: textureView94,
+  clearValue: { r: 602.9, g: 511.5, b: 982.7, a: -590.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet11,
+});
+try {
+renderPassEncoder39.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+renderPassEncoder25.setStencilReference(37);
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+try {
+commandEncoder143.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1512 */
+  offset: 1480,
+  bytesPerRow: 6656,
+  buffer: buffer72,
+}, {
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 14},
+  aspect: 'all',
+}, {width: 8, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder45.insertDebugMarker('\udda4');
+} catch {}
+let bindGroup85 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 211, resource: sampler49},
+    {binding: 62, resource: textureView57},
+    {binding: 86, resource: textureView23},
+  ],
+});
+try {
+computePassEncoder96.setBindGroup(3, bindGroup44);
+} catch {}
+try {
+computePassEncoder56.setBindGroup(2, bindGroup41, new Uint32Array(1884), 1_360, 0);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer21, 'uint16', 2_598, 1_194);
+} catch {}
+let textureView121 = texture20.createView({dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 5});
+let computePassEncoder105 = commandEncoder143.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder5); computePassEncoder5.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup43);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let commandEncoder145 = device0.createCommandEncoder({});
+let texture121 = device0.createTexture({
+  size: [36, 1, 1],
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderPassEncoder57 = commandEncoder145.beginRenderPass({
+  colorAttachments: [{
+  view: textureView120,
+  clearValue: { r: 128.4, g: -970.0, b: 462.2, a: -219.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder104.setBindGroup(0, bindGroup69);
+} catch {}
+try {
+computePassEncoder29.setBindGroup(0, bindGroup39, new Uint32Array(468), 113, 0);
+} catch {}
+try {
+renderPassEncoder47.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(buffer95, 'uint16', 2_156, 331);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let bindGroup86 = device0.createBindGroup({
+  label: '\u55c9\u6cdf\u02ea\u041c\u44ac\uf4ae\u{1fb0e}',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 86, resource: textureView17},
+    {binding: 62, resource: textureView57},
+    {binding: 211, resource: sampler54},
+  ],
+});
+let textureView122 = texture49.createView({label: '\u03e4\ud680\u0d31\u7834\u{1faf2}\u64ea\u991c\u6bfe\u{1fa0b}', aspect: 'all'});
+let texture122 = device0.createTexture({
+  size: [220, 20, 156],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder101.setBindGroup(0, bindGroup79);
+} catch {}
+try {
+computePassEncoder105.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+let videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'unspecified', transfer: 'iec61966-2-1'} });
+try {
+globalThis.someLabel = externalTexture0.label;
+} catch {}
+let textureView123 = texture117.createView({});
+let sampler81 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 29.35,
+  lodMaxClamp: 36.35,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder60); computePassEncoder60.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer28, 'uint32', 100, 801);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_DST});
+} catch {}
+let buffer98 = device0.createBuffer({
+  size: 5728,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder146 = device0.createCommandEncoder({});
+let textureView124 = texture65.createView({baseArrayLayer: 2, arrayLayerCount: 6});
+let sampler82 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  lodMinClamp: 54.62,
+  lodMaxClamp: 87.88,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder68.setBindGroup(3, bindGroup43, []);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup9, new Uint32Array(2613), 66, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 147, height: 1, depthOrArrayLayers: 9}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture110,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+await gc();
+let videoFrame19 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'bt470m', transfer: 'bt2020_10bit'} });
+let bindGroupLayout18 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 204, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let bindGroup87 = device0.createBindGroup({
+  layout: bindGroupLayout17,
+  entries: [{binding: 78, resource: sampler59}, {binding: 113, resource: textureView109}],
+});
+let sampler83 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 5.439,
+  lodMaxClamp: 53.48,
+});
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup85);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup68, new Uint32Array(579), 20, 0);
+} catch {}
+try {
+renderPassEncoder29.setViewport(30.309218784495187, 0.4881356777107151, 58.55187182788767, 0.16552821604416243, 0.6390498684764568, 0.8399279239191656);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(1, buffer94, 60);
+} catch {}
+let texture123 = device0.createTexture({
+  size: {width: 70, height: 72, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView125 = texture25.createView({label: '\u13ff\u4d29\u1eb9\u09aa\u0a0a', dimension: '3d', aspect: 'all', mipLevelCount: 1});
+let computePassEncoder106 = commandEncoder146.beginComputePass({});
+try {
+renderPassEncoder19.executeBundles([renderBundle7, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer53, 'uint32', 1_072, 42);
+} catch {}
+let arrayBuffer9 = buffer35.getMappedRange(184, 68);
+let commandEncoder147 = device0.createCommandEncoder({});
+let texture124 = device0.createTexture({
+  size: {width: 110},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder58 = commandEncoder147.beginRenderPass({
+  colorAttachments: [{
+  view: textureView51,
+  depthSlice: 4,
+  clearValue: { r: 346.4, g: 268.6, b: -685.2, a: -186.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet6,
+});
+try {
+device0.queue.writeBuffer(buffer56, 1316, new DataView(new ArrayBuffer(23048)), 3911, 2468);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 54}
+*/
+{
+  source: imageData1,
+  origin: { x: 4, y: 0 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 30},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let sampler84 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.25,
+  lodMaxClamp: 74.25,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder106.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer83, 'uint32', 2_228, 2_628);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 28, new BigUint64Array(575), 94, 276);
+} catch {}
+let commandEncoder148 = device0.createCommandEncoder({});
+let externalTexture11 = device0.importExternalTexture({label: '\u0be0\u{1fa8b}', source: videoFrame8});
+try {
+computePassEncoder21.setBindGroup(2, bindGroup41, []);
+} catch {}
+try {
+computePassEncoder61.setBindGroup(2, bindGroup29, new Uint32Array(2229), 1_699, 0);
+} catch {}
+try {
+renderPassEncoder56.executeBundles([renderBundle2, renderBundle1, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder42.setBlendConstant({ r: -265.2, g: -128.3, b: -272.7, a: 45.37, });
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(4, buffer62, 0, 3_762);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder148.copyBufferToTexture({
+  /* bytesInLastRow: 256 widthInBlocks: 64 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 188 */
+  offset: 188,
+  bytesPerRow: 3584,
+  buffer: buffer48,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 4, y: 13, z: 0},
+  aspect: 'all',
+}, {width: 64, height: 97, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let buffer99 = device0.createBuffer({
+  size: 18764,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder149 = device0.createCommandEncoder({});
+let texture125 = device0.createTexture({
+  label: '\u86c1\u04ef\u0262\u1303\u0e6f\u35b5\u050c\ue54a\uf43d',
+  size: [70, 72, 1531],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder107 = commandEncoder149.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder5); computePassEncoder5.dispatchWorkgroupsIndirect(buffer73, 164); };
+} catch {}
+try {
+computePassEncoder107.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder35.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer91, 'uint32', 3_936, 75);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+await gc();
+let buffer100 = device0.createBuffer({
+  size: 2410,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder150 = device0.createCommandEncoder({});
+let textureView126 = texture87.createView({baseArrayLayer: 0});
+let computePassEncoder108 = commandEncoder150.beginComputePass({label: '\u047a\u0170'});
+let renderPassEncoder59 = commandEncoder148.beginRenderPass({colorAttachments: [{view: textureView31, loadOp: 'clear', storeOp: 'discard'}]});
+let sampler85 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 85.50,
+  lodMaxClamp: 92.03,
+});
+let externalTexture12 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder42.setBindGroup(0, bindGroup37, new Uint32Array(16), 2, 0);
+} catch {}
+try {
+computePassEncoder108.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder46.executeBundles([renderBundle3]);
+} catch {}
+try {
+buffer56.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_DST});
+} catch {}
+let buffer101 = device0.createBuffer({
+  size: 34143,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder151 = device0.createCommandEncoder({label: '\u0aab\u3446\u059b'});
+try {
+renderPassEncoder52.setBindGroup(3, bindGroup39, new Uint32Array(210), 23, 0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer30, 'uint32', 0, 3);
+} catch {}
+try {
+commandEncoder151.copyTextureToTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture84,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 3, y: 15, z: 0},
+  aspect: 'all',
+}, new Uint8Array(175).fill(54), /* required buffer size: 175 */
+{offset: 175, bytesPerRow: 32, rowsPerImage: 111}, {width: 1, height: 14, depthOrArrayLayers: 0});
+} catch {}
+let buffer102 = device0.createBuffer({
+  size: 1004,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder152 = device0.createCommandEncoder({});
+let texture126 = device0.createTexture({
+  size: {width: 147, height: 1, depthOrArrayLayers: 40},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder109 = commandEncoder151.beginComputePass({});
+try {
+computePassEncoder98.setBindGroup(2, bindGroup49);
+} catch {}
+try {
+computePassEncoder57.setBindGroup(1, bindGroup44, new Uint32Array(96), 0, 0);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer10, 0, 2_989);
+} catch {}
+await gc();
+let commandEncoder153 = device0.createCommandEncoder({label: '\ub7e9\u{1f9b4}\u7976\u7ff1\u360a\u24b7\u{1f6f1}\ub0ce\u5463'});
+let sampler86 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 40.70,
+  lodMaxClamp: 82.35,
+});
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup53);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let computePassEncoder110 = commandEncoder153.beginComputePass();
+let sampler87 = device0.createSampler({
+  label: '\uc031\u2f43\u0bc0\u0469\uf995\u04fd\u8e1b\u5f1a\ucf79',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 70.03,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder36.setBindGroup(1, bindGroup34, new Uint32Array(3183), 1_212, 0);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(0, bindGroup50, new Uint32Array(6117), 455, 0);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(6, buffer86);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer44, 8196, new BigUint64Array(17330), 609, 540);
+} catch {}
+let commandEncoder154 = device0.createCommandEncoder({});
+let computePassEncoder111 = commandEncoder152.beginComputePass({});
+let sampler88 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.02,
+  compare: 'greater',
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder94.setBindGroup(0, bindGroup16, []);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer71, 'uint32', 1_820, 4_422);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(4, buffer15, 0, 1_530);
+} catch {}
+let arrayBuffer10 = buffer35.getMappedRange(256, 8);
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer97, 364, new BigUint64Array(16964), 2905, 92);
+} catch {}
+let bindGroup88 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 52, resource: textureView104}, {binding: 57, resource: textureView22}],
+});
+let commandEncoder155 = device0.createCommandEncoder({});
+let textureView127 = texture92.createView({});
+let computePassEncoder112 = commandEncoder155.beginComputePass();
+try {
+computePassEncoder110.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup29, new Uint32Array(8460), 885, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 295, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: img1,
+  origin: { x: 0, y: 4 },
+  flipY: true,
+}, {
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 11},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder113 = commandEncoder154.beginComputePass({});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], sampleCount: 4, depthReadOnly: true, stencilReadOnly: true});
+let renderBundle8 = renderBundleEncoder8.finish({});
+let sampler89 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 56.95,
+  lodMaxClamp: 60.89,
+});
+try {
+computePassEncoder55.setBindGroup(1, bindGroup44);
+} catch {}
+try {
+computePassEncoder61.end();
+} catch {}
+try {
+computePassEncoder113.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup30, []);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle7]);
+} catch {}
+let commandEncoder156 = device0.createCommandEncoder({});
+try {
+computePassEncoder50.setBindGroup(2, bindGroup36, new Uint32Array(2165), 499, 0);
+} catch {}
+try {
+computePassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(7, buffer10, 2_236, 2_309);
+} catch {}
+try {
+commandEncoder86.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4948 */
+  offset: 4948,
+  buffer: buffer95,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 5},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder156.resolveQuerySet(querySet2, 265, 178, buffer19, 256);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 54}
+*/
+{
+  source: videoFrame13,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 11},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup89 = device0.createBindGroup({
+  label: '\ue269\u{1f95b}\u934d\u2df4\u{1f9b5}\u5c59\u{1faea}\ude18\uae48\u3f94\u0ea9',
+  layout: bindGroupLayout15,
+  entries: [{binding: 44, resource: externalTexture4}],
+});
+let commandEncoder157 = device0.createCommandEncoder({});
+let computePassEncoder114 = commandEncoder86.beginComputePass();
+let sampler90 = device0.createSampler({
+  label: '\u9bf2\u{1ffe6}\ube26\ubc51\u95a1\u3b01\u{1f885}\uee9c\ucf72',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 81.46,
+  lodMaxClamp: 98.90,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder109.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(1, bindGroup64, new Uint32Array(756), 110, 0);
+} catch {}
+let buffer103 = device0.createBuffer({
+  size: 431,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder158 = device0.createCommandEncoder();
+let computePassEncoder115 = commandEncoder8.beginComputePass({});
+let renderPassEncoder60 = commandEncoder157.beginRenderPass({colorAttachments: [{view: textureView82, depthSlice: 8, loadOp: 'load', storeOp: 'discard'}]});
+let sampler91 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.43,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder115.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer24);
+} catch {}
+let querySet14 = device0.createQuerySet({label: '\ua53d\u59d3\u7d7c', type: 'occlusion', count: 589});
+let computePassEncoder116 = commandEncoder156.beginComputePass({});
+let sampler92 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.79,
+  lodMaxClamp: 87.45,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder47); computePassEncoder47.dispatchWorkgroupsIndirect(buffer25, 1_264); };
+} catch {}
+try {
+commandEncoder158.copyBufferToTexture({
+  /* bytesInLastRow: 480 widthInBlocks: 60 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1024 */
+  offset: 1024,
+  bytesPerRow: 23296,
+  rowsPerImage: 1205,
+  buffer: buffer83,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 58, y: 6, z: 0},
+  aspect: 'all',
+}, {width: 60, height: 23, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder112.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(721);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+let texture127 = gpuCanvasContext0.getCurrentTexture();
+let textureView128 = texture10.createView({dimension: '2d-array', aspect: 'depth-only', mipLevelCount: 1});
+try {
+computePassEncoder110.setBindGroup(0, bindGroup74, new Uint32Array(5788), 1_826, 0);
+} catch {}
+try {
+computePassEncoder114.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 3288, new Int16Array(8732), 224, 688);
+} catch {}
+try {
+globalThis.someLabel = computePassEncoder112.label;
+} catch {}
+let shaderModule12 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+requires readonly_and_readwrite_storage_textures;
+
+requires readonly_and_readwrite_storage_textures;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(58) var<uniform> buffer104: array<array<array<array<vec4f, 13>, 1>, 16>, 1>;
+
+@group(0) @binding(225) var tex0: texture_depth_2d;
+
+struct T0 {
+  @align(64) @size(3328) f0: array<atomic<i32>>,
+}
+
+struct T1 {
+  @size(3328) f0: array<u32>,
+}
+
+struct T2 {
+  @align(64) @size(64) f0: array<vec2h>,
+}
+
+struct T3 {
+  @align(128) @size(256) f0: mat3x2h,
+  @size(3072) f1: array<array<mat2x4h, 1>>,
+}
+
+struct T4 {
+  @size(256) f0: array<atomic<u32>, 1>,
+  @align(256) @size(3072) f1: array<atomic<u32>>,
+}
+
+struct VertexOutput11 {
+  @invariant @builtin(position) f37: vec4f,
+}
+
+alias vec3b = vec3<bool>;
+
+fn fn0() -> array<array<array<u32, 1>, 58>, 1> {
+  var out: array<array<array<u32, 1>, 58>, 1>;
+  out[u32(unconst_u32(154))][pack4xU8(vec4u(buffer104[0][u32(unconst_u32(117))][u32(unconst_u32(51))][bitcast<u32>((*&buffer104)[0][15][0][u32(unconst_u32(99))][u32(unconst_u32(110))])]))][0] = pack4x8unorm(buffer104[u32(unconst_u32(82))][15][0][12]);
+  out[u32(unconst_u32(223))][57][u32(unconst_u32(153))] = pack4xU8(bitcast<vec4u>((*&buffer104)[u32(unconst_u32(2))][15][u32(unconst_u32(82))][12]));
+  out[0][u32(unconst_u32(90))][u32(unconst_u32(554))] = pack4xU8(vec4u((*&buffer104)[0][15][0][12]));
+  out[u32(unconst_u32(277))][u32(unconst_u32(5))][u32((*&buffer104)[bitcast<u32>(buffer104[0][u32(unconst_u32(115))][u32(unconst_u32(166))][u32(unconst_u32(444))][u32(unconst_u32(473))])][u32(unconst_u32(145))][0][12][3])] >>= bitcast<u32>(radians(vec2h(unconst_f16(12268.8), unconst_f16(21544.1))));
+  let ptr86: ptr<uniform, vec4f> = &(*&buffer104)[0][u32(unconst_u32(173))][u32(unconst_u32(81))][12];
+  out[u32(unconst_u32(326))][u32(unconst_u32(52))][0] <<= pack4x8unorm(buffer104[u32(unconst_u32(95))][u32(unconst_u32(27))][0][pack4x8snorm(buffer104[0][15][pack2x16unorm(vec2f(unconst_f32(0.1874), unconst_f32(0.2190)))][12])]);
+  out[0][u32((*&buffer104)[pack4xU8Clamp(vec4u(buffer104[0][15][0][12]))][15][u32(unconst_u32(188))][u32(unconst_u32(10))][u32(unconst_u32(440))])][bitcast<u32>(buffer104[bitcast<vec4u>((*&buffer104)[u32(unconst_u32(8))][u32(unconst_u32(59))][pack4x8snorm(buffer104[u32(unconst_u32(210))][u32(unconst_u32(37))][u32(unconst_u32(307))][12])][12]).z][15][0][12][3])] *= u32((*&buffer104)[u32(unconst_u32(91))][u32(unconst_u32(235))][u32(unconst_u32(219))][u32(unconst_u32(132))][u32(unconst_u32(501))]);
+  let ptr87: ptr<uniform, vec4f> = &(*&buffer104)[u32(unconst_u32(292))][15][0][12];
+  let vf215: f32 = buffer104[0][u32(unconst_u32(774))][u32(unconst_u32(114))][u32(unconst_u32(410))][u32(unconst_u32(137))];
+  out[u32(unconst_u32(198))][57][u32(unconst_u32(28))] |= bitcast<u32>(buffer104[0][15][u32(unconst_u32(124))][u32(unconst_u32(60))][u32(unconst_u32(50))]);
+  out[u32(unconst_u32(201))][u32(unconst_u32(74))][u32(unconst_u32(48))] = u32(tan(f16(unconst_f16(369.7))));
+  out[u32(unconst_u32(297))][u32(unconst_u32(161))][u32(unconst_u32(325))] = pack4x8snorm(buffer104[u32(unconst_u32(10))][15][u32(unconst_u32(46))][12]);
+  out[0][u32(unconst_u32(199))][0] *= bitcast<u32>(buffer104[pack4x8snorm(buffer104[0][15][0][12])][15][0][12][u32(unconst_u32(97))]);
+  let ptr88: ptr<uniform, array<array<vec4f, 13>, 1>> = &buffer104[0][u32(unconst_u32(227))];
+  let ptr89: ptr<uniform, vec4f> = &(*&buffer104)[0][15][0][12];
+  let ptr90: ptr<uniform, array<array<array<array<vec4f, 13>, 1>, 16>, 1>> = &(*&buffer104);
+  return out;
+}
+
+fn fn1() -> array<VertexOutput11, 1> {
+  var out: array<VertexOutput11, 1>;
+  let vf216: vec2f = unpack2x16unorm(u32(unconst_u32(11)));
+  var vf217: f32 = textureLoad(tex0, vec2i(unconst_i32(-21), unconst_i32(32)), i32(unconst_i32(46)));
+  let vf218: vec4h = exp2(vec4h(unconst_f16(11792.3), unconst_f16(4429.7), unconst_f16(-12386.5), unconst_f16(19334.0)));
+  var vf219: vec4f = sin(vec4f(unconst_f32(0.5282), unconst_f32(0.2169), unconst_f32(-0.01403), unconst_f32(0.07062)));
+  let vf220: u32 = pack2x16snorm(vec2f(unconst_f32(0.1324), unconst_f32(0.02418)));
+  let vf221: u32 = textureNumLevels(tex0);
+  let vf222: f32 = vf219[u32(unconst_u32(197))];
+  vf219 = bitcast<vec4f>(countOneBits(vec3i(unconst_i32(178), unconst_i32(563), unconst_i32(198))).brgb);
+  var vf223: u32 = vf220;
+  let ptr91: ptr<function, u32> = &vf223;
+  let vf224: f32 = vf219[u32(unconst_u32(117))];
+  var vf225: u32 = vf221;
+  var vf226: f32 = vf216[pack4xI8Clamp(vec4i(unconst_i32(54), unconst_i32(647), unconst_i32(3), unconst_i32(192)))];
+  return out;
+}
+
+var<workgroup> vw50: array<array<array<mat3x3f, 1>, 1>, 1>;
+
+var<workgroup> vw51: array<atomic<i32>, 21>;
+
+var<workgroup> vw52: atomic<i32>;
+
+var<workgroup> vw53: array<vec2i, 1>;
+
+var<workgroup> vw54: VertexOutput11;
+
+@vertex
+fn vertex12(@location(2) a0: vec4f, @location(12) a1: vec2h) -> VertexOutput11 {
+  var out: VertexOutput11;
+  var vf227 = fn1();
+  vf227[u32(vf227[u32(unconst_u32(74))].f37[u32(unconst_u32(123))])].f37 *= vf227[u32(unconst_u32(330))].f37;
+  var vf228 = fn1();
+  vf228[u32(unconst_u32(1))].f37 *= vf228[0].f37;
+  let ptr92: ptr<function, vec4f> = &vf227[u32(unconst_u32(90))].f37;
+  out.f37 += bitcast<vec4f>(textureDimensions(tex0).xyxx);
+  var vf229 = fn1();
+  fn1();
+  out = VertexOutput11(vec4f(determinant(mat4x4f(unconst_f32(0.05077), unconst_f32(0.07971), unconst_f32(0.2079), unconst_f32(0.1197), unconst_f32(0.09585), unconst_f32(0.08026), unconst_f32(0.06861), unconst_f32(0.2036), unconst_f32(0.1884), unconst_f32(0.00260), unconst_f32(0.2690), unconst_f32(0.2116), unconst_f32(0.3501), unconst_f32(0.04959), unconst_f32(-0.1941), unconst_f32(0.00771)))));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute11() {
+  fn0();
+  vw54.f37 -= (*&vw50)[u32(unconst_u32(67))][0][u32(unconst_u32(51))][u32(unconst_u32(47))].zyzx;
+  var vf230 = fn1();
+  vw53[u32(unconst_u32(258))] = vec2i(vw50[u32(unconst_u32(55))][0][0][unconst_i32(2)].rr);
+  let ptr93: ptr<workgroup, VertexOutput11> = &(*&vw54);
+}`,
+});
+let bindGroup90 = device0.createBindGroup({layout: bindGroupLayout15, entries: [{binding: 44, resource: externalTexture8}]});
+let buffer105 = device0.createBuffer({
+  size: 2845,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let computePassEncoder117 = commandEncoder158.beginComputePass({label: '\u447b\u{1f6fb}\u101e\u6b14\u01f1\u8b56'});
+let sampler93 = device0.createSampler({
+  label: '\u5d06\u97fc\u05c3\u0027\ucdb8',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 50.08,
+  lodMaxClamp: 79.42,
+  compare: 'less-equal',
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder77.setBindGroup(3, bindGroup86, new Uint32Array(2888), 397, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer52, 740, new Float32Array(5727), 419, 16);
+} catch {}
+let bindGroup91 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [{binding: 272, resource: {buffer: buffer100, offset: 0, size: 208}}],
+});
+let buffer106 = device0.createBuffer({
+  label: '\u337a\uc3ef\u{1f9cc}\u530e\u{1fc6d}\u5044\u113e\u{1f7b5}\u070e\u32c6\ue9b5',
+  size: 3844,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder159 = device0.createCommandEncoder({});
+let externalTexture13 = device0.importExternalTexture({source: videoFrame8});
+try {
+computePassEncoder116.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup16, new Uint32Array(532), 318, 0);
+} catch {}
+try {
+commandEncoder159.copyBufferToTexture({
+  /* bytesInLastRow: 84 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1944 */
+  offset: 1944,
+  bytesPerRow: 7680,
+  buffer: buffer100,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 9, y: 7, z: 0},
+  aspect: 'all',
+}, {width: 21, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let videoFrame20 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'jedecP22Phosphors', transfer: 'bt2020_12bit'} });
+let commandEncoder160 = device0.createCommandEncoder({});
+let textureView129 = texture86.createView({
+  label: '\u7a2d\u{1f6eb}\ue72a\u087e\ub62d\u{1fda7}\uea97\u05b6\u887f',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+let computePassEncoder118 = commandEncoder159.beginComputePass();
+let renderPassEncoder61 = commandEncoder160.beginRenderPass({
+  colorAttachments: [{
+  view: textureView29,
+  depthSlice: 185,
+  clearValue: { r: -230.2, g: 533.6, b: -628.1, a: -9.904, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet9,
+  maxDrawCount: 376292232,
+});
+try {
+computePassEncoder117.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup49, new Uint32Array(3800), 407, 0);
+} catch {}
+let img3 = await imageWithData(92, 30, '#10101010', '#20202020');
+try {
+computePassEncoder95.setBindGroup(3, bindGroup13, new Uint32Array(112), 19, 0);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer42, 'uint16', 196, 301);
+} catch {}
+let videoFrame21 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'smpte240m', transfer: 'iec6196624'} });
+let commandEncoder161 = device0.createCommandEncoder({});
+let textureView130 = texture119.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder119 = commandEncoder161.beginComputePass();
+try {
+computePassEncoder119.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(3, bindGroup89, []);
+} catch {}
+try {
+renderPassEncoder45.executeBundles([renderBundle0, renderBundle0, renderBundle3, renderBundle3, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline1);
+} catch {}
+try {
+buffer47.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageBitmap2 = await createImageBitmap(videoFrame10);
+let commandEncoder162 = device0.createCommandEncoder({});
+let computePassEncoder120 = commandEncoder162.beginComputePass({});
+try {
+computePassEncoder40.setBindGroup(3, bindGroup72);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(img2);
+let bindGroup92 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 211, resource: sampler59},
+    {binding: 86, resource: textureView104},
+    {binding: 62, resource: textureView57},
+  ],
+});
+let texture128 = device0.createTexture({
+  size: {width: 220, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder120.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer83, 'uint16', 4_786, 2_978);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(6, buffer18, 1_448);
+} catch {}
+try {
+computePassEncoder111.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup81, new Uint32Array(1094), 195, 0);
+} catch {}
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(1, buffer101, 0, 2_529);
+} catch {}
+try {
+commandEncoder6.copyBufferToBuffer(buffer89, 320, buffer23, 8748, 140);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer25, 2684, new DataView(new ArrayBuffer(13791)), 1555, 108);
+} catch {}
+let imageData15 = new ImageData(84, 20);
+let buffer107 = device0.createBuffer({
+  size: 25156,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder163 = device0.createCommandEncoder({});
+try {
+computePassEncoder50.end();
+} catch {}
+try {
+computePassEncoder118.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 240 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 928 */
+  offset: 928,
+  bytesPerRow: 2816,
+  buffer: buffer41,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 70, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture129 = device0.createTexture({
+  size: {width: 140, height: 145, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder121 = commandEncoder163.beginComputePass({label: '\u28e4\u{1ff66}\u646a\u7307\u0568\ua772\ue6c3\u03ce'});
+let renderPassEncoder62 = commandEncoder6.beginRenderPass({
+  colorAttachments: [{
+  view: textureView97,
+  clearValue: { r: -80.12, g: 381.8, b: -355.7, a: 873.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder121.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(1, bindGroup29);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer95, 'uint32', 548, 1_773);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(4, buffer2, 1_428);
+} catch {}
+try {
+renderPassEncoder35.insertDebugMarker('\udefa');
+} catch {}
+let bindGroup93 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 54, resource: {buffer: buffer63, offset: 1024, size: 3688}},
+    {binding: 53, resource: externalTexture1},
+  ],
+});
+let buffer108 = device0.createBuffer({
+  label: '\u{1f7cc}\u3348\u{1f797}',
+  size: 4700,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let texture130 = device0.createTexture({
+  label: '\u5be6\u{1fae0}\u858d\u216d\u01e1',
+  size: [36, 1, 12],
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView131 = texture61.createView({baseMipLevel: 0, baseArrayLayer: 0});
+let computePassEncoder122 = commandEncoder16.beginComputePass({});
+try {
+computePassEncoder94.setBindGroup(1, bindGroup27, new Uint32Array(3274), 177, 0);
+} catch {}
+try {
+computePassEncoder122.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder119.insertDebugMarker('\u036c');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer51, 1848, new Int16Array(5797), 330, 72);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 1,
+  origin: {x: 6, y: 23, z: 0},
+  aspect: 'all',
+}, new Uint8Array(105).fill(88), /* required buffer size: 105 */
+{offset: 105, bytesPerRow: 53, rowsPerImage: 39}, {width: 0, height: 15, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup94 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 103, resource: textureView85}, {binding: 176, resource: textureView51}],
+});
+let commandEncoder164 = device0.createCommandEncoder({});
+let computePassEncoder123 = commandEncoder164.beginComputePass();
+let externalTexture14 = device0.importExternalTexture({source: videoFrame6});
+try {
+computePassEncoder75.setBindGroup(3, bindGroup48);
+} catch {}
+try {
+computePassEncoder108.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder123.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup37, new Uint32Array(2713), 323, 0);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer105, 'uint16', 144, 679);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+let texture131 = device0.createTexture({
+  size: {width: 140, height: 145, depthOrArrayLayers: 10},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup88, new Uint32Array(4984), 959, 0);
+} catch {}
+try {
+renderPassEncoder61.setIndexBuffer(buffer15, 'uint32', 1_024, 1_188);
+} catch {}
+let commandEncoder165 = device0.createCommandEncoder({});
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 450});
+let computePassEncoder124 = commandEncoder165.beginComputePass({});
+let sampler94 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 36.95,
+  lodMaxClamp: 87.06,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder117.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+computePassEncoder88.setBindGroup(2, bindGroup42, new Uint32Array(798), 122, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder71); computePassEncoder71.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder40); computePassEncoder40.dispatchWorkgroupsIndirect(buffer54, 4_560); };
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup79, new Uint32Array(12), 0, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(0, 85, 0, 312_040_344);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer90, 260);
+} catch {}
+let bindGroup95 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 11, resource: {buffer: buffer102, offset: 0}}]});
+let commandEncoder166 = device0.createCommandEncoder({});
+let computePassEncoder125 = commandEncoder166.beginComputePass();
+try {
+computePassEncoder71.end();
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.draw(0, 79, 1, 797_414_109);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(128, 98, 16, 68_770_610, 570_100_848);
+} catch {}
+let videoFrame22 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'bt470m', transfer: 'bt709'} });
+let commandBuffer7 = commandEncoder97.finish();
+let textureView132 = texture112.createView({aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 7, arrayLayerCount: 1});
+let sampler95 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMinClamp: 9.854,
+  lodMaxClamp: 38.97,
+});
+try {
+renderPassEncoder11.drawIndexed(85, 134, 11, 395_962_503, 1_060_046_481);
+} catch {}
+let commandEncoder167 = device0.createCommandEncoder({});
+let textureView133 = texture20.createView({mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 2});
+let computePassEncoder126 = commandEncoder167.beginComputePass({});
+let sampler96 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder51.setBindGroup(2, bindGroup75, new Uint32Array(2561), 738, 0);
+} catch {}
+try {
+computePassEncoder124.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(0, bindGroup93);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(3, bindGroup73, new Uint32Array(3643), 2_442, 0);
+} catch {}
+let imageData16 = new ImageData(12, 16);
+let bindGroup96 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 277, resource: sampler12}]});
+try {
+computePassEncoder112.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup7, []);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(5, 0, 74, 926_558_333, 43_022_389);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline1);
+} catch {}
+let commandEncoder168 = device0.createCommandEncoder({});
+let texture132 = device0.createTexture({
+  size: [440],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder127 = commandEncoder168.beginComputePass({});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u5290\u4482\u6547\u{1f9d8}\u{1f90d}\u{1ff8f}\u0f75\u00c4\uba26',
+  colorFormats: ['rgb10a2unorm'],
+  depthStencilFormat: 'depth24plus',
+});
+let sampler97 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 40.58,
+  lodMaxClamp: 44.94,
+});
+try {
+computePassEncoder108.setBindGroup(0, bindGroup16, []);
+} catch {}
+try {
+computePassEncoder33.setBindGroup(3, bindGroup85, new Uint32Array(673), 108, 0);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup16, new Uint32Array(1059), 513, 0);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(57, 20, 17, 76_148_165, 266_750_746);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer20, 104);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer19, 324);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup24, new Uint32Array(432), 19, 0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(6, buffer62, 0);
+} catch {}
+try {
+computePassEncoder98.setBindGroup(2, bindGroup11, new Uint32Array(2318), 14, 0);
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+renderPassEncoder53.setViewport(30.158332463208048, 0.3703301249095359, 22.527001102130544, 0.31567622919086413, 0.8306538929313358, 0.8710582432348876);
+} catch {}
+try {
+renderPassEncoder11.draw(0, 191, 0, 802_813_346);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(144, 101, 7, 688_451_846, 3_444_187);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer100, 672);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(0, buffer83);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let bindGroup97 = device0.createBindGroup({
+  label: '\u150b\u37a6\u3a24\u2203\u0435\u{1fa0a}\u40d7',
+  layout: bindGroupLayout7,
+  entries: [{binding: 54, resource: {buffer: buffer107, offset: 6400}}, {binding: 53, resource: externalTexture12}],
+});
+let texture133 = device0.createTexture({
+  size: {width: 73, height: 1, depthOrArrayLayers: 51},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundle9 = renderBundleEncoder9.finish({});
+try {
+computePassEncoder69.end();
+} catch {}
+try {
+computePassEncoder126.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer105, 'uint16', 318, 179);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(4, buffer91, 744, 681);
+} catch {}
+try {
+buffer83.unmap();
+} catch {}
+try {
+commandEncoder93.copyTextureToBuffer({
+  texture: texture79,
+  mipLevel: 2,
+  origin: {x: 28, y: 14, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 44 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 740 */
+  offset: 740,
+  bytesPerRow: 26880,
+  rowsPerImage: 413,
+  buffer: buffer87,
+}, {width: 11, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: videoFrame16,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder169 = device0.createCommandEncoder();
+let computePassEncoder128 = commandEncoder169.beginComputePass({label: '\ua675\u0475\ub0b9\u85fc\uf737'});
+try {
+computePassEncoder97.setBindGroup(0, bindGroup67, new Uint32Array(1727), 366, 0);
+} catch {}
+try {
+computePassEncoder127.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer42, 4);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder93.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3808 */
+  offset: 3808,
+  bytesPerRow: 20224,
+  buffer: buffer11,
+}, {
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 43, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder93.resolveQuerySet(querySet2, 186, 818, buffer72, 2816);
+} catch {}
+try {
+computePassEncoder96.insertDebugMarker('\ufa0b');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+let bindGroupLayout19 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 361,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: true },
+    },
+  ],
+});
+let buffer109 = device0.createBuffer({
+  label: '\u9d73\u523a',
+  size: 2549,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder170 = device0.createCommandEncoder({});
+try {
+computePassEncoder117.setBindGroup(0, bindGroup23, new Uint32Array(1532), 488, 0);
+} catch {}
+try {
+computePassEncoder128.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(62, 140, 3, 139_945_384, 919_621_341);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer101, 1_764);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer95, 11_444);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let videoFrame23 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'smpteRp431', transfer: 'iec6196624'} });
+let texture134 = device0.createTexture({
+  size: {width: 440, height: 40, depthOrArrayLayers: 53},
+  mipLevelCount: 2,
+  format: 'astc-8x5-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder129 = commandEncoder93.beginComputePass({});
+try {
+computePassEncoder125.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder170.copyBufferToTexture({
+  /* bytesInLastRow: 2696 widthInBlocks: 337 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 424 */
+  offset: 424,
+  bytesPerRow: 27648,
+  buffer: buffer83,
+}, {
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 31, y: 124, z: 0},
+  aspect: 'all',
+}, {width: 337, height: 240, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img3);
+let computePassEncoder130 = commandEncoder170.beginComputePass({});
+try {
+computePassEncoder49.setBindGroup(0, bindGroup42);
+} catch {}
+try {
+computePassEncoder126.setBindGroup(1, bindGroup92, new Uint32Array(2033), 376, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder17); computePassEncoder17.dispatchWorkgroupsIndirect(buffer91, 180); };
+} catch {}
+try {
+computePassEncoder130.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder11.draw(0, 373, 0, 92_941_230);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(2, 238, 28, -1_603_230_451, 208_718_946);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer50, 232);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer15, 2_708);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer82, 'uint16', 28, 225);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(5, undefined, 0, 1_158_042_292);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 1,
+  origin: {x: 25, y: 27, z: 0},
+  aspect: 'all',
+}, new Uint8Array(56).fill(190), /* required buffer size: 56 */
+{offset: 56, bytesPerRow: 613}, {width: 59, height: 11, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup98 = device0.createBindGroup({
+  label: '\u339e\u0c14\u0d4e\u07fa\u3a12\u{1fca8}\u1431',
+  layout: bindGroupLayout18,
+  entries: [{binding: 204, resource: externalTexture3}, {binding: 116, resource: sampler30}],
+});
+let commandEncoder171 = device0.createCommandEncoder();
+try {
+computePassEncoder66.setBindGroup(2, bindGroup22, new Uint32Array(862), 355, 0);
+} catch {}
+try {
+computePassEncoder129.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.draw(0, 117, 0, 3_961_748_105);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer50, 180);
+} catch {}
+try {
+commandEncoder171.copyTextureToBuffer({
+  texture: texture131,
+  mipLevel: 0,
+  origin: {x: 5, y: 29, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 948 */
+  offset: 948,
+  bytesPerRow: 3840,
+  buffer: buffer93,
+}, {width: 3, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let textureView134 = texture90.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder131 = commandEncoder171.beginComputePass({label: '\u0844\u47e8'});
+try {
+renderPassEncoder11.drawIndexed(9, 43, 8, 73_958_844, 136_920_061);
+} catch {}
+try {
+commandEncoder82.label = '\u05a5\u7295';
+} catch {}
+let buffer110 = device0.createBuffer({size: 64461, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC});
+let textureView135 = texture121.createView({dimension: '2d-array', format: 'rgba16sint', mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder47); computePassEncoder47.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder47); computePassEncoder47.dispatchWorkgroupsIndirect(buffer20, 0); };
+} catch {}
+try {
+renderPassEncoder11.draw(0, 316, 0, 281_349_712);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer22, 284);
+} catch {}
+let commandEncoder172 = device0.createCommandEncoder({});
+let textureView136 = texture70.createView({format: 'rgb10a2uint', arrayLayerCount: 1});
+let computePassEncoder132 = commandEncoder172.beginComputePass({});
+try {
+computePassEncoder132.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer100, 140);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer74, 824, new BigUint64Array(45), 3, 0);
+} catch {}
+let bindGroup99 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [{binding: 272, resource: {buffer: buffer8, offset: 0, size: 278}}],
+});
+let buffer111 = device0.createBuffer({
+  size: 3122,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture135 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 22},
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder126.setBindGroup(0, bindGroup58);
+} catch {}
+try {
+renderPassEncoder11.draw(0, 103, 0, 313_371_217);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(4, 82, 73, 539_809_840, 90_586_416);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer25, 1_376);
+} catch {}
+let commandEncoder173 = device0.createCommandEncoder({});
+let texture136 = device0.createTexture({
+  size: [280],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler98 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 89.47,
+});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+computePassEncoder128.setBindGroup(1, bindGroup24, new Uint32Array(921), 193, 0);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(23, 106, 13, 27_750_970, 930_239_674);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer67, 420);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer112 = device0.createBuffer({
+  size: 11718,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture137 = device0.createTexture({
+  size: [280, 291, 478],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder131.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder11.draw(0, 370, 0, 1_153_361_435);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer64, 1_192);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(4, buffer64, 0, 1_510);
+} catch {}
+try {
+commandEncoder173.copyBufferToBuffer(buffer65, 256, buffer82, 100, 396);
+} catch {}
+try {
+commandEncoder173.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2920 */
+  offset: 2920,
+  bytesPerRow: 34560,
+  buffer: buffer28,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup100 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 5, resource: sampler9}]});
+let texture138 = device0.createTexture({
+  size: {width: 73, height: 1, depthOrArrayLayers: 32},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder133 = commandEncoder173.beginComputePass();
+try {
+computePassEncoder117.setBindGroup(2, bindGroup20, []);
+} catch {}
+try {
+renderPassEncoder11.draw(0, 286, 0, 380_455_159);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer91, 68);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(3, buffer6, 344);
+} catch {}
+let pipeline5 = await device0.createComputePipelineAsync({layout: pipelineLayout6, compute: {module: shaderModule12, entryPoint: 'compute11'}});
+let buffer113 = device0.createBuffer({size: 11118, usage: GPUBufferUsage.INDEX});
+let textureView137 = texture119.createView({mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 1});
+let sampler99 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.72,
+  maxAnisotropy: 16,
+});
+let externalTexture15 = device0.importExternalTexture({source: videoFrame18});
+try {
+computePassEncoder126.setBindGroup(0, bindGroup39, new Uint32Array(3868), 2_888, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(0, 37, 0, 238_247_602);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(37, 47, 22, 212_332_789, 448_551_578);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer87, 1_428);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(0, buffer8, 320, 304);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer102, 168, new DataView(new ArrayBuffer(13841)), 2470, 48);
+} catch {}
+let buffer114 = device0.createBuffer({
+  size: 1089,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let textureView138 = texture135.createView({mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 1});
+try {
+computePassEncoder57.setBindGroup(1, bindGroup92, new Uint32Array(193), 9, 0);
+} catch {}
+try {
+computePassEncoder34.end();
+} catch {}
+try {
+computePassEncoder133.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(3, bindGroup44);
+} catch {}
+try {
+renderPassEncoder11.end();
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(6, buffer82, 0);
+} catch {}
+try {
+commandEncoder47.copyTextureToTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 68, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 85, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder174 = device0.createCommandEncoder({});
+let texture139 = device0.createTexture({
+  size: [64, 64, 22],
+  mipLevelCount: 3,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder89.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup44, new Uint32Array(267), 1, 0);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(39, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer82, 'uint32', 752, 108);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline1);
+} catch {}
+try {
+buffer53.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer109, 408, new Float32Array(6220), 1550, 104);
+} catch {}
+let commandEncoder175 = device0.createCommandEncoder();
+let texture140 = device0.createTexture({
+  size: {width: 147},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder63 = commandEncoder174.beginRenderPass({
+  colorAttachments: [{
+  view: textureView99,
+  depthSlice: 1,
+  clearValue: { r: 804.9, g: 69.95, b: 651.0, a: 569.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet9,
+});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder9.setStencilReference(157);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup75);
+} catch {}
+try {
+buffer103.unmap();
+} catch {}
+try {
+commandEncoder47.clearBuffer(buffer61);
+} catch {}
+document.body.append(img1);
+let imageData17 = new ImageData(88, 12);
+let buffer115 = device0.createBuffer({
+  label: '\u7ae4\u{1fc3a}',
+  size: 458,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture141 = device0.createTexture({
+  label: '\u{1f7d9}\u0cd4\u876c\u7c80\u03ec\u{1f979}\u{1fc8c}\u0db5\u5f51\uc3a2',
+  size: {width: 384, height: 1, depthOrArrayLayers: 524},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView139 = texture2.createView({mipLevelCount: 1});
+let computePassEncoder134 = commandEncoder47.beginComputePass({});
+let renderBundle10 = renderBundleEncoder10.finish({});
+let externalTexture16 = device0.importExternalTexture({source: videoFrame5});
+try {
+renderPassEncoder53.setBindGroup(3, bindGroup61);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup64, new Uint32Array(986), 320, 0);
+} catch {}
+try {
+renderPassEncoder51.setBlendConstant({ r: -419.2, g: 900.4, b: 219.4, a: 724.0, });
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(7, buffer86);
+} catch {}
+try {
+commandEncoder40.copyTextureToTexture({
+  texture: texture57,
+  mipLevel: 1,
+  origin: {x: 48, y: 48, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup101 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 39, resource: textureView103}]});
+let buffer116 = device0.createBuffer({
+  size: 7234,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder134.setPipeline(pipeline2);
+} catch {}
+let texture142 = device0.createTexture({
+  label: '\u0cdc\u8ef3\u{1f773}\u58c8\u2e7b\u346d\ufcce',
+  size: [384, 1, 524],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder91.setBindGroup(1, bindGroup25, new Uint32Array(1202), 21, 0);
+} catch {}
+try {
+computePassEncoder36.end();
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(0, bindGroup47);
+} catch {}
+let videoFrame24 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'bt709', transfer: 'bt2020_12bit'} });
+let bindGroup102 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 172, resource: textureView110},
+    {binding: 462, resource: {buffer: buffer63, offset: 2560, size: 272}},
+    {binding: 67, resource: textureView11},
+    {binding: 8, resource: textureView109},
+    {binding: 264, resource: sampler9},
+    {binding: 57, resource: textureView108},
+    {binding: 9, resource: textureView14},
+    {binding: 51, resource: {buffer: buffer84, offset: 10496, size: 2368}},
+    {binding: 153, resource: {buffer: buffer99, offset: 1792}},
+  ],
+});
+let texture143 = device0.createTexture({
+  label: '\u0621\u1756\u66c5\u855b\u036d\u9a32\ube07\u{1f727}\u2de5\u{1f9e4}',
+  size: [110],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderPassEncoder64 = commandEncoder40.beginRenderPass({
+  label: '\u34fc\u{1f724}\uf671\u0b3c\u52d0',
+  colorAttachments: [{
+  view: textureView52,
+  clearValue: { r: -518.0, g: -707.3, b: -852.2, a: 820.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet10,
+});
+let sampler100 = device0.createSampler({
+  label: '\u{1fddc}\ud30d\u046e\u0754\u0cc6\u7567\u{1f99b}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 40.28,
+  lodMaxClamp: 74.70,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup10, new Uint32Array(157), 4, 0);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(3, bindGroup30, new Uint32Array(2111), 174, 0);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer95, 'uint32', 6_800, 1_240);
+} catch {}
+try {
+  await buffer5.mapAsync(GPUMapMode.READ, 0, 5056);
+} catch {}
+try {
+commandEncoder51.copyBufferToBuffer(buffer84, 204, buffer23, 724, 5440);
+} catch {}
+try {
+device0.queue.submit([commandBuffer7]);
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+let bindGroup103 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [{binding: 272, resource: {buffer: buffer37, offset: 0, size: 1058}}],
+});
+let commandEncoder176 = device0.createCommandEncoder({});
+let textureView140 = texture19.createView({});
+try {
+renderPassEncoder37.executeBundles([renderBundle6]);
+} catch {}
+try {
+commandEncoder51.copyBufferToBuffer(buffer95, 2836, buffer61, 344, 516);
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder177 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder40); computePassEncoder40.dispatchWorkgroupsIndirect(buffer54, 1_724); };
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(0, bindGroup31, new Uint32Array(761), 40, 0);
+} catch {}
+document.body.prepend(img1);
+let imageData18 = new ImageData(16, 16);
+let commandEncoder178 = device0.createCommandEncoder({});
+let computePassEncoder135 = commandEncoder176.beginComputePass({label: '\u{1f7f3}\u0e99\uae37\uda16'});
+try {
+{ clearResourceUsages(device0, computePassEncoder47); computePassEncoder47.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(1, buffer59, 116);
+} catch {}
+try {
+globalThis.someLabel = externalTexture12.label;
+} catch {}
+let buffer117 = device0.createBuffer({size: 21285, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView141 = texture23.createView({
+  label: '\u{1fe20}\ua21c\u0a9e\ub701\u{1f873}\u6b4b\u{1fd31}\u6724\u{1f8ad}',
+  aspect: 'all',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let computePassEncoder136 = commandEncoder175.beginComputePass({});
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup51, []);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer30, 'uint16', 18, 10);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(0, buffer102, 0);
+} catch {}
+try {
+commandEncoder177.copyBufferToTexture({
+  /* bytesInLastRow: 280 widthInBlocks: 280 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 332 */
+  offset: 332,
+  bytesPerRow: 18432,
+  buffer: buffer95,
+}, {
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 0, y: 65, z: 0},
+  aspect: 'stencil-only',
+}, {width: 280, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let imageData19 = new ImageData(88, 80);
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout2]});
+let buffer118 = device0.createBuffer({size: 688, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+try {
+computePassEncoder113.setBindGroup(3, bindGroup57);
+} catch {}
+try {
+computePassEncoder60.end();
+} catch {}
+try {
+computePassEncoder135.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup56, new Uint32Array(3200), 542, 0);
+} catch {}
+let promise14 = shaderModule7.getCompilationInfo();
+let promise15 = device0.queue.onSubmittedWorkDone();
+let commandEncoder179 = device0.createCommandEncoder({});
+let computePassEncoder137 = commandEncoder178.beginComputePass({});
+let renderPassEncoder65 = commandEncoder177.beginRenderPass({
+  colorAttachments: [{
+  view: textureView5,
+  clearValue: { r: -617.1, g: -255.1, b: -621.4, a: 398.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 122772277,
+});
+try {
+computePassEncoder136.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder51.copyBufferToBuffer(buffer43, 960, buffer81, 832, 2088);
+} catch {}
+try {
+commandEncoder179.copyBufferToTexture({
+  /* bytesInLastRow: 88 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 292 */
+  offset: 292,
+  buffer: buffer56,
+}, {
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder179.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 1, y: 11, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 4});
+} catch {}
+let bindGroup104 = device0.createBindGroup({layout: bindGroupLayout15, entries: [{binding: 44, resource: externalTexture13}]});
+let texture144 = device0.createTexture({
+  size: [147],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder138 = commandEncoder179.beginComputePass({label: '\u0150\u{1faed}\u06e4\u{1f6d2}\u{1fb9a}\ubf38\u0ea1\u6937'});
+try {
+computePassEncoder95.setBindGroup(0, bindGroup86, new Uint32Array(4985), 1_196, 0);
+} catch {}
+try {
+computePassEncoder137.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer115, 'uint16', 208, 1);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, buffer100, 0, 1_102);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandBuffer8 = commandEncoder85.finish();
+let computePassEncoder139 = commandEncoder51.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder117); computePassEncoder117.dispatchWorkgroupsIndirect(buffer25, 644); };
+} catch {}
+try {
+computePassEncoder139.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup45);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup16, new Uint32Array(18), 4, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer8]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 32}
+*/
+{
+  source: imageData16,
+  origin: { x: 3, y: 0 },
+  flipY: false,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img1);
+try {
+adapter0.label = '\u0134\uf05e';
+} catch {}
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({
+  label: '\u2143\uf8e1',
+  colorFormats: ['rgb10a2unorm'],
+  depthStencilFormat: 'depth24plus',
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder58.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(3, buffer109, 48);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer13, 'uint16', 522, 1_919);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+let textureView142 = texture143.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder101); computePassEncoder101.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer91, 'uint16', 6_312, 894);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer83, 2232, new BigUint64Array(5731), 767, 260);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(4, buffer83);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer115, 20, new BigUint64Array(14283), 901, 4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(87).fill(75), /* required buffer size: 87 */
+{offset: 87}, {width: 182, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+let commandEncoder180 = device0.createCommandEncoder({});
+let computePassEncoder140 = commandEncoder180.beginComputePass({});
+let sampler101 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 11.32,
+  lodMaxClamp: 99.08,
+});
+try {
+computePassEncoder63.setBindGroup(2, bindGroup39, new Uint32Array(2585), 18, 0);
+} catch {}
+try {
+computePassEncoder117.end();
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(3, bindGroup37, new Uint32Array(137), 1, 0);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(7, buffer43, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet16 = device0.createQuerySet({type: 'occlusion', count: 640});
+let commandBuffer9 = commandEncoder158.finish();
+try {
+renderPassEncoder48.setBindGroup(2, bindGroup52, new Uint32Array(520), 86, 0);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer42, 'uint16', 1_028, 268);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup26, new Uint32Array(1146), 48, 0);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(4, buffer103, 0, 29);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(112).fill(188), /* required buffer size: 112 */
+{offset: 112}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer119 = device0.createBuffer({size: 11535, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM});
+let textureView143 = texture5.createView({});
+let sampler102 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 20.11,
+  lodMaxClamp: 52.02,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder40); computePassEncoder40.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder112); computePassEncoder112.dispatchWorkgroupsIndirect(buffer105, 416); };
+} catch {}
+try {
+renderPassEncoder61.beginOcclusionQuery(34);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer82, 'uint16', 24, 69);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup54, new Uint32Array(584), 123, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST, colorSpace: 'srgb'});
+} catch {}
+let commandEncoder181 = device0.createCommandEncoder({});
+let texture145 = device0.createTexture({
+  size: {width: 48, height: 1, depthOrArrayLayers: 1},
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+computePassEncoder140.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder28.setScissorRect(2, 0, 31, 11);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer57, 'uint32', 716, 1_536);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer105, 'uint32', 480, 87);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(7, buffer89);
+} catch {}
+try {
+commandEncoder181.copyTextureToTexture({
+  texture: texture131,
+  mipLevel: 0,
+  origin: {x: 19, y: 28, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 47, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 2, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas1);
+let buffer120 = device0.createBuffer({
+  size: 2101,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView144 = texture121.createView({mipLevelCount: 1});
+let sampler103 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 70.79,
+  lodMaxClamp: 87.98,
+});
+try {
+renderPassEncoder61.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer59, 'uint16', 618, 66);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(3, undefined);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup50, new Uint32Array(303), 10, 0);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture79,
+  mipLevel: 1,
+  origin: {x: 0, y: 8, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder141 = commandEncoder181.beginComputePass({});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], sampleCount: 4, stencilReadOnly: true});
+try {
+computePassEncoder79.setBindGroup(0, bindGroup79);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle5, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(5, buffer4, 916, 3_441);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup72, new Uint32Array(6079), 68, 0);
+} catch {}
+try {
+commandEncoder24.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1924 */
+  offset: 1924,
+  rowsPerImage: 265,
+  buffer: buffer7,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer9]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas0);
+await gc();
+let texture146 = device0.createTexture({
+  label: '\ua1ad\uab35\ua31b\u0001\u0796',
+  size: {width: 192, height: 1, depthOrArrayLayers: 55},
+  mipLevelCount: 5,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder142 = commandEncoder24.beginComputePass({});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint'], depthReadOnly: true});
+try {
+renderPassEncoder19.setIndexBuffer(buffer1, 'uint16', 28, 3);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup101, []);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(7, buffer65);
+} catch {}
+let bindGroup105 = device0.createBindGroup({
+  label: '\uf179\u07aa\u943a\u{1fea3}\u0e5c\ud272\u89c8',
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 421, resource: {buffer: buffer87, offset: 1024, size: 192}},
+    {binding: 42, resource: externalTexture5},
+    {binding: 398, resource: textureView57},
+    {binding: 243, resource: textureView91},
+    {binding: 35, resource: textureView118},
+    {binding: 94, resource: textureView63},
+    {binding: 567, resource: textureView14},
+    {binding: 132, resource: textureView64},
+    {binding: 999, resource: textureView79},
+  ],
+});
+let textureView145 = texture55.createView({dimension: '2d-array'});
+try {
+computePassEncoder101.setBindGroup(1, bindGroup103, new Uint32Array(3527), 156, 0);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(6, buffer15, 116);
+} catch {}
+try {
+  await promise15;
+} catch {}
+let bindGroup106 = device0.createBindGroup({
+  layout: bindGroupLayout17,
+  entries: [{binding: 78, resource: sampler56}, {binding: 113, resource: textureView109}],
+});
+let textureView146 = texture105.createView({label: '\u0902\u0f56', dimension: '3d', aspect: 'all'});
+let texture147 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 262},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder127.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup54, new Uint32Array(3680), 113, 0);
+} catch {}
+try {
+renderPassEncoder49.setStencilReference(17);
+} catch {}
+try {
+renderPassEncoder57.setViewport(46.73079930747636, 0.18432837143760883, 23.177218678183426, 0.025061073792121143, 0.6940334567536122, 0.8109878259282833);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(6, buffer99, 1_708);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup92, []);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer120, 'uint32', 740, 429);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(1, buffer43);
+} catch {}
+try {
+  await promise14;
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let textureView147 = texture40.createView({dimension: '2d-array', baseMipLevel: 0});
+let sampler104 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 95.97,
+  lodMaxClamp: 99.42,
+  compare: 'less',
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup91);
+} catch {}
+try {
+computePassEncoder7.setBindGroup(2, bindGroup98, new Uint32Array(131), 3, 0);
+} catch {}
+try {
+computePassEncoder142.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer112, 'uint32', 572, 845);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(0, buffer101);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup35, new Uint32Array(1959), 87, 0);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer84, 'uint32', 5_276, 2_475);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(7, buffer62, 400, 2_684);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 2,
+  origin: {x: 4, y: 1, z: 2},
+  aspect: 'all',
+}, new Uint8Array(190_848).fill(223), /* required buffer size: 190_848 */
+{offset: 448, bytesPerRow: 136, rowsPerImage: 56}, {width: 8, height: 0, depthOrArrayLayers: 26});
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 54}
+*/
+{
+  source: videoFrame13,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer121 = device0.createBuffer({
+  size: 2398,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder182 = device0.createCommandEncoder({label: '\ue3db\u{1f740}'});
+let texture148 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder143 = commandEncoder182.beginComputePass({});
+let sampler105 = device0.createSampler({addressModeV: 'clamp-to-edge', addressModeW: 'clamp-to-edge', lodMinClamp: 65.11, lodMaxClamp: 85.78});
+try {
+computePassEncoder139.setBindGroup(2, bindGroup43);
+} catch {}
+try {
+computePassEncoder57.setBindGroup(0, bindGroup19, new Uint32Array(1902), 624, 0);
+} catch {}
+try {
+computePassEncoder138.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup37, new Uint32Array(445), 55, 0);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup75, new Uint32Array(108), 14, 0);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer53, 'uint32', 52, 225);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(2, buffer51);
+} catch {}
+let bindGroup107 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 211, resource: sampler56},
+    {binding: 62, resource: textureView91},
+    {binding: 86, resource: textureView125},
+  ],
+});
+let textureView148 = texture7.createView({});
+try {
+computePassEncoder91.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+computePassEncoder143.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(3, bindGroup68);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer89, 'uint16', 876, 211);
+} catch {}
+try {
+renderBundleEncoder11.insertDebugMarker('\u7ec0');
+} catch {}
+let texture149 = device0.createTexture({
+  size: [384, 1, 1],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView149 = texture118.createView({aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 2});
+try {
+computePassEncoder97.setBindGroup(0, bindGroup56, new Uint32Array(1419), 182, 0);
+} catch {}
+try {
+computePassEncoder141.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(3, bindGroup85);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup41, new Uint32Array(1176), 302, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer81, 'uint32', 1_500, 140);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(2, buffer83, 388);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer26, 'uint32', 888, 29);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(4, buffer62, 0, 3_515);
+} catch {}
+try {
+computePassEncoder25.insertDebugMarker('\u83d2');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 147, height: 1, depthOrArrayLayers: 9}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture110,
+  mipLevel: 1,
+  origin: {x: 17, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture150 = device0.createTexture({
+  size: [55, 5, 39],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint'],
+});
+let texture151 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderPassEncoder38.setScissorRect(83, 104, 282, 88);
+} catch {}
+let imageData20 = new ImageData(12, 64);
+let commandEncoder183 = device0.createCommandEncoder({});
+let sampler106 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 35.75,
+  lodMaxClamp: 78.34,
+});
+try {
+renderPassEncoder31.setIndexBuffer(buffer115, 'uint32', 92, 8);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup55, new Uint32Array(1499), 249, 0);
+} catch {}
+try {
+commandEncoder183.copyTextureToTexture({
+  texture: texture130,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 20},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder183.resolveQuerySet(querySet1, 34, 4, buffer46, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 140, height: 145, depthOrArrayLayers: 239}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 20, y: 5 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 1,
+  origin: {x: 8, y: 24, z: 26},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 66, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup108 = device0.createBindGroup({
+  label: '\u93e5\u{1fd03}\u{1fbdb}',
+  layout: bindGroupLayout11,
+  entries: [{binding: 52, resource: textureView47}, {binding: 57, resource: textureView20}],
+});
+let commandEncoder184 = device0.createCommandEncoder({});
+let computePassEncoder144 = commandEncoder183.beginComputePass({});
+try {
+renderPassEncoder55.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(2, bindGroup35);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup22, new Uint32Array(3178), 1_230, 0);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer79, 'uint16', 874, 1_144);
+} catch {}
+try {
+commandEncoder184.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5452 */
+  offset: 5452,
+  bytesPerRow: 6656,
+  buffer: buffer91,
+}, {
+  texture: texture75,
+  mipLevel: 2,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(174, 70);
+let textureView150 = texture25.createView({label: '\u0083\u0793\ua35c\u{1fc47}\u06f1\u0cfd\u02ca\u7266', mipLevelCount: 1});
+let computePassEncoder145 = commandEncoder184.beginComputePass({});
+try {
+computePassEncoder47.end();
+} catch {}
+try {
+computePassEncoder144.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle7, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer109, 'uint32', 1_060, 605);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(5, buffer42, 0, 62);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup53);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup42, new Uint32Array(355), 213, 0);
+} catch {}
+try {
+commandEncoder67.insertDebugMarker('\u0a15');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer112, 1604, new Int16Array(2806), 510, 104);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: imageData1,
+  origin: { x: 5, y: 0 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 15},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img3);
+let commandEncoder185 = device0.createCommandEncoder({label: '\uee3a\u{1f66e}'});
+try {
+computePassEncoder145.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder44.beginOcclusionQuery(6);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer91, 'uint16', 56, 2_983);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup81);
+} catch {}
+try {
+commandEncoder67.copyTextureToTexture({
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 14, y: 197, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture76,
+  mipLevel: 2,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 147, height: 1, depthOrArrayLayers: 9}
+*/
+{
+  source: videoFrame13,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture110,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(1, bindGroup44, new Uint32Array(3242), 3_242, 0);
+} catch {}
+try {
+renderPassEncoder63.setBlendConstant({ r: -768.2, g: -729.3, b: 978.2, a: 556.5, });
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline1);
+} catch {}
+await gc();
+let texture152 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder146 = commandEncoder67.beginComputePass();
+let renderPassEncoder66 = commandEncoder185.beginRenderPass({
+  colorAttachments: [{
+  view: textureView5,
+  clearValue: { r: -679.6, g: 139.4, b: -997.9, a: 350.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet9,
+});
+let renderBundle11 = renderBundleEncoder13.finish({label: '\u{1f637}\u00e6\ufc85\ud1aa\u0d0e\u{1fbb1}\u0291\u7e91\u25be\u6f47\u3b5f'});
+try {
+{ clearResourceUsages(device0, computePassEncoder110); computePassEncoder110.dispatchWorkgroupsIndirect(buffer72, 52); };
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup48);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: imageData8,
+  origin: { x: 0, y: 7 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 47},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer122 = device0.createBuffer({size: 2312, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder186 = device0.createCommandEncoder({});
+let computePassEncoder147 = commandEncoder186.beginComputePass({label: '\u{1f61a}\u0a14\u{1f81e}\u8c21\u{1fc39}\u{1f922}\ucad3'});
+try {
+renderPassEncoder56.setBindGroup(1, bindGroup31);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer16, 'uint16', 7_544, 1_470);
+} catch {}
+try {
+buffer47.unmap();
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+let videoFrame25 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpteRp431', transfer: 'smpte240m'} });
+let textureView151 = texture18.createView({});
+try {
+computePassEncoder147.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup105, []);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer80, 'uint16', 3_238, 1_792);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(1, buffer112, 0, 1_581);
+} catch {}
+try {
+buffer56.unmap();
+} catch {}
+let videoFrame26 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'smpte240m', transfer: 'pq'} });
+let texture153 = device0.createTexture({
+  size: [560, 582, 1],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture17 = device0.importExternalTexture({source: videoFrame23, colorSpace: 'srgb'});
+try {
+computePassEncoder146.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder44.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle11, renderBundle11, renderBundle5]);
+} catch {}
+let textureView152 = texture125.createView({aspect: 'all'});
+try {
+renderPassEncoder52.setBindGroup(1, bindGroup44, new Uint32Array(1094), 64, 0);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(1, buffer65, 420, 27);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let buffer123 = device0.createBuffer({size: 0, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup50);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder42); computePassEncoder42.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder40); computePassEncoder40.dispatchWorkgroupsIndirect(buffer72, 2_204); };
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer53, 'uint32', 2_404, 1_160);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 32}
+*/
+{
+  source: videoFrame20,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 11},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let pipelineLayout9 = device0.createPipelineLayout({bindGroupLayouts: []});
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup74, new Uint32Array(97), 1, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle11]);
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas2.getContext('webgpu');
+let imageData21 = new ImageData(56, 12);
+let commandEncoder187 = device0.createCommandEncoder();
+let computePassEncoder148 = commandEncoder187.beginComputePass({});
+let renderBundle12 = renderBundleEncoder12.finish();
+try {
+computePassEncoder103.setBindGroup(3, bindGroup49);
+} catch {}
+try {
+computePassEncoder110.end();
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(3, undefined, 1_251_762_401, 140_067_163);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup12, new Uint32Array(429), 60, 0);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let querySet17 = device0.createQuerySet({
+  label: '\u658e\u1e35\udc9d\u{1fdaa}\ub1bb\u{1f712}\u90fe\u{1fd7c}\u{1fc0f}\u{1f9c2}\u57c4',
+  type: 'occlusion',
+  count: 752,
+});
+try {
+computePassEncoder142.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+computePassEncoder101.end();
+} catch {}
+try {
+computePassEncoder148.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup40, new Uint32Array(2334), 72, 0);
+} catch {}
+try {
+renderPassEncoder62.setIndexBuffer(buffer42, 'uint16', 396, 13);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup31, new Uint32Array(332), 107, 0);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(1, buffer91);
+} catch {}
+try {
+commandEncoder138.copyBufferToBuffer(buffer23, 10488, buffer103, 60, 16);
+} catch {}
+let commandEncoder188 = device0.createCommandEncoder();
+let textureView153 = texture134.createView({
+  label: '\u0e02\u82f4\u{1fb30}\u3d57\u{1f76c}\uf984\u765e',
+  mipLevelCount: 1,
+  baseArrayLayer: 36,
+  arrayLayerCount: 2,
+});
+try {
+renderPassEncoder62.setBindGroup(2, bindGroup75);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup34, new Uint32Array(186), 85, 0);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(7, undefined);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer86, 'uint32', 1_844, 200);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(7, buffer59);
+} catch {}
+try {
+commandEncoder138.copyBufferToTexture({
+  /* bytesInLastRow: 200 widthInBlocks: 25 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 168 */
+  offset: 168,
+  rowsPerImage: 34,
+  buffer: buffer117,
+}, {
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder138.copyTextureToTexture({
+  texture: texture89,
+  mipLevel: 1,
+  origin: {x: 33, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 5},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 14});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+document.body.append(img3);
+let videoFrame27 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'jedecP22Phosphors', transfer: 'unspecified'} });
+let bindGroup109 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [{binding: 53, resource: externalTexture5}, {binding: 54, resource: {buffer: buffer40, offset: 22016}}],
+});
+let textureView154 = texture83.createView({label: '\u8ed5\u0343', dimension: 'cube-array', baseArrayLayer: 2, arrayLayerCount: 6});
+let computePassEncoder149 = commandEncoder138.beginComputePass({});
+try {
+computePassEncoder128.setBindGroup(0, bindGroup54);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder42); computePassEncoder42.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder112.end();
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(3, bindGroup84, new Uint32Array(105), 16, 0);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(4, buffer28);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer59, 'uint16', 442, 194);
+} catch {}
+try {
+commandEncoder188.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 944 */
+  offset: 944,
+  bytesPerRow: 0,
+  rowsPerImage: 1117,
+  buffer: buffer26,
+}, {
+  texture: texture20,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 6});
+} catch {}
+try {
+commandEncoder153.insertDebugMarker('\u9235');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await promise17;
+} catch {}
+let bindGroupLayout20 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 152,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let buffer124 = device0.createBuffer({size: 5182, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView155 = texture143.createView({aspect: 'all'});
+let computePassEncoder150 = commandEncoder155.beginComputePass({});
+let renderPassEncoder67 = commandEncoder153.beginRenderPass({
+  colorAttachments: [{view: textureView0, depthSlice: 0, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 324117812,
+});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], depthStencilFormat: 'depth24plus', sampleCount: 1, depthReadOnly: true});
+let sampler107 = device0.createSampler({
+  label: '\u3ff2\u8915\u{1f8f7}\ud161\u0236\u9a04\u{1fa7c}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 76.97,
+  lodMaxClamp: 98.63,
+  compare: 'less',
+  maxAnisotropy: 14,
+});
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup82);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(2, bindGroup11, new Uint32Array(518), 102, 0);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer57, 'uint16', 562, 298);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(7, buffer98, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer52, 100, new Int16Array(21924), 230, 0);
+} catch {}
+try {
+  await promise16;
+} catch {}
+try {
+globalThis.someLabel = device0.label;
+} catch {}
+let bindGroup110 = device0.createBindGroup({layout: bindGroupLayout13, entries: [{binding: 272, resource: {buffer: buffer16, offset: 512}}]});
+let commandEncoder189 = device0.createCommandEncoder({});
+let texture154 = device0.createTexture({size: [64], dimension: '1d', format: 'rgba16uint', usage: GPUTextureUsage.COPY_SRC});
+let textureView156 = texture74.createView({label: '\u5acc\u289c\uab0e', dimension: '2d', mipLevelCount: 1});
+let renderBundle13 = renderBundleEncoder11.finish({});
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup94);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup19, new Uint32Array(216), 129, 0);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer42, 'uint16', 260, 20);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(5, buffer72);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 1,
+  origin: {x: 74, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(109).fill(13), /* required buffer size: 109 */
+{offset: 109}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView157 = texture151.createView({dimension: '2d', arrayLayerCount: 1});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true});
+try {
+computePassEncoder149.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup100, new Uint32Array(1915), 83, 0);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer70, 'uint32', 4_908, 554);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(0, buffer15, 0, 9_092);
+} catch {}
+let arrayBuffer11 = buffer35.getMappedRange(296, 100);
+try {
+commandEncoder189.copyBufferToTexture({
+  /* bytesInLastRow: 120 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 632 */
+  offset: 632,
+  buffer: buffer56,
+}, {
+  texture: texture130,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas1);
+try {
+computePassEncoder42.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(0, bindGroup35, new Uint32Array(372), 68, 0);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer115, 'uint16', 30, 61);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline1);
+} catch {}
+try {
+  await buffer31.mapAsync(GPUMapMode.WRITE, 0, 188);
+} catch {}
+try {
+commandEncoder189.copyBufferToBuffer(buffer10, 384, buffer121, 360, 8);
+} catch {}
+try {
+renderPassEncoder58.pushDebugGroup('\u0508');
+} catch {}
+try {
+computePassEncoder88.insertDebugMarker('\u1a4b');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let imageData22 = new ImageData(12, 44);
+try {
+renderPassEncoder55.setBindGroup(2, bindGroup107, new Uint32Array(1290), 59, 0);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer114, 'uint16', 6, 8);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer120, 'uint16', 738, 175);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(0, buffer89);
+} catch {}
+try {
+textureView22.label = '\u4ffd\u0ebe\u9355\u5181\u4ecb\u0013\u0ee9';
+} catch {}
+let computePassEncoder151 = commandEncoder189.beginComputePass({});
+let renderPassEncoder68 = commandEncoder188.beginRenderPass({
+  colorAttachments: [{
+  view: textureView38,
+  clearValue: { r: 429.2, g: -907.4, b: -388.6, a: 949.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet6,
+  maxDrawCount: 119585885,
+});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup94, new Uint32Array(201), 15, 0);
+} catch {}
+try {
+renderPassEncoder64.beginOcclusionQuery(23);
+} catch {}
+try {
+renderPassEncoder64.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(5, buffer101, 0, 16_078);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup57);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer4, 'uint16', 2_712, 740);
+} catch {}
+try {
+buffer80.unmap();
+} catch {}
+let texture155 = device0.createTexture({size: [560, 582, 1], format: 'rgba8unorm-srgb', usage: GPUTextureUsage.COPY_SRC});
+try {
+renderPassEncoder17.setScissorRect(3, 0, 4, 0);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(5, buffer91, 7_392);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(0, bindGroup53, new Uint32Array(6427), 1_316, 0);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let imageData23 = new ImageData(60, 28);
+let buffer125 = device0.createBuffer({size: 4918, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let sampler108 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 93.88});
+let externalTexture18 = device0.importExternalTexture({source: videoFrame26, colorSpace: 'display-p3'});
+try {
+computePassEncoder85.setBindGroup(1, bindGroup66);
+} catch {}
+try {
+computePassEncoder54.setBindGroup(3, bindGroup43, new Uint32Array(3813), 314, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder128); computePassEncoder128.dispatchWorkgroupsIndirect(buffer115, 28); };
+} catch {}
+try {
+computePassEncoder151.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(0, bindGroup1, new Uint32Array(1465), 1_111, 0);
+} catch {}
+try {
+renderPassEncoder46.executeBundles([renderBundle11, renderBundle5, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(1, undefined, 0);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(7, buffer98, 0, 486);
+} catch {}
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+let commandEncoder190 = device0.createCommandEncoder({label: '\u{1fcc2}\u07f3\u0065\u{1f6b8}\ud7b3'});
+let textureView158 = texture141.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let renderPassEncoder69 = commandEncoder190.beginRenderPass({
+  colorAttachments: [{view: textureView139, depthSlice: 6, loadOp: 'load', storeOp: 'store'}],
+  maxDrawCount: 155324445,
+});
+try {
+computePassEncoder78.setBindGroup(3, bindGroup96);
+} catch {}
+try {
+computePassEncoder124.setBindGroup(0, bindGroup98, new Uint32Array(5568), 3_691, 0);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(6, undefined, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 280, height: 291, depthOrArrayLayers: 478}
+*/
+{
+  source: videoFrame19,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 146, y: 23, z: 90},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle14 = renderBundleEncoder14.finish();
+try {
+computePassEncoder125.setBindGroup(1, bindGroup42);
+} catch {}
+try {
+computePassEncoder42.end();
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup55);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(2, bindGroup24, new Uint32Array(2264), 852, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle2, renderBundle2, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer50, 'uint16', 592, 401);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+adapter0.label = '\u{1fda2}\uc8e2\u{1f754}\u0433\u07dd\u062a';
+} catch {}
+let texture156 = device0.createTexture({
+  size: [64, 64, 22],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder152 = commandEncoder60.beginComputePass({});
+try {
+computePassEncoder41.setBindGroup(1, bindGroup85, new Uint32Array(315), 123, 0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle3, renderBundle0, renderBundle3, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer80, 'uint16', 1_702, 2_272);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer16, 'uint16', 1_584, 608);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline1);
+} catch {}
+let commandEncoder191 = device0.createCommandEncoder({});
+let textureView159 = texture90.createView({baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder153 = commandEncoder191.beginComputePass({});
+let renderBundle15 = renderBundleEncoder15.finish({});
+try {
+renderPassEncoder53.setViewport(90.5906327388818, 0.3216213975588047, 0.3633813622753664, 0.6451178508013696, 0.11890421152365926, 0.8919953151629716);
+} catch {}
+let arrayBuffer12 = buffer31.getMappedRange(0, 20);
+try {
+renderPassEncoder46.pushDebugGroup('\u00b7');
+} catch {}
+try {
+renderPassEncoder58.popDebugGroup();
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+let texture157 = device0.createTexture({
+  label: '\u097b\ua1a6\u{1f7f2}',
+  size: {width: 147},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView160 = texture4.createView({label: '\u{1f8ea}\u{1ff7d}\u8934\u2f33\u8e14\u{1fcae}\u4c1d\ufb18\u{1ffe6}\ucc9a\ub625'});
+try {
+{ clearResourceUsages(device0, computePassEncoder45); computePassEncoder45.dispatchWorkgroups(3); };
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup72);
+} catch {}
+try {
+renderPassEncoder67.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder61.setVertexBuffer(7, buffer28, 0, 2_055);
+} catch {}
+try {
+buffer101.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer99, 1360, new DataView(new ArrayBuffer(5830)), 638);
+} catch {}
+let buffer126 = device0.createBuffer({
+  label: '\ud7e4\u3b10\u{1f77b}\u8449\uab5b',
+  size: 8656,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let sampler109 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 51.46,
+  lodMaxClamp: 52.73,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder150.setPipeline(pipeline3);
+} catch {}
+try {
+buffer57.unmap();
+} catch {}
+let buffer127 = device0.createBuffer({
+  size: 2928,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView161 = texture110.createView({aspect: 'all', mipLevelCount: 1});
+try {
+computePassEncoder153.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(0, bindGroup37, new Uint32Array(981), 1, 0);
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer83, 'uint16', 1_350, 266);
+} catch {}
+let textureView162 = texture23.createView({label: '\uce8a\ufad2\u06f9', mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder40); computePassEncoder40.dispatchWorkgroupsIndirect(buffer115, 76); };
+} catch {}
+try {
+computePassEncoder152.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 140, height: 145, depthOrArrayLayers: 239}
+*/
+{
+  source: img3,
+  origin: { x: 2, y: 4 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 1,
+  origin: {x: 59, y: 2, z: 83},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup111 = device0.createBindGroup({
+  label: '\u03a7\u00ce\u{1fbc2}\u04d7\u6baf\u36aa\u7cfc\u02ef\u6233\u{1fc65}',
+  layout: bindGroupLayout1,
+  entries: [{binding: 277, resource: sampler87}],
+});
+let texture158 = device0.createTexture({
+  size: [64, 64, 3],
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler110 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 87.53,
+  lodMaxClamp: 87.90,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup50);
+} catch {}
+try {
+computePassEncoder79.setBindGroup(1, bindGroup56, new Uint32Array(758), 104, 0);
+} catch {}
+try {
+computePassEncoder45.end();
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup17, new Uint32Array(46), 0, 0);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer116, 'uint32', 620, 46);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let buffer128 = device0.createBuffer({
+  size: 4496,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder192 = device0.createCommandEncoder({});
+let commandBuffer10 = commandEncoder63.finish();
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle16 = renderBundleEncoder16.finish({});
+let sampler111 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 71.52,
+});
+try {
+computePassEncoder115.setBindGroup(1, bindGroup75);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(2, bindGroup31, []);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer95, 'uint32', 5_072, 5_197);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer83, 2_228);
+} catch {}
+try {
+commandEncoder192.copyBufferToTexture({
+  /* bytesInLastRow: 156 widthInBlocks: 39 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3976 */
+  offset: 3976,
+  bytesPerRow: 256,
+  buffer: buffer117,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 39, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 11, y: 23, z: 0},
+  aspect: 'all',
+}, new Uint8Array(384).fill(246), /* required buffer size: 384 */
+{offset: 384, bytesPerRow: 167}, {width: 16, height: 20, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder193 = device0.createCommandEncoder({});
+let querySet18 = device0.createQuerySet({label: '\u0a51\ub552\u033b\u2163\u{1f855}\u{1faa8}', type: 'occlusion', count: 127});
+let computePassEncoder154 = commandEncoder192.beginComputePass({});
+let renderPassEncoder70 = commandEncoder193.beginRenderPass({
+  label: '\u2df0\uc89b\u01e7\u6a36\u6c84\ubf2d',
+  colorAttachments: [{view: textureView134, depthSlice: 0, loadOp: 'clear', storeOp: 'discard'}],
+});
+let sampler112 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 33.93,
+  lodMaxClamp: 90.44,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder128.end();
+} catch {}
+try {
+computePassEncoder154.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup94);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup69, new Uint32Array(135), 24, 0);
+} catch {}
+try {
+renderPassEncoder56.setVertexBuffer(7, buffer59, 0, 101);
+} catch {}
+try {
+commandEncoder169.copyTextureToTexture({
+  texture: texture121,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let buffer129 = device0.createBuffer({size: 6109, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let commandBuffer11 = commandEncoder169.finish();
+try {
+renderPassEncoder69.setIndexBuffer(buffer86, 'uint32', 872, 39);
+} catch {}
+try {
+renderPassEncoder67.setVertexBuffer(6, buffer116, 0, 57);
+} catch {}
+let textureView163 = texture150.createView({});
+try {
+computePassEncoder31.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer10, 'uint16', 1_504, 3_088);
+} catch {}
+let bindGroup112 = device0.createBindGroup({
+  layout: bindGroupLayout19,
+  entries: [{binding: 361, resource: {buffer: buffer116, offset: 0, size: 1368}}],
+});
+let texture159 = device0.createTexture({
+  size: {width: 36, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint']});
+try {
+computePassEncoder83.setBindGroup(1, bindGroup93, new Uint32Array(1082), 190, 0);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(2);
+} catch {}
+let buffer130 = device0.createBuffer({
+  size: 724,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder194 = device0.createCommandEncoder({});
+let textureView164 = texture157.createView({dimension: '1d'});
+try {
+renderPassEncoder34.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(2, buffer89);
+} catch {}
+try {
+commandEncoder194.copyTextureToBuffer({
+  texture: texture66,
+  mipLevel: 2,
+  origin: {x: 6, y: 38, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 180 */
+  offset: 180,
+  bytesPerRow: 27136,
+  buffer: buffer95,
+}, {width: 0, height: 25, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img2);
+let texture160 = device0.createTexture({size: {width: 192}, dimension: '1d', format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder155 = commandEncoder194.beginComputePass({});
+try {
+computePassEncoder65.setBindGroup(3, bindGroup62, new Uint32Array(1261), 72, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup95);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer64, 'uint32', 920, 1_119);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(3, buffer89, 508, 1_308);
+} catch {}
+try {
+device0.queue.submit([commandBuffer11]);
+} catch {}
+let imageBitmap3 = await createImageBitmap(imageData8);
+let commandEncoder195 = device0.createCommandEncoder();
+let texture161 = device0.createTexture({
+  size: [280, 291, 1],
+  mipLevelCount: 2,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder156 = commandEncoder195.beginComputePass({});
+let renderBundle17 = renderBundleEncoder17.finish();
+try {
+renderPassEncoder49.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle3]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 54}
+*/
+{
+  source: videoFrame21,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer131 = device0.createBuffer({size: 13030, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+let commandEncoder196 = device0.createCommandEncoder();
+let textureView165 = texture31.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 11});
+try {
+computePassEncoder40.end();
+} catch {}
+let arrayBuffer13 = buffer31.getMappedRange(24, 16);
+try {
+commandEncoder196.copyBufferToTexture({
+  /* bytesInLastRow: 1060 widthInBlocks: 265 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1124 */
+  offset: 1124,
+  buffer: buffer128,
+}, {
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 265, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture131,
+  mipLevel: 0,
+  origin: {x: 63, y: 35, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder57.clearBuffer(buffer35, 940, 9676);
+} catch {}
+try {
+commandEncoder57.insertDebugMarker('\u0dd6');
+} catch {}
+try {
+device0.queue.submit([commandBuffer10]);
+} catch {}
+let texture162 = device0.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView166 = texture26.createView({dimension: '2d-array'});
+let computePassEncoder157 = commandEncoder196.beginComputePass();
+let renderPassEncoder71 = commandEncoder57.beginRenderPass({
+  colorAttachments: [{view: textureView65, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet8,
+});
+try {
+computePassEncoder24.setBindGroup(1, bindGroup93, new Uint32Array(95), 4, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup89);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(1, bindGroup11, new Uint32Array(967), 117, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 2,
+  origin: {x: 8, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(513).fill(19), /* required buffer size: 513 */
+{offset: 513, bytesPerRow: 20}, {width: 2, height: 32, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup113 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [{binding: 511, resource: {buffer: buffer58, offset: 0, size: 720}}],
+});
+let texture163 = gpuCanvasContext0.getCurrentTexture();
+let textureView167 = texture132.createView({});
+let sampler113 = device0.createSampler({
+  label: '\u{1fafc}\u{1f8a7}\ubca3\udf54\u0d66\u00f3\u0b80\u{1fd67}\u1e0c\u5bbe\u4376',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 43.31,
+  lodMaxClamp: 61.39,
+  compare: 'less-equal',
+});
+try {
+buffer52.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(213).fill(197), /* required buffer size: 213 */
+{offset: 213}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img3);
+let bindGroupLayout21 = device0.createBindGroupLayout({
+  label: '\u20af\u2d2d\u7e93\u5575',
+  entries: [
+    {
+      binding: 606,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 190,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {binding: 125, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 222,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 1399, hasDynamicOffset: false },
+    },
+  ],
+});
+let texture164 = device0.createTexture({
+  size: {width: 280, height: 291, depthOrArrayLayers: 1},
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder31); computePassEncoder31.dispatchWorkgroupsIndirect(buffer25, 472); };
+} catch {}
+try {
+computePassEncoder157.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: -405.5, g: -815.2, b: 11.96, a: -250.7, });
+} catch {}
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 31,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 132,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 75, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 159,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 337,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 265, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 29,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 4,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 44,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 298,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 178,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 304,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 244,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let texture165 = device0.createTexture({
+  size: {width: 96, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler114 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 3.367,
+  lodMaxClamp: 47.35,
+});
+try {
+computePassEncoder54.setBindGroup(3, bindGroup103, new Uint32Array(2677), 68, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder79); computePassEncoder79.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder156.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setViewport(9.689598963351767, 0.1465328768621783, 23.031566855264114, 0.21778297627580062, 0.8142694685499997, 0.9881277112299279);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(4, buffer87, 1_500);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(30_119).fill(250), /* required buffer size: 30_119 */
+{offset: 89, bytesPerRow: 105, rowsPerImage: 26}, {width: 5, height: 0, depthOrArrayLayers: 12});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder197 = device0.createCommandEncoder({});
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 618});
+let textureView168 = texture164.createView({dimension: '2d-array', format: 'r32float'});
+let texture166 = device0.createTexture({
+  size: {width: 73, height: 1, depthOrArrayLayers: 38},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder158 = commandEncoder197.beginComputePass();
+try {
+computePassEncoder158.setBindGroup(1, bindGroup111, new Uint32Array(817), 181, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder79); computePassEncoder79.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder155.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer115, 'uint16', 12, 176);
+} catch {}
+try {
+computePassEncoder24.insertDebugMarker('\u6b8f');
+} catch {}
+let commandEncoder198 = device0.createCommandEncoder({});
+let texture167 = device0.createTexture({
+  label: '\u4d43\u0f34\u{1f60d}\u{1fe20}\u8708\u0b5b',
+  size: [64, 64, 22],
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture168 = device0.createTexture({
+  label: '\uf9f9\u34f5\u0654\u{1fe6e}\uae6f\u7718\u6443\u1cbb',
+  size: {width: 295, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder72 = commandEncoder198.beginRenderPass({
+  colorAttachments: [{
+  view: textureView32,
+  depthSlice: 504,
+  clearValue: { r: 62.40, g: 227.7, b: 401.3, a: 781.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler115 = device0.createSampler({
+  label: '\u{1f6d0}\u32f2\u04ab\u{1fa2a}\u7298',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 31.70,
+  maxAnisotropy: 6,
+});
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup25, new Uint32Array(1318), 415, 0);
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle4]);
+} catch {}
+let imageData24 = new ImageData(4, 56);
+let bindGroup114 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [
+    {binding: 96, resource: {buffer: buffer2, offset: 2048, size: 636}},
+    {binding: 113, resource: sampler0},
+    {binding: 127, resource: sampler16},
+  ],
+});
+let buffer132 = device0.createBuffer({
+  size: 2417,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture169 = device0.createTexture({
+  label: '\u{1fe19}\u{1f8d1}\ucfc9\u25bd\ub551\u2da6\uac94\u766c\u0974',
+  size: {width: 220},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder99.setBindGroup(0, bindGroup27, []);
+} catch {}
+try {
+computePassEncoder158.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup68);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(3, buffer10, 8_268);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup115 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [
+    {binding: 96, resource: {buffer: buffer106, offset: 256}},
+    {binding: 127, resource: sampler50},
+    {binding: 113, resource: sampler19},
+  ],
+});
+let buffer133 = device0.createBuffer({size: 6751, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let textureView169 = texture104.createView({mipLevelCount: 1});
+let textureView170 = texture98.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 6});
+try {
+renderPassEncoder9.setIndexBuffer(buffer121, 'uint16', 508, 226);
+} catch {}
+try {
+computePassEncoder73.label = '\u8657\u1ce7\u1dec\u{1ff90}\u{1fa9d}\u6c2d\u0cbb\u37e2\ua947';
+} catch {}
+let pipelineLayout10 = device0.createPipelineLayout({label: '\u07ec\u7d0d\u{1f61e}\u{1f92f}\u{1ff36}\uc85d\ub513\u0923', bindGroupLayouts: []});
+let commandEncoder199 = device0.createCommandEncoder({});
+let textureView171 = texture167.createView({
+  dimension: 'cube-array',
+  aspect: 'all',
+  format: 'r8sint',
+  mipLevelCount: 1,
+  baseArrayLayer: 1,
+  arrayLayerCount: 6,
+});
+let computePassEncoder159 = commandEncoder199.beginComputePass({});
+try {
+renderPassEncoder9.setIndexBuffer(buffer27, 'uint32', 456, 65);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(7, buffer111, 0, 306);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandEncoder200 = device0.createCommandEncoder({});
+let texture170 = device0.createTexture({
+  size: {width: 36, height: 1, depthOrArrayLayers: 19},
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView172 = texture39.createView({aspect: 'depth-only'});
+let computePassEncoder160 = commandEncoder200.beginComputePass();
+try {
+computePassEncoder151.setBindGroup(0, bindGroup79, new Uint32Array(1560), 121, 0);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup9, new Uint32Array(3217), 297, 0);
+} catch {}
+try {
+buffer117.unmap();
+} catch {}
+try {
+renderPassEncoder46.popDebugGroup();
+} catch {}
+let buffer134 = device0.createBuffer({size: 8465, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder201 = device0.createCommandEncoder({});
+let texture171 = device0.createTexture({
+  size: {width: 70, height: 72, depthOrArrayLayers: 91},
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder73 = commandEncoder201.beginRenderPass({colorAttachments: [{view: textureView139, depthSlice: 0, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+computePassEncoder104.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+computePassEncoder79.end();
+} catch {}
+try {
+computePassEncoder159.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder66.end();
+} catch {}
+try {
+commandEncoder105.resolveQuerySet(querySet9, 5, 7, buffer53, 768);
+} catch {}
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  label: '\u3b89\ud75a\u{1f968}\u1304',
+  entries: [
+    {
+      binding: 63,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 28,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let bindGroup116 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [{binding: 27, resource: {buffer: buffer119, offset: 2048, size: 3626}}],
+});
+let texture172 = device0.createTexture({
+  label: '\u0794\u09c2\u{1f852}\ud8ba\u{1fc6d}\u08cd\u806e\u0715\u{1fc62}',
+  size: {width: 192},
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder67.setBindGroup(2, bindGroup95, []);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(0, bindGroup75);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer115, 120, new Float32Array(8934), 328, 32);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 32}
+*/
+{
+  source: videoFrame15,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder202 = device0.createCommandEncoder();
+let commandBuffer12 = commandEncoder185.finish();
+let texture173 = device0.createTexture({
+  size: [147, 1, 67],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture174 = device0.createTexture({
+  size: [36, 1, 20],
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let texture175 = gpuCanvasContext1.getCurrentTexture();
+let textureView173 = texture53.createView({mipLevelCount: 1});
+try {
+renderPassEncoder71.beginOcclusionQuery(12);
+} catch {}
+try {
+commandEncoder105.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 0 */
+  offset: 0,
+  bytesPerRow: 4608,
+  buffer: buffer7,
+}, {
+  texture: texture78,
+  mipLevel: 1,
+  origin: {x: 7, y: 37, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 27, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer52, 912, new DataView(new ArrayBuffer(13209)), 850, 112);
+} catch {}
+let commandEncoder203 = device0.createCommandEncoder({label: '\u2b25\ucfc4\u05b7\u{1f619}\u{1f89c}\u{1fb42}'});
+let texture176 = device0.createTexture({
+  size: [36],
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder161 = commandEncoder203.beginComputePass({label: '\u2020\u3e00'});
+try {
+computePassEncoder107.setBindGroup(2, bindGroup35, []);
+} catch {}
+try {
+computePassEncoder160.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder71.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder105.copyTextureToBuffer({
+  texture: texture135,
+  mipLevel: 0,
+  origin: {x: 10, y: 10, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 48 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 688 */
+  offset: 688,
+  rowsPerImage: 187,
+  buffer: buffer74,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView174 = texture172.createView({label: '\u{1fe7e}\u2075\u8b87\u{1ff07}\u430f', mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder162 = commandEncoder202.beginComputePass({});
+try {
+renderPassEncoder35.beginOcclusionQuery(6);
+} catch {}
+try {
+renderPassEncoder35.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(6, buffer43, 12, 1_119);
+} catch {}
+document.body.append(img0);
+let bindGroup117 = device0.createBindGroup({
+  label: '\uf6a2\uc51c\u3e0d\u0ef8\u093e\uf540\u0f04\u3c3b',
+  layout: bindGroupLayout1,
+  entries: [{binding: 277, resource: sampler56}],
+});
+let commandEncoder204 = device0.createCommandEncoder({});
+let textureView175 = texture173.createView({aspect: 'all', mipLevelCount: 1});
+try {
+computePassEncoder136.setBindGroup(0, bindGroup54);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(0, bindGroup47, new Uint32Array(25), 5, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer12]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture98,
+  mipLevel: 1,
+  origin: {x: 8, y: 3, z: 1},
+  aspect: 'all',
+}, new Uint8Array(885).fill(120), /* required buffer size: 885 */
+{offset: 68, bytesPerRow: 19, rowsPerImage: 21}, {width: 0, height: 2, depthOrArrayLayers: 3});
+} catch {}
+let commandEncoder205 = device0.createCommandEncoder({});
+let textureView176 = texture164.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder163 = commandEncoder205.beginComputePass({label: '\u04a1\ua0d0\ucfe0\uf2ed\u7fe2'});
+let renderPassEncoder74 = commandEncoder204.beginRenderPass({
+  colorAttachments: [{
+  view: textureView97,
+  clearValue: { r: 593.7, g: -236.2, b: -587.8, a: -766.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder118.setBindGroup(2, bindGroup104, new Uint32Array(442), 47, 0);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let videoFrame28 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'unspecified', transfer: 'pq'} });
+let commandEncoder206 = device0.createCommandEncoder({});
+let textureView177 = texture169.createView({});
+let computePassEncoder164 = commandEncoder206.beginComputePass({});
+let renderPassEncoder75 = commandEncoder105.beginRenderPass({colorAttachments: [{view: textureView8, depthSlice: 2, loadOp: 'load', storeOp: 'discard'}]});
+try {
+computePassEncoder129.setBindGroup(2, bindGroup41, new Uint32Array(440), 8, 0);
+} catch {}
+try {
+computePassEncoder163.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup58);
+} catch {}
+let arrayBuffer14 = buffer35.getMappedRange(640, 672);
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+let bindGroup118 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 11, resource: {buffer: buffer19, offset: 2304, size: 1360}}],
+});
+let buffer135 = device0.createBuffer({size: 44083, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder207 = device0.createCommandEncoder({label: '\u1c3a\u90c4\u8462\u{1fd48}'});
+let renderPassEncoder76 = commandEncoder207.beginRenderPass({
+  label: '\u01a7\u079a',
+  colorAttachments: [{
+  view: textureView98,
+  clearValue: { r: -143.4, g: -64.54, b: 117.1, a: -506.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 148445028,
+});
+let sampler116 = device0.createSampler({
+  label: '\u0dcc\u0914\ubb64\u{1fcb4}\u01fe\u090f\u52e9\u3819\u0a14\u0982',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 18.51,
+  lodMaxClamp: 22.91,
+});
+let commandEncoder208 = device0.createCommandEncoder();
+try {
+computePassEncoder162.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder51.setBlendConstant({ r: 911.5, g: 828.8, b: 263.1, a: -592.3, });
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer85, 'uint32', 2_268, 3_051);
+} catch {}
+let videoFrame29 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'jedecP22Phosphors', transfer: 'linear'} });
+let texture177 = device0.createTexture({
+  label: '\udd23\u02d2\u98de\u4468\u031d\u92c5\u{1f6e3}\u0a12',
+  size: [280, 291, 1],
+  mipLevelCount: 3,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder165 = commandEncoder208.beginComputePass({});
+try {
+renderPassEncoder30.setScissorRect(10, 0, 3, 0);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(3, buffer98, 160, 393);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 1,
+  origin: {x: 3, y: 8, z: 0},
+  aspect: 'all',
+}, new Uint8Array(269).fill(153), /* required buffer size: 269 */
+{offset: 269, bytesPerRow: 217}, {width: 41, height: 29, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroup119 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [{binding: 511, resource: {buffer: buffer28, offset: 256, size: 1380}}],
+});
+try {
+computePassEncoder149.setBindGroup(3, bindGroup106, new Uint32Array(460), 5, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder127); computePassEncoder127.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder127); computePassEncoder127.dispatchWorkgroupsIndirect(buffer3, 136); };
+} catch {}
+try {
+computePassEncoder161.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder209 = device0.createCommandEncoder({label: '\u05d2\u0d37\ua1a8\ucb4a'});
+let computePassEncoder166 = commandEncoder209.beginComputePass({});
+let sampler117 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 71.17,
+  lodMaxClamp: 95.19,
+});
+try {
+computePassEncoder31.end();
+} catch {}
+try {
+computePassEncoder164.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup60);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(2, bindGroup41, new Uint32Array(1299), 130, 0);
+} catch {}
+try {
+buffer71.unmap();
+} catch {}
+let videoFrame30 = videoFrame2.clone();
+let texture178 = device0.createTexture({size: [42, 96, 22], format: 'astc-6x6-unorm-srgb', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder167 = commandEncoder44.beginComputePass({});
+let sampler118 = device0.createSampler({
+  label: '\u0b2b\u0fda\ucee3\u52ac\uc4bd\uc0a6\u013c\u01dd\u{1fa01}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 76.93,
+  lodMaxClamp: 89.81,
+});
+try {
+computePassEncoder165.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(1, bindGroup114);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer76, 'uint16', 7_236, 193);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer87, 2596, new DataView(new ArrayBuffer(10928)), 3644, 1792);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let bindGroup120 = device0.createBindGroup({
+  label: '\ue2c8\u{1fd3d}\ud384\u53ff\u04ff\uae8a\ud08e\u0135\u{1fb90}\u34d0\u013e',
+  layout: bindGroupLayout15,
+  entries: [{binding: 44, resource: externalTexture8}],
+});
+let textureView178 = texture176.createView({label: '\uade9\u06ac\ucc15\u0358\udf18\u21bb\u58a8\u984a\uc545\uaf81\ufa01'});
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup106);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer51, 'uint32', 952, 381);
+} catch {}
+let videoFrame31 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'smpte432', transfer: 'gamma22curve'} });
+try {
+computePassEncoder166.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(0, bindGroup74, new Uint32Array(784), 287, 0);
+} catch {}
+let commandEncoder210 = device0.createCommandEncoder({label: '\u6a89\u0dcc\u{1fc7a}\u{1f75f}\u3286\u2069\u2b79'});
+let texture179 = device0.createTexture({
+  size: {width: 220, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder123.setBindGroup(3, bindGroup120, new Uint32Array(2777), 24, 0);
+} catch {}
+try {
+computePassEncoder167.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder70.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer95, 'uint16', 1_752, 4_991);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(2, buffer98, 0, 1_640);
+} catch {}
+let bindGroup121 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [{binding: 511, resource: {buffer: buffer95, offset: 1792, size: 480}}],
+});
+let commandEncoder211 = device0.createCommandEncoder({label: '\uff15\u6ba9\ue774\u{1fb29}\u24e7\u238c\u1b54\ua46a\u{1f7af}'});
+let computePassEncoder168 = commandEncoder210.beginComputePass();
+try {
+computePassEncoder127.end();
+} catch {}
+try {
+computePassEncoder168.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder46.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder68.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(2, buffer89, 0, 819);
+} catch {}
+try {
+commandEncoder211.copyTextureToTexture({
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 5},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.RENDER_ATTACHMENT, colorSpace: 'srgb'});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 280, height: 291, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture161,
+  mipLevel: 0,
+  origin: {x: 1, y: 187, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+await gc();
+let bindGroup122 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 94, resource: textureView132},
+    {binding: 132, resource: textureView22},
+    {binding: 243, resource: textureView108},
+    {binding: 421, resource: {buffer: buffer92, offset: 768, size: 3552}},
+    {binding: 398, resource: textureView172},
+    {binding: 999, resource: textureView121},
+    {binding: 35, resource: textureView70},
+    {binding: 567, resource: textureView140},
+    {binding: 42, resource: externalTexture4},
+  ],
+});
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 1105});
+try {
+computePassEncoder116.setBindGroup(3, bindGroup86, new Uint32Array(287), 29, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup120, new Uint32Array(6524), 560, 0);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+let commandEncoder212 = device0.createCommandEncoder({label: '\u007a\u024d\uab27\u9794\u2630\u{1fc74}'});
+let texture180 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 18},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder169 = commandEncoder212.beginComputePass({});
+let renderPassEncoder77 = commandEncoder211.beginRenderPass({
+  colorAttachments: [{
+  view: textureView163,
+  depthSlice: 24,
+  clearValue: { r: 559.1, g: -48.92, b: 784.2, a: -980.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet11,
+  maxDrawCount: 132052912,
+});
+try {
+computePassEncoder94.setBindGroup(3, bindGroup100, new Uint32Array(2944), 2_944, 0);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer26, 'uint16', 1_178, 37);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer42, 448, new DataView(new ArrayBuffer(731)), 56, 20);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 140, height: 145, depthOrArrayLayers: 239}
+*/
+{
+  source: imageData22,
+  origin: { x: 1, y: 6 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 1,
+  origin: {x: 0, y: 8, z: 80},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let bindGroup123 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 225, resource: textureView108}, {binding: 58, resource: {buffer: buffer81, offset: 256}}],
+});
+let querySet21 = device0.createQuerySet({
+  label: '\u19bd\u{1f86f}\u{1fa51}\u{1f7e8}\u031f\u{1fa69}\u0630\u7463\u{1fc3a}\u83e7\u9d7f',
+  type: 'occlusion',
+  count: 694,
+});
+try {
+renderPassEncoder52.executeBundles([renderBundle2, renderBundle2]);
+} catch {}
+try {
+commandEncoder168.copyBufferToBuffer(buffer3, 12, buffer50, 12, 80);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer100, 772, new BigUint64Array(23543), 3238, 12);
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55); };
+} catch {}
+let canvas2 = document.createElement('canvas');
+let commandEncoder213 = device0.createCommandEncoder({});
+let texture181 = device0.createTexture({
+  size: {width: 147},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder170 = commandEncoder168.beginComputePass({});
+let renderPassEncoder78 = commandEncoder213.beginRenderPass({
+  label: '\uff21\u834a\ucf6c\u{1f718}\u{1fbc5}',
+  colorAttachments: [{
+  view: textureView156,
+  clearValue: { r: 922.3, g: -405.3, b: 711.5, a: -105.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler119 = device0.createSampler({
+  label: '\ud82f\u8fe9\u{1f6e6}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 16.91,
+  lodMaxClamp: 78.12,
+});
+try {
+computePassEncoder123.setBindGroup(0, bindGroup92, new Uint32Array(1577), 68, 0);
+} catch {}
+try {
+computePassEncoder169.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(1, bindGroup98, new Uint32Array(614), 59, 0);
+} catch {}
+try {
+renderPassEncoder74.setVertexBuffer(5, buffer115, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer136 = device0.createBuffer({
+  label: '\ua7ac\u{1f79f}\u0f02\ucf56\uc50f',
+  size: 655,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+try {
+computePassEncoder78.end();
+} catch {}
+try {
+computePassEncoder170.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder67.setVertexBuffer(6, buffer42, 0, 379);
+} catch {}
+try {
+commandEncoder104.clearBuffer(buffer96, 5348, 156);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer124, 552, new BigUint64Array(549), 185, 144);
+} catch {}
+let videoFrame32 = new VideoFrame(videoFrame8, {timestamp: 0});
+let bindGroup124 = device0.createBindGroup({
+  layout: bindGroupLayout23,
+  entries: [{binding: 63, resource: textureView175}, {binding: 28, resource: textureView174}],
+});
+let texture182 = device0.createTexture({
+  size: [64, 64, 22],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder102.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+computePassEncoder136.setBindGroup(2, bindGroup104, new Uint32Array(1774), 135, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer131, 'uint16', 634, 1_833);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(7, buffer56);
+} catch {}
+try {
+commandEncoder104.copyBufferToTexture({
+  /* bytesInLastRow: 620 widthInBlocks: 155 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2380 */
+  offset: 2380,
+  bytesPerRow: 27392,
+  buffer: buffer100,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 25, y: 18, z: 0},
+  aspect: 'all',
+}, {width: 155, height: 96, depthOrArrayLayers: 0});
+} catch {}
+let texture183 = device0.createTexture({
+  size: {width: 295},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder171 = commandEncoder104.beginComputePass({});
+try {
+computePassEncoder171.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup61);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer131, 'uint16', 146, 277);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(0, buffer24, 824, 1_971);
+} catch {}
+let bindGroup125 = device0.createBindGroup({
+  label: '\uef72\uea6c\u0db3\u0117\ud22c\ud046',
+  layout: bindGroupLayout6,
+  entries: [{binding: 11, resource: {buffer: buffer65, offset: 0}}],
+});
+let commandEncoder214 = device0.createCommandEncoder();
+let computePassEncoder172 = commandEncoder214.beginComputePass({label: '\u0f2a\u050b\u091a\u07ec\u{1fc33}\u1c79\ucd6c'});
+let sampler120 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 46.39,
+  lodMaxClamp: 51.35,
+});
+try {
+computePassEncoder114.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+computePassEncoder77.setBindGroup(0, bindGroup6, new Uint32Array(1062), 3, 0);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup12, new Uint32Array(732), 49, 0);
+} catch {}
+try {
+renderPassEncoder20.setViewport(68.9729530708249, 1.1061837314567802, 0.41709976258613113, 33.74003349570095, 0.602409604321413, 0.7879344676928945);
+} catch {}
+try {
+renderPassEncoder75.setVertexBuffer(0, buffer111);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 41},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = externalTexture1.label;
+} catch {}
+let commandEncoder215 = device0.createCommandEncoder({});
+let querySet22 = device0.createQuerySet({type: 'occlusion', count: 445});
+try {
+computePassEncoder167.setBindGroup(3, bindGroup48);
+} catch {}
+try {
+computePassEncoder172.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(2, bindGroup56);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer76, 'uint32', 2_868, 14_864);
+} catch {}
+try {
+renderPassEncoder67.setVertexBuffer(2, buffer89);
+} catch {}
+try {
+renderPassEncoder45.insertDebugMarker('\u6357');
+} catch {}
+let computePassEncoder173 = commandEncoder215.beginComputePass({});
+try {
+computePassEncoder173.setPipeline(pipeline3);
+} catch {}
+document.body.append(img2);
+let imageData25 = new ImageData(28, 8);
+try {
+querySet7.label = '\u300a\uff34\u7817\u4ca7\u0e97\u6d80\u9b52\u{1fe13}\u72c7\uef25\u7682';
+} catch {}
+let bindGroup126 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [
+    {binding: 96, resource: {buffer: buffer11, offset: 4096, size: 72}},
+    {binding: 127, resource: sampler101},
+    {binding: 113, resource: sampler20},
+  ],
+});
+try {
+renderPassEncoder54.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup69, new Uint32Array(2218), 12, 0);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle15]);
+} catch {}
+let commandEncoder216 = device0.createCommandEncoder();
+let texture184 = gpuCanvasContext1.getCurrentTexture();
+let textureView179 = texture99.createView({dimension: '2d-array'});
+let renderPassEncoder79 = commandEncoder216.beginRenderPass({
+  colorAttachments: [{view: textureView32, depthSlice: 112, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 55033984,
+});
+try {
+renderPassEncoder28.setBindGroup(0, bindGroup27, []);
+} catch {}
+try {
+renderPassEncoder54.beginOcclusionQuery(12);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+let bindGroup127 = device0.createBindGroup({
+  label: '\u0f87\u{1f609}\uee64',
+  layout: bindGroupLayout15,
+  entries: [{binding: 44, resource: externalTexture18}],
+});
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder217 = device0.createCommandEncoder({label: '\u0517\u07de\ua60e\u{1fd4a}\u4bf9\u{1f6fb}\u4d76'});
+let textureView180 = texture167.createView({dimension: 'cube-array', baseArrayLayer: 1, arrayLayerCount: 6});
+let texture185 = device0.createTexture({
+  label: '\ud60c\u30fd\u8bbb\uf798\uc3ca\uaaee\u0922\u0694\u83bc',
+  size: [280, 291, 1],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder174 = commandEncoder217.beginComputePass({});
+try {
+computePassEncoder174.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer13, 'uint16', 2_152, 1_442);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup128 = device0.createBindGroup({layout: bindGroupLayout10, entries: [{binding: 5, resource: sampler51}]});
+let commandEncoder218 = device0.createCommandEncoder({});
+let texture186 = device0.createTexture({
+  size: [560],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView181 = texture51.createView({});
+let computePassEncoder175 = commandEncoder218.beginComputePass({});
+try {
+computePassEncoder77.dispatchWorkgroups(5, 1);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let bindGroupLayout24 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 52,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let texture187 = device0.createTexture({size: {width: 70}, dimension: '1d', format: 'rgba16sint', usage: GPUTextureUsage.STORAGE_BINDING});
+let textureView182 = texture182.createView({dimension: '2d', aspect: 'depth-only', baseArrayLayer: 2});
+try {
+computePassEncoder139.setBindGroup(2, bindGroup91);
+} catch {}
+try {
+computePassEncoder175.setPipeline(pipeline2);
+} catch {}
+try {
+  await shaderModule1.getCompilationInfo();
+} catch {}
+let shaderModule13 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(35) var st22: texture_storage_1d<r32sint, read_write>;
+
+@group(0) @binding(42) var et0: texture_external;
+
+@group(0) @binding(94) var tex1: texture_2d_array<f32>;
+
+@group(0) @binding(132) var tex2: texture_2d<i32>;
+
+@group(0) @binding(243) var tex3: texture_depth_2d;
+
+@group(0) @binding(398) var tex4: texture_depth_2d;
+
+@group(0) @binding(421) var<storage, read> buffer137: T0;
+
+@group(0) @binding(567) var st23: texture_storage_2d<rgba8snorm, write>;
+
+@group(0) @binding(999) var tex5: texture_2d_array<i32>;
+
+struct T0 {
+  f0: array<u32>,
+}
+
+struct VertexOutput12 {
+  @builtin(position) f38: vec4f,
+}
+
+struct VertexOutput13 {
+  @builtin(position) f39: vec4f,
+  @location(9) @interpolate(flat, sample) f40: u32,
+  @location(5) f41: vec4u,
+  @location(6) f42: i32,
+}
+
+struct VertexOutput14 {
+  @builtin(position) f43: vec4f,
+}
+
+struct FragmentOutput8 {
+  @location(0) f0: vec4u,
+  @location(7) f1: vec4i,
+  @location(6) f2: vec2i,
+}
+
+struct FragmentOutput9 {
+  @location(0) @interpolate(linear, centroid) f0: vec4f,
+}
+
+fn fn0() -> array<i32, 39> {
+  var out: array<i32, 39>;
+  let vf231: u32 = atomicExchange(&vw55, u32(unconst_u32(182)));
+  textureStore(st22, i32(unconst_i32(131)), vec4i(vec4i(unconst_i32(24), unconst_i32(33), unconst_i32(25), unconst_i32(14))));
+  var vf232: vec2u = textureDimensions(tex2);
+  let vf233: u32 = textureNumLevels(tex1);
+  var vf234: vec2u = textureDimensions(tex3);
+  out[u32(unconst_u32(14))] ^= bitcast<i32>(atomicLoad(&vw55));
+  let vf235: bool = all(bool(unconst_bool(true)));
+  textureStore(st23, vec2i(bitcast<i32>(textureLoad(tex3, vec2i(unconst_i32(-254), unconst_i32(8)), i32(unconst_i32(89))))), vec4f(vec4f(unconst_f32(0.7199), unconst_f32(0.04554), unconst_f32(0.4185), unconst_f32(0.1026))));
+  vf234 <<= vec2u(u32(vf235));
+  let ptr94: ptr<workgroup, VertexOutput14> = &(*&vw56);
+  var vf236: u32 = vf234[vf232[u32(unconst_u32(83))]];
+  vf232 = vec2u(min(vec3h(unconst_f16(11220.2), unconst_f16(135.6), unconst_f16(2054.9)), vec3h(unconst_f16(5497.0), unconst_f16(8771.1), unconst_f16(92.07))).zz);
+  var vf237: vec4i = textureLoad(tex5, vec2i(unconst_i32(59), unconst_i32(128)), i32(unconst_i32(51)), i32(unconst_i32(188)));
+  let ptr95: ptr<workgroup, atomic<u32>> = &vw55;
+  let ptr96: ptr<function, vec4i> = &vf237;
+  var vf238: u32 = atomicLoad(&vw55);
+  vf234 = vec2u(atomicExchange(&(*ptr95), u32(unconst_u32(851))));
+  let vf239: vec2u = textureDimensions(tex1);
+  var vf240: u32 = textureNumLevels(tex1);
+  let vf241: u32 = vf231;
+  return out;
+}
+
+var<workgroup> vw55: atomic<u32>;
+
+var<workgroup> vw56: VertexOutput14;
+
+@vertex
+fn vertex13(@builtin(vertex_index) a0: u32, @location(9) @interpolate(flat, center) a1: vec2f, @location(15) a2: vec4i) -> VertexOutput12 {
+  var out: VertexOutput12;
+  let vf242: vec2u = textureDimensions(tex5);
+  let vf243: u32 = textureNumLevels(tex5);
+  out.f38 = unpack4x8unorm(textureNumLevels(tex4));
+  out = VertexOutput12(unpack4x8unorm(pack4xI8Clamp(vec4i(unconst_i32(-189), unconst_i32(186), unconst_i32(79), unconst_i32(59)))));
+  var vf244: u32 = arrayLength(&buffer137.f0);
+  out.f38 = bitcast<vec4f>(vf242.yxxy);
+  vf244 <<= bitcast<u32>(faceForward(vec2h(unconst_f16(-3874.3), unconst_f16(15712.3)), vec2h(unconst_f16(35605.4), unconst_f16(2440.6)), vec2h(unconst_f16(29358.5), unconst_f16(8625.5))));
+  let vf245: vec2u = countOneBits(vec2u(unconst_u32(83), unconst_u32(72)));
+  let vf246: vec2u = textureDimensions(tex3);
+  vf244 += textureDimensions(tex5)[1];
+  out.f38 = vec4f(faceForward(vec2h(unconst_f16(10259.4), unconst_f16(-27803.2)), bitcast<vec2h>(buffer137.f0[arrayLength(&buffer137.f0) - 1]), vec2h(unconst_f16(6870.8), unconst_f16(1535.6))).rrgr);
+  var vf247: f16 = log2(f16(unconst_f16(21326.9)));
+  var vf248: u32 = arrayLength(&(*&buffer137).f0);
+  let ptr97: ptr<storage, u32, read> = &buffer137.f0[arrayLength(&buffer137.f0) - 1];
+  var vf249: u32 = pack4xI8Clamp(vec4i(unconst_i32(174), unconst_i32(64), unconst_i32(184), unconst_i32(67)));
+  let ptr98: ptr<storage, u32, read> = &buffer137.f0[arrayLength(&buffer137.f0)];
+  let vf250: vec4f = textureLoad(tex1, vec2i(unconst_i32(199), unconst_i32(58)), i32(unconst_i32(162)), bitcast<i32>(textureDimensions(tex2)[0]));
+  return out;
+}
+
+@vertex
+fn vertex14() -> VertexOutput13 {
+  var out: VertexOutput13;
+  let vf251: u32 = textureNumLevels(tex1);
+  out.f39 = vec4f(extractBits(vec3i(unconst_i32(50), unconst_i32(129), unconst_i32(114)), pack4x8unorm(vec4f(unconst_f32(-0.00789), unconst_f32(0.5104), unconst_f32(0.02833), unconst_f32(-0.00773))), textureDimensions(tex2).y).xzyz);
+  var vf252: f32 = distance(vec2f(unconst_f32(0.03542), unconst_f32(0.1037)), vec2f(abs(f32(unconst_f32(-0.1201)))));
+  let vf253: f32 = distance(vec2f(unconst_f32(0.1611), unconst_f32(0.4981)), vec2f(unconst_f32(0.5526), unconst_f32(0.3021)));
+  out.f39 *= vec4f(bitcast<f32>((*&buffer137).f0[arrayLength(&(*&buffer137).f0)]));
+  out.f40 <<= bitcast<u32>(fma(vec2h(unconst_f16(12658.2), unconst_f16(4877.6)), vec2h(unconst_f16(-13811.2), unconst_f16(24135.6)), vec2h(unconst_f16(9458.8), unconst_f16(489.3))));
+  out.f39 -= vec4f(textureLoad(tex2, vec2i(unconst_i32(18), unconst_i32(252)), i32(unconst_i32(384))));
+  var vf254: u32 = pack4x8unorm(bitcast<vec4f>(reverseBits(vec2i(unconst_i32(118), unconst_i32(76))).yxxy));
+  out.f41 *= unpack4xU8(textureNumLevels(tex3));
+  var vf255: vec2h = clamp(vec2h(unconst_f16(-3343.8), unconst_f16(2901.0)), vec2h(unconst_f16(24144.5), unconst_f16(8467.3)), vec2h(unconst_f16(-2751.8), unconst_f16(-14841.2)));
+  out.f42 *= bitcast<vec2i>(textureDimensions(tex3, i32(unconst_i32(59)))).g;
+  out.f39 += vec4f(reflect(vec2h(unconst_f16(4303.9), unconst_f16(17788.1)), vec2h(unconst_f16(5367.7), unconst_f16(16638.4))).yxxx);
+  var vf256: vec2u = textureDimensions(tex4);
+  let ptr99: ptr<storage, T0, read> = &buffer137;
+  vf252 = bitcast<f32>(dot4I8Packed(u32(unconst_u32(176)), u32(unconst_u32(180))));
+  var vf257: u32 = vf251;
+  out.f42 ^= i32((*&buffer137).f0[arrayLength(&(*&buffer137).f0) - 1]);
+  return out;
+}
+
+@vertex
+fn vertex15(@location(5) @interpolate(flat) a0: vec2h) -> VertexOutput14 {
+  var out: VertexOutput14;
+  out.f43 *= vec4f(bitcast<f32>(pack4xI8Clamp(vec4i(unconst_i32(336), unconst_i32(68), unconst_i32(185), unconst_i32(178)))));
+  out.f43 *= bitcast<vec4f>(textureDimensions(et0).xxyy);
+  let ptr100: ptr<storage, array<u32>, read> = &buffer137.f0;
+  let ptr101: ptr<storage, array<u32>, read> = &buffer137.f0;
+  let ptr102: ptr<storage, u32, read> = &(*&buffer137).f0[u32(unconst_u32(551))];
+  var vf258: vec2u = textureDimensions(tex2);
+  let ptr103: ptr<storage, array<u32>, read> = &(*ptr100);
+  let ptr104: ptr<storage, u32, read> = &buffer137.f0[arrayLength(&buffer137.f0) - 1];
+  var vf259: vec3h = acos(vec3h(unconst_f16(2350.6), unconst_f16(5057.2), unconst_f16(4388.7)));
+  vf259 *= vec3h(f16(buffer137.f0[arrayLength(&buffer137.f0)]));
+  let ptr105: ptr<storage, u32, read> = &(*&buffer137).f0[arrayLength(&(*&buffer137).f0) - 1];
+  let ptr106: ptr<storage, u32, read> = &buffer137.f0[bitcast<vec2i>(insertBits(vec2u(unconst_u32(461), unconst_u32(240)), vec2u(unconst_u32(252), unconst_u32(63)), u32(unconst_u32(51)), u32(unconst_u32(88)))).r];
+  vf258 |= vec2u(textureNumLevels(tex1));
+  var vf260: vec2u = textureDimensions(tex1, i32(unconst_i32(366)));
+  return out;
+}
+
+@fragment
+fn fragment9() -> FragmentOutput8 {
+  var out: FragmentOutput8;
+  out.f1 |= vec4i(i32(buffer137.f0[arrayLength(&buffer137.f0)]));
+  let vf261: vec4h = refract(vec4h(unconst_f16(3874.3), unconst_f16(24478.2), unconst_f16(-24328.8), unconst_f16(12688.4)), vec4h(unconst_f16(-31754.2), unconst_f16(726.6), unconst_f16(4184.9), unconst_f16(15869.0)), f16(unconst_f16(3701.8)));
+  out.f0 -= vec4u(vf261);
+  let ptr107: ptr<storage, u32, read> = &buffer137.f0[i32(unconst_i32(39))];
+  out.f2 = vec2i(i32(vf261[u32(unconst_u32(128))]));
+  out.f2 = vec2i(bitcast<i32>((*&buffer137).f0[u32(unconst_u32(21))]));
+  let ptr108: ptr<storage, array<u32>, read> = &buffer137.f0;
+  let vf262: u32 = pack2x16unorm(vec2f(unconst_f32(0.02720), unconst_f32(0.2128)));
+  let vf263: vec3f = asin(textureLoad(et0, vec2u(unconst_u32(20), unconst_u32(45))).rrb);
+  out.f1 += bitcast<vec4i>(textureDimensions(et0).xyyy);
+  out.f2 |= vec2i(i32(buffer137.f0[u32(unconst_u32(36))]));
+  out.f2 = vec2i(bitcast<i32>(textureNumLevels(tex2)));
+  let ptr109: ptr<storage, u32, read> = &buffer137.f0[i32(unconst_i32(-380))];
+  let ptr110: ptr<storage, u32, read> = &(*&buffer137).f0[u32(unconst_u32(214))];
+  var vf264: f32 = vf263[u32(unconst_u32(123))];
+  let ptr111: ptr<storage, u32, read> = &(*&buffer137).f0[arrayLength(&(*&buffer137).f0)];
+  let ptr112: ptr<storage, u32, read> = &buffer137.f0[arrayLength(&buffer137.f0)];
+  let vf265: vec4h = normalize(vec4h(f16((*&buffer137).f0[u32(unconst_u32(236))])));
+  let vf266: f16 = vf261[u32(unconst_u32(6))];
+  out.f2 = vec2i(i32((*ptr108)[i32(unconst_i32(142))]));
+  var vf267: vec4h = normalize(refract(vec4h(unconst_f16(2013.7), unconst_f16(1316.8), unconst_f16(22856.2), unconst_f16(7595.4)), vec4h(unconst_f16(9049.0), unconst_f16(9563.4), unconst_f16(6347.0), unconst_f16(7148.2)), f16(fract(vec4f(unconst_f32(0.03118), unconst_f32(0.2074), unconst_f32(0.04416), unconst_f32(0.1155))).b)));
+  textureStore(st23, vec2i(unconst_i32(45), unconst_i32(502)), vec4f(vec4f(unconst_f32(-0.04105), unconst_f32(0.2080), unconst_f32(0.1728), unconst_f32(0.01811))));
+  let ptr113: ptr<storage, u32, read> = &(*ptr108)[u32(unconst_u32(122))];
+  return out;
+}
+
+@fragment
+fn fragment10() -> FragmentOutput9 {
+  var out: FragmentOutput9;
+  textureStore(st23, vec2i(unconst_i32(292), unconst_i32(110)), vec4f(vec4f(unconst_f32(0.9010), unconst_f32(0.1022), unconst_f32(0.01056), unconst_f32(0.00137))));
+  var vf268: vec4f = cos(vec4f(bitcast<f32>(dot4U8Packed(textureDimensions(tex2)[0], u32(unconst_u32(210))))));
+  out.f0 *= clamp(vec3f(unconst_f32(-0.2518), unconst_f32(0.5207), unconst_f32(0.07175)), vec3f(unconst_f32(0.02148), unconst_f32(0.09244), unconst_f32(0.6234)), vec3f(unconst_f32(0.02631), unconst_f32(-0.2411), unconst_f32(0.1090))).xzyy;
+  var vf269: u32 = textureNumLevels(tex2);
+  var vf270: vec4i = textureLoad(tex2, vec2i(unconst_i32(45), unconst_i32(221)), i32(unconst_i32(135)));
+  let vf271: u32 = dot4U8Packed(u32(unconst_u32(193)), u32(unconst_u32(302)));
+  let ptr114: ptr<function, vec4f> = &vf268;
+  return out;
+}
+
+@compute @workgroup_size(1, 2, 1)
+fn compute12(@builtin(local_invocation_id) a0: vec3u) {
+  vw56.f43 = unpack4x8unorm(a0[u32(unconst_u32(71))]);
+  var vf272 = fn0();
+  fn0();
+  let vf273: vec3h = cross(vec3h(unconst_f16(19698.4), unconst_f16(-13700.1), unconst_f16(-41792.0)), vec3h(unconst_f16(9465.2), unconst_f16(8385.6), unconst_f16(8879.6)));
+  textureStore(st23, vec2i(unconst_i32(79), unconst_i32(284)), vec4f(vec4f(unconst_f32(0.06529), unconst_f32(0.1829), unconst_f32(0.1053), unconst_f32(0.03838))));
+  var vf274 = fn0();
+  fn0();
+  var vf275: vec2f = radians(vec2f(unconst_f32(0.1159), unconst_f32(0.1922)));
+  fn0();
+  fn0();
+  let vf276: u32 = textureNumLayers(tex1);
+  vf274[u32(unconst_u32(381))] = i32(vf273[1]);
+  let vf277: u32 = atomicLoad(&vw55);
+  fn0();
+  let ptr115: ptr<function, i32> = &vf274[38];
+  var vf278 = fn0();
+  var vf279: vec3u = a0;
+}`,
+  sourceMap: {},
+});
+let commandEncoder219 = device0.createCommandEncoder();
+let textureView183 = texture98.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 4, arrayLayerCount: 6});
+let texture188 = device0.createTexture({
+  size: [560, 582, 1],
+  sampleCount: 1,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder176 = commandEncoder219.beginComputePass({});
+try {
+computePassEncoder176.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(3, bindGroup61);
+} catch {}
+try {
+renderPassEncoder54.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder72.setViewport(9.551801025184794, 0.6617482129186207, 5.083310862463955, 0.2636590524598485, 0.7826364344059625, 0.9005129258205499);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline1);
+} catch {}
+let bindGroup129 = device0.createBindGroup({label: '\u0b9f\u2d40', layout: bindGroupLayout20, entries: [{binding: 152, resource: textureView108}]});
+let textureView184 = texture104.createView({});
+let texture189 = device0.createTexture({size: [110, 10, 81], format: 'rgba32float', usage: GPUTextureUsage.COPY_DST});
+let sampler121 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 48.57,
+  lodMaxClamp: 92.02,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup92, new Uint32Array(7), 1, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder100); computePassEncoder100.dispatchWorkgroupsIndirect(buffer67, 3_292); };
+} catch {}
+try {
+computePassEncoder77.end();
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder77.setVertexBuffer(2, buffer85);
+} catch {}
+try {
+commandEncoder9.copyBufferToTexture({
+  /* bytesInLastRow: 88 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6408 */
+  offset: 6408,
+  bytesPerRow: 15104,
+  buffer: buffer39,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 36, height: 1, depthOrArrayLayers: 20}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture174,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext3 = canvas2.getContext('webgpu');
+let buffer138 = device0.createBuffer({
+  size: 4465,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderPassEncoder80 = commandEncoder9.beginRenderPass({
+  colorAttachments: [{view: textureView145, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 50781338,
+});
+let externalTexture19 = device0.importExternalTexture({source: videoFrame20, colorSpace: 'display-p3'});
+try {
+computePassEncoder167.setBindGroup(2, bindGroup55, []);
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(2, bindGroup100);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup68, new Uint32Array(2312), 343, 0);
+} catch {}
+try {
+renderPassEncoder41.setViewport(236.3408965215245, 340.6369759885509, 103.7735944464909, 187.8198254364005, 0.3679188880805878, 0.7788752957854537);
+} catch {}
+try {
+computePassEncoder125.insertDebugMarker('\u4aad');
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let buffer139 = device0.createBuffer({
+  size: 38651,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture190 = gpuCanvasContext0.getCurrentTexture();
+let textureView185 = texture55.createView({baseMipLevel: 0});
+let sampler122 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 4.506,
+  lodMaxClamp: 6.203,
+});
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup95);
+} catch {}
+try {
+renderPassEncoder77.setBindGroup(0, bindGroup17, new Uint32Array(1208), 711, 0);
+} catch {}
+try {
+renderPassEncoder72.setIndexBuffer(buffer52, 'uint16', 1_684);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(1, buffer62, 0, 3_109);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 32}
+*/
+{
+  source: imageData14,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup130 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 103, resource: textureView160}, {binding: 176, resource: textureView158}],
+});
+let commandEncoder220 = device0.createCommandEncoder({});
+let texture191 = device0.createTexture({
+  label: '\ufee2\u0d27\u0547\u0a19\u0156\u{1f892}\u{1fa3a}\uc22d\u{1f61f}\u51a0\u4510',
+  size: {width: 560, height: 582, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder177 = commandEncoder220.beginComputePass({});
+try {
+computePassEncoder177.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(1, bindGroup49, new Uint32Array(862), 31, 0);
+} catch {}
+let arrayBuffer15 = buffer31.getMappedRange(48, 20);
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let texture192 = gpuCanvasContext1.getCurrentTexture();
+try {
+renderPassEncoder78.setIndexBuffer(buffer51, 'uint32', 204, 3);
+} catch {}
+try {
+renderPassEncoder47.pushDebugGroup('\u{1fbaa}');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+document.body.prepend(canvas1);
+let bindGroup131 = device0.createBindGroup({layout: bindGroupLayout20, entries: [{binding: 152, resource: textureView102}]});
+let commandEncoder221 = device0.createCommandEncoder({});
+let computePassEncoder178 = commandEncoder221.beginComputePass({});
+try {
+computePassEncoder100.end();
+} catch {}
+try {
+renderPassEncoder68.beginOcclusionQuery(29);
+} catch {}
+try {
+renderPassEncoder68.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder136.copyBufferToTexture({
+  /* bytesInLastRow: 120 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 40 */
+  offset: 40,
+  bytesPerRow: 14592,
+  rowsPerImage: 164,
+  buffer: buffer48,
+}, {
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 155, y: 68, z: 0},
+  aspect: 'all',
+}, {width: 15, height: 46, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer32, 1828, new Int16Array(1884), 109, 1308);
+} catch {}
+let texture193 = device0.createTexture({
+  label: '\u{1fdef}\u{1fb7c}\ub4df\u{1f939}\u{1fe40}',
+  size: {width: 220, height: 20, depthOrArrayLayers: 40},
+  mipLevelCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView186 = texture11.createView({label: '\ub99c\u827d\u0b08\u{1fe1c}\ued40\ue5fe\ua82e\u07b7\u{1fe20}\u0c11\u{1fd6b}'});
+let computePassEncoder179 = commandEncoder136.beginComputePass({});
+try {
+computePassEncoder41.setBindGroup(1, bindGroup50, new Uint32Array(1061), 217, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup117, new Uint32Array(245), 128, 0);
+} catch {}
+let commandEncoder222 = device0.createCommandEncoder({});
+let texture194 = device0.createTexture({
+  size: [70, 72, 25],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView187 = texture51.createView({dimension: '1d'});
+let computePassEncoder180 = commandEncoder222.beginComputePass();
+let sampler123 = device0.createSampler({
+  label: '\udc16\u00ee',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 82.93,
+  compare: 'equal',
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder180.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(3, bindGroup116);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(0, bindGroup94, new Uint32Array(1563), 283, 0);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer64, 'uint16', 1_554, 1_186);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 140, height: 145, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData8,
+  origin: { x: 0, y: 4 },
+  flipY: true,
+}, {
+  texture: texture161,
+  mipLevel: 1,
+  origin: {x: 28, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 5, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let shaderModule14 = device0.createShaderModule({
+  label: '\uf815\u092e\u8a8b\u5f25',
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(103) var st24: texture_storage_3d<rgba8unorm, write>;
+
+@group(0) @binding(176) var st25: texture_storage_3d<rgba16uint, write>;
+
+struct T0 {
+  @align(16) @size(80) f0: array<u32>,
+}
+
+struct VertexOutput15 {
+  @builtin(position) f44: vec4f,
+}
+
+struct VertexOutput16 {
+  @location(5) @interpolate(flat) f45: u32,
+  @invariant @builtin(position) f46: vec4f,
+  @location(10) f47: vec2i,
+  @location(12) f48: u32,
+}
+
+struct FragmentOutput10 {
+  @location(5) f0: vec2f,
+  @location(0) f1: vec4u,
+}
+
+@id(56650) override override7 = 0.1572;
+
+@id(48486) override override8: i32;
+
+fn fn0(a0: ptr<workgroup, VertexOutput16>, a1: ptr<function, VertexOutput15>) -> VertexOutput16 {
+  var out: VertexOutput16;
+  vp14[u32(unconst_u32(323))][u32(unconst_u32(231))].f48 += vp14[u32(unconst_u32(63))][u32(unconst_u32(195))].f48;
+  vp14[vec2u(vp14[0][u32(unconst_u32(428))].f47)[0]][0] = VertexOutput16(u32(vp14[u32(unconst_u32(40))][0].f47.x), vec4f(vp14[u32(unconst_u32(40))][0].f47.xyxy), vp14[u32(unconst_u32(40))][0].f47, vec2u(vp14[u32(unconst_u32(40))][0].f47)[1]);
+  let ptr116: ptr<private, vec2i> = &vp14[u32(unconst_u32(114))][u32(unconst_u32(297))].f47;
+  let ptr117: ptr<private, u32> = &vp14[u32(unconst_u32(173))][0].f48;
+  return out;
+}
+
+fn fn1() {
+  vp14[0][u32(unconst_u32(154))].f48 = u32(override8);
+  _ = override8;
+}
+
+fn fn2(a0: array<vec4u, 1>, a1: array<mat4x2f, 1>) -> mat3x4h {
+  var out: mat3x4h;
+  let ptr118: ptr<private, u32> = &vp14[0][0].f45;
+  let vf280: f32 = override7;
+  fn1();
+  out -= mat3x4h(f16(vp14[u32(unconst_u32(168))][0].f48), f16(vp14[u32(unconst_u32(168))][0].f48), f16(vp14[u32(unconst_u32(168))][0].f48), f16(vp14[u32(unconst_u32(168))][0].f48), f16(vp14[u32(unconst_u32(168))][0].f48), f16(vp14[u32(unconst_u32(168))][0].f48), f16(vp14[u32(unconst_u32(168))][0].f48), f16(vp14[u32(unconst_u32(168))][0].f48), f16(vp14[u32(unconst_u32(168))][0].f48), f16(vp14[u32(unconst_u32(168))][0].f48), f16(vp14[u32(unconst_u32(168))][0].f48), f16(vp14[u32(unconst_u32(168))][0].f48));
+  out = mat3x4h(bitcast<vec4h>(vp14[0][u32(unconst_u32(726))].f47), bitcast<vec4h>(vp14[0][u32(unconst_u32(726))].f47), bitcast<vec4h>(vp14[0][u32(unconst_u32(726))].f47));
+  let vf281: mat4x2f = a1[0];
+  out = mat3x4h(vec4h(a0[u32(unconst_u32(160))]), vec4h(a0[u32(unconst_u32(160))]), vec4h(a0[u32(unconst_u32(160))]));
+  var vf282: i32 = vp14[u32(unconst_u32(138))][u32(unconst_u32(379))].f47[u32(unconst_u32(266))];
+  vf282 &= vp14[u32(unconst_u32(110))][0].f47.x;
+  out = mat3x4h(f16(override8), f16(override8), f16(override8), f16(override8), f16(override8), f16(override8), f16(override8), f16(override8), f16(override8), f16(override8), f16(override8), f16(override8));
+  fn1();
+  vp14[vec2u(vp14[u32(unconst_u32(139))][u32(unconst_u32(153))].f47)[1]][pack4x8unorm(vp14[0][u32(unconst_u32(108))].f46)].f45 = u32(vf281[u32(unconst_u32(252))][u32(unconst_u32(997))]);
+  fn1();
+  out -= mat3x4h(f16(vp14[0][0].f45), f16(vp14[0][0].f45), f16(vp14[0][0].f45), f16(vp14[0][0].f45), f16(vp14[0][0].f45), f16(vp14[0][0].f45), f16(vp14[0][0].f45), f16(vp14[0][0].f45), f16(vp14[0][0].f45), f16(vp14[0][0].f45), f16(vp14[0][0].f45), f16(vp14[0][0].f45));
+  return out;
+  _ = override8;
+  _ = override7;
+}
+
+var<workgroup> vw57: array<array<FragmentOutput10, 1>, 1>;
+
+var<workgroup> vw58: VertexOutput15;
+
+var<private> vp14: array<array<VertexOutput16, 1>, 1> = array(array(VertexOutput16(u32(341), vec4f(0.1388, 0.09089, 0.2193, 0.00364), vec2i(157, 16), u32(137))));
+
+@vertex
+fn vertex16(@location(7) @interpolate(flat, center) a0: i32, @location(15) @interpolate(flat) a1: vec2u) -> VertexOutput15 {
+  var out: VertexOutput15;
+  out = VertexOutput15(vec4f(bitcast<f32>(vp14[0][u32(unconst_u32(770))].f48)));
+  vp14[u32(unconst_u32(349))][u32(unconst_u32(32))].f45 >>= vec2u(vp14[0][0].f47).y;
+  let vf283: i32 = vp14[u32(unconst_u32(128))][0].f47[u32(unconst_u32(8))];
+  var vf284: i32 = a0;
+  let vf285: f32 = vp14[0][u32(unconst_u32(620))].f46[u32(unconst_u32(147))];
+  return out;
+}
+
+@vertex
+fn vertex17(@location(5) @interpolate(flat, center) a0: vec2u) -> VertexOutput16 {
+  var out: VertexOutput16;
+  var vf286: f32 = vp14[u32(unconst_u32(53))][0].f46[u32(unconst_u32(17))];
+  var vf287: i32 = vp14[0][u32(unconst_u32(105))].f47[u32(unconst_u32(210))];
+  out.f48 *= vec2u(vp14[u32(unconst_u32(86))][u32(unconst_u32(35))].f47).y;
+  let ptr119: ptr<private, vec2i> = &vp14[0][0].f47;
+  out.f45 = vp14[0][u32(unconst_u32(20))].f48;
+  vp14[u32(unconst_u32(197))][u32(unconst_u32(539))].f45 ^= vp14[u32(unconst_u32(17))][0].f48;
+  out.f45 &= vp14[0][u32(unconst_u32(0))].f48;
+  let ptr120: ptr<private, VertexOutput16> = &vp14[0][0];
+  return out;
+}
+
+@fragment
+fn fragment11(@builtin(sample_mask) a0: u32, @location(11) @interpolate(flat) a1: vec4u) -> FragmentOutput10 {
+  var out: FragmentOutput10;
+  vp14[u32(unconst_u32(406))][u32(unconst_u32(299))].f48 *= pack2x16float(vec2f(unconst_f32(0.05549), unconst_f32(0.09671)));
+  fn1();
+  vp14[u32(unconst_u32(61))][u32(unconst_u32(6))].f46 += bitcast<vec4f>(vp14[u32(unconst_u32(485))][0].f47.grrg);
+  out.f0 += bitcast<vec2f>(a1.xz);
+  out.f1 |= unpack4xU8(vp14[0][u32(unconst_u32(270))].f45);
+  let ptr121: ptr<private, vec4f> = &vp14[0][0].f46;
+  vp14[u32(unconst_u32(358))][u32(unconst_u32(59))].f45 >>= bitcast<vec2u>(vp14[0][0].f47).y;
+  vp14[u32(unconst_u32(62))][u32(unconst_u32(28))] = VertexOutput16(vec2u(vp14[u32(unconst_u32(21))][u32(unconst_u32(192))].f47).g, vec4f(vp14[u32(unconst_u32(21))][u32(unconst_u32(192))].f47.xyyy), vp14[u32(unconst_u32(21))][u32(unconst_u32(192))].f47, bitcast<u32>(vp14[u32(unconst_u32(21))][u32(unconst_u32(192))].f47[1]));
+  out.f0 += vec2f(vp14[0][0].f47);
+  let ptr122: ptr<private, u32> = &vp14[u32(unconst_u32(565))][0].f45;
+  var vf288 = fn2(array<vec4u, 1>(bitcast<vec4u>(vp14[u32(unconst_u32(225))][0].f46)), array<mat4x2f, 1>(mat4x2f(bitcast<f32>(vp14[u32(unconst_u32(58))][u32(unconst_u32(191))].f45), bitcast<f32>(vp14[u32(unconst_u32(58))][u32(unconst_u32(191))].f45), f32(vp14[u32(unconst_u32(58))][u32(unconst_u32(191))].f45), f32(vp14[u32(unconst_u32(58))][u32(unconst_u32(191))].f45), bitcast<f32>(vp14[u32(unconst_u32(58))][u32(unconst_u32(191))].f45), f32(vp14[u32(unconst_u32(58))][u32(unconst_u32(191))].f45), bitcast<f32>(vp14[u32(unconst_u32(58))][u32(unconst_u32(191))].f45), f32(vp14[u32(unconst_u32(58))][u32(unconst_u32(191))].f45))));
+  out.f1 = vec4u(vp14[u32(unconst_u32(148))][u32(unconst_u32(217))].f45);
+  fn1();
+  let ptr123: ptr<private, u32> = &vp14[u32(unconst_u32(106))][u32(vf288[u32(unconst_u32(93))][u32(unconst_u32(20))])].f48;
+  fn1();
+  out.f1 <<= bitcast<vec4u>(vp14[0][0].f46);
+  let ptr124: ptr<private, u32> = &vp14[0][0].f45;
+  vp14[u32(unconst_u32(41))][0].f47 |= vec2i(bitcast<i32>((*ptr123)));
+  fn1();
+  var vf289: f16 = vf288[u32(unconst_u32(43))][u32(unconst_u32(8))];
+  let vf290: u32 = pack2x16float(unpack4x8snorm(u32(unconst_u32(19))).zy);
+  var vf291 = fn2(array<vec4u, 1>(vec4u(vp14[0][0].f47.gggg)), array<mat4x2f, 1>(mat4x2f(unconst_f32(0.1038), unconst_f32(0.09140), unconst_f32(0.1138), unconst_f32(0.1225), unconst_f32(0.00846), unconst_f32(0.1548), unconst_f32(0.00597), unconst_f32(0.2969))));
+  return out;
+  _ = override8;
+  _ = override7;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute13() {
+  let ptr125: ptr<private, vec2i> = &vp14[u32(unconst_u32(17))][0].f47;
+  vw57[0][u32(unconst_u32(74))].f1 ^= bitcast<vec4u>(vw57[bitcast<u32>(cross(vec3f(unconst_f32(0.2857), unconst_f32(0.05832), unconst_f32(0.07622)), vec3f(unconst_f32(0.3864), unconst_f32(0.2686), unconst_f32(0.04109)))[0])][u32(unconst_u32(103))].f0.yyyx);
+  let ptr126: ptr<workgroup, vec4u> = &(*&vw57)[0][u32(unconst_u32(211))].f1;
+  let vf292: f32 = override7;
+  let vf293: i32 = vp14[u32(unconst_u32(172))][u32(unconst_u32(282))].f47[u32(unconst_u32(343))];
+  let vf294: f32 = log2(f32(unconst_f32(0.06391)));
+  _ = override7;
+}`,
+  hints: {},
+});
+let texture195 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder90.setBindGroup(0, bindGroup103, new Uint32Array(1583), 283, 0);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(33);
+} catch {}
+try {
+globalThis.someLabel = textureView175.label;
+} catch {}
+let commandEncoder223 = device0.createCommandEncoder();
+let querySet23 = device0.createQuerySet({label: '\u{1fb1d}\ub07c\u{1fe16}\u{1f7e9}\u5aef\u9d2d\ud04b', type: 'occlusion', count: 227});
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder223.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2544 */
+  offset: 2544,
+  buffer: buffer41,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup132 = device0.createBindGroup({
+  label: '\ud60b\uc036\u1d30',
+  layout: bindGroupLayout24,
+  entries: [{binding: 52, resource: sampler110}],
+});
+let texture196 = device0.createTexture({size: [96, 1, 1], mipLevelCount: 1, format: 'depth24plus', usage: GPUTextureUsage.COPY_DST});
+let textureView188 = texture84.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let renderPassEncoder81 = commandEncoder223.beginRenderPass({
+  colorAttachments: [{view: textureView186, depthSlice: 304, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet5,
+});
+try {
+computePassEncoder135.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder167.setBindGroup(0, bindGroup7, new Uint32Array(3906), 2_397, 0);
+} catch {}
+try {
+computePassEncoder178.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(3, bindGroup85, new Uint32Array(287), 22, 0);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer71, 'uint16', 2_916, 1_688);
+} catch {}
+let buffer140 = device0.createBuffer({
+  label: '\uadeb\u32db\u0540\u{1f622}\u448c\u{1ff9f}',
+  size: 13323,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler124 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.40,
+  lodMaxClamp: 57.12,
+});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup71);
+} catch {}
+try {
+computePassEncoder111.setBindGroup(0, bindGroup101, new Uint32Array(3076), 454, 0);
+} catch {}
+try {
+computePassEncoder179.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder29.end();
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder84.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1556 */
+  offset: 1556,
+  bytesPerRow: 10752,
+  rowsPerImage: 354,
+  buffer: buffer10,
+}, {
+  texture: texture158,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder224 = device0.createCommandEncoder({});
+let texture197 = gpuCanvasContext2.getCurrentTexture();
+let textureView189 = texture101.createView({label: '\u03ab\u{1fc65}\u02c5\u7059\ua471\u2f80\u1cad\u6792\u{1fc77}\u4979', baseArrayLayer: 0});
+try {
+computePassEncoder104.setBindGroup(2, bindGroup100, new Uint32Array(685), 340, 0);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer113, 'uint32', 480, 1_370);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(6, buffer115, 16);
+} catch {}
+try {
+renderPassEncoder47.popDebugGroup();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(img1);
+try {
+adapter0.label = '\u15ef\u3006\u0de6\u{1fb25}\u0572\ueda3\u{1fa28}\u0bf9\uf8e4\u{1ffdd}';
+} catch {}
+let textureView190 = texture18.createView({});
+let computePassEncoder181 = commandEncoder84.beginComputePass({});
+try {
+computePassEncoder181.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder76.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer70, 'uint16', 402, 2);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer98, 936, 91);
+} catch {}
+try {
+commandEncoder224.copyTextureToBuffer({
+  texture: texture151,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 112 */
+  offset: 112,
+  bytesPerRow: 62464,
+  buffer: buffer56,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img3);
+let querySet24 = device0.createQuerySet({type: 'occlusion', count: 496});
+let computePassEncoder182 = commandEncoder224.beginComputePass();
+try {
+computePassEncoder19.setBindGroup(0, bindGroup76, new Uint32Array(79), 14, 0);
+} catch {}
+try {
+computePassEncoder182.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(1, bindGroup70);
+} catch {}
+let arrayBuffer16 = buffer35.getMappedRange(400, 64);
+try {
+computePassEncoder149.pushDebugGroup('\u24c4');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer112, 2092, new BigUint64Array(17849), 3154, 68);
+} catch {}
+let buffer141 = device0.createBuffer({
+  label: '\u{1fccf}\u0b9a\u0bde\u7768\u74d8\u42d2\u{1f9db}\u0557\u03f5\u9466',
+  size: 11815,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder225 = device0.createCommandEncoder({label: '\u046f\u2c80\u08ac\u023e\u0735\u{1ff85}\u7409\u05b5\u{1fc71}\u0b65'});
+let textureView191 = texture15.createView({});
+try {
+renderPassEncoder15.setIndexBuffer(buffer133, 'uint32', 3_016, 4);
+} catch {}
+try {
+commandEncoder225.resolveQuerySet(querySet16, 44, 105, buffer24, 512);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer142 = device0.createBuffer({
+  label: '\u0d0b\u65bd\uced6\uf04a\u6a06\u0684\u0d1f\u{1fc91}',
+  size: 28648,
+  usage: GPUBufferUsage.MAP_WRITE,
+});
+let texture198 = device0.createTexture({
+  label: '\u30b2\uf854\u{1f778}\ub9ce\udaa3\u0ea5\u1b8c\u6889\u3e48',
+  size: [295, 1, 813],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder183 = commandEncoder225.beginComputePass();
+let externalTexture20 = device0.importExternalTexture({source: videoFrame1});
+try {
+{ clearResourceUsages(device0, computePassEncoder108); computePassEncoder108.dispatchWorkgroupsIndirect(buffer105, 900); };
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup92);
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(2, bindGroup105, new Uint32Array(2561), 1_036, 0);
+} catch {}
+try {
+buffer118.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 32}
+*/
+{
+  source: videoFrame21,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer15.detached) { new Uint8Array(arrayBuffer15).fill(0x55); };
+} catch {}
+let buffer143 = device0.createBuffer({
+  size: 6180,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let sampler125 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.57,
+  maxAnisotropy: 8,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder102); computePassEncoder102.dispatchWorkgroupsIndirect(buffer101, 11_824); };
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup94);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup45, new Uint32Array(1175), 479, 0);
+} catch {}
+try {
+gpuCanvasContext3.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_SRC, colorSpace: 'display-p3'});
+} catch {}
+let bindGroupLayout25 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 101,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 20,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 321,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 208, hasDynamicOffset: false },
+    },
+    {
+      binding: 329,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 333,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 17,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 13,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer144 = device0.createBuffer({size: 6126, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder226 = device0.createCommandEncoder({});
+let texture199 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 22},
+  sampleCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder82.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+computePassEncoder136.setBindGroup(1, bindGroup35, new Uint32Array(878), 25, 0);
+} catch {}
+try {
+computePassEncoder108.end();
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup122);
+} catch {}
+try {
+commandEncoder150.copyBufferToBuffer(buffer39, 3468, buffer5, 4484, 816);
+} catch {}
+try {
+computePassEncoder149.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture75,
+  mipLevel: 1,
+  origin: {x: 10, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(29).fill(26), /* required buffer size: 29 */
+{offset: 29, bytesPerRow: 10}, {width: 0, height: 24, depthOrArrayLayers: 0});
+} catch {}
+let buffer145 = device0.createBuffer({
+  size: 2045,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture200 = device0.createTexture({
+  size: {width: 55, height: 5, depthOrArrayLayers: 53},
+  sampleCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder184 = commandEncoder226.beginComputePass();
+let renderPassEncoder82 = commandEncoder150.beginRenderPass({colorAttachments: [{view: textureView51, depthSlice: 1, loadOp: 'clear', storeOp: 'store'}]});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({label: '\uef71\ueb1f', colorFormats: ['rgb10a2uint'], depthReadOnly: true});
+try {
+computePassEncoder146.setBindGroup(0, bindGroup82);
+} catch {}
+try {
+computePassEncoder13.setBindGroup(2, bindGroup82, new Uint32Array(4375), 466, 0);
+} catch {}
+try {
+renderPassEncoder81.setVertexBuffer(6, buffer91, 0, 6_141);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup71, []);
+} catch {}
+try {
+texture54.destroy();
+} catch {}
+document.body.append(img0);
+let textureView192 = texture200.createView({dimension: '2d', baseArrayLayer: 16});
+let textureView193 = texture72.createView({baseMipLevel: 0});
+let sampler126 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 93.29,
+  lodMaxClamp: 99.44,
+  compare: 'less',
+});
+try {
+computePassEncoder85.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(2, bindGroup131, []);
+} catch {}
+try {
+renderPassEncoder37.setScissorRect(18, 53, 14, 94);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(5, buffer65);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer83, 'uint32', 1_084, 19);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 140, height: 145, depthOrArrayLayers: 239}
+*/
+{
+  source: img0,
+  origin: { x: 30, y: 3 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 1,
+  origin: {x: 35, y: 15, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 4, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+document.body.prepend(canvas1);
+let bindGroup133 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 103, resource: textureView7}, {binding: 176, resource: textureView0}],
+});
+let commandEncoder227 = device0.createCommandEncoder();
+let computePassEncoder185 = commandEncoder227.beginComputePass({});
+try {
+renderPassEncoder76.beginOcclusionQuery(135);
+} catch {}
+try {
+renderPassEncoder69.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(2, buffer50, 0);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup112, [0]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 44, new Int16Array(1633), 177, 152);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let canvas3 = document.createElement('canvas');
+let videoFrame33 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'smpteSt4281', transfer: 'gamma22curve'} });
+let commandEncoder228 = device0.createCommandEncoder({});
+try {
+renderPassEncoder38.setVertexBuffer(5, buffer56, 2_116, 1_640);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup121);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer94, 684, new Int16Array(6506), 1017, 116);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 44, y: 32, z: 0},
+  aspect: 'all',
+}, new Uint8Array(191).fill(147), /* required buffer size: 191 */
+{offset: 191, bytesPerRow: 147}, {width: 11, height: 100, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext4 = canvas3.getContext('webgpu');
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer146 = device0.createBuffer({
+  size: 638,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let renderPassEncoder83 = commandEncoder228.beginRenderPass({
+  label: '\uec13\ud5d9\ueaf4\u0de5\u332f\u3026\u{1f6ee}\uce4f',
+  colorAttachments: [{view: textureView97, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet11,
+});
+try {
+renderPassEncoder40.setViewport(35.12494601013924, 0.16574573584553143, 0.7952448865590162, 0.05072539237939795, 0.1766990325621226, 0.4474579077878201);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer109, 'uint32', 552, 14);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup9, new Uint32Array(1281), 75, 0);
+} catch {}
+let commandEncoder229 = device0.createCommandEncoder({});
+let texture201 = device0.createTexture({
+  label: '\ufd5f\u6534\ue321\u{1f7e2}\u633b\u1e01\u0602\u37aa',
+  size: {width: 55},
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], sampleCount: 4, stencilReadOnly: true});
+try {
+computePassEncoder183.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(1, bindGroup127, new Uint32Array(512), 69, 0);
+} catch {}
+try {
+renderPassEncoder80.executeBundles([renderBundle4, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer83);
+} catch {}
+try {
+commandEncoder229.copyBufferToTexture({
+  /* bytesInLastRow: 720 widthInBlocks: 90 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 736 */
+  offset: 736,
+  buffer: buffer99,
+}, {
+  texture: texture157,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 90, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img1);
+let bindGroup134 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 277, resource: sampler4}]});
+let commandEncoder230 = device0.createCommandEncoder();
+let textureView194 = texture61.createView({});
+let computePassEncoder186 = commandEncoder230.beginComputePass({});
+let renderPassEncoder84 = commandEncoder229.beginRenderPass({
+  colorAttachments: [{
+  view: textureView5,
+  clearValue: { r: -469.2, g: 985.4, b: 762.0, a: 341.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder184.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder77.setIndexBuffer(buffer26, 'uint16', 400, 448);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer10, 'uint16', 2_828, 2_967);
+} catch {}
+await gc();
+let imageData26 = new ImageData(8, 20);
+let buffer147 = device0.createBuffer({
+  size: 8253,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let sampler127 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.27,
+});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup67);
+} catch {}
+try {
+computePassEncoder98.setBindGroup(3, bindGroup34, new Uint32Array(2614), 36, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder94); computePassEncoder94.dispatchWorkgroupsIndirect(buffer146, 264); };
+} catch {}
+try {
+computePassEncoder186.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(2, bindGroup43);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(0, buffer99, 2_520);
+} catch {}
+let texture202 = device0.createTexture({
+  size: [280, 291, 18],
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler128 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 16.47,
+  lodMaxClamp: 96.24,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder154.setBindGroup(2, bindGroup33);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup88, new Uint32Array(465), 182, 0);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup79);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer50, 'uint32', 196, 263);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(1, undefined, 403_446_179, 732_183_310);
+} catch {}
+try {
+buffer88.unmap();
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let commandEncoder231 = device0.createCommandEncoder({});
+let textureView195 = texture26.createView({
+  label: '\u91c4\u0849\u2e23\u0d4f\u0ed4\u{1f9f7}\u{1fbf3}\u{1f9f3}\u0a5f\u5823\ubab6',
+  dimension: '2d-array',
+  baseMipLevel: 0,
+});
+let renderPassEncoder85 = commandEncoder231.beginRenderPass({
+  colorAttachments: [{
+  view: textureView8,
+  depthSlice: 2,
+  clearValue: { r: 741.7, g: -699.0, b: -814.0, a: 506.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet15,
+});
+try {
+computePassEncoder82.setBindGroup(3, bindGroup4, new Uint32Array(981), 439, 0);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(1, bindGroup118);
+} catch {}
+try {
+renderPassEncoder76.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder56.setVertexBuffer(1, buffer138, 968, 621);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(4, buffer56);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let imageData27 = new ImageData(12, 64);
+let commandEncoder232 = device0.createCommandEncoder({label: '\u00aa\u0f0a\u{1f9d2}\u08bb'});
+try {
+renderPassEncoder3.setVertexBuffer(7, buffer101);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup29, new Uint32Array(542), 55, 0);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer52, 'uint32', 72, 265);
+} catch {}
+try {
+renderPassEncoder21.insertDebugMarker('\u{1f7d5}');
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+let videoFrame34 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'jedecP22Phosphors', transfer: 'logSqrt'} });
+let buffer148 = device0.createBuffer({
+  label: '\uea54\u{1f87a}\ucd67\u{1ffb2}\u5bc7\uda93\u005d\u{1fa53}',
+  size: 976,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let sampler129 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 46.87,
+  lodMaxClamp: 61.44,
+  compare: 'equal',
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder185.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder76.setViewport(55.73442005528224, 3.122048056669678, 14.419815805395098, 6.2987477308707085, 0.7829735686529619, 0.9213233314533037);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer64, 'uint16', 724, 1_228);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(2, buffer76, 1_756, 14_567);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+commandEncoder232.copyBufferToTexture({
+  /* bytesInLastRow: 176 widthInBlocks: 44 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1076 */
+  offset: 1076,
+  bytesPerRow: 5632,
+  buffer: buffer83,
+}, {
+  texture: texture191,
+  mipLevel: 1,
+  origin: {x: 17, y: 20, z: 0},
+  aspect: 'all',
+}, {width: 44, height: 28, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture133,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 8},
+  aspect: 'all',
+}, new Uint8Array(85_111).fill(63), /* required buffer size: 85_111 */
+{offset: 247, bytesPerRow: 136, rowsPerImage: 78}, {width: 22, height: 0, depthOrArrayLayers: 9});
+} catch {}
+let textureView196 = texture92.createView({dimension: '2d-array'});
+let computePassEncoder187 = commandEncoder232.beginComputePass();
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], sampleCount: 4});
+let sampler130 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 90.59,
+  lodMaxClamp: 92.90,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder165.setBindGroup(1, bindGroup58);
+} catch {}
+try {
+computePassEncoder116.setBindGroup(0, bindGroup94, new Uint32Array(215), 46, 0);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder233 = device0.createCommandEncoder({});
+let computePassEncoder188 = commandEncoder233.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder102); computePassEncoder102.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup75);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup5, new Uint32Array(272), 0, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 2640, new BigUint64Array(596), 29, 32);
+} catch {}
+let commandEncoder234 = device0.createCommandEncoder();
+let textureView197 = texture161.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder189 = commandEncoder234.beginComputePass();
+try {
+computePassEncoder33.setBindGroup(1, bindGroup65);
+} catch {}
+try {
+computePassEncoder102.end();
+} catch {}
+try {
+computePassEncoder187.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup40, new Uint32Array(4448), 929, 0);
+} catch {}
+try {
+renderPassEncoder31.setViewport(11.012076656870747, 0.2743430612132235, 48.142470615482495, 0.0925883458776223, 0.9113735874306068, 0.9407875257013131);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, undefined);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer125, 'uint16', 612, 1_028);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(0, buffer82, 356, 252);
+} catch {}
+let texture203 = device0.createTexture({
+  size: {width: 440},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder179.setBindGroup(1, bindGroup81, new Uint32Array(2952), 597, 0);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(2, undefined, 164_980_430);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(3, bindGroup131, new Uint32Array(349), 73, 0);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer76, 'uint16', 528, 7_030);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(6, buffer109, 112, 33);
+} catch {}
+let texture204 = device0.createTexture({
+  label: '\u32eb\ud4c3\uee52\u0217',
+  size: [55, 5, 1],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder190 = commandEncoder139.beginComputePass({});
+let renderBundle18 = renderBundleEncoder19.finish();
+let sampler131 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 13.61,
+  lodMaxClamp: 95.15,
+});
+try {
+computePassEncoder189.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder63.setVertexBuffer(6, undefined, 81_893_342, 927_713_344);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup134, []);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(1, buffer140, 504);
+} catch {}
+try {
+buffer89.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 560, height: 582, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas2,
+  origin: { x: 34, y: 0 },
+  flipY: false,
+}, {
+  texture: texture191,
+  mipLevel: 0,
+  origin: {x: 6, y: 29, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 105, height: 13, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup135 = device0.createBindGroup({
+  layout: bindGroupLayout17,
+  entries: [{binding: 78, resource: sampler54}, {binding: 113, resource: textureView107}],
+});
+let buffer149 = device0.createBuffer({
+  size: 35723,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder235 = device0.createCommandEncoder({label: '\u{1fdb2}\u9853\ubcc7\u3452'});
+let sampler132 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 35.82,
+  lodMaxClamp: 48.88,
+});
+try {
+computePassEncoder190.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer130, 'uint32', 228, 346);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+if (!arrayBuffer15.detached) { new Uint8Array(arrayBuffer15).fill(0x55); };
+} catch {}
+let commandEncoder236 = device0.createCommandEncoder();
+let computePassEncoder191 = commandEncoder236.beginComputePass({});
+let sampler133 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 8.533,
+  lodMaxClamp: 99.98,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup124, new Uint32Array(4425), 3, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder167); computePassEncoder167.dispatchWorkgroupsIndirect(buffer84, 3_628); };
+} catch {}
+try {
+computePassEncoder137.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder188.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder47.setBlendConstant({ r: 678.8, g: 822.2, b: -158.8, a: -443.2, });
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(6, buffer59, 0, 423);
+} catch {}
+try {
+commandEncoder235.copyTextureToBuffer({
+  texture: texture143,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 48 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4292 */
+  offset: 4292,
+  buffer: buffer9,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let buffer150 = device0.createBuffer({size: 8852, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture205 = device0.createTexture({
+  size: [70, 72, 1],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView198 = texture131.createView({label: '\ud6cc\u00ca\u3486\u0bfb', format: 'rgb10a2uint'});
+let renderBundle19 = renderBundleEncoder18.finish({});
+let sampler134 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 74.62,
+  compare: 'equal',
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder118.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+computePassEncoder191.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(2, bindGroup29, new Uint32Array(844), 271, 0);
+} catch {}
+let buffer151 = device0.createBuffer({
+  size: 54718,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder237 = device0.createCommandEncoder({});
+let computePassEncoder192 = commandEncoder237.beginComputePass({});
+try {
+computePassEncoder192.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder64.setScissorRect(15, 16, 9, 1);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(3, bindGroup133, []);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer86, 'uint16', 530, 30);
+} catch {}
+try {
+buffer63.unmap();
+} catch {}
+try {
+commandEncoder235.copyBufferToBuffer(buffer103, 236, buffer147, 552, 0);
+} catch {}
+let buffer152 = device0.createBuffer({size: 105, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let texture206 = device0.createTexture({
+  label: '\u8cdb\u3cc2\u{1f64e}\u6b2a\u4326\u0dce\u04e9\u0c3e\u03bb\uf7da\uf340',
+  size: [48],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView199 = texture56.createView({mipLevelCount: 1, baseArrayLayer: 12, arrayLayerCount: 3});
+let computePassEncoder193 = commandEncoder235.beginComputePass({});
+try {
+computePassEncoder86.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer96, 2940, new DataView(new ArrayBuffer(1435)), 7, 296);
+} catch {}
+try {
+computePassEncoder135.label = '\u{1fc03}\u2508\u{1f9f3}\uea2a\u{1ffd3}\u5b4a\ua3eb\u302d\u02c1\u0c48';
+} catch {}
+let texture207 = device0.createTexture({
+  size: [110, 10, 36],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder115.setBindGroup(3, bindGroup71);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder116); computePassEncoder116.dispatchWorkgroupsIndirect(buffer130, 32); };
+} catch {}
+try {
+renderPassEncoder74.setBindGroup(1, bindGroup66, new Uint32Array(3412), 96, 0);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(7, buffer103, 0);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(0, bindGroup134, []);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(3, bindGroup70, new Uint32Array(744), 26, 0);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer112, 'uint16', 132, 112);
+} catch {}
+let pipelineLayout12 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout6]});
+let buffer153 = device0.createBuffer({size: 6370, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet25 = device0.createQuerySet({type: 'occlusion', count: 1475});
+let texture208 = device0.createTexture({
+  size: [64, 64, 22],
+  mipLevelCount: 2,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView200 = texture137.createView({format: 'rgb10a2unorm', mipLevelCount: 1});
+let renderBundle20 = renderBundleEncoder20.finish();
+try {
+computePassEncoder193.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(3, bindGroup22, new Uint32Array(654), 6, 0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle16, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(2, buffer6, 412, 297);
+} catch {}
+try {
+buffer57.unmap();
+} catch {}
+let texture209 = device0.createTexture({
+  size: {width: 295},
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView201 = texture192.createView({dimension: '2d-array', aspect: 'all', baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder116); computePassEncoder116.dispatchWorkgroupsIndirect(buffer73, 25_908); };
+} catch {}
+try {
+renderPassEncoder58.setIndexBuffer(buffer77, 'uint32', 400, 257);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture206,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(547).fill(194), /* required buffer size: 547 */
+{offset: 547}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 140, height: 145, depthOrArrayLayers: 239}
+*/
+{
+  source: imageData8,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 1,
+  origin: {x: 16, y: 55, z: 7},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer154 = device0.createBuffer({size: 18627, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder238 = device0.createCommandEncoder({});
+try {
+computePassEncoder57.setBindGroup(3, bindGroup73);
+} catch {}
+try {
+computePassEncoder162.setBindGroup(3, bindGroup64, new Uint32Array(166), 43, 0);
+} catch {}
+try {
+renderPassEncoder83.setPipeline(pipeline1);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let arrayBuffer17 = buffer35.getMappedRange(464, 8);
+try {
+buffer6.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData28 = new ImageData(28, 52);
+let computePassEncoder194 = commandEncoder238.beginComputePass({});
+let sampler135 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  lodMinClamp: 61.92,
+  lodMaxClamp: 83.14,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder136); computePassEncoder136.dispatchWorkgroupsIndirect(buffer72, 4_616); };
+} catch {}
+try {
+computePassEncoder194.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer109, 'uint16', 752, 258);
+} catch {}
+let shaderModule15 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(103) var st26: texture_storage_3d<rgba8unorm, write>;
+
+@group(0) @binding(176) var st27: texture_storage_3d<rgba16uint, write>;
+
+struct T0 {
+  @align(4) @size(16) f0: f16,
+  @size(188) f1: array<atomic<u32>>,
+}
+
+struct FragmentOutput11 {
+  @location(0) f0: vec4u,
+}
+
+alias vec3b = vec3<bool>;
+
+@id(26749) override override9: bool;
+
+override override10: u32 = 55;
+
+@id(30525) override override11: bool;
+
+fn fn0() -> FragmentOutput11 {
+  var out: FragmentOutput11;
+  var vf295: vec4i = unpack4xI8(u32(unconst_u32(406)));
+  out.f0 ^= vec4u(unpack2x16snorm(u32(unconst_u32(103))).rggg);
+  let vf296: vec4h = pow(vec4h(unconst_f16(14190.7), unconst_f16(-3351.9), unconst_f16(9253.2), unconst_f16(1467.8)), vec4h(insertBits(vec3i(smoothstep(vec2f(unconst_f32(0.03481), unconst_f32(0.07413)), vec2f(unconst_f32(0.2155), unconst_f32(0.07687)), vec2f(unconst_f32(0.04415), unconst_f32(0.00528))).ggr), vec3i(unconst_i32(54), unconst_i32(13), unconst_i32(100)), u32(unconst_u32(246)), u32(unconst_u32(78))).zzyz));
+  let vf297: vec3h = refract(vec3h(unconst_f16(-1049.6), unconst_f16(16707.7), unconst_f16(1454.7)), vec3h(unconst_f16(1390.1), unconst_f16(58577.8), unconst_f16(261.1)), f16(unconst_f16(17658.5)));
+  out.f0 -= vec4u(ceil(vec4h(unconst_f16(-1217.8), unconst_f16(17856.5), unconst_f16(7423.3), unconst_f16(610.6))));
+  vf295 &= vec4i(refract(vec3h(unconst_f16(13542.4), unconst_f16(6263.1), unconst_f16(5039.4)), vec3h(unconst_f16(47624.9), unconst_f16(3271.0), unconst_f16(8079.6)), f16(unconst_f16(-12809.3))).zzxy);
+  let vf298: i32 = vf295[u32(unconst_u32(107))];
+  var vf299: vec3i = insertBits(vec3i(i32(abs(f32(unconst_f32(0.00854))))), vec3i(unconst_i32(80), unconst_i32(117), unconst_i32(199)), u32(unconst_u32(9)), u32(unconst_u32(80)));
+  out.f0 &= vec4u(u32(override11));
+  var vf300: u32 = pack2x16float(vec2f(unconst_f32(0.6511), unconst_f32(0.1832)));
+  let vf301: vec3u = countTrailingZeros(vec3u(unconst_u32(559), unconst_u32(58), unconst_u32(1)));
+  vf295 *= vec4i(i32(override11));
+  return out;
+  _ = override11;
+}
+
+@fragment
+fn fragment12() -> FragmentOutput11 {
+  var out: FragmentOutput11;
+  out.f0 = vec4u(u32(override9));
+  fn0();
+  out = FragmentOutput11(unpack4xU8(max(u32(unconst_u32(484)), u32(unconst_u32(183)))));
+  let vf302: vec3f = asin(vec3f(unconst_f32(0.01290), unconst_f32(0.1127), unconst_f32(0.1454)));
+  fn0();
+  out = FragmentOutput11(vec4u(u32(override11)));
+  out.f0 = vec4u(degrees(vec2f(unconst_f32(0.1120), unconst_f32(-0.3167))).gggr);
+  out = FragmentOutput11(bitcast<vec4u>(countTrailingZeros(vec2i(unconst_i32(640), unconst_i32(-173))).yxxx));
+  var vf303: u32 = dot4U8Packed(u32(override11), u32(unconst_u32(621)));
+  return out;
+  _ = override11;
+  _ = override9;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute14() {
+  var vf304: u32 = pack4x8snorm(vec4f(unconst_f32(0.1703), unconst_f32(0.2063), unconst_f32(0.04431), unconst_f32(0.3510)));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer155 = device0.createBuffer({
+  size: 10190,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView202 = texture91.createView({label: '\ufe43\u0847\u1091\u0071'});
+try {
+computePassEncoder105.setBindGroup(1, bindGroup107);
+} catch {}
+try {
+computePassEncoder13.setBindGroup(1, bindGroup48, new Uint32Array(649), 90, 0);
+} catch {}
+try {
+computePassEncoder136.end();
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer80, 'uint16', 7_390, 677);
+} catch {}
+let commandEncoder239 = device0.createCommandEncoder({});
+let commandBuffer13 = commandEncoder175.finish();
+let sampler136 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 77.71,
+  lodMaxClamp: 78.96,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder94); computePassEncoder94.dispatchWorkgroupsIndirect(buffer82, 108); };
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(2, buffer109, 640, 218);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture148,
+  mipLevel: 0,
+  origin: {x: 76, y: 9, z: 0},
+  aspect: 'all',
+}, new Uint8Array(461).fill(151), /* required buffer size: 461 */
+{offset: 461, bytesPerRow: 197}, {width: 43, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame35 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'bt470bg', transfer: 'gamma22curve'} });
+let commandEncoder240 = device0.createCommandEncoder();
+let querySet26 = device0.createQuerySet({type: 'occlusion', count: 641});
+let computePassEncoder195 = commandEncoder239.beginComputePass({});
+let sampler137 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 88.18,
+  lodMaxClamp: 92.98,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder142.setBindGroup(1, bindGroup44);
+} catch {}
+try {
+computePassEncoder153.setBindGroup(3, bindGroup118, new Uint32Array(3071), 260, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 70, height: 72, depthOrArrayLayers: 25}
+*/
+{
+  source: imageData10,
+  origin: { x: 13, y: 3 },
+  flipY: true,
+}, {
+  texture: texture194,
+  mipLevel: 0,
+  origin: {x: 3, y: 5, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img1);
+let bindGroup136 = device0.createBindGroup({layout: bindGroupLayout20, entries: [{binding: 152, resource: textureView108}]});
+let texture210 = gpuCanvasContext2.getCurrentTexture();
+let computePassEncoder196 = commandEncoder240.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder118); computePassEncoder118.dispatchWorkgroupsIndirect(buffer73, 144); };
+} catch {}
+try {
+computePassEncoder196.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder74.executeBundles([renderBundle15, renderBundle10, renderBundle10, renderBundle1, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder69.setVertexBuffer(0, buffer43, 0);
+} catch {}
+let bindGroupLayout26 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 49,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let texture211 = device0.createTexture({
+  size: {width: 220, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'etc2-rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder82.setBindGroup(3, bindGroup36);
+} catch {}
+try {
+computePassEncoder195.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup60);
+} catch {}
+try {
+renderPassEncoder77.executeBundles([renderBundle2, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(13, 0, 39, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup137 = device0.createBindGroup({
+  label: '\u008b\u{1fe44}\u{1f651}\u02a4\u4c6a\u53c5',
+  layout: bindGroupLayout26,
+  entries: [{binding: 49, resource: {buffer: buffer89, offset: 0, size: 600}}],
+});
+let commandEncoder241 = device0.createCommandEncoder({label: '\ua041\ud343\u18b7\u1d92'});
+let texture212 = device0.createTexture({
+  size: {width: 440, height: 40, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler138 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMinClamp: 34.63,
+  lodMaxClamp: 67.13,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder48.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder123.end();
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup124, new Uint32Array(763), 110, 0);
+} catch {}
+try {
+renderPassEncoder70.setIndexBuffer(buffer151, 'uint16', 2_550, 3_561);
+} catch {}
+try {
+commandEncoder241.clearBuffer(buffer144, 724, 236);
+} catch {}
+let commandBuffer14 = commandEncoder164.finish();
+let texture213 = device0.createTexture({
+  size: {width: 73, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderPassEncoder86 = commandEncoder241.beginRenderPass({
+  label: '\u{1fcc0}\u146f\ue4dd\uc440\u{1fa1b}\ufe9d\u{1f9d3}\u38c1\u{1f95f}\u0c8e',
+  colorAttachments: [{
+  view: textureView202,
+  clearValue: { r: -984.5, g: 907.7, b: 92.78, a: 971.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler139 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 94.91,
+  lodMaxClamp: 96.67,
+  compare: 'greater',
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder85.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder80.setIndexBuffer(buffer30, 'uint32', 16, 5);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING, colorSpace: 'srgb'});
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer128);
+} catch {}
+let shaderModule16 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(103) var st28: texture_storage_3d<rgba8unorm, write>;
+
+@group(0) @binding(176) var st29: texture_storage_3d<rgba16uint, write>;
+
+struct T0 {
+  @align(32) @size(288) f0: f16,
+}
+
+struct T1 {
+  @size(640) f0: array<vec4h>,
+}
+
+struct T2 {
+  @size(60) f0: array<f32>,
+}
+
+struct FragmentOutput12 {
+  @location(0) @interpolate(flat) f0: vec4u,
+}
+
+struct S10 {
+  @location(8) @interpolate(flat, centroid) f0: vec2u,
+  @location(11) @interpolate(flat, centroid) f1: vec4u,
+}
+
+struct S11 {
+  @location(10) @interpolate(flat, sample) f0: vec4u,
+}
+
+struct FragmentOutput13 {
+  @location(2) @interpolate(flat) f0: vec4u,
+  @location(1) @interpolate(linear) f1: vec4f,
+  @location(0) @interpolate(flat) f2: vec4i,
+}
+
+struct FragmentOutput14 {
+  @location(4) @interpolate(linear) f0: f32,
+  @location(0) f1: vec4u,
+}
+
+alias vec3b = vec3<bool>;
+
+fn fn0() -> FragmentOutput14 {
+  var out: FragmentOutput14;
+  out.f0 = unpack2x16snorm(u32(unconst_u32(575))).y;
+  var vf305: u32 = reverseBits(u32(unconst_u32(0)));
+  var vf306: vec3f = atan2(vec3f(unconst_f32(0.06234), unconst_f32(0.00172), unconst_f32(0.07151)), vec3f(unconst_f32(0.2999), unconst_f32(0.07801), unconst_f32(0.1738)));
+  let ptr127: ptr<function, u32> = &vf305;
+  var vf307: u32 = clamp(u32(unconst_u32(127)), u32(unconst_u32(301)), u32(unconst_u32(106)));
+  let ptr128: ptr<private, i32> = &vp15.exp;
+  let vf308: vec2f = inverseSqrt(vec2f(unconst_f32(0.4950), unconst_f32(0.02343)));
+  out.f1 -= bitcast<vec4u>(unpack2x16snorm(u32(unconst_u32(80))).xxxx);
+  var vf309: u32 = pack2x16unorm(vec2f(unconst_f32(0.1247), unconst_f32(-0.03901)));
+  let vf310: vec2h = log(vec2h(atan2(vf306, vec3f(unconst_f32(0.07927), unconst_f32(0.05242), unconst_f32(0.2055))).gb));
+  var vf311: vec4f = inverseSqrt(vec4f(unconst_f32(0.05835), unconst_f32(0.05545), unconst_f32(0.1345), unconst_f32(0.2160)));
+  vf305 ^= u32(inverseSqrt(vec2f(f32(vf309)))[1]);
+  var vf312: f32 = vf311[u32(unconst_u32(172))];
+  vf311 = atan2(vec3f(unconst_f32(0.1376), unconst_f32(0.06258), unconst_f32(0.01803)), vec3f(unconst_f32(0.2119), unconst_f32(-0.00502), unconst_f32(0.05863))).zzzz;
+  vf305 >>= u32(vf312);
+  out.f0 -= f32((*ptr127));
+  var vf313: vec2f = inverseSqrt(vec2f(unconst_f32(0.3228), unconst_f32(0.02327)));
+  vf305 = bitcast<u32>(reverseBits(vec2i(unconst_i32(46), unconst_i32(102)))[0]);
+  return out;
+}
+
+fn fn1() -> vec2<bool> {
+  var out: vec2<bool>;
+  out = vec2<bool>(bool(vp15.fract));
+  let vf314: vec4h = trunc(vec4h(unconst_f16(6876.4), unconst_f16(2731.8), unconst_f16(10252.9), unconst_f16(19806.1)));
+  out = vec2<bool>(cross(vec3f(unconst_f32(0.09229), unconst_f32(-0.1708), unconst_f32(0.01431)), vec3f(unconst_f32(0.1198), unconst_f32(0.2830), unconst_f32(0.08248))).gb);
+  vp15 = frexp(f32(vf314[u32(unconst_u32(230))]));
+  vp15.fract = length(vec4f(unconst_f32(0.2011), unconst_f32(0.4949), unconst_f32(0.05517), unconst_f32(0.2427)));
+  var vf315: vec3f = max(vec3f(unconst_f32(0.2660), unconst_f32(0.06936), unconst_f32(0.00120)), vec3f(unconst_f32(0.05703), unconst_f32(0.4443), unconst_f32(0.02661)));
+  let vf316: vec3f = cross(vec3f(unconst_f32(0.02584), unconst_f32(0.04271), unconst_f32(0.01091)), cross(vec3f(unconst_f32(0.09580), unconst_f32(0.05802), unconst_f32(0.09480)), vec3f(unconst_f32(0.1092), unconst_f32(0.1208), unconst_f32(0.4482))));
+  var vf317: vec3f = cross(vec3f(unconst_f32(0.4973), unconst_f32(0.07133), unconst_f32(0.1771)), vec3f(unconst_f32(0.05427), unconst_f32(0.4196), unconst_f32(0.4005)));
+  let vf318: f16 = determinant(mat4x4h());
+  let vf319: f16 = determinant(mat4x4h());
+  vf315 = vec3f(bitcast<f32>(vp15.exp));
+  vf315 -= vec3f(vf317[u32(unconst_u32(860))]);
+  let vf320: f32 = vf316[u32(unconst_u32(57))];
+  return out;
+}
+
+fn fn2() -> vec4f {
+  var out: vec4f;
+  var vf321: vec4<bool> = select(vec4<bool>(unconst_bool(false), unconst_bool(true), unconst_bool(true), unconst_bool(true)), vec4<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(true), unconst_bool(false)), bool(unconst_bool(true)));
+  let ptr129: ptr<private, f32> = &vp15.fract;
+  vp15.fract *= f32(pack2x16unorm(vec2f(unconst_f32(0.1201), unconst_f32(0.1286))));
+  vp15 = frexp(f32(vf321[u32(unconst_u32(90))]));
+  vf321 = vec4<bool>(bool(dot4I8Packed(u32(unconst_u32(17)), u32(unconst_u32(74)))));
+  let vf322: u32 = pack2x16unorm(vec2f(unconst_f32(0.02880), unconst_f32(0.09441)));
+  let vf323: u32 = pack2x16unorm(vec2f(unconst_f32(0.09584), unconst_f32(0.09533)));
+  vf321 = vec4<bool>(bool((*ptr129)));
+  let vf324: u32 = vf323;
+  let ptr130: ptr<private, i32> = &vp15.exp;
+  vp15.fract += asin(vec2f(unconst_f32(0.04879), unconst_f32(0.00944))).y;
+  out *= vec4f((*ptr129));
+  var vf325: vec2h = round(vec2h(unconst_f16(82.61), unconst_f16(8022.3)));
+  vf325 += bitcast<vec2h>((*ptr130));
+  vf325 = vec2h(asin(vec2f(unconst_f32(0.4066), unconst_f32(0.1276))));
+  return out;
+}
+
+var<workgroup> vw59: mat4x2f;
+
+var<workgroup> vw60: array<vec2u, 29>;
+
+var<private> vp15 = frexp(f32(0.06752));
+
+@fragment
+fn fragment13() -> FragmentOutput12 {
+  var out: FragmentOutput12;
+  out.f0 += vec4u(u32(countLeadingZeros(i32(unconst_i32(6)))));
+  var vf326: i32 = countLeadingZeros(i32(unconst_i32(605)));
+  out.f0 &= vec4u(saturate(vec2h(unconst_f16(9077.7), unconst_f16(921.2))).rrgg);
+  vf326 = i32(exp2(vec3f(unconst_f32(0.05081), unconst_f32(0.2669), unconst_f32(0.00597)))[2]);
+  var vf327: vec4h = trunc(vec4h(f16(vp15.exp)));
+  var vf328: u32 = dot(vec4u(unconst_u32(89), unconst_u32(48), unconst_u32(104), unconst_u32(73)), vec4u(tan(vec2h(unconst_f16(12351.4), unconst_f16(7583.6))).rgrr));
+  var vf329 = fn2();
+  discard;
+  return out;
+}
+
+@fragment
+fn fragment14(a0: S10, a1: S11, @location(14) @interpolate(flat) a2: vec4u) -> FragmentOutput13 {
+  var out: FragmentOutput13;
+  var vf330: vec4f = reflect(vec4f(unconst_f32(0.01867), unconst_f32(0.6168), unconst_f32(0.08959), unconst_f32(0.1748)), vec4f(unconst_f32(0.00194), unconst_f32(-0.1062), unconst_f32(0.08288), unconst_f32(-0.05856)));
+  var vf331: S10 = a0;
+  let vf332: vec3h = log(vec3h(unconst_f16(1853.4), unconst_f16(5441.2), unconst_f16(11097.6)));
+  out = FragmentOutput13(vec4u(vf330), vf330, vec4i(vf330));
+  var vf333: vec2u = a0.f0;
+  out.f1 = vec4f(sinh(vec4h(unconst_f16(2033.6), unconst_f16(1797.3), unconst_f16(13149.8), unconst_f16(12467.5))));
+  vf333 = vec2u(bitcast<u32>(vp15.fract));
+  var vf334 = fn2();
+  fn2();
+  vf333 += bitcast<vec2u>(normalize(vec4h(unconst_f16(21843.7), unconst_f16(94.75), unconst_f16(2720.2), unconst_f16(2963.4))));
+  vf330 -= bitcast<vec4f>(reverseBits(vec4i(unconst_i32(-379), unconst_i32(109), unconst_i32(224), unconst_i32(834))));
+  return out;
+}
+
+@fragment
+fn fragment15() -> FragmentOutput14 {
+  var out: FragmentOutput14;
+  out.f1 &= vec4u(quantizeToF16(vec3f(unconst_f32(0.2089), unconst_f32(0.1175), unconst_f32(0.4391))).bggb);
+  var vf335: bool = any(vec2<bool>(unconst_bool(true), unconst_bool(false)));
+  let ptr131 = &vp15;
+  var vf336 = fn2();
+  var vf337: u32 = pack2x16snorm(vec2f(f32(pack2x16snorm(vec2f(bitcast<f32>(vp15.exp))))));
+  var vf338 = fn2();
+  let ptr132: ptr<function, vec4f> = &vf338;
+  let vf339: vec4f = floor(vec4f(unconst_f32(-0.04946), unconst_f32(0.06749), unconst_f32(0.1724), unconst_f32(0.2325)));
+  var vf340 = fn2();
+  vf335 = bool((*ptr131).exp);
+  vf336 += vec4f(f32(min(f16(unconst_f16(89.94)), f16(unconst_f16(38246.2)))));
+  let ptr133: ptr<private, f32> = &(*ptr131).fract;
+  out.f0 -= radians(vec4f(unconst_f32(0.1964), unconst_f32(0.2555), unconst_f32(0.1022), unconst_f32(0.1246))).r;
+  vf340 += vec4f(f32(vf337));
+  vf337 >>= u32(vf339[bitcast<vec3u>(acosh(vec3f(unconst_f32(0.2710), unconst_f32(0.1976), unconst_f32(0.2619))))[0]]);
+  vf340 = acosh(vec3f(unconst_f32(0.1227), unconst_f32(0.3436), unconst_f32(0.2556))).zyyx;
+  fn2();
+  vf340 = vec4f((*ptr133));
+  var vf341 = fn2();
+  var vf342: bool = any(vec2<bool>(unconst_bool(false), unconst_bool(true)));
+  return out;
+}
+
+@compute @workgroup_size(1, 2, 1)
+fn compute15() {
+  let ptr134: ptr<workgroup, vec2u> = &(*&vw60)[28];
+  storageBarrier();
+  var vf343 = fn2();
+  vw59 -= workgroupUniformLoad(&vw59);
+  vw59 = mat4x2f(vec2f(workgroupUniformLoad(&vw60)[28]), vec2f(workgroupUniformLoad(&vw60)[28]), bitcast<vec2f>(workgroupUniformLoad(&vw60)[28]), bitcast<vec2f>(workgroupUniformLoad(&vw60)[28]));
+  let ptr135 = &vp15;
+  vf343 -= vec4f((*&vw60)[28].gggg);
+  let ptr136: ptr<workgroup, vec2u> = &(*&vw60)[28];
+  textureStore(st28, vec3i(unconst_i32(62), unconst_i32(101), unconst_i32(146)), vec4f(vec4f(unconst_f32(0.01458), unconst_f32(0.00351), unconst_f32(0.4589), unconst_f32(0.1896))));
+  let vf344: vec2f = vw59[u32(unconst_u32(346))];
+  var vf345 = fn2();
+  var vf346 = fn1();
+  vw59 = mat4x2f(vf344, vf344, vf344, vf344);
+  vw59 = mat4x2f(bitcast<f32>((*ptr134)[u32(unconst_u32(86))]), f32((*ptr134)[u32(unconst_u32(86))]), bitcast<f32>((*ptr134)[u32(unconst_u32(86))]), bitcast<f32>((*ptr134)[u32(unconst_u32(86))]), f32((*ptr134)[u32(unconst_u32(86))]), bitcast<f32>((*ptr134)[u32(unconst_u32(86))]), bitcast<f32>((*ptr134)[u32(unconst_u32(86))]), f32((*ptr134)[u32(unconst_u32(86))]));
+  let vf347: vec4u = insertBits(vec4u(unconst_u32(513), unconst_u32(122), unconst_u32(3), unconst_u32(30)), vw60[28].rgrr, u32(unconst_u32(74)), u32(unconst_u32(29)));
+  vf346 = vec2<bool>(bool(vw60[workgroupUniformLoad(&vw60)[28][1]][(*&vw60)[u32(unconst_u32(69))][0]]));
+  fn2();
+  vw60[bitcast<u32>(fma(f32(unconst_f32(0.06410)), f32(unconst_f32(0.00024)), f32(unconst_f32(0.01623))))] = vec2u(u32(vp15.fract));
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute16() {
+  vw59 = mat4x2f(bitcast<vec2f>((*&vw60)[28]), bitcast<vec2f>((*&vw60)[28]), vec2f((*&vw60)[28]), vec2f((*&vw60)[28]));
+  vw59 = mat4x2f(length(f32(unconst_f32(-0.05544))), length(f32(unconst_f32(-0.05544))), length(f32(unconst_f32(-0.05544))), length(f32(unconst_f32(-0.05544))), length(f32(unconst_f32(-0.05544))), length(f32(unconst_f32(-0.05544))), length(f32(unconst_f32(-0.05544))), length(f32(unconst_f32(-0.05544))));
+  textureStore(st28, vec3i(unconst_i32(-8), unconst_i32(275), unconst_i32(-1)), vec4f(vec4f(unconst_f32(0.2614), unconst_f32(-0.00240), unconst_f32(0.3538), unconst_f32(0.09359))));
+  fn2();
+  var vf348 = fn2();
+  vw59 += mat4x2f(vw59[u32(unconst_u32(149))], vw59[u32(unconst_u32(149))], vw59[u32(unconst_u32(149))], vw59[u32(unconst_u32(149))]);
+  var vf349 = fn1();
+  fn1();
+  vf348 *= workgroupUniformLoad(&vw59)[unconst_i32(0)].rggg;
+  var vf350: mat4x2f = workgroupUniformLoad(&vw59);
+  let vf351: f32 = length(f32(unconst_f32(0.05813)));
+  vw59 = mat4x2f(vp15.fract, vp15.fract, vp15.fract, vp15.fract, vp15.fract, vp15.fract, vp15.fract, vp15.fract);
+  vf350 = mat4x2f(vw59[u32(unconst_u32(166))], vw59[u32(unconst_u32(166))], vw59[u32(unconst_u32(166))], vw59[u32(unconst_u32(166))]);
+  let ptr137: ptr<function, mat4x2f> = &vf350;
+  let vf352: f32 = length(f32(unconst_f32(0.2392)));
+  let ptr138: ptr<workgroup, vec2u> = &(*&vw60)[u32(unconst_u32(63))];
+  vf349 = vf349;
+  var vf353 = fn2();
+  var vf354 = fn1();
+  let vf355: vec2f = (*ptr137)[u32(unconst_u32(91))];
+  let ptr139: ptr<workgroup, vec2u> = &(*&vw60)[28];
+  fn1();
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer156 = device0.createBuffer({
+  size: 5295,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder242 = device0.createCommandEncoder({});
+let textureView203 = texture145.createView({dimension: '2d-array'});
+let sampler140 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 52.03,
+  lodMaxClamp: 93.77,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder179.setBindGroup(1, bindGroup101, []);
+} catch {}
+try {
+computePassEncoder7.setBindGroup(0, bindGroup16, new Uint32Array(1402), 316, 0);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder242.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 960 */
+  offset: 960,
+  bytesPerRow: 4096,
+  buffer: buffer125,
+}, {
+  texture: texture81,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 32}
+*/
+{
+  source: videoFrame30,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup138 = device0.createBindGroup({
+  label: '\ub0b4\u7c6c\u866c\ua51c\u7dd7',
+  layout: bindGroupLayout4,
+  entries: [{binding: 511, resource: {buffer: buffer143, offset: 0}}],
+});
+let computePassEncoder197 = commandEncoder242.beginComputePass({});
+try {
+computePassEncoder174.setBindGroup(0, bindGroup111, new Uint32Array(290), 43, 0);
+} catch {}
+try {
+computePassEncoder197.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder83.setBindGroup(0, bindGroup98, new Uint32Array(2346), 75, 0);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer82, 'uint32', 88, 23);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture148,
+  mipLevel: 0,
+  origin: {x: 94, y: 16, z: 0},
+  aspect: 'all',
+}, new Uint8Array(19).fill(29), /* required buffer size: 19 */
+{offset: 19, bytesPerRow: 107}, {width: 3, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let sampler141 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 73.04,
+  lodMaxClamp: 98.28,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder116); computePassEncoder116.dispatchWorkgroupsIndirect(buffer130, 76); };
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer100, 'uint32', 104, 233);
+} catch {}
+try {
+buffer122.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 560, height: 582, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame24,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture191,
+  mipLevel: 0,
+  origin: {x: 42, y: 40, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer157 = device0.createBuffer({size: 2931, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let commandEncoder243 = device0.createCommandEncoder({});
+let computePassEncoder198 = commandEncoder243.beginComputePass({});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true});
+let renderBundle21 = renderBundleEncoder21.finish({label: '\uccbd\u99c7\u99df\ufaa7\u3c85\u{1feb0}\uec02\u6a72'});
+try {
+renderPassEncoder64.setBindGroup(3, bindGroup121);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 280, height: 291, depthOrArrayLayers: 478}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 30, y: 35, z: 12},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(132, 227);
+let bindGroup139 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 606, resource: sampler62},
+    {binding: 222, resource: {buffer: buffer145, offset: 0, size: 1669}},
+    {binding: 125, resource: externalTexture9},
+    {binding: 190, resource: textureView168},
+  ],
+});
+let commandEncoder244 = device0.createCommandEncoder({});
+let computePassEncoder199 = commandEncoder244.beginComputePass({label: '\u00b1\u0ab9\u00f1\u{1fc98}\u4500\ufb49\u7ed8'});
+try {
+computePassEncoder176.setBindGroup(3, bindGroup93);
+} catch {}
+try {
+computePassEncoder87.setBindGroup(0, bindGroup118, new Uint32Array(1583), 485, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer13]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder245 = device0.createCommandEncoder({});
+let texture214 = device0.createTexture({
+  size: [64, 64, 22],
+  mipLevelCount: 1,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder200 = commandEncoder245.beginComputePass();
+try {
+computePassEncoder198.setPipeline(pipeline2);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup140 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 606, resource: sampler1},
+    {binding: 125, resource: externalTexture2},
+    {binding: 190, resource: textureView168},
+    {binding: 222, resource: {buffer: buffer127, offset: 0}},
+  ],
+});
+let commandEncoder246 = device0.createCommandEncoder({});
+let textureView204 = texture12.createView({dimension: '2d-array'});
+let renderPassEncoder87 = commandEncoder246.beginRenderPass({
+  colorAttachments: [{
+  view: textureView152,
+  depthSlice: 1183,
+  clearValue: { r: 424.4, g: -725.7, b: -999.5, a: -982.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder20.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder200.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer127, 992, new DataView(new ArrayBuffer(7038)), 476, 248);
+} catch {}
+let videoFrame36 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'smpte240m', transfer: 'iec61966-2-1'} });
+let textureView205 = texture177.createView({
+  label: '\uc5bf\u6d88\u{1f849}\ubfc6\ua368\u{1fd36}\u9026\ub25b\uc910\u{1fce2}\u04e8',
+  mipLevelCount: 1,
+});
+try {
+computePassEncoder163.setBindGroup(1, bindGroup86, new Uint32Array(1528), 132, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder85); computePassEncoder85.dispatchWorkgroups(2); };
+} catch {}
+let arrayBuffer18 = buffer35.getMappedRange(112, 28);
+let promise18 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 147, height: 1, depthOrArrayLayers: 9}
+*/
+{
+  source: imageData20,
+  origin: { x: 1, y: 25 },
+  flipY: true,
+}, {
+  texture: texture110,
+  mipLevel: 1,
+  origin: {x: 86, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let buffer158 = device0.createBuffer({
+  size: 778,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder247 = device0.createCommandEncoder({});
+let computePassEncoder201 = commandEncoder247.beginComputePass();
+try {
+computePassEncoder189.setBindGroup(0, bindGroup52, new Uint32Array(526), 150, 0);
+} catch {}
+try {
+computePassEncoder201.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer128, 'uint32', 240, 19);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas3.getContext('webgpu');
+let buffer159 = device0.createBuffer({
+  size: 7183,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture215 = device0.createTexture({
+  label: '\u0576\u8472\u{1fee8}\ude79\u9071\u5b93\u1aee',
+  size: [36, 1, 46],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder181.setBindGroup(1, bindGroup117, new Uint32Array(2107), 499, 0);
+} catch {}
+try {
+computePassEncoder199.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup24, new Uint32Array(1824), 968, 0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let commandEncoder248 = device0.createCommandEncoder();
+let computePassEncoder202 = commandEncoder248.beginComputePass({label: '\u219c\u1765\u92a4\uc752\u42b9\uf8e7\u{1f75d}\u{1ff0d}\u9b61\u04b0\ubbce'});
+let sampler142 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 96.29,
+  lodMaxClamp: 97.11,
+  maxAnisotropy: 17,
+});
+try {
+renderPassEncoder43.setVertexBuffer(3, buffer76, 0);
+} catch {}
+try {
+computePassEncoder202.setPipeline(pipeline3);
+} catch {}
+let bindGroup141 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [
+    {binding: 58, resource: {buffer: buffer138, offset: 0, size: 3420}},
+    {binding: 225, resource: textureView91},
+  ],
+});
+let sampler143 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 43.92,
+  lodMaxClamp: 60.61,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder168.setBindGroup(2, bindGroup34);
+} catch {}
+try {
+computePassEncoder163.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(7, buffer146);
+} catch {}
+try {
+  await promise18;
+} catch {}
+let textureView206 = texture19.createView({dimension: '2d-array'});
+let texture216 = device0.createTexture({
+  size: {width: 36, height: 1, depthOrArrayLayers: 177},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView207 = texture143.createView({});
+try {
+computePassEncoder63.setBindGroup(3, bindGroup118);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(7, buffer76, 6_600);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 32}
+*/
+{
+  source: imageData21,
+  origin: { x: 14, y: 1 },
+  flipY: false,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData29 = new ImageData(80, 12);
+let sampler144 = device0.createSampler({
+  label: '\u0b37\ue024\u0c90\u0120\ucd91\ua961\u2c0c',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 94.64,
+  lodMaxClamp: 97.05,
+  compare: 'greater-equal',
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder71.setBindGroup(2, bindGroup40, new Uint32Array(2299), 2, 0);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer84, 'uint32', 1_876, 2_442);
+} catch {}
+try {
+renderPassEncoder80.setPipeline(pipeline1);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture89,
+  mipLevel: 1,
+  origin: {x: 16, y: 0, z: 28},
+  aspect: 'all',
+}, new Uint8Array(43).fill(225), /* required buffer size: 43 */
+{offset: 43}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let externalTexture21 = device0.importExternalTexture({source: videoFrame4, colorSpace: 'srgb'});
+try {
+renderPassEncoder79.setBindGroup(1, bindGroup121);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 32}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView208 = texture173.createView({baseArrayLayer: 0});
+try {
+renderPassEncoder87.setBindGroup(0, bindGroup94);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let imageBitmap4 = await createImageBitmap(imageData27);
+let commandEncoder249 = device0.createCommandEncoder();
+let renderPassEncoder88 = commandEncoder249.beginRenderPass({
+  colorAttachments: [{
+  view: textureView197,
+  clearValue: { r: -27.64, g: -129.7, b: 78.03, a: -753.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler145 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 89.29,
+  lodMaxClamp: 96.07,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder115.setBindGroup(2, bindGroup106, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder116); computePassEncoder116.dispatchWorkgroupsIndirect(buffer159, 304); };
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(3, bindGroup113);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer112, 1068, new BigUint64Array(15205), 2148, 532);
+} catch {}
+let videoFrame37 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'film', transfer: 'iec6196624'} });
+let commandEncoder250 = device0.createCommandEncoder({label: '\u{1f829}\u{1fc25}\u06b7\uce2b\u994b\ub625\u6357\u05b5\u14c2\u07ca\uf2ff'});
+let textureView209 = texture137.createView({mipLevelCount: 1});
+try {
+renderPassEncoder78.setBindGroup(1, bindGroup58);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(0, bindGroup5, new Uint32Array(294), 13, 0);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer86, 'uint32', 256, 522);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(3, buffer138, 1_284, 878);
+} catch {}
+let texture217 = device0.createTexture({
+  size: [280, 291, 1],
+  mipLevelCount: 4,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler146 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 77.56,
+  lodMaxClamp: 92.40,
+});
+try {
+computePassEncoder64.setBindGroup(3, bindGroup116);
+} catch {}
+try {
+computePassEncoder121.setBindGroup(3, bindGroup56, new Uint32Array(794), 461, 0);
+} catch {}
+try {
+renderPassEncoder81.setVertexBuffer(1, buffer94, 1_148, 52);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture218 = device0.createTexture({
+  size: [220, 20, 4],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder89 = commandEncoder250.beginRenderPass({
+  colorAttachments: [{
+  view: textureView79,
+  clearValue: { r: 681.2, g: -94.14, b: -206.6, a: -507.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet12,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder189); computePassEncoder189.dispatchWorkgroupsIndirect(buffer89, 176); };
+} catch {}
+try {
+computePassEncoder118.end();
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle2]);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+await gc();
+let texture219 = device0.createTexture({
+  size: {width: 220, height: 20, depthOrArrayLayers: 1},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture220 = device0.createTexture({
+  size: [55, 5, 1],
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder203 = commandEncoder159.beginComputePass();
+let sampler147 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 94.77,
+  lodMaxClamp: 96.29,
+});
+try {
+computePassEncoder203.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle19, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder41.setScissorRect(127, 120, 16, 107);
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(canvas1);
+let videoFrame38 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'smpteSt4281', transfer: 'logSqrt'} });
+let bindGroup142 = device0.createBindGroup({
+  label: '\ua7c9\u{1fda4}\u395c\u201c\u{1f8eb}\ueb1a',
+  layout: bindGroupLayout11,
+  entries: [{binding: 52, resource: textureView175}, {binding: 57, resource: textureView20}],
+});
+let commandEncoder251 = device0.createCommandEncoder({});
+let textureView210 = texture213.createView({dimension: '2d-array', format: 'rgba32float', baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder130.setBindGroup(1, bindGroup137);
+} catch {}
+try {
+commandEncoder251.resolveQuerySet(querySet10, 40, 107, buffer138, 768);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer61, 632, new Int16Array(13921), 1260, 168);
+} catch {}
+let bindGroup143 = device0.createBindGroup({
+  layout: bindGroupLayout6,
+  entries: [{binding: 11, resource: {buffer: buffer12, offset: 0, size: 676}}],
+});
+let commandEncoder252 = device0.createCommandEncoder({});
+let querySet27 = device0.createQuerySet({type: 'occlusion', count: 418});
+let textureView211 = texture205.createView({dimension: '2d-array'});
+let texture221 = device0.createTexture({
+  size: {width: 73, height: 1, depthOrArrayLayers: 10},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView212 = texture85.createView({baseMipLevel: 0});
+let computePassEncoder204 = commandEncoder251.beginComputePass({label: '\u0cc0\u60ba\u4569\u3a26\ue02c'});
+let sampler148 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 41.28,
+  lodMaxClamp: 69.04,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder141.setBindGroup(0, bindGroup54, new Uint32Array(44), 2, 0);
+} catch {}
+try {
+computePassEncoder170.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup56);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer128, 'uint32', 596, 159);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(7, buffer138, 1_900);
+} catch {}
+try {
+commandEncoder252.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 92 */
+  offset: 92,
+  buffer: buffer34,
+}, {
+  texture: texture158,
+  mipLevel: 0,
+  origin: {x: 16, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let buffer160 = device0.createBuffer({
+  size: 10858,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let querySet28 = device0.createQuerySet({type: 'occlusion', count: 1918});
+try {
+renderPassEncoder77.setViewport(45.477922443405014, 4.8284378107369585, 5.302597466803445, 0.022758491058333583, 0.1342871813699148, 0.3152727179990512);
+} catch {}
+try {
+renderPassEncoder87.setVertexBuffer(0, buffer100, 424);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup144 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 42, resource: externalTexture3},
+    {binding: 243, resource: textureView39},
+    {binding: 999, resource: textureView81},
+    {binding: 567, resource: textureView30},
+    {binding: 421, resource: {buffer: buffer11, offset: 4864, size: 572}},
+    {binding: 132, resource: textureView20},
+    {binding: 94, resource: textureView60},
+    {binding: 398, resource: textureView39},
+    {binding: 35, resource: textureView191},
+  ],
+});
+let buffer161 = device0.createBuffer({size: 5165, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+let commandEncoder253 = device0.createCommandEncoder({});
+let texture222 = device0.createTexture({
+  size: [73],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder205 = commandEncoder252.beginComputePass({});
+let sampler149 = device0.createSampler({
+  label: '\u0850\u6c61\ub0e7',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 15.60,
+  lodMaxClamp: 24.80,
+  compare: 'not-equal',
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder197.setBindGroup(0, bindGroup9, new Uint32Array(603), 22, 0);
+} catch {}
+try {
+renderPassEncoder55.setStencilReference(516);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder253.clearBuffer(buffer100, 104, 420);
+} catch {}
+let commandEncoder254 = device0.createCommandEncoder({});
+let textureView213 = texture135.createView({
+  label: '\u{1fdcf}\u04f3\u{1f810}\u0c39\ueb0c\u004f\u7bff\u0539\u5dc8',
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+  arrayLayerCount: 2,
+});
+let computePassEncoder206 = commandEncoder253.beginComputePass({});
+let renderPassEncoder90 = commandEncoder254.beginRenderPass({
+  label: '\u0df4\ufc94\ubf86\u{1fbf8}\u{1fd0e}\u3de8\u07c9',
+  colorAttachments: [{
+  view: textureView99,
+  depthSlice: 3,
+  clearValue: { r: -345.3, g: 418.9, b: 967.9, a: 917.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder205.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder87.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder73.setVertexBuffer(1, buffer106, 0, 1_996);
+} catch {}
+let arrayBuffer19 = buffer5.getMappedRange(1272, 668);
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55); };
+} catch {}
+let commandEncoder255 = device0.createCommandEncoder({});
+let textureView214 = texture206.createView({});
+let renderPassEncoder91 = commandEncoder255.beginRenderPass({
+  label: '\uf322\u{1fdf8}\u6d7b\u8266\u{1f778}\u0f66\u0685\u{1f775}',
+  colorAttachments: [{
+  view: textureView202,
+  clearValue: { r: 735.6, g: -920.0, b: -693.5, a: -651.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet18,
+});
+try {
+computePassEncoder167.setBindGroup(2, bindGroup30, new Uint32Array(187), 122, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let commandEncoder256 = device0.createCommandEncoder({});
+let texture223 = device0.createTexture({
+  size: [55, 5, 1],
+  mipLevelCount: 1,
+  sampleCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder92 = commandEncoder256.beginRenderPass({
+  colorAttachments: [{
+  view: textureView197,
+  clearValue: { r: -202.4, g: 392.0, b: 994.4, a: 687.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet6,
+});
+let sampler150 = device0.createSampler({
+  label: '\u{1fc53}\uef07',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 10.53,
+  lodMaxClamp: 50.61,
+  maxAnisotropy: 12,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder94); computePassEncoder94.dispatchWorkgroupsIndirect(buffer64, 2_220); };
+} catch {}
+try {
+computePassEncoder204.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder87.draw(0, 280, 0, 870_858_773);
+} catch {}
+try {
+renderPassEncoder87.drawIndirect(buffer82, 212);
+} catch {}
+let commandEncoder257 = device0.createCommandEncoder({});
+let computePassEncoder207 = commandEncoder257.beginComputePass({});
+try {
+computePassEncoder198.setBindGroup(1, bindGroup82, new Uint32Array(7), 1, 0);
+} catch {}
+try {
+computePassEncoder206.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup74, new Uint32Array(2540), 988, 0);
+} catch {}
+try {
+renderPassEncoder87.end();
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder246.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2792 */
+  offset: 2792,
+  bytesPerRow: 24576,
+  buffer: buffer106,
+}, {
+  texture: texture93,
+  mipLevel: 0,
+  origin: {x: 11, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder246.copyTextureToTexture({
+  texture: texture179,
+  mipLevel: 0,
+  origin: {x: 3, y: 6, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 32, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder246.clearBuffer(buffer99);
+} catch {}
+let buffer162 = device0.createBuffer({size: 10772, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder258 = device0.createCommandEncoder({label: '\u425c\u02d6\u875b\u{1f640}\u0065\u{1f970}\u998d\u099f\ub37f'});
+let computePassEncoder208 = commandEncoder246.beginComputePass();
+try {
+computePassEncoder86.setBindGroup(2, bindGroup93);
+} catch {}
+try {
+renderPassEncoder70.setBindGroup(0, bindGroup100, new Uint32Array(1078), 316, 0);
+} catch {}
+try {
+renderPassEncoder61.setIndexBuffer(buffer42, 'uint32', 300, 32);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder258.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 544 */
+  offset: 544,
+  bytesPerRow: 34304,
+  buffer: buffer43,
+}, {
+  texture: texture159,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+let textureView215 = texture218.createView({dimension: '2d'});
+let renderPassEncoder93 = commandEncoder258.beginRenderPass({
+  colorAttachments: [{
+  view: textureView98,
+  clearValue: { r: 427.0, g: -79.59, b: -365.0, a: 973.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet23,
+  maxDrawCount: 498912885,
+});
+let sampler151 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.56,
+  lodMaxClamp: 58.81,
+  compare: 'less-equal',
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder64.setBindGroup(0, bindGroup88, new Uint32Array(261), 17, 0);
+} catch {}
+try {
+computePassEncoder207.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle2, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder86.setVertexBuffer(1, buffer156, 628, 242);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture157,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(364).fill(235), /* required buffer size: 364 */
+{offset: 364, bytesPerRow: 148}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture224 = device0.createTexture({
+  size: {width: 55},
+  dimension: '1d',
+  format: 'rg8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture225 = device0.createTexture({
+  size: [440, 40, 312],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler152 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 80.33,
+  lodMaxClamp: 80.49,
+  compare: 'equal',
+});
+try {
+renderPassEncoder34.setBlendConstant({ r: -66.70, g: -547.6, b: 1.412, a: -741.9, });
+} catch {}
+try {
+renderPassEncoder90.setIndexBuffer(buffer54, 'uint32', 1_252, 2_325);
+} catch {}
+let bindGroupLayout27 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 20,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let texture226 = device0.createTexture({
+  size: [96, 1, 131],
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder151.setBindGroup(0, bindGroup6, new Uint32Array(1991), 640, 0);
+} catch {}
+try {
+renderPassEncoder74.executeBundles([renderBundle1, renderBundle19]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 36, height: 1, depthOrArrayLayers: 177}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 1, y: 4 },
+  flipY: false,
+}, {
+  texture: texture216,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 24},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder259 = device0.createCommandEncoder({});
+let textureView216 = texture226.createView({baseMipLevel: 0});
+let renderPassEncoder94 = commandEncoder259.beginRenderPass({
+  colorAttachments: [{
+  view: textureView197,
+  clearValue: { r: -32.86, g: -450.1, b: 100.4, a: 94.97, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder208.setPipeline(pipeline2);
+} catch {}
+let buffer163 = device0.createBuffer({
+  size: 12047,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let textureView217 = texture79.createView({mipLevelCount: 1});
+try {
+renderPassEncoder24.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(5, buffer2, 0);
+} catch {}
+try {
+computePassEncoder155.pushDebugGroup('\u{1fd58}');
+} catch {}
+try {
+device0.queue.submit([commandBuffer14]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer94, 600, new Int16Array(6805), 1645, 224);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 70, height: 72, depthOrArrayLayers: 25}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture194,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture227 = device0.createTexture({
+  size: {width: 147, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], stencilReadOnly: true});
+try {
+computePassEncoder171.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+computePassEncoder198.setBindGroup(2, bindGroup24, new Uint32Array(2335), 775, 0);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(3, bindGroup94);
+} catch {}
+try {
+renderPassEncoder63.executeBundles([renderBundle6, renderBundle6]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 36, height: 1, depthOrArrayLayers: 20}
+*/
+{
+  source: img2,
+  origin: { x: 6, y: 36 },
+  flipY: true,
+}, {
+  texture: texture174,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+  await promise19;
+} catch {}
+let commandEncoder260 = device0.createCommandEncoder();
+let textureView218 = texture143.createView({dimension: '1d'});
+try {
+computePassEncoder67.setBindGroup(1, bindGroup142);
+} catch {}
+try {
+computePassEncoder94.end();
+} catch {}
+try {
+renderPassEncoder86.setIndexBuffer(buffer27, 'uint16', 180, 46);
+} catch {}
+try {
+renderPassEncoder67.setVertexBuffer(6, buffer148, 128);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer133, 'uint16', 1_588, 96);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(7, buffer145, 324, 385);
+} catch {}
+try {
+commandEncoder129.clearBuffer(buffer2, 2288, 156);
+} catch {}
+try {
+computePassEncoder155.popDebugGroup();
+} catch {}
+try {
+commandEncoder129.insertDebugMarker('\u12e3');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let imageData30 = new ImageData(64, 148);
+let texture228 = device0.createTexture({size: {width: 192}, dimension: '1d', format: 'rgba32float', usage: GPUTextureUsage.COPY_DST});
+try {
+renderPassEncoder17.executeBundles([renderBundle17, renderBundle0, renderBundle0, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder54.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(0, bindGroup48, new Uint32Array(1747), 170, 0);
+} catch {}
+try {
+commandEncoder129.copyBufferToTexture({
+  /* bytesInLastRow: 88 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1352 */
+  offset: 1352,
+  rowsPerImage: 1357,
+  buffer: buffer66,
+}, {
+  texture: texture159,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer164 = device0.createBuffer({size: 10867, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture229 = device0.createTexture({
+  size: [384, 1, 524],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder209 = commandEncoder129.beginComputePass({});
+let renderBundle22 = renderBundleEncoder22.finish({label: '\u9e73\u{1fd11}\uedb4\u144b\u6c38\u57da\u0309\u39f3'});
+let sampler153 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 19.81,
+  lodMaxClamp: 78.15,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder209.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup54);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(3, bindGroup66, new Uint32Array(2349), 2, 0);
+} catch {}
+try {
+renderPassEncoder35.beginOcclusionQuery(5);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(6, buffer158, 240, 205);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture157,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(34).fill(190), /* required buffer size: 34 */
+{offset: 34}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 280, height: 291, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame14,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture161,
+  mipLevel: 0,
+  origin: {x: 98, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img2);
+let textureView219 = texture109.createView({});
+try {
+renderPassEncoder70.setBindGroup(0, bindGroup141, new Uint32Array(2922), 5, 0);
+} catch {}
+try {
+renderPassEncoder67.setScissorRect(325, 146, 21, 23);
+} catch {}
+try {
+commandEncoder260.copyBufferToTexture({
+  /* bytesInLastRow: 36 widthInBlocks: 36 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 4356 */
+  offset: 4356,
+  rowsPerImage: 1542,
+  buffer: buffer117,
+}, {
+  texture: texture27,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 36, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+document.body.append(img1);
+let bindGroup145 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 53, resource: externalTexture10},
+    {binding: 54, resource: {buffer: buffer161, offset: 0, size: 2296}},
+  ],
+});
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup107, new Uint32Array(6111), 635, 0);
+} catch {}
+try {
+commandEncoder260.copyBufferToBuffer(buffer160, 28, buffer51, 1212, 144);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer100, 208, new Int16Array(10776), 317, 188);
+} catch {}
+let bindGroup146 = device0.createBindGroup({
+  layout: bindGroupLayout26,
+  entries: [{binding: 49, resource: {buffer: buffer57, offset: 0, size: 372}}],
+});
+let commandEncoder261 = device0.createCommandEncoder();
+let texture230 = device0.createTexture({
+  label: '\u2a74\u07b6\u0963\ud6d2\u07bf\u021d\uea53\u47f1',
+  size: [440, 40, 8],
+  format: 'eac-rg11unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['eac-rg11unorm'],
+});
+let textureView220 = texture143.createView({mipLevelCount: 1});
+let computePassEncoder210 = commandEncoder260.beginComputePass({});
+try {
+computePassEncoder190.setBindGroup(0, bindGroup64);
+} catch {}
+try {
+computePassEncoder210.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder35.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer143, 'uint32', 2_400, 126);
+} catch {}
+try {
+  await promise20;
+} catch {}
+let shaderModule17 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(35) var st30: texture_storage_1d<r32sint, read_write>;
+
+@group(0) @binding(42) var et1: texture_external;
+
+@group(0) @binding(94) var tex6: texture_2d_array<f32>;
+
+@group(0) @binding(132) var tex7: texture_2d<i32>;
+
+@group(0) @binding(243) var tex8: texture_depth_2d;
+
+@group(0) @binding(398) var tex9: texture_depth_2d;
+
+@group(0) @binding(421) var<storage, read> buffer165: u32;
+
+@group(0) @binding(999) var tex10: texture_2d_array<i32>;
+
+struct T0 {
+  @align(4) @size(4) f0: array<f16, 1>,
+}
+
+struct FragmentOutput15 {
+  @location(0) @interpolate(flat, sample) f0: vec4u,
+}
+
+alias vec3b = vec3<bool>;
+
+fn fn0(a0: ptr<uniform, vec2u>) -> u32 {
+  var out: u32;
+  let vf356: vec2u = textureDimensions(tex7, bitcast<i32>((*a0)[u32(unconst_u32(301))]));
+  var vf357: vec4f = textureLoad(et1, vec2u(unconst_u32(207), unconst_u32(107)));
+  vf357 += vec4f(bitcast<f32>(textureNumLevels(tex7)));
+  var vf358: u32 = vf356[u32(unconst_u32(770))];
+  var vf359: vec2u = vf356;
+  let ptr140: ptr<uniform, vec2u> = &(*a0);
+  let vf360: u32 = vf359[u32(unconst_u32(132))];
+  return out;
+}
+
+fn fn1() -> mat3x2h {
+  var out: mat3x2h;
+  out -= mat3x2h(vec2h(textureDimensions(tex7)), vec2h(textureDimensions(tex7)), vec2h(textureDimensions(tex7)));
+  out = mat3x2h(vec2h(max(vec2i(unconst_i32(144), unconst_i32(35)), vec2i(unconst_i32(53), unconst_i32(308)))), vec2h(max(vec2i(unconst_i32(144), unconst_i32(35)), vec2i(unconst_i32(53), unconst_i32(308)))), vec2h(max(vec2i(unconst_i32(144), unconst_i32(35)), vec2i(unconst_i32(53), unconst_i32(308)))));
+  out -= mat3x2h(cosh(vec3h(unconst_f16(574.0), unconst_f16(10931.5), unconst_f16(16336.9))).rg, cosh(vec3h(unconst_f16(574.0), unconst_f16(10931.5), unconst_f16(16336.9))).zz, cosh(vec3h(unconst_f16(574.0), unconst_f16(10931.5), unconst_f16(16336.9))).gr);
+  out += mat3x2h(vec2h(unpack2x16snorm(u32(unconst_u32(224)))), vec2h(unpack2x16snorm(u32(unconst_u32(224)))), vec2h(unpack2x16snorm(u32(unconst_u32(224)))));
+  var vf361: vec3h = cosh(vec3h(unconst_f16(-4475.7), unconst_f16(4574.3), unconst_f16(7283.6)));
+  vf361 *= refract(vec3h(unconst_f16(5250.2), unconst_f16(3684.9), unconst_f16(17795.8)), vec3h(unconst_f16(362.2), unconst_f16(21479.3), unconst_f16(3020.4)), f16(unconst_f16(28978.6)));
+  var vf362: vec2u = textureDimensions(tex7);
+  var vf363: u32 = firstLeadingBit(u32(unconst_u32(39)));
+  vf363 <<= pack4xI8Clamp(textureLoad(tex7, vec2i(unconst_i32(40), unconst_i32(171)), i32(unconst_i32(176))));
+  var vf364: vec2i = max(vec2i(unconst_i32(305), unconst_i32(355)), vec2i(unconst_i32(55), unconst_i32(-35)));
+  return out;
+}
+
+fn fn2() -> array<T0, 36> {
+  var out: array<T0, 36>;
+  var vf365 = fn1();
+  var vf366: u32 = dot4U8Packed(u32(unconst_u32(82)), u32(unconst_u32(163)));
+  return out;
+}
+
+var<workgroup> vw61: FragmentOutput15;
+
+var<workgroup> vw62: array<mat3x2h, 1>;
+
+@fragment
+fn fragment16(@builtin(position) a0: vec4f) -> FragmentOutput15 {
+  var out: FragmentOutput15;
+  let ptr141: ptr<storage, u32, read> = &(*&buffer165);
+  var vf367: u32 = dot4U8Packed(u32(unconst_u32(31)), u32(unconst_u32(15)));
+  vf367 >>= u32(textureLoad(et1, vec2u(unconst_u32(34), unconst_u32(150))).a);
+  let vf368: f32 = a0[u32(unconst_u32(260))];
+  var vf369: vec2u = textureDimensions(et1);
+  out.f0 += unpack4xU8(u32(a0[u32(unconst_u32(98))]));
+  vf367 &= u32(a0[u32(unconst_u32(141))]);
+  vf367 += (*ptr141);
+  let ptr142: ptr<storage, u32, read> = &buffer165;
+  discard;
+  var vf370: f32 = vf368;
+  var vf371: vec4h = saturate(vec4h(unconst_f16(30699.5), unconst_f16(7565.8), unconst_f16(2886.9), unconst_f16(14225.1)));
+  vf369 ^= bitcast<vec2u>(textureLoad(et1, vec2u((*ptr141))).wz);
+  return out;
+}
+
+@compute @workgroup_size(1, 2, 1)
+fn compute17() {
+  vw62[u32(unconst_u32(188))] = mat3x2h(f16((*&vw61).f0[u32(unconst_u32(76))]), f16((*&vw61).f0[u32(unconst_u32(76))]), f16((*&vw61).f0[u32(unconst_u32(76))]), f16((*&vw61).f0[u32(unconst_u32(76))]), f16((*&vw61).f0[u32(unconst_u32(76))]), f16((*&vw61).f0[u32(unconst_u32(76))]));
+  var vf372 = fn2();
+  vw61 = FragmentOutput15(vec4u(textureNumLevels(tex10)));
+  vf372[u32(unconst_u32(168))] = T0(array<f16, 1>(vec4h(vw61.f0).x));
+  var vf373 = fn1();
+  vf373 -= mat3x2h(vec2h(transpose(mat2x4f(unconst_f32(0.05872), unconst_f32(0.1892), unconst_f32(0.1885), unconst_f32(0.2020), unconst_f32(0.1788), unconst_f32(0.1463), unconst_f32(0.03870), unconst_f32(0.2350)))[unconst_i32(3)]), vec2h(transpose(mat2x4f(unconst_f32(0.05872), unconst_f32(0.1892), unconst_f32(0.1885), unconst_f32(0.2020), unconst_f32(0.1788), unconst_f32(0.1463), unconst_f32(0.03870), unconst_f32(0.2350)))[unconst_i32(1)]), vec2h(transpose(mat2x4f(unconst_f32(0.05872), unconst_f32(0.1892), unconst_f32(0.1885), unconst_f32(0.2020), unconst_f32(0.1788), unconst_f32(0.1463), unconst_f32(0.03870), unconst_f32(0.2350)))[unconst_i32(1)]));
+  vf372[u32(unconst_u32(291))] = vf372[35];
+  vw61 = FragmentOutput15(vec4u(u32(vf372[u32(unconst_u32(8))].f0[u32(unconst_u32(81))])));
+  vf372[bitcast<u32>(vw62[0][u32(unconst_u32(33))])] = T0(array<f16, 1>(vf373[u32(unconst_u32(104))][1]));
+  let vf374: vec3f = exp(vec3f(unconst_f32(0.06140), unconst_f32(0.06730), unconst_f32(0.07548)));
+  let ptr143: ptr<function, T0> = &vf372[35];
+  vf373 = mat3x2h(f16(sqrt(f32(unconst_f32(0.6988)))), f16(sqrt(f32(unconst_f32(0.6988)))), f16(sqrt(f32(unconst_f32(0.6988)))), f16(sqrt(f32(unconst_f32(0.6988)))), f16(sqrt(f32(unconst_f32(0.6988)))), f16(sqrt(f32(unconst_f32(0.6988)))));
+  fn2();
+  var vf375: u32 = pack4xU8(vec4u(unconst_u32(23), unconst_u32(227), unconst_u32(132), unconst_u32(10)));
+  var vf376 = fn1();
+  let vf377: u32 = textureNumLevels(tex8);
+  let ptr144: ptr<workgroup, FragmentOutput15> = &(*&vw61);
+  var vf378: vec2u = textureDimensions(tex7);
+  vw61.f0 = vf378.xxyx;
+  let vf379: vec3h = tan(vec3h(unconst_f16(4209.6), unconst_f16(2315.8), unconst_f16(3488.2)));
+  let vf380: vec4i = textureLoad(tex10, vec2i(unconst_i32(746), unconst_i32(804)), i32(unconst_i32(163)), i32(unconst_i32(451)));
+  vf372[u32(unconst_u32(123))] = T0(array<f16, 1>(vf372[35].f0[0]));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup147 = device0.createBindGroup({layout: bindGroupLayout27, entries: [{binding: 20, resource: textureView216}]});
+let buffer166 = device0.createBuffer({
+  label: '\u4ebc\u{1f836}\u7034\u{1fce2}\u4ca4\u{1ffd0}',
+  size: 4657,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let computePassEncoder211 = commandEncoder261.beginComputePass();
+let sampler154 = device0.createSampler({
+  label: '\u{1ff4d}\u7603\u{1f64d}\ue2ae\u9e74\u{1f6b6}\uf56a',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 38.28,
+  lodMaxClamp: 90.42,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder64.setBindGroup(2, bindGroup131);
+} catch {}
+try {
+computePassEncoder168.setBindGroup(3, bindGroup81, new Uint32Array(1452), 36, 0);
+} catch {}
+try {
+computePassEncoder211.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder25.setBindGroup(3, bindGroup10, new Uint32Array(5655), 24, 0);
+} catch {}
+try {
+renderPassEncoder65.setIndexBuffer(buffer85, 'uint16', 2_990, 5_608);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 70, height: 72, depthOrArrayLayers: 25}
+*/
+{
+  source: imageData11,
+  origin: { x: 10, y: 0 },
+  flipY: false,
+}, {
+  texture: texture194,
+  mipLevel: 0,
+  origin: {x: 29, y: 13, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 10, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture231 = device0.createTexture({size: {width: 220}, dimension: '1d', format: 'rgba16uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+renderPassEncoder36.setBindGroup(2, bindGroup135, new Uint32Array(551), 5, 0);
+} catch {}
+try {
+renderPassEncoder62.executeBundles([renderBundle21]);
+} catch {}
+try {
+renderPassEncoder10.setViewport(65.79311583817953, 39.42025707126985, 1.2723530110788328, 6.947091648952119, 0.073414566718637, 0.4081260361017597);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer10, 'uint16', 454, 2_208);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING, colorSpace: 'srgb'});
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise21;
+} catch {}
+let commandEncoder262 = device0.createCommandEncoder({label: '\u4162\uf29c\u0380\ue5bb\u004f\u0bc6\ua5cb\u{1fb00}\u9b5a\u84b5'});
+let textureView221 = texture142.createView({format: 'rgba16sint', mipLevelCount: 1});
+try {
+renderPassEncoder39.setBindGroup(2, bindGroup55, new Uint32Array(529), 4, 0);
+} catch {}
+try {
+buffer89.unmap();
+} catch {}
+let commandEncoder263 = device0.createCommandEncoder({});
+let computePassEncoder212 = commandEncoder262.beginComputePass({});
+let renderPassEncoder95 = commandEncoder263.beginRenderPass({
+  colorAttachments: [{
+  view: textureView197,
+  clearValue: { r: -780.2, g: -174.2, b: -320.2, a: 144.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet21,
+});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint']});
+try {
+computePassEncoder57.setBindGroup(0, bindGroup41, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder48); computePassEncoder48.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder189); computePassEncoder189.dispatchWorkgroupsIndirect(buffer120, 408); };
+} catch {}
+try {
+computePassEncoder212.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder43.end();
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer83, 'uint16', 1_438, 1_706);
+} catch {}
+try {
+renderPassEncoder79.setVertexBuffer(6, buffer130);
+} catch {}
+try {
+buffer51.unmap();
+} catch {}
+let textureView222 = texture149.createView({label: '\ufd58\u{1f891}\u0e3f\u9643', aspect: 'depth-only'});
+let computePassEncoder213 = commandEncoder83.beginComputePass({label: '\ub321\u{1fa20}\u{1fe67}'});
+try {
+computePassEncoder125.setBindGroup(0, bindGroup143, new Uint32Array(1173), 81, 0);
+} catch {}
+try {
+renderPassEncoder26.setScissorRect(23, 19, 13, 13);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer112, 'uint32', 1_772, 842);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(4, buffer140);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(1, bindGroup98, new Uint32Array(314), 9, 0);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer116, 'uint16', 1_946, 573);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 49, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(98).fill(120), /* required buffer size: 98 */
+{offset: 98}, {width: 51, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData31 = new ImageData(16, 80);
+let bindGroup148 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [{binding: 116, resource: sampler44}, {binding: 204, resource: externalTexture11}],
+});
+try {
+computePassEncoder89.setBindGroup(1, bindGroup85);
+} catch {}
+try {
+computePassEncoder213.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(2, bindGroup142, new Uint32Array(2660), 50, 0);
+} catch {}
+let commandEncoder264 = device0.createCommandEncoder({});
+let textureView223 = texture224.createView({});
+let texture232 = device0.createTexture({
+  size: {width: 96},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder96 = commandEncoder264.beginRenderPass({
+  label: '\u9cb1\u2943\u{1fdb5}\u0cf7\uc50a\u0e70\u{1ffd4}\u8570',
+  colorAttachments: [{
+  view: textureView73,
+  clearValue: { r: -534.0, g: -544.0, b: -458.7, a: -307.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderBundleEncoder23.setBindGroup(2, bindGroup129, new Uint32Array(278), 129, 0);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(2, undefined);
+} catch {}
+let bindGroup149 = device0.createBindGroup({
+  label: '\ue863\u08ce\u03b9\ua19a\u{1f701}\uc90c\u{1fe4f}\u7404',
+  layout: bindGroupLayout10,
+  entries: [{binding: 5, resource: sampler134}],
+});
+let commandEncoder265 = device0.createCommandEncoder({});
+let computePassEncoder214 = commandEncoder265.beginComputePass({});
+try {
+computePassEncoder197.setBindGroup(2, bindGroup88, new Uint32Array(335), 85, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder85); computePassEncoder85.dispatchWorkgroupsIndirect(buffer25, 164); };
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(2, bindGroup125, new Uint32Array(976), 162, 0);
+} catch {}
+try {
+renderPassEncoder80.setScissorRect(59, 26, 66, 125);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(1, bindGroup76, new Uint32Array(387), 89, 0);
+} catch {}
+let commandEncoder266 = device0.createCommandEncoder();
+let texture233 = device0.createTexture({size: [110, 10, 40], format: 'rgba16sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView224 = texture57.createView({dimension: '2d-array', format: 'rgba16sint', mipLevelCount: 1});
+try {
+computePassEncoder62.setBindGroup(3, bindGroup64, new Uint32Array(3513), 1_373, 0);
+} catch {}
+try {
+computePassEncoder214.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(0, bindGroup146, new Uint32Array(55), 2, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle17, renderBundle3, renderBundle17, renderBundle17, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder77.setIndexBuffer(buffer131, 'uint16', 2_730, 1_727);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(7, buffer116, 0, 76);
+} catch {}
+try {
+commandEncoder266.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 352 */
+  offset: 352,
+  buffer: buffer17,
+}, {
+  texture: texture213,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup150 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 243, resource: textureView172},
+    {binding: 999, resource: textureView21},
+    {binding: 567, resource: textureView72},
+    {binding: 94, resource: textureView1},
+    {binding: 35, resource: textureView10},
+    {binding: 398, resource: textureView172},
+    {binding: 132, resource: textureView20},
+    {binding: 421, resource: {buffer: buffer37, offset: 768, size: 72}},
+    {binding: 42, resource: externalTexture20},
+  ],
+});
+let texture234 = device0.createTexture({
+  size: [560, 582, 58],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView225 = texture221.createView({
+  label: '\u0bb6\u5d13\u{1fbcd}\u59b4\u{1ff06}\u0582\u{1fcdb}\ud2ab\ufb40\u{1fab2}\u0512',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+});
+let computePassEncoder215 = commandEncoder266.beginComputePass({label: '\ud1cf\u4edb\udda9\u806a\u5ce0\u{1fee2}'});
+let externalTexture22 = device0.importExternalTexture({label: '\u0b68\u{1f6e7}', source: videoFrame18});
+try {
+computePassEncoder27.setBindGroup(3, bindGroup31, new Uint32Array(1974), 219, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder189); computePassEncoder189.dispatchWorkgroupsIndirect(buffer111, 240); };
+} catch {}
+try {
+computePassEncoder75.end();
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup99);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(1, buffer24, 4);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+commandEncoder73.copyTextureToTexture({
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer51, 2508, new BigUint64Array(4243), 115, 20);
+} catch {}
+let commandEncoder267 = device0.createCommandEncoder({label: '\u0eca\u0a67\uac58\u4c6b\uffc7\u{1fdbb}\uef13'});
+let texture235 = device0.createTexture({
+  label: '\u08ba\u0beb\u{1fc26}\u{1fa57}\u8470',
+  size: [384, 1, 1],
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder97 = commandEncoder73.beginRenderPass({
+  colorAttachments: [{
+  view: textureView79,
+  clearValue: { r: 169.1, g: -688.6, b: -148.0, a: -172.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 28288112,
+});
+try {
+computePassEncoder159.setBindGroup(1, bindGroup87);
+} catch {}
+try {
+computePassEncoder121.setBindGroup(1, bindGroup51, new Uint32Array(276), 106, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder215.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder45.beginOcclusionQuery(14);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer42, 'uint32', 468, 150);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(3, bindGroup82);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(3, buffer15, 0, 41);
+} catch {}
+try {
+buffer128.unmap();
+} catch {}
+try {
+commandEncoder267.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1760 */
+  offset: 1760,
+  bytesPerRow: 5632,
+  buffer: buffer17,
+}, {
+  texture: texture93,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView226 = texture226.createView({});
+let computePassEncoder216 = commandEncoder267.beginComputePass({});
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup135, []);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup117, new Uint32Array(998), 249, 0);
+} catch {}
+await gc();
+let bindGroup151 = device0.createBindGroup({layout: bindGroupLayout19, entries: [{binding: 361, resource: {buffer: buffer12, offset: 0}}]});
+let buffer167 = device0.createBuffer({
+  size: 974,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let renderBundle23 = renderBundleEncoder23.finish({});
+try {
+computePassEncoder114.setBindGroup(1, bindGroup47, []);
+} catch {}
+try {
+computePassEncoder88.setBindGroup(2, bindGroup142, new Uint32Array(506), 12, 0);
+} catch {}
+try {
+computePassEncoder216.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder92.setBindGroup(2, bindGroup88);
+} catch {}
+try {
+renderPassEncoder55.executeBundles([renderBundle22, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder74.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder62.insertDebugMarker('\u0ec0');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView227 = texture15.createView({});
+try {
+renderPassEncoder35.setIndexBuffer(buffer70, 'uint32', 2_352, 316);
+} catch {}
+let canvas4 = document.createElement('canvas');
+let bindGroup152 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 125, resource: externalTexture0},
+    {binding: 190, resource: textureView211},
+    {binding: 606, resource: sampler87},
+    {binding: 222, resource: {buffer: buffer64, offset: 0}},
+  ],
+});
+try {
+buffer50.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 640, new Int16Array(6796), 15, 576);
+} catch {}
+document.body.append(img3);
+let commandEncoder268 = device0.createCommandEncoder({label: '\u525e\u002c\u01a1\u6689\u{1f84b}\u0b35\u0aa3'});
+let renderPassEncoder98 = commandEncoder268.beginRenderPass({
+  colorAttachments: [{
+  view: textureView4,
+  depthSlice: 66,
+  clearValue: { r: -704.2, g: -261.2, b: -313.1, a: 236.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler155 = device0.createSampler({
+  label: '\u{1f841}\u1f4c\uf188\u0717\uf881\u7451\u42ec\u9a3d\u1756\u961b',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 94.10,
+  lodMaxClamp: 96.11,
+});
+try {
+renderPassEncoder45.endOcclusionQuery();
+} catch {}
+try {
+  await buffer74.mapAsync(GPUMapMode.READ, 208, 152);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(141).fill(79), /* required buffer size: 141 */
+{offset: 141}, {width: 43, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup153 = device0.createBindGroup({layout: bindGroupLayout20, entries: [{binding: 152, resource: textureView57}]});
+let commandEncoder269 = device0.createCommandEncoder();
+let computePassEncoder217 = commandEncoder269.beginComputePass({});
+try {
+computePassEncoder177.setBindGroup(0, bindGroup114, new Uint32Array(1848), 781, 0);
+} catch {}
+try {
+computePassEncoder217.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder88.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderPassEncoder96.executeBundles([renderBundle21]);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(6, buffer65, 80, 92);
+} catch {}
+let bindGroupLayout28 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 178,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 39,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup154 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [
+    {binding: 57, resource: textureView172},
+    {binding: 462, resource: {buffer: buffer107, offset: 256, size: 1692}},
+    {binding: 51, resource: {buffer: buffer149, offset: 7424, size: 23064}},
+    {binding: 67, resource: textureView10},
+    {binding: 9, resource: textureView140},
+    {binding: 172, resource: textureView110},
+    {binding: 264, resource: sampler6},
+    {binding: 153, resource: {buffer: buffer26, offset: 0, size: 650}},
+    {binding: 8, resource: textureView109},
+  ],
+});
+let commandEncoder270 = device0.createCommandEncoder();
+let textureView228 = texture16.createView({dimension: '2d', aspect: 'depth-only', mipLevelCount: 1});
+try {
+renderPassEncoder73.setBindGroup(0, bindGroup100);
+} catch {}
+try {
+renderPassEncoder74.setBindGroup(1, bindGroup41, new Uint32Array(2023), 118, 0);
+} catch {}
+try {
+renderPassEncoder93.setVertexBuffer(7, buffer103);
+} catch {}
+try {
+commandEncoder270.copyBufferToTexture({
+  /* bytesInLastRow: 1896 widthInBlocks: 237 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1552 */
+  offset: 1552,
+  buffer: buffer39,
+}, {
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 237, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder270.copyTextureToBuffer({
+  texture: texture219,
+  mipLevel: 0,
+  origin: {x: 37, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 88 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1560 */
+  offset: 1560,
+  bytesPerRow: 5120,
+  rowsPerImage: 1113,
+  buffer: buffer96,
+}, {width: 22, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup155 = device0.createBindGroup({
+  layout: bindGroupLayout26,
+  entries: [{binding: 49, resource: {buffer: buffer101, offset: 3584, size: 3513}}],
+});
+let computePassEncoder218 = commandEncoder270.beginComputePass({label: '\u0dcd\u{1f71a}\ufc88\u0134\ubffd\u{1fb43}\u0268\udeda\ua3fa\u6060\u{1f97a}'});
+try {
+computePassEncoder218.setPipeline(pipeline3);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroupLayout29 = device0.createBindGroupLayout({
+  label: '\u079b\u18b3\u01f3\ud65d\u0427\ue20f\u0f2e\u66de\u{1ff72}',
+  entries: [
+    {
+      binding: 131,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture236 = device0.createTexture({
+  size: {width: 384},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup5, new Uint32Array(266), 2, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 2, y: 6 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 50},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let sampler156 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 86.68,
+});
+let textureView229 = texture173.createView({label: '\u{1f831}\u0ba9\u18c3\u2c8a\ue17f\u{1fc7b}\u{1fda4}\u{1feb6}\u3590\u{1f87e}'});
+let textureView230 = texture46.createView({aspect: 'stencil-only'});
+let bindGroupLayout30 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 86,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 517,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8uint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 566,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 577,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32float', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let texture237 = device0.createTexture({
+  size: {width: 55, height: 5, depthOrArrayLayers: 32},
+  dimension: '2d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture238 = gpuCanvasContext3.getCurrentTexture();
+let textureView231 = texture234.createView({mipLevelCount: 1});
+try {
+computePassEncoder158.setBindGroup(0, bindGroup145, []);
+} catch {}
+try {
+renderPassEncoder70.setVertexBuffer(0, buffer62, 8_984);
+} catch {}
+let imageData32 = new ImageData(112, 28);
+let textureView232 = texture237.createView({baseArrayLayer: 5, arrayLayerCount: 2});
+try {
+computePassEncoder120.setBindGroup(0, bindGroup9, []);
+} catch {}
+try {
+computePassEncoder80.setBindGroup(1, bindGroup20, new Uint32Array(2764), 399, 0);
+} catch {}
+try {
+computePassEncoder147.pushDebugGroup('\u3461');
+} catch {}
+let texture239 = device0.createTexture({
+  size: [70],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder95.setIndexBuffer(buffer21, 'uint32', 1_628, 1_850);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 36, height: 1, depthOrArrayLayers: 177}
+*/
+{
+  source: img1,
+  origin: { x: 1, y: 15 },
+  flipY: true,
+}, {
+  texture: texture216,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 94},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup156 = device0.createBindGroup({layout: bindGroupLayout16, entries: [{binding: 0, resource: {buffer: buffer107, offset: 1280}}]});
+let buffer168 = device0.createBuffer({
+  label: '\u702f\u08d0\u5542\uc0c8\u7570',
+  size: 6907,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+try {
+renderPassEncoder77.setPipeline(pipeline1);
+} catch {}
+let bindGroupLayout31 = device0.createBindGroupLayout({
+  label: '\ue38d\u07de\u015e\u{1f6b7}\u0055\u0815',
+  entries: [
+    {
+      binding: 362,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let bindGroup157 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [{binding: 511, resource: {buffer: buffer53, offset: 512, size: 1132}}],
+});
+let texture240 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 262},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder120.setBindGroup(2, bindGroup93);
+} catch {}
+try {
+computePassEncoder205.setBindGroup(3, bindGroup42, new Uint32Array(594), 71, 0);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(2, bindGroup135);
+} catch {}
+try {
+renderPassEncoder83.setVertexBuffer(0, buffer141, 2_188, 329);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture194,
+  mipLevel: 0,
+  origin: {x: 6, y: 40, z: 0},
+  aspect: 'all',
+}, new Uint8Array(240_386).fill(41), /* required buffer size: 240_386 */
+{offset: 6, bytesPerRow: 451, rowsPerImage: 74}, {width: 28, height: 15, depthOrArrayLayers: 8});
+} catch {}
+try {
+renderPassEncoder84.setIndexBuffer(buffer121, 'uint16', 32, 22);
+} catch {}
+try {
+buffer163.unmap();
+} catch {}
+let textureView233 = texture237.createView({format: 'rgba8uint', baseMipLevel: 0, baseArrayLayer: 2, arrayLayerCount: 5});
+try {
+computePassEncoder116.end();
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(2, bindGroup51, new Uint32Array(5063), 80, 0);
+} catch {}
+try {
+computePassEncoder157.insertDebugMarker('\u5b1f');
+} catch {}
+let commandBuffer15 = commandEncoder156.finish();
+try {
+computePassEncoder177.setBindGroup(0, bindGroup48, new Uint32Array(998), 89, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder85); computePassEncoder85.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(3, bindGroup55, new Uint32Array(1305), 236, 0);
+} catch {}
+try {
+renderPassEncoder73.executeBundles([renderBundle22, renderBundle22]);
+} catch {}
+try {
+device0.queue.submit([commandBuffer15]);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder271 = device0.createCommandEncoder({});
+let textureView234 = texture150.createView({mipLevelCount: 1});
+try {
+computePassEncoder97.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder78.setVertexBuffer(7, buffer56);
+} catch {}
+try {
+commandEncoder271.clearBuffer(buffer143);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup158 = device0.createBindGroup({
+  label: '\uf21b\u957d\u0080\u74b0\u3fbc',
+  layout: bindGroupLayout25,
+  entries: [
+    {binding: 17, resource: textureView6},
+    {binding: 329, resource: sampler7},
+    {binding: 20, resource: textureView192},
+    {binding: 321, resource: {buffer: buffer112, offset: 1280, size: 1136}},
+    {binding: 101, resource: textureView57},
+    {binding: 333, resource: textureView189},
+    {binding: 13, resource: {buffer: buffer37, offset: 0, size: 524}},
+  ],
+});
+let textureView235 = texture131.createView({});
+let renderPassEncoder99 = commandEncoder271.beginRenderPass({
+  colorAttachments: [{
+  view: textureView156,
+  clearValue: { r: -201.1, g: -791.9, b: 579.7, a: -729.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 605310578,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder189); computePassEncoder189.dispatchWorkgroupsIndirect(buffer94, 88); };
+} catch {}
+try {
+renderPassEncoder91.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder81.setIndexBuffer(buffer15, 'uint16', 2_378, 1_377);
+} catch {}
+let gpuCanvasContext6 = canvas4.getContext('webgpu');
+try {
+computePassEncoder211.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder58.beginOcclusionQuery(9);
+} catch {}
+try {
+renderPassEncoder58.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder65.setIndexBuffer(buffer81, 'uint16', 1_148, 1_733);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture222,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(459).fill(105), /* required buffer size: 459 */
+{offset: 459, bytesPerRow: 79}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img1);
+let shaderModule18 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(35) var st31: texture_storage_1d<r32sint, read_write>;
+
+@group(0) @binding(42) var et2: texture_external;
+
+@group(0) @binding(94) var tex11: texture_2d_array<f32>;
+
+@group(0) @binding(132) var tex12: texture_2d<i32>;
+
+@group(0) @binding(243) var tex13: texture_depth_2d;
+
+@group(0) @binding(398) var tex14: texture_depth_2d;
+
+@group(0) @binding(421) var<storage, read> buffer169: T0;
+
+@group(0) @binding(567) var st32: texture_storage_2d<rgba8snorm, write>;
+
+@group(0) @binding(999) var tex15: texture_2d_array<i32>;
+
+struct T0 {
+  f0: u32,
+}
+
+struct VertexOutput17 {
+  @builtin(position) f49: vec4f,
+}
+
+alias vec3b = vec3<bool>;
+
+override override12: u32 = 364;
+
+fn fn0() {
+  var vf381: vec4f = sign(vec4f(unconst_f32(0.2196), unconst_f32(0.1157), unconst_f32(0.05305), unconst_f32(0.3316)));
+  vf381 += bitcast<vec4f>(countTrailingZeros(vec3i(unconst_i32(157), unconst_i32(41), unconst_i32(58))).bggr);
+  var vf382: vec4f = sign(vec4f(unconst_f32(-0.03208), unconst_f32(0.06847), unconst_f32(0.1620), unconst_f32(0.2077)));
+  vf381 = saturate(vec4f(unconst_f32(0.01672), unconst_f32(0.01560), unconst_f32(0.1700), unconst_f32(0.4003)));
+  var vf383: vec3f = cross(vec3f(unconst_f32(0.05818), unconst_f32(0.3770), unconst_f32(0.09462)), vec3f(unconst_f32(0.02106), unconst_f32(0.05238), unconst_f32(-0.00197)));
+  var vf384: u32 = override12;
+  var vf385: vec4h = sin(vec4h(unconst_f16(13662.5), unconst_f16(6294.4), unconst_f16(7603.5), unconst_f16(-9578.4)));
+  vf383 = vec3f(sin(vec4h(unconst_f16(5962.7), unconst_f16(6722.6), unconst_f16(20163.5), unconst_f16(-3190.9))).wwx);
+  var vf386: vec4f = textureLoad(et2, vec2u(buffer169.f0));
+  let vf387: vec2f = max(vec2f(unconst_f32(0.9625), unconst_f32(0.1669)), vec2f(unconst_f32(0.1918), unconst_f32(0.3157)));
+  vf382 = unpack4x8unorm(pack2x16float(vec2f(unconst_f32(-0.2276), unconst_f32(-0.05161))));
+  vf383 *= vec3f(f32(atan(f16(unconst_f16(-2915.9)))));
+  let vf388: vec3f = smoothstep(vec3f(unconst_f32(0.1551), unconst_f32(0.02510), unconst_f32(0.06394)), vec3f(unconst_f32(0.1667), unconst_f32(0.09344), unconst_f32(0.09173)), vec3f(unconst_f32(0.1213), unconst_f32(0.03578), unconst_f32(0.1550)));
+  var vf389: vec3i = countTrailingZeros(vec3i(asinh(vec3h(unconst_f16(-2153.1), unconst_f16(5215.6), unconst_f16(7580.0)))));
+  var vf390: vec4f = min(vec4f(unconst_f32(0.02023), unconst_f32(0.04272), unconst_f32(0.1519), unconst_f32(0.1167)), vec4f(unconst_f32(0.1153), unconst_f32(0.1182), unconst_f32(0.2394), unconst_f32(0.02427)));
+  var vf391: vec4f = saturate(vec4f(unconst_f32(0.06651), unconst_f32(0.00645), unconst_f32(0.01818), unconst_f32(0.5856)));
+  var vf392: vec3h = asinh(vec3h(unconst_f16(4129.8), unconst_f16(1019.3), unconst_f16(3904.8)));
+  _ = override12;
+}
+
+var<workgroup> vw63: atomic<u32>;
+
+var<workgroup> vw64: atomic<u32>;
+
+var<workgroup> vw65: T0;
+
+var<workgroup> vw66: atomic<i32>;
+
+var<workgroup> vw67: mat2x3h;
+
+var<workgroup> vw68: T0;
+
+@vertex
+fn vertex18(@location(2) a0: vec2h, @location(15) a1: i32, @location(13) @interpolate(flat, sample) a2: i32, @location(12) a3: vec4u, @location(6) a4: i32, @location(14) @interpolate(linear) a5: vec4f, @location(1) @interpolate(flat, centroid) a6: f16, @location(11) a7: i32) -> VertexOutput17 {
+  var out: VertexOutput17;
+  out = VertexOutput17(unpack4x8unorm(textureNumLevels(tex14)));
+  out.f49 = bitcast<vec4f>(textureDimensions(tex13, i32(unconst_i32(9))).yxyx);
+  out = VertexOutput17(bitcast<vec4f>(textureDimensions(tex14, i32(unconst_i32(239))).rrgr));
+  fn0();
+  out = VertexOutput17(vec4f(bitcast<f32>(buffer169.f0)));
+  out.f49 = vec4f(inverseSqrt(vec2h(unconst_f16(-2022.8), unconst_f16(8532.7))).xxxx);
+  out.f49 += vec4f(f32((*&buffer169).f0));
+  let vf393: vec2f = unpack2x16snorm(u32(unconst_u32(29)));
+  var vf394: u32 = pack2x16snorm(vec2f(unconst_f32(0.1848), unconst_f32(0.02907)));
+  fn0();
+  out = VertexOutput17(unpack2x16snorm(u32(unconst_u32(539))).xyxx);
+  out.f49 = unpack4x8snorm(textureNumLevels(tex15));
+  let vf395: u32 = textureNumLevels(tex15);
+  vf394 = bitcast<u32>(vf393[u32(unconst_u32(34))]);
+  fn0();
+  var vf396: vec4i = textureLoad(tex12, vec2i(unconst_i32(377), unconst_i32(-7)), i32(unconst_i32(139)));
+  return out;
+  _ = override12;
+}
+
+@fragment
+fn fragment17(@location(4) a0: vec4u) -> @location(200) @interpolate(linear, center) vec4u {
+  var out: vec4u;
+  fn0();
+  out ^= vec4u(pack2x16float(vec2f(unconst_f32(0.1372), unconst_f32(0.1703))));
+  var vf397: vec2u = textureDimensions(tex12);
+  textureStore(st32, vec2i(unconst_i32(-529), unconst_i32(378)), vec4f(vec4f(f32(dot4U8Packed(u32(unconst_u32(108)), u32(unconst_u32(306)))))));
+  textureStore(st32, vec2i(unconst_i32(6), unconst_i32(122)), vec4f(vec4f(unconst_f32(0.05247), unconst_f32(0.1019), unconst_f32(0.2661), unconst_f32(0.1937))));
+  fn0();
+  fn0();
+  fn0();
+  fn0();
+  fn0();
+  fn0();
+  vf397 <<= textureDimensions(tex12, i32(unconst_i32(99)));
+  let ptr145: ptr<storage, u32, read> = &buffer169.f0;
+  let ptr146: ptr<storage, u32, read> = &(*&buffer169).f0;
+  return out;
+  _ = override12;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute18(@builtin(workgroup_id) a0: vec3u) {
+  let vf398: u32 = textureNumLevels(tex11);
+  vw68.f0 = textureDimensions(tex11)[0];
+  var vf399: u32 = textureNumLevels(tex12);
+  var vf400: vec2u = textureDimensions(tex15);
+  let vf401: vec2u = textureDimensions(tex12);
+  var vf402: u32 = textureNumLayers(tex15);
+  atomicMin(&vw66, i32(unconst_i32(72)));
+  var vf403: u32 = atomicExchange(&(*&vw64), u32(unconst_u32(68)));
+  let vf404: vec2u = textureDimensions(tex13);
+  var vf405: u32 = atomicLoad(&(*&vw64));
+  let vf406: u32 = atomicLoad(&(*&vw63));
+  atomicAnd(&vw66, i32(unconst_i32(15)));
+  let ptr147: ptr<function, u32> = &vf403;
+  atomicStore(&vw63, u32(unconst_u32(111)));
+  vw65.f0 ^= vf399;
+  var vf407: u32 = atomicExchange(&(*&vw64), u32(unconst_u32(136)));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout32 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 143,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 18,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 911,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 157,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 193,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 178,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let bindGroup159 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [{binding: 204, resource: externalTexture5}, {binding: 116, resource: sampler57}],
+});
+let buffer170 = device0.createBuffer({
+  size: 736,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture241 = device0.createTexture({
+  label: '\u{1fdf6}\u0d92',
+  size: {width: 70, height: 72, depthOrArrayLayers: 1},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture242 = device0.createTexture({size: [560, 582, 1], mipLevelCount: 1, format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_SRC});
+let sampler157 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 88.91,
+  lodMaxClamp: 95.79,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder141); computePassEncoder141.dispatchWorkgroupsIndirect(buffer130, 0); };
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle21, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer143, 'uint16', 1_642, 1_438);
+} catch {}
+try {
+if (!arrayBuffer17.detached) { new Uint8Array(arrayBuffer17).fill(0x55); };
+} catch {}
+let texture243 = device0.createTexture({
+  size: {width: 48, height: 1, depthOrArrayLayers: 42},
+  sampleCount: 1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView236 = texture16.createView({
+  label: '\u081c\u946a\ufdb6',
+  dimension: 'cube-array',
+  aspect: 'depth-only',
+  mipLevelCount: 1,
+  baseArrayLayer: 5,
+  arrayLayerCount: 6,
+});
+let sampler158 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 19.72,
+  lodMaxClamp: 46.05,
+  compare: 'greater',
+});
+try {
+computePassEncoder83.setBindGroup(0, bindGroup125, new Uint32Array(5), 1, 0);
+} catch {}
+try {
+renderPassEncoder99.executeBundles([renderBundle7, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(7, buffer6, 384, 330);
+} catch {}
+let bindGroup160 = device0.createBindGroup({
+  label: '\ufffb\u7292\u064b\uedf5\ua7ed\u{1f6bc}\u994a\u032d\u09a7\u{1fbb3}\u8ed0',
+  layout: bindGroupLayout22,
+  entries: [
+    {binding: 298, resource: {buffer: buffer160, offset: 3584, size: 248}},
+    {binding: 44, resource: {buffer: buffer143, offset: 0}},
+    {binding: 178, resource: textureView182},
+    {binding: 159, resource: {buffer: buffer141, offset: 1024, size: 2212}},
+    {binding: 75, resource: externalTexture20},
+    {binding: 265, resource: sampler75},
+    {binding: 337, resource: textureView22},
+    {binding: 29, resource: sampler149},
+    {binding: 31, resource: textureView177},
+    {binding: 132, resource: {buffer: buffer50, offset: 0, size: 636}},
+    {binding: 244, resource: externalTexture20},
+    {binding: 304, resource: textureView171},
+    {binding: 4, resource: {buffer: buffer82, offset: 0, size: 466}},
+  ],
+});
+let buffer171 = device0.createBuffer({size: 5320, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX});
+let textureView237 = texture243.createView({dimension: '2d', baseArrayLayer: 12});
+let textureView238 = texture20.createView({label: '\u0312\u{1f605}', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 24});
+try {
+{ clearResourceUsages(device0, computePassEncoder120); computePassEncoder120.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer113, 'uint32', 1_584, 4_967);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture235,
+  mipLevel: 0,
+  origin: {x: 101, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(575).fill(251), /* required buffer size: 575 */
+{offset: 575, rowsPerImage: 52}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let textureView239 = texture217.createView({label: '\u{1f8ca}\ufc4b\u1c25', dimension: '2d-array', aspect: 'all', mipLevelCount: 1});
+let texture244 = device0.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 28},
+  mipLevelCount: 2,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup57);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder177); computePassEncoder177.dispatchWorkgroupsIndirect(buffer138, 340); };
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(6, buffer67, 0);
+} catch {}
+document.body.prepend(canvas1);
+let textureView240 = texture241.createView({dimension: '2d-array'});
+try {
+computePassEncoder80.setBindGroup(3, bindGroup87, new Uint32Array(3323), 2_284, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let querySet29 = device0.createQuerySet({label: '\u07d4\u046e\u{1fd8c}', type: 'occlusion', count: 153});
+let textureView241 = texture106.createView({mipLevelCount: 1, baseArrayLayer: 7, arrayLayerCount: 3});
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroupsIndirect(buffer8, 1_356); };
+} catch {}
+try {
+computePassEncoder216.setPipeline(pipeline5);
+} catch {}
+try {
+buffer90.unmap();
+} catch {}
+try {
+computePassEncoder64.insertDebugMarker('\ueea5');
+} catch {}
+let bindGroup161 = device0.createBindGroup({layout: bindGroupLayout13, entries: [{binding: 272, resource: {buffer: buffer4, offset: 768}}]});
+let textureView242 = texture97.createView({label: '\u086e\u{1f8a5}\ubfd3\u0adc\uc1cc'});
+try {
+computePassEncoder187.setBindGroup(2, bindGroup39);
+} catch {}
+try {
+renderPassEncoder94.setBindGroup(1, bindGroup105, new Uint32Array(908), 3, 0);
+} catch {}
+try {
+renderPassEncoder86.setIndexBuffer(buffer70, 'uint16', 238, 1_609);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let buffer172 = device0.createBuffer({size: 5218, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture245 = device0.createTexture({
+  size: {width: 110, height: 10, depthOrArrayLayers: 78},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder119.setBindGroup(1, bindGroup104, new Uint32Array(2596), 242, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder141); computePassEncoder141.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder67.setBindGroup(3, bindGroup66, []);
+} catch {}
+try {
+renderPassEncoder78.setBindGroup(2, bindGroup14, new Uint32Array(3748), 1_136, 0);
+} catch {}
+document.body.append(canvas3);
+let buffer173 = device0.createBuffer({
+  size: 1290,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture246 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+renderPassEncoder85.executeBundles([renderBundle6, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder30.setViewport(61.58868584271414, 0.13895765069893684, 0.18416842085040105, 0.5832341655488852, 0.3544541533040968, 0.45163029835127744);
+} catch {}
+try {
+computePassEncoder147.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroup162 = device0.createBindGroup({
+  layout: bindGroupLayout25,
+  entries: [
+    {binding: 13, resource: {buffer: buffer102, offset: 0, size: 748}},
+    {binding: 17, resource: textureView64},
+    {binding: 329, resource: sampler25},
+    {binding: 101, resource: textureView39},
+    {binding: 20, resource: textureView215},
+    {binding: 333, resource: textureView70},
+    {binding: 321, resource: {buffer: buffer12, offset: 0}},
+  ],
+});
+let querySet30 = device0.createQuerySet({type: 'occlusion', count: 1477});
+let textureView243 = texture47.createView({mipLevelCount: 1});
+try {
+renderPassEncoder99.setIndexBuffer(buffer59, 'uint16', 248, 110);
+} catch {}
+let pipeline6 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule15, constants: {}}});
+let buffer174 = device0.createBuffer({
+  size: 8885,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture247 = device0.createTexture({
+  size: [192, 1, 262],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView244 = texture126.createView({label: '\u0992\u0b10', format: 'rgb10a2uint', mipLevelCount: 1});
+let sampler159 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+});
+try {
+computePassEncoder167.setBindGroup(0, bindGroup54, new Uint32Array(2878), 224, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder120); computePassEncoder120.dispatchWorkgroups(2, 1); };
+} catch {}
+try {
+renderPassEncoder83.setVertexBuffer(7, buffer85, 1_500, 5_930);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 70, height: 72, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 7, y: 0 },
+  flipY: false,
+}, {
+  texture: texture191,
+  mipLevel: 3,
+  origin: {x: 4, y: 20, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 9, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let buffer175 = device0.createBuffer({size: 5856, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let querySet31 = device0.createQuerySet({label: '\uc340\u0837\ub7b7\u0972\u8b17', type: 'occlusion', count: 411});
+try {
+computePassEncoder153.setBindGroup(0, bindGroup44, new Uint32Array(21), 4, 0);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer27, 'uint16', 294, 263);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle21, renderBundle21]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 36, height: 1, depthOrArrayLayers: 177}
+*/
+{
+  source: imageData0,
+  origin: { x: 0, y: 30 },
+  flipY: true,
+}, {
+  texture: texture216,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView245 = texture205.createView({});
+try {
+computePassEncoder217.setBindGroup(1, bindGroup75, new Uint32Array(2668), 914, 0);
+} catch {}
+let textureView246 = texture241.createView({dimension: '2d-array'});
+let textureView247 = texture198.createView({dimension: '3d', mipLevelCount: 1});
+let externalTexture23 = device0.importExternalTexture({source: videoFrame28, colorSpace: 'display-p3'});
+try {
+renderPassEncoder78.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer173, 'uint32', 4, 47);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 64, new Int16Array(26264), 5726, 72);
+} catch {}
+let img4 = await imageWithData(50, 88, '#10101010', '#20202020');
+let texture248 = device0.createTexture({size: [440], dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer148, 76); };
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(1, bindGroup134, new Uint32Array(2382), 320, 0);
+} catch {}
+try {
+renderPassEncoder47.setStencilReference(62);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(4, buffer148, 252);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture222,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(123).fill(50), /* required buffer size: 123 */
+{offset: 123, rowsPerImage: 14}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView248 = texture180.createView({label: '\u{1f844}\u0f2a\u{1fe61}\ub9f6\u245b\u{1fbf4}\u5330\uc958'});
+try {
+{ clearResourceUsages(device0, computePassEncoder120); computePassEncoder120.dispatchWorkgroups(1, 1); };
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+let texture249 = device0.createTexture({
+  label: '\u9f4b\u47ab\u4b62\u{1fa86}\ufd88\u1678\u003c',
+  size: [48, 1, 103],
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder48.setVertexBuffer(3, buffer109, 404);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let bindGroup163 = device0.createBindGroup({
+  layout: bindGroupLayout23,
+  entries: [{binding: 63, resource: textureView208}, {binding: 28, resource: textureView178}],
+});
+let buffer176 = device0.createBuffer({
+  size: 5826,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture250 = gpuCanvasContext3.getCurrentTexture();
+let externalTexture24 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'display-p3'});
+try {
+computePassEncoder203.setBindGroup(3, bindGroup67);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup159, new Uint32Array(2782), 323, 0);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder9.setViewport(35.513284790236035, 0.8669306266239848, 18.55667803388992, 0.07239025981986291, 0.7443917567088355, 0.9682132869699585);
+} catch {}
+try {
+renderPassEncoder83.setPipeline(pipeline1);
+} catch {}
+let arrayBuffer20 = buffer74.getMappedRange(208, 24);
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 75, y: 121, z: 0},
+  aspect: 'all',
+}, new Uint8Array(5).fill(28), /* required buffer size: 5 */
+{offset: 5, bytesPerRow: 307}, {width: 36, height: 30, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame39 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'smpteRp431', transfer: 'log'} });
+let bindGroupLayout33 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 36, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+try {
+computePassEncoder114.setBindGroup(3, bindGroup138);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(2, bindGroup95, new Uint32Array(437), 182, 0);
+} catch {}
+try {
+renderPassEncoder5.setViewport(66.2359971509041, 0.6376822037175481, 12.103738014515004, 0.031012009184995352, 0.4781793680250941, 0.9978637524479301);
+} catch {}
+try {
+renderPassEncoder97.setVertexBuffer(1, buffer24, 392, 593);
+} catch {}
+let buffer177 = device0.createBuffer({
+  size: 21317,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let texture251 = device0.createTexture({size: [70, 72, 1], dimension: '2d', format: 'depth24plus', usage: GPUTextureUsage.COPY_DST});
+let textureView249 = texture6.createView({dimension: '2d-array', baseArrayLayer: 0});
+try {
+renderPassEncoder77.beginOcclusionQuery(769);
+} catch {}
+try {
+renderPassEncoder77.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder62.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(7, buffer10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer46, 1064, new Int16Array(12), 1, 0);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let buffer178 = device0.createBuffer({
+  size: 15114,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder177.setBindGroup(2, bindGroup58);
+} catch {}
+try {
+computePassEncoder139.setBindGroup(3, bindGroup104, new Uint32Array(2242), 225, 0);
+} catch {}
+try {
+computePassEncoder167.end();
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup91);
+} catch {}
+try {
+renderPassEncoder64.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder89.setVertexBuffer(1, buffer103, 84);
+} catch {}
+try {
+commandEncoder44.copyBufferToTexture({
+  /* bytesInLastRow: 36 widthInBlocks: 36 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1076 */
+  offset: 1076,
+  buffer: buffer106,
+}, {
+  texture: texture27,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 36, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise22;
+} catch {}
+let texture252 = gpuCanvasContext3.getCurrentTexture();
+let renderPassEncoder100 = commandEncoder44.beginRenderPass({colorAttachments: [{view: textureView99, depthSlice: 6, loadOp: 'clear', storeOp: 'store'}]});
+try {
+computePassEncoder201.setBindGroup(2, bindGroup44, new Uint32Array(373), 8, 0);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+let textureView250 = texture24.createView({});
+try {
+renderPassEncoder5.setIndexBuffer(buffer21, 'uint32', 1_208, 580);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+globalThis.someLabel = bindGroup153.label;
+} catch {}
+let externalTexture25 = device0.importExternalTexture({source: videoFrame13});
+try {
+renderPassEncoder92.setBindGroup(2, bindGroup29, new Uint32Array(1535), 43, 0);
+} catch {}
+try {
+renderPassEncoder75.setIndexBuffer(buffer115, 'uint16', 20, 117);
+} catch {}
+let bindGroup164 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [{binding: 204, resource: externalTexture22}, {binding: 116, resource: sampler130}],
+});
+let buffer179 = device0.createBuffer({
+  label: '\ua5f0\u05b7\u0640\u046c\u45ca\u6d20\u0d7b\ud510\u5a95\u{1fa1d}\u0a4d',
+  size: 2133,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let texture253 = device0.createTexture({
+  label: '\u2f35\ud327\udfb5\u0707\u5c28\u0ad9\u{1f87f}\u0b9a\ufaf3\uc826\u{1f78f}',
+  size: [48],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler160 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', mipmapFilter: 'nearest', lodMaxClamp: 35.15});
+try {
+computePassEncoder150.setBindGroup(2, bindGroup127);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: -297.6, g: 364.4, b: 876.3, a: -512.9, });
+} catch {}
+try {
+renderPassEncoder82.setViewport(504.8936500482476, 341.2603891722671, 36.30048699089683, 28.107171726931153, 0.7016050800453578, 0.9042489290188462);
+} catch {}
+try {
+renderPassEncoder69.setIndexBuffer(buffer1, 'uint32', 696, 133);
+} catch {}
+try {
+buffer111.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 36, height: 1, depthOrArrayLayers: 177}
+*/
+{
+  source: imageData22,
+  origin: { x: 0, y: 3 },
+  flipY: false,
+}, {
+  texture: texture216,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 44},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture254 = device0.createTexture({
+  size: [192, 1, 1],
+  sampleCount: 4,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder30.setVertexBuffer(1, buffer12, 0, 24);
+} catch {}
+try {
+renderPassEncoder95.setBindGroup(0, bindGroup9, new Uint32Array(942), 29, 0);
+} catch {}
+try {
+renderPassEncoder71.setVertexBuffer(5, buffer76);
+} catch {}
+try {
+  await buffer142.mapAsync(GPUMapMode.WRITE, 7744, 4308);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture84,
+  mipLevel: 1,
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(761).fill(123), /* required buffer size: 761 */
+{offset: 761}, {width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup165 = device0.createBindGroup({layout: bindGroupLayout20, entries: [{binding: 152, resource: textureView13}]});
+let textureView251 = texture164.createView({});
+try {
+computePassEncoder153.setBindGroup(2, bindGroup164);
+} catch {}
+try {
+computePassEncoder189.end();
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(3, bindGroup76, new Uint32Array(1394), 43, 0);
+} catch {}
+try {
+renderPassEncoder52.executeBundles([renderBundle10]);
+} catch {}
+try {
+  await buffer136.mapAsync(GPUMapMode.WRITE, 0, 48);
+} catch {}
+try {
+commandEncoder234.copyTextureToBuffer({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 47, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 316 widthInBlocks: 79 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 480 */
+  offset: 480,
+  bytesPerRow: 2560,
+  buffer: buffer59,
+}, {width: 79, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder234.clearBuffer(buffer38, 7064, 256);
+} catch {}
+try {
+renderPassEncoder70.insertDebugMarker('\ucb22');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer150, 1540, new Float32Array(3039), 382, 80);
+} catch {}
+let shaderModule19 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(11) var<storage, read_write> buffer180: array<array<array<f16, 14>, 4>>;
+
+struct T0 {
+  @size(112) f0: array<i32>,
+}
+
+struct S12 {
+  @location(14) @interpolate(linear) f0: vec2f,
+  @location(15) @interpolate(perspective) f1: vec2h,
+  @location(0) @interpolate(flat) f2: vec4i,
+}
+
+struct VertexOutput18 {
+  @invariant @builtin(position) f50: vec4f,
+}
+
+struct S13 {
+  @builtin(workgroup_id) @size(16) f0: vec3u,
+  @builtin(global_invocation_id) @size(16) f1: vec3u,
+}
+
+struct FragmentOutput16 {
+  @location(1) @interpolate(flat, centroid) f0: vec4u,
+  @location(0) f1: vec4f,
+}
+
+fn fn0() -> mat2x2h {
+  var out: mat2x2h;
+  let vf408: vec4h = exp2(vec4h(unconst_f16(204.3), unconst_f16(420.8), unconst_f16(-3889.9), unconst_f16(3471.8)));
+  var vf409: vec4i = firstTrailingBit(vec4i(unconst_i32(50), unconst_i32(108), unconst_i32(-64), unconst_i32(287)));
+  var vf410: f16 = vf408[u32(unconst_u32(249))];
+  vf409 += vec4i(round(vec2f(unconst_f32(0.01007), unconst_f32(0.05177))).grrr);
+  let vf411: vec4h = exp2(vec4h(unconst_f16(196.3), unconst_f16(1180.2), unconst_f16(20432.1), unconst_f16(6595.0)));
+  let vf412: f16 = step(f16(unconst_f16(14272.0)), f16(unconst_f16(5353.9)));
+  var vf413: f16 = step(f16(unconst_f16(6395.3)), f16(unconst_f16(2255.0)));
+  out += mat2x2h(vec2h(firstTrailingBit(vec4i(unconst_i32(544), unconst_i32(74), unconst_i32(61), unconst_i32(17))).br), vec2h(firstTrailingBit(vec4i(unconst_i32(544), unconst_i32(74), unconst_i32(61), unconst_i32(17))).gg));
+  var vf414: f16 = step(f16(unconst_f16(46799.5)), f16(unconst_f16(6510.5)));
+  let vf415: vec2f = round(vec2f(unconst_f32(0.2999), unconst_f32(0.02953)));
+  var vf416: f16 = vf408[u32(unconst_u32(431))];
+  vf416 *= vf408[3];
+  return out;
+}
+
+fn fn1() -> array<vec4h, 1> {
+  var out: array<vec4h, 1>;
+  fn0();
+  var vf417 = fn0();
+  out[u32(unconst_u32(150))] = vec4h(f16(pack2x16snorm(vec2f(unconst_f32(0.1250), unconst_f32(0.2256)))));
+  var vf418: vec2i = abs(vec2i(unconst_i32(-187), unconst_i32(53)));
+  let vf419: vec3h = min(vec3h(unconst_f16(2819.7), unconst_f16(8167.1), unconst_f16(30037.5)), vec3h(unconst_f16(8988.8), unconst_f16(-9899.9), unconst_f16(8449.6)));
+  let vf420: f32 = quantizeToF16(bitcast<f32>(pack2x16unorm(vec2f(unconst_f32(0.07619), unconst_f32(0.1557)))));
+  vf418 |= bitcast<vec2i>(step(vec3f(unconst_f32(-0.05256), unconst_f32(0.3524), unconst_f32(0.2594)), vec3f(unconst_f32(0.1125), unconst_f32(0.06023), unconst_f32(0.01833))).bb);
+  let ptr148: ptr<function, mat2x2h> = &vf417;
+  var vf421 = fn0();
+  fn0();
+  vf421 = mat2x2h(vec2h(tan(tan(vec3f(unconst_f32(0.06554), unconst_f32(0.5243), unconst_f32(0.02118)))).rb), vec2h(tan(tan(vec3f(unconst_f32(0.06554), unconst_f32(0.5243), unconst_f32(0.02118)))).yy));
+  out[u32(unconst_u32(315))] = vec4h(vf417[u32(unconst_u32(193))][u32(unconst_u32(154))]);
+  var vf422: vec4h = mix(vec4h(step(vec3f(unconst_f32(-0.2371), unconst_f32(0.2271), unconst_f32(0.01627)), vec3f(unconst_f32(0.6099), unconst_f32(0.2146), unconst_f32(0.3600))).bbbg), vec4h(unconst_f16(-2520.6), unconst_f16(3946.9), unconst_f16(11250.8), unconst_f16(19439.6)), vec4h(unconst_f16(14658.1), unconst_f16(-2442.7), unconst_f16(12680.1), unconst_f16(11476.2)));
+  vf422 += vf421[u32(unconst_u32(111))].grrg;
+  out[u32(unconst_u32(72))] = vec4h(f16(degrees(f32(unconst_f32(0.1739)))));
+  var vf423: vec3h = vf419;
+  let ptr149: ptr<function, vec2i> = &vf418;
+  vf418 -= (*ptr149);
+  var vf424 = fn0();
+  vf423 += vec3h(step(vec3f(unconst_f32(0.1186), unconst_f32(0.07502), unconst_f32(0.3917)), vec3f(unconst_f32(0.02272), unconst_f32(-0.08165), unconst_f32(0.00164))));
+  return out;
+}
+
+fn fn2() -> VertexOutput18 {
+  var out: VertexOutput18;
+  out = VertexOutput18(unpack2x16unorm(u32(unconst_u32(35))).ggrg);
+  out = VertexOutput18(vec4f(f32(distance(vec3h(unconst_f16(60000.0), unconst_f16(-19607.9), unconst_f16(4518.4)), vec3h(unconst_f16(17382.0), unconst_f16(9242.0), unconst_f16(4163.1))))));
+  let vf425: u32 = pack4xI8(unpack4xI8(dot4U8Packed(u32(unconst_u32(118)), u32(unconst_u32(23)))));
+  var vf426 = fn0();
+  var vf427 = fn0();
+  vf427 -= vf426;
+  let vf428: vec2f = unpack2x16unorm(u32(unconst_u32(98)));
+  fn0();
+  let vf429: u32 = vf425;
+  vf427 = mat2x2h(f16(dot4U8Packed(u32(unconst_u32(30)), u32(unconst_u32(39)))), f16(dot4U8Packed(u32(unconst_u32(30)), u32(unconst_u32(39)))), f16(dot4U8Packed(u32(unconst_u32(30)), u32(unconst_u32(39)))), f16(dot4U8Packed(u32(unconst_u32(30)), u32(unconst_u32(39)))));
+  var vf430 = fn0();
+  return out;
+}
+
+var<workgroup> vw69: u32;
+
+var<workgroup> vw70: S12;
+
+var<workgroup> vw71: atomic<u32>;
+
+var<workgroup> vw72: mat2x2h;
+
+@vertex
+fn vertex19(@location(10) @interpolate(flat) a0: i32, @location(1) @interpolate(flat) a1: i32, @location(3) @interpolate(flat) a2: vec2f, @location(5) a3: vec4u, @location(9) a4: vec4u, a5: S12, @location(4) a6: vec4f, @location(13) @interpolate(flat, sample) a7: f16, @location(11) a8: vec2i, @location(6) @interpolate(flat, centroid) a9: vec4h) -> VertexOutput18 {
+  var out: VertexOutput18;
+  out = VertexOutput18(vec4f(a5.f1.grgr));
+  out = VertexOutput18(vec4f(f32(a1)));
+  out.f50 -= vec4f(tan(vec2h(unconst_f16(2801.7), unconst_f16(1605.4))).yxyy);
+  out = VertexOutput18(vec4f(a5.f1.grrr));
+  var vf431 = fn1();
+  out.f50 = vec4f(vf431[u32(unconst_u32(116))]);
+  let vf432: vec4f = atan(vec4f(unconst_f32(0.01356), unconst_f32(0.6379), unconst_f32(1.000), unconst_f32(0.01560)));
+  vf431[u32(unconst_u32(9))] += vf431[0];
+  var vf433: u32 = a3[u32(unconst_u32(205))];
+  return out;
+}
+
+@fragment
+fn fragment18() -> FragmentOutput16 {
+  var out: FragmentOutput16;
+  let vf434: vec4i = unpack4xI8(u32(acosh(vec2f(unconst_f32(0.04638), unconst_f32(0.1552))).g));
+  var vf435 = fn2();
+  let ptr150: ptr<function, vec4f> = &vf435.f50;
+  fn2();
+  out = FragmentOutput16(vec4u(vf435.f50), vf435.f50);
+  out.f1 = vf435.f50;
+  var vf436: f32 = determinant(mat3x3f());
+  let vf437: vec4i = vf434;
+  out.f0 = vec4u(sign(vec2f(unconst_f32(0.04442), unconst_f32(0.3909))).xxyx);
+  let vf438: f32 = (*ptr150)[u32(unconst_u32(35))];
+  fn2();
+  var vf439 = fn2();
+  fn2();
+  vf439 = vf435;
+  out.f0 ^= vec4u((*ptr150));
+  vf436 = vf439.f50[u32(unconst_u32(7))];
+  out.f1 += (*ptr150);
+  vf436 = vec4f(tan(vec4h(unconst_f16(646.2), unconst_f16(2769.0), unconst_f16(10488.8), unconst_f16(13780.8)))).y;
+  var vf440: vec2f = acosh(vec2f(unconst_f32(-0.1476), unconst_f32(0.1166)));
+  out.f0 = unpack4xU8(bitcast<u32>(vf440[bitcast<u32>(vf437[0])]));
+  var vf441: vec4f = fract(vec4f(unconst_f32(0.1744), unconst_f32(0.08771), unconst_f32(0.1690), unconst_f32(0.03171)));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute19(@builtin(local_invocation_index) a0: u32, a1: S13) {
+  vw69 = u32(buffer180[u32((*&buffer180)[u32(unconst_u32(181))][3][13])][3][13]);
+  atomicMin(&vw71, u32(unconst_u32(73)));
+  fn2();
+  let vf442: vec4f = trunc(vec4f(unconst_f32(0.04450), unconst_f32(0.2672), unconst_f32(0.04728), unconst_f32(0.05413)));
+  var vf443 = fn2();
+  fn2();
+  let ptr151: ptr<storage, f16, read_write> = &(*&buffer180)[u32(unconst_u32(35))][u32(unconst_u32(62))][13];
+  let ptr152: ptr<storage, f16, read_write> = &(*&buffer180)[arrayLength(&(*&buffer180))][u32(unconst_u32(155))][13];
+  vw70.f2 = (*&vw70).f2;
+  atomicStore(&vw71, bitcast<vec4u>(vf442).g);
+  var vf444 = fn0();
+  fn0();
+  let vf445: f32 = vf442[u32(unconst_u32(136))];
+  var vf446: S13 = a1;
+  buffer180[u32(unconst_u32(118))][u32(unconst_u32(8))][13] += buffer180[arrayLength(&buffer180)][3][13];
+  vf446 = S13(vec3u(u32(buffer180[u32(unconst_u32(228))][3][13])), vec3u(u32(buffer180[u32(unconst_u32(228))][3][13])));
+  fn2();
+  var vf447 = fn0();
+  vf446.f1 <<= vec3u(vf447[unconst_i32(1)].grg);
+  fn0();
+  let vf448: u32 = vf446.f1[u32(unconst_u32(165))];
+  fn2();
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let computePassEncoder219 = commandEncoder234.beginComputePass({label: '\u{1f781}\u09cc'});
+let sampler161 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 58.92,
+  lodMaxClamp: 75.21,
+});
+try {
+computePassEncoder129.setBindGroup(1, bindGroup96);
+} catch {}
+try {
+computePassEncoder185.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder97.setBlendConstant({ r: -424.8, g: -75.53, b: -392.2, a: 98.11, });
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(3, bindGroup90);
+} catch {}
+try {
+renderPassEncoder55.executeBundles([renderBundle6]);
+} catch {}
+let pipeline7 = await device0.createComputePipelineAsync({layout: pipelineLayout12, compute: {module: shaderModule19, constants: {}}});
+let texture255 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 262},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder178.setBindGroup(2, bindGroup148);
+} catch {}
+try {
+computePassEncoder219.setPipeline(pipeline3);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView252 = texture181.createView({label: '\u{1ff5e}\u{1f669}\u14f2\uc349\u09dc\udfaf\ud610\ud99d\u{1faf6}\ub2d1'});
+let externalTexture26 = device0.importExternalTexture({source: videoFrame15});
+try {
+{ clearResourceUsages(device0, computePassEncoder85); computePassEncoder85.dispatchWorkgroupsIndirect(buffer72, 3_196); };
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer16, 'uint16', 480, 1_180);
+} catch {}
+try {
+renderPassEncoder94.setVertexBuffer(4, buffer178, 1_392, 333);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+globalThis.someLabel = externalTexture19.label;
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer23, 'uint32', 456, 2_109);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let videoFrame40 = videoFrame24.clone();
+let buffer181 = device0.createBuffer({
+  size: 26396,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT,
+  mappedAtCreation: false,
+});
+let texture256 = device0.createTexture({
+  size: {width: 192},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView253 = texture222.createView({});
+let sampler162 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 49.23,
+  lodMaxClamp: 77.29,
+  compare: 'greater',
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder139.setBindGroup(0, bindGroup51);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle0]);
+} catch {}
+try {
+buffer173.unmap();
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(70, 13);
+try {
+computePassEncoder149.setBindGroup(3, bindGroup112, [1280]);
+} catch {}
+try {
+renderPassEncoder88.setBindGroup(3, bindGroup49, new Uint32Array(2232), 50, 0);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer27, 'uint16', 118, 709);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(3, buffer64, 576, 895);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer182 = device0.createBuffer({
+  label: '\ub18e\u0327\u5318\u{1fd9c}\u{1f730}\u{1f766}\ubbc7\ub933',
+  size: 7857,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup94);
+} catch {}
+try {
+computePassEncoder141.end();
+} catch {}
+try {
+renderPassEncoder95.setBindGroup(1, bindGroup143);
+} catch {}
+try {
+renderPassEncoder17.setViewport(68.38341273882449, 0.1419970438928151, 5.068120371546142, 0.7550093713357119, 0.8447243180331617, 0.8564782061632051);
+} catch {}
+try {
+commandEncoder181.clearBuffer(buffer122);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+document.body.prepend(img3);
+await gc();
+let bindGroup166 = device0.createBindGroup({layout: bindGroupLayout26, entries: [{binding: 49, resource: {buffer: buffer99, offset: 4608}}]});
+let computePassEncoder220 = commandEncoder181.beginComputePass({label: '\u966c\u5085\u90e9\u{1fe29}\u00ab\u8d97\u0c78\u2f5e'});
+try {
+{ clearResourceUsages(device0, computePassEncoder177); computePassEncoder177.dispatchWorkgroupsIndirect(buffer54, 1_612); };
+} catch {}
+try {
+computePassEncoder85.end();
+} catch {}
+try {
+computePassEncoder220.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle16, renderBundle5, renderBundle3, renderBundle3, renderBundle3, renderBundle16, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder93.setIndexBuffer(buffer77, 'uint32', 1_904, 155);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(1, buffer62, 0, 15_315);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+try {
+commandEncoder109.copyTextureToTexture({
+  texture: texture181,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture247,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+let renderPassEncoder101 = commandEncoder109.beginRenderPass({
+  colorAttachments: [{
+  view: textureView197,
+  clearValue: { r: -859.8, g: 673.7, b: -735.8, a: 529.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet8,
+});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup151, [0]);
+} catch {}
+try {
+computePassEncoder82.end();
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup41);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(0, bindGroup112, new Uint32Array(279), 76, 1);
+} catch {}
+try {
+renderPassEncoder73.setIndexBuffer(buffer175, 'uint16', 468, 4_354);
+} catch {}
+try {
+commandEncoder110.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1840 */
+  offset: 1840,
+  bytesPerRow: 18176,
+  buffer: buffer43,
+}, {
+  texture: texture174,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer96, 1164, new Float32Array(10896), 1350, 352);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout34 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 122,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 259,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let bindGroup167 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 103, resource: textureView7}, {binding: 176, resource: textureView0}],
+});
+let computePassEncoder221 = commandEncoder110.beginComputePass({});
+try {
+computePassEncoder48.end();
+} catch {}
+try {
+computePassEncoder221.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder7.copyBufferToTexture({
+  /* bytesInLastRow: 528 widthInBlocks: 66 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 600 */
+  offset: 600,
+  bytesPerRow: 5376,
+  buffer: buffer160,
+}, {
+  texture: texture60,
+  mipLevel: 1,
+  origin: {x: 7, y: 16, z: 0},
+  aspect: 'all',
+}, {width: 66, height: 13, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder7.copyTextureToTexture({
+  texture: texture241,
+  mipLevel: 0,
+  origin: {x: 7, y: 6, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 3, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 104, new DataView(new ArrayBuffer(6171)), 2560, 136);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let videoFrame41 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'smpteSt4281', transfer: 'gamma28curve'} });
+let bindGroup168 = device0.createBindGroup({
+  label: '\u{1f7e7}\u1b46\u4113\ua206\u05ee\u0a1a\u0d9b\u{1f66b}',
+  layout: bindGroupLayout29,
+  entries: [{binding: 131, resource: {buffer: buffer26, offset: 256, size: 849}}],
+});
+let computePassEncoder222 = commandEncoder7.beginComputePass({});
+try {
+computePassEncoder222.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup103, new Uint32Array(2058), 152, 0);
+} catch {}
+try {
+renderPassEncoder99.executeBundles([renderBundle17, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder84.setViewport(13.255090701590248, 0.7881194095785887, 28.11667379440744, 0.13277858363960596, 0.5914100302493642, 0.593427110482975);
+} catch {}
+let buffer183 = device0.createBuffer({size: 4489, usage: GPUBufferUsage.MAP_READ});
+try {
+renderPassEncoder24.setIndexBuffer(buffer132, 'uint32', 288, 815);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let imageData33 = new ImageData(20, 132);
+let buffer184 = device0.createBuffer({size: 29388, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder69.executeBundles([renderBundle6, renderBundle6, renderBundle22, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(5, buffer145, 0, 557);
+} catch {}
+try {
+buffer132.unmap();
+} catch {}
+try {
+computePassEncoder177.pushDebugGroup('\u{1f736}');
+} catch {}
+try {
+computePassEncoder177.popDebugGroup();
+} catch {}
+let shaderModule20 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(11) var<storage, read_write> buffer185: T0;
+
+struct T0 {
+  @size(112) f0: array<atomic<i32>>,
+}
+
+struct VertexOutput19 {
+  @location(7) f51: vec2i,
+  @location(14) f52: f32,
+  @location(12) f53: i32,
+  @location(15) f54: vec2u,
+  @location(6) f55: vec4f,
+  @location(13) @interpolate(flat) f56: i32,
+  @builtin(position) f57: vec4f,
+  @location(11) f58: vec4h,
+  @location(3) f59: u32,
+  @location(8) f60: f32,
+}
+
+struct FragmentOutput17 {
+  @location(5) @interpolate(flat, centroid) f0: vec4i,
+  @location(0) f1: vec4f,
+  @builtin(sample_mask) f2: u32,
+}
+
+alias vec3b = vec3<bool>;
+
+fn fn0(a0: vec4i) -> array<vec4u, 12> {
+  var out: array<vec4u, 12>;
+  let vf449: i32 = a0[u32(unconst_u32(42))];
+  vp16[u32(unconst_u32(127))] ^= vp16[0];
+  out[u32(unconst_u32(89))] ^= max(vec3u(unconst_u32(51), unconst_u32(24), unconst_u32(172)), vec3u(bitcast<u32>(a0[u32(unconst_u32(23))]))).gbbg;
+  let vf450: vec2f = normalize(vec2f(unconst_f32(0.7097), unconst_f32(-0.9041)));
+  out[11] = vec4u(vf450.ggrr);
+  out[u32(unconst_u32(197))] = bitcast<vec4u>(a0);
+  var vf451: vec3u = firstTrailingBit(vec3u(unconst_u32(200), unconst_u32(249), unconst_u32(363)));
+  out[u32(unconst_u32(21))] *= vec4u(u32(vf449));
+  vf451 >>= vec3u(vf451[u32(unconst_u32(106))]);
+  return out;
+}
+
+var<private> vp16: array<vec4u, 1> = array(vec4u(280, 148, 105, 62));
+
+@vertex
+fn vertex20(@location(15) @interpolate(linear, centroid) a0: f32, @location(1) a1: f16, @location(5) @interpolate(flat) a2: vec2i) -> VertexOutput19 {
+  var out: VertexOutput19;
+  var vf452 = fn0(vec4i(i32(pack4xU8Clamp(vp16[0]))));
+  var vf453: u32 = vp16[0][u32(unconst_u32(102))];
+  var vf454 = fn0(vec4i(normalize(vec2h(unconst_f16(5419.2), unconst_f16(14101.7))).xxxx));
+  var vf455: f32 = length(f32(unconst_f32(0.1209)));
+  fn0(vec4i(unconst_i32(321), unconst_i32(-94), unconst_i32(71), unconst_i32(88)));
+  out.f60 = a0;
+  vp16[u32(unconst_u32(222))] *= unpack4xU8(pack4xU8Clamp(vec4u(unconst_u32(108), unconst_u32(77), unconst_u32(166), unconst_u32(144))));
+  return out;
+}
+
+@fragment
+fn fragment19() -> FragmentOutput17 {
+  var out: FragmentOutput17;
+  out.f0 |= vec4i(countLeadingZeros(vec4u(unconst_u32(51), unconst_u32(174), unconst_u32(459), unconst_u32(322))));
+  fn0(bitcast<vec4i>(vp16[0]));
+  out.f2 <<= u32(refract(vec4f(unconst_f32(0.04771), unconst_f32(-0.4773), unconst_f32(0.3092), unconst_f32(0.02865)), vec4f(asinh(f32(unconst_f32(0.1409)))), f32(unconst_f32(0.3432)))[2]);
+  out = FragmentOutput17(vec4i(countLeadingZeros(vec4u(unconst_u32(190), unconst_u32(123), unconst_u32(213), unconst_u32(32)))), vec4f(countLeadingZeros(vec4u(unconst_u32(190), unconst_u32(123), unconst_u32(213), unconst_u32(32)))), countLeadingZeros(vec4u(unconst_u32(190), unconst_u32(123), unconst_u32(213), unconst_u32(32)))[1]);
+  var vf456 = fn0(vec4i(vp16[u32(unconst_u32(106))]));
+  vf456[u32(unconst_u32(18))] &= vf456[u32(unconst_u32(4))];
+  var vf457: vec4h = normalize(vec4h(unconst_f16(6665.3), unconst_f16(473.3), unconst_f16(169.4), unconst_f16(5200.2)));
+  let ptr153: ptr<private, array<vec4u, 1>> = &vp16;
+  let ptr154: ptr<function, vec4u> = &vf456[11];
+  var vf458 = fn0(vec4i(i32((*ptr153)[0][u32(unconst_u32(52))])));
+  fn0(vec4i(unconst_i32(49), unconst_i32(97), unconst_i32(-172), unconst_i32(20)));
+  out = FragmentOutput17(vec4i(bitcast<i32>(acos(f32(unconst_f32(0.09525))))), vec4f(acos(f32(unconst_f32(0.09525)))), u32(acos(f32(unconst_f32(0.09525)))));
+  fn0(vec4i(i32((*ptr153)[0][u32(unconst_u32(283))])));
+  fn0(vec4i(i32(vf458[u32(unconst_u32(83))][u32(unconst_u32(10))])));
+  var vf459: f32 = acos(f32(unconst_f32(0.1370)));
+  out = FragmentOutput17(bitcast<vec4i>(vf458[11]), bitcast<vec4f>(vf458[11]), pack4xU8(vf458[11]));
+  let ptr155: ptr<function, f32> = &vf459;
+  fn0(vec4i(unconst_i32(-185), unconst_i32(364), unconst_i32(159), unconst_i32(366)));
+  var vf460: u32 = (*ptr153)[0][u32(unconst_u32(50))];
+  let ptr156: ptr<function, vec4u> = &vf458[u32(unconst_u32(284))];
+  out.f1 += bitcast<vec4f>((*ptr153)[u32(unconst_u32(195))]);
+  vf459 = bitcast<f32>((*ptr156)[u32(unconst_u32(110))]);
+  out.f0 = bitcast<vec4i>((*ptr153)[0]);
+  var vf461 = fn0(vec4i(unconst_i32(129), unconst_i32(83), unconst_i32(278), unconst_i32(37)));
+  return out;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let externalTexture27 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder56.setBindGroup(1, bindGroup36);
+} catch {}
+try {
+computePassEncoder133.setBindGroup(3, bindGroup86, new Uint32Array(1565), 15, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroups(3); };
+} catch {}
+document.body.prepend(canvas2);
+let imageData34 = new ImageData(52, 12);
+try {
+renderPassEncoder101.setBindGroup(2, bindGroup106);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(3, bindGroup50, new Uint32Array(372), 29, 0);
+} catch {}
+let texture257 = device0.createTexture({
+  size: [280, 291, 18],
+  dimension: '3d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView254 = texture247.createView({label: '\ufe01\u1429\u64ea', mipLevelCount: 1});
+try {
+computePassEncoder86.setBindGroup(1, bindGroup27, new Uint32Array(1254), 29, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder177); computePassEncoder177.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer82, 100); };
+} catch {}
+try {
+renderPassEncoder73.setIndexBuffer(buffer179, 'uint32', 564, 278);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let texture258 = device0.createTexture({
+  size: [147, 1, 35],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup152, new Uint32Array(333), 3, 0);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer159, 0);
+} catch {}
+let texture259 = device0.createTexture({
+  size: [140, 145, 1],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView255 = texture37.createView({});
+try {
+computePassEncoder51.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer91, 0, 1_583);
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas4.getContext('webgpu');
+let buffer186 = device0.createBuffer({size: 30729, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC});
+let textureView256 = texture56.createView({mipLevelCount: 1, baseArrayLayer: 7, arrayLayerCount: 7});
+try {
+computePassEncoder139.setBindGroup(2, bindGroup91, []);
+} catch {}
+try {
+renderPassEncoder97.setBindGroup(0, bindGroup160);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer91, 'uint32', 3_556, 273);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(4, buffer139, 0, 2_125);
+} catch {}
+try {
+buffer45.unmap();
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+let imageData35 = new ImageData(8, 96);
+let sampler163 = device0.createSampler({
+  label: '\u0ed2\u3990\ub80e\u{1fb7d}\u190f\u328d\u0b1a\u{1fee0}\u{1f6fb}\u7342',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 75.89,
+  lodMaxClamp: 93.70,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder64.setBindGroup(0, bindGroup60, new Uint32Array(149), 123, 0);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer131, 'uint32', 40, 3_225);
+} catch {}
+document.body.prepend(canvas0);
+let videoFrame42 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'bt2020', transfer: 'hlg'} });
+let videoFrame43 = new VideoFrame(videoFrame8, {timestamp: 0});
+try {
+commandEncoder20.label = '\u{1f6c9}\u7753\u767b\u{1ff58}\u2f39';
+} catch {}
+let texture260 = device0.createTexture({
+  size: {width: 96, height: 1, depthOrArrayLayers: 131},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup54);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(2, bindGroup144, []);
+} catch {}
+let texture261 = device0.createTexture({
+  label: '\u3d75\u0e4a\u5872\u8574\u39d3\u7d9b\ue02b\u1678\u0eef',
+  size: {width: 147, height: 1, depthOrArrayLayers: 29},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder200.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(4, buffer184, 0, 2_421);
+} catch {}
+try {
+  await promise23;
+} catch {}
+let texture262 = device0.createTexture({
+  size: [110, 10, 78],
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler164 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 88.95,
+  lodMaxClamp: 89.92,
+  maxAnisotropy: 2,
+});
+try {
+renderPassEncoder30.beginOcclusionQuery(7);
+} catch {}
+try {
+renderPassEncoder78.setScissorRect(9, 0, 23, 0);
+} catch {}
+let textureView257 = texture70.createView({});
+let sampler165 = device0.createSampler({
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 97.23,
+  lodMaxClamp: 98.13,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder153.setBindGroup(3, bindGroup82);
+} catch {}
+try {
+renderPassEncoder61.beginOcclusionQuery(3);
+} catch {}
+try {
+renderPassEncoder82.setIndexBuffer(buffer50, 'uint16', 222, 502);
+} catch {}
+let bindGroup169 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 190, resource: textureView168},
+    {binding: 125, resource: externalTexture11},
+    {binding: 606, resource: sampler112},
+    {binding: 222, resource: {buffer: buffer49, offset: 0}},
+  ],
+});
+let buffer187 = device0.createBuffer({
+  size: 14387,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let querySet32 = device0.createQuerySet({type: 'occlusion', count: 836});
+let textureView258 = texture249.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 1});
+try {
+renderPassEncoder61.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder38.setBlendConstant({ r: 448.7, g: -554.3, b: 132.8, a: 92.53, });
+} catch {}
+let bindGroup170 = device0.createBindGroup({
+  layout: bindGroupLayout29,
+  entries: [{binding: 131, resource: {buffer: buffer70, offset: 0, size: 5966}}],
+});
+let buffer188 = device0.createBuffer({
+  size: 18387,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder213.setBindGroup(0, bindGroup79, new Uint32Array(1042), 33, 0);
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+let buffer189 = device0.createBuffer({
+  size: 8820,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView259 = texture28.createView({dimension: '2d-array', aspect: 'all'});
+try {
+renderPassEncoder61.setBindGroup(1, bindGroup36);
+} catch {}
+try {
+renderPassEncoder68.executeBundles([renderBundle4, renderBundle21, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder97.setBlendConstant({ r: 882.4, g: 437.8, b: 338.7, a: -213.7, });
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer85, 'uint32', 8_076, 3_397);
+} catch {}
+let texture263 = device0.createTexture({
+  size: {width: 560, height: 582, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder58.setBindGroup(1, bindGroup157);
+} catch {}
+try {
+renderPassEncoder95.setBindGroup(0, bindGroup89, new Uint32Array(253), 68, 0);
+} catch {}
+try {
+  await promise24;
+} catch {}
+let buffer190 = device0.createBuffer({size: 1397, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE, mappedAtCreation: false});
+let texture264 = device0.createTexture({
+  label: '\u0aeb\u{1fc98}\ud5a7\u317b\u8307\uf7cf\u2b52\u{1fe5a}',
+  size: {width: 55, height: 5, depthOrArrayLayers: 22},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView260 = texture198.createView({format: 'rgba16uint', mipLevelCount: 1});
+try {
+computePassEncoder146.setBindGroup(0, bindGroup43, new Uint32Array(1133), 20, 0);
+} catch {}
+try {
+renderPassEncoder67.setVertexBuffer(7, buffer158, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer97, 464, new DataView(new ArrayBuffer(25999)), 3773, 356);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture234,
+  mipLevel: 2,
+  origin: {x: 9, y: 20, z: 0},
+  aspect: 'all',
+}, new Uint8Array(21_128).fill(2), /* required buffer size: 21_128 */
+{offset: 494, bytesPerRow: 150, rowsPerImage: 86}, {width: 21, height: 52, depthOrArrayLayers: 2});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle1, renderBundle1, renderBundle10]);
+} catch {}
+document.body.append(img3);
+let buffer191 = device0.createBuffer({
+  size: 5776,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let sampler166 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 76.47,
+  lodMaxClamp: 97.81,
+  maxAnisotropy: 2,
+});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: videoFrame32,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture265 = device0.createTexture({
+  size: [36, 1, 5],
+  mipLevelCount: 3,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder43.setBindGroup(0, bindGroup37, []);
+} catch {}
+try {
+computePassEncoder27.end();
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(0, bindGroup53);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(2, buffer62, 0);
+} catch {}
+try {
+commandEncoder35.copyTextureToBuffer({
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 38, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2796 */
+  offset: 2796,
+  buffer: buffer23,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder35.insertDebugMarker('\uaad0');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let buffer192 = device0.createBuffer({
+  size: 10712,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let renderPassEncoder102 = commandEncoder35.beginRenderPass({
+  label: '\u{1fefc}\u0f4d\u{1f986}',
+  colorAttachments: [{
+  view: textureView260,
+  depthSlice: 789,
+  clearValue: { r: -150.2, g: 736.4, b: -290.5, a: -622.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder87.setBindGroup(3, bindGroup111);
+} catch {}
+try {
+renderPassEncoder30.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder73.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder52.setBlendConstant({ r: 410.1, g: -61.50, b: 231.1, a: -178.4, });
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let texture266 = device0.createTexture({
+  size: [140, 145, 1],
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder30.setBindGroup(2, bindGroup140);
+} catch {}
+try {
+renderPassEncoder25.setScissorRect(44, 0, 13, 0);
+} catch {}
+let promise25 = shaderModule18.getCompilationInfo();
+let arrayBuffer21 = buffer136.getMappedRange(0, 16);
+let buffer193 = device0.createBuffer({
+  size: 14051,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint']});
+let renderBundle24 = renderBundleEncoder24.finish({label: '\u{1fbdf}\uea90\uc7b6\u0f65\u{1fff7}\u26bf\u087a\uae65\uc350'});
+let sampler167 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 14.24,
+  maxAnisotropy: 6,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer54, 340); };
+} catch {}
+try {
+renderPassEncoder83.setBindGroup(0, bindGroup163, new Uint32Array(132), 45, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 147, height: 1, depthOrArrayLayers: 9}
+*/
+{
+  source: imageData23,
+  origin: { x: 8, y: 2 },
+  flipY: true,
+}, {
+  texture: texture110,
+  mipLevel: 1,
+  origin: {x: 95, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let bindGroupLayout35 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 113,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup171 = device0.createBindGroup({
+  layout: bindGroupLayout16,
+  entries: [{binding: 0, resource: {buffer: buffer187, offset: 512, size: 2588}}],
+});
+let sampler168 = device0.createSampler({
+  label: '\u{1fa7b}\u{1f95b}',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 81.77,
+  compare: 'less-equal',
+});
+try {
+renderPassEncoder99.setIndexBuffer(buffer157, 'uint16', 756, 794);
+} catch {}
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({
+  label: '\u3cb8\u032a\u{1f84c}\u01f1\u235a\u9104\u0c1e\u0018\u{1ff9c}\u7158',
+  colorFormats: ['rgba32float'],
+});
+try {
+computePassEncoder222.setBindGroup(0, bindGroup141);
+} catch {}
+try {
+computePassEncoder171.setBindGroup(1, bindGroup14, new Uint32Array(484), 76, 0);
+} catch {}
+try {
+renderPassEncoder60.executeBundles([renderBundle7]);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+document.body.append(canvas4);
+let canvas5 = document.createElement('canvas');
+let bindGroup172 = device0.createBindGroup({
+  label: '\u1caf\u094b\u{1ffcb}\u0b13\u1cfd',
+  layout: bindGroupLayout23,
+  entries: [{binding: 63, resource: textureView229}, {binding: 28, resource: textureView174}],
+});
+let pipelineLayout13 = device0.createPipelineLayout({bindGroupLayouts: []});
+try {
+computePassEncoder120.end();
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer113, 'uint16', 2_068, 3_529);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(0, bindGroup65, new Uint32Array(3443), 219, 0);
+} catch {}
+try {
+buffer150.unmap();
+} catch {}
+try {
+commandEncoder162.clearBuffer(buffer80, 3340, 4800);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 295, height: 1, depthOrArrayLayers: 19}
+*/
+{
+  source: videoFrame13,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 100, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup173 = device0.createBindGroup({
+  label: '\u03f7\ud50a\uaa8c\u3dd6\uba22',
+  layout: bindGroupLayout33,
+  entries: [{binding: 36, resource: {buffer: buffer127, offset: 0}}],
+});
+let computePassEncoder223 = commandEncoder162.beginComputePass();
+let renderBundle25 = renderBundleEncoder25.finish({label: '\u0822\u11c8\uba79\u3839\u021f\u3919\u04f0\u{1f68e}\u2f8e'});
+try {
+buffer42.unmap();
+} catch {}
+let videoFrame44 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'unspecified', transfer: 'smpte170m'} });
+try {
+globalThis.someLabel = externalTexture22.label;
+} catch {}
+try {
+computePassEncoder223.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(1, bindGroup162);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(0, bindGroup82, new Uint32Array(4104), 616, 0);
+} catch {}
+let bindGroup174 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [{binding: 116, resource: sampler59}, {binding: 204, resource: externalTexture24}],
+});
+let buffer194 = device0.createBuffer({
+  size: 6875,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder16); computePassEncoder16.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(1, bindGroup91, new Uint32Array(2617), 22, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture265,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(62).fill(218), /* required buffer size: 62 */
+{offset: 62}, {width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext8 = canvas5.getContext('webgpu');
+document.body.append(canvas0);
+let buffer195 = device0.createBuffer({
+  label: '\u4683\u9fa7\u0cf4\u{1facb}\u0ae1\u3ccb\u{1f92a}\u385f\ue2d5',
+  size: 819,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture267 = device0.createTexture({size: [384, 1, 24], format: 'depth24plus', usage: GPUTextureUsage.TEXTURE_BINDING});
+let renderPassEncoder103 = commandEncoder20.beginRenderPass({colorAttachments: [{view: textureView38, loadOp: 'load', storeOp: 'discard'}]});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  label: '\u1f6f\u0744\u06b8\u0451\u{1ffca}\u1524\ua0d2\u119f\u4b45\uf124\u6849',
+  colorFormats: ['rgba16sint'],
+  depthReadOnly: true,
+});
+let renderBundle26 = renderBundleEncoder26.finish({});
+let sampler169 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMinClamp: 64.14, lodMaxClamp: 69.98});
+try {
+renderPassEncoder31.setIndexBuffer(buffer95, 'uint32', 228, 1_212);
+} catch {}
+let sampler170 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.52,
+  lodMaxClamp: 75.53,
+  compare: 'never',
+  maxAnisotropy: 7,
+});
+try {
+renderPassEncoder55.setVertexBuffer(4, buffer64);
+} catch {}
+let buffer196 = device0.createBuffer({size: 47097, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({
+  label: '\u01a2\uf833\u0454\u5e3f\u3103\u0ced\ue9d8\u793b\u{1fddb}\u{1f631}',
+  colorFormats: ['rgb10a2unorm'],
+  depthStencilFormat: 'depth24plus',
+  stencilReadOnly: true,
+});
+let sampler171 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 24.13,
+  lodMaxClamp: 74.78,
+});
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup126, new Uint32Array(4416), 470, 0);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(4, buffer98);
+} catch {}
+let canvas6 = document.createElement('canvas');
+try {
+renderPassEncoder56.setIndexBuffer(buffer187, 'uint16', 3_978, 2_650);
+} catch {}
+try {
+renderPassEncoder68.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer105, 'uint16', 364, 718);
+} catch {}
+let promise26 = device0.queue.onSubmittedWorkDone();
+let offscreenCanvas5 = new OffscreenCanvas(12, 278);
+let bindGroupLayout36 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 23, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let textureView261 = texture182.createView({aspect: 'depth-only', baseArrayLayer: 6, arrayLayerCount: 1});
+let externalTexture28 = device0.importExternalTexture({source: videoFrame25});
+try {
+computePassEncoder185.setBindGroup(2, bindGroup28, new Uint32Array(4202), 1_050, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder213); computePassEncoder213.dispatchWorkgroupsIndirect(buffer129, 356); };
+} catch {}
+try {
+renderPassEncoder92.setIndexBuffer(buffer10, 'uint16', 4_780, 426);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup1, new Uint32Array(1551), 101, 0);
+} catch {}
+let textureView262 = texture48.createView({mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder183.setBindGroup(1, bindGroup13, new Uint32Array(4954), 521, 0);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup148);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup53, new Uint32Array(796), 179, 0);
+} catch {}
+let bindGroup175 = device0.createBindGroup({
+  label: '\u8611\u3994\u0644\u29c8\u7562\u0954\u{1f6a8}\uecaa\u{1f685}\u0afe',
+  layout: bindGroupLayout31,
+  entries: [{binding: 362, resource: textureView64}],
+});
+let renderBundle27 = renderBundleEncoder27.finish({});
+try {
+computePassEncoder165.setBindGroup(2, bindGroup148, new Uint32Array(121), 12, 0);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(0, bindGroup90, new Uint32Array(6026), 1_563, 0);
+} catch {}
+try {
+renderPassEncoder70.executeBundles([renderBundle17]);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let sampler172 = device0.createSampler({
+  label: '\u198c\u{1fdf2}\u44a8\u{1f963}\u{1fc9c}\u{1fba3}',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 22.97,
+  lodMaxClamp: 35.15,
+});
+try {
+computePassEncoder207.setBindGroup(1, bindGroup50, new Uint32Array(1290), 56, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder213); computePassEncoder213.dispatchWorkgroupsIndirect(buffer179, 144); };
+} catch {}
+try {
+renderPassEncoder86.setBindGroup(2, bindGroup90, new Uint32Array(77), 22, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer71, 'uint16', 726, 5_404);
+} catch {}
+try {
+renderPassEncoder67.setVertexBuffer(7, buffer111, 0, 76);
+} catch {}
+let textureView263 = texture154.createView({});
+try {
+computePassEncoder177.setBindGroup(1, bindGroup124, new Uint32Array(238), 8, 0);
+} catch {}
+try {
+computePassEncoder219.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup10, new Uint32Array(1255), 25, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: videoFrame23,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 16},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer197 = device0.createBuffer({size: 24432, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], sampleCount: 1});
+let renderBundle28 = renderBundleEncoder28.finish({label: '\u1e17\u7d27\u3801\ue528\u00c8\u{1faf8}\u0c68\u03c0\u08e7\uf8a9'});
+try {
+computePassEncoder195.setBindGroup(3, bindGroup62, new Uint32Array(1586), 87, 0);
+} catch {}
+try {
+renderPassEncoder70.setBindGroup(1, bindGroup57, []);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle5]);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer198 = device0.createBuffer({
+  label: '\u3c29\u0a1d\uac10\u216b\u6f27\u09bd\u{1f79a}\u00ea\u46d3\uf470\u4644',
+  size: 1740,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder170.setBindGroup(2, bindGroup135);
+} catch {}
+let gpuCanvasContext9 = canvas6.getContext('webgpu');
+try {
+textureView224.label = '\u289d\uc224\u6aee\u0f08\u0c12\u0b56\ud4e8\u{1f6ff}';
+} catch {}
+try {
+computePassEncoder173.setBindGroup(2, bindGroup52);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup9, []);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup69, new Uint32Array(3290), 140, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle15, renderBundle15]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer30, 'uint16', 16, 8);
+} catch {}
+try {
+buffer59.unmap();
+} catch {}
+let textureView264 = texture22.createView({});
+let sampler173 = device0.createSampler({
+  label: '\u0135\u{1fabe}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 45.32,
+  lodMaxClamp: 63.13,
+});
+try {
+renderPassEncoder100.executeBundles([renderBundle22, renderBundle24, renderBundle6, renderBundle22]);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup176 = device0.createBindGroup({
+  label: '\u{1fe9e}\u{1fe65}\u{1f906}',
+  layout: bindGroupLayout30,
+  entries: [
+    {binding: 566, resource: externalTexture26},
+    {binding: 577, resource: textureView197},
+    {binding: 86, resource: {buffer: buffer198, offset: 0}},
+    {binding: 517, resource: textureView232},
+  ],
+});
+let buffer199 = device0.createBuffer({size: 39574, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let querySet33 = device0.createQuerySet({type: 'occlusion', count: 93});
+let bindGroupLayout37 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 29,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let bindGroup177 = device0.createBindGroup({
+  label: '\u{1fe82}\u{1f8fd}\u0718\u38a2\ua0e2',
+  layout: bindGroupLayout4,
+  entries: [{binding: 511, resource: {buffer: buffer84, offset: 1024, size: 2580}}],
+});
+let texture268 = device0.createTexture({
+  size: [36, 1, 1],
+  mipLevelCount: 2,
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture269 = device0.createTexture({
+  size: {width: 36, height: 1, depthOrArrayLayers: 22},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder164.setBindGroup(0, bindGroup108, new Uint32Array(1147), 98, 0);
+} catch {}
+let texture270 = device0.createTexture({
+  label: '\ud20f\uda5c\ufd0e\ub845\u5af6\u0515\ub9b4\u0ad2\u01b1\ue322',
+  size: {width: 96, height: 1, depthOrArrayLayers: 78},
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler174 = device0.createSampler({
+  label: '\ufb91\u{1fbca}\uab5f\u5a30\u{1f730}\u6c84\u64e7',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 68.62,
+  lodMaxClamp: 86.03,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder74.setBindGroup(3, bindGroup65, new Uint32Array(516), 224, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer184, 7_676); };
+} catch {}
+try {
+renderPassEncoder35.executeBundles([renderBundle3, renderBundle3, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder69.setVertexBuffer(2, buffer72, 0);
+} catch {}
+let arrayBuffer22 = buffer5.getMappedRange(360, 12);
+try {
+device0.queue.writeTexture({
+  texture: texture218,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(244).fill(10), /* required buffer size: 244 */
+{offset: 244, bytesPerRow: 179}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup178 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 606, resource: sampler83},
+    {binding: 222, resource: {buffer: buffer119, offset: 0, size: 5139}},
+    {binding: 190, resource: textureView168},
+    {binding: 125, resource: externalTexture19},
+  ],
+});
+let texture271 = device0.createTexture({
+  size: {width: 110, height: 10, depthOrArrayLayers: 63},
+  mipLevelCount: 1,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer20, 'uint32', 32, 0);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup179 = device0.createBindGroup({
+  label: '\u0962\u3206\ubf66\u9cda\u3ff6\u1098\ud38e\u49a6\u77c7\u0ce4\u5f70',
+  layout: bindGroupLayout15,
+  entries: [{binding: 44, resource: externalTexture12}],
+});
+let texture272 = device0.createTexture({
+  size: [96, 1, 1],
+  sampleCount: 1,
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], depthStencilFormat: 'depth24plus', depthReadOnly: true});
+let sampler175 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 32.36,
+  lodMaxClamp: 36.56,
+});
+try {
+computePassEncoder159.setBindGroup(3, bindGroup127, new Uint32Array(105), 27, 0);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(2, bindGroup162, new Uint32Array(4522), 493, 0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle0, renderBundle0, renderBundle16, renderBundle0, renderBundle0, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer198, 'uint16', 118, 95);
+} catch {}
+try {
+renderPassEncoder93.setVertexBuffer(5, buffer65);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(5, buffer156, 0, 842);
+} catch {}
+let buffer200 = device0.createBuffer({size: 38134, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let texture273 = device0.createTexture({
+  size: [220, 20, 71],
+  mipLevelCount: 6,
+  format: 'astc-5x4-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle29 = renderBundleEncoder29.finish({});
+let sampler176 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 63.13,
+  lodMaxClamp: 71.78,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder151); computePassEncoder151.dispatchWorkgroupsIndirect(buffer87, 368); };
+} catch {}
+try {
+computePassEncoder192.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup49, new Uint32Array(1768), 436, 0);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(1, buffer195, 0);
+} catch {}
+let arrayBuffer23 = buffer35.getMappedRange(272, 4);
+let gpuCanvasContext10 = offscreenCanvas5.getContext('webgpu');
+try {
+adapter0.label = '\u2e3b\u{1fa2c}\udce5\ua6da\uf176';
+} catch {}
+let bindGroup180 = device0.createBindGroup({layout: bindGroupLayout15, entries: [{binding: 44, resource: externalTexture13}]});
+let texture274 = device0.createTexture({
+  label: '\u{1fce0}\u2909\u68e5\u2cb4\u0cef\u04c4\u{1ff04}\uf2f8\u0df7',
+  size: {width: 440, height: 40, depthOrArrayLayers: 4},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'astc-8x5-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture275 = device0.createTexture({
+  label: '\u{1f782}\u{1fa45}\u0c38\ua182\u{1f741}',
+  size: {width: 147, height: 1, depthOrArrayLayers: 26},
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'depth24plus',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView265 = texture165.createView({mipLevelCount: 1});
+try {
+renderPassEncoder54.executeBundles([renderBundle28]);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+await gc();
+let imageData36 = new ImageData(104, 24);
+let texture276 = device0.createTexture({
+  size: [48, 1, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder44.setBindGroup(2, bindGroup126);
+} catch {}
+try {
+renderPassEncoder78.setBindGroup(1, bindGroup118, new Uint32Array(763), 1, 0);
+} catch {}
+let texture277 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 22},
+  sampleCount: 1,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint'], stencilReadOnly: true});
+try {
+buffer112.unmap();
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let videoFrame45 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'bt470bg', transfer: 'bt1361ExtendedColourGamut'} });
+let buffer201 = device0.createBuffer({size: 2087, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let textureView266 = texture277.createView({label: '\u3fb9\u{1f6f3}\u0b49\u{1fb14}', dimension: 'cube-array', arrayLayerCount: 6});
+let texture278 = device0.createTexture({
+  size: [560],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder81.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+computePassEncoder7.setBindGroup(3, bindGroup5, new Uint32Array(1543), 938, 0);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup162);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder79.setVertexBuffer(3, buffer24);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(2, bindGroup106);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(0, bindGroup99, new Uint32Array(1914), 1_914, 0);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(7, buffer151);
+} catch {}
+document.body.append(canvas4);
+let imageBitmap5 = await createImageBitmap(imageData28);
+let texture279 = device0.createTexture({
+  size: [192, 1, 262],
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle30 = renderBundleEncoder30.finish({label: '\ue3dd\u{1ffa4}\u{1fa93}\u05fb'});
+try {
+renderPassEncoder96.setBindGroup(2, bindGroup172, new Uint32Array(1463), 171, 0);
+} catch {}
+try {
+renderPassEncoder47.beginOcclusionQuery(89);
+} catch {}
+try {
+renderPassEncoder59.setIndexBuffer(buffer112, 'uint16', 314, 3_031);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(0, buffer43);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer93, 596, new DataView(new ArrayBuffer(24696)), 4086, 92);
+} catch {}
+let textureView267 = texture32.createView({dimension: '2d-array'});
+let sampler177 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 92.67,
+  lodMaxClamp: 97.32,
+});
+try {
+renderPassEncoder47.endOcclusionQuery();
+} catch {}
+let promise27 = shaderModule9.getCompilationInfo();
+let canvas7 = document.createElement('canvas');
+try {
+computePassEncoder197.setBindGroup(3, bindGroup140);
+} catch {}
+try {
+computePassEncoder119.setBindGroup(0, bindGroup39, new Uint32Array(739), 163, 0);
+} catch {}
+try {
+computePassEncoder43.end();
+} catch {}
+try {
+renderPassEncoder51.setBlendConstant({ r: -679.4, g: -33.58, b: -940.9, a: 415.0, });
+} catch {}
+try {
+renderPassEncoder13.setViewport(34.321888928785384, 0.9324577415569325, 45.609799181336356, 0.033423630141037594, 0.3542933338189449, 0.6087211310512131);
+} catch {}
+try {
+commandEncoder61.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3112 */
+  offset: 3112,
+  buffer: buffer174,
+}, {
+  texture: texture159,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture126,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 5},
+  aspect: 'all',
+}, new Uint8Array(57_654).fill(96), /* required buffer size: 57_654 */
+{offset: 54, bytesPerRow: 384, rowsPerImage: 25}, {width: 89, height: 0, depthOrArrayLayers: 7});
+} catch {}
+let bindGroup181 = device0.createBindGroup({
+  layout: bindGroupLayout30,
+  entries: [
+    {binding: 566, resource: externalTexture20},
+    {binding: 86, resource: {buffer: buffer128, offset: 2048}},
+    {binding: 517, resource: textureView233},
+    {binding: 577, resource: textureView210},
+  ],
+});
+let buffer202 = device0.createBuffer({
+  size: 1570,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let renderPassEncoder104 = commandEncoder61.beginRenderPass({
+  colorAttachments: [{
+  view: textureView147,
+  clearValue: { r: 580.4, g: 34.99, b: 903.9, a: 168.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler178 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 46.92,
+});
+try {
+computePassEncoder106.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+renderPassEncoder74.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder61.setVertexBuffer(4, buffer170);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext11 = canvas7.getContext('webgpu');
+let texture280 = device0.createTexture({
+  size: {width: 55, height: 5, depthOrArrayLayers: 14},
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView268 = texture63.createView({dimension: '2d-array'});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], sampleCount: 4, depthReadOnly: true});
+let renderBundle31 = renderBundleEncoder31.finish({label: '\uf806\u{1fe33}'});
+try {
+computePassEncoder95.setBindGroup(1, bindGroup65);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+  await buffer162.mapAsync(GPUMapMode.READ, 0, 160);
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(185, 8);
+let textureView269 = texture12.createView({dimension: '2d-array'});
+try {
+computePassEncoder99.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+  await buffer97.mapAsync(GPUMapMode.READ, 0, 396);
+} catch {}
+let imageBitmap6 = await createImageBitmap(imageBitmap1);
+let sampler179 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 58.08,
+  lodMaxClamp: 74.06,
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder129.setBindGroup(3, bindGroup171);
+} catch {}
+try {
+renderPassEncoder61.beginOcclusionQuery(2);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(4, buffer95, 3_048);
+} catch {}
+let gpuCanvasContext12 = offscreenCanvas6.getContext('webgpu');
+document.body.prepend(img1);
+let texture281 = device0.createTexture({
+  size: {width: 96, height: 1, depthOrArrayLayers: 131},
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder182.setBindGroup(2, bindGroup160);
+} catch {}
+try {
+renderPassEncoder100.executeBundles([renderBundle24, renderBundle24, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder68.setIndexBuffer(buffer82, 'uint32', 352, 24);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture216,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 26},
+  aspect: 'all',
+}, new Uint8Array(26_284).fill(214), /* required buffer size: 26_284 */
+{offset: 76, bytesPerRow: 39, rowsPerImage: 6}, {width: 2, height: 0, depthOrArrayLayers: 113});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 32}
+*/
+{
+  source: imageData7,
+  origin: { x: 2, y: 0 },
+  flipY: false,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let videoFrame46 = videoFrame28.clone();
+try {
+computePassEncoder140.setBindGroup(3, bindGroup119, new Uint32Array(841), 120, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder106); computePassEncoder106.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+computePassEncoder87.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder61.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle7, renderBundle7, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder95.setScissorRect(81, 25, 31, 68);
+} catch {}
+try {
+renderPassEncoder77.setVertexBuffer(4, buffer6);
+} catch {}
+let bindGroupLayout38 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 769,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let buffer203 = device0.createBuffer({
+  size: 2384,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView270 = texture277.createView({dimension: 'cube-array', arrayLayerCount: 6});
+let texture282 = device0.createTexture({
+  size: {width: 96, height: 1, depthOrArrayLayers: 3},
+  format: 'depth24plus',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder224 = commandEncoder0.beginComputePass({});
+let sampler180 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.550,
+  lodMaxClamp: 33.21,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder224.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder67.setBindGroup(1, bindGroup106, []);
+} catch {}
+try {
+renderPassEncoder102.setIndexBuffer(buffer59, 'uint16', 96, 382);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(1, buffer148, 128);
+} catch {}
+try {
+commandEncoder12.copyBufferToTexture({
+  /* bytesInLastRow: 144 widthInBlocks: 36 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 292 */
+  offset: 292,
+  bytesPerRow: 1536,
+  buffer: buffer45,
+}, {
+  texture: texture191,
+  mipLevel: 2,
+  origin: {x: 27, y: 12, z: 0},
+  aspect: 'all',
+}, {width: 36, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder225 = commandEncoder12.beginComputePass({label: '\ub6d0\u00ee\ub4bf\ud664\uadaf\u5148\u5734\u{1fd03}\u{1fae0}'});
+try {
+computePassEncoder197.setBindGroup(1, bindGroup39, new Uint32Array(3261), 1_337, 0);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer198, 'uint16', 380, 210);
+} catch {}
+try {
+renderPassEncoder96.setVertexBuffer(2, buffer109, 112, 855);
+} catch {}
+let bindGroup182 = device0.createBindGroup({
+  layout: bindGroupLayout3,
+  entries: [{binding: 58, resource: {buffer: buffer99, offset: 4096}}, {binding: 225, resource: textureView13}],
+});
+let textureView271 = texture93.createView({baseArrayLayer: 0});
+try {
+computePassEncoder76.setBindGroup(3, bindGroup170, new Uint32Array(477), 26, 0);
+} catch {}
+try {
+renderPassEncoder83.setVertexBuffer(7, buffer6, 0, 262);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 0, y: 8, z: 10},
+  aspect: 'all',
+}, new Uint8Array(351).fill(39), /* required buffer size: 351 */
+{offset: 351}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView272 = texture15.createView({aspect: 'all'});
+let sampler181 = device0.createSampler({
+  label: '\u098f\u8bb2\u{1fbbf}\u{1f85d}\u01f0\u6562\ubb9e',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 84.66,
+  lodMaxClamp: 87.25,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder221.setBindGroup(2, bindGroup96, []);
+} catch {}
+try {
+computePassEncoder225.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder82.setBindGroup(2, bindGroup88);
+} catch {}
+try {
+renderPassEncoder71.beginOcclusionQuery(89);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer187, 2688, new Float32Array(14606), 4603, 680);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let buffer204 = device0.createBuffer({size: 15479, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let querySet34 = device0.createQuerySet({type: 'occlusion', count: 97});
+let textureView273 = texture276.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+renderPassEncoder76.setIndexBuffer(buffer157, 'uint16', 316, 177);
+} catch {}
+let offscreenCanvas7 = new OffscreenCanvas(9, 33);
+let buffer205 = device0.createBuffer({
+  size: 6127,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder139.setBindGroup(3, bindGroup61, new Uint32Array(372), 14, 0);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(1, bindGroup116, new Uint32Array(5339), 631, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+renderPassEncoder98.pushDebugGroup('\u3d00');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 560, height: 582, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData22,
+  origin: { x: 5, y: 2 },
+  flipY: true,
+}, {
+  texture: texture191,
+  mipLevel: 0,
+  origin: {x: 81, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext13 = offscreenCanvas7.getContext('webgpu');
+try {
+  await promise25;
+} catch {}
+let img5 = await imageWithData(3, 5, '#10101010', '#20202020');
+let bindGroup183 = device0.createBindGroup({
+  layout: bindGroupLayout0,
+  entries: [{binding: 176, resource: textureView158}, {binding: 103, resource: textureView3}],
+});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({label: '\ud69b\u450b\u04e7\u0e9f', colorFormats: ['rgba16uint'], stencilReadOnly: true});
+let renderBundle32 = renderBundleEncoder32.finish({});
+try {
+computePassEncoder180.setBindGroup(1, bindGroup70);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup172, new Uint32Array(2348), 5, 0);
+} catch {}
+try {
+renderPassEncoder71.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder98.popDebugGroup();
+} catch {}
+let bindGroupLayout39 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 164,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let buffer206 = device0.createBuffer({
+  size: 18865,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView274 = texture219.createView({});
+let texture283 = device0.createTexture({
+  size: {width: 220, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView275 = texture124.createView({});
+let sampler182 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 81.34,
+  lodMaxClamp: 83.95,
+});
+try {
+computePassEncoder81.setBindGroup(1, bindGroup162, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder222); computePassEncoder222.dispatchWorkgroupsIndirect(buffer70, 5_440); };
+} catch {}
+try {
+computePassEncoder151.end();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 48, new BigUint64Array(10074), 679, 28);
+} catch {}
+let bindGroup184 = device0.createBindGroup({
+  layout: bindGroupLayout30,
+  entries: [
+    {binding: 566, resource: externalTexture22},
+    {binding: 577, resource: textureView197},
+    {binding: 86, resource: {buffer: buffer85, offset: 256, size: 2320}},
+    {binding: 517, resource: textureView232},
+  ],
+});
+let buffer207 = device0.createBuffer({size: 14611, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let textureView276 = texture164.createView({});
+let computePassEncoder226 = commandEncoder189.beginComputePass({});
+try {
+computePassEncoder103.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+computePassEncoder213.end();
+} catch {}
+try {
+renderPassEncoder88.setVertexBuffer(2, buffer67, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let computePassEncoder227 = commandEncoder83.beginComputePass({});
+try {
+renderPassEncoder47.setBindGroup(2, bindGroup26, new Uint32Array(874), 166, 0);
+} catch {}
+try {
+renderPassEncoder64.setVertexBuffer(5, buffer98, 304, 722);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup185 = device0.createBindGroup({
+  layout: bindGroupLayout17,
+  entries: [{binding: 78, resource: sampler101}, {binding: 113, resource: textureView109}],
+});
+let buffer208 = device0.createBuffer({
+  size: 4861,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView277 = texture247.createView({});
+try {
+computePassEncoder49.setBindGroup(1, bindGroup113, new Uint32Array(490), 73, 0);
+} catch {}
+try {
+renderPassEncoder65.setViewport(1.1399012560514805, 0.4273462549858461, 36.86398102250775, 0.2979116630516998, 0.11785049518388468, 0.7154620367500557);
+} catch {}
+try {
+renderPassEncoder83.setPipeline(pipeline1);
+} catch {}
+try {
+globalThis.someLabel = texture42.label;
+} catch {}
+let bindGroup186 = device0.createBindGroup({
+  label: '\u04e0\u{1fb91}\u92cf\u0dbe\u{1f728}\u0a7e\u0e81\u{1fdb7}\u2fe6\u{1f83f}\u{1fa9d}',
+  layout: bindGroupLayout16,
+  entries: [{binding: 0, resource: {buffer: buffer200, offset: 0, size: 3676}}],
+});
+try {
+computePassEncoder202.setBindGroup(0, bindGroup95, new Uint32Array(626), 101, 0);
+} catch {}
+try {
+renderPassEncoder101.setBindGroup(0, bindGroup142);
+} catch {}
+try {
+buffer87.unmap();
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let textureView278 = texture202.createView({});
+try {
+computePassEncoder217.setBindGroup(2, bindGroup89, new Uint32Array(1476), 106, 0);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(0, bindGroup114);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint8Array(22_806).fill(90), /* required buffer size: 22_806 */
+{offset: 82, bytesPerRow: 26, rowsPerImage: 46}, {width: 0, height: 0, depthOrArrayLayers: 20});
+} catch {}
+try {
+  await promise27;
+} catch {}
+let imageData37 = new ImageData(32, 16);
+let sampler183 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 32.20,
+  lodMaxClamp: 46.71,
+});
+try {
+computePassEncoder90.setBindGroup(2, bindGroup150, new Uint32Array(296), 90, 0);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(1, bindGroup158, new Uint32Array(445), 86, 0);
+} catch {}
+try {
+renderPassEncoder50.executeBundles([renderBundle0, renderBundle26]);
+} catch {}
+try {
+renderPassEncoder76.setIndexBuffer(buffer192, 'uint16', 92, 864);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer81, 1284, new DataView(new ArrayBuffer(20431)), 5781, 1208);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup84, new Uint32Array(135), 8, 0);
+} catch {}
+try {
+renderPassEncoder15.setScissorRect(5, 2, 3, 15);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 80, new Float32Array(32394), 526, 80);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 47, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(174).fill(13), /* required buffer size: 174 */
+{offset: 174}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture14.label = '\u8ddd\udf8a\u3503';
+} catch {}
+let textureView279 = texture84.createView({format: 'rgb10a2uint', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+renderPassEncoder96.setIndexBuffer(buffer201, 'uint16', 224, 237);
+} catch {}
+try {
+if (!arrayBuffer22.detached) { new Uint8Array(arrayBuffer22).fill(0x55); };
+} catch {}
+let buffer209 = device0.createBuffer({
+  size: 11749,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture284 = device0.createTexture({
+  label: '\u0b98\ufcab\ub8cc\u6a6e\uef75\u422d\uf033\ub20d\u91f9\u0082',
+  size: {width: 220},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView280 = texture130.createView({label: '\u4fd8\u0a72\u0afc\u7080', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 2});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint'], depthReadOnly: true, stencilReadOnly: true});
+let sampler184 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 7.902,
+  lodMaxClamp: 29.62,
+});
+try {
+computePassEncoder177.end();
+} catch {}
+try {
+computePassEncoder227.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder96.setBindGroup(2, bindGroup139);
+} catch {}
+try {
+renderPassEncoder84.end();
+} catch {}
+try {
+renderPassEncoder99.setVertexBuffer(4, buffer51, 652, 285);
+} catch {}
+try {
+commandEncoder229.clearBuffer(buffer49);
+} catch {}
+let bindGroup187 = device0.createBindGroup({
+  layout: bindGroupLayout32,
+  entries: [
+    {binding: 157, resource: textureView57},
+    {binding: 143, resource: textureView258},
+    {binding: 193, resource: textureView22},
+    {binding: 911, resource: textureView239},
+    {binding: 178, resource: textureView246},
+    {binding: 18, resource: textureView57},
+  ],
+});
+let computePassEncoder228 = commandEncoder220.beginComputePass({});
+let renderBundle33 = renderBundleEncoder33.finish({label: '\u0b30\ufcab\u0d5e\ued34\u2314\u{1fc81}'});
+try {
+computePassEncoder222.end();
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle1, renderBundle1]);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let renderPassEncoder105 = commandEncoder7.beginRenderPass({
+  colorAttachments: [{
+  view: textureView197,
+  clearValue: { r: 110.3, g: 655.7, b: 200.9, a: -660.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder54.setBindGroup(0, bindGroup25, new Uint32Array(597), 13, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder106); computePassEncoder106.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup40);
+} catch {}
+let texture285 = device0.createTexture({
+  size: [110, 10, 43],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture286 = gpuCanvasContext4.getCurrentTexture();
+let computePassEncoder229 = commandEncoder229.beginComputePass();
+let sampler185 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMinClamp: 46.24, lodMaxClamp: 49.65});
+try {
+computePassEncoder76.setBindGroup(2, bindGroup43);
+} catch {}
+try {
+computePassEncoder122.setBindGroup(2, bindGroup138, new Uint32Array(424), 111, 0);
+} catch {}
+try {
+renderPassEncoder78.setBindGroup(1, bindGroup103, new Uint32Array(44), 5, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture216,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 7},
+  aspect: 'all',
+}, new Uint8Array(576_586).fill(12), /* required buffer size: 576_586 */
+{offset: 269, bytesPerRow: 119, rowsPerImage: 167}, {width: 0, height: 0, depthOrArrayLayers: 30});
+} catch {}
+canvas5.height = 2759;
+let textureView281 = texture110.createView({mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder106.end();
+} catch {}
+try {
+computePassEncoder226.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder74.setStencilReference(85);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 1, depthOrArrayLayers: 262}
+*/
+{
+  source: imageData9,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture279,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 25},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let computePassEncoder230 = commandEncoder146.beginComputePass({});
+try {
+computePassEncoder158.setBindGroup(2, bindGroup56, []);
+} catch {}
+try {
+computePassEncoder76.setBindGroup(0, bindGroup74, new Uint32Array(232), 21, 0);
+} catch {}
+try {
+computePassEncoder230.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder50.setIndexBuffer(buffer13, 'uint16', 510, 76);
+} catch {}
+try {
+renderPassEncoder104.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+if (!arrayBuffer23.detached) { new Uint8Array(arrayBuffer23).fill(0x55); };
+} catch {}
+let pipelineLayout14 = device0.createPipelineLayout({bindGroupLayouts: []});
+let querySet35 = device0.createQuerySet({type: 'occlusion', count: 465});
+try {
+computePassEncoder146.setBindGroup(0, bindGroup143);
+} catch {}
+try {
+computePassEncoder228.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder100.setVertexBuffer(0, buffer83, 3_684, 4_234);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let texture287 = device0.createTexture({
+  size: [280],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView282 = texture138.createView({label: '\u9f85\ueb7f\u72c8\u641a', baseArrayLayer: 4, arrayLayerCount: 3});
+let sampler186 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 46.12,
+  lodMaxClamp: 97.66,
+});
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+renderPassEncoder54.beginOcclusionQuery(25);
+} catch {}
+try {
+renderPassEncoder54.endOcclusionQuery();
+} catch {}
+try {
+  await promise26;
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(0, bindGroup33, new Uint32Array(1065), 208, 0);
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer42, 'uint16', 270, 193);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup188 = device0.createBindGroup({
+  layout: bindGroupLayout22,
+  entries: [
+    {binding: 337, resource: textureView35},
+    {binding: 178, resource: textureView108},
+    {binding: 298, resource: {buffer: buffer50, offset: 256, size: 328}},
+    {binding: 44, resource: {buffer: buffer132, offset: 0, size: 488}},
+    {binding: 75, resource: externalTexture9},
+    {binding: 244, resource: externalTexture1},
+    {binding: 132, resource: {buffer: buffer128, offset: 2816, size: 212}},
+    {binding: 31, resource: textureView184},
+    {binding: 265, resource: sampler131},
+    {binding: 304, resource: textureView180},
+    {binding: 29, resource: sampler51},
+    {binding: 4, resource: {buffer: buffer175, offset: 512, size: 443}},
+    {binding: 159, resource: {buffer: buffer100, offset: 256, size: 20}},
+  ],
+});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({
+  label: '\u0b9f\u1d92\uc467\u0cc6\u0658\u9bbe\u0b80\u0b5e',
+  colorFormats: ['rgba16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder109.setBindGroup(1, bindGroup117, new Uint32Array(423), 6, 0);
+} catch {}
+try {
+computePassEncoder229.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder69.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipelineLayout15 = device0.createPipelineLayout({label: '\u0da6\ub4b5\u8c77\u0ffe\u{1f6ee}\ud668', bindGroupLayouts: []});
+let querySet36 = device0.createQuerySet({type: 'occlusion', count: 199});
+let renderBundle34 = renderBundleEncoder34.finish({});
+try {
+computePassEncoder225.setBindGroup(1, bindGroup75);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder76); computePassEncoder76.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder105.setIndexBuffer(buffer126, 'uint16', 2_416, 6);
+} catch {}
+try {
+renderPassEncoder74.setVertexBuffer(3, buffer192);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let promise28 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule13,
+  entryPoint: 'fragment9',
+  targets: [{format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule18,
+    constants: {override12: 0},
+    buffers: [
+      {
+        arrayStride: 64,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 0, shaderLocation: 13},
+          {format: 'uint16x2', offset: 36, shaderLocation: 12},
+          {format: 'float32', offset: 8, shaderLocation: 1},
+          {format: 'float32x3', offset: 8, shaderLocation: 14},
+          {format: 'sint32x2', offset: 24, shaderLocation: 15},
+          {format: 'sint32x2', offset: 0, shaderLocation: 11},
+          {format: 'sint32x3', offset: 4, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 52,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 0, shaderLocation: 2}],
+      },
+    ],
+  },
+});
+document.body.append(img0);
+let buffer210 = device0.createBuffer({
+  size: 9782,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture288 = device0.createTexture({
+  label: '\u96c1\u3df0\u5a3d\u014d',
+  size: [295],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder20.setStencilReference(522);
+} catch {}
+try {
+renderPassEncoder94.setVertexBuffer(3, buffer115, 0, 54);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(158).fill(33), /* required buffer size: 158 */
+{offset: 158, bytesPerRow: 214}, {width: 38, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData38 = new ImageData(8, 116);
+let pipelineLayout16 = device0.createPipelineLayout({bindGroupLayouts: []});
+let sampler187 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 99.12,
+  lodMaxClamp: 99.53,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder76); computePassEncoder76.dispatchWorkgroupsIndirect(buffer210, 560); };
+} catch {}
+try {
+renderPassEncoder55.setIndexBuffer(buffer52, 'uint32', 236, 224);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline1);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+let texture289 = device0.createTexture({size: [96, 1, 37], format: 'rgb10a2unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView283 = texture273.createView({dimension: '2d', baseMipLevel: 3, mipLevelCount: 1, baseArrayLayer: 16});
+try {
+computePassEncoder62.setBindGroup(3, bindGroup86);
+} catch {}
+try {
+computePassEncoder98.setBindGroup(0, bindGroup121, new Uint32Array(605), 106, 0);
+} catch {}
+try {
+renderPassEncoder101.setIndexBuffer(buffer26, 'uint16', 546, 174);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline1);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline8 = await device0.createComputePipelineAsync({layout: pipelineLayout12, compute: {module: shaderModule19}});
+let texture290 = device0.createTexture({
+  size: [36, 1, 1],
+  mipLevelCount: 4,
+  dimension: '2d',
+  format: 'depth24plus',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder96.setBindGroup(1, bindGroup142, new Uint32Array(315), 42, 0);
+} catch {}
+await gc();
+let buffer211 = device0.createBuffer({size: 1852, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture291 = device0.createTexture({
+  size: [560, 582, 1],
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler188 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMinClamp: 26.26,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder76); computePassEncoder76.dispatchWorkgroups(3, 1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder76); computePassEncoder76.dispatchWorkgroupsIndirect(buffer206, 1_692); };
+} catch {}
+try {
+computePassEncoder149.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder78.setBindGroup(1, bindGroup23, new Uint32Array(413), 7, 0);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle4, renderBundle15, renderBundle10, renderBundle28, renderBundle10, renderBundle21, renderBundle15]);
+} catch {}
+try {
+renderPassEncoder20.pushDebugGroup('\ubfd6');
+} catch {}
+try {
+renderPassEncoder20.popDebugGroup();
+} catch {}
+let textureView284 = texture131.createView({label: '\u{1fb29}\u0d36\u7a83\uc302', aspect: 'all', mipLevelCount: 1});
+try {
+computePassEncoder165.setBindGroup(1, bindGroup127, new Uint32Array(1823), 315, 0);
+} catch {}
+try {
+renderPassEncoder52.beginOcclusionQuery(126);
+} catch {}
+let texture292 = device0.createTexture({
+  size: {width: 440, height: 40, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler189 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMinClamp: 95.44,
+  lodMaxClamp: 97.65,
+});
+try {
+computePassEncoder76.end();
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer21, 'uint32', 1_576, 379);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer146, 236, new BigUint64Array(16551), 2378, 4);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 32}
+*/
+{
+  source: imageData8,
+  origin: { x: 2, y: 7 },
+  flipY: false,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let buffer212 = device0.createBuffer({
+  label: '\u{1f873}\u0495\u0a3f',
+  size: 19863,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let commandBuffer16 = commandEncoder102.finish();
+let sampler190 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 39.99,
+  lodMaxClamp: 98.24,
+  compare: 'less-equal',
+});
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture134,
+  mipLevel: 1,
+  origin: {x: 40, y: 0, z: 10},
+  aspect: 'all',
+}, new Uint8Array(103).fill(176), /* required buffer size: 103 */
+{offset: 103, bytesPerRow: 14, rowsPerImage: 0}, {width: 0, height: 0, depthOrArrayLayers: 4});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 36, height: 1, depthOrArrayLayers: 20}
+*/
+{
+  source: imageData0,
+  origin: { x: 3, y: 1 },
+  flipY: true,
+}, {
+  texture: texture174,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer213 = device0.createBuffer({
+  size: 5424,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder272 = device0.createCommandEncoder({label: '\u{1ff36}\u{1f75f}'});
+let texture293 = device0.createTexture({
+  size: [280, 291, 1],
+  mipLevelCount: 4,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup90, new Uint32Array(3428), 7, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 70, height: 72, depthOrArrayLayers: 25}
+*/
+{
+  source: imageData35,
+  origin: { x: 2, y: 2 },
+  flipY: false,
+}, {
+  texture: texture194,
+  mipLevel: 0,
+  origin: {x: 13, y: 1, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 19, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = sampler115.label;
+} catch {}
+let buffer214 = device0.createBuffer({
+  size: 2476,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder231 = commandEncoder272.beginComputePass({});
+let sampler191 = device0.createSampler({
+  label: '\u{1fbae}\u0d5f\u2ddd\u0eb3\u0a45\u01bf\u0f5b\u895f\u04e0\u8614\u0330',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 78.62,
+  lodMaxClamp: 78.69,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder231.setPipeline(pipeline0);
+} catch {}
+document.body.append(canvas2);
+let bindGroup189 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [{binding: 27, resource: {buffer: buffer23, offset: 256, size: 7806}}],
+});
+let texture294 = device0.createTexture({
+  label: '\u033d\u06e0\u03c4\u258f\u{1f93a}\u7278\u7882',
+  size: {width: 560, height: 582, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder88.setBindGroup(1, bindGroup171);
+} catch {}
+try {
+computePassEncoder206.setBindGroup(3, bindGroup86, new Uint32Array(934), 169, 0);
+} catch {}
+try {
+renderPassEncoder102.setBindGroup(0, bindGroup57);
+} catch {}
+try {
+renderPassEncoder88.setBindGroup(2, bindGroup35, new Uint32Array(618), 218, 0);
+} catch {}
+try {
+renderPassEncoder52.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(0, buffer72, 0, 1_226);
+} catch {}
+try {
+device0.queue.submit([commandBuffer16]);
+} catch {}
+try {
+computePassEncoder63.setBindGroup(1, bindGroup139);
+} catch {}
+try {
+computePassEncoder184.setBindGroup(0, bindGroup47, new Uint32Array(150), 2, 0);
+} catch {}
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], stencilReadOnly: false});
+try {
+computePassEncoder80.setBindGroup(3, bindGroup116, new Uint32Array(1170), 518, 0);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(2, buffer115, 92, 26);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(0, bindGroup183, new Uint32Array(3901), 139, 0);
+} catch {}
+let buffer215 = device0.createBuffer({size: 13435, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture295 = device0.createTexture({size: [110], mipLevelCount: 1, dimension: '1d', format: 'rgba16sint', usage: GPUTextureUsage.COPY_SRC});
+let textureView285 = texture93.createView({label: '\u6b7a\uaacc\ub517', dimension: '2d-array'});
+try {
+computePassEncoder87.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+computePassEncoder217.setBindGroup(1, bindGroup58, new Uint32Array(5361), 386, 0);
+} catch {}
+try {
+renderPassEncoder65.setBlendConstant({ r: 281.9, g: 703.5, b: 700.5, a: -766.5, });
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer105, 'uint16', 250, 268);
+} catch {}
+try {
+renderPassEncoder103.setVertexBuffer(0, buffer140, 5_856, 229);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(3, bindGroup73, new Uint32Array(150), 30, 0);
+} catch {}
+document.body.prepend(canvas7);
+let bindGroup190 = device0.createBindGroup({
+  layout: bindGroupLayout18,
+  entries: [{binding: 116, resource: sampler100}, {binding: 204, resource: externalTexture3}],
+});
+let texture296 = device0.createTexture({
+  size: {width: 110},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder119.setBindGroup(1, bindGroup145, new Uint32Array(36), 3, 0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup14, new Uint32Array(1179), 53, 0);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(0, bindGroup93);
+} catch {}
+let arrayBuffer24 = buffer74.getMappedRange(232, 20);
+try {
+device0.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(193).fill(221), /* required buffer size: 193 */
+{offset: 193}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+document.body.append(img1);
+await gc();
+try {
+computePassEncoder52.setBindGroup(2, bindGroup91);
+} catch {}
+try {
+computePassEncoder202.setBindGroup(0, bindGroup8, new Uint32Array(1964), 266, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder202); computePassEncoder202.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer139, 'uint32', 1_476, 2_719);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let bindGroupLayout40 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 423,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 311,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 166,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 113,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 283,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let textureView286 = texture157.createView({});
+try {
+renderPassEncoder63.setBindGroup(0, bindGroup76);
+} catch {}
+try {
+renderPassEncoder85.setVertexBuffer(2, buffer196, 0, 7_941);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(2, buffer2, 936, 12);
+} catch {}
+try {
+textureView34.label = '\u7931\u{1fb93}\u0f51';
+} catch {}
+let texture297 = device0.createTexture({
+  size: [220, 20, 1],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder45.beginOcclusionQuery(2);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(1, buffer173, 0, 23);
+} catch {}
+let renderBundle35 = renderBundleEncoder35.finish({});
+let sampler192 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 17.11,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder202); computePassEncoder202.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder45.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer21, 'uint16', 1_644, 1_122);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 5, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(20).fill(47), /* required buffer size: 20 */
+{offset: 20, bytesPerRow: 143}, {width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder84.setBindGroup(0, bindGroup12, new Uint32Array(5605), 3_806, 0);
+} catch {}
+try {
+computePassEncoder202.end();
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(2, buffer205, 364, 755);
+} catch {}
+let bindGroup191 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 53, resource: externalTexture13},
+    {binding: 54, resource: {buffer: buffer106, offset: 0, size: 1128}},
+  ],
+});
+let textureView287 = texture92.createView({label: '\ua74c\ub02b', dimension: '2d-array'});
+let externalTexture29 = device0.importExternalTexture({source: videoFrame31});
+try {
+computePassEncoder148.setBindGroup(0, bindGroup126, new Uint32Array(218), 3, 0);
+} catch {}
+try {
+renderPassEncoder86.executeBundles([renderBundle32]);
+} catch {}
+try {
+commandEncoder248.copyTextureToTexture({
+  texture: texture179,
+  mipLevel: 0,
+  origin: {x: 114, y: 5, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture95,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise29;
+} catch {}
+let texture298 = device0.createTexture({
+  label: '\u0fee\ufe03\u38bc\uc35a\u314a\u09e3',
+  size: [70],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler193 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 14.89,
+  lodMaxClamp: 72.93,
+  maxAnisotropy: 9,
+});
+try {
+renderPassEncoder77.beginOcclusionQuery(236);
+} catch {}
+try {
+renderPassEncoder77.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder248.clearBuffer(buffer112, 3568, 2884);
+} catch {}
+let texture299 = device0.createTexture({
+  label: '\u0f0a\u02fb\u9882\u{1ff5b}\ucf2c\u6cd1\u04aa\u{1f803}\u0e8c',
+  size: {width: 220, height: 20, depthOrArrayLayers: 34},
+  mipLevelCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder106 = commandEncoder248.beginRenderPass({
+  colorAttachments: [{
+  view: textureView173,
+  depthSlice: 34,
+  clearValue: { r: -749.8, g: -980.5, b: -216.7, a: -305.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 11643662,
+});
+try {
+computePassEncoder139.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder94.executeBundles([renderBundle35]);
+} catch {}
+try {
+renderPassEncoder68.setIndexBuffer(buffer15, 'uint32', 508, 270);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.append(img4);
+let texture300 = device0.createTexture({
+  size: {width: 560, height: 582, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder122.setBindGroup(3, bindGroup81);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 36, height: 1, depthOrArrayLayers: 20}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture174,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroupLayout41 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 230,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '2d' },
+    },
+    {
+      binding: 53,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 355,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32uint', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let texture301 = device0.createTexture({
+  label: '\ucab8\u63d9\u0f61\udd04\u{1f728}\u3e74\u9ca5\ub734\ub09f',
+  size: [140, 145, 1],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder194.setBindGroup(2, bindGroup8, new Uint32Array(855), 155, 0);
+} catch {}
+let buffer216 = device0.createBuffer({
+  size: 10009,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture302 = device0.createTexture({
+  size: [220, 20, 1],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder196.setBindGroup(3, bindGroup128);
+} catch {}
+try {
+renderPassEncoder85.executeBundles([renderBundle22, renderBundle22, renderBundle24, renderBundle24, renderBundle6, renderBundle32]);
+} catch {}
+try {
+renderPassEncoder79.setIndexBuffer(buffer203, 'uint32', 636, 548);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(2, buffer28, 0, 314);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let textureView288 = texture302.createView({baseArrayLayer: 0});
+let textureView289 = texture265.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let sampler194 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 54.01,
+  lodMaxClamp: 86.44,
+});
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(2, buffer87, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 36, height: 1, depthOrArrayLayers: 20}
+*/
+{
+  source: videoFrame31,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture174,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture303 = device0.createTexture({
+  size: [140, 145, 229],
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture304 = device0.createTexture({
+  size: {width: 140},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView290 = texture90.createView({dimension: '3d', mipLevelCount: 1});
+try {
+computePassEncoder171.setBindGroup(2, bindGroup111, []);
+} catch {}
+try {
+renderPassEncoder42.pushDebugGroup('\u0c2f');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 64, height: 64, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData12,
+  origin: { x: 3, y: 1 },
+  flipY: true,
+}, {
+  texture: texture277,
+  mipLevel: 0,
+  origin: {x: 3, y: 3, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture305 = device0.createTexture({
+  label: '\u05eb\u5785\u04e9\u1a01',
+  size: [36, 1, 54],
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView291 = texture169.createView({});
+try {
+computePassEncoder193.setBindGroup(0, bindGroup126);
+} catch {}
+try {
+computePassEncoder209.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer16, 'uint16', 5_084, 125);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(6, buffer160);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture126,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(779).fill(104), /* required buffer size: 779 */
+{offset: 140, bytesPerRow: 71, rowsPerImage: 9}, {width: 5, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let textureView292 = texture303.createView({dimension: '3d', format: 'rg32uint', baseArrayLayer: 0});
+let textureView293 = texture26.createView({dimension: '2d-array', baseMipLevel: 0, baseArrayLayer: 0});
+try {
+computePassEncoder214.setBindGroup(2, bindGroup184);
+} catch {}
+try {
+computePassEncoder52.setBindGroup(3, bindGroup124, new Uint32Array(278), 7, 0);
+} catch {}
+try {
+renderPassEncoder67.setBindGroup(0, bindGroup95);
+} catch {}
+try {
+renderPassEncoder69.setBindGroup(1, bindGroup140, new Uint32Array(1719), 257, 0);
+} catch {}
+try {
+renderPassEncoder106.executeBundles([renderBundle21]);
+} catch {}
+try {
+renderPassEncoder103.setVertexBuffer(4, buffer83, 12_404);
+} catch {}
+try {
+  await buffer29.mapAsync(GPUMapMode.WRITE);
+} catch {}
+let texture306 = device0.createTexture({
+  size: [280, 291, 1],
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView294 = texture255.createView({baseMipLevel: 0, mipLevelCount: 1});
+let externalTexture30 = device0.importExternalTexture({source: videoFrame2});
+try {
+computePassEncoder119.setBindGroup(1, bindGroup60);
+} catch {}
+try {
+computePassEncoder179.setBindGroup(1, bindGroup40, new Uint32Array(3642), 201, 0);
+} catch {}
+try {
+renderPassEncoder90.setBindGroup(2, bindGroup151, [0]);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup128, new Uint32Array(1173), 261, 0);
+} catch {}
+try {
+renderPassEncoder91.setIndexBuffer(buffer16, 'uint32', 772, 1_078);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(4, buffer56, 4_536, 1_404);
+} catch {}
+try {
+computePassEncoder150.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder74.setBindGroup(1, bindGroup189, new Uint32Array(930), 256, 0);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer189, 'uint16', 174, 3_716);
+} catch {}
+try {
+renderPassEncoder78.setVertexBuffer(0, buffer208, 0);
+} catch {}
+try {
+  await shaderModule10.getCompilationInfo();
+} catch {}
+document.body.prepend(canvas2);
+let textureView295 = texture74.createView({mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 1});
+try {
+renderPassEncoder104.setBindGroup(2, bindGroup43);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer149, 1824, new Int16Array(391), 1, 84);
+} catch {}
+let textureView296 = texture3.createView({});
+let sampler195 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 24.64,
+  lodMaxClamp: 60.00,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder109.setBindGroup(2, bindGroup173);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup70);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup184, new Uint32Array(744), 61, 0);
+} catch {}
+try {
+renderPassEncoder42.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 36, height: 1, depthOrArrayLayers: 177}
+*/
+{
+  source: offscreenCanvas7,
+  origin: { x: 2, y: 9 },
+  flipY: false,
+}, {
+  texture: texture216,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup192 = device0.createBindGroup({
+  label: '\u01f3\ubf5d\u0f80\u131e\u278d\u8169',
+  layout: bindGroupLayout17,
+  entries: [{binding: 78, resource: sampler128}, {binding: 113, resource: textureView107}],
+});
+let textureView297 = texture73.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 18});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle36 = renderBundleEncoder36.finish({});
+try {
+buffer108.unmap();
+} catch {}
+try {
+computePassEncoder163.insertDebugMarker('\u{1fcb1}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(251).fill(217), /* required buffer size: 251 */
+{offset: 251}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer19.detached) { new Uint8Array(arrayBuffer19).fill(0x55); };
+} catch {}
+await gc();
+let imageBitmap7 = await createImageBitmap(imageData23);
+let pipelineLayout17 = device0.createPipelineLayout({bindGroupLayouts: []});
+let textureView298 = texture222.createView({});
+let sampler196 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 99.09,
+  lodMaxClamp: 99.14,
+  compare: 'less',
+});
+try {
+computePassEncoder89.setBindGroup(3, bindGroup138, new Uint32Array(1475), 381, 0);
+} catch {}
+try {
+renderPassEncoder74.setStencilReference(226);
+} catch {}
+document.body.prepend(canvas1);
+let textureView299 = texture182.createView({dimension: 'cube-array', baseArrayLayer: 4, arrayLayerCount: 6});
+try {
+renderPassEncoder65.setIndexBuffer(buffer173, 'uint32', 324, 122);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(4, buffer59, 804);
+} catch {}
+try {
+buffer188.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 3,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(464).fill(69), /* required buffer size: 464 */
+{offset: 464}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas5,
+  origin: { x: 7, y: 338 },
+  flipY: true,
+}, {
+  texture: texture276,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup193 = device0.createBindGroup({layout: bindGroupLayout37, entries: [{binding: 29, resource: textureView266}]});
+let textureView300 = texture105.createView({});
+let texture307 = gpuCanvasContext9.getCurrentTexture();
+let textureView301 = texture161.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+renderPassEncoder18.setIndexBuffer(buffer128, 'uint16', 722, 905);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup194 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [{binding: 511, resource: {buffer: buffer37, offset: 256, size: 204}}],
+});
+let querySet37 = device0.createQuerySet({type: 'occlusion', count: 734});
+try {
+renderPassEncoder5.setIndexBuffer(buffer10, 'uint32', 2_160, 1_932);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1, depthOrArrayLayers: 78}
+*/
+{
+  source: videoFrame31,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture270,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = querySet6.label;
+} catch {}
+let externalTexture31 = device0.importExternalTexture({label: '\ubf74\u{1ff38}\u50fa\u0718\u0a9d', source: videoFrame3, colorSpace: 'srgb'});
+try {
+computePassEncoder163.setBindGroup(1, bindGroup121, new Uint32Array(703), 23, 0);
+} catch {}
+try {
+renderPassEncoder85.setVertexBuffer(2, buffer184);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+buffer107.unmap();
+} catch {}
+let bindGroup195 = device0.createBindGroup({
+  layout: bindGroupLayout2,
+  entries: [
+    {binding: 42, resource: externalTexture6},
+    {binding: 35, resource: textureView118},
+    {binding: 94, resource: textureView261},
+    {binding: 243, resource: textureView57},
+    {binding: 421, resource: {buffer: buffer37, offset: 512, size: 776}},
+    {binding: 398, resource: textureView222},
+    {binding: 567, resource: textureView140},
+    {binding: 132, resource: textureView48},
+    {binding: 999, resource: textureView166},
+  ],
+});
+let textureView302 = texture303.createView({baseMipLevel: 0});
+let textureView303 = texture72.createView({});
+try {
+computePassEncoder99.setBindGroup(0, bindGroup131, []);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(2, bindGroup86);
+} catch {}
+try {
+renderPassEncoder39.executeBundles([renderBundle26]);
+} catch {}
+document.body.append(canvas0);
+let buffer217 = device0.createBuffer({
+  size: 87,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder65.setBindGroup(2, bindGroup167);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup150, new Uint32Array(3848), 448, 0);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer209, 'uint32', 2_916, 159);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer109, 656, new Float32Array(10707), 486, 60);
+} catch {}
+try {
+globalThis.someLabel = bindGroup7.label;
+} catch {}
+let buffer218 = device0.createBuffer({
+  label: '\u{1fab4}\u5cd3\u117f\u8261\u9464\u{1fff2}\u11b9\u{1f865}\u{1f860}\u7904\u{1f64a}',
+  size: 2033,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let texture308 = device0.createTexture({
+  size: [96, 1, 58],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler197 = device0.createSampler({
+  label: '\u07b2\u0e33\u{1fb62}\u{1fb9f}\u0add\u9a00\u308d\u{1fcf5}\ua9e2',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 85.25,
+  lodMaxClamp: 96.62,
+});
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup40);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle19]);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 54}
+*/
+{
+  source: videoFrame22,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame47 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'smpteRp431', transfer: 'bt1361ExtendedColourGamut'} });
+let buffer219 = device0.createBuffer({
+  size: 20697,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let textureView304 = texture219.createView({dimension: '2d-array', aspect: 'all', mipLevelCount: 1});
+let promise30 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let bindGroup196 = device0.createBindGroup({layout: bindGroupLayout24, entries: [{binding: 52, resource: sampler139}]});
+let buffer220 = device0.createBuffer({
+  label: '\ud521\u{1fc3e}',
+  size: 5582,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder139.setBindGroup(1, bindGroup105, new Uint32Array(441), 83, 0);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle22, renderBundle32]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout42 = device0.createBindGroupLayout({
+  label: '\u3fcb\u{1ffe9}\uce4a\u027a\u61e2\u{1f9cb}',
+  entries: [{binding: 224, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }}],
+});
+let bindGroup197 = device0.createBindGroup({
+  layout: bindGroupLayout19,
+  entries: [{binding: 361, resource: {buffer: buffer120, offset: 256, size: 828}}],
+});
+let texture309 = device0.createTexture({
+  size: {width: 70, height: 72, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let sampler198 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 85.38,
+  lodMaxClamp: 96.55,
+});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+renderPassEncoder97.setBindGroup(1, bindGroup19, new Uint32Array(134), 9, 0);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer114, 920, new Float32Array(55108), 19132, 0);
+} catch {}
+let buffer221 = device0.createBuffer({size: 50418, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let querySet38 = device0.createQuerySet({type: 'occlusion', count: 530});
+let sampler199 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 84.71,
+  lodMaxClamp: 89.72,
+});
+try {
+computePassEncoder146.setBindGroup(0, bindGroup61, new Uint32Array(3208), 668, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer161, 'uint16', 872, 1_530);
+} catch {}
+let bindGroup198 = device0.createBindGroup({
+  label: '\u03ce\u5d1c\u0305\ua0f4\u0287\ubb76\u7152\u736e\u{1fa57}',
+  layout: bindGroupLayout36,
+  entries: [{binding: 5, resource: textureView170}, {binding: 23, resource: externalTexture26}],
+});
+let textureView305 = texture72.createView({label: '\ue490\u0d5f\u0d8b\u51d2\u{1fa5a}', baseArrayLayer: 0});
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint']});
+let renderBundle37 = renderBundleEncoder37.finish({});
+try {
+computePassEncoder188.setBindGroup(3, bindGroup26, new Uint32Array(2683), 1_449, 0);
+} catch {}
+try {
+renderPassEncoder71.setIndexBuffer(buffer216, 'uint16', 3_608, 507);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture247,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 73},
+  aspect: 'all',
+}, new Uint8Array(1_454_151).fill(191), /* required buffer size: 1_454_151 */
+{offset: 174, bytesPerRow: 1029, rowsPerImage: 157}, {width: 121, height: 0, depthOrArrayLayers: 10});
+} catch {}
+let buffer222 = device0.createBuffer({
+  size: 1922,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture310 = device0.createTexture({size: [220], dimension: '1d', format: 'rgb10a2unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView306 = texture124.createView({});
+try {
+renderPassEncoder86.setVertexBuffer(4, buffer210, 0);
+} catch {}
+let promise31 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise30;
+} catch {}
+let texture311 = device0.createTexture({
+  size: {width: 96},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView307 = texture202.createView({baseArrayLayer: 0});
+let externalTexture32 = device0.importExternalTexture({source: videoFrame9});
+try {
+buffer162.unmap();
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+computePassEncoder211.setBindGroup(2, bindGroup142);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline1);
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 140, height: 145, depthOrArrayLayers: 239}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 1,
+  origin: {x: 11, y: 2, z: 89},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise31;
+} catch {}
+let texture312 = device0.createTexture({
+  size: {width: 36, height: 1, depthOrArrayLayers: 1},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView308 = texture278.createView({label: '\u0839\u022b', dimension: '1d'});
+try {
+renderPassEncoder54.executeBundles([renderBundle19]);
+} catch {}
+try {
+renderPassEncoder65.setIndexBuffer(buffer52, 'uint16', 12, 28);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline1);
+} catch {}
+let promise32 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 36, height: 1, depthOrArrayLayers: 177}
+*/
+{
+  source: imageData1,
+  origin: { x: 5, y: 2 },
+  flipY: false,
+}, {
+  texture: texture216,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 60},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView309 = texture215.createView({format: 'depth24plus', baseArrayLayer: 23, arrayLayerCount: 2});
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup145, new Uint32Array(250), 20, 0);
+} catch {}
+try {
+renderPassEncoder103.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline1);
+} catch {}
+await gc();
+let shaderModule21 = device0.createShaderModule({
+  label: '\u0831\ua3ee\u08f1',
+  code: `
+enable f16;
+
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(11) var<storage, read_write> buffer223: array<f16, 56>;
+
+struct T0 {
+  @align(16) @size(112) f0: array<atomic<i32>>,
+}
+
+struct VertexOutput20 {
+  @builtin(position) f61: vec4f,
+}
+
+struct FragmentOutput18 {
+  @location(0) f0: vec4f,
+  @builtin(frag_depth) f1: f32,
+}
+
+@id(29639) override override13 = false;
+
+@id(25765) override override14: f32;
+
+override override15: f16;
+
+var<workgroup> vw73: array<f16, 1>;
+
+var<workgroup> vw74: atomic<i32>;
+
+var<workgroup> vw75: f16;
+
+var<workgroup> vw76: vec4h;
+
+@vertex
+fn vertex21(@location(2) a0: vec4h, @location(7) @interpolate(flat) a1: vec2h, @location(13) @interpolate(flat) a2: i32) -> VertexOutput20 {
+  var out: VertexOutput20;
+  var vf462: vec4h = sign(vec4h(unconst_f16(11379.5), unconst_f16(17835.9), unconst_f16(4188.1), unconst_f16(8942.6)));
+  var vf463: f16 = a0[u32(unconst_u32(21))];
+  return out;
+}
+
+@fragment
+fn fragment20() -> FragmentOutput18 {
+  var out: FragmentOutput18;
+  let vf464: vec4f = unpack4x8snorm(u32(unconst_u32(50)));
+  out = FragmentOutput18(unpack4x8snorm(u32(unconst_u32(48))), unpack4x8snorm(u32(unconst_u32(48)))[2]);
+  let vf465: vec3i = max(vec3i(unconst_i32(85), unconst_i32(84), unconst_i32(54)), vec3i(unconst_i32(98), unconst_i32(209), unconst_i32(574)));
+  let vf466: bool = override13;
+  out.f1 = floor(saturate(vec2f(unconst_f32(0.3343), unconst_f32(0.1209))).xyy)[2];
+  let vf467: u32 = pack4x8unorm(vec4f(unconst_f32(0.03253), unconst_f32(-0.07423), unconst_f32(0.1958), unconst_f32(0.06364)));
+  let vf468: f32 = override14;
+  let vf469: bool = override13;
+  let vf470: i32 = vf465[u32(unconst_u32(341))];
+  out.f1 = saturate(vec2f(unconst_f32(0.02105), unconst_f32(0.5568)))[1];
+  let vf471: vec3i = max(vec3i(firstTrailingBit(i32(unconst_i32(48)))), vec3i(unconst_i32(171), unconst_i32(58), unconst_i32(-56)));
+  return out;
+  _ = override14;
+  _ = override13;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute20() {
+  let vf472: f32 = override14;
+  buffer223[u32(unconst_u32(31))] += buffer223[55];
+  let ptr157: ptr<workgroup, atomic<i32>> = &vw74;
+  var vf473: bool = override13;
+  vf473 = bool(buffer223[u32(unconst_u32(145))]);
+  vw76 = vec4h(vw73[u32(unconst_u32(364))]);
+  let ptr158: ptr<workgroup, atomic<i32>> = &(*&vw74);
+  buffer223[u32(unconst_u32(257))] -= f16(atomicExchange(&(*ptr158), i32(unconst_i32(435))));
+  buffer223[u32(unconst_u32(256))] = f16(atomicLoad(&(*&vw74)));
+  vw73[u32(unconst_u32(153))] = (*&buffer223)[55];
+  let vf474: f16 = vw76[u32(unconst_u32(301))];
+  let ptr159: ptr<storage, array<f16, 56>, read_write> = &(*&buffer223);
+  let vf475: i32 = atomicLoad(&(*&vw74));
+  _ = override13;
+  _ = override14;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder171.setBindGroup(0, bindGroup72);
+} catch {}
+try {
+computePassEncoder74.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(1, bindGroup160);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer83, 1_160, 14_110);
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame41.close();
+videoFrame42.close();
+videoFrame43.close();
+videoFrame44.close();
+videoFrame47.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -402,6 +402,8 @@ static void imageBytesForSource(const auto& sourceDescriptor, const auto& destin
         return getImageBytesFromImageBuffer(imageBitmap->buffer(), destination, needsPremultipliedAlpha, WTFMove(callback));
 #if ENABLE(VIDEO) && ENABLE(WEB_CODECS)
     }, [&](const RefPtr<ImageData> imageData) -> ResultType {
+        if (!imageData)
+            return callback({ }, 0, 0);
         callback(imageData->pixelBuffer()->bytes(), imageData->width(), imageData->height());
     }, [&](const RefPtr<HTMLImageElement> imageElement) -> ResultType {
 #if PLATFORM(COCOA)
@@ -990,7 +992,7 @@ ExceptionOr<void> GPUQueue::copyExternalImageToTexture(ScriptExecutionContext& c
         bool supportedFormat;
         auto newImageBytes = copyToDestinationFormat(imageBytes, destination.texture->format(), supportedFormat, rows, needsYFlip, needsPremultipliedAlpha, source.origin);
         uint32_t sourceX = 0, sourceY = 0;
-        auto widthInBytes = sizeInBytes / rows;
+        auto widthInBytes = (newImageBytes ? newImageBytes.sizeInBytes() : sizeInBytes) / rows;
         auto channels = widthInBytes / columns;
         GPUImageDataLayout dataLayout { 0, widthInBytes, rows };
 

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -515,14 +515,11 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
     }
 
     if (m_shaderModule.usesMin()) {
-        m_stringBuilder.append(m_indent, "template<typename T>\n"_s,
-            m_indent, "static T __attribute((always_inline)) __wgslMin(T a, T b)\n"_s,
+        m_stringBuilder.append(m_indent, "static uint __attribute((always_inline)) __wgslMin(uint a, uint b)\n"_s,
             m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "volatile T va = a;\n"_s,
-                m_indent, "volatile T vb = b;\n"_s,
-                m_indent, "return min(va, vb);\n"_s);
+            m_stringBuilder.append("return select(b, a, a < b);\n"_s);
         }
         m_stringBuilder.append(m_indent, "}\n\n"_s);
     }


### PR DESCRIPTION
#### d9758a8fd190860ac6c4a468dfdea906786530e5
<pre>
[WebGPU] Make it explicit that __wgslMin is only called on uint parameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=282937">https://bugs.webkit.org/show_bug.cgi?id=282937</a>
<a href="https://rdar.apple.com/138789162">rdar://138789162</a>

Reviewed by Tadeu Zagallo.

__wgslMin was only ever called with uint arguments so no need
for it to be templated.

Furthermore, we can remove the use of volatile indices by using
select() instead of min().

* LayoutTests/fast/webgpu/nocrash/fuzz-282937-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-282937.html: Added.
Add regression test.

* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::imageBytesForSource):
(WebCore::GPUQueue::copyExternalImageToTexture):
Test case found web content crash as well, fixing so the test passes.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
Use select() instead of min() to avoid volatile variables.

Canonical link: <a href="https://commits.webkit.org/286488@main">https://commits.webkit.org/286488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c315b19b0151715b673b4012223746de24a655df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80510 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27279 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78129 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3338 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59599 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17755 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49490 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65284 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39957 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46889 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22768 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25606 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68005 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81974 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67830 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3536 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67139 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16755 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11092 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9215 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3332 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6138 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3353 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4291 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/3360 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->