### PR TITLE
Ensure usage of ReadOperation is thread-safe

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -431,15 +431,15 @@ void Cache::retrieve(const WebCore::ResourceRequest& request, std::optional<Glob
     m_storage->retrieve(storageKey, priority, [this, protectedThis = Ref { *this }, request, completionHandler = WTFMove(completionHandler), info = WTFMove(info), storageKey, networkProcess = Ref { networkProcess() }, sessionID = m_sessionID, frameID, isNavigatingToAppBoundDomain, allowPrivacyProxy, advancedPrivacyProtections](auto record, auto timings) mutable {
         info.storageTimings = timings;
 
-        if (!record) {
+        if (record.isNull()) {
             LOG(NetworkCache, "(NetworkProcess) not found in storage");
             completeRetrieve(WTFMove(completionHandler), nullptr, info);
             return false;
         }
 
-        ASSERT(record->key == storageKey);
+        ASSERT(record.key == storageKey);
 
-        auto entry = Entry::decodeStorageRecord(*record);
+        auto entry = Entry::decodeStorageRecord(record);
 
         auto useDecision = entry ? makeUseDecision(networkProcess, sessionID, *entry, request) : UseDecision::NoDueToDecodeFailure;
         switch (useDecision) {

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
@@ -428,11 +428,12 @@ void SpeculativeLoadManager::addPreloadedEntry(std::unique_ptr<Entry> entry, con
 void SpeculativeLoadManager::retrieveEntryFromStorage(const SubresourceInfo& info, RetrieveCompletionHandler&& completionHandler)
 {
     protectedStorage()->retrieve(info.key(), static_cast<unsigned>(info.priority()), [completionHandler = WTFMove(completionHandler)](auto record, auto timings) {
-        if (!record) {
+        if (record.isNull()) {
             completionHandler(nullptr);
             return false;
         }
-        auto entry = Entry::decodeStorageRecord(*record);
+
+        auto entry = Entry::decodeStorageRecord(record);
         if (!entry) {
             completionHandler(nullptr);
             return false;
@@ -628,12 +629,12 @@ void SpeculativeLoadManager::retrieveSubresourcesEntry(const Key& storageKey, WT
     RefPtr storage = m_storage.get();
     auto subresourcesStorageKey = makeSubresourcesKey(storageKey, storage->salt());
     storage->retrieve(subresourcesStorageKey, static_cast<unsigned>(ResourceLoadPriority::Medium), [completionHandler = WTFMove(completionHandler)](auto record, auto timings) {
-        if (!record) {
+        if (record.isNull()) {
             completionHandler(nullptr);
             return false;
         }
 
-        auto subresourcesEntry = SubresourcesEntry::decodeStorageRecord(*record);
+        auto subresourcesEntry = SubresourcesEntry::decodeStorageRecord(record);
         if (!subresourcesEntry) {
             completionHandler(nullptr);
             return false;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -53,19 +53,30 @@ public:
     enum class Mode { Normal, AvoidRandomness };
     static RefPtr<Storage> open(const String& cachePath, Mode, size_t capacity);
 
+    enum class ReadOperationIdentifierType { };
+    using ReadOperationIdentifier = ObjectIdentifier<ReadOperationIdentifierType>;
     enum class WriteOperationIdentifierType { };
     using WriteOperationIdentifier = ObjectIdentifier<WriteOperationIdentifierType>;
 
     struct Record {
+        Record() = default;
+        Record(const Key& key, WallTime timeStamp, const Data& header, const Data& body, std::optional<SHA1::Digest> bodyHash)
+            : key(key)
+            , timeStamp(timeStamp)
+            , header(header)
+            , body(body)
+            , bodyHash(bodyHash)
+        {
+        }
         Record isolatedCopy() const & { return { crossThreadCopy(key), timeStamp, header, body, bodyHash }; }
         Record isolatedCopy() && { return { crossThreadCopy(WTFMove(key)), timeStamp, WTFMove(header), WTFMove(body), WTFMove(bodyHash) }; }
+        bool isNull() const { return key.isNull(); }
+
         Key key;
         WallTime timeStamp;
         Data header;
         Data body;
         std::optional<SHA1::Digest> bodyHash;
-
-        WTF_MAKE_TZONE_ALLOCATED(Record);
     };
 
     struct Timings {
@@ -86,7 +97,7 @@ public:
     };
 
     // This may call completion handler synchronously on failure.
-    using RetrieveCompletionHandler = CompletionHandler<bool(std::unique_ptr<Record>, const Timings&)>;
+    using RetrieveCompletionHandler = CompletionHandler<bool(Record&&, const Timings&)>;
     void retrieve(const Key&, unsigned priority, RetrieveCompletionHandler&&);
 
     using MappedBodyHandler = Function<void (const Data& mappedBody)>;
@@ -142,10 +153,10 @@ private:
     void shrinkIfNeeded();
     void shrink();
 
-    struct ReadOperation;
+    class ReadOperation;
     void dispatchReadOperation(std::unique_ptr<ReadOperation>);
     void dispatchPendingReadOperations();
-    void finishReadOperation(ReadOperation&);
+    void finishReadOperation(Storage::ReadOperationIdentifier);
     void cancelAllReadOperations();
 
     class WriteOperation;
@@ -158,7 +169,9 @@ private:
     bool shouldStoreBodyAsBlob(const Data& bodyData);
     std::optional<BlobStorage::Blob> storeBodyAsBlob(WriteOperationIdentifier, const Storage::Record&);
     Data encodeRecord(const Record&, std::optional<BlobStorage::Blob>);
-    void readRecord(ReadOperation&, const Data&);
+    Record readRecord(const Data&);
+    void readRecordFromData(Storage::ReadOperationIdentifier, MonotonicTime, Data&&, int error);
+    void readBlobIfNecessary(Storage::ReadOperationIdentifier, const String& blobPath);
 
     void updateFileModificationTime(String&& path);
     void removeFromPendingWriteOperations(const Key&);
@@ -202,7 +215,7 @@ private:
     Vector<Key::HashType> m_blobFilterHashesAddedDuringSynchronization;
 
     PriorityQueue<std::unique_ptr<ReadOperation>, &isHigherPriority> m_pendingReadOperations;
-    HashSet<std::unique_ptr<ReadOperation>> m_activeReadOperations;
+    HashMap<ReadOperationIdentifier, std::unique_ptr<ReadOperation>> m_activeReadOperations;
     WebCore::Timer m_readOperationTimeoutTimer;
 
     Lock m_activitiesLock;


### PR DESCRIPTION
#### 95f161190996936606fdf875b3d25a1f61639234
<pre>
Ensure usage of ReadOperation is thread-safe
<a href="https://bugs.webkit.org/show_bug.cgi?id=282994">https://bugs.webkit.org/show_bug.cgi?id=282994</a>
<a href="https://rdar.apple.com/139734750">rdar://139734750</a>

Reviewed by Ben Nham.

NetworkCache::Storage::ReadOperation is not thread-safe. However, NetworkCache::Storage is accessing ReadOperation and
its members directly from different threads; see Storage::dispatchReadOperation for an example. This existing usage
is error-prone and could lead to unexpected results, like the issue 286129@main fixed. To make it more robust, this
patch makes a few changes:
1. Ensure ReadOperation is only accessed from main thread. The background threads only get identifier of ReadOperation,
and file paths. When they complete tasks to read and parse file data, they send back the identifier and results back to
main thread, and main thread will finish operation.
2. Make ReadOperation not hold strong reference to Storage and capture the reference in tasks instead.
3. Make ReadOperation class instead of struct, so that access to members needs to be done via member functions, which
have threading assertion.
4. Stop using unique_ptr for Record, so it&apos;s easier to remember to do isolated copy when passing it across threads.

* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::retrieve):
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp:
(WebKit::NetworkCache::SpeculativeLoadManager::retrieveEntryFromStorage):
(WebKit::NetworkCache::SpeculativeLoadManager::retrieveSubresourcesEntry):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
(WebKit::NetworkCache::Storage::ReadOperation::ReadOperation):
(WebKit::NetworkCache::Storage::ReadOperation::identifier const):
(WebKit::NetworkCache::Storage::ReadOperation::key const):
(WebKit::NetworkCache::Storage::ReadOperation::priority const):
(WebKit::NetworkCache::Storage::ReadOperation::isCanceled const):
(WebKit::NetworkCache::Storage::ReadOperation::canFinish const):
(WebKit::NetworkCache::Storage::ReadOperation::setWaitsForBlob):
(WebKit::NetworkCache::Storage::isHigherPriority):
(WebKit::NetworkCache::Storage::ReadOperation::updateForStart):
(WebKit::NetworkCache::Storage::ReadOperation::updateForDispatch):
(WebKit::NetworkCache::Storage::ReadOperation::cancel):
(WebKit::NetworkCache::Storage::ReadOperation::finish):
(WebKit::NetworkCache::Storage::ReadOperation::finishReadRecord):
(WebKit::NetworkCache::Storage::ReadOperation::finishReadBlob):
(WebKit::NetworkCache::Storage::readRecord):
(WebKit::NetworkCache::Storage::dispatchReadOperation):
(WebKit::NetworkCache::Storage::readRecordFromData):
(WebKit::NetworkCache::Storage::readBlobIfNecessary):
(WebKit::NetworkCache::Storage::finishReadOperation):
(WebKit::NetworkCache::Storage::cancelAllReadOperations):
(WebKit::NetworkCache::retrieveFromMemory):
(WebKit::NetworkCache::Storage::retrieve):
(WebKit::NetworkCache::nextReadOperationOrdinal): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:
(WebKit::NetworkCache::Storage::Record::Record):
(WebKit::NetworkCache::Storage::Record::isNull const):

Canonical link: <a href="https://commits.webkit.org/286646@main">https://commits.webkit.org/286646@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58825dbc1a0b939e191c6002a01ad1b2b91cfbb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80826 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27587 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3641 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59843 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17966 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79382 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40183 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47144 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25909 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82282 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2413 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68062 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67375 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16863 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11339 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9440 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3635 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6442 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3658 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7087 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5416 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->