### PR TITLE
REGRESSION(265569@main): SVG paths can get clipped at tile boundaries

### DIFF
--- a/LayoutTests/svg/custom/quadratic-path-in-tiled-layer-expected.html
+++ b/LayoutTests/svg/custom/quadratic-path-in-tiled-layer-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <style>
+        .container {
+            width: 2049px;
+            will-change: transform;
+            border: 1px solid blue;
+        }
+        
+        svg {
+            width: 1024px;
+        }
+    </style>
+</head>
+<body>
+    <p>You should see a complete curve below.</p>
+    <div class="container">
+        <svg viewBox="0 0 676 480">
+           <g transform="translate(15, 300) scale(1, -1)">
+              <path fill="green" stroke="none" stroke-width="2" d="M100,0 C166,218 233,218 300,0"></path>
+           </g>
+        </svg>
+    </div>
+</body>
+</html>

--- a/LayoutTests/svg/custom/quadratic-path-in-tiled-layer.html
+++ b/LayoutTests/svg/custom/quadratic-path-in-tiled-layer.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-934" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <style>
+        .container {
+            width: 2049px;
+            will-change: transform;
+            border: 1px solid blue;
+        }
+        
+        svg {
+            width: 1024px;
+        }
+    </style>
+</head>
+<body>
+    <p>You should see a complete curve below.</p>
+    <div class="container">
+        <svg viewBox="0 0 676 480">
+           <g transform="translate(15, 300) scale(1, -1)">
+              <path fill="green" stroke="none" d="M100,0 Q200,328 300,0"></path>
+           </g>
+        </svg>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/PathSegmentData.cpp
+++ b/Source/WebCore/platform/graphics/PathSegmentData.cpp
@@ -243,8 +243,17 @@ static std::pair<float, float> calculateBezierExtremities(float p0, float p1, fl
     float b = 6 * j - 6 * i;
     float c = 3 * i;
 
-    if (abs(a) < 0.00001) {
-        float t = -c / b;
+    static constexpr float epsilon = 0.1;
+
+    // Solve for the linear equation bt + c = 0.
+    if (abs(a) < epsilon) {
+        float t;
+        // Get the t-coordinate of the quadartic curve vertex. It has to
+        // be the mid-point between the current point and the end point.
+        if (abs(b) < epsilon)
+            t = 0.5;
+        else
+            t = -c / b;
         float s = calculateBezier(t, p0, p1, p2, p3);
         return std::make_pair(s, s);
     }


### PR DESCRIPTION
#### 5eadead07f655bd2a9728cf87b8bbfe89e9e8cda
<pre>
REGRESSION(265569@main): SVG paths can get clipped at tile boundaries
<a href="https://bugs.webkit.org/show_bug.cgi?id=279105">https://bugs.webkit.org/show_bug.cgi?id=279105</a>
<a href="https://rdar.apple.com/135280080">rdar://135280080</a>

Reviewed by Simon Fraser.

When the distance between the current point and the end point of a cubic Bézier
curve is split into three equal parts with the two control points, the slope of
the curve can&apos;t be calculated from the derivative of the curve equation.

But in this case, the curve has to be quadratic which means the t-coordinate of
its vertex must be the mid-point between the current point and the end point.

* LayoutTests/svg/custom/quadratic-path-in-tiled-layer-expected.html: Added.
* LayoutTests/svg/custom/quadratic-path-in-tiled-layer.html: Added.
* Source/WebCore/platform/graphics/PathSegmentData.cpp:
(WebCore::calculateBezierExtremities):

Canonical link: <a href="https://commits.webkit.org/286550@main">https://commits.webkit.org/286550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a334d155fe9fb73586b9cd06ceb305ab6159ab24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80740 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27506 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78350 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59827 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17915 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65470 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40121 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47075 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22956 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25828 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68205 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82199 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2353 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68002 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67311 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16797 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11268 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9381 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3554 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6361 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3577 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7006 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5335 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->