### PR TITLE
[WebDriver][GLIB] Potential use after free due to early SessionHost destruction

### DIFF
--- a/Source/WebDriver/Session.cpp
+++ b/Source/WebDriver/Session.cpp
@@ -66,7 +66,7 @@ const String& Session::shadowRootIdentifier()
     return shadowRootID;
 }
 
-Session::Session(std::unique_ptr<SessionHost>&& host)
+Session::Session(Ref<SessionHost>&& host)
     : m_host(WTFMove(host))
     , m_scriptTimeout(defaultScriptTimeout)
     , m_pageLoadTimeout(defaultPageLoadTimeout)
@@ -77,7 +77,7 @@ Session::Session(std::unique_ptr<SessionHost>&& host)
 }
 
 #if ENABLE(WEBDRIVER_BIDI)
-Session::Session(std::unique_ptr<SessionHost>&& host, WeakPtr<WebSocketServer>&& bidiServer)
+Session::Session(Ref<SessionHost>&& host, WeakPtr<WebSocketServer>&& bidiServer)
     : Session(WTFMove(host))
 {
     m_bidiServer = WTFMove(bidiServer);

--- a/Source/WebDriver/Session.h
+++ b/Source/WebDriver/Session.h
@@ -49,13 +49,13 @@ class SessionHost;
 
 class Session : public RefCounted<Session> {
 public:
-    static Ref<Session> create(std::unique_ptr<SessionHost>&& host)
+    static Ref<Session> create(Ref<SessionHost>&& host)
     {
         return adoptRef(*new Session(WTFMove(host)));
     }
     ~Session();
 #if ENABLE(WEBDRIVER_BIDI)
-    static Ref<Session> create(std::unique_ptr<SessionHost>&& host, WeakPtr<WebSocketServer> bidiServer)
+    static Ref<Session> create(Ref<SessionHost>&& host, WeakPtr<WebSocketServer> bidiServer)
     {
         return adoptRef(*new Session(WTFMove(host), WTFMove(bidiServer)));
     }
@@ -151,9 +151,9 @@ public:
     void takeScreenshot(std::optional<String> elementID, std::optional<bool> scrollIntoView, Function<void(CommandResult&&)>&&);
 
 private:
-    Session(std::unique_ptr<SessionHost>&&);
+    Session(Ref<SessionHost>&&);
 #if ENABLE(WEBDRIVER_BIDI)
-    Session(std::unique_ptr<SessionHost>&&, WeakPtr<WebSocketServer>&&);
+    Session(Ref<SessionHost>&&, WeakPtr<WebSocketServer>&&);
 #endif
 
     void switchToTopLevelBrowsingContext(const String&);
@@ -247,7 +247,7 @@ private:
     };
     InputSourceState& inputSourceState(const String& id);
 
-    std::unique_ptr<SessionHost> m_host;
+    RefPtr<SessionHost> m_host;
     double m_scriptTimeout;
     double m_pageLoadTimeout;
     double m_implicitWaitTimeout;

--- a/Source/WebDriver/SessionHost.cpp
+++ b/Source/WebDriver/SessionHost.cpp
@@ -43,6 +43,7 @@ static WeakHashSet<SessionHost::BrowserTerminatedObserver>& browserTerminatedObs
 
 void SessionHost::inspectorDisconnected()
 {
+    Ref<SessionHost> protectedThis(*this);
     // Browser closed or crashed, finish all pending commands with error.
     for (auto messageID : copyToVector(m_commandRequests.keys())) {
         auto responseHandler = m_commandRequests.take(messageID);

--- a/Source/WebDriver/SessionHost.h
+++ b/Source/WebDriver/SessionHost.h
@@ -45,17 +45,20 @@ namespace WebDriver {
 
 struct ConnectToBrowserAsyncData;
 
-class SessionHost
+class SessionHost final
+    : public RefCounted<SessionHost>
 #if USE(INSPECTOR_SOCKET_SERVER)
-    : public Inspector::RemoteInspectorConnectionClient
+    , public Inspector::RemoteInspectorConnectionClient
 #endif
 {
     WTF_MAKE_FAST_ALLOCATED(SessionHost);
 public:
-    explicit SessionHost(Capabilities&& capabilities)
-        : m_capabilities(WTFMove(capabilities))
+
+    static Ref<SessionHost> create(Capabilities&& capabilities)
     {
+        return adoptRef(*new SessionHost(WTFMove(capabilities)));
     }
+
     ~SessionHost();
 
 #if ENABLE(WEBDRIVER_BIDI)
@@ -82,6 +85,12 @@ public:
     long sendCommandToBackend(const String&, RefPtr<JSON::Object>&& parameters, Function<void (CommandResponse&&)>&&);
 
 private:
+
+    explicit SessionHost(Capabilities&& capabilities)
+        : m_capabilities(WTFMove(capabilities))
+    {
+    }
+
     struct Target {
         uint64_t id { 0 };
         CString name;

--- a/Source/WebDriver/WebDriverService.h
+++ b/Source/WebDriver/WebDriverService.h
@@ -150,7 +150,7 @@ private:
     void parseCapabilities(const JSON::Object& desiredCapabilities, Capabilities&) const;
     void platformParseCapabilities(const JSON::Object& desiredCapabilities, Capabilities&) const;
     void connectToBrowser(Vector<Capabilities>&&, Function<void (CommandResult&&)>&&);
-    void createSession(Vector<Capabilities>&&, std::unique_ptr<SessionHost>&&, Function<void (CommandResult&&)>&&);
+    void createSession(Vector<Capabilities>&&, Ref<SessionHost>&&, Function<void (CommandResult&&)>&&);
     bool findSessionOrCompleteWithError(JSON::Object&, Function<void (CommandResult&&)>&);
 
     void handleRequest(HTTPRequestHandler::Request&&, Function<void (HTTPRequestHandler::Response&&)>&& replyHandler) override;

--- a/Source/WebDriver/glib/SessionHostGlib.cpp
+++ b/Source/WebDriver/glib/SessionHostGlib.cpp
@@ -222,6 +222,7 @@ void SessionHost::connectToBrowser(std::unique_ptr<ConnectToBrowserAsyncData>&& 
 
 void SessionHost::connectionDidClose()
 {
+    Ref<SessionHost> protectedThis(*this);
     m_browser = nullptr;
     m_isRemoteBrowser = false;
 


### PR DESCRIPTION
#### 623870b2aa3cc186f3f7929f36a4b87adabd0bf0
<pre>
[WebDriver][GLIB] Potential use after free due to early SessionHost destruction
<a href="https://bugs.webkit.org/show_bug.cgi?id=282910">https://bugs.webkit.org/show_bug.cgi?id=282910</a>

Reviewed by Carlos Garcia Campos.

Make SessionHost refcounted, to ensure it lives through while
dispatching the pending commands.

Namely, WebDriverService::deleteSession transfers the ownership of the
Session instance to the completionHandler passed to Session::close. When
the SessionHost gets a DidClose message due to, for example, the browser
exiting, it&apos;ll dispatch the pending commands, which can delete the
Session instance, taking its unique_ptr SessionHost alongside.

This fixes the issue on the SessionHost destructor side, but valgrind
is still reporting the GSocketMonitor invalid write inside
socketSourceCallback as reported in the bug, but this will be fixed
on a separate patch.

* Source/WebDriver/Session.cpp:
(WebDriver::Session::Session):
* Source/WebDriver/Session.h:
(WebDriver::Session::create):
* Source/WebDriver/SessionHost.cpp:
(WebDriver::SessionHost::inspectorDisconnected):
* Source/WebDriver/SessionHost.h:
(WebDriver::SessionHost::SessionHost): Deleted.
(WebDriver::SessionHost::setHostAddress): Deleted.
(WebDriver::SessionHost::sessionID const): Deleted.
(WebDriver::SessionHost::capabilities const): Deleted.
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::WebDriverService::connectToBrowser):
(WebDriver::WebDriverService::createSession):
* Source/WebDriver/WebDriverService.h:
* Source/WebDriver/glib/SessionHostGlib.cpp:
(WebDriver::SessionHost::connectionDidClose):

Canonical link: <a href="https://commits.webkit.org/286523@main">https://commits.webkit.org/286523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13feaf8ddde9c2f6b9e6a36bb5680eeb73b69bbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80644 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27408 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59706 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17849 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40055 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46996 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22874 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25735 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68129 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23209 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82105 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3513 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67931 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67241 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16780 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11193 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9308 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3461 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3484 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/6878 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5242 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->