### PR TITLE
Extract CSS::None/CSS::Range into their own files to avoid cycle with calc

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -952,7 +952,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     css/values/motion/CSSRayFunction.h
 
+    css/values/primitives/CSSNone.h
     css/values/primitives/CSSPosition.h
+    css/values/primitives/CSSPrimitiveNumericRange.h
     css/values/primitives/CSSPrimitiveNumericTypes.h
     css/values/primitives/CSSUnevaluatedCalc.h
 
@@ -2599,6 +2601,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     style/values/motion/StyleRayFunction.h
 
+    style/values/primitives/StyleNone.h
     style/values/primitives/StylePosition.h
     style/values/primitives/StylePrimitiveNumericTypes.h
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1127,6 +1127,7 @@ css/typedom/transform/CSSTransformValue.cpp
 css/typedom/transform/CSSTranslate.cpp
 css/values/backgrounds/CSSBorderRadius.cpp
 css/values/images/CSSGradient.cpp
+css/values/primitives/CSSNone.cpp
 css/values/primitives/CSSPosition.cpp
 css/values/primitives/CSSPrimitiveNumericTypes+ComputedStyleDependencies.cpp
 css/values/primitives/CSSPrimitiveNumericTypes+Serialization.cpp

--- a/Source/WebCore/css/CSSGradientValue.cpp
+++ b/Source/WebCore/css/CSSGradientValue.cpp
@@ -95,7 +95,7 @@ template<RawNumeric CSSType> struct StyleImageIsUncacheable<CSSType> {
 };
 
 template<RawNumeric CSSType> struct StyleImageIsUncacheable<UnevaluatedCalc<CSSType>> {
-    constexpr bool operator()(const auto& value) { return value.calc->requiresConversionData(); }
+    constexpr bool operator()(const auto& value) { return value.protectedCalc()->requiresConversionData(); }
 };
 
 template<RawNumeric CSSType> struct StyleImageIsUncacheable<PrimitiveNumeric<CSSType>> {

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -30,7 +30,6 @@
 #include "CSSCalcTree+Serialization.h"
 #include "CSSCalcTree+Simplification.h"
 #include "CSSCalcTree.h"
-#include "CSSCalcValue.h"
 #include "CSSParserContext.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPropertyParserConsumer+Ident.h"

--- a/Source/WebCore/css/calc/CSSCalcTree.h
+++ b/Source/WebCore/css/calc/CSSCalcTree.h
@@ -25,7 +25,8 @@
 #pragma once
 
 #include "CSSCalcType.h"
-#include "CSSPrimitiveNumericTypes.h"
+#include "CSSNone.h"
+#include "CSSPrimitiveNumericRange.h"
 #include "CSSUnits.h"
 #include "CSSValueKeywords.h"
 #include "CalculationTree.h"

--- a/Source/WebCore/css/color/CSSColorDescriptors.h
+++ b/Source/WebCore/css/color/CSSColorDescriptors.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "CSSCalcValue.h"
 #include "CSSPrimitiveNumericTypes.h"
 #include "CSSValueKeywords.h"
 #include "Color.h"

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.cpp
@@ -26,7 +26,6 @@
 #include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
 
 #include "CSSCalcSymbolTable.h"
-#include "CSSCalcValue.h"
 #include "CSSParserTokenRange.h"
 
 namespace WebCore {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h
@@ -54,7 +54,7 @@ struct CSSPrimitiveValueResolverBase {
 
     template<typename T> static RefPtr<CSSPrimitiveValue> resolve(CSS::UnevaluatedCalc<T> value, const CSSCalcSymbolTable&, CSSPropertyParserOptions)
     {
-        return CSSPrimitiveValue::create(WTFMove(value.calc));
+        return CSSPrimitiveValue::create(value.protectedCalc());
     }
 
     template<typename T> static RefPtr<CSSPrimitiveValue> resolve(CSS::PrimitiveNumeric<T> value, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumer.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumer.h
@@ -24,8 +24,6 @@
 
 #pragma once
 
-#include "CSSCalcSymbolsAllowed.h"
-#include "CSSCalcValue.h"
 #include "CSSParserToken.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPrimitiveNumericTypes.h"

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumerDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumerDefinitions.h
@@ -25,7 +25,6 @@
 #pragma once
 
 #include "CSSCalcSymbolsAllowed.h"
-#include "CSSCalcValue.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPrimitiveNumericTypes.h"
 #include "CSSPropertyParserOptions.h"

--- a/Source/WebCore/css/values/backgrounds/CSSBorderRadius.cpp
+++ b/Source/WebCore/css/values/backgrounds/CSSBorderRadius.cpp
@@ -25,7 +25,6 @@
 #include "config.h"
 #include "CSSBorderRadius.h"
 
-#include "CSSCalcValue.h"
 #include "CSSPrimitiveNumericTypes+Serialization.h"
 #include <wtf/text/StringBuilder.h>
 

--- a/Source/WebCore/css/values/images/CSSGradient.cpp
+++ b/Source/WebCore/css/values/images/CSSGradient.cpp
@@ -27,8 +27,6 @@
 #include "config.h"
 #include "CSSGradient.h"
 
-#include "CSSCalcSymbolTable.h"
-#include "CSSCalcValue.h"
 #include "CSSPrimitiveNumericTypes+CSSValueVisitation.h"
 #include "CSSPrimitiveNumericTypes+ComputedStyleDependencies.h"
 #include "CSSPrimitiveNumericTypes+Serialization.h"
@@ -82,7 +80,7 @@ void Serialize<GradientDeprecatedColorStop>::operator()(StringBuilder& builder, 
     };
 
     auto appendCalc = [&](const auto& calc) {
-        builder.append("color-stop("_s, calc.calc->cssText(), ", "_s, stop.protectedColor()->cssText(), ')');
+        builder.append("color-stop("_s, calc.protectedCalc()->cssText(), ", "_s, stop.protectedColor()->cssText(), ')');
     };
 
     WTF::switchOn(stop.position,

--- a/Source/WebCore/css/values/primitives/CSSNone.cpp
+++ b/Source/WebCore/css/values/primitives/CSSNone.cpp
@@ -23,24 +23,24 @@
  */
 
 #include "config.h"
-#include "CSSRectFunction.h"
+#include "CSSNone.h"
 
-#include "CSSPrimitiveNumericTypes+Serialization.h"
+#include "CSSValueKeywords.h"
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 namespace CSS {
 
-void Serialize<Rect>::operator()(StringBuilder& builder, const Rect& value)
+// MARK: - Serialization
+
+void Serialize<NoneRaw>::operator()(StringBuilder& builder, const NoneRaw&)
 {
-    // <rect()> = rect( [ <length-percentage> | auto ]{4} [ round <'border-radius'> ]? )
+    builder.append(nameLiteralForSerialization(CSSValueNone));
+}
 
-    serializationForCSS(builder, value.edges);
-
-    if (!hasDefaultValue(value.radii)) {
-        builder.append(' ', nameLiteralForSerialization(CSSValueRound), ' ');
-        serializationForCSS(builder, value.radii);
-    }
+void Serialize<None>::operator()(StringBuilder& builder, const None&)
+{
+    builder.append(nameLiteralForSerialization(CSSValueNone));
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/primitives/CSSNone.h
+++ b/Source/WebCore/css/values/primitives/CSSNone.h
@@ -22,26 +22,32 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "CSSRectFunction.h"
+#pragma once
 
-#include "CSSPrimitiveNumericTypes+Serialization.h"
-#include <wtf/text/StringBuilder.h>
+#include "CSSValueTypes.h"
 
 namespace WebCore {
 namespace CSS {
 
-void Serialize<Rect>::operator()(StringBuilder& builder, const Rect& value)
-{
-    // <rect()> = rect( [ <length-percentage> | auto ]{4} [ round <'border-radius'> ]? )
+struct NoneRaw {
+    constexpr bool operator==(const NoneRaw&) const = default;
+};
 
-    serializationForCSS(builder, value.edges);
+struct None {
+    using Raw = NoneRaw;
 
-    if (!hasDefaultValue(value.radii)) {
-        builder.append(' ', nameLiteralForSerialization(CSSValueRound), ' ');
-        serializationForCSS(builder, value.radii);
-    }
-}
+    constexpr None() = default;
+    constexpr None(NoneRaw&&) { }
+    constexpr None(const NoneRaw&) { }
+
+    constexpr bool operator==(const None&) const = default;
+};
+
+template<> struct Serialize<NoneRaw> { void operator()(StringBuilder&, const NoneRaw&); };
+template<> struct Serialize<None> { void operator()(StringBuilder&, const None&); };
+
+template<> struct ComputedStyleDependenciesCollector<NoneRaw> { constexpr void operator()(ComputedStyleDependencies&, const NoneRaw&) { } };
+template<> struct ComputedStyleDependenciesCollector<None> { constexpr void operator()(ComputedStyleDependencies&, const None&) { } };
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPosition.cpp
+++ b/Source/WebCore/css/values/primitives/CSSPosition.cpp
@@ -25,7 +25,6 @@
 #include "config.h"
 #include "CSSPosition.h"
 
-#include "CSSCalcValue.h"
 #include "CSSPrimitiveNumericTypes+CSSValueVisitation.h"
 #include "CSSPrimitiveNumericTypes+ComputedStyleDependencies.h"
 #include "CSSPrimitiveNumericTypes+Serialization.h"

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+ComputedStyleDependencies.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+ComputedStyleDependencies.h
@@ -67,9 +67,7 @@ template<RawNumeric RawType> struct ComputedStyleDependenciesCollector<Primitive
     }
 };
 
-// None/Symbol have trivially nothing to collect.
-template<> struct ComputedStyleDependenciesCollector<NoneRaw> { constexpr void operator()(ComputedStyleDependencies&, const NoneRaw&) { } };
-template<> struct ComputedStyleDependenciesCollector<None> { constexpr void operator()(ComputedStyleDependencies&, const None&) { } };
+// Symbol has trivially nothing to collect.
 template<> struct ComputedStyleDependenciesCollector<Symbol> { constexpr void operator()(ComputedStyleDependencies&, const SymbolRaw&) { } };
 template<> struct ComputedStyleDependenciesCollector<SymbolRaw> { constexpr void operator()(ComputedStyleDependencies&, const Symbol&) { } };
 

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+EvaluateCalc.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+EvaluateCalc.h
@@ -36,7 +36,7 @@ namespace CSS {
 
 template<RawNumeric T> auto evaluateCalcNoConversionDataRequired(const UnevaluatedCalc<T>& calc, const CSSCalcSymbolTable& symbolTable) -> T
 {
-    return { unevaluatedCalcEvaluateNoConversionDataRequired(calc.calc, symbolTable, T::category) };
+    return { unevaluatedCalcEvaluateNoConversionDataRequired(calc.protectedCalc(), symbolTable, T::category) };
 }
 
 template<typename T> constexpr auto evaluateCalcNoConversionDataRequired(const T& component, const CSSCalcSymbolTable&) -> T

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.cpp
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.cpp
@@ -39,21 +39,10 @@ void rawNumericSerialization(StringBuilder& builder, double value, CSSUnitType t
     formatCSSNumberValue(builder, value, CSSPrimitiveValue::unitTypeString(type));
 }
 
-void Serialize<NoneRaw>::operator()(StringBuilder& builder, const NoneRaw&)
-{
-    builder.append("none"_s);
-}
-
-void Serialize<None>::operator()(StringBuilder& builder, const None&)
-{
-    builder.append("none"_s);
-}
-
 void Serialize<SymbolRaw>::operator()(StringBuilder& builder, const SymbolRaw& value)
 {
     builder.append(nameLiteralForSerialization(value.value));
 }
-
 
 void Serialize<Symbol>::operator()(StringBuilder& builder, const Symbol& value)
 {

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h
@@ -48,9 +48,6 @@ template<RawNumeric RawType> struct Serialize<PrimitiveNumeric<RawType>> {
     }
 };
 
-template<> struct Serialize<NoneRaw> { void operator()(StringBuilder&, const NoneRaw&); };
-template<> struct Serialize<None> { void operator()(StringBuilder&, const None&); };
-
 template<> struct Serialize<SymbolRaw> { void operator()(StringBuilder&, const SymbolRaw&); };
 template<> struct Serialize<Symbol> { void operator()(StringBuilder&, const Symbol&); };
 

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include "CSSNone.h"
+#include "CSSPrimitiveNumericRange.h"
 #include "CSSUnevaluatedCalc.h"
 #include "CSSUnits.h"
 #include "CSSValueTypes.h"
@@ -32,30 +34,6 @@
 
 namespace WebCore {
 namespace CSS {
-
-// Representation for `CSS bracketed range notation`. Represents a closed range between (and including) `min` and `max`.
-// https://drafts.csswg.org/css-values-4/#numeric-ranges
-struct Range {
-    // Convenience to allow for a shorter spelling of the appropriate infinity.
-    static constexpr auto infinity = std::numeric_limits<double>::infinity();
-
-    double min { -infinity };
-    double max {  infinity };
-
-    constexpr bool operator==(const Range&) const = default;
-};
-
-// Constant value for `[−∞,∞]`.
-inline constexpr auto All = Range { -Range::infinity, Range::infinity };
-
-// Constant value for `[0,∞]`.
-inline constexpr auto Nonnegative = Range { 0, Range::infinity };
-
-// Clamps a floating point value to within `range`.
-template<Range range, std::floating_point T> constexpr float clampToRange(T value)
-{
-    return std::clamp<T>(value, range.min, range.max);
-}
 
 // Concept for use in generic contexts to filter on *Raw types.
 template<typename T> concept RawNumeric = requires(T raw) {
@@ -209,10 +187,6 @@ template<Range R = All> struct LengthPercentageRaw {
 
 // MARK: Additional Numeric Adjacent Types Raw
 
-struct NoneRaw {
-    constexpr bool operator==(const NoneRaw&) const = default;
-};
-
 struct SymbolRaw {
     CSSValueID value;
 
@@ -296,16 +270,6 @@ template<Range R = All> using AnglePercentage = PrimitiveNumeric<AnglePercentage
 template<Range R = All> using LengthPercentage = PrimitiveNumeric<LengthPercentageRaw<R>>;
 
 // MARK: Additional Numeric Adjacent Types
-
-struct None {
-    using Raw = NoneRaw;
-
-    constexpr None() = default;
-    constexpr None(NoneRaw&&) { }
-    constexpr None(const NoneRaw&) { }
-
-    constexpr bool operator==(const None&) const = default;
-};
 
 struct Symbol {
     using Raw = SymbolRaw;

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
@@ -26,29 +26,12 @@
 #include "CSSUnevaluatedCalc.h"
 
 #include "CSSCalcSymbolTable.h"
-#include "CSSCalcValue.h"
+#include "FloatConversion.h"
 #include "StyleBuilderState.h"
-#include "StylePrimitiveNumericTypes.h"
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 namespace CSS {
-
-BaseUnevaluatedCalc::~BaseUnevaluatedCalc() = default;
-BaseUnevaluatedCalc::BaseUnevaluatedCalc(const BaseUnevaluatedCalc&) = default;
-BaseUnevaluatedCalc::BaseUnevaluatedCalc(BaseUnevaluatedCalc&&) = default;
-BaseUnevaluatedCalc& BaseUnevaluatedCalc::operator=(const BaseUnevaluatedCalc&) = default;
-BaseUnevaluatedCalc& BaseUnevaluatedCalc::operator=(BaseUnevaluatedCalc&&) = default;
-
-BaseUnevaluatedCalc::BaseUnevaluatedCalc(Ref<CSSCalcValue>&& value)
-    : calc(WTFMove(value))
-{
-}
-
-Ref<CSSCalcValue> BaseUnevaluatedCalc::protectedCalc() const
-{
-    return calc;
-}
 
 bool unevaluatedCalcEqual(const Ref<CSSCalcValue>& a, const Ref<CSSCalcValue>& b)
 {

--- a/Source/WebCore/css/values/shapes/CSSCircleFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSCircleFunction.cpp
@@ -25,7 +25,6 @@
 #include "config.h"
 #include "CSSCircleFunction.h"
 
-#include "CSSCalcValue.h"
 #include "CSSPrimitiveNumericTypes+Serialization.h"
 #include <wtf/text/StringBuilder.h>
 

--- a/Source/WebCore/css/values/shapes/CSSEllipseFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSEllipseFunction.cpp
@@ -25,7 +25,6 @@
 #include "config.h"
 #include "CSSEllipseFunction.h"
 
-#include "CSSCalcValue.h"
 #include "CSSPrimitiveNumericTypes+Serialization.h"
 #include <wtf/text/StringBuilder.h>
 

--- a/Source/WebCore/css/values/shapes/CSSInsetFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSInsetFunction.cpp
@@ -25,7 +25,6 @@
 #include "config.h"
 #include "CSSInsetFunction.h"
 
-#include "CSSCalcValue.h"
 #include "CSSPrimitiveNumericTypes+Serialization.h"
 #include <wtf/text/StringBuilder.h>
 

--- a/Source/WebCore/css/values/shapes/CSSPathFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSPathFunction.cpp
@@ -25,7 +25,6 @@
 #include "config.h"
 #include "CSSPathFunction.h"
 
-#include "CSSCalcValue.h"
 #include "CSSMarkup.h"
 #include "CSSPrimitiveNumericTypes+CSSValueVisitation.h"
 #include "CSSPrimitiveNumericTypes+ComputedStyleDependencies.h"

--- a/Source/WebCore/css/values/shapes/CSSPolygonFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSPolygonFunction.cpp
@@ -25,7 +25,6 @@
 #include "config.h"
 #include "CSSPolygonFunction.h"
 
-#include "CSSCalcValue.h"
 #include "CSSPrimitiveNumericTypes+Serialization.h"
 #include <wtf/text/StringBuilder.h>
 

--- a/Source/WebCore/css/values/shapes/CSSShapeFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSShapeFunction.cpp
@@ -25,7 +25,6 @@
 #include "config.h"
 #include "CSSShapeFunction.h"
 
-#include "CSSCalcValue.h"
 #include "CSSPrimitiveNumericTypes+Serialization.h"
 #include <wtf/text/StringBuilder.h>
 

--- a/Source/WebCore/css/values/shapes/CSSShapeFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSShapeFunction.h
@@ -24,7 +24,6 @@
 
 #pragma once
 
-#include "CSSCalcValue.h"
 #include "CSSFillRule.h"
 #include "CSSPosition.h"
 #include "CSSPrimitiveNumericTypes.h"

--- a/Source/WebCore/css/values/shapes/CSSXywhFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSXywhFunction.cpp
@@ -25,7 +25,6 @@
 #include "config.h"
 #include "CSSXywhFunction.h"
 
-#include "CSSCalcValue.h"
 #include "CSSPrimitiveNumericTypes+Serialization.h"
 #include <wtf/text/StringBuilder.h>
 

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -25,7 +25,6 @@
 #pragma once
 
 #include "CSSCalcSymbolTable.h"
-#include "CSSCalcValue.h"
 #include "CSSValueTypes.h"
 #include <optional>
 #include <tuple>

--- a/Source/WebCore/style/values/primitives/StyleNone.h
+++ b/Source/WebCore/style/values/primitives/StyleNone.h
@@ -22,26 +22,35 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "CSSRectFunction.h"
+#pragma once
 
-#include "CSSPrimitiveNumericTypes+Serialization.h"
-#include <wtf/text/StringBuilder.h>
+#include "CSSNone.h"
+#include "StyleValueTypes.h"
 
 namespace WebCore {
-namespace CSS {
+namespace Style {
 
-void Serialize<Rect>::operator()(StringBuilder& builder, const Rect& value)
-{
-    // <rect()> = rect( [ <length-percentage> | auto ]{4} [ round <'border-radius'> ]? )
+struct None {
+    using CSS = WebCore::CSS::None;
+    using Raw = WebCore::CSS::NoneRaw;
 
-    serializationForCSS(builder, value.edges);
+    constexpr bool operator==(const None&) const = default;
+};
 
-    if (!hasDefaultValue(value.radii)) {
-        builder.append(' ', nameLiteralForSerialization(CSSValueRound), ' ');
-        serializationForCSS(builder, value.radii);
-    }
-}
+template<> struct ToPrimaryCSSTypeMapping<CSS::NoneRaw> { using type = CSS::None; };
 
-} // namespace CSS
+template<> struct ToCSS<None> { constexpr auto operator()(const None&, const RenderStyle&) -> CSS::None { return { }; } };
+
+template<> struct ToStyle<CSS::None> {
+    auto operator()(const CSS::None&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&) -> None { return { }; }
+    auto operator()(const CSS::None&, const BuilderState&, const CSSCalcSymbolTable&) -> None { return { }; }
+    auto operator()(const CSS::None&, NoConversionDataRequiredToken, const CSSCalcSymbolTable&) -> None { return { }; }
+};
+
+template<> struct Blending<None> {
+    constexpr auto canBlend(const None&, const None&) -> bool { return true; }
+    constexpr auto blend(const None&, const None&, const BlendingContext&) -> None { return { }; }
+};
+
+} // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h
@@ -111,11 +111,5 @@ template<auto R> struct Blending<LengthPercentage<R>> {
     }
 };
 
-// None just needs its trivial implementation.
-template<> struct Blending<None> {
-    constexpr auto canBlend(const None&, const None&) -> bool { return true; }
-    constexpr auto blend(const None&, const None&, const BlendingContext&) -> None { return { }; }
-};
-
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
@@ -27,6 +27,7 @@
 #include "CSSPrimitiveNumericTypes.h"
 #include "CalculationValue.h"
 #include "FloatConversion.h"
+#include "StyleNone.h"
 #include "StyleValueTypes.h"
 #include <variant>
 #include <wtf/Forward.h>
@@ -946,15 +947,6 @@ using LengthPercentagePointNonnegative = Point<LengthPercentageNonnegative>;
 // Standing Sizes
 using LengthPercentageSizeAll = Size<LengthPercentageAll>;
 using LengthPercentageSizeNonnegative = Size<LengthPercentageNonnegative>;
-
-// MARK: Additional Numeric Adjacent Types
-
-struct None {
-    using CSS = WebCore::CSS::None;
-    using Raw = WebCore::CSS::NoneRaw;
-
-    constexpr bool operator==(const None&) const = default;
-};
 
 } // namespace Style
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXAggregateTarget section */


### PR DESCRIPTION
#### d963cf33c1630e3db30df7dd51c9167d4c27768f
<pre>
Extract CSS::None/CSS::Range into their own files to avoid cycle with calc
<a href="https://bugs.webkit.org/show_bug.cgi?id=282955">https://bugs.webkit.org/show_bug.cgi?id=282955</a>

Reviewed by Fujii Hironori.

In order for CSSUnevaluatedCalc.h to include CSSCalcValue.h, a few types
needed to extracted into their own files.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSGradientValue.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
* Source/WebCore/css/calc/CSSCalcTree.h:
* Source/WebCore/css/color/CSSColorDescriptors.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumer.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumerDefinitions.h:
* Source/WebCore/css/values/backgrounds/CSSBorderRadius.cpp:
* Source/WebCore/css/values/images/CSSGradient.cpp:
* Source/WebCore/css/values/primitives/CSSNone.cpp: Added.
* Source/WebCore/css/values/primitives/CSSNone.h: Added.
* Source/WebCore/css/values/primitives/CSSPosition.cpp:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h: Added.
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+ComputedStyleDependencies.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+EvaluateCalc.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.cpp:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h:
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp:
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h:
* Source/WebCore/css/values/shapes/CSSCircleFunction.cpp:
* Source/WebCore/css/values/shapes/CSSEllipseFunction.cpp:
* Source/WebCore/css/values/shapes/CSSInsetFunction.cpp:
* Source/WebCore/css/values/shapes/CSSPathFunction.cpp:
* Source/WebCore/css/values/shapes/CSSPolygonFunction.cpp:
* Source/WebCore/css/values/shapes/CSSRectFunction.cpp:
* Source/WebCore/css/values/shapes/CSSShapeFunction.cpp:
* Source/WebCore/css/values/shapes/CSSShapeFunction.h:
* Source/WebCore/css/values/shapes/CSSXywhFunction.cpp:
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/primitives/StyleNone.h: Added.
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h:

Canonical link: <a href="https://commits.webkit.org/286531@main">https://commits.webkit.org/286531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1362a7ed6e69e956b340220e7461fa1ecaeeb522

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76222 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27494 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59770 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17910 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65463 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40115 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47067 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22949 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25816 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68199 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23283 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82187 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2345 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67989 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3748 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67300 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16786 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11261 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9374 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3542 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6349 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3565 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/6994 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5323 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->