### PR TITLE
Reduce granularity of ServiceWorker process assertions/activities

### DIFF
--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -241,6 +241,7 @@ public:
     WEBCORE_EXPORT void addContextConnection(SWServerToContextConnection&);
     WEBCORE_EXPORT void removeContextConnection(SWServerToContextConnection&);
     WEBCORE_EXPORT void terminateIdleServiceWorkers(SWServerToContextConnection&);
+    WEBCORE_EXPORT bool areServiceWorkersIdle(const SWServerToContextConnection&);
 
     WEBCORE_EXPORT SWServerToContextConnection* contextConnectionForRegistrableDomain(const RegistrableDomain&);
     WEBCORE_EXPORT void createContextConnection(const Site&, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier);

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.h
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.h
@@ -104,6 +104,7 @@ public:
     virtual void terminateDueToUnresponsiveness() = 0;
 
     virtual void setInspectable(ServiceWorkerIsInspectable) = 0;
+    virtual void serviceWorkerNeedsRunning() = 0;
 
 protected:
     WEBCORE_EXPORT SWServerToContextConnection(SWServer&, Site&&, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -137,6 +137,11 @@ private:
     void connectionClosed();
 
     void setInspectable(WebCore::ServiceWorkerIsInspectable) final;
+    void serviceWorkerNeedsRunning() final;
+
+    void processAssertionTimerFired();
+    void startProcessAssertionTimer();
+    bool areServiceWorkersIdle() const;
 
     WebCore::ProcessIdentifier m_webProcessIdentifier;
     WeakPtr<NetworkConnectionToWebProcess> m_connection;
@@ -144,8 +149,9 @@ private:
     HashMap<WebCore::FetchIdentifier, ThreadSafeWeakPtr<ServiceWorkerDownloadTask>> m_ongoingDownloads;
     bool m_isThrottleable { true };
     WebPageProxyIdentifier m_webPageProxyID;
-    size_t m_processingFunctionalEventCount { 0 };
     WebCore::ServiceWorkerIsInspectable m_isInspectable { WebCore::ServiceWorkerIsInspectable::Yes };
+    bool m_isTakingProcessAssertion { false };
+    WebCore::Timer m_processAssertionTimer;
 }; // class WebSWServerToContextConnection
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -594,10 +594,8 @@ void NetworkProcessProxy::terminateWebProcess(WebCore::ProcessIdentifier webProc
 
 void NetworkProcessProxy::processHasUnresponseServiceWorker(WebCore::ProcessIdentifier processIdentifier)
 {
-    if (auto process = WebProcessProxy::processForIdentifier(processIdentifier)) {
-        process->endServiceWorkerBackgroundProcessing();
+    if (auto process = WebProcessProxy::processForIdentifier(processIdentifier))
         process->disableRemoteWorkers(RemoteWorkerType::ServiceWorker);
-    }
 }
 
 void NetworkProcessProxy::terminateIdleServiceWorkers(WebCore::ProcessIdentifier processIdentifier, CompletionHandler<void()>&& callback)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2543,41 +2543,65 @@ void WebProcessProxy::updateRemoteWorkerPreferencesStore(const WebPreferencesSto
         send(Messages::WebSharedWorkerContextManagerConnection::UpdatePreferencesStore { store }, 0);
 }
 
-void WebProcessProxy::updateRemoteWorkerProcessAssertion(RemoteWorkerType workerType)
+void WebProcessProxy::updateServiceWorkerProcessAssertion()
 {
-    auto& workerInformation = workerType == RemoteWorkerType::SharedWorker ? m_sharedWorkerInformation : m_serviceWorkerInformation;
-    ASSERT(workerInformation);
-    if (!workerInformation)
+    WEBPROCESSPROXY_RELEASE_LOG(ProcessSuspension, "updateServiceWorkerProcessAssertion");
+
+    if (!m_serviceWorkerInformation->hasBackgroundProcessing) {
+        m_serviceWorkerInformation->activity = nullptr;
         return;
+    }
 
-    WEBPROCESSPROXY_RELEASE_LOG(ProcessSuspension, "updateRemoteWorkerProcessAssertion: workerType=%" PUBLIC_LOG_STRING, workerType == RemoteWorkerType::SharedWorker ? "shared" : "service");
-
-    bool shouldTakeForegroundActivity = WTF::anyOf(workerInformation->clientProcesses, [&](auto& process) {
+    bool shouldTakeForegroundActivity = WTF::anyOf(m_serviceWorkerInformation->clientProcesses, [&](auto& process) {
         return &process != this && !!process.m_foregroundToken;
     });
     if (shouldTakeForegroundActivity) {
-        if (!ProcessThrottler::isValidForegroundActivity(workerInformation->activity.get()))
-            workerInformation->activity = protectedThrottler()->foregroundActivity("Worker for foreground view(s)"_s);
+        if (!ProcessThrottler::isValidForegroundActivity(m_serviceWorkerInformation->activity.get()))
+            m_serviceWorkerInformation->activity = protectedThrottler()->foregroundActivity("Service Worker for foreground view(s)"_s);
         return;
     }
 
-    bool shouldTakeBackgroundActivity = WTF::anyOf(workerInformation->clientProcesses, [&](auto& process) {
+    WEBPROCESSPROXY_RELEASE_LOG(ProcessSuspension, "Service Worker for background processing");
+    if (!ProcessThrottler::isValidBackgroundActivity(m_serviceWorkerInformation->activity.get()))
+        m_serviceWorkerInformation->activity = protectedThrottler()->backgroundActivity("Service Worker for background processing"_s);
+}
+
+void WebProcessProxy::updateSharedWorkerProcessAssertion()
+{
+    WEBPROCESSPROXY_RELEASE_LOG(ProcessSuspension, "updateSharedWorkerProcessAssertion");
+
+    bool shouldTakeForegroundActivity = WTF::anyOf(m_sharedWorkerInformation->clientProcesses, [&](auto& process) {
+        return &process != this && !!process.m_foregroundToken;
+    });
+    if (shouldTakeForegroundActivity) {
+        if (!ProcessThrottler::isValidForegroundActivity(m_sharedWorkerInformation->activity.get()))
+            m_sharedWorkerInformation->activity = protectedThrottler()->foregroundActivity("Shared Worker for foreground view(s)"_s);
+        return;
+    }
+
+    bool shouldTakeBackgroundActivity = WTF::anyOf(m_sharedWorkerInformation->clientProcesses, [&](auto& process) {
         return &process != this && !!process.m_backgroundToken;
     });
     if (shouldTakeBackgroundActivity) {
-        if (!ProcessThrottler::isValidBackgroundActivity(workerInformation->activity.get()))
-            workerInformation->activity = protectedThrottler()->backgroundActivity("Worker for background view(s)"_s);
+        if (!ProcessThrottler::isValidBackgroundActivity(m_sharedWorkerInformation->activity.get()))
+            m_sharedWorkerInformation->activity = protectedThrottler()->backgroundActivity("Shared Worker for background view(s)"_s);
         return;
     }
 
-    if (workerType == RemoteWorkerType::ServiceWorker && m_hasServiceWorkerBackgroundProcessing) {
-        WEBPROCESSPROXY_RELEASE_LOG(ProcessSuspension, "Service Worker for background processing");
-        if (!ProcessThrottler::isValidBackgroundActivity(workerInformation->activity.get()))
-            workerInformation->activity = protectedThrottler()->backgroundActivity("Service Worker for background processing"_s);
-        return;
-    }
+    m_sharedWorkerInformation->activity = nullptr;
+}
 
-    workerInformation->activity = nullptr;
+void WebProcessProxy::updateRemoteWorkerProcessAssertion(RemoteWorkerType workerType)
+{
+    ASSERT(workerType == RemoteWorkerType::SharedWorker ? !!m_sharedWorkerInformation : !!m_serviceWorkerInformation);
+    switch (workerType) {
+    case RemoteWorkerType::ServiceWorker:
+        updateServiceWorkerProcessAssertion();
+        break;
+    case RemoteWorkerType::SharedWorker:
+        updateSharedWorkerProcessAssertion();
+        break;
+    }
 }
 
 void WebProcessProxy::registerRemoteWorkerClientProcess(RemoteWorkerType workerType, WebProcessProxy& proxy)
@@ -2618,7 +2642,7 @@ void WebProcessProxy::startServiceWorkerBackgroundProcessing()
         return;
 
     WEBPROCESSPROXY_RELEASE_LOG(ProcessSuspension, "startServiceWorkerBackgroundProcessing");
-    m_hasServiceWorkerBackgroundProcessing = true;
+    m_serviceWorkerInformation->hasBackgroundProcessing = true;
     updateRemoteWorkerProcessAssertion(RemoteWorkerType::ServiceWorker);
 }
 
@@ -2628,7 +2652,7 @@ void WebProcessProxy::endServiceWorkerBackgroundProcessing()
         return;
 
     WEBPROCESSPROXY_RELEASE_LOG(ProcessSuspension, "endServiceWorkerBackgroundProcessing");
-    m_hasServiceWorkerBackgroundProcessing = false;
+    m_serviceWorkerInformation->hasBackgroundProcessing = false;
     updateRemoteWorkerProcessAssertion(RemoteWorkerType::ServiceWorker);
 }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -646,6 +646,9 @@ private:
     void updateRuntimeStatistics();
     void enableMediaPlaybackIfNecessary();
 
+    void updateSharedWorkerProcessAssertion();
+    void updateServiceWorkerProcessAssertion();
+
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
     void setupLogStream(uint32_t pid, IPC::StreamServerConnectionHandle&&, LogStreamIdentifier, CompletionHandler<void(IPC::Semaphore& streamWakeUpSemaphore, IPC::Semaphore& streamClientWaitSemaphore)>&&);
 #endif
@@ -756,10 +759,10 @@ private:
         RemoteWorkerInitializationData initializationData;
         RefPtr<ProcessThrottler::Activity> activity;
         WeakHashSet<WebProcessProxy> clientProcesses;
+        bool hasBackgroundProcessing { false };
     };
     std::optional<RemoteWorkerInformation> m_serviceWorkerInformation;
     std::optional<RemoteWorkerInformation> m_sharedWorkerInformation;
-    bool m_hasServiceWorkerBackgroundProcessing { false };
 
     struct AudibleMediaActivity {
         Ref<ProcessAssertion> assertion;


### PR DESCRIPTION
#### 0218ef6e826361d6ed71581b980887d4925a0ade
<pre>
Reduce granularity of ServiceWorker process assertions/activities
<a href="https://rdar.apple.com/137705981">rdar://137705981</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=282828">https://bugs.webkit.org/show_bug.cgi?id=282828</a>

Reviewed by Ben Nham.

Before the patch, we were taking service worker process assertion based on the clients of the service worker.
If clients had forward or backward process assertions, we would take the same assertion for the service worker process.
The exception was for functional events where we could run service workers without clients.

We are now reusing the same principle as functional events by having network process monitor whether a service worker process should take a process assertion.
This is done by WebSWServerToContextConnection, which sends IPC messages to NetworkProcessProxy when there is a need to take or drop the process assertion.

WebSWServerToContextConnection decides whether taking a process assertion  by being notified each time one of its service worker needs to run.
This happens for all events sent to the service worker.

WebSWServerToContextConnection also makes sure to keep the process assertion as long as these events are not fully handled by the service worker.
This is done by checking the ServiceWorker can be idle.

We also add a check for ongoing fetches, since a service worker load might take time which are not captured by events.
This is implemented in WebSWServerToContextConnection::areServiceWorkersIdle.

When a WebSWServerToContextConnection takes an assertion, it will schedule a timer to try removing the process assertion, timer default value is 10 seconds.

We update WebProcessProxy::updateRemoteWorkerProcessAssertion to not take any process assertion when a service worker process is not doing any processing.
If the service worker process is doing some processing, we will either take a foreground or backgorund assertion based on the service worker process clients.

We move WebProcessProxy::m_hasServiceWorkerBackgroundProcessing to WebProcessProxy::m_serviceWorkerInformation::hasBackgroundProcessing.
This allows to set it back this flag to false by nullifying WebProcessProxy::m_serviceWorkerInformation in disableRemoteWorkers.
We can also remove the call to endServiceWorkerBackgroundProcessing in NetworkProcessProxy::processHasUnresponseServiceWorker, since this will be handled in disableRemoteWorkers.

* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::runServiceWorkerIfNecessary):
(WebCore::SWServer::areServiceWorkersIdle):
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebCore/workers/service/server/SWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::WebSWServerToContextConnection):
(WebKit::WebSWServerToContextConnection::installServiceWorkerContext):
(WebKit::WebSWServerToContextConnection::fireInstallEvent):
(WebKit::WebSWServerToContextConnection::fireActivateEvent):
(WebKit::WebSWServerToContextConnection::firePushEvent):
(WebKit::WebSWServerToContextConnection::fireNotificationEvent):
(WebKit::WebSWServerToContextConnection::fireBackgroundFetchEvent):
(WebKit::WebSWServerToContextConnection::fireBackgroundFetchClickEvent):
(WebKit::WebSWServerToContextConnection::terminateWorker):
(WebKit::WebSWServerToContextConnection::workerTerminated):
(WebKit::WebSWServerToContextConnection::startProcessAssertionTimer):
(WebKit::WebSWServerToContextConnection::serviceWorkerNeedsRunning):
(WebKit::WebSWServerToContextConnection::areServiceWorkersIdle const):
(WebKit::WebSWServerToContextConnection::processAssertionTimerFired):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::processHasUnresponseServiceWorker):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::updateServiceWorkerProcessAssertion):
(WebKit::WebProcessProxy::updateSharedWorkerProcessAssertion):
(WebKit::WebProcessProxy::updateRemoteWorkerProcessAssertion):
(WebKit::WebProcessProxy::startServiceWorkerBackgroundProcessing):
(WebKit::WebProcessProxy::endServiceWorkerBackgroundProcessing):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:

Canonical link: <a href="https://commits.webkit.org/286796@main">https://commits.webkit.org/286796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79d7ba0aea1311c9d441c54b4394802adfeb24ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76454 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80979 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27730 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78571 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59950 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18062 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65653 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40274 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47256 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23142 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26053 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68382 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82427 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3830 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2517 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68224 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67469 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16950 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11441 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9534 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3777 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6586 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3800 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7230 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5558 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->