### PR TITLE
media/media-vp8-hiddenframes.html is an intermittent failure on iOS simulator

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -145,7 +145,6 @@ webkit.org/b/269897 media/media-source/media-managedmse-poster.html [ Skip ]
 
 webkit.org/b/282969 media/media-video-fullrange.html [ Timeout Pass ]
 webkit.org/b/282969 media/media-video-videorange.html [ Timeout Pass ]
-webkit.org/b/282968 media/media-vp8-hiddenframes.html [ ImageOnlyFailure Pass ]
 
 fast/images/text-recognition [ Pass ]
 fast/images/text-recognition/ios [ Pass ]

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -103,16 +103,15 @@ private:
     void flushCompressedSampleQueue();
     void flushDecodedSampleQueue();
     void purgeDecodedSampleQueue();
-    CMBufferQueueRef ensureCompressedSampleQueue();
     CMBufferQueueRef ensureDecodedSampleQueue();
     void assignResourceOwner(CMSampleBufferRef);
     void maybeBecomeReadyForMoreMediaData();
 
-    Ref<WTF::WorkQueue> m_workQueue;
+    const Ref<WTF::WorkQueue> m_workQueue;
     RetainPtr<AVSampleBufferDisplayLayer> m_displayLayer;
     RetainPtr<AVSampleBufferVideoRenderer> m_renderer;
     RetainPtr<CMTimebaseRef> m_timebase;
-    RetainPtr<CMBufferQueueRef> m_compressedSampleQueue;
+    RetainPtr<CMBufferQueueRef> m_compressedSampleQueue; // created on the main thread, always set if m_decompressionSession and on workQueue.
     RetainPtr<CMBufferQueueRef> m_decodedSampleQueue;
     OSObjectPtr<dispatch_source_t> m_timerSource;
     RefPtr<WebCoreDecompressionSession> m_decompressionSession;

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
@@ -155,7 +155,7 @@ private:
     std::atomic<unsigned> m_framesSinceLastQosCheck { 0 };
     double m_decodeRatioMovingAverage { 0 };
 
-    uint32_t m_flushId { 0 };
+    std::atomic<uint32_t> m_flushId { 0 };
     std::atomic<bool> m_isUsingVideoDecoder { true };
     std::unique_ptr<VideoDecoder> m_videoDecoder WTF_GUARDED_BY_LOCK(m_lock);
     bool m_videoDecoderCreationFailed { false };


### PR DESCRIPTION
#### e5d420f7968f657885649914e9cf121ce250605c
<pre>
media/media-vp8-hiddenframes.html is an intermittent failure on iOS simulator
<a href="https://bugs.webkit.org/show_bug.cgi?id=282968">https://bugs.webkit.org/show_bug.cgi?id=282968</a>
<a href="https://rdar.apple.com/139697918">rdar://139697918</a>

Reviewed by Youenn Fablet.

When the VideoMediaSampleRenderer was flushed, it flushed its WebCoreDecompressionSession and queued a task to flush
the pending compressed samples queued to be decoded.
However, if any decoding tasks ran prior, it would continue to feed the old samples (due to be dismissed) to the decoder.
This resulted in corrupted decoding.

A CMBufferQueue is thread-safe, we can flush it on the main thread. Which guarantee than any pending decode task will be aborted.
Covered by existing test.

* LayoutTests/platform/ios/TestExpectations: Re-enable test.
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::enqueueSample):
(WebCore::VideoMediaSampleRenderer::decodeNextSample):
(WebCore::VideoMediaSampleRenderer::initializeDecompressionSession):
(WebCore::VideoMediaSampleRenderer::flushCompressedSampleQueue):
(WebCore::VideoMediaSampleRenderer::flush):
(WebCore::VideoMediaSampleRenderer::ensureCompressedSampleQueue): Deleted.
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h: Make member m_flushId atomic as it&apos;s concurrently accessed on both the main thread and the decode queue.
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm:
(WebCore::WebCoreDecompressionSession::enqueueSample):
(WebCore::WebCoreDecompressionSession::maybeDecodeNextSample): Drop compressed samples if flushed before attempting to decode it.
(WebCore::WebCoreDecompressionSession::decodeSample): Do not attempt to decode the sample if it&apos;s been flushed (its flushId would have changed).

Canonical link: <a href="https://commits.webkit.org/286512@main">https://commits.webkit.org/286512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/283a7bac555efc759b45cf8837033eeb2d671670

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80706 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/27473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3527 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59745 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/27473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65446 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40093 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47042 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22932 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/25795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/68175 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/23266 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82166 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3573 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/2327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67970 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67280 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16770 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11248 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3521 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6328 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3544 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/6972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5302 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->