### PR TITLE
[WebGPU] Release assertion triggered in GPUQueue.copyExternalImageToTexture

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-282995-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-282995-expected.txt
@@ -1,0 +1,62 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 785x665
+  RenderView at (0,0) size 785x600
+layer at (0,0) size 785x665
+  RenderBlock {HTML} at (0,0) size 785x665 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x649
+      RenderImage {IMG} at (0,88) size 55x62
+      RenderImage {IMG} at (55,84) size 155x66
+      RenderHTMLCanvas {CANVAS} at (210,0) size 300x150
+      RenderText {#text} at (510,137) size 31x17
+        text run at (510,137) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (540,137) size 80x17
+        text run at (540,137) width 80: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (619,137) size 70x17
+        text run at (619,137) width 7 RTL: "\x{692}"
+        text run at (625,137) width 64: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (316,156) size 298x170
+      RenderText {#text} at (614,313) size 103x17
+        text run at (614,313) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (130,573) size 100x17
+        text run at (130,573) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (229,573) size 117x17
+        text run at (229,573) width 31: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (259,573) width 11 RTL: "\x{79B}"
+        text run at (269,573) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (345,333) size 293x253
+      RenderText {#text} at (637,573) size 104x17
+        text run at (637,573) width 104: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (0,573) size 762x48
+        text run at (740,573) width 22: "\x{10D}\x{BA96}"
+        text run at (0,604) width 83: "\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (82,604) size 102x17
+        text run at (82,604) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (183,604) size 115x17
+        text run at (183,604) width 115: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (297,604) size 35x17
+        text run at (297,604) width 35: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (331,604) size 120x17
+        text run at (331,604) width 26: "\x{24BF}\x{B00}"
+        text run at (356,604) width 12 RTL: "\x{5FF}"
+        text run at (367,604) width 14: "\x{2FA}\x{B13}"
+        text run at (380,604) width 11 RTL: "\x{8BC}"
+        text run at (390,604) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (450,604) size 88x17
+        text run at (450,604) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (537,604) size 88x17
+        text run at (537,604) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (624,604) size 22x17
+        text run at (624,604) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (645,604) size 111x17
+        text run at (645,604) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (0,604) size 767x43
+        text run at (755,604) width 12: "\x{ECB8}"
+        text run at (0,630) width 68: "\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (67,630) size 85x17
+        text run at (67,630) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+layer at (8,184) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,176) size 300x150
+layer at (308,318) size 16x16
+  RenderVideo {VIDEO} at (300,310) size 16x16
+layer at (8,381) size 130x213
+  RenderVideo {VIDEO} at (0,373) size 130x213

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-282995.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-282995.html
@@ -1,0 +1,9458 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let promise0 = navigator.gpu.requestAdapter({});
+let adapter0 = await promise0;
+let device0 = await adapter0.requestDevice({
+  label: '\u02b8\uafce\u{1fe96}\u7370\u01ae\u7303',
+  requiredFeatures: [
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+  ],
+  requiredLimits: {
+    maxColorAttachmentBytesPerSample: 32,
+    maxVertexAttributes: 16,
+    maxStorageTexturesPerShaderStage: 4,
+    maxUniformBufferBindingSize: 75685324,
+    maxStorageBufferBindingSize: 141623920,
+  },
+});
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  label: '\u39a1\ude30\ufffb\u{1f800}\u{1f6ae}\ueb5b\u{1fbb4}\u0f6f\u0771',
+  entries: [
+    {
+      binding: 17,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let buffer0 = device0.createBuffer({
+  size: 4413,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture0 = device0.createTexture({
+  size: [1, 740, 1],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture1 = device0.createTexture({
+  size: [1, 185, 1],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView0 = texture1.createView({dimension: '2d-array'});
+let sampler0 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMinClamp: 60.76,
+  lodMaxClamp: 64.40,
+});
+let textureView1 = texture0.createView({});
+let textureView2 = texture0.createView({dimension: '2d-array'});
+let imageData0 = new ImageData(104, 76);
+let bindGroup0 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 17, resource: textureView1}]});
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer1 = device0.createBuffer({
+  size: 12758,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+});
+let texture2 = device0.createTexture({
+  label: '\u502e\u{1fa94}\ueeaf\u03c6',
+  size: [64],
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderBundleEncoder0.setBindGroup(0, bindGroup0, new Uint32Array(388), 57, 0);
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+let canvas0 = document.createElement('canvas');
+let bindGroup1 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 17, resource: textureView1}]});
+let commandEncoder0 = device0.createCommandEncoder({});
+let querySet0 = device0.createQuerySet({label: '\u5470\u5189', type: 'occlusion', count: 240});
+let computePassEncoder0 = commandEncoder0.beginComputePass({});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup1, []);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+document.body.append(canvas0);
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 115,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 201,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let texture3 = device0.createTexture({
+  label: '\u3df2\u0c27\ue339\uba53\uaff2\uf1ab\u{1f616}\u{1ffd8}\u069a\u{1fa0a}\u2596',
+  size: {width: 1},
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture4 = device0.createTexture({size: [1], dimension: '1d', format: 'rgba8unorm-srgb', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView3 = texture0.createView({label: '\u{1ff96}\u5be6\u{1fc48}'});
+try {
+renderBundleEncoder0.setIndexBuffer(buffer1, 'uint16', 700, 1_910);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(6, undefined, 43_148_778, 556_050_077);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 1988, new Int16Array(5385), 101, 296);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder1 = device0.createCommandEncoder();
+let textureView4 = texture3.createView({label: '\u81b1\u067e\ud9c8', dimension: '1d'});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup1, new Uint32Array(3257), 565, 0);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(5, undefined, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup2 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 17, resource: textureView1}]});
+let commandEncoder2 = device0.createCommandEncoder({});
+let textureView5 = texture3.createView({baseMipLevel: 0});
+let renderBundle0 = renderBundleEncoder0.finish({label: '\u5b80\u{1fdbe}\u{1feab}\u0001'});
+try {
+commandEncoder2.copyBufferToBuffer(buffer1, 368, buffer0, 528, 764);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(49).fill(166), /* required buffer size: 49 */
+{offset: 49}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer2 = device0.createBuffer({
+  label: '\u4a86\u{1faca}\u9193\uacc6\ub2cb\u03da\u0fe6\u9591',
+  size: 2832,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder3 = device0.createCommandEncoder({});
+let texture5 = device0.createTexture({
+  size: [64],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+commandEncoder2.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 79,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 1475});
+let textureView6 = texture5.createView({baseArrayLayer: 0});
+let sampler1 = device0.createSampler({
+});
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(10).fill(141), /* required buffer size: 10 */
+{offset: 10}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let bindGroup3 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 79, resource: textureView3}]});
+let commandEncoder4 = device0.createCommandEncoder({});
+let computePassEncoder1 = commandEncoder3.beginComputePass({});
+let sampler2 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 84.68});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+commandEncoder1.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  aspect: 'all',
+}, {width: 0, height: 79, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: []});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup3, new Uint32Array(2053), 260, 0);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 532, new Int16Array(16083), 4262, 52);
+} catch {}
+try {
+canvas0.getContext('webgl');
+} catch {}
+let bindGroup4 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 79, resource: textureView1}]});
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout2]});
+let buffer3 = device0.createBuffer({
+  size: 4832,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 533});
+let texture6 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 22},
+  mipLevelCount: 2,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture7 = device0.createTexture({
+  label: '\u{1fbe1}\u042f',
+  size: {width: 1, height: 92, depthOrArrayLayers: 4},
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let sampler3 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.90,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup0);
+commandEncoder2.insertDebugMarker('\ufb5d');
+} catch {}
+let bindGroup5 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 79, resource: textureView1}]});
+let commandEncoder5 = device0.createCommandEncoder({});
+let textureView7 = texture6.createView({mipLevelCount: 1, baseArrayLayer: 11, arrayLayerCount: 3});
+let computePassEncoder2 = commandEncoder2.beginComputePass();
+try {
+buffer2.unmap();
+} catch {}
+try {
+computePassEncoder1.pushDebugGroup('\u{1f7a7}');
+} catch {}
+let texture8 = device0.createTexture({
+  size: [1, 92, 1],
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView8 = texture2.createView({arrayLayerCount: 1});
+let sampler4 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 92.42,
+  lodMaxClamp: 96.06,
+});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup3, new Uint32Array(2646), 264, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 24, z: 0},
+  aspect: 'all',
+}, new Uint8Array(107).fill(190), /* required buffer size: 107 */
+{offset: 107, bytesPerRow: 12}, {width: 0, height: 34, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 115, resource: textureView5}, {binding: 201, resource: textureView6}],
+});
+let commandEncoder6 = device0.createCommandEncoder({});
+let textureView9 = texture4.createView({});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(0, bindGroup6, new Uint32Array(5026), 914, 0);
+} catch {}
+try {
+commandEncoder5.clearBuffer(buffer2);
+} catch {}
+try {
+commandEncoder1.resolveQuerySet(querySet0, 14, 98, buffer0, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 0, y: 15, z: 1},
+  aspect: 'all',
+}, new Uint8Array(13).fill(52), /* required buffer size: 13 */
+{offset: 13, bytesPerRow: 9, rowsPerImage: 25}, {width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let buffer4 = device0.createBuffer({
+  size: 820,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder7 = device0.createCommandEncoder({});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup4, new Uint32Array(75), 6, 0);
+} catch {}
+let textureView10 = texture3.createView({});
+try {
+computePassEncoder1.popDebugGroup();
+} catch {}
+let imageData1 = new ImageData(16, 20);
+let buffer5 = device0.createBuffer({
+  size: 16296,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView11 = texture1.createView({
+  label: '\u0022\u5016\u{1f718}\u{1faac}\u69ab\u7cb2\ubb7a\u48d3\u2cf5\u5333\u{1fbc5}',
+  mipLevelCount: 1,
+});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(0, bindGroup3, new Uint32Array(1317), 316, 0);
+} catch {}
+let computePassEncoder3 = commandEncoder4.beginComputePass({label: '\u13c2\ua6a7\u0822\u0185\u04e3\uf968'});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder6.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1488 */
+  offset: 1488,
+  bytesPerRow: 12800,
+  rowsPerImage: 56,
+  buffer: buffer3,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(252).fill(64), /* required buffer size: 252 */
+{offset: 252, bytesPerRow: 238}, {width: 0, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder();
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 392});
+let texture9 = device0.createTexture({
+  label: '\u9c71\ufa71\u8daf\ub014\u97c8\u55cc',
+  size: {width: 64, height: 64, depthOrArrayLayers: 22},
+  mipLevelCount: 2,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8unorm-srgb'],
+});
+let textureView12 = texture3.createView({});
+let computePassEncoder4 = commandEncoder8.beginComputePass();
+try {
+computePassEncoder0.setBindGroup(2, bindGroup6, new Uint32Array(2617), 373, 0);
+} catch {}
+try {
+commandEncoder7.copyBufferToTexture({
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let buffer7 = device0.createBuffer({size: 464, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let computePassEncoder5 = commandEncoder6.beginComputePass({});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup1);
+adapter0.label = '\u8733\u4f55\u685c\u0d17\u0fba\u25d6\u08e3';
+} catch {}
+let bindGroup7 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 79, resource: textureView3}]});
+let buffer8 = device0.createBuffer({size: 6484, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let commandEncoder9 = device0.createCommandEncoder();
+let textureView13 = texture7.createView({dimension: '3d'});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(125).fill(19), /* required buffer size: 125 */
+{offset: 125, bytesPerRow: 94}, {width: 0, height: 29, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 284,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+  ],
+});
+let bindGroup8 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 201, resource: textureView6}, {binding: 115, resource: textureView10}],
+});
+let buffer9 = device0.createBuffer({
+  label: '\u4547\uf55e\u0bdb\u0b98\u00b2\u6aa7\u0ddb\uaab0\u02b7',
+  size: 10015,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture10 = device0.createTexture({
+  size: [1, 370, 1],
+  sampleCount: 4,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+commandEncoder5.copyBufferToBuffer(buffer6, 1588, buffer2, 1368, 84);
+} catch {}
+await gc();
+let bindGroup9 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 79, resource: textureView3}]});
+let textureView14 = texture5.createView({});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb'], depthReadOnly: true});
+try {
+renderBundleEncoder1.setVertexBuffer(1, buffer9, 3_712);
+} catch {}
+let buffer10 = device0.createBuffer({
+  size: 1931,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture11 = device0.createTexture({
+  label: '\u047a\ub873\u{1fe85}\u0953\u52b3\ua8d4\u0a09\u3968\u132e',
+  size: {width: 1, height: 92, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture12 = device0.createTexture({
+  size: {width: 1, height: 370, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle1 = renderBundleEncoder1.finish({});
+try {
+commandEncoder9.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  origin: {x: 0, y: 9, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 27, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(querySet0, 11, 69, buffer4, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(186).fill(188), /* required buffer size: 186 */
+{offset: 186, rowsPerImage: 32}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture13 = device0.createTexture({
+  size: {width: 1, height: 92, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture14 = device0.createTexture({size: {width: 1}, dimension: '1d', format: 'rgba8unorm-srgb', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView15 = texture5.createView({format: 'rgba32sint', mipLevelCount: 1});
+let computePassEncoder6 = commandEncoder1.beginComputePass({});
+let bindGroup10 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 79, resource: textureView1}]});
+let buffer11 = device0.createBuffer({
+  size: 17872,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder10 = device0.createCommandEncoder({label: '\u0af6\uce06\uc581'});
+let textureView16 = texture10.createView({dimension: '2d'});
+let texture15 = device0.createTexture({
+  size: [1, 740, 1],
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView17 = texture13.createView({label: '\ub88c\u0516\uaa9a\ue9f5\u0881\u6d04\u0c38\ud0eb\u0e1f', aspect: 'stencil-only'});
+try {
+device0.queue.writeBuffer(buffer9, 76, new DataView(new ArrayBuffer(25560)), 5040, 2036);
+} catch {}
+await gc();
+let textureView18 = texture1.createView({dimension: '2d-array', baseMipLevel: 0});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'bt470bg', transfer: 'iec61966-2-1'} });
+let bindGroup11 = device0.createBindGroup({
+  label: '\u346d\u{1fdd3}\u05dd\u707b\u880e\u{1fe04}\u{1fc66}\u028b\uaf70\u0787',
+  layout: bindGroupLayout2,
+  entries: [{binding: 79, resource: textureView3}],
+});
+let texture16 = device0.createTexture({
+  size: [64, 64, 102],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView19 = texture14.createView({});
+let computePassEncoder7 = commandEncoder5.beginComputePass({});
+let shaderModule0 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(79) var tex0: texture_2d<f32>;
+
+struct T0 {
+  @align(32) f0: array<vec2i, 112>,
+  @align(32) @size(224) f1: array<mat4x2h, 1>,
+}
+
+struct VertexOutput0 {
+  @location(3) @interpolate(flat, centroid) f0: vec2i,
+  @location(4) @interpolate(flat, sample) f1: vec2f,
+  @location(7) @interpolate(flat) f2: f16,
+  @builtin(position) f3: vec4f,
+  @location(12) f4: vec2u,
+  @location(5) f5: vec2f,
+}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec2i,
+  @location(0) f1: vec4f,
+}
+
+alias vec3b = vec3<bool>;
+
+@id(16025) override override0: i32;
+
+@id(46321) override override1 = true;
+
+override override2: f16;
+
+@id(12016) override override3: f16;
+
+@id(23917) override override4: bool;
+
+fn fn0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  let vf0: f32 = determinant(mat3x3f(unconst_f32(0.1118), unconst_f32(0.05396), unconst_f32(0.01304), unconst_f32(-0.1186), unconst_f32(0.1425), unconst_f32(0.02026), unconst_f32(0.09893), unconst_f32(0.1776), unconst_f32(0.00534)));
+  var vf1: f16 = override2;
+  let vf2: vec3u = min(vec3u(unconst_u32(129), unconst_u32(471), unconst_u32(261)), vec3u(unconst_u32(104), unconst_u32(26), unconst_u32(37)));
+  let vf3: vec4f = textureLoad(tex0, vec2i(unconst_i32(48), unconst_i32(523)), vec2i(textureDimensions(tex0, i32(unconst_i32(144))))[0]);
+  out.f5 -= vec2f(textureDimensions(tex0));
+  let vf4: f16 = override2;
+  var vf5: vec2u = textureDimensions(tex0, i32(override3));
+  var vf6: vec4h = asinh(vec4h(unconst_f16(8871.3), unconst_f16(9869.2), unconst_f16(10373.1), unconst_f16(25220.6)));
+  let vf7: u32 = vf5[u32(unconst_u32(15))];
+  var vf8: vec2u = firstTrailingBit(vec2u(unconst_u32(636), unconst_u32(144)));
+  let vf9: f16 = vf6[u32(unconst_u32(275))];
+  vf6 += vec4h(sign(vec4i(unconst_i32(-494), unconst_i32(-49), unconst_i32(196), unconst_i32(76))));
+  out.f4 = vec2u(vf3.aa);
+  return out;
+  _ = override3;
+  _ = override2;
+}
+
+fn fn1(a0: mat3x2f) -> mat2x3h {
+  var out: mat2x3h;
+  out += mat2x3h(vec3h(a0[u32(unconst_u32(333))].yxx), vec3h(a0[u32(unconst_u32(333))].rgr));
+  var vf10: vec4i = unpack4xI8(u32(unconst_u32(99)));
+  let vf11: u32 = pack4x8unorm(vec4f(unconst_f32(0.02233), unconst_f32(0.1801), unconst_f32(0.3348), unconst_f32(-0.2116)));
+  let vf12: f16 = override2;
+  var vf13: i32 = vf10[u32(unconst_u32(254))];
+  let vf14: i32 = dot4I8Packed(u32(unconst_u32(76)), u32(unconst_u32(150)));
+  out = mat2x3h(f16(a0[u32(unconst_u32(64))][u32(unconst_u32(384))]), f16(a0[u32(unconst_u32(64))][u32(unconst_u32(384))]), f16(a0[u32(unconst_u32(64))][u32(unconst_u32(384))]), f16(a0[u32(unconst_u32(64))][u32(unconst_u32(384))]), f16(a0[u32(unconst_u32(64))][u32(unconst_u32(384))]), f16(a0[u32(unconst_u32(64))][u32(unconst_u32(384))]));
+  var vf15: u32 = pack4x8unorm(vec4f(unconst_f32(0.2886), unconst_f32(0.2150), unconst_f32(-0.1010), unconst_f32(0.1318)));
+  let vf16: bool = override1;
+  var vf17: bool = override1;
+  return out;
+  _ = override1;
+  _ = override2;
+}
+
+@vertex @must_use
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  var vf18: f16 = length(f16(unconst_f16(360.7)));
+  let vf19: vec2h = asinh(vec2h(unconst_f16(570.9), unconst_f16(1258.7)));
+  out.f1 += vec2f(asinh(vec2h(unconst_f16(23472.1), unconst_f16(6372.9))));
+  out.f4 <<= vec2u(tan(vec3h(unconst_f16(21755.1), unconst_f16(2035.7), unconst_f16(2595.6))).rr);
+  var vf20: f32 = determinant(mat2x2f());
+  out.f2 = f16(override1);
+  out.f3 += vec4f(min(vec2i(unconst_i32(45), unconst_i32(37)), vec2i(unconst_i32(91), unconst_i32(207))).yyyx);
+  var vf21: vec2i = min(vec2i(unconst_i32(267), unconst_i32(89)), vec2i(unconst_i32(484), unconst_i32(44)));
+  let vf22: vec2h = pow(vec2h(unconst_f16(10545.5), unconst_f16(6925.7)), vec2h(unconst_f16(3336.0), unconst_f16(14628.9)));
+  var vf23: u32 = textureNumLevels(tex0);
+  let vf24: vec2i = min(vec2i(unconst_i32(97), unconst_i32(424)), vec2i(unconst_i32(548), unconst_i32(136)));
+  let vf25: f16 = vf22[u32(unconst_u32(71))];
+  var vf31: u32 = textureNumLevels(tex0);
+  var vf32: f16 = vf25;
+  var vf33: f16 = vf22[pack4xI8(bitcast<vec4i>(textureDimensions(tex0).rgrr))];
+  return out;
+  _ = override3;
+  _ = override1;
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  out.f0 = unpack4xI8(u32(unconst_u32(198))).gr;
+  var vf34 = fn1(mat3x2f(vec2f(reverseBits(vec2i(unconst_i32(10), unconst_i32(227)))), bitcast<vec2f>(reverseBits(vec2i(unconst_i32(10), unconst_i32(227)))), bitcast<vec2f>(reverseBits(vec2i(unconst_i32(10), unconst_i32(227))))));
+  let vf35: vec4f = textureLoad(tex0, vec2i(unconst_i32(193), unconst_i32(11)), i32(unconst_i32(243)));
+  let vf36: vec4i = unpack4xI8(u32(unconst_u32(346)));
+  var vf37: vec2u = textureDimensions(tex0, i32(unconst_i32(63)));
+  let vf38: vec4i = vf36;
+  let vf39: f16 = override2;
+  var vf40 = fn0();
+  var vf41 = fn0();
+  var vf42 = fn1(mat3x2f(bitcast<vec2f>(vf38.rb), bitcast<vec2f>(vf38.bg), vec2f(vf38.rr)));
+  vf34 += mat2x3h(vec3h(vf40.f4.xxx), vec3h(vf40.f4.yyy));
+  vf42 = mat2x3h(vec3h(vf41.f4.xxy), vec3h(vf41.f4.xxx));
+  let vf43: vec2i = reverseBits(vec2i(unconst_i32(23), unconst_i32(78)));
+  return out;
+  _ = override1;
+  _ = override2;
+  _ = override3;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0() {
+  fn1(mat3x2f());
+  var vf46: u32 = pack4xI8(vec4i(unconst_i32(435), unconst_i32(438), unconst_i32(-137), unconst_i32(206)));
+  fn1(mat3x2f(f32(pack4xI8(vec4i(unconst_i32(55), unconst_i32(18), unconst_i32(24), unconst_i32(166)))), bitcast<f32>(pack4xI8(vec4i(unconst_i32(55), unconst_i32(18), unconst_i32(24), unconst_i32(166)))), bitcast<f32>(pack4xI8(vec4i(unconst_i32(55), unconst_i32(18), unconst_i32(24), unconst_i32(166)))), f32(pack4xI8(vec4i(unconst_i32(55), unconst_i32(18), unconst_i32(24), unconst_i32(166)))), bitcast<f32>(pack4xI8(vec4i(unconst_i32(55), unconst_i32(18), unconst_i32(24), unconst_i32(166)))), bitcast<f32>(pack4xI8(vec4i(unconst_i32(55), unconst_i32(18), unconst_i32(24), unconst_i32(166))))));
+  var vf47: vec2h = normalize(vec2h(unconst_f16(5748.7), unconst_f16(6784.7)));
+  var vf48: vec2h = normalize(vec2h(unconst_f16(306.6), unconst_f16(5643.1)));
+  fn1(mat3x2f(f32(vf47[u32(unconst_u32(241))]), f32(vf47[u32(unconst_u32(241))]), f32(vf47[u32(unconst_u32(241))]), f32(vf47[u32(unconst_u32(241))]), f32(vf47[u32(unconst_u32(241))]), f32(vf47[u32(unconst_u32(241))])));
+  var vf49 = fn1(mat3x2f(exp2(exp2(vec3f(unconst_f32(0.07299), unconst_f32(0.1067), unconst_f32(-0.2740)))).xx, exp2(exp2(vec3f(unconst_f32(0.07299), unconst_f32(0.1067), unconst_f32(-0.2740)))).xy, exp2(exp2(vec3f(unconst_f32(0.07299), unconst_f32(0.1067), unconst_f32(-0.2740)))).bg));
+  fn1(mat3x2f(unpack4x8snorm(u32(unconst_u32(255))).yy, unpack4x8snorm(u32(unconst_u32(255))).wy, unpack4x8snorm(u32(unconst_u32(255))).aa));
+  vf46 = u32(determinant(mat4x4h(unconst_f16(8723.4), unconst_f16(269.4), unconst_f16(8058.6), unconst_f16(11534.4), unconst_f16(7395.7), unconst_f16(24243.7), unconst_f16(12427.9), unconst_f16(13416.0), unconst_f16(5684.2), unconst_f16(-1729.5), unconst_f16(30114.4), unconst_f16(30560.3), unconst_f16(861.8), unconst_f16(-11866.5), unconst_f16(6760.7), unconst_f16(6839.8))));
+  fn1(mat3x2f(unconst_f32(0.5808), unconst_f32(-0.1295), unconst_f32(0.4302), unconst_f32(0.3121), unconst_f32(0.3761), unconst_f32(0.03403)));
+  var vf50 = fn1(mat3x2f(exp2(vec3f(unconst_f32(0.03684), unconst_f32(0.04541), unconst_f32(0.4573))).gr, exp2(vec3f(unconst_f32(0.03684), unconst_f32(0.04541), unconst_f32(0.4573))).yz, exp2(vec3f(unconst_f32(0.03684), unconst_f32(0.04541), unconst_f32(0.4573))).zy));
+  textureBarrier();
+  let vf51: f16 = vf48[bitcast<u32>(exp2(vec3f(vf49[u32(unconst_u32(75))]))[0])];
+  var vf52 = fn1(mat3x2f(vec2f(unpack4xU8(u32(unconst_u32(7))).wz), bitcast<vec2f>(unpack4xU8(u32(unconst_u32(7))).gg), vec2f(unpack4xU8(u32(unconst_u32(7))).bg)));
+  let ptr3: ptr<function, mat2x3h> = &vf49;
+  vf52 = mat2x3h(vec3h(unpack4x8snorm(u32(unconst_u32(363))).wxz), vec3h(unpack4x8snorm(u32(unconst_u32(363))).aba));
+  vf49 = mat2x3h(vec3h(extractBits(vec3i(i32(determinant(mat2x2f()))), u32(unconst_u32(566)), u32(unconst_u32(2)))), vec3h(extractBits(vec3i(i32(determinant(mat2x2f()))), u32(unconst_u32(566)), u32(unconst_u32(2)))));
+  vf48 = bitcast<vec2h>(override0);
+  vf50 += mat2x3h(vec3h(unpack4xU8(u32(unconst_u32(787))).bra), vec3h(unpack4xU8(u32(unconst_u32(787))).aba));
+  let ptr4: ptr<function, mat2x3h> = &vf49;
+  let vf53: f16 = (*ptr3)[u32(unconst_u32(107))][u32(unconst_u32(28))];
+  vf46 *= bitcast<u32>(vf47);
+  _ = override0;
+  _ = override1;
+  _ = override2;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup12 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 284, resource: textureView16}]});
+try {
+commandEncoder9.copyBufferToBuffer(buffer8, 800, buffer1, 4080, 2364);
+} catch {}
+let promise2 = device0.createRenderPipelineAsync({
+  label: '\u17f2\u3263\u0f68\u0943\u6900\udde5\u5287',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule0,
+  constants: {override2: 0, 12_016: 0},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {module: shaderModule0, constants: {12_016: 0}, buffers: []},
+});
+let buffer12 = device0.createBuffer({size: 1611, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder11 = device0.createCommandEncoder({});
+let computePassEncoder8 = commandEncoder7.beginComputePass({});
+let sampler5 = device0.createSampler({
+  label: '\u0925\u652e\u5e32\uf5ef',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 86.67,
+  lodMaxClamp: 91.41,
+  maxAnisotropy: 4,
+});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 1, y: 8, z: 5},
+  aspect: 'all',
+}, new Uint8Array(46).fill(94), /* required buffer size: 46 */
+{offset: 10, bytesPerRow: 85}, {width: 9, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise1;
+} catch {}
+let commandEncoder12 = device0.createCommandEncoder({});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData2 = new ImageData(64, 8);
+let bindGroup13 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 79, resource: textureView1}]});
+let buffer13 = device0.createBuffer({
+  size: 2414,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let pipeline0 = await promise2;
+let shaderModule1 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(79) var tex1: texture_2d<f32>;
+
+struct T0 {
+  f0: array<array<atomic<u32>, 1>, 1>,
+}
+
+struct T1 {
+  @align(32) @size(1792) f0: array<array<T0, 2>>,
+}
+
+struct FragmentOutput1 {
+  @location(5) @interpolate(linear, center) f0: f32,
+  @location(0) f1: vec4f,
+  @location(6) @interpolate(flat) f2: vec2f,
+}
+
+var<workgroup> vw0: array<mat4x3h, 1>;
+
+var<workgroup> vw1: atomic<i32>;
+
+var<workgroup> vw2: vec2u;
+
+@vertex
+fn vertex1(@location(14) a0: vec2f, @builtin(vertex_index) a1: u32, @location(15) @interpolate(flat, center) a2: f32, @location(9) a3: vec4u, @location(8) a4: u32, @location(6) a5: vec4h, @location(3) @interpolate(flat, centroid) a6: vec4f, @location(7) a7: vec2i, @location(0) a8: vec2h, @location(12) a9: vec2i, @location(5) a10: i32, @location(13) @interpolate(linear) a11: vec4f, @location(1) a12: vec4h) -> @builtin(position) vec4f {
+  var out: vec4f;
+  var vf54: f16 = length(vec4h(unconst_f16(16024.4), unconst_f16(20428.7), unconst_f16(1230.6), unconst_f16(4447.3)));
+  let ptr5: ptr<function, f16> = &vf54;
+  let vf55: f16 = step(f16(unconst_f16(695.5)), f16(unconst_f16(4733.9)));
+  return out;
+}
+
+@fragment
+fn fragment1() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  let vf61: vec4f = atan2(vec4f(unconst_f32(-0.1122), unconst_f32(0.08691), unconst_f32(0.09223), unconst_f32(-0.08140)), unpack4x8unorm(pack4xI8(vec4i(unconst_i32(151), unconst_i32(-457), unconst_i32(35), unconst_i32(33)))));
+  out.f1 += transpose(mat2x4f(unconst_f32(0.03863), unconst_f32(0.4519), unconst_f32(0.1537), unconst_f32(0.1866), unconst_f32(0.07412), unconst_f32(0.06323), unconst_f32(0.04678), unconst_f32(-0.4886)))[unconst_i32(1)].yyyy;
+  var vf62: bool = all(bool(unconst_bool(false)));
+  var vf63: mat4x2f = transpose(mat2x4f(unconst_f32(0.1121), unconst_f32(0.00133), unconst_f32(0.09628), unconst_f32(-0.01067), unconst_f32(0.03645), unconst_f32(0.06629), unconst_f32(1.000), unconst_f32(0.5195)));
+  out.f2 -= atan2(vec4f(unconst_f32(0.01172), unconst_f32(0.2601), unconst_f32(0.02679), unconst_f32(0.1109)), vec4f(unconst_f32(0.05164), unconst_f32(0.09785), unconst_f32(-0.3136), unconst_f32(0.2960))).rr;
+  return out;
+}`,
+});
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 178});
+let texture17 = device0.createTexture({
+  size: [1, 92, 1],
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder10 = commandEncoder10.beginComputePass({});
+let sampler6 = device0.createSampler({
+});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup12, new Uint32Array(2287), 161, 0);
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(querySet2, 57, 8, buffer4, 0);
+} catch {}
+canvas0.width = 209;
+let commandEncoder13 = device0.createCommandEncoder({});
+let texture18 = device0.createTexture({
+  size: {width: 1, height: 740, depthOrArrayLayers: 6},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let buffer14 = device0.createBuffer({
+  size: 870,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder14 = device0.createCommandEncoder({});
+let texture19 = device0.createTexture({
+  size: {width: 1, height: 185, depthOrArrayLayers: 96},
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView21 = texture4.createView({});
+let computePassEncoder11 = commandEncoder14.beginComputePass({});
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture15,
+  aspect: 'all',
+},
+{width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder9.setBindGroup(3, bindGroup11, new Uint32Array(565), 89, 0);
+} catch {}
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+try {
+textureView17.label = '\u4222\u88cf';
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  label: '\ufd56\u0eb7\u0616\u7dda\u7b01\u{1fb31}\u{1fac4}\ub7b2\u{1f99b}\uc22c',
+  code: `
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(79) var tex2: texture_2d<f32>;
+
+struct T0 {
+  @align(8) @size(8) f0: array<array<atomic<i32>, 1>>,
+}
+
+struct S0 {
+  @location(4) @interpolate(perspective) f0: vec2h,
+  @location(8) @interpolate(flat, sample) f1: i32,
+}
+
+struct VertexOutput1 {
+  @location(0) @interpolate(flat) f6: vec4i,
+  @location(11) f7: vec4h,
+  @location(1) f8: f16,
+  @location(13) f9: f32,
+  @invariant @builtin(position) f10: vec4f,
+}
+
+struct FragmentOutput2 {
+  @location(5) @interpolate(flat, centroid) f0: vec2i,
+  @builtin(sample_mask) f1: u32,
+  @location(0) @interpolate(linear, centroid) f2: vec4f,
+}
+
+alias vec3b = vec3<bool>;
+
+fn fn0() {
+  let vf64: vec4f = radians(vec4f(unconst_f32(0.04821), unconst_f32(0.08008), unconst_f32(0.07634), unconst_f32(0.01737)));
+}
+
+fn fn1() -> array<array<vec2h, 1>, 47> {
+  var out: array<array<vec2h, 1>, 47>;
+  var vf65: vec2h = round(vec2h(unconst_f16(-3208.4), unconst_f16(9838.2)));
+  out[u32(unconst_u32(72))][u32(unconst_u32(181))] += bitcast<vec2h>(dot4I8Packed(u32(unconst_u32(84)), u32(unconst_u32(105))));
+  vf65 = vec2h(ceil(vec2f(unconst_f32(0.2946), unconst_f32(0.9147))));
+  out[u32(unconst_u32(98))][u32(unconst_u32(194))] *= round(vec2h(unconst_f16(-17883.5), unconst_f16(2188.1)));
+  fn0();
+  fn0();
+  fn0();
+  out[u32(unconst_u32(75))][u32(unconst_u32(79))] = vec2h(firstTrailingBit(vec4u(unconst_u32(141), unconst_u32(56), unconst_u32(23), unconst_u32(36))).yz);
+  out[u32(unconst_u32(242))][u32(unconst_u32(358))] = vec2h(ceil(vec2f(unconst_f32(0.04021), unconst_f32(0.1866))));
+  let ptr7: ptr<function, vec2h> = &vf65;
+  return out;
+}
+
+fn fn2() -> VertexOutput1 {
+  var out: VertexOutput1;
+  let vf66: f16 = exp2(f16(unconst_f16(4948.2)));
+  out.f10 = vec4f(f32(exp2(f16(unconst_f16(221.5)))));
+  out.f7 -= vec4h(abs(f16(unconst_f16(-20124.5))));
+  fn0();
+  out.f9 *= f32(abs(f16(unconst_f16(7206.8))));
+  var vf67: f16 = exp2(f16(unconst_f16(9011.5)));
+  let vf68: f32 = max(f32(unconst_f32(0.1325)), f32(unconst_f32(0.2176)));
+  out.f9 = unpack2x16unorm(u32(unconst_u32(31)))[0];
+  return out;
+}
+
+var<workgroup> vw3: array<atomic<i32>, 1>;
+
+var<workgroup> vw4: S0;
+
+@vertex
+fn vertex2(@location(7) @interpolate(flat) a0: vec4h, @location(14) a1: vec4f, @builtin(vertex_index) a2: u32, @location(1) a3: vec4h, a4: S0, @location(12) a5: vec2i) -> VertexOutput1 {
+  var out: VertexOutput1;
+  fn1();
+  out.f10 += vec4f(a0);
+  var vf69: vec2u = textureDimensions(tex2);
+  fn2();
+  out.f9 -= f32(a0.w);
+  return out;
+}
+
+@fragment
+fn fragment2() -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  var vf70 = fn1();
+  let ptr8: ptr<function, array<vec2h, 1>> = &vf70[u32(unconst_u32(825))];
+  let ptr9: ptr<function, vec2h> = &(*ptr8)[u32(unconst_u32(74))];
+  var vf71 = fn2();
+  return out;
+}`,
+  hints: {},
+});
+let commandEncoder15 = device0.createCommandEncoder();
+let computePassEncoder12 = commandEncoder12.beginComputePass();
+try {
+commandEncoder15.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 448 */
+  offset: 448,
+  bytesPerRow: 3584,
+  buffer: buffer10,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'jedecP22Phosphors', transfer: 'bt2020_10bit'} });
+let bindGroup15 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 284, resource: textureView16}]});
+let buffer15 = device0.createBuffer({
+  size: 948,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder16 = device0.createCommandEncoder({});
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 1660});
+try {
+device0.queue.writeBuffer(buffer11, 536, new BigUint64Array(4170), 1541, 300);
+} catch {}
+document.body.append(canvas0);
+let commandEncoder17 = device0.createCommandEncoder();
+let texture20 = device0.createTexture({size: [1], dimension: '1d', format: 'rgba8unorm-srgb', usage: GPUTextureUsage.COPY_DST});
+let commandEncoder18 = device0.createCommandEncoder({label: '\u80a5\u56a6\u08d6\ue406\u20a4\u0e7b\u{1fab8}\u4fcc\u0ca2\u4ec1\u{1ffa3}'});
+let texture21 = device0.createTexture({
+  label: '\u030f\u0a0f\ub2e5\u{1fd61}\u{1f767}\u0311',
+  size: [1, 740, 1],
+  dimension: '2d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder13 = commandEncoder16.beginComputePass({});
+let sampler7 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 38.22,
+  lodMaxClamp: 94.87,
+  maxAnisotropy: 17,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(34).fill(237), /* required buffer size: 34 */
+{offset: 34, rowsPerImage: 43}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'smpteSt4281', transfer: 'gamma28curve'} });
+let computePassEncoder14 = commandEncoder13.beginComputePass({});
+try {
+commandEncoder9.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1120 */
+  offset: 1120,
+  bytesPerRow: 0,
+  buffer: buffer6,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup16 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 284, resource: textureView16}]});
+let commandEncoder19 = device0.createCommandEncoder({});
+let textureView22 = texture16.createView({mipLevelCount: 1});
+let computePassEncoder15 = commandEncoder18.beginComputePass();
+let externalTexture0 = device0.importExternalTexture({label: '\u{1f8b4}\u4a48\ue3cf\u{1fa90}\u02b3\u00b0', source: videoFrame2});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(2, bindGroup1, new Uint32Array(2984), 16, 0);
+} catch {}
+try {
+computePassEncoder8.end();
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer16 = device0.createBuffer({
+  size: 28227,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder20 = device0.createCommandEncoder();
+let textureView23 = texture1.createView({});
+let texture22 = device0.createTexture({
+  size: [64],
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler8 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 56.16,
+  lodMaxClamp: 95.35,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup17 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 284, resource: textureView16}]});
+let buffer17 = device0.createBuffer({
+  size: 999,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  entries: [{binding: 17, resource: textureView3}],
+});
+let texture23 = device0.createTexture({
+  size: [1, 370, 1],
+  mipLevelCount: 2,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler9 = device0.createSampler({
+  label: '\u{1f8e4}\u0251\ue30b\u28f5',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 58.21,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+commandEncoder7.copyBufferToTexture({
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData3 = new ImageData(32, 44);
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'smpte432', transfer: 'linear'} });
+let buffer18 = device0.createBuffer({size: 9306, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder21 = device0.createCommandEncoder();
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 208});
+let texture24 = device0.createTexture({
+  size: [1, 370, 1769],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup17, new Uint32Array(1075), 87, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 740, depthOrArrayLayers: 1}
+*/
+{
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 25,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 158,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 50,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let computePassEncoder16 = commandEncoder19.beginComputePass({});
+let sampler10 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 39.00,
+  lodMaxClamp: 98.23,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(75).fill(30), /* required buffer size: 75 */
+{offset: 75, rowsPerImage: 39}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'bt2020', transfer: 'iec61966-2-1'} });
+let commandEncoder22 = device0.createCommandEncoder();
+let commandBuffer0 = commandEncoder7.finish({});
+let sampler11 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 58.15,
+  lodMaxClamp: 84.02,
+  compare: 'never',
+});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup10, new Uint32Array(318), 60, 0);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let buffer19 = device0.createBuffer({
+  size: 3074,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture25 = device0.createTexture({size: [64, 64, 22], format: 'eac-rg11snorm', usage: GPUTextureUsage.COPY_DST});
+let textureView24 = texture18.createView({dimension: '3d', mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder17 = commandEncoder15.beginComputePass({label: '\u1ba3\u0077'});
+let sampler12 = device0.createSampler({
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 74.19,
+  compare: 'equal',
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+  await buffer7.mapAsync(GPUMapMode.WRITE, 16);
+} catch {}
+try {
+commandEncoder9.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5408 */
+  offset: 5408,
+  bytesPerRow: 20480,
+  buffer: buffer9,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 160, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 18, depthOrArrayLayers: 0});
+computePassEncoder6.insertDebugMarker('\ufb33');
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder({});
+let computePassEncoder18 = commandEncoder22.beginComputePass({label: '\ub07f\ua765\u0d87\ub098\uf16d\u{1f908}\u{1f7c1}\u3ec7'});
+let renderPassEncoder0 = commandEncoder20.beginRenderPass({
+  colorAttachments: [{
+  view: textureView24,
+  depthSlice: 3,
+  clearValue: { r: 648.1, g: -198.3, b: -0.2628, a: -334.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup7, []);
+} catch {}
+try {
+commandEncoder23.copyTextureToBuffer({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 0, y: 24, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1416 */
+  offset: 1416,
+  bytesPerRow: 21760,
+  buffer: buffer11,
+}, {width: 0, height: 9, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder({});
+let texture26 = device0.createTexture({
+  size: {width: 1},
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder3.setBindGroup(3, bindGroup12, new Uint32Array(1583), 1_135, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer17, 0, 180);
+} catch {}
+await gc();
+let textureView26 = texture24.createView({aspect: 'all', mipLevelCount: 1});
+let computePassEncoder20 = commandEncoder24.beginComputePass({});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle1, renderBundle0, renderBundle1, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint32', 868, 20);
+} catch {}
+try {
+renderPassEncoder0.insertDebugMarker('\u{1fe01}');
+} catch {}
+let commandEncoder25 = device0.createCommandEncoder({label: '\u7aeb\u03f2\u03e7\u5782\u{1fd2f}\u1cee'});
+let sampler14 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  label: '\u08ce\u3852\u4f06\u9d63\u0a9e\ua842\u019a',
+  size: 17349,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder21 = commandEncoder17.beginComputePass();
+try {
+computePassEncoder3.setBindGroup(3, bindGroup13, new Uint32Array(4995), 241, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(163);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer2, 'uint32', 172, 1_538);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  label: '\u9390\u{1ffa7}\u4497',
+  entries: [
+    {
+      binding: 83,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 235,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder26 = device0.createCommandEncoder({});
+let texture27 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 22},
+  sampleCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture28 = device0.createTexture({
+  size: [1, 185, 1],
+  sampleCount: 1,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView27 = texture9.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 12, arrayLayerCount: 6});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 808.8, g: -103.6, b: -615.9, a: -210.8, });
+} catch {}
+try {
+renderPassEncoder0.draw(206, 49, 956_369_893, 671_269_487);
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 52 */
+  offset: 52,
+  bytesPerRow: 6144,
+  buffer: buffer12,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 8, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 135, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(104, 27);
+let buffer21 = device0.createBuffer({
+  size: 813,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView28 = texture27.createView({
+  label: '\udc37\ua1de\uac02\u2c06\u38a2\u7d7a\u21eb\u{1f765}\u0a52',
+  aspect: 'all',
+  baseArrayLayer: 10,
+  arrayLayerCount: 1,
+});
+let computePassEncoder22 = commandEncoder26.beginComputePass({label: '\u2fa7\u{1f907}\u{1fc02}\udc64'});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup5, new Uint32Array(577), 50, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer5, 680);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer13, 2_100);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer17, 'uint16', 100, 13);
+} catch {}
+let texture29 = device0.createTexture({
+  size: {width: 516, height: 520, depthOrArrayLayers: 1},
+  format: 'astc-12x10-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture30 = device0.createTexture({
+  size: {width: 1},
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder1 = commandEncoder25.beginRenderPass({
+  label: '\u{1fd35}\uc21d',
+  colorAttachments: [{
+  view: textureView24,
+  depthSlice: 0,
+  clearValue: { r: 116.6, g: -304.7, b: 988.6, a: 853.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet3,
+});
+try {
+renderPassEncoder0.draw(264, 3, 782_447_636, 54_367_233);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 143, 2, 315_697_269, 236_638_333);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer19, 0, 69);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture31 = device0.createTexture({
+  label: '\u{1fd7e}\u007e\u{1ffa6}\u8564\u0eaf\u{1fdb9}\uc3aa\u849b\u{1f64b}\u{1fef4}',
+  size: {width: 64, height: 64, depthOrArrayLayers: 22},
+  format: 'astc-4x4-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder23 = commandEncoder9.beginComputePass({});
+let sampler15 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 59.98,
+  lodMaxClamp: 95.40,
+  label: '\u0be7\ua960\ufdfc\u{1fdbf}\u0cbd\ue77b\u{1fb4c}\u4f70\u399a\u2df6',
+  size: 8747,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let texture32 = device0.createTexture({
+  label: '\udfc4\u0139\u563f\u4b2d\u{1f6b7}\ufbb4\u{1fa8a}\ud5e0\ue1ec\ue7bb\u{1f907}',
+  size: [1, 185, 1],
+  dimension: '2d',
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView29 = texture15.createView({});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 32, 0, 270_294_268, 1_580_402_857);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer3, 772);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer2, 400);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer1, 'uint16', 4_090, 968);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let textureView30 = texture31.createView({dimension: 'cube-array', baseArrayLayer: 2, arrayLayerCount: 6});
+let bindGroup20 = device0.createBindGroup({
+  label: '\ub075\uc459\u0efa\u815d\uac89\u09a2\u0561\u86c3',
+  layout: bindGroupLayout5,
+  entries: [{binding: 235, resource: textureView28}, {binding: 83, resource: textureView30}],
+});
+let commandEncoder27 = device0.createCommandEncoder({label: '\u3fc0\u66bd\u0dda\u{1ff98}\u676b\u0068\u0010\u7280\u{1fc68}'});
+let renderPassEncoder2 = commandEncoder27.beginRenderPass({
+  colorAttachments: [{
+  view: textureView26,
+  depthSlice: 589,
+  clearValue: { r: -37.96, g: 695.1, b: 520.7, a: -346.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb'], sampleCount: 1, depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 29, 1, 185_647_611, 741_857_525);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer9, 5_828);
+renderPassEncoder1.beginOcclusionQuery(74);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 7, 0, 64_730_450, 169_051_621);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer9, 692);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer8, 0, 437);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+let videoFrame5 = new VideoFrame(videoFrame1, {timestamp: 0});
+let commandEncoder28 = device0.createCommandEncoder({});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup16, new Uint32Array(561), 71, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer13, 312);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(32).fill(173), /* required buffer size: 32 */
+{offset: 32}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData4 = new ImageData(28, 40);
+let commandEncoder29 = device0.createCommandEncoder({});
+let computePassEncoder25 = commandEncoder29.beginComputePass({});
+let externalTexture1 = device0.importExternalTexture({source: videoFrame1});
+try {
+renderPassEncoder0.draw(63, 64, 2_201_559_154, 329_561_092);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer16, 'uint32', 3_132, 242);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder28.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3008 */
+  offset: 3008,
+  bytesPerRow: 13312,
+  buffer: buffer3,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 4, y: 4, z: 1},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer1, 'uint32', 8_228, 1_803);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder({});
+let texture33 = device0.createTexture({size: [1, 740, 1], format: 'stencil8', usage: GPUTextureUsage.COPY_DST});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame5, colorSpace: 'srgb'});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+computePassEncoder15.setBindGroup(3, bindGroup17, new Uint32Array(2018), 79, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer19, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer10, 'uint32', 8, 12);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(6, buffer8);
+} catch {}
+try {
+commandEncoder30.copyBufferToTexture({
+  origin: {x: 0, y: 92, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1796 */
+  offset: 1796,
+  buffer: buffer19,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+let buffer23 = device0.createBuffer({
+  label: '\u7b2e\u078a\u0102\uc8f3\u{1fe0e}\u063c\u8d80\u{1fb45}\ub69b\u85f1\u0e03',
+  size: 3299,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let computePassEncoder26 = commandEncoder30.beginComputePass({});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup1, new Uint32Array(1866), 20, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1, renderBundle0, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer19, 372);
+} catch {}
+try {
+commandEncoder28.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2628 */
+}, {width: 0, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let buffer24 = device0.createBuffer({size: 1023, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup9, new Uint32Array(1669), 87, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(198, 138, 9, 232_603_950, 305_808_834);
+renderPassEncoder2.setVertexBuffer(1, buffer16, 2_552, 2_091);
+} catch {}
+let buffer25 = device0.createBuffer({
+  label: '\u0d92\u01bc\u082d\u0f23\u7493\u{1fa17}\u58db\ud875\u0597\u062b\u0f62',
+  size: 16540,
+  usage: GPUBufferUsage.MAP_READ,
+});
+let commandEncoder31 = device0.createCommandEncoder({});
+let renderPassEncoder3 = commandEncoder31.beginRenderPass({
+  colorAttachments: [{
+  view: textureView29,
+  clearValue: { r: 345.0, g: -11.86, b: -162.8, a: -839.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet5,
+});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder2.draw(12, 259, 1_676_745_482, 516_533_382);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer13, 92);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer10, 'uint16', 404, 37);
+} catch {}
+let buffer26 = device0.createBuffer({
+  size: 14345,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder32 = device0.createCommandEncoder({label: '\u{1fb76}\u1912\u0c4e\ub6fa\u0399\u{1f990}\u01d9\u3ab4\u{1f682}'});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup1, new Uint32Array(2546), 109, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer13, 356);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+globalThis.someLabel = externalTexture0.label;
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder28.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 556 */
+  offset: 556,
+  bytesPerRow: 11520,
+  buffer: buffer11,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 12, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 276, depthOrArrayLayers: 0});
+} catch {}
+let sampler19 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 66.18,
+  lodMaxClamp: 74.47,
+});
+try {
+renderPassEncoder0.drawIndexed(0, 41, 0, 137_606_737, 859_348_976);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer26, 992);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 256, new DataView(new ArrayBuffer(2546)), 661, 364);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 740, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 9, y: 2 },
+  flipY: false,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 148, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let imageData5 = new ImageData(48, 28);
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpte170m', transfer: 'linear'} });
+let bindGroup21 = device0.createBindGroup({
+  label: '\u{1f80a}\u{1fdcc}\u01fe\u00a5\uda74\ua364',
+  layout: bindGroupLayout2,
+  entries: [{binding: 79, resource: textureView3}],
+});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup8, new Uint32Array(392), 31, 0);
+renderBundleEncoder3.setBindGroup(2, bindGroup16, new Uint32Array(237), 7, 0);
+} catch {}
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer11, 596, buffer23, 252, 380);
+} catch {}
+let renderPassEncoder4 = commandEncoder28.beginRenderPass({
+  label: '\u4eb1\u{1f8f6}\u0e08\u9505\ub051\u0626\u023f',
+  colorAttachments: [{
+  view: textureView29,
+  clearValue: { r: -532.2, g: 29.92, b: 575.4, a: -922.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 22203578,
+});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup17, new Uint32Array(1952), 787, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(254, 306, 172_265_602, 1_417_188_533);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer26, 3_776, 24);
+} catch {}
+try {
+commandEncoder32.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 9, y: 1, z: 18},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 3204, new Float32Array(14191), 929, 36);
+} catch {}
+let commandEncoder33 = device0.createCommandEncoder({});
+let textureView33 = texture18.createView({mipLevelCount: 1});
+let computePassEncoder27 = commandEncoder32.beginComputePass({});
+let sampler20 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 77.23,
+  lodMaxClamp: 80.93,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 212, new Int16Array(13726), 2082, 180);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 740, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 12, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup22 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 115, resource: textureView4}, {binding: 201, resource: textureView15}],
+});
+let textureView34 = texture31.createView({
+  dimension: 'cube-array',
+  format: 'astc-4x4-unorm-srgb',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  baseArrayLayer: 1,
+  arrayLayerCount: 6,
+});
+let computePassEncoder28 = commandEncoder33.beginComputePass({});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup0, new Uint32Array(344), 62, 0);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(4, buffer9, 0, 1_599);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 202,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder34 = device0.createCommandEncoder({});
+let texture36 = device0.createTexture({
+  label: '\uecdc\u03e1\u06df\u2bde\u0520\u6a0a\udd5f\u{1fe57}',
+  size: {width: 1, height: 370, depthOrArrayLayers: 1},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder29 = commandEncoder34.beginComputePass({});
+let renderBundle3 = renderBundleEncoder3.finish();
+let externalTexture3 = device0.importExternalTexture({source: videoFrame2});
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup13, new Uint32Array(3408), 886, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 52, 0, 74_083_227, 764_392_711);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer3, 296);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  label: '\u0329\u0c64\ua967\u8eea\ub597\u3de5\ua62f\udc0b',
+  entries: [
+    {
+      binding: 79,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 45,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 337,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 309,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer27 = device0.createBuffer({size: 12373, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let commandEncoder35 = device0.createCommandEncoder({label: '\u9612\u9b3d'});
+let textureView35 = texture28.createView({arrayLayerCount: 1});
+let texture37 = device0.createTexture({
+  size: {width: 1, height: 370, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView36 = texture6.createView({dimension: 'cube-array', mipLevelCount: 1, arrayLayerCount: 6});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg16uint'],
+  depthStencilFormat: 'stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer9, 1_076);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer3, 1_568);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(6, buffer14, 0);
+} catch {}
+document.body.append(canvas0);
+let bindGroup23 = device0.createBindGroup({label: '\u5124\ub103', layout: bindGroupLayout0, entries: [{binding: 17, resource: textureView3}]});
+let buffer28 = device0.createBuffer({
+  size: 5654,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture38 = device0.createTexture({
+  size: {width: 1, height: 92, depthOrArrayLayers: 12},
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder30 = commandEncoder35.beginComputePass({});
+let renderBundle4 = renderBundleEncoder4.finish();
+try {
+computePassEncoder3.setBindGroup(0, bindGroup20, new Uint32Array(303), 9, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup19, new Uint32Array(530), 48, 0);
+buffer8.unmap();
+} catch {}
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'film', transfer: 'iec61966-2-1'} });
+try {
+adapter0.label = '\u0457\u7f64\u674b\u6329\u1b73\u0f07\u07bb\u{1f84e}';
+} catch {}
+let buffer29 = device0.createBuffer({size: 38908, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder36 = device0.createCommandEncoder({});
+let textureView37 = texture38.createView({});
+let texture39 = device0.createTexture({
+  label: '\u146f\u{1f8d6}\u0968\u{1f9a3}\u03e6\u3c72\u{1f879}',
+  size: {width: 1},
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device0.queue.writeBuffer(buffer0, 504, new BigUint64Array(7348), 174, 68);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder37 = device0.createCommandEncoder({});
+let textureView38 = texture27.createView({label: '\u0eb8\u{1fcd5}\u8241\ud40f', baseArrayLayer: 3, arrayLayerCount: 2});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer28, 'uint32', 912, 2_603);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer26);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let buffer30 = device0.createBuffer({
+  size: 3959,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder38 = device0.createCommandEncoder({});
+let texture40 = device0.createTexture({
+  size: [1, 92, 1],
+  sampleCount: 1,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder32 = commandEncoder38.beginComputePass();
+try {
+renderPassEncoder1.drawIndexed(274, 215, 115, 649_154_840, 400_167_888);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer9, 1_404);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer14, 'uint16', 78, 24);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+let imageData6 = new ImageData(4, 4);
+let videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'smpte240m', transfer: 'linear'} });
+let commandEncoder39 = device0.createCommandEncoder({});
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 2254});
+let textureView39 = texture40.createView({});
+try {
+device0.queue.writeBuffer(buffer8, 340, new DataView(new ArrayBuffer(8340)), 1104, 1464);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder({label: '\ud411\u032d'});
+let textureView40 = texture6.createView({
+  label: '\ud9ad\u650d\uc800\u1d92',
+  dimension: 'cube-array',
+  aspect: 'all',
+  mipLevelCount: 1,
+  baseArrayLayer: 1,
+  arrayLayerCount: 6,
+});
+let computePassEncoder33 = commandEncoder37.beginComputePass({});
+try {
+renderPassEncoder0.draw(11, 35, 193_501_769, 430_795_572);
+} catch {}
+try {
+commandEncoder39.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 688 */
+  offset: 688,
+  bytesPerRow: 10496,
+  buffer: buffer26,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 38, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 96, depthOrArrayLayers: 0});
+} catch {}
+let querySet9 = device0.createQuerySet({label: '\u4c57\u40c5\u{1fff3}\ucdcd\u{1fa7c}', type: 'occlusion', count: 192});
+let textureView41 = texture31.createView({dimension: 'cube-array', baseArrayLayer: 2, arrayLayerCount: 6});
+let textureView42 = texture6.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 3});
+let computePassEncoder34 = commandEncoder39.beginComputePass({});
+let sampler21 = device0.createSampler({
+  label: '\u0ae6\u{1fd79}\u37f5\u2d1f\u28c8\u{1f988}\u85ed\u1ef5\u{1f679}\ua131',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 73.36,
+  lodMaxClamp: 96.90,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup4, new Uint32Array(4), 0, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup2, new Uint32Array(7134), 88, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(34, 150, 509_882_381, 19_807_868);
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+commandEncoder40.copyTextureToTexture({
+  texture: texture16,
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder35 = commandEncoder40.beginComputePass({});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer28, 2_264);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer16, 'uint32', 3_812, 10_148);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture41 = device0.createTexture({
+  size: [1, 92, 1],
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler22 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  lodMinClamp: 74.41,
+  lodMaxClamp: 93.74,
+});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(296);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(397, 404, 81, 155_615_182, 2_331_480_615);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer21, 'uint16', 36, 134);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer16, 2_408, 1_834);
+} catch {}
+let commandEncoder41 = device0.createCommandEncoder({});
+let textureView43 = texture38.createView({});
+let texture42 = device0.createTexture({
+  size: [1],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder36 = commandEncoder41.beginComputePass({label: '\u06ea\u59eb\u47bc'});
+let sampler23 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 88.62,
+  lodMaxClamp: 95.21,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer13, 544);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer28, 'uint16', 80, 1_399);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder43 = device0.createCommandEncoder({});
+let textureView45 = texture21.createView({dimension: '2d-array', arrayLayerCount: 1});
+let computePassEncoder38 = commandEncoder43.beginComputePass();
+let sampler24 = device0.createSampler({
+  label: '\uc95f\u00eb\u5521\u97c1\u{1f94c}\u0b30\u07a9\uacec\u6c58',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 97.87,
+  lodMaxClamp: 98.58,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer2, 168);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer3, 308);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer2, 'uint32', 248, 214);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(44).fill(1), /* required buffer size: 44 */
+{offset: 44, bytesPerRow: 167}, {width: 38, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer31 = device0.createBuffer({
+  size: 19960,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture43 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder24.setBindGroup(2, bindGroup19, new Uint32Array(4773), 443, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup23, new Uint32Array(191), 54, 0);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.draw(60, 34, 609_509_781, 304_575_325);
+commandEncoder24.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 0, y: 38, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData7 = new ImageData(20, 24);
+let bindGroup24 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [{binding: 83, resource: textureView41}, {binding: 235, resource: textureView28}],
+});
+let commandBuffer1 = commandEncoder20.finish();
+let textureView46 = texture10.createView({
+  label: '\ua539\ue9b1\u06c6\uf971\u{1f92d}\u7f8b\u02c9\u{1f6de}',
+  aspect: 'all',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let texture44 = device0.createTexture({
+  size: [1],
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+computePassEncoder34.setBindGroup(2, bindGroup13, new Uint32Array(257), 15, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup3, new Uint32Array(44), 29, 0);
+buffer18.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup25 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 202, resource: textureView0}]});
+let commandBuffer2 = commandEncoder24.finish();
+let textureView47 = texture40.createView({});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup4, new Uint32Array(226), 190, 0);
+} catch {}
+try {
+computePassEncoder32.end();
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(86);
+renderPassEncoder4.setVertexBuffer(5, buffer13, 388, 84);
+} catch {}
+try {
+computePassEncoder21.insertDebugMarker('\u6fd0');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 740, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 235, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let textureView48 = texture28.createView({});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup12, new Uint32Array(2428), 195, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(623, 86, 39_792_543, 2_353_733_061);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer19, 632);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder38.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 204 */
+  aspect: 'all',
+}, {width: 0, height: 46, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 2276, new BigUint64Array(339), 65, 40);
+} catch {}
+document.body.prepend(canvas0);
+let shaderModule3 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+diagnostic(info, xyz);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(79) var tex3: texture_2d<f32>;
+
+struct T0 {
+  f0: array<array<array<vec4h, 1>, 1>, 5>,
+}
+
+struct T1 {
+  @size(176) f0: mat4x2h,
+  @align(8) @size(16) f1: u32,
+  @size(264) f2: i32,
+}
+
+struct VertexOutput2 {
+  @location(0) f11: f16,
+  @invariant @builtin(position) f12: vec4f,
+}
+
+struct FragmentOutput3 {
+  @location(0) f0: vec4f,
+}
+
+alias vec3b = vec3<bool>;
+
+fn fn0(a0: ptr<storage, array<mat3x2f, 1>, read_write>) -> vec2i {
+  var out: vec2i;
+  let ptr10: ptr<private, array<array<vec4h, 1>, 1>> = &vp0.f0[4];
+  vp0.f0[u32(unconst_u32(4))][u32(unconst_u32(84))][0] *= bitcast<vec4h>((*a0)[u32(unconst_u32(220))][unconst_i32(2)]);
+  var vf72: f16 = (*ptr10)[0][u32(unconst_u32(83))][u32(unconst_u32(854))];
+  (*a0)[0] = mat3x2f(bitcast<vec2f>(textureDimensions(tex3)), vec2f(textureDimensions(tex3)), bitcast<vec2f>(textureDimensions(tex3)));
+  out ^= bitcast<vec2i>((*ptr10)[u32(unconst_u32(477))][u32(unconst_u32(185))]);
+  let ptr11: ptr<private, vec4h> = &vp0.f0[4][0][0];
+  return out;
+}
+
+fn fn1() -> array<vec4h, 1> {
+  var out: array<vec4h, 1>;
+  atomicCompareExchangeWeak(&vw5, unconst_u32(258), unconst_u32(81));
+  return out;
+}
+
+fn fn2() -> T0 {
+  var out: T0;
+  fn1();
+  out.f0[u32(unconst_u32(61))][u32(unconst_u32(100))][u32(unconst_u32(276))] = vec4h((*&vw13).f11);
+  var vf78 = fn1();
+  let ptr19: ptr<workgroup, FragmentOutput3> = &vw8[u32(unconst_u32(441))];
+  out.f0[u32(unconst_u32(20))][u32(unconst_u32(238))][u32(unconst_u32(235))] = vec4h((*&vw12));
+  var vf79 = fn1();
+  vw15[0] = vw15[0];
+  let ptr20: ptr<workgroup, atomic<u32>> = &(*&vw7);
+  return out;
+}
+
+var<workgroup> vw5: atomic<u32>;
+
+var<workgroup> vw6: vec2i;
+
+var<workgroup> vw7: atomic<u32>;
+
+var<workgroup> vw8: array<FragmentOutput3, 14>;
+
+var<workgroup> vw9: vec4i;
+
+var<workgroup> vw10: atomic<u32>;
+
+var<workgroup> vw11: atomic<i32>;
+
+var<workgroup> vw12: vec4i;
+
+var<workgroup> vw13: VertexOutput2;
+
+var<workgroup> vw14: VertexOutput2;
+
+var<workgroup> vw15: array<mat2x4f, 1>;
+
+var<private> vp0: T0 = T0(array<array<array<vec4h, 1>, 1>, 5>());
+
+@vertex
+fn vertex3() -> VertexOutput2 {
+  var out: VertexOutput2;
+  var vf80: u32 = pack4x8snorm(vec4f(f32(vp0.f0[4][u32(unconst_u32(249))][u32(unconst_u32(55))][u32(unconst_u32(102))])));
+  vp0 = T0(array<array<array<vec4h, 1>, 1>, 5>(array<array<vec4h, 1>, 1>(array<vec4h, 1>(vp0.f0[u32(unconst_u32(40))][u32(unconst_u32(354))][0])), array<array<vec4h, 1>, 1>(array<vec4h, 1>(vp0.f0[u32(unconst_u32(40))][u32(unconst_u32(354))][0])), array<array<vec4h, 1>, 1>(array<vec4h, 1>(vp0.f0[u32(unconst_u32(40))][u32(unconst_u32(354))][0])), array<array<vec4h, 1>, 1>(array<vec4h, 1>(vp0.f0[u32(unconst_u32(40))][u32(unconst_u32(354))][0])), array<array<vec4h, 1>, 1>(array<vec4h, 1>(vp0.f0[u32(unconst_u32(40))][u32(unconst_u32(354))][0]))));
+  let vf81: f16 = vp0.f0[u32(unconst_u32(6))][u32(unconst_u32(151))][0][u32(vp0.f0[4][0][u32(unconst_u32(98))][3])];
+  let ptr21: ptr<private, vec4h> = &vp0.f0[4][0][u32(unconst_u32(91))];
+  var vf82: f16 = length(vec3h(unconst_f16(7812.6), unconst_f16(36321.7), unconst_f16(14924.2)));
+  out = VertexOutput2(f16(dot4U8Packed(u32(unconst_u32(75)), u32(atan2(vec3f(unconst_f32(-0.1770), unconst_f32(0.2167), unconst_f32(0.1173)), vec3f(unconst_f32(0.2324), unconst_f32(-0.1238), unconst_f32(0.1387))).b))), unpack4x8snorm(dot4U8Packed(u32(unconst_u32(75)), u32(atan2(vec3f(unconst_f32(-0.1770), unconst_f32(0.2167), unconst_f32(0.1173)), vec3f(unconst_f32(0.2324), unconst_f32(-0.1238), unconst_f32(0.1387))).b))));
+  var vf83: f32 = degrees(f32(unconst_f32(0.1539)));
+  return out;
+}
+
+@fragment
+fn fragment3() -> @location(200) vec4f {
+  var out: vec4f;
+  let ptr22: ptr<private, T0> = &vp0;
+  vp0 = T0(array<array<array<vec4h, 1>, 1>, 5>(array<array<vec4h, 1>, 1>(array<vec4h, 1>(vec4h((*ptr22).f0[u32(unconst_u32(66))][u32((*ptr22).f0[4][0][0].w)][0][u32(unconst_u32(38))]))), array<array<vec4h, 1>, 1>(array<vec4h, 1>(vec4h((*ptr22).f0[u32(unconst_u32(66))][u32((*ptr22).f0[4][0][0].w)][0][u32(unconst_u32(38))]))), array<array<vec4h, 1>, 1>(array<vec4h, 1>(vec4h((*ptr22).f0[u32(unconst_u32(66))][u32((*ptr22).f0[4][0][0].w)][0][u32(unconst_u32(38))]))), array<array<vec4h, 1>, 1>(array<vec4h, 1>(vec4h((*ptr22).f0[u32(unconst_u32(66))][u32((*ptr22).f0[4][0][0].w)][0][u32(unconst_u32(38))]))), array<array<vec4h, 1>, 1>(array<vec4h, 1>(vec4h((*ptr22).f0[u32(unconst_u32(66))][u32((*ptr22).f0[4][0][0].w)][0][u32(unconst_u32(38))])))));
+  let ptr23: ptr<private, array<array<vec4h, 1>, 1>> = &(*ptr22).f0[4];
+  vp0 = T0(array<array<array<vec4h, 1>, 1>, 5>(array<array<vec4h, 1>, 1>(array<vec4h, 1>((*ptr22).f0[u32(unconst_u32(49))][0][0])), array<array<vec4h, 1>, 1>(array<vec4h, 1>((*ptr22).f0[u32(unconst_u32(49))][0][0])), array<array<vec4h, 1>, 1>(array<vec4h, 1>((*ptr22).f0[u32(unconst_u32(49))][0][0])), array<array<vec4h, 1>, 1>(array<vec4h, 1>((*ptr22).f0[u32(unconst_u32(49))][0][0])), array<array<vec4h, 1>, 1>(array<vec4h, 1>((*ptr22).f0[u32(unconst_u32(49))][0][0]))));
+  return out;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute1() {
+  let ptr25: ptr<workgroup, atomic<i32>> = &(*&vw11);
+  let ptr26: ptr<workgroup, mat2x4f> = &(*&vw15)[0];
+  var vf85: f32 = vw15[u32(unconst_u32(249))][u32(unconst_u32(78))][atomicLoad(&(*&vw7))];
+  vw15[u32(unconst_u32(397))] = mat2x4f(f32((*&vw13).f11), f32((*&vw13).f11), f32((*&vw13).f11), f32((*&vw13).f11), f32((*&vw13).f11), f32((*&vw13).f11), f32((*&vw13).f11), f32((*&vw13).f11));
+  vw14 = VertexOutput2(f16((*&vw8)[13].f0[3]), (*&vw8)[13].f0);
+  atomicMin(&vw7, u32(unconst_u32(110)));
+  vf85 = f32(vw12[u32(unconst_u32(128))]);
+  atomicAdd(&vw5, u32(unconst_u32(166)));
+  var vf86 = fn2();
+  atomicMin(&vw7, u32(unconst_u32(32)));
+  let ptr27: ptr<workgroup, f16> = &(*&vw14).f11;
+  var vf87 = fn1();
+  fn1();
+  let ptr28: ptr<private, array<vec4h, 1>> = &vp0.f0[4][u32(unconst_u32(917))];
+}
+
+@compute @workgroup_size(6, 1, 1)
+fn compute2(@builtin(global_invocation_id) a0: vec3u, @builtin(local_invocation_id) a1: vec3u) {
+  let ptr29: ptr<private, array<vec4h, 1>> = &vp0.f0[bitcast<u32>(vw14.f12.r)][0];
+  var vf89 = fn2();
+  let ptr30: ptr<function, array<array<vec4h, 1>, 1>> = &vf89.f0[4];
+  var vf90: u32 = atomicLoad(&(*&vw7));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup26 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 115, resource: textureView4}, {binding: 201, resource: textureView14}],
+});
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer19, 172, 186);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer31, 836, new DataView(new ArrayBuffer(10773)), 487, 4132);
+} catch {}
+document.body.append(canvas0);
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 17,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 18,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 266,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 60,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 127,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let bindGroup27 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [{binding: 83, resource: textureView30}, {binding: 235, resource: textureView38}],
+});
+let commandEncoder44 = device0.createCommandEncoder();
+let texture45 = device0.createTexture({
+  label: '\u0da0\u08a3\u1a9d\u{1fff0}\u0821\u0881\u5f3e\u0992',
+  size: [1, 370, 1],
+  mipLevelCount: 1,
+  sampleCount: 4,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView49 = texture4.createView({});
+let computePassEncoder39 = commandEncoder38.beginComputePass();
+let renderPassEncoder5 = commandEncoder44.beginRenderPass({
+  label: '\uc25a\u192d',
+  colorAttachments: [{view: textureView26, depthSlice: 1481, loadOp: 'load', storeOp: 'store'}],
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\u6c2d\u{1f61d}\u05ab\u4356\ub444\u8e6c\u49af\u0603\u0d7e\u0cd9\u83af',
+  colorFormats: ['rg16uint'],
+  depthStencilFormat: 'stencil8',
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+computePassEncoder31.pushDebugGroup('\u{1fb0a}');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let texture46 = device0.createTexture({
+  label: '\ua9db\u{1f78e}\u94b4\u0732\u5275\u{1f617}\u80f4\u{1f620}\u2017',
+  size: [1, 740, 1],
+  mipLevelCount: 1,
+  sampleCount: 4,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle5 = renderBundleEncoder5.finish({label: '\u0f29\u4319\u8172\u0dfa\u0d93\u0f36'});
+let sampler25 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 47.26,
+  lodMaxClamp: 83.16,
+});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder1.draw(292, 297, 295_286_222, 116_000_926);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(5, 117, 22, 306_103_484, 109_467_969);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 185, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas0,
+  origin: { x: 54, y: 3 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 113, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let buffer32 = device0.createBuffer({
+  size: 31739,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture47 = device0.createTexture({
+  size: {width: 1, height: 185, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup12, new Uint32Array(3568), 295, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(5, 214, 0, 1_011_102_615, 479_110_422);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer1, 'uint32', 356, 2_258);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder31.popDebugGroup();
+} catch {}
+let buffer33 = device0.createBuffer({size: 751, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView50 = texture47.createView({format: 'rg8sint'});
+try {
+renderPassEncoder3.beginOcclusionQuery(256);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(38, 358, 219, -1_939_660_959, 194_726_097);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(262).fill(158), /* required buffer size: 262 */
+{offset: 262}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame9 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'smpte170m', transfer: 'smpte240m'} });
+let textureView51 = texture33.createView({mipLevelCount: 1});
+let sampler26 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 36.45,
+  lodMaxClamp: 75.13,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder27.setBindGroup(1, bindGroup0, new Uint32Array(727), 77, 0);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 20, z: 0},
+  aspect: 'all',
+}, new Uint8Array(231).fill(96), /* required buffer size: 231 */
+{offset: 231, bytesPerRow: 44}, {width: 0, height: 135, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(canvas0);
+let imageData8 = new ImageData(108, 76);
+try {
+renderPassEncoder2.executeBundles([renderBundle0, renderBundle0, renderBundle3, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer13, 260);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+adapter0.label = '\u51c9\u04d3\u{1f6cd}\u16e9\u0bc9\u0308\ude87';
+} catch {}
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 44});
+let textureView52 = texture1.createView({label: '\u0cbb\u072c'});
+let sampler28 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 18.32,
+});
+try {
+renderPassEncoder2.drawIndirect(buffer28, 212);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 0, y: 42, z: 0},
+  aspect: 'all',
+}, new Uint8Array(346).fill(142), /* required buffer size: 346 */
+{offset: 346, bytesPerRow: 93}, {width: 0, height: 56, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+await gc();
+let buffer35 = device0.createBuffer({
+  label: '\u0958\u0b2d\u083a',
+  size: 8316,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT,
+});
+try {
+computePassEncoder37.setBindGroup(3, bindGroup25, new Uint32Array(211), 11, 0);
+} catch {}
+try {
+renderPassEncoder1.draw(43, 209, 434_257_246, 206_441_737);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(26, 121, 35, 391_691_385, 921_555_829);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer13, 708);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 30, z: 0},
+  aspect: 'all',
+}, new Uint8Array(9).fill(159), /* required buffer size: 9 */
+{offset: 9, bytesPerRow: 68}, {width: 24, height: 60, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup29 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 284, resource: textureView16}]});
+let buffer36 = device0.createBuffer({size: 13637, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let commandEncoder46 = device0.createCommandEncoder();
+try {
+  await promise3;
+} catch {}
+let buffer37 = device0.createBuffer({
+  size: 15015,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder47 = device0.createCommandEncoder({});
+let computePassEncoder42 = commandEncoder47.beginComputePass({});
+try {
+computePassEncoder25.setBindGroup(2, bindGroup6, new Uint32Array(1577), 293, 0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(3, buffer9, 788);
+} catch {}
+try {
+renderPassEncoder3.pushDebugGroup('\uf293');
+} catch {}
+try {
+renderPassEncoder3.popDebugGroup();
+} catch {}
+try {
+computePassEncoder0.insertDebugMarker('\u0376');
+} catch {}
+document.body.prepend(canvas0);
+let texture48 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 22},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder26.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+computePassEncoder41.setBindGroup(0, bindGroup10, new Uint32Array(2250), 218, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer5, 1_128);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+buffer33.unmap();
+} catch {}
+try {
+computePassEncoder35.setBindGroup(3, bindGroup20, new Uint32Array(971), 620, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer5, 820);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(406).fill(10), /* required buffer size: 406 */
+{offset: 406, bytesPerRow: 2}, {width: 0, height: 26, depthOrArrayLayers: 0});
+} catch {}
+let buffer38 = device0.createBuffer({
+  size: 25398,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder48 = device0.createCommandEncoder({label: '\u5a3b\u4ae1\u0135\ud415\u8b60\u{1fa2f}\u{1f818}\u299b\u{1f854}'});
+let texture49 = device0.createTexture({
+  size: {width: 1, height: 92, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder43 = commandEncoder48.beginComputePass();
+try {
+} catch {}
+let bindGroup30 = device0.createBindGroup({
+  label: '\u{1fbdb}\u{1ff50}\ue5e0\u{1f85f}',
+  layout: bindGroupLayout5,
+  entries: [{binding: 235, resource: textureView38}, {binding: 83, resource: textureView30}],
+});
+let commandEncoder49 = device0.createCommandEncoder({});
+let texture50 = device0.createTexture({
+  size: [1, 185, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView54 = texture24.createView({mipLevelCount: 1});
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer3, 472);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer30, 324);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup31 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 79, resource: textureView3}]});
+let computePassEncoder44 = commandEncoder49.beginComputePass({label: '\u2013\u7ca6\u0a01\ud875'});
+let sampler31 = device0.createSampler({
+  label: '\u03a1\u0ab3',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 77.66,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle0, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder3.draw(15, 146, 56_344_482, 125_719_085);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(6, 558, 4, 52_766_771, 1_123_250_903);
+renderPassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+let bindGroup32 = device0.createBindGroup({
+  label: '\u80be\u2ed2\u729f\u0743\u{1fbb9}\u2f03\u{1fe72}',
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 25, resource: {buffer: buffer28, offset: 1280, size: 716}},
+    {binding: 50, resource: textureView3},
+    {binding: 158, resource: {buffer: buffer26, offset: 1280, size: 956}},
+  ],
+});
+let buffer39 = device0.createBuffer({size: 8756, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder50 = device0.createCommandEncoder({label: '\u{1f709}\ubdf8\u047d\u0ef9\u034e\u{1fdae}\u45d5\u{1fa65}\u685c\u42f8\u{1fbc5}'});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder51 = device0.createCommandEncoder({label: '\ua32c\ud7eb\u46f3\u239a\u0957\ueb81\uc84a\u1b5a'});
+let textureView55 = texture13.createView({});
+let computePassEncoder46 = commandEncoder51.beginComputePass({});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup19, []);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let externalTexture4 = device0.importExternalTexture({source: videoFrame6});
+try {
+computePassEncoder25.setBindGroup(3, bindGroup31, new Uint32Array(5764), 1_852, 0);
+} catch {}
+try {
+renderPassEncoder1.draw(145, 167, 1_838_727_061, 880_541_484);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer35, 1_120);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+await gc();
+let bindGroup33 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 284, resource: textureView46}]});
+let sampler32 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 36.32,
+  lodMaxClamp: 91.67,
+  compare: 'less',
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup6);
+computePassEncoder3.insertDebugMarker('\uc5fa');
+} catch {}
+let buffer40 = device0.createBuffer({
+  size: 3164,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder52 = device0.createCommandEncoder({});
+let computePassEncoder47 = commandEncoder52.beginComputePass({});
+let sampler33 = device0.createSampler({
+  label: '\u{1f950}\uca33\u9bb5\u0540\u{1ff88}\uc1fd\u0a19',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 75.73,
+  lodMaxClamp: 95.96,
+  maxAnisotropy: 6,
+});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup33, []);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(8, 92, 5, 110_848_979, 260_430_620);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer2, 508);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer9, 732);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer1, 'uint16', 270, 3_684);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 740, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData6,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 127, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame10 = new VideoFrame(videoFrame2, {timestamp: 0});
+try {
+renderPassEncoder3.drawIndexed(8, 8, 4, 522_868_123, 758_118_174);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer19, 904);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer35, 100);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer30, 228, 91);
+} catch {}
+let textureView56 = texture38.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let texture52 = device0.createTexture({
+  size: [64, 64, 22],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthStencilFormat: 'stencil8', stencilReadOnly: true});
+let renderBundle6 = renderBundleEncoder6.finish({label: '\ud7ec\u173f\u8477\u{1fa97}\ufa52\u028f\u0c7c\u0eb1'});
+try {
+} catch {}
+try {
+device0.queue.writeBuffer(buffer29, 3196, new Float32Array(1209));
+} catch {}
+document.body.prepend(canvas0);
+let buffer41 = device0.createBuffer({
+  size: 2136,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 501});
+let texture53 = device0.createTexture({
+  size: [1, 740, 1],
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView57 = texture39.createView({});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder5.draw(53, 167, 962_941_066, 1_268_268_508);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer40, 2_148);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer30, 312);
+} catch {}
+let buffer42 = device0.createBuffer({
+  size: 350,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder54 = device0.createCommandEncoder();
+let textureView58 = texture21.createView({dimension: '2d-array'});
+let computePassEncoder49 = commandEncoder54.beginComputePass();
+let sampler34 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 4.214,
+  lodMaxClamp: 77.72,
+});
+try {
+computePassEncoder44.setBindGroup(3, bindGroup25, new Uint32Array(483), 130, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer0, 1_172);
+} catch {}
+let img0 = await imageWithData(39, 65, '#10101010', '#20202020');
+let buffer43 = device0.createBuffer({size: 10446, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+renderPassEncoder1.end();
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise4 = device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule0, constants: {override2: 0, 16_025: 0}}});
+let commandEncoder55 = device0.createCommandEncoder({});
+let computePassEncoder50 = commandEncoder55.beginComputePass({});
+try {
+renderPassEncoder5.drawIndexed(14, 334, 7, 249_657_585, 238_203_992);
+} catch {}
+try {
+commandEncoder25.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4788 */
+  offset: 4788,
+  bytesPerRow: 1024,
+  buffer: buffer34,
+}, {
+  texture: texture48,
+  mipLevel: 1,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 14, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder56 = device0.createCommandEncoder({});
+let texture54 = device0.createTexture({
+  label: '\u4992\u18af\u{1ff5f}\u8bc7\u5c92\u1362\u2a7f\u02ca\u0e77',
+  size: {width: 64},
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView59 = texture53.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderPassEncoder6 = commandEncoder25.beginRenderPass({
+  colorAttachments: [{
+  view: textureView29,
+  clearValue: { r: 164.9, g: 444.0, b: 65.46, a: 49.92, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 29951169,
+});
+let sampler35 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 82.10,
+  lodMaxClamp: 95.04,
+  compare: 'greater',
+});
+try {
+renderPassEncoder3.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -268.9, g: -113.6, b: 465.1, a: 260.4, });
+} catch {}
+try {
+texture30.label = '\u2667\u00d5\u0b70\u013b\u6ddc\u0e5f\u8f42';
+} catch {}
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 1113});
+let textureView60 = texture40.createView({arrayLayerCount: 1});
+let computePassEncoder51 = commandEncoder56.beginComputePass();
+let sampler36 = device0.createSampler({
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.31,
+  lodMaxClamp: 71.86,
+  maxAnisotropy: 10,
+});
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+renderPassEncoder2.draw(367, 213, 120_395_258, 1_108_201_804);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup34 = device0.createBindGroup({
+  label: '\u1421\u0e5e\ub4b0\u{1fdb6}\ubc06\u{1fdea}\ucd8b\u3230\ufff6',
+  layout: bindGroupLayout8,
+  entries: [
+    {binding: 18, resource: textureView50},
+    {binding: 17, resource: textureView3},
+    {binding: 60, resource: {buffer: buffer5, offset: 256}},
+    {binding: 266, resource: textureView56},
+    {binding: 127, resource: textureView29},
+  ],
+});
+let querySet13 = device0.createQuerySet({type: 'occlusion', count: 418});
+let textureView61 = texture46.createView({arrayLayerCount: 1});
+let sampler37 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 51.68,
+  lodMaxClamp: 63.38,
+  compare: 'not-equal',
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+computePassEncoder15.setBindGroup(2, bindGroup2, new Uint32Array(635), 4, 0);
+renderPassEncoder5.drawIndexed(30, 121, 1, -1_385_294_099, 832_569_556);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer9, 392);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer31, 1_484);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer42, 'uint16', 32, 75);
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 225,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32float', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 185,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 49,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 267, hasDynamicOffset: false },
+    },
+    {
+      binding: 86,
+      visibility: GPUShaderStage.VERTEX,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 191,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 44,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 66,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+    },
+    {binding: 173, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {binding: 330, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 91,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 88, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {binding: 70, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 52,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 189,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 416,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 71, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 34, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 118, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 0, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 60, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let textureView62 = texture6.createView({
+  label: '\u829b\u32ac\u003c\u{1fa73}\u2257\u90c2',
+  dimension: 'cube',
+  mipLevelCount: 1,
+  baseArrayLayer: 4,
+});
+let texture56 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 22},
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView63 = texture8.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 1});
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer37, 4_516);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 352, new DataView(new ArrayBuffer(4927)), 657, 44);
+} catch {}
+let buffer44 = device0.createBuffer({
+  size: 47149,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder57 = device0.createCommandEncoder({});
+let texture57 = device0.createTexture({
+  size: [1, 92, 2048],
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder52 = commandEncoder57.beginComputePass();
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(0, 115, 0, 100);
+renderPassEncoder4.setIndexBuffer(buffer14, 'uint32', 88, 47);
+} catch {}
+try {
+commandEncoder27.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 0, y: 182, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let textureView64 = texture57.createView({});
+let sampler38 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 25.62,
+  lodMaxClamp: 45.34,
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup11, new Uint32Array(394), 13, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle3, renderBundle1, renderBundle3, renderBundle2, renderBundle3, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder3.draw(843, 243, 509_428_846, 1_557_547);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer22, 'uint16', 224, 2_993);
+} catch {}
+try {
+commandEncoder27.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 0, y: 53, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer45 = device0.createBuffer({size: 4022, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandBuffer3 = commandEncoder27.finish();
+let texture58 = device0.createTexture({
+  size: [1, 370, 1],
+  sampleCount: 1,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView65 = texture49.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+renderPassEncoder4.draw(123, 205, 1_903_633_506, 18_888_322);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(14, 19, 16, -1_433_818_348, 1_887_066_374);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer38, 284);
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 47, z: 0},
+  aspect: 'all',
+}, new Uint8Array(91).fill(196), /* required buffer size: 91 */
+{offset: 91, bytesPerRow: 5}, {width: 0, height: 16, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup35 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [{binding: 235, resource: textureView28}, {binding: 83, resource: textureView34}],
+});
+let textureView66 = texture58.createView({label: '\u0ae7\u0b94', dimension: '2d-array'});
+let externalTexture5 = device0.importExternalTexture({label: '\u{1ffe4}\uacb7\u0bc0\u{1f693}\ube10', source: videoFrame3, colorSpace: 'srgb'});
+try {
+renderPassEncoder6.draw(182, 136, 376_659_301, 573_103_748);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(0, 3, 35, -1_665_285_179, 43_757_330);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+let commandEncoder58 = device0.createCommandEncoder({label: '\u0a2b\u{1ff06}\u0fc5'});
+let textureView67 = texture58.createView({dimension: '2d'});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup31);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(1, bindGroup6, new Uint32Array(1029), 160, 0);
+renderPassEncoder3.setIndexBuffer(buffer31, 'uint16', 8_884, 5_065);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+commandEncoder58.copyBufferToBuffer(buffer17, 52, buffer21, 16, 48);
+} catch {}
+try {
+commandEncoder58.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1428 */
+  offset: 1428,
+  rowsPerImage: 633,
+  buffer: buffer11,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture59 = device0.createTexture({
+  label: '\u0c93\u27ac\udcf3\uf45a\u04d6\u2561\u{1fe83}\uf0fe\uacec',
+  size: {width: 1, height: 185, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture60 = device0.createTexture({
+  size: [1, 370, 579],
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder5.draw(175, 180, 205_638_634, 399_561_683);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline0);
+} catch {}
+let videoFrame11 = videoFrame7.clone();
+let textureView68 = texture47.createView({});
+let sampler39 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 8.204,
+  lodMaxClamp: 59.09,
+});
+try {
+renderPassEncoder5.drawIndexed(7, 176, 1, 564_469_211, 761_127_926);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer35, 492);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(5, buffer30, 1_516, 211);
+} catch {}
+try {
+buffer32.unmap();
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(canvas0);
+let textureView69 = texture22.createView({});
+let externalTexture6 = device0.importExternalTexture({source: videoFrame11, colorSpace: 'display-p3'});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup5, new Uint32Array(624), 165, 0);
+} catch {}
+try {
+renderPassEncoder3.draw(475, 93, 432_298_256, 300_733_440);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer5, 2_368);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer0, 364);
+} catch {}
+try {
+  await promise5;
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  label: '\u5bab\u29fd\u0309\u05d4',
+  entries: [
+    {
+      binding: 56,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 239,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder59 = device0.createCommandEncoder({});
+let texture61 = device0.createTexture({
+  size: {width: 1, height: 740, depthOrArrayLayers: 1},
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView70 = texture10.createView({label: '\u8c39\u{1f83e}\u8c9e\u2bc4\u1bac\ufaee\ud8c7\u1dbb'});
+let computePassEncoder54 = commandEncoder59.beginComputePass({});
+let sampler40 = device0.createSampler({
+});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer44, 13_356);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer36, 'uint16', 2_136, 774);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer6, 0, 4_953);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 740, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 65, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+computePassEncoder30.setBindGroup(1, bindGroup31, new Uint32Array(2028), 860, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+renderPassEncoder4.draw(145, 226, 3_442_815_619, 660_106_215);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(24, 20, 201, 173_389_470, 281_917_906);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer3, 2_232);
+} catch {}
+let bindGroup36 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [
+    {binding: 60, resource: {buffer: buffer31, offset: 0}},
+    {binding: 17, resource: textureView3},
+    {binding: 266, resource: textureView56},
+    {binding: 18, resource: textureView68},
+    {binding: 127, resource: textureView29},
+  ],
+});
+try {
+renderPassEncoder4.drawIndexed(75, 174, 69, 100_026_930, 315_636_147);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer10, 'uint32', 164, 94);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 3176, new Int16Array(211), 94, 48);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 3, y: 3, z: 94},
+  aspect: 'all',
+}, new Uint8Array(336_983).fill(27), /* required buffer size: 336_983 */
+{offset: 263, bytesPerRow: 91, rowsPerImage: 35}, {width: 5, height: 26, depthOrArrayLayers: 106});
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 740, depthOrArrayLayers: 1}
+*/
+{
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder60 = device0.createCommandEncoder({label: '\u{1fbc9}\u70aa\u0132\uae7e\u{1f823}\u0a9f\uf5d6\u28b1'});
+let textureView72 = texture21.createView({dimension: '2d', mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder56 = commandEncoder60.beginComputePass({});
+let sampler41 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 24.32,
+  lodMaxClamp: 85.41,
+  compare: 'less',
+});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+computePassEncoder35.setBindGroup(3, bindGroup6, new Uint32Array(338), 96, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup22, new Uint32Array(234), 7, 0);
+renderPassEncoder6.setVertexBuffer(0, buffer22, 640, 469);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 740, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  premultipliedAlpha: false,
+}, {width: 0, height: 14, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup37 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 50, resource: textureView1},
+    {binding: 25, resource: {buffer: buffer45, offset: 512, size: 13}},
+    {binding: 158, resource: {buffer: buffer44, offset: 5376, size: 8020}},
+  ],
+});
+let buffer46 = device0.createBuffer({
+  label: '\u0a4b\u0291\u6b39\u08f7\u{1fae3}\u0b79',
+  size: 11554,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture62 = device0.createTexture({
+  size: {width: 64},
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder5.drawIndexed(8, 129, 9, 704_752_421, 386_385_595);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer2, 556);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(43).fill(68), /* required buffer size: 43 */
+{offset: 43, rowsPerImage: 24}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let bindGroup38 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 115, resource: textureView4}, {binding: 201, resource: textureView14}],
+});
+try {
+computePassEncoder53.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(21, 382, 2, 1_162_390_110, 660_996_068);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer19, 1_324);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let commandEncoder61 = device0.createCommandEncoder({});
+let textureView73 = texture30.createView({arrayLayerCount: 1});
+let computePassEncoder57 = commandEncoder61.beginComputePass({});
+let sampler42 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 49.71,
+  lodMaxClamp: 81.45,
+});
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup10, new Uint32Array(1502), 319, 0);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer40, 20);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer2, 'uint16', 304, 88);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 1,
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(1_421).fill(15), /* required buffer size: 1_421 */
+{offset: 46, bytesPerRow: 25, rowsPerImage: 22}, {width: 0, height: 12, depthOrArrayLayers: 3});
+} catch {}
+let commandEncoder62 = device0.createCommandEncoder({});
+let textureView74 = texture58.createView({dimension: '2d-array'});
+let computePassEncoder58 = commandEncoder62.beginComputePass({label: '\u1717\u0d3d\u{1f741}'});
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup37);
+} catch {}
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(41, 4, 8, 108_982_062, 618_864_936);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer26, 424);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer13, 944);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer29, 2172, new Float32Array(2530));
+} catch {}
+let bindGroup39 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 309, resource: {buffer: buffer37, offset: 256, size: 580}},
+    {binding: 79, resource: textureView56},
+    {binding: 337, resource: textureView47},
+    {binding: 45, resource: textureView48},
+  ],
+});
+let commandEncoder63 = device0.createCommandEncoder({});
+let textureView75 = texture48.createView({
+  label: '\u3c40\uba72\u{1f7de}\u0303\ud98a\u7dc2\u0887\u2710',
+  dimension: 'cube-array',
+  mipLevelCount: 1,
+  arrayLayerCount: 6,
+});
+try {
+renderPassEncoder6.draw(9, 59, 310_210_248, 1_356_184_573);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(5, 608, 8, -1_428_455_732, 881_331_419);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup40 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 45, resource: textureView35},
+    {binding: 309, resource: {buffer: buffer13, offset: 256, size: 547}},
+    {binding: 337, resource: textureView47},
+    {binding: 79, resource: textureView37},
+  ],
+});
+let commandEncoder65 = device0.createCommandEncoder({});
+let textureView76 = texture22.createView({label: '\ufdc1\u0562', format: 'rgba8unorm-srgb', arrayLayerCount: 1});
+let computePassEncoder60 = commandEncoder63.beginComputePass({});
+try {
+computePassEncoder42.setBindGroup(1, bindGroup36);
+} catch {}
+try {
+renderPassEncoder6.draw(41, 122, 6_807_101, 609_422_638);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(17, 415, 33, 237_851_875, 1_047_077_657);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer9, 360, 17);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 740, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 76, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer47 = device0.createBuffer({size: 253, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder66 = device0.createCommandEncoder({label: '\u7dd9\u078a\u08bc'});
+let textureView77 = texture6.createView({dimension: 'cube', mipLevelCount: 1, baseArrayLayer: 1});
+let computePassEncoder61 = commandEncoder28.beginComputePass({label: '\u{1f9a9}\u06bc\uc44e\u0b06\ub502'});
+try {
+renderPassEncoder5.draw(3, 388, 494_095_033, 143_457_412);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer10, 'uint16', 312, 34);
+} catch {}
+try {
+commandEncoder66.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1420 */
+  offset: 1420,
+  bytesPerRow: 15872,
+  buffer: buffer9,
+}, {
+  texture: texture34,
+  mipLevel: 1,
+  origin: {x: 0, y: 62, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 23, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder66.resolveQuerySet(querySet2, 1, 14, buffer21, 0);
+} catch {}
+try {
+computePassEncoder36.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup28, new Uint32Array(696), 18, 0);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer26, 2_732);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+let pipeline1 = device0.createComputePipeline({layout: pipelineLayout2, compute: {module: shaderModule0, constants: {16_025: 0, override2: 0}}});
+await gc();
+let imageData9 = new ImageData(20, 28);
+let bindGroup41 = device0.createBindGroup({
+  label: '\u13c8\u22d4\udbfb\u6a34\u35db\ud901\u2377\u{1fa0d}\u46cf',
+  layout: bindGroupLayout1,
+  entries: [{binding: 201, resource: textureView15}, {binding: 115, resource: textureView10}],
+});
+let computePassEncoder63 = commandEncoder66.beginComputePass({label: '\u0fda\u01fa\u6ef0\u8902\u{1f852}\udf51\u8edd'});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer30, 328);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer19, 512);
+} catch {}
+let bindGroup42 = device0.createBindGroup({
+  layout: bindGroupLayout5,
+  entries: [{binding: 235, resource: textureView28}, {binding: 83, resource: textureView34}],
+});
+let buffer48 = device0.createBuffer({
+  size: 4637,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView78 = texture8.createView({mipLevelCount: 1});
+try {
+computePassEncoder58.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 273, z: 0},
+  aspect: 'all',
+}, new Uint8Array(106).fill(99), /* required buffer size: 106 */
+{offset: 106, bytesPerRow: 300, rowsPerImage: 150}, {width: 0, height: 105, depthOrArrayLayers: 0});
+} catch {}
+let pipeline2 = await promise4;
+let buffer49 = device0.createBuffer({size: 25676, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let textureView79 = texture53.createView({dimension: '2d-array', aspect: 'stencil-only', mipLevelCount: 1});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthStencilFormat: 'stencil8', stencilReadOnly: true});
+let sampler43 = device0.createSampler({
+  label: '\u{1f91a}\u5115\u6f5c\u{1fe8d}\u7f21',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 33.50,
+  lodMaxClamp: 41.91,
+});
+try {
+computePassEncoder52.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(1304);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 0, y: 20, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup43 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 79, resource: textureView3}]});
+let buffer50 = device0.createBuffer({
+  size: 5841,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+renderPassEncoder5.setIndexBuffer(buffer19, 'uint32', 48, 273);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline0);
+} catch {}
+await gc();
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  label: '\u9dae\u6b01\uca60\u7b49\u{1fd8c}',
+  entries: [
+    {
+      binding: 107,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 44,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'write-only', viewDimension: '2d' },
+    },
+  ],
+});
+let commandEncoder67 = device0.createCommandEncoder({});
+let texture63 = device0.createTexture({
+  label: '\u{1fbd0}\u37d5\u02ad\u04f6\u{1f9a8}',
+  size: {width: 1, height: 370, depthOrArrayLayers: 19},
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture64 = device0.createTexture({
+  size: [1, 185, 1],
+  dimension: '2d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler44 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 0.02031,
+  lodMaxClamp: 51.38,
+  compare: 'less',
+});
+try {
+computePassEncoder13.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer28, 976);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer13, 164);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer26, 0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup20, new Uint32Array(902), 182, 0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer36, 'uint16', 1_266, 952);
+} catch {}
+try {
+renderPassEncoder5.insertDebugMarker('\u040f');
+} catch {}
+let buffer51 = device0.createBuffer({
+  size: 2430,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture65 = device0.createTexture({
+  label: '\u09cd\u01ae\u2acf\u7e6d',
+  size: {width: 1, height: 370, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture66 = device0.createTexture({
+  label: '\u3c27\u03be\u5706\u4940\u94cf\u083e\u0daa\ub58b',
+  size: {width: 1, height: 740, depthOrArrayLayers: 1},
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup35);
+} catch {}
+try {
+renderPassEncoder5.setViewport(0.9888301436578373, 250.27705890119918, 0.00989528380528524, 116.26068238360052, 0.23667054814116972, 0.7939247113777294);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer9, 2_720);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer38, 2_460);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer41, 'uint16', 184, 37);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder67.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1192 */
+  offset: 1192,
+  bytesPerRow: 16896,
+  rowsPerImage: 98,
+  buffer: buffer51,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 7, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(267).fill(194), /* required buffer size: 267 */
+{offset: 267, bytesPerRow: 66}, {width: 10, height: 17, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 740, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 22, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'smpteSt4281', transfer: 'pq'} });
+let bindGroup44 = device0.createBindGroup({
+  label: '\u{1fe1d}\u2608\ufa4d\u009e',
+  layout: bindGroupLayout6,
+  entries: [{binding: 202, resource: textureView18}],
+});
+let commandEncoder68 = device0.createCommandEncoder({});
+let texture67 = device0.createTexture({
+  size: {width: 1, height: 185, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture68 = device0.createTexture({
+  size: {width: 1, height: 92, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView80 = texture38.createView({label: '\u0beb\ue1da\u35d6\u0154\u02b2\u427a', baseMipLevel: 0});
+let computePassEncoder64 = commandEncoder67.beginComputePass({});
+try {
+computePassEncoder57.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup2, new Uint32Array(5888), 1_835, 0);
+} catch {}
+try {
+renderPassEncoder6.draw(59, 101, 1_517_773_359, 1_035_992_274);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer9, 1_760);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer1, 'uint16', 288, 703);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup40);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer50, 'uint16', 94, 3_680);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+let videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'film', transfer: 'smpte240m'} });
+try {
+textureView75.label = '\u0c3d\u3613';
+} catch {}
+let commandEncoder69 = device0.createCommandEncoder({});
+let texture69 = device0.createTexture({
+  label: '\u09f8\u05bf\u{1fd46}\ua981\u2373\ufc28',
+  size: [1, 185, 1],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture70 = device0.createTexture({size: [1], dimension: '1d', format: 'rg16uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder65 = commandEncoder69.beginComputePass({});
+let renderBundle7 = renderBundleEncoder7.finish({label: '\u000a\u0cd7\u1f56\u{1ff6c}\u0979\u{1f94e}\u0949\u{1fec0}\u0d6b\u0061\u50cf'});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder5.draw(332, 131, 162_658_961, 71_156_953);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer26, 748);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder25.clearBuffer(buffer49);
+} catch {}
+let imageData10 = new ImageData(24, 48);
+let buffer52 = device0.createBuffer({
+  size: 50295,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder70 = device0.createCommandEncoder();
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 3118});
+let textureView81 = texture63.createView({format: 'rgba8sint'});
+let renderPassEncoder7 = commandEncoder25.beginRenderPass({
+  label: '\u{1f744}\u5d41',
+  colorAttachments: [{
+  view: textureView33,
+  depthSlice: 1,
+  clearValue: { r: -589.6, g: 485.4, b: 795.5, a: -254.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb'], depthReadOnly: true});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+computePassEncoder54.setBindGroup(3, bindGroup37, new Uint32Array(5956), 1_917, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer48, 1_104); };
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup35, new Uint32Array(205), 28, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(18, 64, 98, 7_156_625, 993_490_985);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer52, 0, 26_475);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(6, buffer22, 0, 602);
+} catch {}
+try {
+commandEncoder68.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 328 */
+  offset: 328,
+},
+{
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 0, y: 7, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 42, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  label: '\u5722\u0d8b',
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout2]});
+let textureView82 = texture65.createView({});
+let computePassEncoder66 = commandEncoder68.beginComputePass({label: '\u6df0\u0420\u{1fd8b}\u08b5\u0327\u6b7d\u{1fb5b}\uafd1\u08a5'});
+let renderPassEncoder8 = commandEncoder70.beginRenderPass({
+  label: '\u{1f8a4}\u{1f622}\u92e8\u0386\ub4c4\ub420',
+  colorAttachments: [{view: textureView54, depthSlice: 1369, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet3,
+});
+let renderBundle8 = renderBundleEncoder8.finish({});
+let sampler45 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 87.82,
+  compare: 'greater-equal',
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder38.setBindGroup(0, bindGroup0, new Uint32Array(5976), 2, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer28, 1_352); };
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer13, 484);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(7, buffer40, 1_464, 208);
+} catch {}
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 205,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 370});
+let texture71 = device0.createTexture({
+  size: {width: 1, height: 92, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView83 = texture2.createView({baseArrayLayer: 0});
+let sampler46 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 90.65,
+  lodMaxClamp: 93.32,
+});
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup11, new Uint32Array(2098), 475, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(8, 21, 9, 419_013_818, 198_896_723);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer0, 2_268);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+let imageData11 = new ImageData(20, 64);
+let buffer53 = device0.createBuffer({
+  label: '\ue136\ud538\u5983\u283d\u8974\u{1fc03}\uad56\u{1fbb3}\u0ab4\u0766\ue0eb',
+  size: 6908,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder5.drawIndexed(30, 70, 12, -2_084_769_406, 541_126_777);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer3, 308);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline0);
+} catch {}
+let bindGroup45 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [
+    {binding: 65, resource: textureView3},
+    {binding: 180, resource: {buffer: buffer5, offset: 7424}},
+    {binding: 68, resource: {buffer: buffer3, offset: 0}},
+    {binding: 66, resource: textureView23},
+    {binding: 108, resource: sampler6},
+    {binding: 96, resource: textureView77},
+    {binding: 137, resource: externalTexture2},
+    {binding: 358, resource: sampler23},
+    {binding: 70, resource: externalTexture3},
+    {binding: 404, resource: {buffer: buffer44, offset: 4608, size: 3192}},
+    {binding: 919, resource: externalTexture2},
+  ],
+});
+let buffer54 = device0.createBuffer({size: 38, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture72 = device0.createTexture({
+  size: [1, 370, 13],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView84 = texture2.createView({format: 'r8sint'});
+try {
+computePassEncoder22.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup4, new Uint32Array(391), 16, 0);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(310);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(4, 1, 39, 509_491_585, 1_216_036_690);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer26);
+} catch {}
+let commandEncoder71 = device0.createCommandEncoder();
+let textureView85 = texture30.createView({});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup13, new Uint32Array(406), 101, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer3, 1_444); };
+} catch {}
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup41, new Uint32Array(46), 4, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer28, 1_420);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer13, 4);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+commandEncoder5.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 336 */
+  offset: 336,
+  buffer: buffer19,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer23, 184, new Int16Array(15698), 3232, 352);
+} catch {}
+try {
+textureView77.label = '\u007c\u21bc\u013e\ue275';
+} catch {}
+let commandEncoder72 = device0.createCommandEncoder({});
+let texture73 = device0.createTexture({
+  size: [1752, 115, 1],
+  mipLevelCount: 2,
+  format: 'astc-6x5-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler47 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 7.391,
+});
+try {
+computePassEncoder64.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup40);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(28, 266, 15, 752_992_610, 1_104_794_372);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer2, 316);
+} catch {}
+try {
+commandEncoder72.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 500 */
+  offset: 500,
+  bytesPerRow: 2816,
+  buffer: buffer11,
+}, {
+  texture: texture49,
+  mipLevel: 1,
+  origin: {x: 0, y: 5, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 9, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder5.clearBuffer(buffer14, 144, 200);
+} catch {}
+let texture74 = device0.createTexture({
+  label: '\u055d\u3db0\u{1fa2f}\u0e30\u0efe',
+  size: {width: 64, height: 64, depthOrArrayLayers: 22},
+  mipLevelCount: 3,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView86 = texture43.createView({label: '\uf906\u{1fa9c}\u6f3a\ua76e\uce9c\u1e9b\u06fb\u23fa', dimension: '2d-array'});
+let computePassEncoder67 = commandEncoder71.beginComputePass();
+try {
+computePassEncoder38.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup10, new Uint32Array(91), 15, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle0, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(57, 7, 5, -1_577_779_105, 851_127_471);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(5, buffer16, 1_740);
+} catch {}
+try {
+commandEncoder5.copyBufferToBuffer(buffer2, 480, buffer52, 1060, 448);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 0, y: 7, z: 0},
+  aspect: 'all',
+}, new Uint8Array(29).fill(143), /* required buffer size: 29 */
+{offset: 29, bytesPerRow: 37}, {width: 0, height: 18, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let buffer55 = device0.createBuffer({
+  size: 871,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder73 = device0.createCommandEncoder();
+let computePassEncoder68 = commandEncoder5.beginComputePass({});
+try {
+computePassEncoder41.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+computePassEncoder25.setBindGroup(2, bindGroup10, new Uint32Array(215), 70, 0);
+} catch {}
+try {
+computePassEncoder1.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup36, new Uint32Array(1017), 10, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(0, 40, 71, 20_180_046, 335_262_520);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer6, 0, 925);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let buffer56 = device0.createBuffer({size: 25754, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let textureView87 = texture63.createView({baseMipLevel: 0});
+let computePassEncoder69 = commandEncoder72.beginComputePass({});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+renderPassEncoder7.draw(37, 74, 1_366_591_830, 219_225_586);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer5, 484);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer31, 6_548);
+} catch {}
+try {
+commandEncoder73.copyBufferToTexture({
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 38, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup46 = device0.createBindGroup({
+  label: '\u107b\u06ce\uee60\u01a8\uf539\uca8f\u0c07\u{1fbc1}\u3311',
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 309, resource: {buffer: buffer5, offset: 1536}},
+    {binding: 120, resource: {buffer: buffer26, offset: 512, size: 4448}},
+    {binding: 86, resource: {buffer: buffer19, offset: 768, size: 608}},
+    {binding: 18, resource: externalTexture0},
+    {binding: 163, resource: textureView14},
+    {binding: 22, resource: {buffer: buffer0, offset: 0, size: 129}},
+  ],
+});
+let texture75 = device0.createTexture({
+  size: {width: 1, height: 92, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder72 = commandEncoder44.beginComputePass();
+try {
+computePassEncoder34.setBindGroup(2, bindGroup12, new Uint32Array(2243), 104, 0);
+renderPassEncoder9.setScissorRect(0, 62, 0, 190);
+} catch {}
+try {
+commandEncoder25.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9032 */
+  offset: 9032,
+  bytesPerRow: 63488,
+  buffer: buffer1,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise6;
+} catch {}
+try {
+adapter0.label = '\u0b75\u053a';
+} catch {}
+let pipelineLayout6 = device0.createPipelineLayout({label: '\u361f\u825a\uc67a\u527f\u0d84\u43bc\u{1f69c}\u9234\u0ed9', bindGroupLayouts: []});
+let commandEncoder76 = device0.createCommandEncoder({});
+let textureView88 = texture67.createView({});
+let texture76 = device0.createTexture({
+  size: [1, 740, 1],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder73 = commandEncoder25.beginComputePass({});
+try {
+computePassEncoder27.setBindGroup(3, bindGroup13, new Uint32Array(24), 5, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup37);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(6, buffer19, 0);
+} catch {}
+try {
+commandEncoder76.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3056 */
+  offset: 2288,
+  bytesPerRow: 768,
+  rowsPerImage: 1146,
+  buffer: buffer11,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 8, depthOrArrayLayers: 1});
+} catch {}
+document.body.append(img0);
+let commandEncoder77 = device0.createCommandEncoder({});
+let textureView89 = texture65.createView({});
+try {
+computePassEncoder29.setBindGroup(3, bindGroup25, new Uint32Array(751), 144, 0);
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.draw(338, 189, 96_775_734, 877_881_435);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+try {
+commandEncoder77.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 0, y: 7, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 1,
+  origin: {x: 0, y: 12, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let pipeline4 = await device0.createComputePipelineAsync({layout: pipelineLayout5, compute: {module: shaderModule3, entryPoint: 'compute2', constants: {}}});
+let commandEncoder78 = device0.createCommandEncoder({});
+try {
+computePassEncoder49.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer9, 24);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer19, 0, 956);
+} catch {}
+try {
+renderPassEncoder9.insertDebugMarker('\ud29d');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 41, z: 0},
+  aspect: 'all',
+}, new Uint8Array(29).fill(236), /* required buffer size: 29 */
+{offset: 29, bytesPerRow: 47}, {width: 0, height: 97, depthOrArrayLayers: 0});
+} catch {}
+let img1 = await imageWithData(62, 6, '#10101010', '#20202020');
+let buffer57 = device0.createBuffer({size: 6164, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let computePassEncoder74 = commandEncoder78.beginComputePass({});
+try {
+computePassEncoder21.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup19, new Uint32Array(736), 1, 0);
+} catch {}
+try {
+commandEncoder76.copyBufferToBuffer(buffer34, 1056, buffer46, 1036, 1464);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer35, 572, new BigUint64Array(24968), 283, 8);
+} catch {}
+let textureView90 = texture72.createView({});
+let computePassEncoder75 = commandEncoder77.beginComputePass({});
+let sampler48 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 64.99,
+  lodMaxClamp: 68.43,
+});
+try {
+computePassEncoder47.setBindGroup(1, bindGroup40);
+} catch {}
+try {
+computePassEncoder74.setBindGroup(3, bindGroup14, new Uint32Array(1907), 302, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup17, new Uint32Array(4928), 1_827, 0);
+} catch {}
+try {
+renderPassEncoder9.end();
+} catch {}
+document.body.prepend(canvas0);
+let imageData12 = new ImageData(40, 12);
+let textureView91 = texture58.createView({dimension: '2d-array'});
+let computePassEncoder76 = commandEncoder76.beginComputePass({});
+let sampler49 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 98.77,
+});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+computePassEncoder3.setBindGroup(0, bindGroup9, new Uint32Array(12), 1, 0);
+} catch {}
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder8.draw(49, 64, 1_975_611_661, 568_100_557);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer50, 'uint16', 144, 4_194);
+} catch {}
+try {
+commandEncoder3.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2844 */
+  offset: 2844,
+  bytesPerRow: 27392,
+  buffer: buffer1,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup49 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 202, resource: textureView18}]});
+let renderPassEncoder10 = commandEncoder73.beginRenderPass({
+  colorAttachments: [{
+  view: textureView45,
+  clearValue: { r: 735.2, g: 207.4, b: 496.7, a: -769.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet13,
+});
+try {
+computePassEncoder23.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup18, new Uint32Array(4592), 415, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer41, 548);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer45, 116);
+} catch {}
+document.body.prepend(img0);
+offscreenCanvas0.width = 148;
+let textureView92 = texture30.createView({
+  dimension: '1d',
+  aspect: 'all',
+  format: 'rg16uint',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 38.44,
+  lodMaxClamp: 69.38,
+  maxAnisotropy: 5,
+});
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle8, renderBundle3, renderBundle1, renderBundle2, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder8.draw(40, 111, 2_629_992_779, 936_039_203);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer40, 'uint16', 52, 443);
+} catch {}
+let bindGroup50 = device0.createBindGroup({
+  label: '\u9b9f\u0999\u697d\u0c4b\ubbfd\u71c0',
+  layout: bindGroupLayout9,
+  entries: [
+    {binding: 49, resource: {buffer: buffer3, offset: 512}},
+    {binding: 179, resource: textureView47},
+    {binding: 163, resource: textureView15},
+    {binding: 155, resource: textureView29},
+    {binding: 210, resource: textureView3},
+    {binding: 404, resource: {buffer: buffer11, offset: 2304}},
+    {binding: 20, resource: sampler0},
+    {binding: 66, resource: textureView42},
+    {binding: 71, resource: externalTexture0},
+    {binding: 225, resource: textureView67},
+    {binding: 108, resource: sampler44},
+    {binding: 9, resource: sampler35},
+    {binding: 20, resource: sampler24},
+    {binding: 200, resource: textureView47},
+  ],
+});
+let buffer58 = device0.createBuffer({
+  label: '\u{1fa20}\u03c4\u{1ff8a}\uc50f\u7972',
+  size: 1037,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture78 = device0.createTexture({
+  size: {width: 1, height: 370, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder38.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+computePassEncoder46.setBindGroup(3, bindGroup29, new Uint32Array(2158), 464, 0);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(216, 88, 526, -1_914_631_318, 264_027_118);
+} catch {}
+try {
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer9, 12);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer9, 0);
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+let bindGroup52 = device0.createBindGroup({layout: bindGroupLayout12, entries: [{binding: 205, resource: {buffer: buffer11, offset: 3328}}]});
+let commandEncoder80 = device0.createCommandEncoder({label: '\ua8aa\u2205\u67cd\u6bcf\u060b\u{1fa9a}\u1da9\u7c59\u934b\u1427'});
+let texture79 = device0.createTexture({
+  size: [1, 92, 491],
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise8;
+} catch {}
+let buffer60 = device0.createBuffer({
+  size: 2735,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder81 = device0.createCommandEncoder({label: '\u678b\u{1fd80}'});
+let texture80 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 47},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler51 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 91.83,
+});
+try {
+computePassEncoder74.setBindGroup(3, bindGroup29, new Uint32Array(158), 34, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(71, 141, 2, 148_637_889, 5_549_660);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer40, 204);
+} catch {}
+try {
+commandEncoder81.resolveQuerySet(querySet11, 33, 56, buffer38, 256);
+} catch {}
+try {
+computePassEncoder48.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 0, y: 16, z: 0},
+  aspect: 'all',
+}, new Uint8Array(109).fill(133), /* required buffer size: 109 */
+{offset: 109, bytesPerRow: 113}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder79 = commandEncoder81.beginComputePass({});
+let sampler52 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 72.34,
+  lodMaxClamp: 73.14,
+});
+let externalTexture7 = device0.importExternalTexture({
+  label: '\u2bcf\u0aa0\u066a\u08c1\u{1fb88}\u{1f7d2}\ueedd\u57fe\u8ce4\u{1fe0b}\ua8c2',
+  source: videoFrame1,
+});
+try {
+computePassEncoder48.setBindGroup(2, bindGroup36, new Uint32Array(3084), 48, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(36, 316, 624_254_333, 817_961_538);
+} catch {}
+let commandEncoder82 = device0.createCommandEncoder({});
+let texture81 = device0.createTexture({
+  size: [1, 92, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder80 = commandEncoder82.beginComputePass({label: '\ubb59\u0a93\u16c8\u{1f7cc}\udd7f\u{1f94d}\u0d82\u0633\u{1fcc4}\u033b'});
+try {
+computePassEncoder19.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(10, 102, 22, 83_139_180, 430_236_292);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer59, 'uint32', 464, 2_006);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(102).fill(110), /* required buffer size: 102 */
+{offset: 102, bytesPerRow: 3}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: []});
+let buffer61 = device0.createBuffer({
+  size: 4897,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder8.draw(50, 35, 447_468_387, 915_619_686);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer0, 604);
+} catch {}
+let commandEncoder83 = device0.createCommandEncoder({});
+let textureView93 = texture19.createView({aspect: 'all'});
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer61);
+} catch {}
+try {
+renderPassEncoder10.insertDebugMarker('\u0fa4');
+} catch {}
+let commandEncoder84 = device0.createCommandEncoder({});
+let texture82 = device0.createTexture({
+  size: {width: 1, height: 370, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler53 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 45.87,
+  lodMaxClamp: 59.28,
+  maxAnisotropy: 11,
+});
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup29, new Uint32Array(3706), 639, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(190, 202, 1_835_336_140, 293_078_108);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(6, 155, 7, 101_423_212, 983_163_784);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer19, 1_620);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 740, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 112, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup53 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 201, resource: textureView6}, {binding: 115, resource: textureView5}],
+});
+let texture83 = device0.createTexture({
+  size: {width: 1},
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView94 = texture5.createView({});
+let computePassEncoder82 = commandEncoder84.beginComputePass({});
+let sampler54 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 54.53,
+  lodMaxClamp: 69.73,
+});
+try {
+computePassEncoder30.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(77);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer46, 424);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+buffer58.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(283).fill(190), /* required buffer size: 283 */
+{offset: 283}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView95 = texture61.createView({dimension: '2d-array'});
+let sampler55 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.44,
+  compare: 'not-equal',
+  maxAnisotropy: 12,
+});
+let externalTexture8 = device0.importExternalTexture({source: videoFrame13});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup12, new Uint32Array(47), 7, 0);
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(219);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(10, 3, 1, 583_996_683, 44_240_632);
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 0, y: 13, z: 0},
+  aspect: 'all',
+}, new Uint8Array(93).fill(131), /* required buffer size: 93 */
+{offset: 93, bytesPerRow: 105}, {width: 0, height: 64, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder85 = device0.createCommandEncoder();
+try {
+computePassEncoder0.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup49);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(0, buffer10, 0, 897);
+} catch {}
+try {
+commandEncoder85.copyBufferToBuffer(buffer41, 328, buffer21, 36, 48);
+} catch {}
+try {
+  await promise7;
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup54 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 79, resource: textureView3}]});
+let commandEncoder86 = device0.createCommandEncoder({});
+let textureView96 = texture43.createView({label: '\u06e5\uc39a\ud2ed\u9d54\u{1fcee}\u{1fb4a}\u7142\u02cc\udc82', dimension: '2d-array'});
+let computePassEncoder83 = commandEncoder86.beginComputePass({});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup13, []);
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.draw(9, 317, 289_255_615, 70_141_380);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer13, 352);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer50, 'uint16', 2_276, 375);
+} catch {}
+try {
+} catch {}
+try {
+computePassEncoder37.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle3, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(0, 168, 0, 83);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(1, 237, 0, -2_144_822_002, 496_253_525);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline0);
+} catch {}
+let texture85 = device0.createTexture({
+  size: {width: 1, height: 740, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder8.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(13, 3, 6, -1_925_813_719, 946_974_568);
+} catch {}
+try {
+  await buffer18.mapAsync(GPUMapMode.WRITE, 1792, 1328);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup56 = device0.createBindGroup({
+  layout: bindGroupLayout4,
+  entries: [
+    {binding: 25, resource: {buffer: buffer51, offset: 512, size: 202}},
+    {binding: 50, resource: textureView1},
+    {binding: 158, resource: {buffer: buffer10, offset: 0, size: 884}},
+  ],
+});
+try {
+renderPassEncoder11.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder8.draw(218, 242, 935_782_595, 306_892_700);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(6, 62, 7, 700_133_449, 466_811_841);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline0);
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 448, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+  ],
+});
+let bindGroup57 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [{binding: 448, resource: {buffer: buffer10, offset: 0, size: 781}}],
+});
+let buffer62 = device0.createBuffer({
+  label: '\u{1fb9f}\u811e\u1598',
+  size: 7421,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup15, new Uint32Array(1959), 74, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroupsIndirect(buffer61, 744); };
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(4, 149, 10, -2_115_152_151, 605_376_596);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline0);
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 224,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 221,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture87 = device0.createTexture({
+  size: [1, 92, 1],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(0, 633, 10, 1_381_564, 58_971_696);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer5, 3_528);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer30, 472);
+} catch {}
+let buffer63 = device0.createBuffer({
+  size: 24780,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture88 = device0.createTexture({
+  label: '\u{1fa15}\u3aa8\u{1fa5d}\u096a\u27b2\u1a7d\u0a6e\u003d\u4a0f',
+  size: [1, 92, 1],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder69.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup4, new Uint32Array(298), 14, 0);
+} catch {}
+try {
+renderPassEncoder12.draw(72, 20, 153_247_742, 532_913_941);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer58, 248);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer61, 'uint32', 712, 285);
+} catch {}
+let arrayBuffer0 = buffer18.getMappedRange(1792, 24);
+let buffer64 = device0.createBuffer({
+  size: 221,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder89 = device0.createCommandEncoder({});
+let textureView98 = texture88.createView({dimension: '2d-array', baseMipLevel: 0});
+let textureView99 = texture50.createView({dimension: '2d-array', aspect: 'all', mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder86 = commandEncoder89.beginComputePass();
+let sampler57 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 60.69,
+  lodMaxClamp: 63.59,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+computePassEncoder14.setBindGroup(3, bindGroup40, new Uint32Array(2188), 106, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup16);
+} catch {}
+let sampler58 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 43.00,
+  lodMaxClamp: 79.73,
+  compare: 'less',
+});
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 20, z: 0},
+  aspect: 'all',
+}, new Uint8Array(130).fill(142), /* required buffer size: 130 */
+{offset: 130, bytesPerRow: 7}, {width: 0, height: 202, depthOrArrayLayers: 0});
+} catch {}
+let buffer66 = device0.createBuffer({
+  size: 7859,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder90 = device0.createCommandEncoder({});
+let computePassEncoder87 = commandEncoder90.beginComputePass({});
+let sampler59 = device0.createSampler({
+  label: '\ub5dd\uedb7\u0369\u0e37\u{1fc8c}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 13.45,
+  lodMaxClamp: 87.34,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder45.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup53);
+} catch {}
+try {
+renderPassEncoder11.draw(66, 237, 2_161_926_115, 92_540_763);
+} catch {}
+let buffer67 = device0.createBuffer({size: 13495, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder91 = device0.createCommandEncoder({label: '\u{1fc55}\u{1fb8c}\u18d9\uc990\u038b\udf8f\u062d\u0dae\uc274\u{1f877}'});
+try {
+computePassEncoder76.setBindGroup(3, bindGroup43);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup49, new Uint32Array(190), 2, 0);
+} catch {}
+try {
+renderPassEncoder10.draw(743, 174, 608_302_026, 1_056_574_303);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer56, 5_380);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+commandEncoder91.copyBufferToBuffer(buffer38, 10272, buffer33, 292, 48);
+} catch {}
+try {
+commandEncoder91.copyBufferToTexture({
+  /* bytesInLastRow: 1344 widthInBlocks: 84 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 848 */
+  offset: 848,
+  buffer: buffer52,
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 60, y: 5, z: 0},
+  aspect: 'all',
+}, {width: 504, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let buffer68 = device0.createBuffer({
+  size: 294,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder92 = device0.createCommandEncoder({});
+let computePassEncoder88 = commandEncoder92.beginComputePass({label: '\u0f13\udffb\u0788\ua436\u31d9\u0d76\u74cc\u0353\u0997'});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthStencilFormat: 'stencil8', depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder51.setBindGroup(3, bindGroup10, new Uint32Array(258), 6, 0);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder10.draw(131, 73, 143_159_782, 70_290_180);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(10, 238, 0, 142_303_245, 279_033_400);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup35);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(3, buffer3, 1_188, 873);
+} catch {}
+try {
+buffer26.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 185, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData8,
+  origin: { x: 9, y: 13 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 0, y: 54, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder93 = device0.createCommandEncoder({});
+let computePassEncoder89 = commandEncoder93.beginComputePass({label: '\ub880\ub915\u0e97\u9a3f\u0871'});
+let renderPassEncoder13 = commandEncoder91.beginRenderPass({
+  colorAttachments: [{
+  view: textureView58,
+  clearValue: { r: -379.6, g: 344.1, b: -891.0, a: 277.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let externalTexture9 = device0.importExternalTexture({label: '\uab87\u{1ff6d}\u{1ff21}', source: videoFrame4});
+try {
+computePassEncoder50.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer56, 18_028);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup43, new Uint32Array(328), 9, 0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(0, buffer30, 0, 914);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 740, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame13,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 48, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData13 = new ImageData(84, 16);
+let buffer69 = device0.createBuffer({
+  size: 5556,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderBundle9 = renderBundleEncoder9.finish({});
+try {
+computePassEncoder25.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer2, 104);
+} catch {}
+let commandEncoder94 = device0.createCommandEncoder({label: '\u09f6\u9375\u0b9f\u{1f9ca}\u0564\u0093\u095d'});
+let texture90 = device0.createTexture({
+  size: [1, 92, 68],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder60.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup6, new Uint32Array(1909), 174, 0);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(17, 112, 14, 65_840_913, 979_785_777);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer46, 496);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer41, 'uint16', 56, 410);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup58 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 45, resource: textureView88},
+    {binding: 337, resource: textureView60},
+    {binding: 79, resource: textureView43},
+    {binding: 309, resource: {buffer: buffer5, offset: 1536, size: 2863}},
+  ],
+});
+let commandEncoder95 = device0.createCommandEncoder({label: '\u0627\u{1f95e}\u{1f7bc}\ub2c9\u{1ff35}\ucb3b'});
+let sampler60 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 83.40,
+  lodMaxClamp: 96.25,
+});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup33, new Uint32Array(424), 22, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroupsIndirect(buffer26, 76); };
+} catch {}
+try {
+commandEncoder95.resolveQuerySet(querySet11, 18, 284, buffer59, 768);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(70).fill(86), /* required buffer size: 70 */
+{offset: 70, bytesPerRow: 25}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet16 = device0.createQuerySet({type: 'occlusion', count: 190});
+let texture91 = device0.createTexture({
+  label: '\u9e61\u{1f84c}\uc80c\u7845\ucfe9',
+  size: [1, 740, 1],
+  format: 'rg16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture92 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer68, 84);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer50, 'uint16', 306, 652);
+} catch {}
+let textureView100 = texture82.createView({
+  label: '\ucb60\u01fd\u1057\u{1f609}\u70be\uac9e\u0678\u{1fd4d}\ud1cb\u{1fbf5}',
+  dimension: '2d-array',
+  arrayLayerCount: 1,
+});
+let computePassEncoder90 = commandEncoder94.beginComputePass({});
+let renderPassEncoder14 = commandEncoder95.beginRenderPass({
+  colorAttachments: [{
+  view: textureView35,
+  clearValue: { r: -113.3, g: 117.8, b: -300.6, a: -564.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView99,
+    depthReadOnly: true,
+    stencilClearValue: 28046,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'store',
+  },
+});
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup43, []);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer30, 24);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer22, 'uint16', 1_530, 213);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(6, buffer68);
+} catch {}
+try {
+commandEncoder4.copyTextureToBuffer({
+  aspect: 'all',
+}, new Uint8Array(80).fill(117), /* required buffer size: 80 */
+{offset: 80, bytesPerRow: 44}, {width: 0, height: 124, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 94,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 135,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let texture93 = device0.createTexture({
+  size: [1, 740, 1],
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler61 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 47.27,
+  lodMaxClamp: 65.97,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder82.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup40);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(0, 63, 0, 194);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(39, 101, 3, 57_476_442, 226_304_498);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer58, 88);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer28, 1_128);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder80.pushDebugGroup('\u85ee');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer46, 728, new DataView(new ArrayBuffer(19520)), 10844, 924);
+} catch {}
+let pipeline5 = device0.createRenderPipeline({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule1,
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'src-alpha-saturated'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'dst', dstFactor: 'src'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule2,
+    buffers: [
+      {
+        arrayStride: 216,
+        attributes: [
+          {format: 'float32x3', offset: 8, shaderLocation: 7},
+          {format: 'float16x4', offset: 0, shaderLocation: 14},
+          {format: 'sint32x2', offset: 8, shaderLocation: 12},
+          {format: 'float32x2', offset: 36, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 32, shaderLocation: 4},
+          {format: 'sint8x4', offset: 8, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'none', unclippedDepth: false},
+});
+let buffer70 = device0.createBuffer({size: 6383, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let textureView101 = texture52.createView({
+  label: '\u0f89\u0dbd\uf785\udf08\ub394\u880a',
+  dimension: 'cube-array',
+  baseMipLevel: 0,
+  baseArrayLayer: 4,
+  arrayLayerCount: 6,
+});
+let textureView102 = texture1.createView({baseArrayLayer: 0});
+try {
+computePassEncoder2.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup31, new Uint32Array(1189), 173, 0);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(3, 274, 30, 42_632_651, 255_854_046);
+} catch {}
+try {
+} catch {}
+try {
+renderPassEncoder12.draw(93, 180, 859_398_805, 261_837_209);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer61, 84);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 3252, new Float32Array(4861), 1251, 360);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let buffer71 = device0.createBuffer({
+  size: 7829,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture96 = gpuCanvasContext0.getCurrentTexture();
+let textureView104 = texture69.createView({label: '\u5ad8\udc89\u049d\ue1d0\u2680\u0b2c\u09bc\u9779\u0c96', dimension: '2d-array'});
+let computePassEncoder91 = commandEncoder4.beginComputePass({});
+try {
+computePassEncoder71.setBindGroup(0, bindGroup36, new Uint32Array(334), 124, 0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup35);
+} catch {}
+try {
+renderPassEncoder14.setViewport(0.7731548772316099, 90.04632641477731, 0.1486020533935277, 66.23615919147228, 0.8224352942742823, 0.9149073450353925);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer41, 'uint16', 464, 25);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise9;
+} catch {}
+let commandEncoder96 = device0.createCommandEncoder({});
+let texture97 = device0.createTexture({
+  label: '\u{1f606}\u1fcb\u153c\u{1f8da}\u{1fbc7}\u{1fcab}\uae11\u{1ffba}\u98ca\ub630\u0a0f',
+  size: [1],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView105 = texture39.createView({label: '\u{1f76d}\uedda\u3714\u{1fc93}'});
+let sampler62 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 90.11,
+  lodMaxClamp: 99.93,
+  lodMinClamp: 49.79,
+  lodMaxClamp: 98.70,
+  compare: 'never',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder48.setBindGroup(0, bindGroup41);
+} catch {}
+try {
+computePassEncoder79.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder88.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+renderPassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer38, 5_592);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer62, 'uint32', 1_336, 43);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder97 = device0.createCommandEncoder({});
+let texture98 = device0.createTexture({
+  label: '\u62ab\u5db9\ub1a0\u6b8f\u{1fc65}\u0fa6\ue18f\u268e',
+  size: [1, 185, 1],
+  mipLevelCount: 6,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder93 = commandEncoder97.beginComputePass({label: '\u9f8b\u50e4\u0858\u06e4'});
+let renderPassEncoder15 = commandEncoder95.beginRenderPass({
+  colorAttachments: [{
+  view: textureView48,
+  clearValue: { r: -779.1, g: 748.6, b: 576.6, a: 861.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView99,
+    depthClearValue: -3.244594353335108,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'discard',
+  },
+  maxDrawCount: 184930660,
+});
+try {
+computePassEncoder65.setBindGroup(2, bindGroup3, new Uint32Array(493), 348, 0);
+} catch {}
+try {
+renderPassEncoder12.draw(197, 262, 569_577_546, 1_897_225_393);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(8, 14, 13, 30_708_306, 1_241_232_850);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer71, 432);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, undefined, 0, 272_010_715);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let querySet17 = device0.createQuerySet({label: '\u16fd\u{1fe33}\ud906', type: 'occlusion', count: 424});
+let textureView107 = texture64.createView({});
+try {
+computePassEncoder57.setBindGroup(0, bindGroup10, new Uint32Array(343), 4, 0);
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder11.draw(49, 45, 296_974_456, 938_112_756);
+} catch {}
+try {
+computePassEncoder80.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer31, 3636, new Float32Array(8032), 831, 968);
+} catch {}
+let bindGroup61 = device0.createBindGroup({
+  label: '\u{1f6ad}\u598f\ua746',
+  layout: bindGroupLayout0,
+  entries: [{binding: 17, resource: textureView1}],
+});
+let buffer72 = device0.createBuffer({size: 5047, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let textureView108 = texture88.createView({label: '\u0a91\u9712\u{1fbf5}\u{1fcd4}\u{1ff7f}\u2ce1', dimension: '2d-array', arrayLayerCount: 1});
+let textureView109 = texture4.createView({baseArrayLayer: 0});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup57);
+} catch {}
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle8, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(0, 302, 0, 12);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(7, 404, 19, 384_545_644, 28_278_827);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline5);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder2.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1912 */
+  offset: 1912,
+  bytesPerRow: 8192,
+  rowsPerImage: 280,
+  buffer: buffer9,
+}, {
+  texture: texture80,
+  mipLevel: 2,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 776, new BigUint64Array(28100), 5443, 480);
+} catch {}
+document.body.append(img1);
+let commandBuffer4 = commandEncoder2.finish();
+let texture99 = device0.createTexture({size: [1, 740, 1], format: 'rgba8unorm-srgb', usage: GPUTextureUsage.COPY_DST});
+let sampler64 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 24.57,
+  lodMaxClamp: 26.91,
+  compare: 'not-equal',
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup41);
+} catch {}
+try {
+computePassEncoder39.setBindGroup(3, bindGroup38, new Uint32Array(332), 89, 0);
+} catch {}
+try {
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(6, buffer5, 588, 10_625);
+} catch {}
+let buffer73 = device0.createBuffer({size: 5937, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let commandEncoder98 = device0.createCommandEncoder({});
+let textureView110 = texture58.createView({dimension: '2d-array'});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder57); computePassEncoder57.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder57.end();
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup1, []);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup58, new Uint32Array(997), 93, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(75, 211, 119_494_479, 734_857_350);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer30, 912);
+} catch {}
+try {
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder11.draw(30, 33, 187_556_053, 153_825_023);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer26, 2_588);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer38, 5_200);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.append(img1);
+let bindGroup62 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 201, resource: textureView94}, {binding: 115, resource: textureView4}],
+});
+let buffer75 = device0.createBuffer({
+  size: 22991,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder99 = device0.createCommandEncoder({label: '\u7e58\u{1fec4}\u{1feed}\u0212\u5ae7\u95ed\u0f2f\u0aff'});
+let renderPassEncoder16 = commandEncoder99.beginRenderPass({
+  colorAttachments: [{view: textureView48, loadOp: 'load', storeOp: 'discard'}],
+  depthStencilAttachment: {
+    view: textureView99,
+    depthClearValue: 5.606052137287049,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'store',
+  },
+});
+let externalTexture11 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer13, 456);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer58, 120);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer20, 'uint32', 524, 1_660);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(3, buffer38, 0, 3_380);
+} catch {}
+let commandEncoder100 = device0.createCommandEncoder({});
+let texture100 = device0.createTexture({
+  size: [1, 740, 38],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView111 = texture61.createView({});
+let renderPassEncoder17 = commandEncoder100.beginRenderPass({
+  colorAttachments: [{
+  view: textureView90,
+  depthSlice: 3,
+  clearValue: { r: -400.6, g: -192.9, b: 113.2, a: 425.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet15,
+});
+try {
+renderPassEncoder8.draw(115, 77, 583_104_275, 298_319_540);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer52, 10_380);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer0, 252);
+} catch {}
+try {
+} catch {}
+try {
+computePassEncoder70.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup63);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(26, 441, 24, 48_054_462, 1_146_975_561);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer52, 5_548);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer31, 2_500);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(106).fill(178), /* required buffer size: 106 */
+{offset: 106}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture101 = device0.createTexture({
+  label: '\u6b98\ue6a3\u{1fe57}\u24a7\u02c1\u001b\u{1fdce}\ue7d7',
+  size: {width: 1, height: 92, depthOrArrayLayers: 1},
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup4, new Uint32Array(1537), 105, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(336, 260, 176_988_361, 756_856_895);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(0, 143, 0, 167_493_222, 890_126_471);
+} catch {}
+let commandEncoder102 = device0.createCommandEncoder({});
+let computePassEncoder97 = commandEncoder102.beginComputePass({});
+let sampler65 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 77.38,
+  lodMaxClamp: 86.94,
+  compare: 'not-equal',
+});
+try {
+renderPassEncoder8.draw(313, 215, 502_663_399, 4_294_967_295);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(6, 186, 3, 31_635_886, 125_253_622);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(0, buffer57);
+} catch {}
+await gc();
+let buffer76 = device0.createBuffer({size: 16221, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let sampler66 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 54.02,
+  lodMaxClamp: 83.40,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder97.setBindGroup(2, bindGroup55);
+} catch {}
+try {
+computePassEncoder31.setBindGroup(1, bindGroup55, new Uint32Array(428), 23, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroupsIndirect(buffer26, 896); };
+} catch {}
+try {
+renderPassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer76, 2_944);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(7, buffer22, 748, 3_221);
+} catch {}
+try {
+commandEncoder85.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 671 */
+  offset: 671,
+  bytesPerRow: 40448,
+  rowsPerImage: 698,
+  buffer: buffer6,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer48, 256, new BigUint64Array(2000), 1155, 108);
+} catch {}
+document.body.prepend(img1);
+let commandEncoder103 = device0.createCommandEncoder({});
+let textureView112 = texture52.createView({dimension: 'cube-array', baseArrayLayer: 0, arrayLayerCount: 6});
+let textureView113 = texture69.createView({dimension: '2d-array', arrayLayerCount: 1});
+try {
+computePassEncoder94.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup39, new Uint32Array(1036), 48, 0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder17.setViewport(0.04490991049359838, 204.68626238294544, 0.6435005786206028, 163.49115722111895, 0.6063924607682768, 0.7542798982161151);
+} catch {}
+try {
+renderPassEncoder10.draw(64, 68, 650_334_032, 746_622_073);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer55, 136);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer5, 72);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer72, 'uint32', 680, 2_276);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(2, buffer13, 796, 133);
+} catch {}
+try {
+adapter0.label = '\u{1f624}\uf460';
+} catch {}
+let bindGroup64 = device0.createBindGroup({
+  label: '\u62fc\u0dcd\u087b\u{1fe2b}\u10bf\u60db',
+  layout: bindGroupLayout15,
+  entries: [
+    {binding: 135, resource: textureView101},
+    {binding: 94, resource: {buffer: buffer71, offset: 256, size: 2656}},
+  ],
+});
+let texture102 = device0.createTexture({
+  label: '\u1429\u0eca\u{1f666}\u04a7\u554c',
+  size: [64, 64, 22],
+  mipLevelCount: 1,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder98 = commandEncoder103.beginComputePass({});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb']});
+try {
+computePassEncoder30.setBindGroup(1, bindGroup40);
+} catch {}
+try {
+computePassEncoder96.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup49);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup58, new Uint32Array(2030), 483, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(0, buffer36, 0);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(3, bindGroup64, new Uint32Array(431), 22, 0);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(7, buffer13, 0, 142);
+} catch {}
+let buffer77 = device0.createBuffer({size: 8003, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let commandEncoder104 = device0.createCommandEncoder({});
+let texture103 = device0.createTexture({
+  size: {width: 1, height: 740, depthOrArrayLayers: 1},
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture104 = device0.createTexture({
+  size: [1, 740, 1],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let texture105 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder99 = commandEncoder85.beginComputePass({});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthStencilFormat: 'stencil8', depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder52.setBindGroup(3, bindGroup55, new Uint32Array(891), 36, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroupsIndirect(buffer41, 392); };
+} catch {}
+try {
+computePassEncoder89.setPipeline(pipeline4);
+} catch {}
+let commandEncoder105 = device0.createCommandEncoder({});
+let textureView114 = texture58.createView({});
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup58, new Uint32Array(2406), 2_112, 0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle5, renderBundle9]);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup55, new Uint32Array(4240), 190, 0);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(2, buffer45, 0);
+} catch {}
+let arrayBuffer1 = buffer18.getMappedRange(2280, 0);
+try {
+commandEncoder0.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 936 */
+  offset: 936,
+  buffer: buffer13,
+}, {
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder0.copyTextureToBuffer({
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 456 */
+  offset: 456,
+  bytesPerRow: 24576,
+  buffer: buffer58,
+}, {width: 1, height: 740, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let shaderModule5 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+requires unrestricted_pointer_parameters;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+  _ = override8;
+  _ = override6;
+  _ = override15;
+}`,
+});
+let commandEncoder106 = device0.createCommandEncoder({});
+let computePassEncoder100 = commandEncoder104.beginComputePass({label: '\u024e\u4466\u9aa2\ufe53\uc2d3\u02c5\u{1f669}\u0226\u3f41'});
+let renderBundle10 = renderBundleEncoder11.finish({});
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup11, new Uint32Array(1079), 143, 0);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(162);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.draw(81, 48, 51_691_773, 540_320_373);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer3, 1_040);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer66, 'uint32', 920, 234);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(1, buffer13, 560, 11);
+} catch {}
+try {
+commandEncoder105.copyBufferToBuffer(buffer8, 40, buffer58, 292, 104);
+} catch {}
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture100,
+  mipLevel: 2,
+  origin: {x: 0, y: 11, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 1, y: 5, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder106.clearBuffer(buffer61, 884, 68);
+} catch {}
+try {
+computePassEncoder96.pushDebugGroup('\u{1f997}');
+} catch {}
+let commandEncoder107 = device0.createCommandEncoder({});
+let textureView115 = texture61.createView({baseMipLevel: 0});
+try {
+computePassEncoder95.setBindGroup(3, bindGroup41, new Uint32Array(527), 142, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer21, 'uint16', 126, 152);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer65, 'uint16', 1_382, 27);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(0, buffer66);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(175).fill(132), /* required buffer size: 175 */
+{offset: 175, bytesPerRow: 37}, {width: 0, height: 46, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup65 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 284, resource: textureView70}]});
+let commandEncoder108 = device0.createCommandEncoder({label: '\u0cc7\uc0fa\u04f9\u{1fefb}\u{1f6d1}\u006c\u050c\u80ac\u5d2d'});
+let textureView116 = texture104.createView({mipLevelCount: 1});
+try {
+computePassEncoder82.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder64); computePassEncoder64.dispatchWorkgroupsIndirect(buffer30, 472); };
+} catch {}
+try {
+computePassEncoder98.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup48);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup31, new Uint32Array(425), 148, 0);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer5, 1_784);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup26, new Uint32Array(7541), 662, 0);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(2, buffer53, 476, 49);
+} catch {}
+try {
+commandEncoder0.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 636 */
+  offset: 636,
+  buffer: buffer19,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder105.resolveQuerySet(querySet2, 45, 46, buffer20, 3584);
+} catch {}
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'smpte432', transfer: 'iec6196624'} });
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 167,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let bindGroup66 = device0.createBindGroup({
+  label: '\ud64d\u4248\u0bd4\udea8\u049b\u0c39\uc161\udf96\u10ff',
+  layout: bindGroupLayout0,
+  entries: [{binding: 17, resource: textureView3}],
+});
+let commandEncoder109 = device0.createCommandEncoder({});
+let texture106 = device0.createTexture({
+  size: {width: 1, height: 92, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder101 = commandEncoder0.beginComputePass({});
+let renderPassEncoder18 = commandEncoder107.beginRenderPass({colorAttachments: [{view: textureView45, loadOp: 'clear', storeOp: 'discard'}]});
+let sampler67 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 79.29,
+  lodMaxClamp: 82.70,
+});
+try {
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder110 = device0.createCommandEncoder({});
+let texture107 = device0.createTexture({size: {width: 1}, dimension: '1d', format: 'rgba8unorm-srgb', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder102 = commandEncoder105.beginComputePass();
+let renderPassEncoder19 = commandEncoder108.beginRenderPass({
+  colorAttachments: [{
+  view: textureView29,
+  clearValue: { r: -203.4, g: -895.5, b: -48.58, a: -200.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderBundleEncoder10.setVertexBuffer(4, buffer20, 0);
+} catch {}
+try {
+computePassEncoder96.popDebugGroup();
+} catch {}
+let texture109 = device0.createTexture({
+  size: [1, 370, 1138],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture110 = device0.createTexture({
+  size: [64],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let renderPassEncoder20 = commandEncoder110.beginRenderPass({
+  colorAttachments: [{
+  view: textureView45,
+  clearValue: { r: -149.9, g: -182.7, b: -280.1, a: -60.45, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundle11 = renderBundleEncoder10.finish({});
+let sampler68 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.63,
+  lodMaxClamp: 84.57,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder44.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+computePassEncoder64.setBindGroup(3, bindGroup38, new Uint32Array(83), 29, 0);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderPassEncoder10.draw(498, 242, 1_736_366_932, 1_021_153_801);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(5, buffer28, 2_356);
+} catch {}
+try {
+commandEncoder106.copyBufferToTexture({
+  /* bytesInLastRow: 240 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1088 */
+  offset: 1088,
+  bytesPerRow: 2816,
+  buffer: buffer74,
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 14, y: 10, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup67 = device0.createBindGroup({
+  layout: bindGroupLayout1,
+  entries: [{binding: 201, resource: textureView14}, {binding: 115, resource: textureView4}],
+});
+let commandEncoder111 = device0.createCommandEncoder({});
+let querySet18 = device0.createQuerySet({label: '\uc253\ud7a6\u089e\u0a3d', type: 'occlusion', count: 420});
+let texture111 = device0.createTexture({
+  label: '\u0476\u6a81\uf901',
+  size: {width: 1, height: 370, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView117 = texture3.createView({});
+let computePassEncoder104 = commandEncoder111.beginComputePass({});
+try {
+computePassEncoder84.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+computePassEncoder85.setBindGroup(2, bindGroup5, new Uint32Array(41), 14, 0);
+} catch {}
+try {
+computePassEncoder64.end();
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderPassEncoder10.draw(34, 159, 2_030_366_663, 736_315_654);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(1, buffer49, 280, 392);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 7},
+  aspect: 'all',
+}, new Uint8Array(1_684).fill(105), /* required buffer size: 1_684 */
+{offset: 116, bytesPerRow: 14, rowsPerImage: 36}, {width: 0, height: 5, depthOrArrayLayers: 4});
+} catch {}
+let commandEncoder112 = device0.createCommandEncoder({});
+let texture112 = device0.createTexture({size: [1, 92, 1], format: 'rg32uint', usage: GPUTextureUsage.RENDER_ATTACHMENT, viewFormats: []});
+let computePassEncoder105 = commandEncoder67.beginComputePass({});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({label: '\u{1fa1b}\u847c\u4410\u02c4\u95b9\u8f18', colorFormats: ['rg32uint'], stencilReadOnly: true});
+let sampler69 = device0.createSampler({
+  label: '\u0ba4\u0311\uf89e\u0f0d\u{1f988}\u144b',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 49.77,
+  maxAnisotropy: 4,
+});
+try {
+renderPassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder13.setViewport(0.22699624715989453, 247.62305357792846, 0.3990336187128826, 301.48551928897575, 0.1516274995818473, 0.8517021404661559);
+} catch {}
+try {
+renderPassEncoder11.draw(195, 596, 198_918_355, 205_734_624);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(6, 90, 17, 255_525_413, 764_917_132);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer13, 1_148);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder112.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 824 */
+  offset: 824,
+  bytesPerRow: 6144,
+  rowsPerImage: 258,
+  buffer: buffer39,
+}, {
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 125, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup68 = device0.createBindGroup({
+  layout: bindGroupLayout8,
+  entries: [
+    {binding: 266, resource: textureView37},
+    {binding: 60, resource: {buffer: buffer10, offset: 256, size: 364}},
+    {binding: 18, resource: textureView50},
+    {binding: 127, resource: textureView29},
+    {binding: 17, resource: textureView1},
+  ],
+});
+let buffer78 = device0.createBuffer({size: 9773, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder113 = device0.createCommandEncoder({});
+let textureView118 = texture13.createView({dimension: '2d'});
+try {
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+computePassEncoder83.insertDebugMarker('\uf8e6');
+} catch {}
+let bindGroupLayout17 = device0.createBindGroupLayout({
+  label: '\u{1f9ee}\ub10f\u4cd9\u{1f7dc}\u{1fe74}',
+  entries: [
+    {
+      binding: 447,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder114 = device0.createCommandEncoder();
+let textureView119 = texture109.createView({label: '\u0eb0\u0ac8'});
+let textureView120 = texture99.createView({dimension: '2d-array', format: 'rgba8unorm-srgb', mipLevelCount: 1});
+let computePassEncoder106 = commandEncoder114.beginComputePass({label: '\uedb3\u2ed4\u0dfe\u33d0\u0c15\u0601\u{1ff31}\u1502\u{1ff54}\ub7a8'});
+let sampler70 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 27.76,
+  lodMaxClamp: 35.33,
+});
+try {
+computePassEncoder92.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(67, 121, 131, 106_888_333, 99_423_326);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup12, new Uint32Array(2836), 7, 0);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(7, buffer63);
+} catch {}
+try {
+commandEncoder113.clearBuffer(buffer50, 1460, 1180);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let commandEncoder115 = device0.createCommandEncoder({});
+let computePassEncoder107 = commandEncoder106.beginComputePass({});
+try {
+commandEncoder73.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 800 */
+  offset: 800,
+  bytesPerRow: 0,
+  rowsPerImage: 186,
+  buffer: buffer66,
+}, {
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 0, y: 47, z: 6},
+  aspect: 'all',
+}, {width: 0, height: 22, depthOrArrayLayers: 18});
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(11);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+let computePassEncoder109 = commandEncoder73.beginComputePass({});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\u95e2\ucdb6\u07d2\u0e52\u733f\uf3a8\u1fb2\u0575\u02bb\u001f',
+  colorFormats: ['rgba8unorm-srgb'],
+});
+let renderBundle13 = renderBundleEncoder13.finish({});
+try {
+computePassEncoder70.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup28, new Uint32Array(5121), 30, 0);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle13]);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer76, 3_184);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer14, 'uint16', 88, 1);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(1, buffer9, 0, 2_232);
+} catch {}
+document.body.append(canvas0);
+let computePassEncoder110 = commandEncoder113.beginComputePass({label: '\uface\u{1fa32}\u9c0a\u0ddd\u{1fd45}\u4d95\u7bb6\u0a42\ue165\ub9c7\u0072'});
+let sampler72 = device0.createSampler({
+  label: '\u3558\u51a5\u7973\u{1feeb}\u74c3\u033a\ucda8',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 59.59,
+  lodMaxClamp: 86.19,
+});
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup49);
+} catch {}
+try {
+renderPassEncoder8.draw(37, 46, 1, 777_309_226);
+} catch {}
+let commandEncoder116 = device0.createCommandEncoder({});
+try {
+computePassEncoder71.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+commandEncoder116.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5688 */
+  offset: 5688,
+  bytesPerRow: 44288,
+  buffer: buffer34,
+}, {
+  texture: texture108,
+  mipLevel: 2,
+  origin: {x: 0, y: 11, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame15 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'smpte240m', transfer: 'smpte240m'} });
+let buffer79 = device0.createBuffer({
+  size: 5639,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderPassEncoder22 = commandEncoder116.beginRenderPass({
+  colorAttachments: [{
+  view: textureView45,
+  clearValue: { r: -571.6, g: -850.7, b: 457.8, a: 61.31, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler73 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 28.29,
+  lodMaxClamp: 62.82,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder33.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(59);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer56, 2_392);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let promise10 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout5,
+  multisample: {mask: 0x354baee3},
+  fragment: {
+  module: shaderModule0,
+  constants: {override2: 0, 12_016: 0},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one', dstFactor: 'src'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}],
+},
+  vertex: {module: shaderModule3, entryPoint: 'vertex3', buffers: []},
+});
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 559});
+let sampler74 = device0.createSampler({lodMinClamp: 94.03, lodMaxClamp: 99.87});
+try {
+computePassEncoder44.setBindGroup(2, bindGroup48);
+} catch {}
+try {
+computePassEncoder46.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.draw(25, 104, 2, 2_432_060_714);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer2, 456);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer13, 1_496);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer66, 'uint16', 5_248, 569);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(4, buffer26, 5_244, 6_094);
+} catch {}
+let imageBitmap0 = await createImageBitmap(videoFrame15);
+let imageData15 = new ImageData(60, 172);
+let videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'smpte240m', transfer: 'iec6196624'} });
+let bindGroup70 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 45, resource: textureView35},
+    {binding: 309, resource: {buffer: buffer16, offset: 8960, size: 6818}},
+    {binding: 79, resource: textureView80},
+    {binding: 337, resource: textureView39},
+  ],
+});
+try {
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer38, 3_368);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer3, 868);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer61, 'uint16', 212, 328);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  origin: {x: 0, y: 21, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout18 = device0.createBindGroupLayout({
+  label: '\u019b\u83d7',
+  entries: [
+    {
+      binding: 136,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let commandEncoder117 = device0.createCommandEncoder();
+let texture114 = device0.createTexture({size: [1, 740, 1], mipLevelCount: 2, format: 'rgba8unorm-srgb', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup68, new Uint32Array(1300), 57, 0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup65, new Uint32Array(659), 155, 0);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(136, 387, 12, 828_471_013, 601_882_309);
+} catch {}
+try {
+renderPassEncoder13.drawIndexedIndirect(buffer55, 12);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer60, 852);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(5, buffer5, 6_524);
+} catch {}
+try {
+commandEncoder117.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 560 */
+  offset: 560,
+  bytesPerRow: 11520,
+  buffer: buffer2,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 18, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder117.resolveQuerySet(querySet19, 262, 4, buffer21, 0);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let commandBuffer5 = commandEncoder117.finish({});
+try {
+computePassEncoder93.setBindGroup(1, bindGroup31, new Uint32Array(2153), 50, 0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder11.draw(40, 72, 1_899_862_997, 793_509_638);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(27, 49, 128, 1_660_996_864, 2_304_960_589);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer59, 'uint16', 7_964, 534);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+  code: `
+enable f16;
+
+enable f16;
+
+requires unrestricted_pointer_parameters;
+  var vf218: f32 = fma(f32(unconst_f32(0.04133)), f32(unconst_f32(0.2001)), f32(unconst_f32(0.1160)));
+  let ptr63: ptr<function, f32> = &vf218;
+  let vf219: f16 = vf213[u32(unconst_u32(296))];
+  let ptr64: ptr<function, f32> = &vf211;
+  vf217 = i32(round(vec3h(vf213[u32(unconst_u32(280))])).b);
+  vf217 |= bitcast<i32>(vf216);
+  _ = override25;
+  _ = override23;
+  _ = override22;
+}`,
+  sourceMap: {},
+});
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 599});
+try {
+computePassEncoder78.setBindGroup(2, bindGroup43, new Uint32Array(4202), 327, 0);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: 999.0, g: -359.0, b: 637.1, a: -66.25, });
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer35, 1_656);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 370, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData7,
+  origin: { x: 3, y: 2 },
+  flipY: false,
+}, {
+  texture: texture23,
+  source: videoFrame13,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 170, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+try {
+externalTexture3.label = '\u0235\ue53d\u{1ff4a}\uaa60\u03e9\u3193\udda1\ub1ed\u433a';
+} catch {}
+let buffer81 = device0.createBuffer({size: 81, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+computePassEncoder76.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer40, 'uint32', 388, 458);
+} catch {}
+try {
+adapter0.label = '\u2671\u{1f8b0}\u27f9';
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+  code: `
+enable f16;
+
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute8() {
+  fn0();
+  vp2 = FragmentOutput9(bitcast<vec2i>(abs(vec3f(unconst_f32(-0.1764), unconst_f32(0.1238), unconst_f32(0.1710))).zz), abs(vec3f(unconst_f32(-0.1764), unconst_f32(0.1238), unconst_f32(0.1710))).zzyy, vec3u(abs(vec3f(unconst_f32(-0.1764), unconst_f32(0.1238), unconst_f32(0.1710))))[1]);
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let texture115 = device0.createTexture({
+  size: [1, 92, 4],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView121 = texture17.createView({label: '\u53ab\u{1f7f5}\u0285\u7a20\u0de9\u{1f6ba}\u07d8\ua6a2\u06dc', dimension: '2d'});
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup27, new Uint32Array(49), 5, 0);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: -243.6, g: -389.1, b: -403.9, a: 440.9, });
+} catch {}
+try {
+renderPassEncoder11.draw(6, 90, 638_029_093, 235_447_608);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(9, 176, 22, 149_244_781, 304_275_899);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer76, 1_428);
+} catch {}
+try {
+commandEncoder91.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3244 */
+  offset: 3244,
+  bytesPerRow: 9728,
+  buffer: buffer61,
+}, {
+  texture: texture81,
+  mipLevel: 1,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let imageData17 = new ImageData(144, 12);
+try {
+renderPassEncoder11.drawIndexed(32, 0, 198, 49_141_961, 297_437_985);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer46, 2_652);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer31, 'uint32', 100, 14_776);
+} catch {}
+let bindGroupLayout20 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 371,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 71,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let buffer82 = device0.createBuffer({size: 8069, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT});
+let texture118 = device0.createTexture({
+  size: {width: 1, height: 370, depthOrArrayLayers: 444},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture119 = device0.createTexture({
+  size: {width: 1, height: 92, depthOrArrayLayers: 970},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView125 = texture100.createView({aspect: 'all', mipLevelCount: 1, arrayLayerCount: 1});
+let sampler77 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 76.25,
+  lodMaxClamp: 87.75,
+  compare: 'greater',
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder68.end();
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder17.draw(2, 295, 17, 1_334_100_860);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+adapter0.label = '\u92eb\uf9a3';
+} catch {}
+let bindGroup74 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 202, resource: textureView0}]});
+let texture120 = device0.createTexture({
+  label: '\u5e46\udb90\u7dee\u0870',
+  size: {width: 64, height: 64, depthOrArrayLayers: 95},
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler78 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 28.72,
+  lodMaxClamp: 41.50,
+  compare: 'greater-equal',
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder113.setBindGroup(3, bindGroup71);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder44); computePassEncoder44.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+computePassEncoder77.setPipeline(pipeline6);
+} catch {}
+document.body.append(canvas0);
+let imageData18 = new ImageData(20, 4);
+let bindGroup75 = device0.createBindGroup({layout: bindGroupLayout6, entries: [{binding: 202, resource: textureView104}]});
+let commandEncoder122 = device0.createCommandEncoder({});
+let textureView127 = texture42.createView({});
+let computePassEncoder115 = commandEncoder91.beginComputePass({label: '\u074d\uf69f\u0ec7\u0a4c\u3403\u29bb\u6950'});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup14, new Uint32Array(1560), 540, 0);
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.draw(1, 28, 2, 419_141_024);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(48, 421, 8, 25_698_760, 500_080_848);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(6, buffer49, 3_908, 3_807);
+} catch {}
+try {
+buffer75.destroy();
+} catch {}
+let commandEncoder123 = device0.createCommandEncoder({});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthStencilFormat: 'stencil8', stencilReadOnly: true});
+let texture122 = device0.createTexture({
+  size: {width: 1, height: 740, depthOrArrayLayers: 1},
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder86.setBindGroup(3, bindGroup44, new Uint32Array(125), 2, 0);
+} catch {}
+try {
+computePassEncoder90.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup41);
+} catch {}
+try {
+renderPassEncoder17.draw(9, 57, 0, 1_431_659_862);
+} catch {}
+try {
+renderPassEncoder17.drawIndexedIndirect(buffer3, 964);
+} catch {}
+try {
+renderPassEncoder17.drawIndirect(buffer60, 24);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(7, buffer50, 164, 1_344);
+} catch {}
+try {
+  await buffer7.mapAsync(GPUMapMode.WRITE, 0, 48);
+} catch {}
+document.body.prepend(canvas0);
+let textureView128 = texture59.createView({baseArrayLayer: 0});
+try {
+computePassEncoder41.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder17.drawIndexedIndirect(buffer38, 680);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(3, buffer45, 0);
+} catch {}
+try {
+commandEncoder124.copyTextureToBuffer({
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 0, y: 27, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 29, depthOrArrayLayers: 0});
+} catch {}
+let texture123 = device0.createTexture({
+  size: [1, 92, 1],
+  mipLevelCount: 2,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder117 = commandEncoder110.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder56); computePassEncoder56.dispatchWorkgroupsIndirect(buffer3, 636); };
+} catch {}
+try {
+computePassEncoder87.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer56, 3_944);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer48, 1_300);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer68, 'uint16', 12, 28);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(6, buffer71);
+} catch {}
+try {
+computePassEncoder102.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder17.drawIndexed(12, 162, 3, -1_583_553_575, 150_806_581);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline0);
+} catch {}
+let buffer84 = device0.createBuffer({
+  size: 21984,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture124 = device0.createTexture({
+  label: '\u38e5\u8309\uc335\u{1f827}',
+  size: [64, 64, 22],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderPassEncoder23 = commandEncoder123.beginRenderPass({
+  colorAttachments: [{
+  view: textureView58,
+  clearValue: { r: -862.8, g: -568.9, b: 890.2, a: -702.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 271992661,
+});
+try {
+renderPassEncoder11.setIndexBuffer(buffer69, 'uint32', 280, 606);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(0, buffer6, 0, 13_159);
+} catch {}
+try {
+commandEncoder124.copyBufferToTexture({
+  /* bytesInLastRow: 38 widthInBlocks: 38 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1031 */
+  offset: 1031,
+  bytesPerRow: 3840,
+  rowsPerImage: 615,
+  buffer: buffer10,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup76 = device0.createBindGroup({
+  layout: bindGroupLayout15,
+  entries: [
+    {binding: 94, resource: {buffer: buffer44, offset: 4352, size: 1328}},
+    {binding: 135, resource: textureView112},
+  ],
+});
+let commandBuffer6 = commandEncoder70.finish();
+let textureView129 = texture0.createView({aspect: 'depth-only'});
+let sampler80 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  entries: [
+    {binding: 50, resource: textureView1},
+    {binding: 158, resource: {buffer: buffer10, offset: 0, size: 512}},
+    {binding: 25, resource: {buffer: buffer61, offset: 256, size: 587}},
+  ],
+});
+let computePassEncoder119 = commandEncoder49.beginComputePass({label: '\ua198\u6c4c\u{1f721}\u2f49\uf5e1\u326b\u18ac\u3116\u{1fe44}\u{1fded}\u2518'});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthStencilFormat: 'stencil8', stencilReadOnly: true});
+let sampler81 = device0.createSampler({
+  label: '\u3f64\ub64c',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  mipmapFilter: 'linear',
+  lodMinClamp: 12.15,
+});
+let externalTexture13 = device0.importExternalTexture({source: videoFrame6});
+try {
+computePassEncoder112.setBindGroup(2, bindGroup79);
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder11.draw(87, 313, 191_498_054, 219_235_121);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer61, 836);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer22, 'uint16', 50, 2_281);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(4, buffer22, 868, 69);
+} catch {}
+try {
+computePassEncoder16.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+let commandEncoder125 = device0.createCommandEncoder({});
+let texture126 = device0.createTexture({
+  size: {width: 1, height: 185, depthOrArrayLayers: 5},
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder25 = commandEncoder125.beginRenderPass({
+  colorAttachments: [{
+  view: textureView26,
+  depthSlice: 1201,
+  clearValue: { r: 543.4, g: -428.8, b: -697.4, a: 602.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder11.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup22, new Uint32Array(3707), 352, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(19, 16, 419_712_525, 436_713_073);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup15, new Uint32Array(143), 17, 0);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer40, 'uint16', 308, 171);
+} catch {}
+let arrayBuffer4 = buffer7.getMappedRange(40, 4);
+try {
+buffer54.unmap();
+} catch {}
+try {
+renderBundleEncoder15.insertDebugMarker('\u0978');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 370, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas0,
+  origin: { x: 24, y: 27 },
+  flipY: false,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture115,
+  mipLevel: 1,
+  origin: {x: 0, y: 14, z: 0},
+  aspect: 'all',
+}, new Uint8Array(81).fill(113), /* required buffer size: 81 */
+{offset: 81, bytesPerRow: 55}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let buffer86 = device0.createBuffer({
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let texture131 = gpuCanvasContext0.getCurrentTexture();
+let textureView133 = texture116.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let sampler82 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 34.77,
+  lodMaxClamp: 52.70,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder79.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder79); computePassEncoder79.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup58);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(131);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.drawIndexed(11, 215, 0, 888_129_873, 1_071_820_280);
+} catch {}
+try {
+renderPassEncoder17.drawIndirect(buffer50, 1_192);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder3.resolveQuerySet(querySet20, 5, 21, buffer59, 0);
+} catch {}
+offscreenCanvas0.width = 1013;
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 43,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 21,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let buffer87 = device0.createBuffer({size: 8568, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView135 = texture129.createView({});
+let computePassEncoder122 = commandEncoder3.beginComputePass({});
+let renderPassEncoder26 = commandEncoder60.beginRenderPass({
+  label: '\u6c05\u052a\uf6e1\ue51f\ua017\u2fe8\u050c\u5c2f\u9716\u0e1d',
+  colorAttachments: [{
+  view: textureView134,
+  clearValue: { r: 967.9, g: -567.0, b: 830.7, a: -437.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let externalTexture14 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder53.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+renderPassEncoder26.end();
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle1]);
+} catch {}
+try {
+computePassEncoder73.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(4, buffer76, 1_232);
+} catch {}
+try {
+device0.queue.submit([commandBuffer7]);
+} catch {}
+let buffer90 = device0.createBuffer({
+  size: 904,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder129 = device0.createCommandEncoder();
+let texture135 = device0.createTexture({
+  size: {width: 1, height: 370, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView138 = texture25.createView({dimension: 'cube-array', baseMipLevel: 0, arrayLayerCount: 12});
+let sampler85 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMinClamp: 95.23,
+  lodMaxClamp: 96.20,
+});
+let commandBuffer8 = commandEncoder81.finish({});
+let renderPassEncoder27 = commandEncoder127.beginRenderPass({
+  colorAttachments: [{
+  view: textureView134,
+  clearValue: { r: 88.64, g: 555.8, b: 412.8, a: 419.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup69, new Uint32Array(2636), 1_225, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer89, 'uint16', 322, 1_109);
+} catch {}
+try {
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder96); computePassEncoder96.dispatchWorkgroupsIndirect(buffer50, 3_412); };
+} catch {}
+try {
+commandEncoder131.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1768 */
+  offset: 1768,
+  bytesPerRow: 3328,
+  buffer: buffer60,
+}, {
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+  origin: {x: 0, y: 92, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 25,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 384, hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+renderPassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer35, 104, new Int16Array(3904), 72, 1820);
+} catch {}
+let bindGroup84 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [
+    {binding: 120, resource: {buffer: buffer6, offset: 6400, size: 549}},
+    {binding: 155, resource: textureView130},
+    {binding: 118, resource: externalTexture11},
+    {binding: 171, resource: sampler45},
+    {binding: 52, resource: externalTexture4},
+    {binding: 416, resource: sampler74},
+    {binding: 83, resource: textureView3},
+    {binding: 108, resource: sampler77},
+    {binding: 58, resource: sampler41},
+    {binding: 185, resource: textureView1},
+    {binding: 144, resource: externalTexture14},
+  ],
+});
+let commandEncoder134 = device0.createCommandEncoder();
+let texture136 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderPassEncoder19.setIndexBuffer(buffer22, 'uint32', 212, 4_346);
+} catch {}
+try {
+commandEncoder130.resolveQuerySet(querySet20, 218, 28, buffer0, 512);
+} catch {}
+try {
+device0.queue.submit([commandBuffer8]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 64, height: 64, depthOrArrayLayers: 22}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture102,
+  mipLevel: 0,
+  origin: {x: 9, y: 26, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup85 = device0.createBindGroup({
+  label: '\u78d1\u65b3\ua52b\u5167\u0e5b\u{1f6c4}\u{1fcfe}\u028b\u6340',
+  layout: bindGroupLayout10,
+  entries: [
+    {binding: 56, resource: textureView71},
+    {binding: 239, resource: {buffer: buffer44, offset: 1024, size: 3152}},
+  ],
+});
+let buffer92 = device0.createBuffer({
+  size: 12999,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture137 = device0.createTexture({
+  label: '\u0d55\uc6cf',
+  size: {width: 1, height: 92, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView139 = texture117.createView({label: '\ud588\u77ec\u{1faa1}\u{1f9a2}\uf6a8\u{1fd1b}\u7574', arrayLayerCount: 1});
+let computePassEncoder126 = commandEncoder133.beginComputePass({});
+try {
+computePassEncoder65.setBindGroup(1, bindGroup35, []);
+} catch {}
+try {
+computePassEncoder76.setBindGroup(3, bindGroup83, new Uint32Array(825), 87, 0);
+} catch {}
+try {
+computePassEncoder127.setBindGroup(2, bindGroup79, new Uint32Array(2916), 21, 0);
+} catch {}
+try {
+computePassEncoder114.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup33, new Uint32Array(3660), 270, 0);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(4, buffer11, 0);
+} catch {}
+try {
+commandEncoder135.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 320 */
+  offset: 320,
+  bytesPerRow: 8448,
+  buffer: buffer41,
+}, {
+  texture: texture121,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer93 = device0.createBuffer({
+  label: '\uc4cd\u6edf\u5b65\u07b1\u1fc3\u0bab\u3059\u6ccf\u04ad\ue253',
+  size: 17563,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let computePassEncoder130 = commandEncoder135.beginComputePass({});
+let renderPassEncoder28 = commandEncoder131.beginRenderPass({
+  colorAttachments: [{
+  view: textureView125,
+  depthSlice: 27,
+  clearValue: { r: -412.4, g: 56.23, b: 185.3, a: -941.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 105191632,
+});
+try {
+computePassEncoder122.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup14, new Uint32Array(102), 26, 0);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(64);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle13, renderBundle8, renderBundle3]);
+} catch {}
+try {
+commandEncoder132.copyTextureToBuffer({
+  texture: texture44,
+  mipLevel: 0,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 0, y: 37, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup86 = device0.createBindGroup({
+  layout: bindGroupLayout10,
+  entries: [{binding: 56, resource: textureView95}, {binding: 239, resource: {buffer: buffer90, offset: 0}}],
+});
+let buffer94 = device0.createBuffer({
+  size: 6203,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  lodMaxClamp: 99.75,
+});
+let externalTexture15 = device0.importExternalTexture({label: '\u{1fc52}\u7bab', source: videoFrame11});
+try {
+computePassEncoder40.setBindGroup(3, bindGroup16, new Uint32Array(760), 72, 0);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup55);
+} catch {}
+try {
+} catch {}
+let shaderModule9 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+@compute @workgroup_size(2, 1, 1)
+fn compute9() {
+  var vf253: u32 = pack4x8snorm(vec4f(unconst_f32(0.1130), unconst_f32(0.08893), unconst_f32(0.2792), unconst_f32(0.06667)));
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer96 = device0.createBuffer({size: 7139, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder140 = device0.createCommandEncoder({});
+try {
+computePassEncoder120.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder16.drawIndirect(buffer35, 2_040);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture117,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(548).fill(207), /* required buffer size: 548 */
+{offset: 548, bytesPerRow: 36}, {width: 0, height: 16, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img1);
+let renderPassEncoder32 = commandEncoder140.beginRenderPass({
+  colorAttachments: [{
+  view: textureView45,
+  clearValue: { r: -953.4, g: 449.6, b: 880.8, a: -99.83, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 26.37,
+  lodMaxClamp: 80.39,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup1, new Uint32Array(455), 71, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder101); computePassEncoder101.dispatchWorkgroupsIndirect(buffer94, 1_864); };
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle1, renderBundle16, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline5);
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+let pipeline9 = device0.createRenderPipeline({
+  layout: pipelineLayout2,
+  multisample: {count: 1, mask: 0x47d1ba9e},
+  fragment: {module: shaderModule0, constants: {12_016: 0, override2: 0}, targets: [{format: 'rgba8unorm-srgb'}]},
+  vertex: {
+    module: shaderModule5,
+    constants: {override5: 0},
+    buffers: [
+      {
+        arrayStride: 36,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32', offset: 0, shaderLocation: 15}, {format: 'unorm16x4', offset: 4, shaderLocation: 3}],
+      },
+      {arrayStride: 376, attributes: [{format: 'uint32', offset: 168, shaderLocation: 10}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', cullMode: 'back'},
+});
+let texture140 = device0.createTexture({
+  size: [1, 185, 1],
+  mipLevelCount: 1,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView144 = texture80.createView({label: '\ud596\u738f', mipLevelCount: 1});
+try {
+computePassEncoder93.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let videoFrame21 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'film', transfer: 'gamma22curve'} });
+let bindGroupLayout24 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 9,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 63,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 106,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+try {
+computePassEncoder63.setBindGroup(3, bindGroup69);
+} catch {}
+try {
+computePassEncoder108.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup5, new Uint32Array(1413), 61, 0);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer69, 'uint32', 64, 435);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(3, buffer84, 344, 2_374);
+} catch {}
+try {
+renderPassEncoder16.insertDebugMarker('\u0ea3');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 740, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame15,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 50, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+try {
+  await promise14;
+} catch {}
+let bindGroup89 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 17, resource: textureView3}]});
+let commandEncoder142 = device0.createCommandEncoder({});
+let textureView145 = texture141.createView({dimension: '3d', baseMipLevel: 0});
+let texture143 = device0.createTexture({size: [64, 64, 22], format: 'rg16uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView146 = texture137.createView({mipLevelCount: 1});
+let computePassEncoder136 = commandEncoder142.beginComputePass({label: '\u{1fba8}\u5d6e\u18eb'});
+try {
+computePassEncoder134.setBindGroup(3, bindGroup38, new Uint32Array(1337), 1, 0);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup49);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer36, 'uint32', 2_760, 136);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer82, 484, new Int16Array(8814), 299, 2308);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup81);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(526);
+} catch {}
+let commandEncoder143 = device0.createCommandEncoder({});
+let renderPassEncoder33 = commandEncoder143.beginRenderPass({
+  colorAttachments: [{
+  view: textureView90,
+  depthSlice: 12,
+  clearValue: { r: -933.5, g: -107.1, b: 697.6, a: 417.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder83.setBindGroup(0, bindGroup3, new Uint32Array(822), 34, 0);
+} catch {}
+try {
+computePassEncoder70.end();
+} catch {}
+try {
+computePassEncoder109.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder105.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline5);
+} catch {}
+try {
+computePassEncoder113.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(7, buffer99);
+} catch {}
+try {
+buffer47.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer71, 1252, new Float32Array(19921), 4465, 384);
+} catch {}
+try {
+computePassEncoder101.setBindGroup(1, bindGroup72);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup70);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(0, buffer49);
+} catch {}
+let commandEncoder144 = device0.createCommandEncoder({});
+let renderPassEncoder34 = commandEncoder144.beginRenderPass({
+  colorAttachments: [{
+  view: textureView146,
+  clearValue: { r: 514.3, g: 666.8, b: 873.6, a: 281.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  viewFormats: [],
+});
+let computePassEncoder140 = commandEncoder150.beginComputePass({});
+let sampler97 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 66.04,
+  lodMaxClamp: 93.10,
+});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup43, new Uint32Array(3378), 2_413, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder83); computePassEncoder83.dispatchWorkgroupsIndirect(buffer60, 488); };
+} catch {}
+let bindGroup94 = device0.createBindGroup({
+  layout: bindGroupLayout9,
+  entries: [
+    {binding: 225, resource: textureView88},
+    {binding: 150, resource: textureView119},
+    {binding: 52, resource: externalTexture1},
+    {binding: 155, resource: textureView115},
+    {binding: 49, resource: {buffer: buffer37, offset: 256, size: 754}},
+    {binding: 18, resource: externalTexture6},
+    {binding: 99, resource: sampler70},
+    {binding: 120, resource: {buffer: buffer101, offset: 768, size: 459}},
+    {binding: 189, resource: {buffer: buffer51, offset: 0, size: 1069}},
+    {binding: 216, resource: externalTexture2},
+    {binding: 71, resource: externalTexture11},
+    {binding: 118, resource: externalTexture10},
+    {binding: 358, resource: sampler1},
+    {binding: 117, resource: textureView74},
+    {binding: 7, resource: sampler25},
+    {binding: 70, resource: externalTexture8},
+    {binding: 38, resource: externalTexture9},
+    {binding: 173, resource: {buffer: buffer11, offset: 0, size: 2446}},
+    {binding: 562, resource: textureView132},
+    {binding: 122, resource: externalTexture10},
+    {binding: 9, resource: sampler95},
+    {binding: 58, resource: sampler65},
+    {binding: 204, resource: externalTexture10},
+    {binding: 340, resource: sampler6},
+    {binding: 60, resource: externalTexture10},
+    {binding: 416, resource: sampler83},
+    {binding: 330, resource: sampler35},
+  ],
+  mipmapFilter: 'linear',
+  lodMinClamp: 83.44,
+  lodMaxClamp: 99.83,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder117.setBindGroup(0, bindGroup88, new Uint32Array(970), 230, 0);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup7, new Uint32Array(738), 67, 0);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(2, buffer94, 0, 871);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 0, y: 100, z: 30},
+  aspect: 'all',
+}, new Uint8Array(35_733).fill(165), /* required buffer size: 35_733 */
+{offset: 217, bytesPerRow: 26, rowsPerImage: 156}, {width: 0, height: 119, depthOrArrayLayers: 9});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder83); computePassEncoder83.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer72, 'uint32', 896, 891);
+} catch {}
+try {
+commandEncoder42.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2516 */
+  offset: 2516,
+  bytesPerRow: 67840,
+  buffer: buffer66,
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 173, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup95 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 71, resource: {buffer: buffer0, offset: 256, size: 1464}},
+    {binding: 239, resource: textureView134},
+    {binding: 45, resource: externalTexture11},
+    {binding: 55, resource: {buffer: buffer58, offset: 256, size: 58}},
+    {binding: 190, resource: textureView135},
+    {binding: 103, resource: sampler95},
+  ],
+});
+let buffer107 = device0.createBuffer({
+  label: '\ud00e\u{1f6ae}\ub826\u01e1\u0f94\u2d6f\u{1fbb4}\u5ac7\u0ef6\u0376',
+  size: 34279,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder152 = device0.createCommandEncoder({});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup61);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup38);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle16]);
+} catch {}
+try {
+commandEncoder152.copyBufferToTexture({
+  /* bytesInLastRow: 108 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 356 */
+  offset: 356,
+  bytesPerRow: 19456,
+  buffer: buffer34,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 16, y: 6, z: 0},
+  aspect: 'all',
+}, {width: 27, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder138.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(0, buffer104);
+} catch {}
+document.body.prepend(img0);
+let videoFrame22 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'unspecified', transfer: 'gamma22curve'} });
+let buffer108 = device0.createBuffer({
+  size: 16239,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder153 = device0.createCommandEncoder({});
+let computePassEncoder141 = commandEncoder42.beginComputePass({label: '\u0fe5\u8313\u3111\ufbd5\u672d\u7239\u09bf'});
+let renderPassEncoder40 = commandEncoder153.beginRenderPass({
+  colorAttachments: [{
+  view: textureView54,
+  depthSlice: 1437,
+  clearValue: { r: 528.0, g: -327.0, b: 201.9, a: -757.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup82, new Uint32Array(2398), 767, 0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup82, []);
+} catch {}
+try {
+renderPassEncoder39.executeBundles([renderBundle18]);
+} catch {}
+try {
+computePassEncoder110.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+computePassEncoder133.setBindGroup(0, bindGroup54, new Uint32Array(3780), 382, 0);
+} catch {}
+try {
+computePassEncoder132.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer21, 'uint32', 24, 76);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(3, buffer68, 24, 29);
+} catch {}
+let sampler103 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 73.47,
+  lodMaxClamp: 90.24,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder133); computePassEncoder133.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder133); computePassEncoder133.dispatchWorkgroupsIndirect(buffer19, 80); };
+} catch {}
+try {
+computePassEncoder115.end();
+} catch {}
+try {
+computePassEncoder131.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup54);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup74, new Uint32Array(206), 71, 0);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer75.unmap();
+} catch {}
+try {
+commandEncoder91.copyBufferToTexture({
+  aspect: 'all',
+}, new Uint8Array(13_542).fill(237), /* required buffer size: 13_542 */
+{offset: 26, bytesPerRow: 62, rowsPerImage: 95}, {width: 0, height: 29, depthOrArrayLayers: 3});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder142 = commandEncoder91.beginComputePass({});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup67);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup39, new Uint32Array(5999), 2_416, 0);
+} catch {}
+try {
+renderPassEncoder37.beginOcclusionQuery(84);
+computePassEncoder133.end();
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle12, renderBundle12, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder19.setViewport(0.5509914252166663, 446.75621997400077, 0.09949510091409779, 5.685274151645425, 0.8949389600413042, 0.9043552890345704);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(4, buffer50);
+} catch {}
+try {
+commandEncoder132.copyBufferToTexture({
+  /* bytesInLastRow: 13 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 985 */
+  offset: 985,
+  bytesPerRow: 11008,
+  buffer: buffer46,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout10 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout4]});
+let texture157 = device0.createTexture({
+  size: [1, 740, 1],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder143 = commandEncoder132.beginComputePass({label: '\u05e5\u9df7\ud6bc'});
+try {
+computePassEncoder42.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder129.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(3, buffer79, 0);
+} catch {}
+let gpuCanvasContext1 = offscreenCanvas1.getContext('webgpu');
+let bindGroup97 = device0.createBindGroup({
+  layout: bindGroupLayout23,
+  entries: [{binding: 25, resource: {buffer: buffer26, offset: 5120, size: 1416}}],
+});
+let commandEncoder154 = device0.createCommandEncoder({});
+let texture158 = device0.createTexture({
+  size: [1, 92, 1],
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder144 = commandEncoder154.beginComputePass();
+try {
+computePassEncoder66.setBindGroup(3, bindGroup36, new Uint32Array(1085), 184, 0);
+} catch {}
+try {
+computePassEncoder111.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 456, new Float32Array(2999), 692, 24);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let buffer110 = device0.createBuffer({
+  size: 1243,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder109.setBindGroup(2, bindGroup1, new Uint32Array(361), 65, 0);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(0, buffer48, 1_180, 293);
+} catch {}
+document.body.append(img1);
+let commandEncoder155 = device0.createCommandEncoder({label: '\udeb7\u{1fc78}\u{1f62a}\u451b\uce7f\u48ec\u92e4\u6dc8\u1d3f\u04e0\u6db4'});
+let computePassEncoder145 = commandEncoder155.beginComputePass({});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({
+  label: '\u0500\u9c02\u32ad\u9a2f\uaa13\u32b6\u0754\u0ede',
+  colorFormats: ['r16uint'],
+  stencilReadOnly: true,
+});
+let renderBundle20 = renderBundleEncoder20.finish({});
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline9);
+} catch {}
+let shaderModule10 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute11(@builtin(workgroup_id) a0: vec3u, @builtin(local_invocation_index) a1: u32, @builtin(global_invocation_id) a2: vec3u) {
+  vp3.f0 *= vec4u((*&vw24)[0][unconst_i32(2)].ggrg);
+  let ptr84 = &vp4;
+  vw24[u32(unconst_u32(313))] = mat3x2h(vw24[u32(unconst_u32(164))][u32(unconst_u32(269))][u32(unconst_u32(71))], vw24[u32(unconst_u32(164))][u32(unconst_u32(269))][u32(unconst_u32(71))], vw24[u32(unconst_u32(164))][u32(unconst_u32(269))][u32(unconst_u32(71))], vw24[u32(unconst_u32(164))][u32(unconst_u32(269))][u32(unconst_u32(71))], vw24[u32(unconst_u32(164))][u32(unconst_u32(269))][u32(unconst_u32(71))], vw24[u32(unconst_u32(164))][u32(unconst_u32(269))][u32(unconst_u32(71))]);
+  let ptr85: ptr<workgroup, atomic<u32>> = &vw25;
+}`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout11 = device0.createPipelineLayout({
+  label: '\u{1fad3}\ub22d\u23fb\u387e\u0472\uc03b\u0b53\u0230\u{1fd8b}\u4352\u4cb7',
+  bindGroupLayouts: [],
+});
+let commandEncoder156 = device0.createCommandEncoder({});
+let textureView159 = texture121.createView({});
+let computePassEncoder146 = commandEncoder156.beginComputePass({label: '\u0a7d\uec42\u258b\u0709\u0e27\ubf25\uf8a6\uc4be\u9626\uee1d'});
+try {
+computePassEncoder98.setBindGroup(3, bindGroup69);
+} catch {}
+try {
+computePassEncoder126.setBindGroup(0, bindGroup55, new Uint32Array(391), 12, 0);
+} catch {}
+try {
+computePassEncoder136.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(0, bindGroup56);
+} catch {}
+try {
+renderPassEncoder39.beginOcclusionQuery(16);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(3, buffer48, 0, 78);
+} catch {}
+try {
+commandEncoder86.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1084 */
+  offset: 1084,
+  bytesPerRow: 1024,
+  buffer: buffer22,
+}, {
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 0, y: 15, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder86.copyTextureToTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 0, y: 19, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture127,
+  mipLevel: 0,
+  origin: {x: 0, y: 209, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u{1fbc0}\ue99f\u0123\ua7d6\u0818\u633a\u09f8\u{1feae}\u0c6d\u{1fe38}';
+} catch {}
+let bindGroup98 = device0.createBindGroup({
+  label: '\u63af\u7760\u{1f973}\u0885\u47bd\u781b\u6801\u7060\u2354\u4b90\ud4c6',
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 71, resource: {buffer: buffer4, offset: 0}},
+    {binding: 190, resource: textureView135},
+    {binding: 239, resource: textureView155},
+    {binding: 103, resource: sampler91},
+    {binding: 45, resource: externalTexture14},
+    {binding: 55, resource: {buffer: buffer6, offset: 13312, size: 1967}},
+  ],
+});
+let buffer111 = device0.createBuffer({
+  size: 2814,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder147 = commandEncoder86.beginComputePass({});
+let sampler104 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 82.77,
+  lodMaxClamp: 93.51,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder52.setBindGroup(3, bindGroup74);
+} catch {}
+try {
+computePassEncoder120.setBindGroup(3, bindGroup35, new Uint32Array(353), 170, 0);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline4);
+} catch {}
+let shaderModule11 = device0.createShaderModule({
+  label: '\ub871\u{1f963}\u{1f63f}\uf261\u{1fc33}\uea59\u0b72\uc371\u0ce9\u00fa\ufccf',
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+  textureBarrier();
+  fn0();
+  vf306 = vec2u(sign(vec2h(unconst_f16(2217.3), unconst_f16(2209.1))));
+  vf306 *= vec2u(vf308.f1[u32(unconst_u32(533))]);
+  vf308 = FragmentOutput12();
+  vf306 >>= vf308.f2;
+  let ptr94: ptr<function, vec4u> = &vf308.f1;
+}`,
+});
+let buffer115 = device0.createBuffer({
+  label: '\u{1fd53}\u{1fdef}\u0294\u{1fab6}\uafdf\u{1fa3a}\u7a57',
+  size: 8130,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder160 = device0.createCommandEncoder({});
+let texture160 = device0.createTexture({
+  size: {width: 1, height: 185, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderPassEncoder42 = commandEncoder160.beginRenderPass({
+  colorAttachments: [{
+  view: textureView26,
+  depthSlice: 1252,
+  clearValue: { r: -789.2, g: -504.8, b: 4.054, a: -454.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 39619663,
+});
+let sampler108 = device0.createSampler({magFilter: 'nearest', mipmapFilter: 'linear', lodMinClamp: 32.78, lodMaxClamp: 38.84});
+let buffer116 = device0.createBuffer({
+  label: '\ue01a\u23b2\ua2be',
+  size: 1451,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder162 = device0.createCommandEncoder({});
+let textureView164 = texture154.createView({});
+let texture162 = device0.createTexture({
+  size: {width: 1, height: 92, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView165 = texture110.createView({mipLevelCount: 1});
+let computePassEncoder151 = commandEncoder162.beginComputePass();
+let sampler110 = device0.createSampler({
+  label: '\u4090\u17b9\u04e6\uaba2\ub4db\u1408\u02c8\ude39\u0e3e\u0c99',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 31.18,
+  lodMaxClamp: 31.92,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder93); computePassEncoder93.dispatchWorkgroupsIndirect(buffer63, 244); };
+} catch {}
+try {
+computePassEncoder106.setPipeline(pipeline10);
+} catch {}
+try {
+computePassEncoder143.setPipeline(pipeline8);
+} catch {}
+let buffer117 = device0.createBuffer({
+  size: 7270,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let textureView166 = texture47.createView({});
+try {
+computePassEncoder101.setBindGroup(3, bindGroup58, new Uint32Array(131), 27, 0);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer101, 'uint32', 368, 556);
+} catch {}
+try {
+computePassEncoder35.setBindGroup(0, bindGroup78, [0]);
+} catch {}
+let buffer119 = device0.createBuffer({
+  size: 841,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder163 = device0.createCommandEncoder({label: '\ub4cf\u2c1f\u0d64\uc809\ucde8\u{1f722}\ufafb\uf033\u0882'});
+let textureView167 = texture23.createView({
+  label: '\u{1fd0c}\ua6a9\ua01d\uded2\ud1f6\u3554\u9f66\u0229\u3503\uadac\u8e5c',
+  dimension: '2d',
+  mipLevelCount: 1,
+});
+let renderPassEncoder43 = commandEncoder163.beginRenderPass({
+  colorAttachments: [{
+  view: textureView33,
+  depthSlice: 2,
+  clearValue: { r: 590.9, g: 60.83, b: -75.26, a: -828.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet10,
+});
+let sampler111 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 41.11,
+  lodMaxClamp: 54.29,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder116.setBindGroup(0, bindGroup24, new Uint32Array(2227), 37, 0);
+} catch {}
+try {
+computePassEncoder50.end();
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup38, new Uint32Array(1411), 203, 0);
+} catch {}
+try {
+renderPassEncoder28.beginOcclusionQuery(28);
+} catch {}
+let buffer120 = device0.createBuffer({size: 11577, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture163 = device0.createTexture({
+  size: {width: 1, height: 92, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  dimension: '2d',
+  size: 864,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup83);
+} catch {}
+try {
+computePassEncoder146.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+renderPassEncoder36.setViewport(0.6901617084482511, 64.67646049888428, 0.19849045623116013, 93.53384122064934, 0.8804299567836135, 0.9266308582485184);
+} catch {}
+try {
+computePassEncoder67.setBindGroup(3, bindGroup112, new Uint32Array(123), 3, 0);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(0, bindGroup97, new Uint32Array(1135), 82, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 185, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData23,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture185,
+  mipLevel: 1,
+  origin: {x: 0, y: 15, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout32 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 188,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 84,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup120 = device0.createBindGroup({
+  layout: bindGroupLayout21,
+  entries: [
+    {binding: 239, resource: textureView134},
+    {binding: 103, resource: sampler30},
+    {binding: 45, resource: externalTexture20},
+    {binding: 190, resource: textureView186},
+    {binding: 71, resource: {buffer: buffer51, offset: 0, size: 968}},
+    {binding: 55, resource: {buffer: buffer4, offset: 512}},
+  ],
+});
+let buffer143 = device0.createBuffer({
+  label: '\u95e7\u9074\u771c',
+  size: 11969,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+});
+let texture188 = device0.createTexture({
+  size: [1, 185, 1],
+  format: 'r32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture189 = gpuCanvasContext1.getCurrentTexture();
+let textureView193 = texture47.createView({});
+try {
+computePassEncoder173.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(0, bindGroup111);
+} catch {}
+try {
+renderPassEncoder31.setViewport(0.14449830913267647, 724.4889131790983, 0.09552129156574393, 4.3654521317837105, 0.4611439267166072, 0.7283595218937736);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(6, buffer119, 420, 99);
+} catch {}
+let textureView194 = texture188.createView({baseMipLevel: 0});
+let texture190 = device0.createTexture({
+  size: {width: 1, height: 185, depthOrArrayLayers: 172},
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView195 = texture111.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder43.setBindGroup(2, bindGroup95);
+} catch {}
+try {
+computePassEncoder137.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(0, bindGroup80);
+} catch {}
+let bindGroup121 = device0.createBindGroup({
+  layout: bindGroupLayout25,
+  entries: [{binding: 761, resource: sampler117}, {binding: 406, resource: textureView65}],
+});
+let texture191 = device0.createTexture({
+  label: '\u0bdc\u01a2',
+  size: [1],
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView196 = texture13.createView({aspect: 'depth-only'});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup43, new Uint32Array(1953), 91, 0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup118, new Uint32Array(1484), 542, 0);
+} catch {}
+try {
+renderPassEncoder50.executeBundles([renderBundle20, renderBundle24, renderBundle24, renderBundle24, renderBundle20]);
+} catch {}
+try {
+buffer136.unmap();
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup69);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer115, 'uint32', 1_592, 511);
+} catch {}
+let bindGroup124 = device0.createBindGroup({
+  layout: bindGroupLayout30,
+  entries: [
+    {binding: 103, resource: textureView129},
+    {binding: 366, resource: textureView30},
+    {binding: 122, resource: textureView188},
+    {binding: 273, resource: {buffer: buffer55, offset: 0, size: 19}},
+    {binding: 195, resource: {buffer: buffer108, offset: 2048, size: 4060}},
+    {binding: 23, resource: {buffer: buffer3, offset: 0}},
+    {binding: 22, resource: {buffer: buffer108, offset: 1536, size: 3324}},
+    {binding: 63, resource: textureView99},
+    {binding: 16, resource: {buffer: buffer116, offset: 0, size: 56}},
+    {binding: 117, resource: textureView140},
+    {binding: 76, resource: textureView48},
+    {binding: 500, resource: textureView1},
+    {binding: 14, resource: {buffer: buffer110, offset: 0, size: 278}},
+    {binding: 62, resource: {buffer: buffer55, offset: 0, size: 116}},
+    {binding: 341, resource: sampler86},
+    {binding: 96, resource: sampler6},
+    {binding: 204, resource: {buffer: buffer109, offset: 768, size: 612}},
+    {binding: 31, resource: textureView82},
+    {binding: 75, resource: {buffer: buffer58, offset: 0, size: 761}},
+    {binding: 399, resource: textureView148},
+  ],
+});
+try {
+renderPassEncoder32.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder170.copyTextureToBuffer({
+  texture: texture164,
+  mipLevel: 1,
+  origin: {x: 0, y: 65, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 964 */
+  offset: 964,
+  bytesPerRow: 23040,
+  buffer: buffer123,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer11 = commandEncoder170.finish();
+try {
+computePassEncoder75.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline9);
+} catch {}
+try {
+commandEncoder198.copyBufferToBuffer(buffer90, 168, buffer127, 68, 256);
+} catch {}
+try {
+commandEncoder198.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4524 */
+  offset: 4524,
+  bytesPerRow: 4352,
+  buffer: buffer73,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 0, y: 29, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 45, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup125 = device0.createBindGroup({
+  layout: bindGroupLayout11,
+  entries: [{binding: 107, resource: textureView81}, {binding: 44, resource: textureView123}],
+});
+let buffer145 = device0.createBuffer({size: 5407, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT, mappedAtCreation: false});
+let commandEncoder199 = device0.createCommandEncoder({});
+let texture192 = device0.createTexture({
+  size: {width: 1, height: 92, depthOrArrayLayers: 1},
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture193 = device0.createTexture({
+  size: [1, 740, 14],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder182 = commandEncoder199.beginComputePass({});
+try {
+computePassEncoder92.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer127, 'uint16', 714, 17);
+} catch {}
+let imageData25 = new ImageData(112, 12);
+let buffer148 = device0.createBuffer({size: 3948, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE, mappedAtCreation: false});
+let commandEncoder201 = device0.createCommandEncoder({});
+let texture197 = device0.createTexture({size: [64, 64, 22], format: 'rg16uint', usage: GPUTextureUsage.COPY_SRC});
+let renderPassEncoder57 = commandEncoder201.beginRenderPass({colorAttachments: [{view: textureView134, loadOp: 'clear', storeOp: 'store'}]});
+let externalTexture22 = device0.importExternalTexture({source: videoFrame21});
+try {
+computePassEncoder43.setBindGroup(3, bindGroup60);
+} catch {}
+try {
+renderPassEncoder22.setScissorRect(0, 119, 0, 11);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer150 = device0.createBuffer({
+  label: '\u{1f826}\u0635',
+  size: 3598,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder184.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer55, 8, new BigUint64Array(1383), 59, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let sampler134 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 57.56,
+  lodMaxClamp: 75.35,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup122);
+} catch {}
+let querySet26 = device0.createQuerySet({type: 'occlusion', count: 476});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup71, []);
+} catch {}
+try {
+computePassEncoder104.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(2, bindGroup82, new Uint32Array(187), 116, 0);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer116, 'uint16', 48, 60);
+} catch {}
+try {
+adapter0.label = '\ubb83\u{1fa2f}\u283f\ub07e\ub02e\u03aa\u085f\u027e';
+} catch {}
+let commandEncoder203 = device0.createCommandEncoder({});
+let textureView208 = texture122.createView({label: '\u{1f8dd}\u4738\u606b\u0358\u47b2\u8d0c\u{1ff31}', dimension: '2d-array'});
+let sampler135 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 98.07,
+  lodMaxClamp: 99.61,
+});
+try {
+computePassEncoder177.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder47.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder53.insertDebugMarker('\u93e3');
+} catch {}
+try {
+device0.queue.submit([commandBuffer11]);
+} catch {}
+document.body.prepend(img1);
+let textureView209 = texture181.createView({dimension: 'cube', aspect: 'all'});
+let renderPassEncoder58 = commandEncoder68.beginRenderPass({
+  colorAttachments: [{
+  view: textureView146,
+  clearValue: { r: 172.9, g: 759.8, b: 250.1, a: 891.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let externalTexture23 = device0.importExternalTexture({source: videoFrame17, colorSpace: 'display-p3'});
+try {
+computePassEncoder109.setBindGroup(0, bindGroup124);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(0, bindGroup5, new Uint32Array(278), 54, 0);
+} catch {}
+try {
+computePassEncoder182.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup44, new Uint32Array(1391), 535, 0);
+} catch {}
+try {
+renderPassEncoder22.setViewport(0.3658157287733439, 38.7826946759793, 0.3516359660943419, 459.7226646032156, 0.2312666706528239, 0.9483204837652132);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline5);
+} catch {}
+document.body.append(canvas1);
+try {
+globalThis.someLabel = externalTexture18.label;
+} catch {}
+let buffer153 = device0.createBuffer({
+  size: 1844,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture201 = device0.createTexture({
+  size: [1, 92, 1],
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView210 = texture90.createView({label: '\u5534\u6820\u4bb8\uecb5\uff8e\u3428\u{1ff6b}\u03b7\u02cd', aspect: 'all', mipLevelCount: 1});
+let sampler136 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 97.14,
+  lodMaxClamp: 99.59,
+});
+try {
+renderPassEncoder38.setBindGroup(2, bindGroup123);
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer16, 'uint16', 5_534, 2_545);
+} catch {}
+let bindGroupLayout33 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 184,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture202 = device0.createTexture({
+  label: '\u569a\ud4fd\u36c4\u1932\uc886\u073e\u{1fcae}\u23a6\u{1f713}\u07e9\uacef',
+  size: {width: 1},
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb'], depthReadOnly: true});
+let renderBundle27 = renderBundleEncoder27.finish({label: '\u{1ff28}\u{1fdce}\u08c3'});
+try {
+computePassEncoder183.setPipeline(pipeline10);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let pipeline13 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule4,
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {module: shaderModule3, constants: {}, buffers: []},
+});
+document.body.append(img0);
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup127 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 284, resource: textureView118}]});
+let buffer154 = device0.createBuffer({
+  size: 493,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder204 = device0.createCommandEncoder({});
+let renderPassEncoder60 = commandEncoder204.beginRenderPass({
+  colorAttachments: [{
+  view: textureView204,
+  depthSlice: 76,
+  clearValue: { r: -598.9, g: 191.7, b: 705.9, a: -350.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet4,
+});
+try {
+computePassEncoder49.setBindGroup(1, bindGroup12, new Uint32Array(200), 102, 0);
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(0, bindGroup97, new Uint32Array(1370), 174, 0);
+} catch {}
+try {
+buffer60.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 185, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture185,
+  mipLevel: 1,
+  origin: {x: 0, y: 24, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+  origin: {x: 0, y: 19, z: 7},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder207 = device0.createCommandEncoder({});
+let texture207 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 22},
+  format: 'eac-r11snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture209 = device0.createTexture({
+  size: {width: 1, height: 92, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder188 = commandEncoder208.beginComputePass({});
+try {
+computePassEncoder174.setBindGroup(3, bindGroup64);
+} catch {}
+try {
+computePassEncoder42.setBindGroup(0, bindGroup56, new Uint32Array(1286), 16, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder61); computePassEncoder61.dispatchWorkgroupsIndirect(buffer154, 28); };
+} catch {}
+try {
+computePassEncoder188.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup97, []);
+} catch {}
+try {
+renderPassEncoder48.pushDebugGroup('\udeb3');
+} catch {}
+try {
+device0.queue.label = '\u6cd1\u0e9e\u19a3\u0cde\ue482';
+} catch {}
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -996,7 +996,7 @@ ExceptionOr<void> GPUQueue::copyExternalImageToTexture(ScriptExecutionContext& c
         auto channels = widthInBytes / columns;
         GPUImageDataLayout dataLayout { 0, widthInBytes, rows };
 
-        if (source.origin) {
+        if (source.origin && supportedFormat) {
             populdateXYFromOrigin(*source.origin, sourceX, sourceY);
             if (sourceX || sourceY) {
                 RELEASE_ASSERT(newImageBytes);


### PR DESCRIPTION
#### 230104875eb753470b07a836b4c3704e60462157
<pre>
[WebGPU] Release assertion triggered in GPUQueue.copyExternalImageToTexture
<a href="https://bugs.webkit.org/show_bug.cgi?id=282995">https://bugs.webkit.org/show_bug.cgi?id=282995</a>
<a href="https://rdar.apple.com/139732505">rdar://139732505</a>

Reviewed by Tadeu Zagallo.

We triggered a release assertion when an invalid format was used with an origin offset.

* LayoutTests/fast/webgpu/nocrash/fuzz-282995-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-282995.html: Added.
Add regression test.

* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::GPUQueue::copyExternalImageToTexture):

Canonical link: <a href="https://commits.webkit.org/286547@main">https://commits.webkit.org/286547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2593a0e58480a1b43ce2ab0b756e7fce1cbe636a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80651 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27415 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78264 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3474 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59711 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17855 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49604 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65396 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40060 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47000 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22879 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25742 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68133 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82112 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3520 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2281 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67938 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3674 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67248 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16796 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11200 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9313 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3468 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6275 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3491 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/6885 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5249 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->