### PR TITLE
Remove spurious logs about KVO ivar access when using old SDKs

### DIFF
--- a/Source/WebKit/Shared/Cocoa/WKObject.h
+++ b/Source/WebKit/Shared/Cocoa/WKObject.h
@@ -168,14 +168,6 @@ using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
 #define WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS \
 + (BOOL)accessInstanceVariablesDirectly \
 { \
-    if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ThrowOnKVCInstanceVariableAccess)) { \
-        static bool didLogFault; \
-        if (!didLogFault) { \
-            didLogFault = true; \
-            RELEASE_LOG_FAULT(API, "Do not access private instance variables of %{public}s via key-value coding. This will raise an exception when linking against newer SDKs.", class_getName(self)); \
-        } \
-        return YES; \
-    } \
-    return NO; \
+    return !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ThrowOnKVCInstanceVariableAccess); \
 } \
 using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int


### PR DESCRIPTION
#### 7808f86a5b15494edc53380b7df0a0f4ec413a5f
<pre>
Remove spurious logs about KVO ivar access when using old SDKs
<a href="https://bugs.webkit.org/show_bug.cgi?id=282996">https://bugs.webkit.org/show_bug.cgi?id=282996</a>
<a href="https://rdar.apple.com/139464152">rdar://139464152</a>

Reviewed by Richard Robinson.

In 277751@main, I added a fault log that was supposed to only fire when a client tries to access
instance variables of WebKit objects via key-value coding. However, this is causing spurious faults
because it fires even when a client accesses non-ivar properties on those objects (since
`-addObserver:forKeyPath:options:context:` ends up calling `+accessInstanceVariablesDirectly`
irregardless of the keypath).

To reduce confusion, just remove this logging entirely.

* Source/WebKit/Shared/Cocoa/WKObject.h:

Canonical link: <a href="https://commits.webkit.org/286496@main">https://commits.webkit.org/286496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bcc23405d95fef2dfc89cea678d021a71b9b71d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76147 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80650 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27414 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3473 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59710 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17853 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40059 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47001 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25741 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68134 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82111 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3519 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2282 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67937 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65366 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67247 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16762 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11199 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9315 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3467 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6274 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3490 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/6884 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/5248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->