### PR TITLE
REGRESSION(285567@main) platform/visionos/transforms/separated-update.html is a constant failure

### DIFF
--- a/LayoutTests/platform/visionos/transforms/separated-update.html
+++ b/LayoutTests/platform/visionos/transforms/separated-update.html
@@ -1,5 +1,4 @@
-
-<!DOCTYPE HTML><!-- webkit-test-runner [ CSSTransformStyleSeparatedEnabled=true ] -->
+<!DOCTYPE HTML><!-- webkit-test-runner [ CSSTransformStyleSeparatedEnabled=true useFlexibleViewport=false ] -->
 <html>
 <style>
     body { margin: 0; }
@@ -39,10 +38,12 @@ window.onload = async function () {
 
     // Hide first separated layer, bring the second one into view.
     window.scrollTo(0, 2500);
+    await UIHelper.ensureStablePresentationUpdate();
+
     // Separate the last layer, already in view.
     document.querySelector("div.transformed:last-child").classList.add("separated");
-
     await UIHelper.ensureStablePresentationUpdate();
+
     results.textContent = await UIHelper.getCALayerTree();
     document.getElementById('test').remove();
 

--- a/LayoutTests/platform/visionos/transforms/separated.html
+++ b/LayoutTests/platform/visionos/transforms/separated.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML><!-- webkit-test-runner [ CSSTransformStyleSeparatedEnabled=true ] -->
+<!DOCTYPE HTML><!-- webkit-test-runner [ CSSTransformStyleSeparatedEnabled=true useFlexibleViewport=false ] -->
 <html>
 <style>
     body { margin: 0; }


### PR DESCRIPTION
#### e95199848ee6b51ccb38b4efbcb202b3c7d8929c
<pre>
REGRESSION(285567@main) platform/visionos/transforms/separated-update.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=282947">https://bugs.webkit.org/show_bug.cgi?id=282947</a>
&lt;<a href="https://rdar.apple.com/139664735">rdar://139664735</a>&gt;

Reviewed by Jonathan Bedard.

Always opt out of `useFlexibleViewport` to avoid extra layers in the
layer dump dependant on test order.

* LayoutTests/platform/visionos/transforms/separated-update.html:
Wait for a stable presentation after scrolling.
* LayoutTests/platform/visionos/transforms/separated.html:

Canonical link: <a href="https://commits.webkit.org/286485@main">https://commits.webkit.org/286485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72f76b2873154491b217561c49e0ad13090e4094

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80634 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27398 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59696 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17837 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49589 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40045 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46985 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22864 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25725 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68117 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82095 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3503 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/2267 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67923 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3657 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65349 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67233 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/page-visibility (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16753 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11184 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9298 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3451 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3474 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/6868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/5232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->