### PR TITLE
[iOS] Selection in overflow scroller is sometimes offset from selected content while scrolling

### DIFF
--- a/Source/WebCore/platform/ios/SelectionGeometry.cpp
+++ b/Source/WebCore/platform/ios/SelectionGeometry.cpp
@@ -139,6 +139,15 @@ void SelectionGeometry::setRect(const IntRect& rect)
     m_cachedEnclosingRect = rect;
 }
 
+void SelectionGeometry::move(float x, float y)
+{
+    m_quad.move(x, y);
+    m_minX += x;
+    m_maxX += x;
+    m_maxY += y;
+    m_cachedEnclosingRect.reset();
+}
+
 TextStream& operator<<(TextStream& stream, const SelectionGeometry& rect)
 {
     TextStream::GroupScope group(stream);

--- a/Source/WebCore/platform/ios/SelectionGeometry.h
+++ b/Source/WebCore/platform/ios/SelectionGeometry.h
@@ -92,6 +92,8 @@ public:
     void setBehavior(SelectionRenderingBehavior behavior) { m_behavior = behavior; }
     void setMayAppearLogicallyDiscontiguous(bool value) { m_mayAppearLogicallyDiscontiguous = value; }
 
+    WEBCORE_EXPORT void move(float x, float y);
+
 private:
     FloatQuad m_quad;
     SelectionRenderingBehavior m_behavior { SelectionRenderingBehavior::CoalesceBoundingRects };

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -199,7 +199,7 @@ public:
     IntPoint convertFromScrollbarToContainingView(const Scrollbar&, const IntPoint&) const final;
     IntPoint convertFromContainingViewToScrollbar(const Scrollbar&, const IntPoint&) const final;
     void setScrollOffset(const ScrollOffset&) final;
-    std::optional<ScrollingNodeID> scrollingNodeID() const final;
+    WEBCORE_EXPORT std::optional<ScrollingNodeID> scrollingNodeID() const final;
 
     IntRect visibleContentRectInternal(VisibleContentRectIncludesScrollbars, VisibleContentRectBehavior) const final;
     IntSize overhangAmount() const final;

--- a/Source/WebKit/Shared/EditorState.cpp
+++ b/Source/WebKit/Shared/EditorState.cpp
@@ -180,4 +180,33 @@ void EditorState::clipOwnedRectExtentsToNumericLimits()
         sanitizeVisualData(*visualData);
 }
 
