### PR TITLE
Avoid overreleasing NSNumbers in CoreIPCNSURLCredential::toID() after 286450@main

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.mm
@@ -174,20 +174,20 @@ RetainPtr<id> CoreIPCNSURLCredential::toID() const
     RetainPtr<NSNumber> persistence;
     switch (m_data.persistence) {
     case CoreIPCNSURLCredentialPersistence::None:
-        persistence = adoptNS([NSNumber numberWithInt:kCFURLCredentialPersistenceNone]);
+        persistence = @(kCFURLCredentialPersistenceNone);
         break;
     case CoreIPCNSURLCredentialPersistence::Session:
-        persistence = adoptNS([NSNumber numberWithInt:kCFURLCredentialPersistenceForSession]);
+        persistence = @(kCFURLCredentialPersistenceForSession);
         break;
     case CoreIPCNSURLCredentialPersistence::Permanent:
-        persistence = adoptNS([NSNumber numberWithInt:kCFURLCredentialPersistencePermanent]);
+        persistence = @(kCFURLCredentialPersistencePermanent);
         break;
     case CoreIPCNSURLCredentialPersistence::Synchronizable:
-        persistence = adoptNS([NSNumber numberWithInt:kCFURLCredentialPersistenceSynchronizable]);
+        persistence = @(kCFURLCredentialPersistenceSynchronizable);
         break;
     default:
         ASSERT_NOT_REACHED();
-        persistence = adoptNS([NSNumber numberWithInt:kCFURLCredentialPersistenceNone]);
+        persistence = @(kCFURLCredentialPersistenceNone);
         break;
     }
     [dict setObject:persistence.get() forKey:@"persistence"];


### PR DESCRIPTION
#### c0a285660ab18ace28599908325482914c6f7b72
<pre>
Avoid overreleasing NSNumbers in CoreIPCNSURLCredential::toID() after 286450@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=282950">https://bugs.webkit.org/show_bug.cgi?id=282950</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

The results of `+[NSNumber numberWithInt:]` are incorrectly adopted here, since `+numberWithInt:`
does not return a +1 object. As a result, we&apos;ll end up calling `-release` when the `RetainPtr` falls
out of scope, without a matching `-retain`.

Fix this by just using the normal `RetainPtr` constructor, which retains the given instance (and
also deploy the more modern Objective-C `@()` syntax).

* Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.mm:
(WebKit::CoreIPCNSURLCredential::toID const):

Canonical link: <a href="https://commits.webkit.org/286458@main">https://commits.webkit.org/286458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/020dacfc29ba80649a69f3e6b46fccdcdfd5730d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80543 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27311 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59621 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17781 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49514 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65302 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39978 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46913 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25638 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68029 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82006 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3414 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2188 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67851 "Found 21 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/hit-test-unpainted-element.html imported/w3c/web-platform-tests/css/css-view-transitions/iframe-old-has-scrollbar.html imported/w3c/web-platform-tests/css/css-view-transitions/japanese-tag.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-ancestor-clipped.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-clip-path.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-changes-overflow-left.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-container-writing-modes.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-element-writing-modes.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-inline-with-offset-from-containing-block-clipped.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-object-fit-fill.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3568 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65270 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67161 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16735 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11117 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3364 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6170 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3385 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/4615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/4077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->