### PR TITLE
:root CSS container breaks history navigation with back-forward cache

### DIFF
--- a/LayoutTests/fast/css/root-container-back-forward-expected.html
+++ b/LayoutTests/fast/css/root-container-back-forward-expected.html
@@ -1,0 +1,5 @@
+<style>
+div { color: green }
+</style>
+<div>Green</div>
+

--- a/LayoutTests/fast/css/root-container-back-forward.html
+++ b/LayoutTests/fast/css/root-container-back-forward.html
@@ -1,0 +1,14 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<style>
+:root {
+  container: root / inline-size;
+}
+@container root (width >= 100px) {
+  div { color: green }
+}
+</style>
+<div>Green</div>
+<script>
+testRunner.queueLoad("about:blank");
+testRunner.queueBackNavigation(1);
+</script>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2600,6 +2600,7 @@ void Element::invalidateForQueryContainerSizeChange()
 
 void Element::invalidateForResumingQueryContainerResolution()
 {
+    setChildNeedsStyleRecalc();
     markAncestorsForInvalidatedStyle();
 }
 


### PR DESCRIPTION
#### c0e31be07ba885691afe8b6b23b8676e1bd9b447
<pre>
:root CSS container breaks history navigation with back-forward cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=282592">https://bugs.webkit.org/show_bug.cgi?id=282592</a>
<a href="https://rdar.apple.com/120951698">rdar://120951698</a>

Reviewed by Anne van Kesteren.

* LayoutTests/fast/css/root-container-back-forward-expected.html: Added.
* LayoutTests/fast/css/root-container-back-forward.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::invalidateForResumingQueryContainerResolution):

When restoring a page with the document element as a container from the back-forward cache we may fail
to compute style for its descedants. This happens because the child invalidity bit is not set and
we think the tree is clean.

Fix by setting the child invalidty bit when invalidating container queries for resume.

Canonical link: <a href="https://commits.webkit.org/286487@main">https://commits.webkit.org/286487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cae9454c64574e0335460128f2887a6914314f49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80623 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27388 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59686 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17834 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79188 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65371 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40036 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46976 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22855 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25715 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68108 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82085 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3493 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2257 "Found 2 new test failures: fast/selectors/selection-window-inactive-stroke-color.html imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67916 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3647 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65340 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67225 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16754 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11177 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3441 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6248 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3464 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/6858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/5222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->