### PR TITLE
Stack overflow and OOM should not be catchable from Wasm

### DIFF
--- a/JSTests/wasm/stress/catch-should-keep-alive-inline-parent-expression-stack.js
+++ b/JSTests/wasm/stress/catch-should-keep-alive-inline-parent-expression-stack.js
@@ -38,8 +38,14 @@ async function test() {
     const instance = await instantiate(wat, { m: { x: globalX } }, { exceptions: true });
     const { outer } = instance.exports;
     for (let i = 0; i < 10; i++) {
-        let result = outer(null, {}, {});
-        assert.eq(result, undefined);
+        try {
+            let result = outer(null, {}, {});
+            throw "FAILED";
+        } catch (e) {
+            let exception = e;
+            if (exception != "RangeError: Maximum call stack size exceeded.")
+                throw "FAILED";
+        }
     }
 }
 

--- a/Source/JavaScriptCore/runtime/ErrorInstance.h
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.h
@@ -80,9 +80,17 @@ public:
     void clearRuntimeTypeForCause() { m_runtimeTypeForCause = TypeNothing; }
 
     ErrorType errorType() const { return m_errorType; }
-    void setStackOverflowError() { m_stackOverflowError = true; }
+    void setStackOverflowError()
+    {
+        m_catchableFromWasm = false;
+        m_stackOverflowError = true;
+    }
     bool isStackOverflowError() const { return m_stackOverflowError; }
-    void setOutOfMemoryError() { m_outOfMemoryError = true; }
+    void setOutOfMemoryError()
+    {
+        m_catchableFromWasm = false;
+        m_outOfMemoryError = true;
+    }
     bool isOutOfMemoryError() const { return m_outOfMemoryError; }
 
     void setNativeGetterTypeError() { m_nativeGetterTypeError = true; }

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -1100,7 +1100,9 @@ WASM_SLOW_PATH_DECL(retrieve_and_clear_exception)
     else if (pc->is<WasmCatchAll>())
         handleCatchAll(pc->as<WasmCatchAll>());
     else if (pc->is<WasmTryTableCatch>()) {
-        payload = bitwise_cast<void*>(jsDynamicCast<JSWebAssemblyException*>(thrownValue)->payload().span().data());
+        JSWebAssemblyException* wasmException = jsDynamicCast<JSWebAssemblyException*>(thrownValue);
+        RELEASE_ASSERT(!!wasmException);
+        payload = bitwise_cast<void*>(wasmException->payload().span().data());
         auto instr = pc->as<WasmTryTableCatch>();
         if (instr.m_kind == static_cast<unsigned>(Wasm::CatchKind::CatchRef) || instr.m_kind == static_cast<unsigned>(Wasm::CatchKind::CatchAllRef))
             callFrame->uncheckedR(pc->as<WasmTryTableCatch>().m_exception) = thrownValue;


### PR DESCRIPTION
#### a2ba2b6959dbba3345b8c931e297ec59fa57dc1d
<pre>
Stack overflow and OOM should not be catchable from Wasm
<a href="https://bugs.webkit.org/show_bug.cgi?id=282959">https://bugs.webkit.org/show_bug.cgi?id=282959</a>
<a href="https://rdar.apple.com/139515612">rdar://139515612</a>

Reviewed by Justin Michaud and Keith Miller.

According to both the old and new exception specs, stack overflow and
out of memory errors should not be catchable from WebAssembly `catch`
(or similar). However, the exceptions were still marked as catchable
from Wasm, meaning they could trigger incorrect handlers.

* JSTests/wasm/stress/catch-should-keep-alive-inline-parent-expression-stack.js:
(async test):
* Source/JavaScriptCore/runtime/ErrorInstance.h:
(JSC::ErrorInstance::setStackOverflowError):
(JSC::ErrorInstance::setOutOfMemoryError):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):

Canonical link: <a href="https://commits.webkit.org/286486@main">https://commits.webkit.org/286486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a2c4a28420404a82ea4ca72e0dba66b09cbfd71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/28970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80571 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27337 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64242 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3396 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59651 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17796 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65327 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40002 "Found 1 new API test failure: /WPE/TestAuthentication:/webkit/Authentication/authentication-storage (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46931 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22812 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25664 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69248 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68047 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82032 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75347 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2209 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67878 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3594 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65295 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67189 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11136 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9253 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97601 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11778 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3390 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21351 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3411 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/6808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/4278 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->