### PR TITLE
[webkitscmpy] Make parsing of trailers stricter

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/__init__.py
@@ -52,7 +52,7 @@ class Canonicalize(Command):
             default='origin',
         )
         parser.add_argument(
-            '--number', '-n',  type=int,
+            '--number', '-n', type=int,
             help='Number of commits to be canonicalized, regardless of the state of the remote',
             dest='number',
             default=None,

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/message.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/message.py
@@ -58,6 +58,8 @@ def rewrite_message(inputfile: IO[str], outputfile: IO[str], commit: Commit, ide
     for line in inputfile.readlines():
         lines.append(line.rstrip())
 
+    identifier_template_key = identifier_template.format('').split(':', maxsplit=1)[0]
+
     identifier_index = len(lines)
     if identifier_index and Git.GIT_SVN_REVISION.match(lines[-1]):
         identifier_index -= 1
@@ -72,12 +74,12 @@ def rewrite_message(inputfile: IO[str], outputfile: IO[str], commit: Commit, ide
     #     Canonical link: ...
     #
     #     git-svn-id: ...
-    if identifier_index and lines[identifier_index - 1].startswith(identifier_template.format('').split(':')[0]):
+    if identifier_index and lines[identifier_index - 1].startswith(identifier_template_key):
         lines[identifier_index - 1] = identifier_template.format(commit)
         identifier_index = identifier_index - 2
     else:
         for index in [2, 3]:
-            if identifier_index - index > 0 and lines[identifier_index - index].startswith(identifier_template.format('').split(':')[0]):
+            if identifier_index - index > 0 and lines[identifier_index - index].startswith(identifier_template_key):
                 del lines[identifier_index - index]
                 lines.insert(identifier_index - 1, identifier_template.format(commit))
                 identifier_index = identifier_index - 2

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/canonicalize_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/canonicalize_unittest.py
@@ -21,17 +21,20 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import unittest
+from io import StringIO
 
 from webkitcorepy import OutputCapture, testing
 from webkitcorepy.mocks import Time as MockTime
 from webkitscmpy import program, mocks, local, Commit, Contributor
+from webkitscmpy.program.canonicalize.message import rewrite_message
 
 
-class TestCanonicalize(testing.PathTestCase):
+class TestCanonicalizeProgam(testing.PathTestCase):
     basepath = 'mock/repository'
 
     def setUp(self):
-        super(TestCanonicalize, self).setUp()
+        super().setUp()
         os.mkdir(os.path.join(self.path, '.git'))
         os.mkdir(os.path.join(self.path, '.svn'))
 
@@ -299,7 +302,7 @@ class TestCanonicalize(testing.PathTestCase):
         )
 
     def test_number(self):
-        with OutputCapture() as captured, mocks.local.Git(self.path) as mock, mocks.local.Svn(), MockTime:
+        with OutputCapture() as captured, mocks.local.Git(self.path), mocks.local.Svn(), MockTime:
             contirbutors = Contributor.Mapping()
             contirbutors.create('Jonathan Bedard', 'jbedard@apple.com')
 
@@ -360,3 +363,641 @@ class TestCanonicalize(testing.PathTestCase):
             '    GIT_COMMITTER_EMAIL=jbedard@apple.com\n'
             '1 commit successfully canonicalized!\n',
         )
+
+
+class TestCanonicalizeMessage(unittest.TestCase):
+    def assert_canonicalized_commit_message(self, *, message, expected):
+        stdin = StringIO(message)
+        stdout = StringIO()
+
+        commit = Commit(
+            hash='38ea50d28ae394c9c8b80e13c3fb21f1c262871f',
+            branch='main',
+            author=Contributor('Jonathan Bedard', emails=['jbedard@apple.com']),
+            identifier='6@main',
+            timestamp=1601669000,
+            message=message,
+        )
+
+        rewrite_message(stdin, stdout, commit, 'Identifier: {}')
+
+        self.assertEqual(stdout.getvalue(), expected)
+
+    def test_incomplete_line(self):
+        # By POSIX, a line must end in new line character.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+    def test_multiple_existing_identifier_trailers(self):
+        # Only the final trailer gets updated.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                'Identifier: 3@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                'Identifier: 6@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 6@main\n'
+                'Identifier: 3@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 6@main\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 6@main\n'
+                'Identifier: 6@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 6@main\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+    def test_multiple_existing_identifier_single_trailer(self):
+        # Only the trailer gets updated.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                '\n'
+                'Identifier: 3@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 6@main\n'
+                '\n'
+                'Identifier: 3@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 6@main\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 6@main\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 6@main\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+    def test_existing_non_trailer_identifier_regression(self):
+        # This behaviour is wrong, see test_existing_non_trailer_identifier
+        # below. Remove this test when the expectedFailure goes away.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                '\n'
+                'Commit message body\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                '\n'
+                'Commit message body\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 6@main\n'
+                '\n'
+                'Commit message body\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                '\n'
+                'Commit message body\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+    @unittest.expectedFailure
+    def test_existing_non_trailer_identifier(self):
+        # A trailer gets added.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                '\n'
+                'Commit message body'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                '\n'
+                'Commit message body\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 6@main\n'
+                '\n'
+                'Commit message body\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                '\n'
+                'Commit message body\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+    def test_existing_non_trailer_identifier_long(self):
+        # A trailer gets added.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                '\n'
+                'Kinda\n'
+                'long\n'
+                'commit\n'
+                'message\n'
+                'body\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                '\n'
+                'Kinda\n'
+                'long\n'
+                'commit\n'
+                'message\n'
+                'body\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 6@main\n'
+                '\n'
+                'Kinda\n'
+                'long\n'
+                'commit\n'
+                'message\n'
+                'body\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 6@main\n'
+                '\n'
+                'Kinda\n'
+                'long\n'
+                'commit\n'
+                'message\n'
+                'body\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+    def test_existing_identifier_and_non_trailer_identifier(self):
+        # Only the trailer gets updated.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                '\n'
+                'Commit message body\n'
+                '\n'
+                'Identifier: 3@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                '\n'
+                'Commit message body\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                '\n'
+                'Commit message body\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                '\n'
+                'Commit message body\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 6@main\n'
+                '\n'
+                'Commit message body\n'
+                '\n'
+                'Identifier: 3@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 6@main\n'
+                '\n'
+                'Commit message body\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 6@main\n'
+                '\n'
+                'Commit message body\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 6@main\n'
+                '\n'
+                'Commit message body\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+    def test_not_alternate_trailer(self):
+        # Add a trailer group after the commit body.
+        non_trailer_lines = [
+            'not a trailer: line',
+            '* a: b',
+            '0a b: c',
+            '[0]: https://example.com',
+            '`a: b`',
+            '`a`: b',
+            'a b: https://example.com',
+        ]
+
+        for line in non_trailer_lines:
+            self.assert_canonicalized_commit_message(
+                message=(
+                    'New commit\n'
+                    '\n'
+                    f'{line}\n'
+                ),
+                expected=(
+                    'New commit\n'
+                    '\n'
+                    f'{line}\n'
+                    '\n'
+                    'Identifier: 6@main\n'
+                ),
+            )
+
+    def test_partial_trailer_group_unknown_trailer_regression(self):
+        # This behaviour is wrong, see test_partial_trailer_group_unknown_trailer
+        # below. Remove this test when the expectedFailure goes away.
+        non_trailer_lines = [
+            'not a trailer: line',
+            '* a: b',
+            '0a b: c',
+            '[0]: https://example.com',
+            '`a: b`',
+            '`a`: b',
+            'a b: https://example.com',
+        ]
+
+        for line in non_trailer_lines:
+            self.assert_canonicalized_commit_message(
+                message=(
+                    'New commit\n'
+                    '\n'
+                    f'{line}\n'
+                    'trailer: some metadata\n'
+                ),
+                expected=(
+                    'New commit\n'
+                    '\n'
+                    f'{line}\n'
+                    '\n'
+                    'trailer: some metadata\n'
+                    'Identifier: 6@main\n'
+                ),
+            )
+
+            self.assert_canonicalized_commit_message(
+                message=(
+                    'New commit\n'
+                    '\n'
+                    'trailer: some metadata\n'
+                    f'{line}\n'
+                ),
+                expected=(
+                    'New commit\n'
+                    '\n'
+                    'trailer: some metadata\n'
+                    f'{line}\n'
+                    '\n'
+                    'Identifier: 6@main\n'
+                ),
+            )
+
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'I proposed this change in:\n'
+                'https://github.example.com/WebKit/WebKit/pull/19920\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'I proposed this change in:\n'
+                '\n'
+                'https://github.example.com/WebKit/WebKit/pull/19920\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+    @unittest.expectedFailure
+    def test_partial_trailer_group_unknown_trailer(self):
+        # Add a trailer group after the commit body.
+        non_trailer_lines = [
+            'not a trailer: line',
+            '* a: b',
+            '0a b: c',
+            '[0]: https://example.com',
+            '`a: b`',
+            '`a`: b',
+            'a b: https://example.com',
+        ]
+
+        for line in non_trailer_lines:
+            self.assert_canonicalized_commit_message(
+                message=(
+                    'New commit\n'
+                    '\n'
+                    f'{line}\n'
+                    'trailer: some metadata\n'
+                ),
+                expected=(
+                    'New commit\n'
+                    '\n'
+                    f'{line}\n'
+                    'trailer: some metadata\n'
+                    '\n'
+                    'Identifier: 6@main'
+                ),
+            )
+
+            self.assert_canonicalized_commit_message(
+                message=(
+                    'New commit\n'
+                    '\n'
+                    'trailer: some metadata\n'
+                    f'{line}\n'
+                ),
+                expected=(
+                    'New commit\n'
+                    '\n'
+                    'trailer: some metadata\n'
+                    f'{line}\n'
+                    '\n'
+                    'Identifier: 6@main'
+                ),
+            )
+
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'I proposed this change in:\n'
+                'https://github.example.com/WebKit/WebKit/pull/19920\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'I proposed this change in:\n'
+                'https://github.example.com/WebKit/WebKit/pull/19920\n'
+                '\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+    def test_partial_trailer_group_known_trailer(self):
+        # Move the existing trailers to a proper group and append.
+        non_trailer_lines = [
+            'not a trailer: line',
+            '* a: b',
+            '0a b: c',
+            '[0]: https://example.com',
+            '`a: b`',
+            '`a`: b',
+            'a b: https://example.com',
+        ]
+
+        for line in non_trailer_lines:
+            self.assert_canonicalized_commit_message(
+                message=(
+                    'New commit\n'
+                    '\n'
+                    f'{line}\n'
+                    'Signed-off-by: Heather Letty <heather.letty@example.com>\n'
+                ),
+                expected=(
+                    'New commit\n'
+                    '\n'
+                    f'{line}\n'
+                    '\n'
+                    'Signed-off-by: Heather Letty <heather.letty@example.com>\n'
+                    'Identifier: 6@main\n'
+                ),
+            )
+
+            self.assert_canonicalized_commit_message(
+                message=(
+                    'New commit\n'
+                    '\n'
+                    'Signed-off-by: Heather Letty <heather.letty@example.com>\n'
+                    f'{line}\n'
+                ),
+                expected=(
+                    'New commit\n'
+                    '\n'
+                    'Signed-off-by: Heather Letty <heather.letty@example.com>\n'
+                    f'{line}\n'
+                    '\n'
+                    'Identifier: 6@main\n'
+                ),
+            )
+
+    def test_partial_trailer_group_known_identifier_trailer(self):
+        # Move the existing trailers to a property group and append.
+        non_trailer_lines = [
+            'not a trailer: line',
+            '* a: b',
+            '0a b: c',
+            '[0]: https://example.com',
+            '`a: b`',
+            '`a`: b',
+            'a b: https://example.com',
+        ]
+
+        for line in non_trailer_lines:
+            self.assert_canonicalized_commit_message(
+                message=(
+                    'New commit\n'
+                    '\n'
+                    f'{line}\n'
+                    'Identifier: 3@main\n'
+                ),
+                expected=(
+                    'New commit\n'
+                    '\n'
+                    f'{line}\n'
+                    '\n'
+                    'Identifier: 6@main\n'
+                ),
+            )
+
+            self.assert_canonicalized_commit_message(
+                message=(
+                    'New commit\n'
+                    '\n'
+                    'Identifier: 3@main\n'
+                    f'{line}\n'
+                ),
+                expected=(
+                    'New commit\n'
+                    '\n'
+                    f'{line}\n'
+                    '\n'
+                    'Identifier: 6@main\n'
+                ),
+            )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py
@@ -72,9 +72,21 @@ class TestRelationship(TestCase):
             ))
         )
         self.assertEqual(
-            ('original', ['123@main']), Relationship.parse(Commit(
+            (None, []), Relationship.parse(Commit(
                 hash='deadbeef1234', revision=1234, identifier='1234@main',
                 message='Commit title\n\nOriginally landed as: 123@main. <rdar://54321>',
+            ))
+        )
+        self.assertEqual(
+            ('original', ['123@main']), Relationship.parse(Commit(
+                hash='deadbeef1234', revision=1234, identifier='1234@main',
+                message='Originally landed as: 123@main. <rdar://54321>',
+            ))
+        )
+        self.assertEqual(
+            ('original', ['123@main']), Relationship.parse(Commit(
+                hash='deadbeef1234', revision=1234, identifier='1234@main',
+                message='Commit title\n\nOriginally-landed-as: 123@main. <rdar://54321>',
             ))
         )
 


### PR DESCRIPTION
#### 09a80b732c63a08a1398784f85b057577589aefc
<pre>
[webkitscmpy] Make parsing of trailers stricter
<a href="https://bugs.webkit.org/show_bug.cgi?id=282792">https://bugs.webkit.org/show_bug.cgi?id=282792</a>

Reviewed by Brianna Fan and Jonathan Bedard.

This requires trailer keys to match either the grammar allowed by git
or to be literally the string (case sensitively) &quot;Canonical link&quot;.

This prevents webkitscmpy.program.trace.Relationship from finding
trailers whose key is &quot;Originally landed as&quot;, but we&apos;ve never actually
landed such a commit (we always use Originally-landed-as).

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py:
(Commit): Change constants TRAILER_RE per above, add GIT_SPACE to
  match what git treats as space.
(Commit.trailers): Split literally just on \n, and trim whitespace on
  the value. Also avoid prepending repeatedly (O(n*2)), instead just
  reverse at the end (O(n)).
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/__init__.py:
(Canonicalize.parser): Drive-by: fix double-space.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/message.py:
(rewrite_message): Drive-by: factor out identifier_template_key.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/canonicalize_unittest.py:
(TestCanonicalizeProgam): Renamed from TestCanonicalize.
(TestCanonicalizeProgam.setUp): Ditto.
(TestCanonicalizeProgam.test_number): Drive-by: remove unused variable.
(TestCanonicalizeMessage): Add a lot of new tests.
(TestCanonicalizeMessage.assert_canonicalized_commit_message):
(TestCanonicalizeMessage.test_incomplete_line):
(TestCanonicalizeMessage.test_multiple_existing_identifier_trailers):
(TestCanonicalizeMessage.test_multiple_existing_identifier_single_trailer):
(TestCanonicalizeMessage.test_existing_non_trailer_identifier_regression):
(TestCanonicalizeMessage.test_existing_non_trailer_identifier):
(TestCanonicalizeMessage.test_existing_non_trailer_identifier_long):
(TestCanonicalizeMessage.test_existing_identifier_and_non_trailer_identifier):
(TestCanonicalizeMessage.test_not_alternate_trailer):
(TestCanonicalizeMessage.test_partial_trailer_group_unknown_trailer_regression):
(TestCanonicalizeMessage.test_partial_trailer_group_unknown_trailer):
(TestCanonicalizeMessage.test_partial_trailer_group_known_trailer):
(TestCanonicalizeMessage.test_partial_trailer_group_known_identifier_trailer):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py:
  Even more new tests.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py:
(TestRelationship.test_cherry_pick): Test parsing of &apos;Originally landed as&apos;.

Canonical link: <a href="https://commits.webkit.org/289828@main">https://commits.webkit.org/289828@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63ddab3a8e2db2dc5792799fa610c0f8f0c0475e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33189 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84315 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30796 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81899 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7082 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62365 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20206 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72661 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42669 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/79245 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49765 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26809 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29240 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70893 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27280 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85741 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4918 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70624 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/79431 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7198 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69864 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13876 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12786 "Passed tests") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13756 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6982 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6845 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10354 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8652 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->