### PR TITLE
[macOS] Entering fullscreen with content menu results in visible controls upon exiting

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8136,6 +8136,9 @@ imported/w3c/web-platform-tests/WebIDL/idlharness.any.worker.html [ Skip ]
 webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-mac.html [ Skip ]
 webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-ios.html [ Skip ]
 
+# macOS-only test.
+media/webkit-media-controls-not-visible-after-exiting-fullscreen.html [ Skip ]
+
 # webkit.org/b/280685 imported/w3c/web-platform-tests/css/selectors/featureless-004/5.html are failures.
 imported/w3c/web-platform-tests/css/selectors/featureless-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/selectors/featureless-005.html [ ImageOnlyFailure ]

--- a/LayoutTests/media/webkit-media-controls-not-visible-after-exiting-fullscreen-expected.txt
+++ b/LayoutTests/media/webkit-media-controls-not-visible-after-exiting-fullscreen-expected.txt
@@ -1,0 +1,12 @@
+This tests that when controls have been shown and hidden, they continue to be hidden after exiting fullscreen.
+
+RUN(video.src = findMediaFile("video", "content/test"))
+EVENT(canplay)
+RUN(video.controls = false)
+RUN(video.webkitEnterFullscreen())
+EVENT(fullscreenchange)
+RUN(video.webkitExitFullscreen())
+EVENT(fullscreenchange)
+EXPECTED (shadow.querySelector(".media-controls").children.length == '0') OK
+END OF TEST
+

--- a/LayoutTests/media/webkit-media-controls-not-visible-after-exiting-fullscreen.html
+++ b/LayoutTests/media/webkit-media-controls-not-visible-after-exiting-fullscreen.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>webkit-media-controls-not-visible-after-exiting-fullscreen</title>
+    <script src=video-test.js></script>
+    <script src=media-file.js></script>
+    <script>
+    var shadow;
+    async function runTest() {
+        findMediaElement();
+        run('video.src = findMediaFile("video", "content/test")');
+        await waitFor(video, 'canplay');
+        run('video.controls = false');
+        runWithKeyDown('video.webkitEnterFullscreen()');
+        await waitFor(document, 'fullscreenchange');
+
+        await sleepFor(100);
+
+        runWithKeyDown('video.webkitExitFullscreen()');
+        await waitFor(document, 'fullscreenchange');
+
+        if (window.internals) {
+            shadow = internals.shadowRoot(mediaElement);
+            await testExpectedEventually('shadow.querySelector(".media-controls").children.length', 0, '==', 1000);
+        }
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <div>
+        This tests that when controls have been shown and hidden, they continue to be hidden after exiting fullscreen.
+    </div>
+    <video controls></video>
+</body>
+</html>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2437,6 +2437,9 @@ webkit.org/b/280792 inspector/worker/debugger-pause-subworker.html [ Skip ]
 # Platform-specific test enabled on macOS and iOS separately.
 webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-mac.html [ Pass ]
 
+# macOS-only test.
+media/webkit-media-controls-not-visible-after-exiting-fullscreen.html [ Pass ]
+
 # webkit.org/b/281765 PROGRESSION (285251@main): [ macOS iOS ] imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect.html is a constant failure. 
 imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect.html [ Skip ]
 

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -98,6 +98,7 @@ class MediaController
         scheduler.flushScheduledLayoutCallbacks();
 
         shadowRoot.addEventListener("resize", this);
+        shadowRoot.addEventListener("fullscreenchange", this);
 
         media.videoTracks.addEventListener("addtrack", this);
         media.videoTracks.addEventListener("removetrack", this);
@@ -256,6 +257,8 @@ class MediaController
             this._updateControlsIfNeeded();
             // We must immediately perform layouts so that we don't lag behind the media layout size.
             scheduler.flushScheduledLayoutCallbacks();
+        } else if (event.type === "fullscreenchange" && event.currentTarget === this.shadowRoot) {
+            this._updateControlsAvailability();
         } else if (event.type === "keydown" && this.isFullscreen && event.key === " ") {
             this.togglePlayback();
             event.preventDefault();


### PR DESCRIPTION
#### 99a807ac097fcc794775e9802368620f4363d85f
<pre>
[macOS] Entering fullscreen with content menu results in visible controls upon exiting
<a href="https://bugs.webkit.org/show_bug.cgi?id=282767">https://bugs.webkit.org/show_bug.cgi?id=282767</a>
<a href="https://rdar.apple.com/138995480">rdar://138995480</a>

Reviewed by Jer Noble.

Similar to 285602@main, listen for the &quot;fullscreenchange&quot; event on the media controls shadow root
and update media controls available upon receiving that event.

* LayoutTests/TestExpectations: Skip the new test, it is macOS-only.

* LayoutTests/media/webkit-media-controls-not-visible-after-exiting-fullscreen-expected.txt: Added.
* LayoutTests/media/webkit-media-controls-not-visible-after-exiting-fullscreen.html: Added.

* LayoutTests/platform/mac/TestExpectations: Enable the new test.

* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController): Register for the &apos;fullscreenchange&apos; event on the shadow root.
(MediaController.prototype.handleEvent): Update controls when the shadow root gets a
&apos;fullscreenchange&apos; event.

Canonical link: <a href="https://commits.webkit.org/286459@main">https://commits.webkit.org/286459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74ddab707d6a56470e2bcd15d2d2c5b707083b06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76037 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80535 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27303 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78153 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59617 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17771 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39974 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22784 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25630 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68019 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81998 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67846 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3560 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65268 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67155 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16736 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11107 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9229 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3356 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6162 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3377 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4325 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/3567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->