### PR TITLE
[WebIDL] Update IDL modeling of undefined to match other types

### DIFF
--- a/LayoutTests/fast/css-custom-paint/properties.html
+++ b/LayoutTests/fast/css-custom-paint/properties.html
@@ -40,8 +40,8 @@ class MyPaint {
     assert_equals(properties.get('height').unit, 'px');
     assert_equals(properties.get('--my-prop').toString(), args[1].toString());
     assert_equals(properties.get('--my-registered-prop').toString(), args[2].toString());
-    assert_equals(properties.get('width'), null);
-    assert_equals(properties.get('--never-specified'), null);
+    assert_equals(properties.get('width'), undefined);
+    assert_equals(properties.get('--never-specified'), undefined);
 
     assert_equals(this.testThis(), 42);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/computed/get-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/computed/get-expected.txt
@@ -1,5 +1,5 @@
 
-PASS Getting a custom property not in the computed style returns null
+PASS Getting a custom property not in the computed style returns undefined
 PASS Getting a valid property from computed style returns the correct entry
 PASS Getting a valid custom property from computed style returns the correct entry
 PASS Getting a list-valued property from computed style returns only the first value

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/computed/get.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/computed/get.html
@@ -13,8 +13,8 @@
 
 test(t => {
   const styleMap = createComputedStyleMap(t, '--foo: auto');
-  assert_equals(styleMap.get('--Foo'), null);
-}, 'Getting a custom property not in the computed style returns null');
+  assert_equals(styleMap.get('--Foo'), undefined);
+}, 'Getting a custom property not in the computed style returns undefined');
 
 test(t => {
   const styleMap = createComputedStyleMap(t, 'width: 10px; height: 20px');

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/clear.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/clear.html
@@ -21,11 +21,11 @@ test(t => {
   let styleMap = createInlineStyleMap(t, '--foo: auto; width: 10px; transition-duration: 1s, 2s');
 
   styleMap.clear();
-  assert_equals(styleMap.get('--foo'), null,
+  assert_equals(styleMap.get('--foo'), undefined,
     'Custom properties should be cleared');
-  assert_equals(styleMap.get('width'), null,
+  assert_equals(styleMap.get('width'), undefined,
     'CSS properties should be cleared');
-  assert_equals(styleMap.get('transition-duration'), null,
+  assert_equals(styleMap.get('transition-duration'), undefined,
     'List-valued properties should be cleared');
   assert_array_equals([...styleMap], []);
 }, 'Can clear a CSS rule containing properties');

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/declared.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/declared.tentative.html
@@ -40,8 +40,8 @@ test(() => {
 }, 'Declared StylePropertyMap contains CSS property declarations in style rules');
 
 test(() => {
-  assert_equals(styleMap.get('top'), null);
-  assert_equals(styleMap.get('--bar'), null);
+  assert_equals(styleMap.get('top'), undefined);
+  assert_equals(styleMap.get('--bar'), undefined);
 }, 'Declared StylePropertyMap does not contain inline styles');
 
 test(() => {
@@ -49,7 +49,7 @@ test(() => {
 }, 'Declared StylePropertyMap contains custom property declarations');
 
 test(() => {
-  assert_equals(styleMap.get('color'), null);
+  assert_equals(styleMap.get('color'), undefined);
 }, 'Declared StylePropertyMap does not contain properties with invalid values');
 
 test(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/get-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/get-expected.txt
@@ -1,6 +1,6 @@
 
-PASS Getting a custom property not in the CSS rule returns null
-PASS Getting a valid property not in the CSS rule returns null
+PASS Getting a custom property not in the CSS rule returns undefined
+PASS Getting a valid property not in the CSS rule returns undefined
 PASS Getting a valid property from CSS rule returns the correct entry
 PASS Getting a valid custom property from CSS rule returns the correct entry
 PASS Getting a list-valued property from CSS rule returns only the first value

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/get-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/get-shorthand-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Getting a shorthand property set explicitly in css rule returns a base CSSStyleValue
-PASS Getting a shorthand property that is partially set in css rule returns null
+PASS Getting a shorthand property that is partially set in css rule returns undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/get-shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/get-shorthand.html
@@ -13,7 +13,7 @@
 test(t => {
   const styleMap = createDeclaredStyleMap(t, 'margin: 1px 2px 3px 4px');
   const result = styleMap.get('margin');
-  assert_not_equals(result, null, 'Shorthand value must not be null');
+  assert_not_equals(result, undefined, 'Shorthand value must not be undefined');
   assert_class_string(result, 'CSSStyleValue',
     'Shorthand value must be a base CSSStyleValue');
 }, 'Getting a shorthand property set explicitly in css rule returns ' +
@@ -22,9 +22,9 @@ test(t => {
 test(t => {
   const styleMap = createDeclaredStyleMap(t, 'margin-top: 1px');
   const result = styleMap.get('margin');
-  assert_equals(result, null,
-    'Shorthand value must be null as it is not explicitly set');
+  assert_equals(result, undefined,
+    'Shorthand value must be undefined as it is not explicitly set');
 }, 'Getting a shorthand property that is partially set in css rule ' +
-   'returns null');
+   'returns undefined');
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/get.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/get.html
@@ -13,13 +13,13 @@
 
 test(t => {
   const styleMap = createDeclaredStyleMap(t, '--foo: auto');
-  assert_equals(styleMap.get('--Foo'), null);
-}, 'Getting a custom property not in the CSS rule returns null');
+  assert_equals(styleMap.get('--Foo'), undefined);
+}, 'Getting a custom property not in the CSS rule returns undefined');
 
 test(t => {
   const styleMap = createDeclaredStyleMap(t, '');
-  assert_equals(styleMap.get('width'), null);
-}, 'Getting a valid property not in the CSS rule returns null');
+  assert_equals(styleMap.get('width'), undefined);
+}, 'Getting a valid property not in the CSS rule returns undefined');
 
 test(t => {
   const styleMap = createDeclaredStyleMap(t, 'width: 10px; height: 20px');

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/clear.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/clear.html
@@ -21,11 +21,11 @@ test(t => {
   let styleMap = createInlineStyleMap(t, '--foo: auto; width: 10px; transition-duration: 1s, 2s');
 
   styleMap.clear();
-  assert_equals(styleMap.get('--foo'), null,
+  assert_equals(styleMap.get('--foo'), undefined,
     'Custom properties should be cleared');
-  assert_equals(styleMap.get('width'), null,
+  assert_equals(styleMap.get('width'), undefined,
     'CSS properties should be cleared');
-  assert_equals(styleMap.get('transition-duration'), null,
+  assert_equals(styleMap.get('transition-duration'), undefined,
     'List-valued properties should be cleared');
   assert_array_equals([...styleMap], []);
 }, 'Can clear an inline style containing properties');

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/get-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/get-expected.txt
@@ -1,6 +1,6 @@
 
-PASS Getting a custom property not in the inline style returns null
-PASS Getting a valid property not in the inline style returns null
+PASS Getting a custom property not in the inline style returns undefined
+PASS Getting a valid property not in the inline style returns undefined
 PASS Getting a valid property from inline style returns the correct entry
 PASS Getting a valid custom property from inline style returns the correct entry
 PASS Getting a list-valued property from inline style returns only the first value

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/get-shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/get-shorthand.html
@@ -22,15 +22,15 @@ test(t => {
 test(t => {
   const styleMap = createInlineStyleMap(t, 'margin-top: 1px');
   const result = styleMap.get('margin');
-  assert_equals(result, null,
-    'Shorthand value must be null as it is not explicitly set');
+  assert_equals(result, undefined,
+    'Shorthand value must be undefined as it is not explicitly set');
 }, 'Getting a shorthand property that is partially set in inline style ' +
    'returns null');
 
 test(t => {
   const styleMap = createDivWithoutStyle(t).attributeStyleMap;
-  assert_equals(styleMap.get('margin'), null,
-    'Shorthand value must be null for element without style');
+  assert_equals(styleMap.get('margin'), undefined,
+    'Shorthand value must be undefined for element without style');
 }, 'Getting an attributeStyleMap shorthand property from an element without ' +
    'a style attribute');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/get.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/get.html
@@ -13,13 +13,13 @@
 
 test(t => {
   const styleMap = createInlineStyleMap(t, '--foo: auto');
-  assert_equals(styleMap.get('--Foo'), null);
-}, 'Getting a custom property not in the inline style returns null');
+  assert_equals(styleMap.get('--Foo'), undefined);
+}, 'Getting a custom property not in the inline style returns undefined');
 
 test(t => {
   const styleMap = createInlineStyleMap(t, '');
-  assert_equals(styleMap.get('width'), null);
-}, 'Getting a valid property not in the inline style returns null');
+  assert_equals(styleMap.get('width'), undefined);
+}, 'Getting a valid property not in the inline style returns undefined');
 
 test(t => {
   const styleMap = createInlineStyleMap(t, 'width: 10px; height: 20px');

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-path-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-path-expected.txt
@@ -38,5 +38,5 @@ PASS Setting 'clip-path' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'clip-path' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'clip-path' to a transform: perspective(10em) throws TypeError
 PASS Setting 'clip-path' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'clip' does not support 'inset(22% 12% 15px 35px)' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'clip' does not support 'inset(22% 12% 15px 35px)' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-name-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-name-expected.txt
@@ -32,5 +32,5 @@ PASS Setting 'container-name' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'container-name' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'container-name' to a transform: perspective(10em) throws TypeError
 PASS Setting 'container-name' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'container-type' does not support 'name1 name2' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'container-type' does not support 'name1 name2' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/display-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/display-expected.txt
@@ -51,8 +51,8 @@ PASS Setting 'display' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'display' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'display' to a transform: perspective(10em) throws TypeError
 PASS Setting 'display' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'display' does not support setting 'inline math' assert_not_equals: got disallowed value null
-FAIL 'display' does not support setting 'math inline' assert_not_equals: got disallowed value null
-FAIL 'display' does not support 'block math' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'display' does not support 'math block' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'display' does not support setting 'inline math' assert_in_array: value "[object Undefined]" not in array ["[object CSSStyleValue]", "[object CSSKeywordValue]"]
+FAIL 'display' does not support setting 'math inline' assert_in_array: value "[object Undefined]" not in array ["[object CSSStyleValue]", "[object CSSKeywordValue]"]
+FAIL 'display' does not support 'block math' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
+FAIL 'display' does not support 'math block' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL 'fill' does not support 'black' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'fill' does not support 'red gray' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'fill' does not support 'red gray' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-palette-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-palette-expected.txt
@@ -33,5 +33,5 @@ PASS Setting 'font-palette' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'font-palette' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'font-palette' to a transform: perspective(10em) throws TypeError
 PASS Setting 'font-palette' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'font-palette' does not support 'Augusta' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'font-palette' does not support 'Augusta' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-type-expected.txt
@@ -33,5 +33,5 @@ PASS Setting 'list-style-type' to a transform: translate(50%, 50%) throws TypeEr
 PASS Setting 'list-style-type' to a transform: perspective(10em) throws TypeError
 PASS Setting 'list-style-type' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS 'list-style-type' does not support '"Note: "'
-FAIL 'list-style-type' does not support 'symbols("*" "A" "B" "C")' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'list-style-type' does not support 'symbols("*" "A" "B" "C")' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-wrap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-wrap-expected.txt
@@ -33,5 +33,5 @@ PASS Setting 'overflow-wrap' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'overflow-wrap' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'overflow-wrap' to a transform: perspective(10em) throws TypeError
 PASS Setting 'overflow-wrap' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'overflow-wrap' does not support 'break-overflow break-spaces' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'overflow-wrap' does not support 'break-overflow break-spaces' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/page-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/page-expected.txt
@@ -1,11 +1,11 @@
 
-FAIL Can set 'page' to CSS-wide keywords: initial assert_not_equals: Computed value must not be null got disallowed value null
-FAIL Can set 'page' to CSS-wide keywords: inherit assert_not_equals: Computed value must not be null got disallowed value null
-FAIL Can set 'page' to CSS-wide keywords: unset assert_not_equals: Computed value must not be null got disallowed value null
-FAIL Can set 'page' to CSS-wide keywords: revert assert_not_equals: Computed value must not be null got disallowed value null
-FAIL Can set 'page' to var() references:  var(--A) assert_not_equals: Computed value must not be null got disallowed value null
-FAIL Can set 'page' to the 'auto' keyword: auto assert_not_equals: Computed value must not be null got disallowed value null
-FAIL Can set 'page' to the 'custom-ident' keyword: custom-ident assert_not_equals: Computed value must not be null got disallowed value null
+FAIL Can set 'page' to CSS-wide keywords: initial assert_true: Computed value must be a CSSStyleValue expected true got false
+FAIL Can set 'page' to CSS-wide keywords: inherit assert_true: Computed value must be a CSSStyleValue expected true got false
+FAIL Can set 'page' to CSS-wide keywords: unset assert_true: Computed value must be a CSSStyleValue expected true got false
+FAIL Can set 'page' to CSS-wide keywords: revert assert_true: Computed value must be a CSSStyleValue expected true got false
+FAIL Can set 'page' to var() references:  var(--A) assert_true: Computed value must be a CSSStyleValue expected true got false
+FAIL Can set 'page' to the 'auto' keyword: auto assert_true: Computed value must be a CSSStyleValue expected true got false
+FAIL Can set 'page' to the 'custom-ident' keyword: custom-ident assert_true: Computed value must be a CSSStyleValue expected true got false
 PASS Setting 'page' to a length: 0px throws TypeError
 PASS Setting 'page' to a length: -3.14em throws TypeError
 PASS Setting 'page' to a length: 3.14cm throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL 'stroke' does not support 'black' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'stroke' does not support 'red gray' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'stroke' does not support 'red gray' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linejoin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linejoin-expected.txt
@@ -36,6 +36,6 @@ PASS Setting 'stroke-linejoin' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'stroke-linejoin' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'stroke-linejoin' to a transform: perspective(10em) throws TypeError
 PASS Setting 'stroke-linejoin' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'stroke-linejoin' does not support 'crop bevel' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'stroke-linejoin' does not support 'round arcs' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'stroke-linejoin' does not support 'crop bevel' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
+FAIL 'stroke-linejoin' does not support 'round arcs' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-combine-upright-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-combine-upright-expected.txt
@@ -32,5 +32,5 @@ PASS Setting 'text-combine-upright' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'text-combine-upright' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'text-combine-upright' to a transform: perspective(10em) throws TypeError
 PASS Setting 'text-combine-upright' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'text-combine-upright' does not support 'digits 3' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'text-combine-upright' does not support 'digits 3' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-expected.txt
@@ -1,5 +1,5 @@
 
 PASS 'text-decoration' does not support 'underline'
-FAIL 'text-decoration' does not support 'underline dotted #ff3028' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'text-decoration' does not support 'green wavy underline' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'text-decoration' does not support 'underline dotted #ff3028' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
+FAIL 'text-decoration' does not support 'green wavy underline' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-expected.txt
@@ -35,7 +35,7 @@ PASS Setting 'text-decoration-skip' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'text-decoration-skip' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'text-decoration-skip' to a transform: perspective(10em) throws TypeError
 PASS Setting 'text-decoration-skip' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'text-decoration-skip' does not support 'objects spaces' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'text-decoration-skip' does not support 'leading-spaces trailing-spaces' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'text-decoration-skip' does not support 'objects edges box-decoration' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'text-decoration-skip' does not support 'objects spaces' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
+FAIL 'text-decoration-skip' does not support 'leading-spaces trailing-spaces' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
+FAIL 'text-decoration-skip' does not support 'objects edges box-decoration' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-overflow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-overflow-expected.txt
@@ -33,7 +33,7 @@ PASS Setting 'text-overflow' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'text-overflow' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'text-overflow' to a transform: perspective(10em) throws TypeError
 PASS Setting 'text-overflow' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'text-overflow' does not support 'clip ellipsis' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'text-overflow' does not support '"..."' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'text-overflow' does not support 'fade(1px, 50%)' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'text-overflow' does not support 'clip ellipsis' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
+FAIL 'text-overflow' does not support '"..."' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
+FAIL 'text-overflow' does not support 'fade(1px, 50%)' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/touch-action-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/touch-action-expected.txt
@@ -40,6 +40,6 @@ PASS Setting 'touch-action' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'touch-action' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'touch-action' to a transform: perspective(10em) throws TypeError
 PASS Setting 'touch-action' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'touch-action' does not support 'pan-x pan-down' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'touch-action' does not support 'pan-down pinch-zoom pan-right' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'touch-action' does not support 'pan-x pan-down' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
+FAIL 'touch-action' does not support 'pan-down pinch-zoom pan-right' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-expected.txt
@@ -1,6 +1,6 @@
 
 PASS 'transition' does not support 'none'
-FAIL 'transition' does not support 'none, none' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'transition' does not support 'none, none' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
 PASS 'transition' does not support 'margin-right 4s'
 PASS 'transition' does not support 'all 0.5s ease-out, color 1s'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-wrap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-wrap-expected.txt
@@ -33,5 +33,5 @@ PASS Setting 'word-wrap' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'word-wrap' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'word-wrap' to a transform: perspective(10em) throws TypeError
 PASS Setting 'word-wrap' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'word-wrap' does not support 'break-word break-spaces' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'word-wrap' does not support 'break-word break-spaces' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -763,6 +763,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     bindings/js/JSDOMConvertSequences.h
     bindings/js/JSDOMConvertSerializedScriptValue.h
     bindings/js/JSDOMConvertStrings.h
+    bindings/js/JSDOMConvertUndefined.h
     bindings/js/JSDOMConvertUnion.h
     bindings/js/JSDOMConvertWebGL.h
     bindings/js/JSDOMConvertXPathNSResolver.h

--- a/Source/WebCore/bindings/IDLTypes.h
+++ b/Source/WebCore/bindings/IDLTypes.h
@@ -119,7 +119,10 @@ struct IDLAny : IDLType<JSC::Strong<JSC::Unknown>> {
     template<typename U> static inline U&& extractValueFromNullable(U&& value) { return std::forward<U>(value); }
 };
 
-struct IDLUndefined : IDLType<void> { };
+struct IDLUndefined : IDLType<std::monostate> {
+    using CallbackReturnType = void;
+    using NullableCallbackReturnType = void;
+};
 
 struct IDLBoolean : IDLType<bool> { };
 

--- a/Source/WebCore/bindings/js/JSDOMConvert.h
+++ b/Source/WebCore/bindings/js/JSDOMConvert.h
@@ -44,4 +44,5 @@
 #include "JSDOMConvertSequences.h"
 #include "JSDOMConvertSerializedScriptValue.h"
 #include "JSDOMConvertStrings.h"
+#include "JSDOMConvertUndefined.h"
 #include "JSDOMConvertUnion.h"

--- a/Source/WebCore/bindings/js/JSDOMConvertUndefined.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertUndefined.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,27 +25,29 @@
 
 #pragma once
 
-#include "URLPattern.h"
+#include "IDLTypes.h"
+#include "JSDOMConvertBase.h"
 
 namespace WebCore {
 
-struct URLPatternComponentResult {
-    using GroupsRecord = Vector<KeyValuePair<String, std::variant<std::monostate, String>>>;
-    String input;
-    GroupsRecord groups;
+template<> struct Converter<IDLUndefined> : DefaultConverter<IDLUndefined> {
+    static constexpr bool conversionHasSideEffects = false;
+    using Result = ConversionResult<IDLUndefined>;
+
+    static Result convert(JSC::JSGlobalObject&, JSC::JSValue)
+    {
+        return Result { std::monostate { } };
+    }
 };
 
-struct URLPatternResult {
-    Vector<URLPattern::URLPatternInput> inputs;
+template<> struct JSConverter<IDLUndefined> {
+    static constexpr bool needsState = false;
+    static constexpr bool needsGlobalObject = false;
 
-    URLPatternComponentResult protocol;
-    URLPatternComponentResult username;
-    URLPatternComponentResult password;
-    URLPatternComponentResult hostname;
-    URLPatternComponentResult port;
-    URLPatternComponentResult pathname;
-    URLPatternComponentResult search;
-    URLPatternComponentResult hash;
+    static JSC::JSValue convert(std::monostate)
+    {
+        return JSC::jsUndefined();
+    }
 };
 
-}
+} // namespace WebCore

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -7306,7 +7306,6 @@ sub GetNumberOfNullableMemberTypes
 
     foreach my $memberType (@{$idlUnionType->subtypes}) {
         $count++ if $memberType->isNullable;
-        $count++ if $memberType->name eq "undefined" && $undefinedAsNull;
         $count += GetNumberOfNullableMemberTypes($memberType) if $memberType->isUnion;
     }
 
@@ -7317,7 +7316,7 @@ sub GetIDLUnionMemberTypes
 {
     my ($interface, $idlUnionType) = @_;
 
-    my $numberOfNullableMembers = GetNumberOfNullableMemberTypes($idlUnionType, 1);
+    my $numberOfNullableMembers = GetNumberOfNullableMemberTypes($idlUnionType);
     assert("Union types must only have 0 or 1 nullable types.") if $numberOfNullableMembers > 1;
 
     my @idlUnionMemberTypes = ();
@@ -7325,8 +7324,7 @@ sub GetIDLUnionMemberTypes
     push(@idlUnionMemberTypes, "IDLNull") if $numberOfNullableMembers == 1;
 
     foreach my $memberType (GetFlattenedMemberTypes($idlUnionType)) {
-        my $nonnullType = GetIDLTypeExcludingNullability($interface, $memberType);
-        push(@idlUnionMemberTypes, $nonnullType) if $nonnullType ne "IDLUndefined";
+        push(@idlUnionMemberTypes, GetIDLTypeExcludingNullability($interface, $memberType));
     }
 
     return @idlUnionMemberTypes;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -994,6 +994,19 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
             return ConversionResultException { };
         result.stringWithoutDefault = stringWithoutDefaultConversionResult.releaseReturnValue();
     }
+    JSValue undefinedUnionMemberValue;
+    if (isNullOrUndefined)
+        undefinedUnionMemberValue = jsUndefined();
+    else {
+        undefinedUnionMemberValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "undefinedUnionMember"_s));
+        RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
+    }
+    if (!undefinedUnionMemberValue.isUndefined()) {
+        auto undefinedUnionMemberConversionResult = convert<IDLUnion<IDLUndefined, IDLInterface<Node>>>(lexicalGlobalObject, undefinedUnionMemberValue);
+        if (UNLIKELY(undefinedUnionMemberConversionResult.hasException(throwScope)))
+            return ConversionResultException { };
+        result.undefinedUnionMember = undefinedUnionMemberConversionResult.releaseReturnValue();
+    }
     JSValue unionMemberValue;
     if (isNullOrUndefined)
         unionMemberValue = jsUndefined();
@@ -1257,6 +1270,11 @@ JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject& lexicalGlobalObject, J
         auto stringWithoutDefaultValue = toJS<IDLDOMString>(lexicalGlobalObject, throwScope, IDLDOMString::extractValueFromNullable(dictionary.stringWithoutDefault));
         RETURN_IF_EXCEPTION(throwScope, { });
         result->putDirect(vm, JSC::Identifier::fromString(vm, "stringWithoutDefault"_s), stringWithoutDefaultValue);
+    }
+    if (!IDLUnion<IDLUndefined, IDLInterface<Node>>::isNullValue(dictionary.undefinedUnionMember)) {
+        auto undefinedUnionMemberValue = toJS<IDLUnion<IDLUndefined, IDLInterface<Node>>>(lexicalGlobalObject, globalObject, throwScope, IDLUnion<IDLUndefined, IDLInterface<Node>>::extractValueFromNullable(dictionary.undefinedUnionMember));
+        RETURN_IF_EXCEPTION(throwScope, { });
+        result->putDirect(vm, JSC::Identifier::fromString(vm, "undefinedUnionMember"_s), undefinedUnionMemberValue);
     }
     if (!IDLUnion<IDLLong, IDLInterface<Node>>::isNullValue(dictionary.unionMember)) {
         auto unionMemberValue = toJS<IDLUnion<IDLLong, IDLInterface<Node>>>(lexicalGlobalObject, globalObject, throwScope, IDLUnion<IDLLong, IDLInterface<Node>>::extractValueFromNullable(dictionary.unionMember));
@@ -3991,7 +4009,7 @@ static inline JSValue jsTestObj_annotatedTypeInUnionAttrGetter(JSGlobalObject& l
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLUnion<IDLDOMString, IDLClampAdaptor<IDLLong>>>(lexicalGlobalObject, *thisObject.globalObject(), throwScope, impl.annotatedTypeInUnionAttr())));
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLUnion<IDLDOMString, IDLClampAdaptor<IDLLong>, IDLUndefined>>(lexicalGlobalObject, *thisObject.globalObject(), throwScope, impl.annotatedTypeInUnionAttr())));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTestObj_annotatedTypeInUnionAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
@@ -4005,7 +4023,7 @@ static inline bool setJSTestObj_annotatedTypeInUnionAttrSetter(JSGlobalObject& l
     UNUSED_PARAM(vm);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
-    auto nativeValueConversionResult = convert<IDLUnion<IDLDOMString, IDLClampAdaptor<IDLLong>>>(lexicalGlobalObject, value);
+    auto nativeValueConversionResult = convert<IDLUnion<IDLDOMString, IDLClampAdaptor<IDLLong>, IDLUndefined>>(lexicalGlobalObject, value);
     if (UNLIKELY(nativeValueConversionResult.hasException(throwScope)))
         return false;
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {

--- a/Source/WebCore/bindings/scripts/test/TestObj.idl
+++ b/Source/WebCore/bindings/scripts/test/TestObj.idl
@@ -90,7 +90,7 @@ enum TestConfidence { "high", "kinda-low" };
     attribute record<DOMString, VoidCallback> stringVoidCallbackRecordAttr;
     attribute TestDictionary dictionaryAttr;
     attribute TestDictionary? nullableDictionaryAttr;
-    attribute (DOMString or [Clamp] long) annotatedTypeInUnionAttr;
+    attribute (DOMString or [Clamp] long or undefined) annotatedTypeInUnionAttr;
     attribute sequence<[Clamp] long> annotatedTypeInSequenceAttr;
 
     attribute TestEnumTypeWithAlternateImplementationName implementationEnumAttr;
@@ -525,6 +525,7 @@ typedef any AnyTypedef;
     ParentDictionary dictionaryMemberWithDefault = {};
     (long or Node) unionMember;
     (long or Node)? nullableUnionMember = null;
+    (undefined or Node) undefinedUnionMember;
     BufferSource bufferSourceValue;
     required BufferSource requiredBufferSourceValue;
     (DOMString or [Clamp] long) annotatedTypeInUnionMember;

--- a/Source/WebCore/css/typedom/StylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/StylePropertyMapReadOnly.h
@@ -63,7 +63,7 @@ public:
     Iterator createIterator(ScriptExecutionContext* context) { return Iterator(*this, context); }
 
     virtual ~StylePropertyMapReadOnly() = default;
-    using CSSStyleValueOrUndefined = std::variant<std::nullptr_t, RefPtr<CSSStyleValue>>;
+    using CSSStyleValueOrUndefined = std::variant<std::monostate, RefPtr<CSSStyleValue>>;
     virtual ExceptionOr<CSSStyleValueOrUndefined> get(ScriptExecutionContext&, const AtomString& property) const = 0;
     virtual ExceptionOr<Vector<RefPtr<CSSStyleValue>>> getAll(ScriptExecutionContext&, const AtomString&) const = 0;
     virtual ExceptionOr<bool> has(ScriptExecutionContext&, const AtomString&) const = 0;


### PR DESCRIPTION
#### a613d8e8a303fd5ca7416f9d8cf2d235eadb3e3c
<pre>
[WebIDL] Update IDL modeling of undefined to match other types
<a href="https://bugs.webkit.org/show_bug.cgi?id=282962">https://bugs.webkit.org/show_bug.cgi?id=282962</a>

Reviewed by Chris Dumez and Sihui Liu.

Updates support for IDLUndefined as a distinct type that is
represented as either:

 `void` - when used as the result of a method or callback
 `std::monostate` - when used in an IDLUnion

Syncs the IDL union code with the latest spec, updating comments
to match the currently missing steps.

* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp:
* Source/WebCore/bindings/scripts/test/TestObj.idl:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/url-pattern/URLPatternResult.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/IDLTypes.h:
* Source/WebCore/bindings/js/JSDOMConvert.h:
* Source/WebCore/bindings/js/JSDOMConvertUndefined.h: Added.
* Source/WebCore/bindings/js/JSDOMConvertUnion.h:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
* Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp:
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.h:

* LayoutTests/fast/css-custom-paint/properties.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/computed/get-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/computed/get.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/clear.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/declared.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/get-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/get-shorthand-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/get-shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/get.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/clear.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/get-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/get-shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/get.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-path-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-name-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/display-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-palette-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-type-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-wrap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/page-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linejoin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-combine-upright-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-overflow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/touch-action-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-wrap-expected.txt:
    Updated tests and results for change from null to undefined.

Canonical link: <a href="https://commits.webkit.org/286569@main">https://commits.webkit.org/286569@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45387d6818c48913aa3975420cbdaa26b840a1db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80822 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27583 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78427 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59846 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17967 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79378 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40186 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47138 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23023 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25905 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68265 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82278 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68060 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65508 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67373 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16807 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11338 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9438 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3631 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6438 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3654 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7083 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5412 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->