### PR TITLE
[WebGPU] GPUCommandEncoder.beginRend erPass() with destroyed depth stencil attachment fails metal validation

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-283006-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-283006-expected.txt
@@ -1,0 +1,62 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 785x665
+  RenderView at (0,0) size 785x600
+layer at (0,0) size 785x665
+  RenderBlock {HTML} at (0,0) size 785x665 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x649
+      RenderImage {IMG} at (0,88) size 55x62
+      RenderImage {IMG} at (55,84) size 155x66
+      RenderHTMLCanvas {CANVAS} at (210,0) size 300x150
+      RenderText {#text} at (510,137) size 31x17
+        text run at (510,137) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (540,137) size 80x17
+        text run at (540,137) width 80: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (619,137) size 70x17
+        text run at (619,137) width 7 RTL: "\x{692}"
+        text run at (625,137) width 64: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (316,156) size 298x170
+      RenderText {#text} at (614,313) size 103x17
+        text run at (614,313) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (130,573) size 100x17
+        text run at (130,573) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (229,573) size 117x17
+        text run at (229,573) width 31: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (259,573) width 11 RTL: "\x{79B}"
+        text run at (269,573) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (345,333) size 293x253
+      RenderText {#text} at (637,573) size 104x17
+        text run at (637,573) width 104: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (0,573) size 762x48
+        text run at (740,573) width 22: "\x{10D}\x{BA96}"
+        text run at (0,604) width 83: "\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (82,604) size 102x17
+        text run at (82,604) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (183,604) size 115x17
+        text run at (183,604) width 115: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (297,604) size 35x17
+        text run at (297,604) width 35: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (331,604) size 120x17
+        text run at (331,604) width 26: "\x{24BF}\x{B00}"
+        text run at (356,604) width 12 RTL: "\x{5FF}"
+        text run at (367,604) width 14: "\x{2FA}\x{B13}"
+        text run at (380,604) width 11 RTL: "\x{8BC}"
+        text run at (390,604) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (450,604) size 88x17
+        text run at (450,604) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (537,604) size 88x17
+        text run at (537,604) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (624,604) size 22x17
+        text run at (624,604) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (645,604) size 111x17
+        text run at (645,604) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (0,604) size 767x43
+        text run at (755,604) width 12: "\x{ECB8}"
+        text run at (0,630) width 68: "\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (67,630) size 85x17
+        text run at (67,630) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+layer at (8,184) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,176) size 300x150
+layer at (308,318) size 16x16
+  RenderVideo {VIDEO} at (300,310) size 16x16
+layer at (8,381) size 130x213
+  RenderVideo {VIDEO} at (0,373) size 130x213

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-283006.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-283006.html
@@ -1,0 +1,317 @@
+</style>
+<script>
+async function videoWithData() {
+ Promise(resolve => {
+ });
+}
+/**
+*/
+async function makeDataUrl(width, color1) {
+ Promise(resolve => {
+ fileReader.onload = () => {
+ };
+ });
+}
+onload = async () => {
+ try {
+let adapter0 = await navigator.gpu.requestAdapter();
+let device0 = await adapter0.requestDevice({
+ requiredFeatures: [
+ ],
+ requiredLimits: {
+ },
+});
+let = device0.createRenderBundleEncoder({
+ colorFormats: [],
+});
+let = device0.createBuffer({
+ size: 4464,
+ usage: GPUBufferUsage.VERTEX,
+});
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+let = device0.createRenderBundleEncoder({
+ colorFormats: [],
+});
+let texture0 = device0.createTexture({
+ size: {width: 110, depthOrArrayLayers: 1},
+ format: 'depth32float',
+ usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let = texture0.createView({label: '\u0680\u{1f7f7}\uc877', aspect: 'depth-only'});
+try {
+} catch {}
+let = device0.createBuffer({
+ size: 12499,
+ usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+try {
+} catch {}
+try {
+} catch {}
+let texture3 = device0.createTexture({
+ size: [27, 1],
+ format: 'depth32float',
+ usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let = device0.createTexture({
+ size: {width: 1},
+ format: 'depth32float',
+ usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+} catch {}
+try {
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder({label: '\u9d94\u{1fa6b}\u904a\u0340\u48dc\ue9a9\uda76'});
+try {
+} catch {}
+let textureView4 = texture3.createView({
+});
+let = commandEncoder22.beginRenderPass({
+ colorAttachments: [],
+ depthStencilAttachment: {
+ view: textureView4,
+ },
+});
+try {
+} catch {}
+try {
+} catch {}
+let texture5 = device0.createTexture({
+ size: {width: 220, depthOrArrayLayers: 1},
+ sampleCount: 4,
+ format: 'depth32float',
+ usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder({});
+let = device0.createTexture({
+ size: [471, 1],
+ format: 'depth32float',
+ usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let = commandEncoder23.beginRenderPass({
+ colorAttachments: [],
+});
+try {
+} catch {}
+try {
+} catch {}
+try {
+gpuCanvasContext0.configure({
+});
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder({});
+let = commandEncoder24.beginRenderPass({
+ colorAttachments: [],
+});
+try {
+} catch {}
+try {
+} catch {}
+let = device0.createShaderModule({
+ code: `
+`,
+});
+let commandEncoder26 = device0.createCommandEncoder({label: '\u0c18\u{1f6c9}\u198d\u59bb\u9f55'});
+let = commandEncoder26.beginRenderPass({
+ colorAttachments: [],
+});
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+let = device0.createRenderBundleEncoder({
+ colorFormats: ['rgba16float'],
+});
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+let = device0.createComputePipelineAsync({
+});
+let = device0.createRenderBundleEncoder({
+ colorFormats: [],
+});
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+let = device0.createBindGroupLayout({
+ entries: [
+ {
+ binding: 221,
+ visibility: GPUShaderStage.FRAGMENT,
+ },
+ {
+ binding: 167,
+ visibility: GPUShaderStage.COMPUTE,
+ },
+ ],
+});
+let = device0.createSampler({
+});
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+let = device0.createBindGroupLayout({
+ entries: [
+ ],
+});
+let = device0.createBuffer({
+ size: 28498,
+ usage: GPUBufferUsage.QUERY_RESOLVE,
+});
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+let = device0.createBuffer({
+ size: 5286,
+ usage: GPUBufferUsage.MAP_WRITE,
+});
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+try {
+commandEncoder34.copyTextureToBuffer({
+}, {width: 117, depthOrArrayLayers: 0});
+} catch {}
+try {
+} catch {}
+let = device0.createShaderModule({
+ code: `
+`,
+});
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+try {
+} catch {}
+let textureView9 = texture5.createView({label: '\u0d7c\u013f\u{1fb02}\u03a1\u0914\u{1f843}', usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+} catch {}
+let = device0.createTexture({
+ size: {width: 35},
+ format: 'depth32float',
+ usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+} catch {}
+try {
+} catch {}
+try {
+device0.queue.writeTexture({
+}, /* */
+{offset: 12}, {width: 155, depthOrArrayLayers: 0});
+} catch {}
+try {
+} catch {}
+try {
+texture5.destroy();
+} catch {}
+let = device0.createTexture({
+ size: [27, 21],
+ format: 'depth32float',
+ usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+} catch {}
+try {
+} catch {}
+let = device0.createRenderBundleEncoder({
+ colorFormats: [],
+});
+try {
+} catch {}
+try {
+gpuCanvasContext0.configure({
+});
+} catch {}
+let commandEncoder66 = device0.createCommandEncoder({label: '\u738b\u7632\ufd36\u0da4\u0627'});
+try {
+} catch {}
+try {
+} catch {}
+let = commandEncoder66.beginRenderPass({
+ colorAttachments: [],
+ depthStencilAttachment: {
+ view: textureView9,
+ },
+});
+try {
+} catch {}
+try {
+} catch {}
+try {
+device0.queue.writeTexture({
+}, /* {
+device0.queue.copyExternalImageToTexture(/*
+*/
+{
+}, {width: 0, depthOrArrayLayers: 0});
+} catch {}
+let = device1.createBuffer({
+});
+try {
+} catch {}
+ } catch {
+ if (e instanceof GPUPipelineError) {
+ {
+ }
+ }
+ }
+};
+</script>

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -661,7 +661,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             return RenderPassEncoder::createInvalid(*this, m_device, @"depth clear value is invalid");
 
         if (zeroColorTargets) {
-            mtlDescriptor.defaultRasterSampleCount = textureView->sampleCount();
+            mtlDescriptor.defaultRasterSampleCount = metalDepthStencilTexture.sampleCount;
             if (!mtlDescriptor.defaultRasterSampleCount)
                 return RenderPassEncoder::createInvalid(*this, m_device, @"no color targets and depth-stencil texture is nil");
             mtlDescriptor.renderTargetWidth = metalDepthStencilTexture.width;


### PR DESCRIPTION
#### 7462a7f829b55d76be6cc2562995a321ea678bfe
<pre>
[WebGPU] GPUCommandEncoder.beginRend erPass() with destroyed depth stencil attachment fails metal validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=283006">https://bugs.webkit.org/show_bug.cgi?id=283006</a>
<a href="https://rdar.apple.com/139724374">rdar://139724374</a>

Reviewed by Tadeu Zagallo.

Followup from <a href="https://commits.webkit.org/278326@main">https://commits.webkit.org/278326@main</a>, we should use the
sample count on the actual texture, as it may have been destroyed.

* LayoutTests/fast/webgpu/nocrash/fuzz-283006-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-283006.html: Added.
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::beginRenderPass):

Canonical link: <a href="https://commits.webkit.org/286546@main">https://commits.webkit.org/286546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9347a8b5b8bffc5b07d3619bf46d48539440aa3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29071 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80672 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27437 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59720 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17868 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49620 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40069 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22897 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25763 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68149 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23232 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82133 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3541 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2300 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67949 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67259 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16794 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11218 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9330 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3489 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3512 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/6939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->