### PR TITLE
[CSS] Don't combine :not() with :host

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7972,6 +7972,12 @@ webkit.org/b/268995 [ Debug ] fast/misc/out-of-flow-position-inside-mathml-crash
 
 webkit.org/b/261557 media/video-remove-insert-repaints.html [ Pass Crash ]
 
+# CSS match :not(:not(:host))
+# webkit.org/b/283062
+imported/w3c/web-platform-tests/css/css-scoping/host-multiple-002.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-scoping/host-multiple-004.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-scoping/host-multiple-006.html [ ImageOnlyFailure ]
+
 # Out-of-flow line break handling
 [ Debug ] fast/text/remove-renderer-and-select-crash.html [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-descendant-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-descendant-003-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-descendant-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-descendant-003.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:host combined with :not</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#featureless">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<style>
+my-host {
+  display: block;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+</style>
+<p>Test passes if there is a filled green square.</p>
+<my-host id="host"></my-host>
+<script>
+  host.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      :host > div {
+        background-color: red;
+        width: 100%;
+        height: 100%;
+      }
+      :host > :not(span) {
+        background-color: green;
+      }
+    </style>
+    <div></div>
+  `;
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-002-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-002.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:host</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#featureless">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id=host>
+</div>
+<script>
+  host.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      :host {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+      }
+      :not(:not(:host)):host {
+        background-color: green;
+      }
+    </style>
+  `;
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-003-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-003.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:host</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#featureless">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id=host>
+</div>
+<script>
+  host.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      :host {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+      }
+      :is(div, :host) {
+        background-color: green;
+      }
+    </style>
+  `;
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-004-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-004-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-004.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:host</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#featureless">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id=host>
+</div>
+<script>
+  host.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      :host {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+      }
+      :not(div, :not(:host)) {
+        background-color: green;
+      }
+    </style>
+  `;
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-005-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-005-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-005.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:host</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#featureless">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id=host>
+</div>
+<script>
+  host.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      :host {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+      }
+      :is(:host):host {
+        background-color: green;
+      }
+    </style>
+  `;
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-006-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-006-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-006.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:host</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#featureless">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id=host>
+</div>
+<script>
+  host.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      :host {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+      }
+      :not(:not(:host)):host {
+        background-color: green;
+      }
+    </style>
+  `;
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-not-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-not-001-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-not-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-not-001.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:host combined with :not</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#featureless">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id=host>
+</div>
+<script>
+  host.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      :host {
+        width: 100px;
+        height: 100px;
+        background-color: green;
+      }
+      div:host {
+        background-color: red;
+      }
+      :not(div):host {
+        background-color: red;
+      }
+      :host:not(div) {
+        background-color: red;
+      }
+      :host:is(div) {
+        background-color: red;
+      }
+      :is(div):host {
+        background-color: red;
+      }
+      :host:not(:hover) {
+        background-color: red;
+      }
+      :host:not(:defined) {
+        background-color: red;
+      }
+    </style>
+  `;
+
+</script>

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -710,8 +710,12 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
         // :host doesn't combine with anything except pseudo elements.
         bool isHostPseudoClass = selector.match() == CSSSelector::Match::PseudoClass && selector.pseudoClass() == CSSSelector::PseudoClass::Host;
         bool isPseudoElement = selector.match() == CSSSelector::Match::PseudoElement;
-        // We can early return when we know it's neither :host, a compound like :is(:host), a pseudo-element.
-        if (!isHostPseudoClass && !isPseudoElement && !selector.selectorList())
+        // FIXME: We do not support combining :host with :not() functional pseudoclass. Combination with functional pseudoclass has been allowed for the useful :is(:host) ; but combining with :not() doesn't sound useful like :host():not(:not(:host))
+        // https://bugs.webkit.org/show_bug.cgi?id=283062
+        bool isNotPseudoClass = selector.match() == CSSSelector::Match::PseudoClass && selector.pseudoClass() == CSSSelector::PseudoClass::Not;
+
+        // We can early return when we know it's neither :host, a compound :is(:host) , a pseudo-element.
+        if (!isHostPseudoClass && !isPseudoElement && (!selector.selectorList() || isNotPseudoClass))
             return false;
     }
 


### PR DESCRIPTION
#### 33507394bab520401cc6904e737ec053229e98eb
<pre>
[CSS] Don&apos;t combine :not() with :host
<a href="https://bugs.webkit.org/show_bug.cgi?id=282960">https://bugs.webkit.org/show_bug.cgi?id=282960</a>
<a href="https://rdar.apple.com/139198548">rdar://139198548</a>

Reviewed by Tim Nguyen.

As a featureless element, only :host matches the shadow host.
Functional pseudoclasses pass the behavior to their arguments,
so :is(:host) matches the same as :host (the shadow host).

This fixes a regression introduced in 281963@main.
Before 281963, :host combination with a functional pseudoclass
(or anything but a pseudo-element more generally)
was early returning &quot;not match&quot;.
281963 has removed the early return for all functional pseudoclass
(to allow :is() combined with :host, but also :not()).

Properly supporting :host combining with :not() is tricky
and will be handled in a followup patch.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-descendant-003-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-descendant-003.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-003-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-003.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-004-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-004.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-005-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-005.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-006-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-006.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-not-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-not-001.html: Added.
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):

Canonical link: <a href="https://commits.webkit.org/286611@main">https://commits.webkit.org/286611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06fdf05e4a1079069d797c2c70f3ab648c174a97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81016 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27765 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78606 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59977 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18090 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49889 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65684 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40304 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47284 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23173 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26088 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68410 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82462 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3865 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2547 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68252 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4018 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65653 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67498 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16841 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11473 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9563 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3812 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6621 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3835 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7265 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5593 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->