### PR TITLE
Further reduce use of IsDeprecatedTimerSmartPointerException

### DIFF
--- a/Source/WebCore/Modules/mediasession/MediaMetadata.h
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.h
@@ -50,6 +50,7 @@ using MediaSessionMetadata = MediaMetadataInit;
 
 class ArtworkImageLoader final : public CachedImageClient {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ArtworkImageLoader, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ArtworkImageLoader);
 public:
     using ArtworkImageLoaderCallback = Function<void(Image*)>;
     // The callback will only be called upon success or explicit failure to retrieve the image. If the operation is interrupted following the

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -59,8 +59,9 @@ namespace WebCore {
 
 #if ENABLE(DRAG_SUPPORT)
 
-class DragImageLoader final : private CachedImageClient {
+class DragImageLoader final : public CachedImageClient {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(DragImageLoader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DragImageLoader);
     WTF_MAKE_NONCOPYABLE(DragImageLoader);
 public:
     explicit DragImageLoader(DataTransfer&);

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -84,7 +84,7 @@ HTMLImageElement::HTMLImageElement(const QualifiedName& tagName, Document& docum
     : HTMLElement(tagName, document, { TypeFlag::HasCustomStyleResolveCallbacks, TypeFlag::HasDidMoveToNewDocument })
     , FormAssociatedElement(form)
     , ActiveDOMObject(document)
-    , m_imageLoader(makeUnique<HTMLImageLoader>(*this))
+    , m_imageLoader(makeUniqueWithoutRefCountedCheck<HTMLImageLoader>(*this))
     , m_compositeOperator(CompositeOperator::SourceOver)
     , m_imageDevicePixelRatio(1.0f)
 {

--- a/Source/WebCore/html/HTMLImageLoader.h
+++ b/Source/WebCore/html/HTMLImageLoader.h
@@ -27,6 +27,8 @@
 namespace WebCore {
 
 class HTMLImageLoader final : public ImageLoader {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(HTMLImageLoader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLImageLoader);
 public:
     explicit HTMLImageLoader(Element&);
     virtual ~HTMLImageLoader();

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -136,7 +136,7 @@ Ref<Element> HTMLInputElement::cloneElementWithoutAttributesAndChildren(Document
 HTMLImageLoader& HTMLInputElement::ensureImageLoader()
 {
     if (!m_imageLoader)
-        m_imageLoader = makeUnique<HTMLImageLoader>(*this);
+        m_imageLoader = makeUniqueWithoutRefCountedCheck<HTMLImageLoader>(*this);
     return *m_imageLoader;
 }
 

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -295,7 +295,7 @@ void HTMLObjectElement::renderFallbackContent()
         return;
 
     // Before we give up and use fallback content, check to see if this is a MIME type issue.
-    auto* loader = imageLoader();
+    RefPtr loader = imageLoader();
     if (loader && loader->image() && loader->image()->status() != CachedResource::LoadError) {
         m_serviceType = loader->image()->response().mimeType();
         if (!isImageType()) {

--- a/Source/WebCore/html/HTMLPlugInImageElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInImageElement.cpp
@@ -218,7 +218,7 @@ void HTMLPlugInImageElement::updateAfterStyleResolution()
     if (renderer() && !useFallbackContent()) {
         if (isImageType()) {
             if (!m_imageLoader)
-                m_imageLoader = makeUnique<HTMLImageLoader>(*this);
+                m_imageLoader = makeUniqueWithoutRefCountedCheck<HTMLImageLoader>(*this);
             if (m_needsImageReload)
                 m_imageLoader->updateFromElementIgnoringPreviousError();
             else

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -111,7 +111,7 @@ void HTMLVideoElement::didAttachRenderers()
 
     if (shouldDisplayPosterImage()) {
         if (!m_imageLoader)
-            m_imageLoader = makeUnique<HTMLImageLoader>(*this);
+            m_imageLoader = makeUniqueWithoutRefCountedCheck<HTMLImageLoader>(*this);
         m_imageLoader->updateFromElement();
         if (CheckedPtr renderer = this->renderer())
             renderer->checkedImageResource()->setCachedImage(m_imageLoader->protectedImage());
@@ -191,7 +191,7 @@ void HTMLVideoElement::attributeChanged(const QualifiedName& name, const AtomStr
     if (name == posterAttr) {
         if (shouldDisplayPosterImage()) {
             if (!m_imageLoader)
-                m_imageLoader = makeUnique<HTMLImageLoader>(*this);
+                m_imageLoader = makeUniqueWithoutRefCountedCheck<HTMLImageLoader>(*this);
             m_imageLoader->updateFromElementIgnoringPreviousError();
         } else {
             if (CheckedPtr renderer = this->renderer()) {

--- a/Source/WebCore/inspector/InspectorAuditResourcesObject.h
+++ b/Source/WebCore/inspector/InspectorAuditResourcesObject.h
@@ -79,7 +79,10 @@ private:
     class InspectorAuditCachedFontClient : public CachedFontClient { };
     InspectorAuditCachedFontClient m_cachedFontClient;
 
-    class InspectorAuditCachedImageClient : public CachedImageClient { };
+    class InspectorAuditCachedImageClient final : public CachedImageClient {
+        WTF_MAKE_FAST_ALLOCATED;
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorAuditCachedImageClient);
+    };
     InspectorAuditCachedImageClient m_cachedImageClient;
 
     class InspectorAuditCachedRawResourceClient : public CachedRawResourceClient { };

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -158,6 +158,16 @@ ImageLoader::~ImageLoader()
         loadEventSender().cancelEvent(*this);
 }
 
+void ImageLoader::ref() const
+{
+    m_element->ref();
+}
+
+void ImageLoader::deref() const
+{
+    m_element->deref();
+}
+
 void ImageLoader::clearImage()
 {
     clearImageWithoutConsideringPendingLoadEvent();

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -31,18 +31,6 @@
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
-class ImageLoader;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::ImageLoader> : std::true_type { };
-
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::ImageLoader> : std::true_type { };
-}
-
-namespace WebCore {
 
 class DeferredPromise;
 class Document;
@@ -59,8 +47,12 @@ enum class LazyImageLoadState : uint8_t { None, Deferred, LoadImmediately, FullI
 
 class ImageLoader : public CachedImageClient {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ImageLoader);
 public:
     virtual ~ImageLoader();
+
+    void ref() const;
+    void deref() const;
 
     // This function should be called when the element is attached to a document; starts
     // loading if a load hasn't already been started.

--- a/Source/WebCore/loader/LinkPreloadResourceClients.h
+++ b/Source/WebCore/loader/LinkPreloadResourceClients.h
@@ -37,7 +37,6 @@
 #include "CachedScript.h"
 #include "CachedStyleSheetClient.h"
 #include "CachedTextTrack.h"
-
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -114,6 +113,7 @@ private:
 
 class LinkPreloadImageResourceClient : public LinkPreloadResourceClient, public CachedImageClient {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LinkPreloadImageResourceClient);
 public:
     LinkPreloadImageResourceClient(LinkLoader& loader, CachedImage& resource)
         : LinkPreloadResourceClient(loader, resource)

--- a/Source/WebCore/loader/cache/CachedImageClient.h
+++ b/Source/WebCore/loader/cache/CachedImageClient.h
@@ -22,17 +22,9 @@
 
 #pragma once
 
+#include <wtf/CheckedPtr.h>
 #include "CachedResourceClient.h"
 #include "ImageTypes.h"
-
-namespace WebCore {
-class CachedImageClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CachedImageClient> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -42,7 +34,9 @@ class IntRect;
 
 enum class VisibleInViewportState { Unknown, Yes, No };
 
-class CachedImageClient : public CachedResourceClient {
+class CachedImageClient : public CachedResourceClient, public CanMakeCheckedPtr<CachedImageClient> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CachedImageClient);
 public:
     virtual ~CachedImageClient() = default;
     static CachedResourceClientType expectedType() { return ImageType; }

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -38,15 +38,6 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
-namespace WebCore {
-class ScrollableArea;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::ScrollableArea> : std::true_type { };
-}
-
 namespace WTF {
 class TextStream;
 }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -112,7 +112,7 @@ RenderObject::SetLayoutNeededForbiddenScope::~SetLayoutNeededForbiddenScope()
 
 #endif
 
-struct SameSizeAsRenderObject final : public CachedImageClient, public CanMakeCheckedPtr<SameSizeAsRenderObject> {
+struct SameSizeAsRenderObject final : public CachedImageClient {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
     WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(SameSizeAsRenderObject);
 

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -101,7 +101,7 @@ enum class RepaintOutlineBounds : bool { No, Yes };
 enum class RequiresFullRepaint : bool { No, Yes };
 
 // Base class for all rendering tree objects.
-class RenderObject : public CachedImageClient, public CanMakeCheckedPtr<RenderObject> {
+class RenderObject : public CachedImageClient {
     WTF_MAKE_COMPACT_TZONE_OR_ISO_ALLOCATED(RenderObject);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderObject);
     friend class RenderBlock;

--- a/Source/WebCore/rendering/style/StyleCrossfadeImage.h
+++ b/Source/WebCore/rendering/style/StyleCrossfadeImage.h
@@ -35,6 +35,8 @@ namespace WebCore {
 struct BlendingContext;
 
 class StyleCrossfadeImage final : public StyleGeneratedImage, private CachedImageClient {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(StyleCrossfadeImage);
 public:
     static Ref<StyleCrossfadeImage> create(RefPtr<StyleImage> from, RefPtr<StyleImage> to, double percentage, bool isPrefixed)
     {

--- a/Source/WebCore/rendering/style/StyleFilterImage.h
+++ b/Source/WebCore/rendering/style/StyleFilterImage.h
@@ -34,6 +34,8 @@
 namespace WebCore {
 
 class StyleFilterImage final : public StyleGeneratedImage, private CachedImageClient {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(StyleFilterImage);
 public:
     static Ref<StyleFilterImage> create(RefPtr<StyleImage> image, FilterOperations filterOperations)
     {

--- a/Source/WebCore/svg/SVGFEImageElement.h
+++ b/Source/WebCore/svg/SVGFEImageElement.h
@@ -29,13 +29,19 @@
 
 namespace WebCore {
 
-class SVGFEImageElement final : public SVGFilterPrimitiveStandardAttributes, public SVGURIReference, public CachedImageClient {
+class SVGFEImageElement final : public SVGFilterPrimitiveStandardAttributes, public SVGURIReference, private CachedImageClient {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(SVGFEImageElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEImageElement);
 public:
     static Ref<SVGFEImageElement> create(const QualifiedName&, Document&);
 
     virtual ~SVGFEImageElement();
+
+    // CheckedPtr interface
+    uint32_t checkedPtrCount() const { return SVGFilterPrimitiveStandardAttributes::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const { return SVGFilterPrimitiveStandardAttributes::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const { SVGFilterPrimitiveStandardAttributes::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const { SVGFilterPrimitiveStandardAttributes::decrementCheckedPtrCount(); }
 
     bool renderingTaintsOrigin() const;
 

--- a/Source/WebCore/svg/SVGImageLoader.h
+++ b/Source/WebCore/svg/SVGImageLoader.h
@@ -26,6 +26,8 @@ namespace WebCore {
 class SVGImageElement;
 
 class SVGImageLoader final : public ImageLoader {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(SVGImageLoader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGImageLoader);
 public:
     explicit SVGImageLoader(SVGImageElement&);
     virtual ~SVGImageLoader();

--- a/Source/WebKit/Shared/SharedStringHashStore.h
+++ b/Source/WebKit/Shared/SharedStringHashStore.h
@@ -28,20 +28,14 @@
 #include "SharedStringHashTable.h"
 #include <WebCore/SharedMemory.h>
 #include <WebCore/SharedStringHash.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/RunLoop.h>
 
 namespace WebKit {
-class SharedStringHashStore;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebKit::SharedStringHashStore> : std::true_type { };
-}
-
-namespace WebKit {
-
-class SharedStringHashStore {
+class SharedStringHashStore : public CanMakeCheckedPtr<SharedStringHashStore> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SharedStringHashStore);
 public:
     class Client {
     public:


### PR DESCRIPTION
#### 345db9a215e5c13c34289b71b9d731fdfacd99bd
<pre>
Further reduce use of IsDeprecatedTimerSmartPointerException
<a href="https://bugs.webkit.org/show_bug.cgi?id=282958">https://bugs.webkit.org/show_bug.cgi?id=282958</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/mediasession/MediaMetadata.h:
* Source/WebCore/dom/DataTransfer.cpp:
* Source/WebCore/html/HTMLImageLoader.h:
* Source/WebCore/inspector/InspectorAuditResourcesObject.h:
* Source/WebCore/loader/ImageLoader.h:
* Source/WebCore/loader/LinkPreloadResourceClients.h:
* Source/WebCore/loader/cache/CachedImageClient.h:
* Source/WebCore/rendering/RenderListBox.h:
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/style/StyleCrossfadeImage.h:
* Source/WebCore/rendering/style/StyleFilterImage.h:
* Source/WebCore/svg/SVGFEImageElement.h:
* Source/WebCore/svg/SVGImageLoader.h:
* Source/WebKit/Shared/SharedStringHashStore.h:
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(promisedDataClient):

Canonical link: <a href="https://commits.webkit.org/286533@main">https://commits.webkit.org/286533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c38a698748a839c866a5bf0136573388b4eeceb5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29145 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80750 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27515 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59795 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17921 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49685 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65481 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40132 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47082 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22967 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25837 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68212 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82208 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3615 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2361 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68009 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3769 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67320 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11279 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9390 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11796 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3563 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6370 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3586 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7015 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5344 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->