### PR TITLE
Unreviewed, reverting 286428@main (ebd307719a8e) and 286323@main (3539c8a950f6)

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -100,11 +100,6 @@ bool GStreamerMediaEndpoint::initializePipeline()
     m_pipeline = gst_pipeline_new(pipelineName.ascii().data());
     registerActivePipeline(m_pipeline);
 
-    auto clock = adoptGRef(gst_system_clock_obtain());
-    gst_pipeline_use_clock(GST_PIPELINE(m_pipeline.get()), clock.get());
-    gst_element_set_base_time(m_pipeline.get(), 0);
-    gst_element_set_start_time(m_pipeline.get(), GST_CLOCK_TIME_NONE);
-
     connectSimpleBusMessageCallback(m_pipeline.get(), [this](GstMessage* message) {
         handleMessage(message);
     });
@@ -113,9 +108,6 @@ bool GStreamerMediaEndpoint::initializePipeline()
     m_webrtcBin = makeGStreamerElement("webrtcbin", binName.ascii().data());
     if (!m_webrtcBin)
         return false;
-
-    // Lower default latency from 200ms to 40ms.
-    g_object_set(m_webrtcBin.get(), "latency", 40, nullptr);
 
     auto rtpBin = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_webrtcBin.get()), "rtpbin"));
     if (!rtpBin) {

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -829,11 +829,6 @@ void connectSimpleBusMessageCallback(GstElement* pipeline, Function<void(GstMess
             break;
         }
         case GST_MESSAGE_LATENCY:
-            // Recalculate the latency, we don't need any special handling
-            // here other than the GStreamer default.
-            // This can happen if the latency of live elements changes, or
-            // for one reason or another a new live element is added or
-            // removed from the pipeline.
             gst_bin_recalculate_latency(GST_BIN_CAST(pipeline.get()));
             break;
         default:

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2118,6 +2118,14 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
         gst_element_set_state(m_pipeline.get(), GST_STATE_PAUSED);
         gst_element_set_state(m_pipeline.get(), GST_STATE_PLAYING);
         break;
+    case GST_MESSAGE_LATENCY:
+        // Recalculate the latency, we don't need any special handling
+        // here other than the GStreamer default.
+        // This can happen if the latency of live elements changes, or
+        // for one reason or another a new live element is added or
+        // removed from the pipeline.
+        gst_bin_recalculate_latency(GST_BIN(m_pipeline.get()));
+        break;
     case GST_MESSAGE_ELEMENT:
 #if USE(GSTREAMER_MPEGTS)
         if (GstMpegtsSection* section = gst_message_parse_mpegts_section(message)) {
@@ -3140,13 +3148,6 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
     GST_INFO_OBJECT(m_pipeline.get(), "WebCore logs identifier for this pipeline is: %s", identifier.convertToASCIIUppercase().ascii().data());
 #endif
     registerActivePipeline(m_pipeline);
-
-    if (isMediaStream) {
-        auto clock = adoptGRef(gst_system_clock_obtain());
-        gst_pipeline_use_clock(GST_PIPELINE(m_pipeline.get()), clock.get());
-        gst_element_set_base_time(m_pipeline.get(), 0);
-        gst_element_set_start_time(m_pipeline.get(), GST_CLOCK_TIME_NONE);
-    }
 
     setStreamVolumeElement(GST_STREAM_VOLUME(m_pipeline.get()));
 

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -401,12 +401,6 @@ bool MediaRecorderPrivateBackend::preparePipeline()
     m_transcoder = adoptGRef(gst_transcoder_new_full("mediastream://", "appsink://", GST_ENCODING_PROFILE(profile.get())));
     gst_transcoder_set_avoid_reencoding(m_transcoder.get(), true);
     m_pipeline = gst_transcoder_get_pipeline(m_transcoder.get());
-
-    auto clock = adoptGRef(gst_system_clock_obtain());
-    gst_pipeline_use_clock(GST_PIPELINE(m_pipeline.get()), clock.get());
-    gst_element_set_base_time(m_pipeline.get(), 0);
-    gst_element_set_start_time(m_pipeline.get(), GST_CLOCK_TIME_NONE);
-
     registerActivePipeline(m_pipeline);
 
     g_signal_connect_swapped(m_pipeline.get(), "source-setup", G_CALLBACK(+[](MediaRecorderPrivateBackend* recorder, GstElement* sourceElement) {

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
@@ -131,14 +131,6 @@ void GStreamerAudioCaptureSource::stopProducingData()
     m_capturer->stop();
 }
 
-std::pair<GstClockTime, GstClockTime> GStreamerAudioCaptureSource::queryLatency()
-{
-    if (!m_capturer)
-        return { GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE };
-
-    return m_capturer->queryLatency();
-}
-
 const RealtimeMediaSourceCapabilities& GStreamerAudioCaptureSource::capabilities()
 {
     if (m_capabilities)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.h
@@ -41,8 +41,6 @@ public:
     GstElement* pipeline() { return m_capturer->pipeline(); }
     GStreamerCapturer* capturer() { return m_capturer.get(); }
 
-    std::pair<GstClockTime, GstClockTime> queryLatency();
-
     void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerAudioCaptureSource>::ref(); }
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerAudioCaptureSource>::deref(); }
     ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerAudioCaptureSource>::controlBlock(); }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -189,11 +189,6 @@ void GStreamerCapturer::setupPipeline()
     }
 
     m_pipeline = makeElement("pipeline");
-    auto clock = adoptGRef(gst_system_clock_obtain());
-    gst_pipeline_use_clock(GST_PIPELINE(m_pipeline.get()), clock.get());
-    gst_element_set_base_time(m_pipeline.get(), 0);
-    gst_element_set_start_time(m_pipeline.get(), GST_CLOCK_TIME_NONE);
-
     registerActivePipeline(m_pipeline);
 
     GRefPtr<GstElement> source = createSource();
@@ -239,18 +234,6 @@ void GStreamerCapturer::stop()
 {
     GST_INFO_OBJECT(pipeline(), "Stopping");
     tearDown(false);
-}
-
-std::pair<GstClockTime, GstClockTime> GStreamerCapturer::queryLatency()
-{
-    if (!m_sink)
-        return { GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE };
-
-    GstClockTime minLatency, maxLatency;
-    if (gst_base_sink_query_latency(GST_BASE_SINK_CAST(m_sink.get()), nullptr, nullptr, &minLatency, &maxLatency))
-        return { minLatency, maxLatency };
-
-    return { GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE };
 }
 
 bool GStreamerCapturer::isInterrupted() const

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
@@ -66,8 +66,6 @@ public:
     void stop();
     WARN_UNUSED_RETURN GRefPtr<GstCaps> caps();
 
-    std::pair<GstClockTime, GstClockTime> queryLatency();
-
     GstElement* makeElement(const char* factoryName);
     virtual GstElement* createSource();
     GstElement* source() { return m_src.get();  }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -27,10 +27,8 @@
 #if ENABLE(VIDEO) && ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
 
 #include "AudioTrackPrivateMediaStream.h"
-#include "GStreamerAudioCaptureSource.h"
 #include "GStreamerAudioData.h"
 #include "GStreamerCommon.h"
-#include "GStreamerVideoCaptureSource.h"
 #include "MediaStreamPrivate.h"
 #include "VideoFrameGStreamer.h"
 #include "VideoFrameMetadataGStreamer.h"
@@ -168,7 +166,7 @@ public:
         m_src = makeGStreamerElement("appsrc", elementName.ascii().data());
 
         g_object_set(m_src.get(), "is-live", TRUE, "format", GST_FORMAT_TIME, "emit-signals", TRUE, "min-percent", 100,
-            "do-timestamp", isCaptureTrack, "handle-segment-change", TRUE, nullptr);
+            "do-timestamp", isCaptureTrack, nullptr);
         g_signal_connect(m_src.get(), "enough-data", G_CALLBACK(+[](GstElement*, InternalSource* data) {
             data->m_enoughData = true;
         }), this);
@@ -178,58 +176,20 @@ public:
 
         createGstStream();
 
-        // RealtimeMediaSource::source() is usable only from the main thread, so keep track of
-        // capture sources separately.
-        m_captureSource = nullptr;
-        auto& trackSource = m_track->source();
-        if (trackSource.isCaptureSource()) {
-            if (trackSource.isVideo()) {
-                auto& videoSource = static_cast<GStreamerVideoCaptureSource&>(trackSource);
-                m_captureSource = ThreadSafeWeakPtr<GStreamerVideoCaptureSource> { &videoSource };
-            } else {
-                auto& audioSource = static_cast<GStreamerAudioCaptureSource&>(trackSource);
-                m_captureSource = ThreadSafeWeakPtr<GStreamerAudioCaptureSource> { &audioSource };
-            }
-        }
-
-        auto pad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
-        gst_pad_add_probe(pad.get(), GST_PAD_PROBE_TYPE_QUERY_UPSTREAM, reinterpret_cast<GstPadProbeCallback>(+[](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
-            auto self = reinterpret_cast<InternalSource*>(userData);
-            auto query = GST_PAD_PROBE_INFO_QUERY(info);
-            switch (GST_QUERY_TYPE(query)) {
 #if GST_CHECK_VERSION(1, 22, 0)
+        auto pad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
+        gst_pad_add_probe(pad.get(), GST_PAD_PROBE_TYPE_QUERY_UPSTREAM, reinterpret_cast<GstPadProbeCallback>(+[](GstPad*, GstPadProbeInfo* info, InternalSource*) -> GstPadProbeReturn {
+            auto* query = GST_PAD_PROBE_INFO_QUERY(info);
+            switch (GST_QUERY_TYPE(query)) {
             case GST_QUERY_SELECTABLE:
                 gst_query_set_selectable(query, TRUE);
                 return GST_PAD_PROBE_HANDLED;
-#endif
-            case GST_QUERY_LATENCY: {
-                std::pair<GstClockTime, GstClockTime> latency { GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE };
-                WTF::switchOn(self->m_captureSource, [&](ThreadSafeWeakPtr<GStreamerVideoCaptureSource>& source) {
-                    RefPtr videoSource = source.get();
-                    if (!videoSource)
-                        return;
-                    latency = videoSource->queryLatency();
-                }, [&](ThreadSafeWeakPtr<GStreamerAudioCaptureSource>& source) {
-                    RefPtr audioSource = source.get();
-                    if (!audioSource)
-                        return;
-                    latency = audioSource->queryLatency();
-                }, [](std::nullptr_t) {
-                });
-
-                auto [minLatency, maxLatency] = latency;
-                GST_DEBUG_OBJECT(self->m_src.get(), "Latency from capture source is min: %" GST_TIME_FORMAT " max: %" GST_TIME_FORMAT, GST_TIME_ARGS(minLatency), GST_TIME_ARGS(maxLatency));
-                if (GST_CLOCK_TIME_IS_VALID(minLatency) && GST_CLOCK_TIME_IS_VALID(maxLatency)) {
-                    gst_query_set_latency(query, TRUE, minLatency, maxLatency);
-                    return GST_PAD_PROBE_HANDLED;
-                }
-                break;
-            }
             default:
                 break;
             }
             return GST_PAD_PROBE_OK;
-        }), this, nullptr);
+        }), nullptr, nullptr);
+#endif
     }
 
     void replaceTrack(RefPtr<MediaStreamTrackPrivate>&& newTrack)
@@ -672,7 +632,6 @@ private:
 
     GstElement* m_parent { nullptr };
     RefPtr<MediaStreamTrackPrivate> m_track;
-    std::variant<ThreadSafeWeakPtr<GStreamerVideoCaptureSource>, ThreadSafeWeakPtr<GStreamerAudioCaptureSource>, std::nullptr_t> m_captureSource;
     GRefPtr<GstElement> m_src;
     GstClockTime m_firstBufferPts { GST_CLOCK_TIME_NONE };
     bool m_enoughData { false };

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp
@@ -42,7 +42,7 @@ static GstElement* webkitMockDeviceCreateElement([[maybe_unused]] GstDevice* dev
 {
     GST_INFO_OBJECT(device, "Creating source element for device %s", name);
     auto* element = makeGStreamerElement("appsrc", name);
-    g_object_set(element, "format", GST_FORMAT_TIME, "is-live", TRUE, "do-timestamp", TRUE, nullptr);
+    g_object_set(element, "format", GST_FORMAT_TIME, "is-live", TRUE, nullptr);
     return element;
 }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
@@ -176,14 +176,6 @@ void GStreamerVideoCaptureSource::sourceCapsChanged(const GstCaps* caps)
         ensureIntrinsicSizeMaintainsAspectRatio();
 }
 
-std::pair<GstClockTime, GstClockTime> GStreamerVideoCaptureSource::queryLatency()
-{
-    if (!m_capturer)
-        return { GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE };
-
-    return m_capturer->queryLatency();
-}
-
 void GStreamerVideoCaptureSource::captureEnded()
 {
     m_capturer->stop();

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h
@@ -46,8 +46,6 @@ public:
     GstElement* pipeline() { return m_capturer->pipeline(); }
     GStreamerCapturer* capturer() { return m_capturer.get(); }
 
-    std::pair<GstClockTime, GstClockTime> queryLatency();
-
     // GStreamerCapturerObserver
     void sourceCapsChanged(const GstCaps*) final;
     void captureEnded() final;


### PR DESCRIPTION
#### 401002651d3f9df1f5a7472be75c5b549214f7e5
<pre>
Unreviewed, reverting 286428@main (ebd307719a8e) and 286323@main (3539c8a950f6)
<a href="https://bugs.webkit.org/show_bug.cgi?id=282974">https://bugs.webkit.org/show_bug.cgi?id=282974</a>

REGRESSION(286428@main): [GStreamer][MediaStream] ASSERTs due to invalid memory access

Reverted changes:

    REGRESSION(286323@main): [GStreamer][MediaStream] ASSERTs during latency query handling
    <a href="https://bugs.webkit.org/show_bug.cgi?id=282925">https://bugs.webkit.org/show_bug.cgi?id=282925</a>
    286428@main (ebd307719a8e)

    [GStreamer][WebRTC] Latency improvements
    <a href="https://bugs.webkit.org/show_bug.cgi?id=282756">https://bugs.webkit.org/show_bug.cgi?id=282756</a>
    286323@main (3539c8a950f6)

Canonical link: <a href="https://commits.webkit.org/286473@main">https://commits.webkit.org/286473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23f99fe9e10ae2db2933d8dbffbff4cfc3b18c26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80608 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27373 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78222 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3432 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59674 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17816 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65358 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40024 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46961 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/22842 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25700 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/68093 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23177 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82069 "") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3478 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/2244 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/82069 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65327 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/82069 "") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16745 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11163 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9278 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3426 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6233 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3449 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/6843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/5207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->