### PR TITLE
[css-masonry] Update Intrinsic Sizing Rows 003 FR Expected / Ref Test Case

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1770,7 +1770,6 @@ imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/mas
 
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/grid-placement/masonry-grid-placement-named-lines-002.html [ ImageOnlyFailure ]
 
-webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-columns-item-placement-auto-flow-next-001.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr-expected.html
@@ -8,6 +8,7 @@
   <meta charset="utf-8">
   <title>Reference: Masonry layout min-content sizing</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";
@@ -21,6 +22,7 @@ grid {
   padding: 1px 0 2px 0;
   vertical-align: top;
   height: min-content;
+  font-family: Ahem;
 }
 
 item {
@@ -31,6 +33,30 @@ item {
 .hidden {
   visibility: hidden;
   width: 0;
+}
+
+grid > item:nth-child(1) {
+  background-color: #89CFF0;
+}
+
+grid > item:nth-child(2) {
+  background-color: #FF6F61;
+}
+
+grid > item:nth-child(3) {
+  background-color: #FDF3E7;
+}
+
+grid > item:nth-child(4) {
+  background-color: #F4C542;
+}
+
+grid > item:nth-child(5) {
+  background-color: #333333;
+}
+
+grid > item:nth-child(6) {
+  background-color: #B2C8A5;
 }
 </style>
 
@@ -52,7 +78,7 @@ item {
   <item style="grid-column: span 2">2 2</item>
   <item style="grid-column: span 2">3 3</item>
   <item>4</item>
-  <item style="grid-column: span 2">5 5</item>
+  <item style="height: 2ch;">5 5</item>
 
   <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
@@ -71,7 +97,7 @@ item {
 <grid>
   <item>1</item>
   <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>3 3</item>
   <item>4</item>
   <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
 
@@ -82,7 +108,7 @@ item {
 <grid>
   <item style="grid-row: 4">1</item>
   <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>3 3</item>
   <item>4</item>
   <item style="grid-area: 2/1/4/2">5 5</item>
   <item style="height:5ch; grid-area: 1/2/4/3">6</item>
@@ -94,48 +120,35 @@ item {
 
 <grid>
   <item style="grid-row: 4">1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5 5</item>
+  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
   <item style="height:5ch; grid-area: 1/2/4/3">6</item>
-
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
 </grid>
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 1/3/5/4">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/3">0 0</item>
-  <item class="hidden" style="grid-area: 3/3">0 0</item>
+  <item style="grid-row: span 4;">5 5</item>
 </grid>
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="height:6ch; grid-area: 1/3/5/4">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/3">0 0</item>
-  <item class="hidden" style="grid-area: 4/3">0 0</item>
+  <item style="height:6ch; grid-row: span 4;">5 5</item>
 </grid>
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="height:6ch; grid-area: 1/3/4/4">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/3">0 0</item>
-  <item class="hidden" style="grid-area: 4/3">0 0</item>
-  <item class="hidden" style="height:6ch; grid-area: 2/3/5/4">0 0</item>
+  <item style="height:6ch; grid-row: span 3;">5 5</item>
 </grid>
 </section>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr-ref.html
@@ -8,6 +8,7 @@
   <meta charset="utf-8">
   <title>Reference: Masonry layout min-content sizing</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";
@@ -21,6 +22,7 @@ grid {
   padding: 1px 0 2px 0;
   vertical-align: top;
   height: min-content;
+  font-family: Ahem;
 }
 
 item {
@@ -31,6 +33,30 @@ item {
 .hidden {
   visibility: hidden;
   width: 0;
+}
+
+grid > item:nth-child(1) {
+  background-color: #89CFF0;
+}
+
+grid > item:nth-child(2) {
+  background-color: #FF6F61;
+}
+
+grid > item:nth-child(3) {
+  background-color: #FDF3E7;
+}
+
+grid > item:nth-child(4) {
+  background-color: #F4C542;
+}
+
+grid > item:nth-child(5) {
+  background-color: #333333;
+}
+
+grid > item:nth-child(6) {
+  background-color: #B2C8A5;
 }
 </style>
 
@@ -52,7 +78,7 @@ item {
   <item style="grid-column: span 2">2 2</item>
   <item style="grid-column: span 2">3 3</item>
   <item>4</item>
-  <item style="grid-column: span 2">5 5</item>
+  <item style="height: 2ch;">5 5</item>
 
   <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
@@ -71,7 +97,7 @@ item {
 <grid>
   <item>1</item>
   <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>3 3</item>
   <item>4</item>
   <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
 
@@ -82,7 +108,7 @@ item {
 <grid>
   <item style="grid-row: 4">1</item>
   <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>3 3</item>
   <item>4</item>
   <item style="grid-area: 2/1/4/2">5 5</item>
   <item style="height:5ch; grid-area: 1/2/4/3">6</item>
@@ -94,48 +120,35 @@ item {
 
 <grid>
   <item style="grid-row: 4">1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5 5</item>
+  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
   <item style="height:5ch; grid-area: 1/2/4/3">6</item>
-
-  <item class="hidden" style="grid-area: 2/1">0 0</item>
-  <item class="hidden" style="grid-area: 3/1">0 0</item>
 </grid>
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="grid-area: 1/3/5/4">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/3">0 0</item>
-  <item class="hidden" style="grid-area: 3/3">0 0</item>
+  <item style="grid-row: span 4;">5 5</item>
 </grid>
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="height:6ch; grid-area: 1/3/5/4">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/3">0 0</item>
-  <item class="hidden" style="grid-area: 4/3">0 0</item>
+  <item style="height:6ch; grid-row: span 4;">5 5</item>
 </grid>
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="height:6ch; grid-area: 1/3/4/4">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/3">0 0</item>
-  <item class="hidden" style="grid-area: 4/3">0 0</item>
-  <item class="hidden" style="height:6ch; grid-area: 2/3/5/4">0 0</item>
+  <item style="height:6ch; grid-row: span 3;">5 5</item>
 </grid>
 </section>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr.html
@@ -9,6 +9,7 @@
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
   <link rel="match" href="masonry-intrinsic-sizing-rows-003-ref.html">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";
@@ -22,12 +23,37 @@ grid {
   padding: 1px 0 2px 0;
   vertical-align: top;
   height: min-content;
+  font-family: Ahem;
 }
 
 item {
   /* allow for differing min-content and max-content sizes */
   writing-mode: vertical-rl;
   text-orientation: sideways;
+}
+
+grid > item:nth-child(1) {
+  background-color: #89CFF0;
+}
+
+grid > item:nth-child(2) {
+  background-color: #FF6F61;
+}
+
+grid > item:nth-child(3) {
+  background-color: #FDF3E7;
+}
+
+grid > item:nth-child(4) {
+  background-color: #F4C542;
+}
+
+grid > item:nth-child(5) {
+  background-color: #333333;
+}
+
+grid > item:nth-child(6) {
+  background-color: #B2C8A5;
 }
 </style>
 


### PR DESCRIPTION
#### 7abc3005b876577618d227b274bfee64e7386a87
<pre>
[css-masonry] Update Intrinsic Sizing Rows 003 FR Expected / Ref Test Case
<a href="https://bugs.webkit.org/show_bug.cgi?id=282992">https://bugs.webkit.org/show_bug.cgi?id=282992</a>
<a href="https://rdar.apple.com/problem/139727829">rdar://problem/139727829</a>

Reviewed by Sammy Gill.

Updated the font to Ahem to tackle the computed width sizing issue of &quot;3 3&quot;. Added colors to the different items to catch ordering issues.

* Grid 2

Item 5 should be a height of 2ch.

* Grid 4

Remove item 3 span, because it was causing width issues with the grid.

* Grid 5

Remove item 3 span, because it was causing width issues with the grid.

* Grid 6

Remove item&apos;s 2 &amp; 3 spans; they were causing width issues.
Remove extra 5 that is not in the original test case.
Removed hidden items.

* Grid 7

Remove item&apos;s 2 &amp; 3 spans.
Removed hidden items.
Simplified item 5 to just span 4.

* Grid 8

Remove item&apos;s 2 &amp; 3 spans.
Removed hidden items.
Simplified item 5 to just span 4 and have a height of 6ch.

* Grid 9

Remove item&apos;s 2 &amp; 3 spans.
Removed hidden items.
Simplified item 5 to just span 3 and have a height of 6ch.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr.html:

Canonical link: <a href="https://commits.webkit.org/286749@main">https://commits.webkit.org/286749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3b2b05af7c28c150fc54b84eef5daba6e32ee59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81542 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28273 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4325 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18413 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50282 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66095 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40652 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47684 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23592 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26599 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68804 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82977 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4374 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/2933 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68611 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4529 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66068 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67862 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16915 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/11851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4320 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/4340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/7775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6099 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->