### PR TITLE
Reduce use of IsDeprecatedTimerSmartPointerException in WebKit

### DIFF
--- a/Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.h
+++ b/Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.h
@@ -38,15 +38,6 @@
 @class WKDeferringGestureRecognizer;
 
 namespace WebKit {
-class GestureRecognizerConsistencyEnforcer;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebKit::GestureRecognizerConsistencyEnforcer> : std::true_type { };
-}
-
-namespace WebKit {
 
 class GestureRecognizerConsistencyEnforcer {
     WTF_MAKE_TZONE_ALLOCATED(GestureRecognizerConsistencyEnforcer);
@@ -54,6 +45,9 @@ class GestureRecognizerConsistencyEnforcer {
 public:
     GestureRecognizerConsistencyEnforcer(WKContentView *);
     ~GestureRecognizerConsistencyEnforcer();
+
+    void ref() const;
+    void deref() const;
 
     void beginTracking(WKDeferringGestureRecognizer *);
     void endTracking(WKDeferringGestureRecognizer *);
@@ -63,7 +57,7 @@ public:
 private:
     void timerFired();
 
-    WeakObjCPtr<WKContentView> m_view;
+    WeakObjCPtr<WKContentView> m_view; // Cannot be null.
     RunLoop::Timer m_timer;
     HashSet<RetainPtr<WKDeferringGestureRecognizer>> m_deferringGestureRecognizersWithTouches;
 };

--- a/Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.mm
+++ b/Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.mm
@@ -68,9 +68,6 @@ void GestureRecognizerConsistencyEnforcer::reset()
 
 void GestureRecognizerConsistencyEnforcer::timerFired()
 {
-    if (!m_view)
-        return;
-
     auto strongView = m_view.get();
     auto possibleDeferringGestures = [NSMutableArray<WKDeferringGestureRecognizer *> array];
     for (WKDeferringGestureRecognizer *gesture in [strongView deferringGestures]) {
@@ -89,6 +86,18 @@ void GestureRecognizerConsistencyEnforcer::timerFired()
         [gesture setState:UIGestureRecognizerStateEnded];
 
     RELEASE_LOG_FAULT(ViewGestures, "Touch event gesture recognizer failed to reset after ending gesture deferral: %@", possibleDeferringGestures);
+}
+
+void GestureRecognizerConsistencyEnforcer::ref() const
+{
+    auto strongView = m_view.get();
+    [strongView retain];
+}
+
+void GestureRecognizerConsistencyEnforcer::deref() const
+{
+    auto strongView = m_view.get();
+    [strongView release];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -2379,7 +2379,7 @@ static WebCore::FloatQuad inflateQuad(const WebCore::FloatQuad& quad, float infl
 - (WebKit::GestureRecognizerConsistencyEnforcer&)gestureRecognizerConsistencyEnforcer
 {
     if (!_gestureRecognizerConsistencyEnforcer)
-        _gestureRecognizerConsistencyEnforcer = makeUnique<WebKit::GestureRecognizerConsistencyEnforcer>(self);
+        _gestureRecognizerConsistencyEnforcer = makeUniqueWithoutRefCountedCheck<WebKit::GestureRecognizerConsistencyEnforcer>(self);
 
     return *_gestureRecognizerConsistencyEnforcer;
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -681,32 +681,6 @@ bool WKBundlePageRegisterScrollOperationCompletionCallback(WKBundlePageRef pageR
     return true;
 }
 
-class TimerOwner {
-public:
-    TimerOwner(WTF::Function<void (void*)>&& callback, void* context)
-        : m_timer(*this, &TimerOwner::timerFired)
-        , m_callback(WTFMove(callback))
-        , m_context(context)
-    {
-        m_timer.startOneShot(0_s);
-    }
-
-    void timerFired()
-    {
-        m_callback(m_context);
-        delete this;
-    }
-
-    WebCore::Timer m_timer;
-    WTF::Function<void (void*)> m_callback;
-    void* m_context;
-};
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<TimerOwner> : std::true_type { };
-}
-
 void WKBundlePageCallAfterTasksAndTimers(WKBundlePageRef pageRef, WKBundlePageTestNotificationCallback callback, void* context)
 {
     if (!callback)
@@ -726,7 +700,9 @@ void WKBundlePageCallAfterTasksAndTimers(WKBundlePageRef pageRef, WKBundlePageTe
         return;
     
     document->postTask([=] (WebCore::ScriptExecutionContext&) {
-        new TimerOwner(callback, context); // deletes itself when done.
+        WebCore::Timer::schedule(0_s, [=] {
+            callback(context);
+        });
     });
 }
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -103,13 +103,22 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebLoaderStrategy);
 
-WebLoaderStrategy::WebLoaderStrategy()
-    : m_internallyFailedLoadTimer(RunLoop::main(), this, &WebLoaderStrategy::internallyFailedLoadTimerFired)
+WebLoaderStrategy::WebLoaderStrategy(WebProcess& webProcess)
+    : m_webProcess(webProcess)
+    , m_internallyFailedLoadTimer(RunLoop::main(), this, &WebLoaderStrategy::internallyFailedLoadTimerFired)
 {
 }
 
-WebLoaderStrategy::~WebLoaderStrategy()
+WebLoaderStrategy::~WebLoaderStrategy() = default;
+
+void WebLoaderStrategy::ref() const
 {
+    m_webProcess->ref();
+}
+
+void WebLoaderStrategy::deref() const
+{
+    m_webProcess->deref();
 }
 
 void WebLoaderStrategy::loadResource(LocalFrame& frame, CachedResource& resource, ResourceRequest&& request, const ResourceLoaderOptions& options, CompletionHandler<void(RefPtr<SubresourceLoader>&&)>&& completionHandler)

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
@@ -35,18 +35,10 @@
 #include <wtf/HashSet.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 struct FetchOptions;
-}
-
-namespace WebKit {
-class WebLoaderStrategy;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebKit::WebLoaderStrategy> : std::true_type { };
 }
 
 namespace WebKit {
@@ -54,14 +46,18 @@ namespace WebKit {
 class NetworkProcessConnection;
 class WebFrame;
 class WebPage;
+class WebProcess;
 class WebURLSchemeTaskProxy;
 
 class WebLoaderStrategy final : public WebCore::LoaderStrategy {
     WTF_MAKE_TZONE_ALLOCATED(WebLoaderStrategy);
     WTF_MAKE_NONCOPYABLE(WebLoaderStrategy);
 public:
-    WebLoaderStrategy();
+    explicit WebLoaderStrategy(WebProcess&);
     ~WebLoaderStrategy() final;
+
+    void ref() const;
+    void deref() const;
     
     void loadResource(WebCore::LocalFrame&, WebCore::CachedResource&, WebCore::ResourceRequest&&, const WebCore::ResourceLoaderOptions&, CompletionHandler<void(RefPtr<WebCore::SubresourceLoader>&&)>&&) final;
     void loadResourceSynchronously(WebCore::FrameLoader&, WebCore::ResourceLoaderIdentifier, const WebCore::ResourceRequest&, WebCore::ClientCredentialPolicy, const WebCore::FetchOptions&, const WebCore::HTTPHeaderMap&, WebCore::ResourceError&, WebCore::ResourceResponse&, Vector<uint8_t>& data) final;
@@ -142,6 +138,7 @@ private:
         });
     }
 
+    WeakRef<WebProcess> m_webProcess;
     HashSet<RefPtr<WebCore::ResourceLoader>> m_internallyFailedResourceLoaders;
     RunLoop::Timer m_internallyFailedLoadTimer;
     

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -285,7 +285,7 @@ WebProcess& WebProcess::singleton()
 }
 
 WebProcess::WebProcess()
-    : m_webLoaderStrategy(makeUniqueRef<WebLoaderStrategy>())
+    : m_webLoaderStrategy(makeUniqueRefWithoutRefCountedCheck<WebLoaderStrategy>(*this))
 #if PLATFORM(COCOA) && USE(LIBWEBRTC) && ENABLE(WEB_CODECS)
     , m_remoteVideoCodecFactory(*this)
 #endif


### PR DESCRIPTION
#### ec6769bbe1c4724c8f2b1454de491f27568cdc2e
<pre>
Reduce use of IsDeprecatedTimerSmartPointerException in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=282953">https://bugs.webkit.org/show_bug.cgi?id=282953</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.h:
* Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.mm:
(WebKit::GestureRecognizerConsistencyEnforcer::timerFired):
(WebKit::GestureRecognizerConsistencyEnforcer::ref const):
(WebKit::GestureRecognizerConsistencyEnforcer::deref const):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView gestureRecognizerConsistencyEnforcer]):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageCallAfterTasksAndTimers):
(TimerOwner::TimerOwner): Deleted.
(TimerOwner::timerFired): Deleted.
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::WebLoaderStrategy):
(WebKit::WebLoaderStrategy::ref const):
(WebKit::WebLoaderStrategy::deref const):
(WebKit::WebLoaderStrategy::~WebLoaderStrategy): Deleted.
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::WebProcess):

Canonical link: <a href="https://commits.webkit.org/286467@main">https://commits.webkit.org/286467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/401bae78cd33f9acac4962912ec636f172fd942d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80552 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27318 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3377 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59630 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17782 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79119 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65310 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39987 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46916 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25645 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68032 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23132 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82013 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2191 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67855 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3575 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65278 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/67196 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11118 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9238 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11772 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3371 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6177 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3392 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/4784 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/4118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->