### PR TITLE
[Yarr] Improve processing of [\s\S] character classes

### DIFF
--- a/JSTests/microbenchmarks/regexp-anychar-character-classes.js
+++ b/JSTests/microbenchmarks/regexp-anychar-character-classes.js
@@ -1,0 +1,22 @@
+(function() {
+    var result = 0;
+    var n = 1000000;
+    let str1 = "1234  Abc123 5678 EOL";
+    for (let i = 0; i < n; ++i) {
+        let re1 = /([\s\S]+?)Abc123([\s\S]+)EOL/;
+        let re2 = /([\s\S]+)ABC123([\s\S]+)EOL/i;
+        let re3 = /([\s\S]*?)Abc123([\s\S]+)EOL/;
+        let re4 = /([\s\S]*)ABC123([\s\S]+)EOL/i;
+
+        if (re1.test(str1))
+            ++result;
+        if (re2.test(str1))
+            ++result;
+        if (re3.test(str1))
+            ++result;
+        if (re4.test(str1))
+            ++result;
+    }
+    if (result != n * 4)
+        throw "Error: bad result: " + result;
+})();

--- a/JSTests/stress/regexp-character-class-coalescing.js
+++ b/JSTests/stress/regexp-character-class-coalescing.js
@@ -1,0 +1,195 @@
+// With verbose set to false, this test is successful if there is no output.  Set verbose to true to see expected matches.
+let verbose = false;
+
+function arrayToString(arr)
+{
+    let str = '';
+    arr.forEach(function(v, index) {
+        if (typeof v == "string")
+            str += "\"" + v + "\"";
+        else
+            str += v;
+
+        if (index != (arr.length - 1))
+            str += ',';
+      });
+  return str;
+}
+
+function objectToString(obj)
+{
+    let str = "";
+
+    firstEntry = true;
+
+    for (const [key, value] of Object.entries(obj)) {
+        if (!firstEntry)
+            str += ", ";
+
+        str += key + ": " + dumpValue(value);
+
+        firstEntry = false;
+    }
+
+    return "{ " + str + " }";
+}
+
+function dumpValue(v)
+{
+    if (v === null)
+        return "<null>";
+
+    if (v === undefined)
+        return "<undefined>";
+
+    if (typeof v == "string")
+        return "\"" + v + "\"";
+
+    let str = "";
+
+    if (v.length)
+        str += arrayToString(v);
+
+    if (v.groups) {
+        groupStr = objectToString(v.groups);
+
+        if (str.length) {
+            if ( groupStr.length)
+                str += ", " + groupStr;
+        } else
+            str = groupStr;
+    }
+
+    return "[ " + str + " ]";
+}
+
+function compareArray(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected is null, actual is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected is not null, actual is null");
+        return false;
+    }
+
+    if (expected.length !== actual.length) {
+        print("### expected.length: " + expected.length + ", actual.length: " + actual.length);
+        return false;
+    }
+
+    for (var i = 0; i < expected.length; i++) {
+        if (expected[i] !== actual[i]) {
+            print("### expected[" + i + "]: \"" + expected[i] + "\" !== actual[" + i + "]: \"" + actual[i] + "\"");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function compareGroups(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected group is null, actual group is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected group is not null, actual group is null");
+        return false;
+    }
+
+    for (const key in expected) {
+        if (expected[key] !== actual[key]) {
+            print("### expected." + key + ": " + dumpValue(expected[key]) + " !== actual." + key + ": " + dumpValue(actual[key]));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+let testNumber = 0;
+
+function testRegExp(re, str, exp, groups)
+{
+    testNumber++;
+
+    if (groups)
+        exp.groups = groups;
+
+    let actual = re.exec(str);
+
+    let result = compareArray(exp, actual);;
+
+    if (exp && exp.groups) {
+        if (!compareGroups(exp.groups, actual.groups))
+            result = false;
+    }
+
+    if (result) {
+        if (verbose)
+            print(re.toString() + ".exec(" + dumpValue(str) + "), passed ", dumpValue(exp));
+    } else
+        print(re.toString() + ".exec(" + dumpValue(str) + "), FAILED test #" + testNumber + ", Expected ", dumpValue(exp), " got ", dumpValue(actual));
+}
+
+function testRegExpSyntaxError(reString, flags, expError)
+{
+    testNumber++;
+
+
+    try {
+        let re = new RegExp(reString, flags);
+        print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\", but it didn't");
+    } catch (e) {
+        if (e != expError)
+            print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\" got \"" + e + "\"");
+        else if (verbose)
+            print("/" + reString + "/" + flags + " passed, it threw \"" + expError + "\" as expected");
+    }
+}
+
+// Test 1
+testRegExp(/([\s\S]+?)Abc123([\s\S]+)EOL/, "1234  Abc123 5678 EOL", ["1234  Abc123 5678 EOL", "1234  ", " 5678 "]);
+testRegExp(/([\s\S]+)ABC123([\s\S]+)EOL/i, "1234  Abc123 5678 EOL", ["1234  Abc123 5678 EOL", "1234  ", " 5678 "]);
+testRegExp(/([\s\S]*?)Abc123([\s\S]+)EOL/, "1234  Abc123 5678 EOL", ["1234  Abc123 5678 EOL", "1234  ", " 5678 "]);
+testRegExp(/([\s\S]*)ABC123([\s\S]+)EOL/i, "1234  Abc123 5678 EOL", ["1234  Abc123 5678 EOL", "1234  ", " 5678 "]);
+testRegExp(/([\s\S]+?)Français([\s\S]+)EOL/, "1234  Français 5678 EOL", ["1234  Français 5678 EOL", "1234  ", " 5678 "]);
+
+// Test 6
+testRegExp(/([\s\S]+?)\u{03c0} = 3\.1415([\s\S]+)/u, "The value of \u{03c0} = 3.14159265358979", ["The value of \u{03c0} = 3.14159265358979", "The value of ", "9265358979"]);
+testRegExp(/([\s\S]+?) Abc123([\s\S]+)EOL/u, "1234 \u{180e} Abc123 5678 EOL", ["1234 \u{180e} Abc123 5678 EOL", "1234 \u{180e}", " 5678 "]);
+testRegExp(/([\s\S\u{180e}]+?) Abc123([\s\S]+)EOL/u, "1234 \u{180e} Abc123 5678 EOL", ["1234 \u{180e} Abc123 5678 EOL", "1234 \u{180e}", " 5678 "]);
+testRegExp(/\S+/, " \u{180e} ", ["\u{180e}"]);
+testRegExp(/[\S+X]/, " \u{180e} ", ["\u{180e}"]);
+
+// Test 11
+testRegExp(/([\s\S\q{Abc123}]+?)Abc123([\s\S]+)EOL/v, "1234  Abc123 5678 EOL", ["1234  Abc123 5678 EOL", "1234  ", " 5678 "]);
+testRegExp(/([\s\S\q{Abc123}]+)Abc123([\s\S]+)EOL/v, "1234  Abc123 5678 EOL", ["1234  Abc123 5678 EOL", "1234  ", " 5678 "]);
+
+// Test 13...22
+// Create a character class of all lower and upper case characters in random order.
+let r1 = /([vcWZtzagTVGHjshEKJUCYueMoQyAFPSqDwilIkBROpmfNnrxdbLX]*)[\s\.]/g;
+let s1 = "The quick brown fox jumped over the lazy dogs back.";
+
+testRegExp(r1, s1, ["The ", "The"]);
+testRegExp(r1, s1, ["quick ", "quick"]);
+testRegExp(r1, s1, ["brown ", "brown"]);
+testRegExp(r1, s1, ["fox ", "fox"]);
+testRegExp(r1, s1, ["jumped ", "jumped"]);
+testRegExp(r1, s1, ["over ", "over"]);
+testRegExp(r1, s1, ["the ", "the"]);
+testRegExp(r1, s1, ["lazy ", "lazy"]);
+testRegExp(r1, s1, ["dogs ", "dogs"]);
+testRegExp(r1, s1, ["back.", "back"]);
+

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -129,6 +129,8 @@ public:
     {
     }
 
+    void copyOnly8BitCharacterData(const CharacterClass& other);
+
     bool hasNonBMPCharacters() const { return m_characterWidths & CharacterClassWidths::HasNonBMPChars; }
 
     bool hasOneCharacterSize() const { return m_characterWidths == CharacterClassWidths::HasBMPChars || m_characterWidths == CharacterClassWidths::HasNonBMPChars; }

--- a/Source/JavaScriptCore/yarr/create_regex_tables
+++ b/Source/JavaScriptCore/yarr/create_regex_tables
@@ -33,7 +33,7 @@ types = {
     "nonwordUnicodeIgnoreCaseChar": { "UseTable" : False, "Inverse": "wordUnicodeIgnoreCaseChar", "data": ['`', (0, ord('0') - 1), (ord('9') + 1, ord('A') - 1), (ord('Z') + 1, ord('_') - 1), (ord('z') + 1, 0x017e), (0x0180, 0x2129), (0x212b, 0x10ffff)]},
     "newline": { "UseTable" : False, "data": ['\n', '\r', 0x2028, 0x2029]},
     "spaces": { "UseTable" : True, "data": [' ', ('\t', '\r'), 0xa0, 0x1680, 0x2028, 0x2029, 0x202f, 0x205f, 0x3000, (0x2000, 0x200a), 0xfeff]},
-    "nonspaces": { "UseTable" : True, "Inverse": "spaces", "data": [(0, ord('\t') - 1), (ord('\r') + 1, ord(' ') - 1), (ord(' ') + 1, 0x009f), (0x00a1, 0x167f), (0x1681, 0x180d), (0x180f, 0x1fff), (0x200b, 0x2027), (0x202a, 0x202e), (0x2030, 0x205e), (0x2060, 0x2fff), (0x3001, 0xfefe), (0xff00, 0x10ffff)]},
+    "nonspaces": { "UseTable" : True, "Inverse": "spaces", "data": [(0, ord('\t') - 1), (ord('\r') + 1, ord(' ') - 1), (ord(' ') + 1, 0x009f), (0x00a1, 0x167f), (0x1681, 0x1fff), (0x200b, 0x2027), (0x202a, 0x202e), (0x2030, 0x205e), (0x2060, 0x2fff), (0x3001, 0xfefe), (0xff00, 0x10ffff)]},
     "digits": { "UseTable" : False, "data": [('0', '9')]},
     "nondigits": { "UseTable" : False, "Inverse": "digits", "data": [(0, ord('0') - 1), (ord('9') + 1, 0x10ffff)] }
 }


### PR DESCRIPTION
#### e6ee2eb472c1b527eef8a439a7c6d227955271ac
<pre>
[Yarr] Improve processing of [\s\S] character classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=283003">https://bugs.webkit.org/show_bug.cgi?id=283003</a>
<a href="https://rdar.apple.com/135409524">rdar://135409524</a>

Reviewed by Yusuke Suzuki.

The character class [\s\S], which is all white space and non-white space characters is used in lieu of
‘.’ (any character).  Many developers use [\s\S] instead of ’.’ because the ‘.’ any character does not
include line terminators unless the dot all ’s’ flag is added to the regex.  The character class [\s\S]
matches any character regardless of flags added to the expression.

The processing of [\s\S] was sub optimal due to several issues.
 1. The code was not coalescing the combination of \s and \S into a single combined range of 0...max
    character.
 2. The JIT generation of regex’s for 8-bit strings that contained character classes with code points
    greater than 255 still included comparisons to 16 bit code points.
 3. The code point U+180E, the Mongolian Vowel Separator, was changed from being white space to non-white
    space with ECMAScript 2016.  Our code generator for \S was not changed to include that code point.
    When \S was used by itself, matching was done with the _spacesData table instead of using individual
    code points and ranges.  When combined with \s, or any other character class, we weren’t matching U+180E.
 4. When using the ‘v’ flag, the character class processing for an “any character” character classes that
    also contained strings did not process those strings.

Fixed these issues by fixing the coalescing code to reduce produced character classes to the minimum set
of individual code points and code point ranges to check.  Added code to extract the 8 bit only part of
a character class before emitting the JIT code.  Added U+180E to the non-spaces built-in character class.
Changed Yarr::matchCharacterClassTermInner() to handle strings with with all character class sets including
those that match all character.

After these changes, the ARM v8 code size for the test regexp, /([\s\S]+?)Abc123([\s\S]+)EOL/ went from
1460 bytes down to 356 bytes.

Added tests for these changes.  Also added a new micro benchmark to test performance improvements of
[\s\S] in four similar regular expressions.  These regular expressions differ in greediness and the
minimum match size.  On an M3 equipped MacBook Pro, that benchmark shows a 2+ times improvement.

                                     Baseline         FixCharacterClasses
regexp-anychar-character-classes:  112.3561+-2.4038  52.8811+-3.0929    ^ definitely 2.1247x faster

* JSTests/microbenchmarks/regexp-anychar-character-classes.js: Added.
* JSTests/stress/regexp-character-class-coalescing.js: Added.
(arrayToString):
(objectToString):
(dumpValue):
(compareArray):
(compareGroups):
(testRegExp):
(testRegExpSyntaxError):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::CharacterClassConstructor::unicodeOpSorted):
(JSC::Yarr::CharacterClassConstructor::coalesceTables):
(JSC::Yarr::YarrPatternConstructor::atomCharacterClassEnd):
(JSC::Yarr::CharacterClass::copyOnly8BitCharacterData):
* Source/JavaScriptCore/yarr/YarrPattern.h:
* Source/JavaScriptCore/yarr/create_regex_tables:

Canonical link: <a href="https://commits.webkit.org/286509@main">https://commits.webkit.org/286509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb0fbf0f3327fa9e8c23bbfd18a01ef79ee8ce27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80696 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27438 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3489 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17874 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79230 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65415 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/40088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47012 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22898 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25757 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69342 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68145 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82127 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75439 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3535 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2296 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/stale-while-revalidate/fetch.any.serviceworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67947 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67257 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11211 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9331 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97693 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11789 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3483 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21375 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3506 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/6933 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5264 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->