+void EditorState::move(float x, float y)
+{
+    if (!hasVisualData())
+        return;
+
+    if (!x && !y)
+        return;
+
+#if PLATFORM(IOS_FAMILY) || PLATFORM(GTK) || PLATFORM(WPE)
+    int roundedX = std::round(x);
+    int roundedY = std::round(y);
+    visualData->caretRectAtStart.move(roundedX, roundedY);
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+    visualData->selectionClipRect.move(roundedX, roundedY);
+    visualData->editableRootBounds.move(roundedX, roundedY);
+    visualData->caretRectAtEnd.move(roundedX, roundedY);
+    visualData->markedTextCaretRectAtStart.move(roundedX, roundedY);
+    visualData->markedTextCaretRectAtEnd.move(roundedX, roundedY);
+    for (auto& geometry : visualData->selectionGeometries)
+        geometry.move(x, y);
+    for (auto& geometry : visualData->markedTextRects)
+        geometry.move(x, y);
+#endif // PLATFORM(IOS_FAMILY)
+
+    clipOwnedRectExtentsToNumericLimits();
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/EditorState.h
+++ b/Source/WebKit/Shared/EditorState.h
@@ -32,6 +32,7 @@
 #include <WebCore/FontAttributes.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/PlatformLayerIdentifier.h>
+#include <WebCore/ScrollTypes.h>
 #include <WebCore/WritingDirection.h>
 #include <wtf/text/WTFString.h>
 
@@ -71,6 +72,8 @@ enum class ListType : uint8_t {
 };
 
 struct EditorState {
+    void move(float x, float y);
+
     EditorStateIdentifier identifier;
     bool shouldIgnoreSelectionChanges { false };
     bool selectionIsNone { true }; // This will be false when there is a caret selection.
@@ -155,6 +158,8 @@ struct EditorState {
         WebCore::IntRect markedTextCaretRectAtStart;
         WebCore::IntRect markedTextCaretRectAtEnd;
         std::optional<WebCore::PlatformLayerIdentifier> enclosingLayerID;
+        std::optional<WebCore::ScrollingNodeID> enclosingScrollingNodeID;
+        WebCore::ScrollPosition enclosingScrollPosition;
 #endif // PLATFORM(IOS_FAMILY)
     };
 

--- a/Source/WebKit/Shared/EditorState.serialization.in
+++ b/Source/WebKit/Shared/EditorState.serialization.in
@@ -61,6 +61,8 @@ struct WebKit::EditorState {
     std::optional<WebKit::EditorState::VisualData> visualData;
 };
 
+using WebCore::ScrollPosition = WebCore::IntPoint;
+
 [Nested] struct WebKit::EditorState::PostLayoutData {
     OptionSet<WebKit::TypingAttribute> typingAttributes;
 #if PLATFORM(COCOA)
@@ -126,5 +128,7 @@ struct WebKit::EditorState {
     WebCore::IntRect markedTextCaretRectAtStart;
     WebCore::IntRect markedTextCaretRectAtEnd;
     std::optional<WebCore::PlatformLayerIdentifier> enclosingLayerID;
+    std::optional<WebCore::ScrollingNodeID> enclosingScrollingNodeID;
+    WebCore::ScrollPosition enclosingScrollPosition;
 #endif
 };

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -195,6 +195,7 @@ class WebProcessProxy;
 
 enum class ContinueUnsafeLoad : bool { No, Yes };
 
+struct EditorState;
 struct FocusedElementInformation;
 struct FrameInfoData;
 struct InteractionInformationAtPosition;
@@ -536,6 +537,8 @@ public:
 
     virtual CocoaWindow *platformWindow() const = 0;
 #endif
+
+    virtual void reconcileEnclosingScrollViewContentOffset(EditorState&) { };
 
 #if PLATFORM(IOS_FAMILY)
     virtual void commitPotentialTapFailed() = 0;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -300,7 +300,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
         m_activityStateChangeID = layerTreeTransaction.activityStateChangeID();
 
         // FIXME(site-isolation): Editor state should be updated for subframes.
-        didUpdateEditorState = layerTreeTransaction.hasEditorState() && webPageProxy->updateEditorState(layerTreeTransaction.editorState(), WebPageProxy::ShouldMergeVisualEditorState::Yes);
+        didUpdateEditorState = layerTreeTransaction.hasEditorState() && webPageProxy->updateEditorState(EditorState { layerTreeTransaction.editorState() }, WebPageProxy::ShouldMergeVisualEditorState::Yes);
     }
 
 #if ENABLE(ASYNC_SCROLLING)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2014,9 +2014,9 @@ public:
 #if PLATFORM(COCOA)
     void createSandboxExtensionsIfNeeded(const Vector<String>& files, SandboxExtensionHandle& fileReadHandle, Vector<SandboxExtensionHandle>& fileUploadHandles);
 #endif
-    void editorStateChanged(const EditorState&);
+    void editorStateChanged(EditorState&&);
     enum class ShouldMergeVisualEditorState : uint8_t { No, Yes, Default };
-    bool updateEditorState(const EditorState& newEditorState, ShouldMergeVisualEditorState = ShouldMergeVisualEditorState::Default);
+    bool updateEditorState(EditorState&& newEditorState, ShouldMergeVisualEditorState = ShouldMergeVisualEditorState::Default);
     void scheduleFullEditorStateUpdate();
     void dispatchDidUpdateEditorState();
 
@@ -2928,7 +2928,7 @@ private:
     void didReceiveEvent(IPC::Connection&, WebEventType, bool handled, std::optional<WebCore::RemoteUserInputEventData>);
     void didUpdateRenderingAfterCommittingLoad();
 #if PLATFORM(IOS_FAMILY)
-    void interpretKeyEvent(const EditorState&, bool isCharEvent, CompletionHandler<void(bool)>&&);
+    void interpretKeyEvent(EditorState&&, bool isCharEvent, CompletionHandler<void(bool)>&&);
     void showPlaybackTargetPicker(bool hasVideo, const WebCore::IntRect& elementRect, WebCore::RouteSharingPolicy, const String&);
 
     void updateStringForFind(const String&);

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -201,6 +201,7 @@ private:
     void elementDidBlur() override;
     void focusedElementDidChangeInputMode(WebCore::InputMode) override;
     void didUpdateEditorState() override;
+    void reconcileEnclosingScrollViewContentOffset(EditorState&) final;
     bool isFocusingElement() override;
     void selectionDidChange() override;
     bool interpretKeyEvent(const NativeWebKeyboardEvent&, bool isCharEvent) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -700,6 +700,11 @@ void PageClientImpl::didUpdateEditorState()
     [contentView() _didUpdateEditorState];
 }
 
+void PageClientImpl::reconcileEnclosingScrollViewContentOffset(EditorState& state)
+{
+    [contentView() _reconcileEnclosingScrollViewContentOffset:state];
+}
+
 void PageClientImpl::showPlaybackTargetPicker(bool hasVideo, const IntRect& elementRect, WebCore::RouteSharingPolicy policy, const String& contextUID)
 {
     [contentView() _showPlaybackTargetPicker:hasVideo fromRect:elementRect routeSharingPolicy:policy routingContextUID:contextUID];

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -743,6 +743,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (void)_elementDidBlur;
 - (void)_didUpdateInputMode:(WebCore::InputMode)mode;
 - (void)_didUpdateEditorState;
+- (void)_reconcileEnclosingScrollViewContentOffset:(WebKit::EditorState&)state;
 - (void)_hardwareKeyboardAvailabilityChanged;
 - (void)_selectionChanged;
 - (void)_updateChangedSelection;

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -736,9 +736,9 @@ void WebPageProxy::moveSelectionByOffset(int32_t offset, CompletionHandler<void(
     }, webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::interpretKeyEvent(const EditorState& state, bool isCharEvent, CompletionHandler<void(bool)>&& completionHandler)
+void WebPageProxy::interpretKeyEvent(EditorState&& state, bool isCharEvent, CompletionHandler<void(bool)>&& completionHandler)
 {
-    updateEditorState(state);
+    updateEditorState(WTFMove(state));
     if (!hasQueuedKeyEvent())
         return completionHandler(false);
     RefPtr pageClient = this->pageClient();


### PR DESCRIPTION
#### 1e0a8f21db25c527d049ed36604c90d679f63ad5
<pre>
[iOS] Selection in overflow scroller is sometimes offset from selected content while scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=283018">https://bugs.webkit.org/show_bug.cgi?id=283018</a>

Reviewed by Aditya Keerthi.

When `SelectionHonorsOverflowScrolling` is enabled, the selection sometimes (visually) lags behind
the selected content in an overflow scrolling container. This can happen if:

1.  The editor state (which contains selection rects relative to the root view) is computed in the
    web process and sent to the UI process.

2.  While the editor state IPC is being sent via remote layer tree commit, the subscrollable area
    containing selection UI is scrolled (i.e. the content offset changes).

3.  The editor state arrives in the UI process, and we use the stale geometry data from (1) when
    generating selection drawing info.

To fix this, we add logic in the web process to send the scroll position of the enclosing scrollable
area over to the UI process, along with the rest of the editor state&apos;s visual data. In the UI
process, we then use this information to reconcile the enclosing composited scroll view&apos;s scroll
position with the (possibly stale) scroll position when we computed the editor state. If the
difference in scroll offset is more than a tiny delta (1 px), we shift the entire editor state&apos;s
geometry by the necessary amount (mapped to root view coordinates) to ensure that the selection UI
doesn&apos;t get out of sync with its enclosing scroller.

* Source/WebCore/platform/ios/SelectionGeometry.cpp:
(WebCore::SelectionGeometry::move):

Add a helper method to shift the entire `SelectionGeometry` by a given offset.

* Source/WebCore/platform/ios/SelectionGeometry.h:
* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* Source/WebKit/Shared/EditorState.cpp:
(WebKit::EditorState::move):

Add a helper method to shift all owned rects and quads in the `EditorState` by a given offset. Note
that we call `clipOwnedRectExtentsToNumericLimits()` afterwards, to ensure that the editor state
geometry is still robust against underflow / overflow.

* Source/WebKit/Shared/EditorState.h:
* Source/WebKit/Shared/EditorState.serialization.in:

Add `ScrollingNodeID` and `ScrollPosition` to the editor state&apos;s visual data.

* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::reconcileEnclosingScrollViewContentOffset):

See above for more details.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::editorStateChanged):
(WebKit::WebPageProxy::updateEditorState):

Make these take an `EditorState&amp;&amp;` rvalue reference instead of a const reference, so that we can
call into the new `PageClient` hook to reconcile the incoming editor state with subscrollers if
needed.

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::reconcileEnclosingScrollViewContentOffset):

Implement the main fix here — check if the enclosing scroller has scrolled since the editor state
was computed, and adjust incoming selection rects.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _reconcileEnclosingScrollViewContentOffset:]):
(-[WKContentView _scrollViewForScrollingNodeID:]):

Pull logic to map a `ScrollingNodeID` to `UIScrollView` out into a separate helper method, so that
we can call it from multiple places.

(-[WKContentView _updateTargetedPreviewScrollViewUsingContainerScrollingNodeID:]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::interpretKeyEvent):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::computeEnclosingLayerID const):

Additionally compute the enclosing `ScrollingNodeID` and its corresponding scroll position, and send
it through the editor state update.

Canonical link: <a href="https://commits.webkit.org/286537@main">https://commits.webkit.org/286537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa953796e69e461060b5c4fa2c9d460a4b0dd0f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11800 "Built successfully and passed tests") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-11-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-11-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->