### PR TITLE
[DEBUG-ONLY] MarkedBlock instrumentation

### DIFF
--- a/Source/JavaScriptCore/heap/BlockDirectory.cpp
+++ b/Source/JavaScriptCore/heap/BlockDirectory.cpp
@@ -174,9 +174,9 @@ void BlockDirectory::addBlock(MarkedBlock::Handle* block)
 void BlockDirectory::removeBlock(MarkedBlock::Handle* block, WillDeleteBlock willDelete)
 {
     assertIsMutatorOrMutatorIsStopped();
-    ASSERT(block->directory() == this);
-    ASSERT(m_blocks[block->index()] == block);
-    ASSERT(isInUse(block));
+    RELEASE_ASSERT(block->directory() == this);
+    RELEASE_ASSERT(m_blocks[block->index()] == block);
+    RELEASE_ASSERT(isInUse(block));
     
     subspace()->didRemoveBlock(block->index());
     

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1423,6 +1423,7 @@ NEVER_INLINE bool Heap::runBeginPhase(GCConductor conn)
         m_verifier->startGC();
         m_verifier->gatherLiveCells(HeapVerifier::Phase::BeforeMarking);
     }
+    objectSpace().checkConsistency();
         
     prepareForMarking();
         
@@ -1692,6 +1693,7 @@ NEVER_INLINE bool Heap::runEndPhase(GCConductor conn)
         m_verifier->trimDeadCells();
         m_verifier->verify(HeapVerifier::Phase::AfterGC);
     }
+    objectSpace().checkConsistency();
 
     auto endingCollectionScope = *m_collectionScope;
 

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -405,7 +405,7 @@ Heap::Heap(VM& vm, HeapType heapType)
         m_scheduler = makeUnique<SynchronousStopTheWorldMutatorScheduler>();
     }
     
-    if (Options::verifyHeap())
+    if (Options::verifyHeap() || true)
         m_verifier = makeUnique<HeapVerifier>(this, Options::numberOfGCCyclesToRecordForVerification());
     
     m_collectorSlotVisitor->optimizeForStoppedMutator();
@@ -1415,6 +1415,7 @@ NEVER_INLINE bool Heap::runBeginPhase(GCConductor conn)
     
     willStartCollection();
         
+    objectSpace().checkConsistency();
     if (UNLIKELY(m_verifier)) {
         // Verify that live objects from the last GC cycle haven't been corrupted by
         // mutators before we begin this new GC cycle.
@@ -1423,7 +1424,6 @@ NEVER_INLINE bool Heap::runBeginPhase(GCConductor conn)
         m_verifier->startGC();
         m_verifier->gatherLiveCells(HeapVerifier::Phase::BeforeMarking);
     }
-    objectSpace().checkConsistency();
         
     prepareForMarking();
         
@@ -1650,6 +1650,7 @@ NEVER_INLINE bool Heap::runEndPhase(GCConductor conn)
     if (UNLIKELY(Options::verifyGC()))
         verifyGC();
 
+    objectSpace().checkConsistency();
     if (UNLIKELY(m_verifier)) {
         m_verifier->gatherLiveCells(HeapVerifier::Phase::AfterMarking);
         m_verifier->verify(HeapVerifier::Phase::AfterMarking);
@@ -1689,11 +1690,11 @@ NEVER_INLINE bool Heap::runEndPhase(GCConductor conn)
     m_objectSpace.prepareForAllocation();
     updateAllocationLimits();
 
+    objectSpace().checkConsistency();
     if (UNLIKELY(m_verifier)) {
         m_verifier->trimDeadCells();
         m_verifier->verify(HeapVerifier::Phase::AfterGC);
     }
-    objectSpace().checkConsistency();
 
     auto endingCollectionScope = *m_collectionScope;
 

--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -83,6 +83,8 @@ MarkedBlock::Handle::~Handle()
         if (!(balance % 10))
             dataLog("MarkedBlock Balance: ", balance, "\n");
     }
+    RELEASE_ASSERT(&m_block->handle() == this);
+    RELEASE_ASSERT(m_block->heap() == &heap);
     m_directory->removeBlock(this, BlockDirectory::WillDeleteBlock::Yes);
     m_block->~MarkedBlock();
     m_alignedMemoryAllocator->freeAlignedMemory(m_block);

--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -429,7 +429,7 @@ private:
     inline bool marksConveyLivenessDuringMarking(HeapVersion myMarkingVersion, HeapVersion markingVersion);
 
     // This is only used for debugging. We should remove this once the issue is resolved (rdar://136782494)
-    NO_RETURN_DUE_TO_CRASH NEVER_INLINE void dumpInfoAndCrashForInvalidHandle(AbstractLocker&, HeapCell*, VM*);
+    JS_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NEVER_INLINE void dumpInfoAndCrashForInvalidHandle(AbstractLocker&, HeapCell*, VM*);
 };
 
 inline MarkedBlock::Header& MarkedBlock::header()

--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -117,7 +117,8 @@ public:
         friend class MarkedBlock;
         friend struct VerifyMarked;
     public:
-            
+        static constexpr uintptr_t invalid = 1;
+
         ~Handle();
             
         MarkedBlock& block();
@@ -411,6 +412,8 @@ public:
     
     void setVerifierMemo(void*);
     template<typename T> T verifierMemo() const;
+
+    void checkConsistency(Heap*, JSCell*);
 
 private:
     MarkedBlock(VM&, Handle&);

--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -429,7 +429,14 @@ private:
     inline bool marksConveyLivenessDuringMarking(HeapVersion myMarkingVersion, HeapVersion markingVersion);
 
     // This is only used for debugging. We should remove this once the issue is resolved (rdar://136782494)
-    JS_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NEVER_INLINE void dumpInfoAndCrashForInvalidHandle(AbstractLocker&, HeapCell*, VM*);
+    JS_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NEVER_INLINE void dumpInfoAndCrashForInvalidHandleV2(AbstractLocker&, HeapCell*, VM*);
+
+#define ENABLE_MARKEDBLOCK_TEST_DUMP_INFO 1
+#if ENABLE(MARKEDBLOCK_TEST_DUMP_INFO)
+    inline void setupTestForDumpInfoAndCrash();
+#else
+    inline void setupTestForDumpInfoAndCrash() { }
+#endif
 };
 
 inline MarkedBlock::Header& MarkedBlock::header()

--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -413,7 +413,7 @@ public:
     void setVerifierMemo(void*);
     template<typename T> T verifierMemo() const;
 
-    inline void checkConsistency(Heap*, JSCell*);
+    inline void checkConsistency(Heap*, JSCell*, bool knownBad);
 
 private:
     MarkedBlock(VM&, Handle&);

--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -413,7 +413,7 @@ public:
     void setVerifierMemo(void*);
     template<typename T> T verifierMemo() const;
 
-    void checkConsistency(Heap*, JSCell*);
+    inline void checkConsistency(Heap*, JSCell*);
 
 private:
     MarkedBlock(VM&, Handle&);
@@ -429,7 +429,7 @@ private:
     inline bool marksConveyLivenessDuringMarking(HeapVersion myMarkingVersion, HeapVersion markingVersion);
 
     // This is only used for debugging. We should remove this once the issue is resolved (rdar://136782494)
-    NO_RETURN_DUE_TO_CRASH NEVER_INLINE void dumpInfoAndCrashForInvalidHandle(AbstractLocker&, HeapCell*);
+    NO_RETURN_DUE_TO_CRASH NEVER_INLINE void dumpInfoAndCrashForInvalidHandle(AbstractLocker&, HeapCell*, VM*);
 };
 
 inline MarkedBlock::Header& MarkedBlock::header()

--- a/Source/JavaScriptCore/heap/MarkedBlockInlines.h
+++ b/Source/JavaScriptCore/heap/MarkedBlockInlines.h
@@ -625,6 +625,16 @@ inline IterationStatus MarkedBlock::Handle::forEachMarkedCell(const Functor& fun
     return IterationStatus::Continue;
 }
 
+inline void MarkedBlock::checkConsistency(Heap* heap, JSCell* cell)
+{
+    uintptr_t handle = bitwise_cast<uintptr_t>(header().handlePointerForNullCheck());
+    if (UNLIKELY(handle <= MarkedBlock::Handle::invalid)) {
+        Locker locker { header().m_lock };
+        dumpInfoAndCrashForInvalidHandle(locker, cell);
+    } else
+        RELEASE_ASSERT(&heap->vm() == &vm());
+}
+
 } // namespace JSC
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/heap/MarkedBlockInlines.h
+++ b/Source/JavaScriptCore/heap/MarkedBlockInlines.h
@@ -625,12 +625,12 @@ inline IterationStatus MarkedBlock::Handle::forEachMarkedCell(const Functor& fun
     return IterationStatus::Continue;
 }
 
-inline void MarkedBlock::checkConsistency(Heap* heap, JSCell* cell)
+inline void MarkedBlock::checkConsistency(Heap* heap, JSCell* cell, bool knownBad)
 {
     uintptr_t handle = bitwise_cast<uintptr_t>(header().handlePointerForNullCheck());
-    if (UNLIKELY(handle <= MarkedBlock::Handle::invalid || &heap->vm() != &vm())) {
+    if (UNLIKELY(knownBad || handle <= MarkedBlock::Handle::invalid || &heap->vm() != &vm())) {
         Locker locker { header().m_lock };
-        dumpInfoAndCrashForInvalidHandle(locker, cell, &heap->vm());
+        dumpInfoAndCrashForInvalidHandleV2(locker, cell, &heap->vm());
     }
 }
 

--- a/Source/JavaScriptCore/heap/MarkedBlockInlines.h
+++ b/Source/JavaScriptCore/heap/MarkedBlockInlines.h
@@ -628,11 +628,10 @@ inline IterationStatus MarkedBlock::Handle::forEachMarkedCell(const Functor& fun
 inline void MarkedBlock::checkConsistency(Heap* heap, JSCell* cell)
 {
     uintptr_t handle = bitwise_cast<uintptr_t>(header().handlePointerForNullCheck());
-    if (UNLIKELY(handle <= MarkedBlock::Handle::invalid)) {
+    if (UNLIKELY(handle <= MarkedBlock::Handle::invalid || &heap->vm() != &vm())) {
         Locker locker { header().m_lock };
-        dumpInfoAndCrashForInvalidHandle(locker, cell);
-    } else
-        RELEASE_ASSERT(&heap->vm() == &vm());
+        dumpInfoAndCrashForInvalidHandle(locker, cell, &heap->vm());
+    }
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/MarkedSpace.cpp
+++ b/Source/JavaScriptCore/heap/MarkedSpace.cpp
@@ -592,6 +592,15 @@ void MarkedSpace::addBlockDirectory(const AbstractLocker&, BlockDirectory* direc
     m_directories.append(std::mem_fn(&BlockDirectory::setNextDirectory), directory);
 }
 
+void MarkedSpace::checkConsistency()
+{
+    RELEASE_ASSERT(heap().worldIsStopped() || heap().vm().currentThreadIsHoldingAPILock());
+    auto& set = blocks().set();
+    for (auto& block: set) {
+        block->checkConsistency(&heap(), nullptr);
+    }
+}
+
 } // namespace JSC
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/heap/MarkedSpace.cpp
+++ b/Source/JavaScriptCore/heap/MarkedSpace.cpp
@@ -194,7 +194,7 @@ void MarkedSpace::freeMemory()
 {
     forEachBlock(
         [&] (MarkedBlock::Handle* block) {
-            freeBlock(block);
+            freeBlock(block, true);
         });
     for (PreciseAllocation* allocation : m_preciseAllocations)
         allocation->destroy();
@@ -375,8 +375,9 @@ MarkedBlock::Handle* MarkedSpace::findMarkedBlockHandleDebug(MarkedBlock* block)
     return result;
 }
 
-void MarkedSpace::freeBlock(MarkedBlock::Handle* block)
+void MarkedSpace::freeBlock(MarkedBlock::Handle* block, bool notEmptyOkay)
 {
+    RELEASE_ASSERT(notEmptyOkay || block->isEmpty());
     m_capacity -= MarkedBlock::blockSize;
     m_blocks.remove(&block->block());
     delete block;

--- a/Source/JavaScriptCore/heap/MarkedSpace.cpp
+++ b/Source/JavaScriptCore/heap/MarkedSpace.cpp
@@ -598,7 +598,7 @@ void MarkedSpace::checkConsistency()
     RELEASE_ASSERT(heap().worldIsStopped() || heap().vm().currentThreadIsHoldingAPILock());
     auto& set = blocks().set();
     for (auto& block: set) {
-        block->checkConsistency(&heap(), nullptr);
+        block->checkConsistency(&heap(), nullptr, false);
     }
 }
 

--- a/Source/JavaScriptCore/heap/MarkedSpace.h
+++ b/Source/JavaScriptCore/heap/MarkedSpace.h
@@ -132,7 +132,7 @@ public:
     template<typename Functor> void forEachSubspace(const Functor&);
 
     void shrink();
-    void freeBlock(MarkedBlock::Handle*);
+    void freeBlock(MarkedBlock::Handle*, bool notEmptyOkay=false);
     void freeOrShrinkBlock(MarkedBlock::Handle*);
 
     void didAddBlock(MarkedBlock::Handle*);

--- a/Source/JavaScriptCore/heap/MarkedSpace.h
+++ b/Source/JavaScriptCore/heap/MarkedSpace.h
@@ -180,6 +180,8 @@ public:
     bool isMarking() const { return m_isMarking; }
     
     void dumpBits(PrintStream& = WTF::dataFile());
+
+    void checkConsistency();
     
     JS_EXPORT_PRIVATE static std::array<unsigned, numSizeClasses> s_sizeClassForSizeStep;
     

--- a/Source/JavaScriptCore/heap/SlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/SlotVisitor.cpp
@@ -149,6 +149,7 @@ void SlotVisitor::appendJSCellOrAuxiliary(HeapCell* heapCell)
     auto validateCell = [&] (JSCell* jsCell) {
         StructureID structureID = jsCell->structureID();
         
+        // XXX
         auto die = [&] (const char* text) {
             WTF::dataFile().atomically(
                 [&] (PrintStream& out) {

--- a/Source/JavaScriptCore/heap/SlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/SlotVisitor.cpp
@@ -182,6 +182,7 @@ void SlotVisitor::appendJSCellOrAuxiliary(HeapCell* heapCell)
                         out.print("Newly allocated version: ", block.newlyAllocatedVersion(), "\n");
                         out.print("Heap newly allocated version: ", heap()->objectSpace().newlyAllocatedVersion(), "\n");
                     }
+                    jsCell->checkConsistency(heap(), true);
                     UNREACHABLE_FOR_PLATFORM();
                 });
         };

--- a/Source/JavaScriptCore/heap/SlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/SlotVisitor.cpp
@@ -147,6 +147,8 @@ void SlotVisitor::appendJSCellOrAuxiliary(HeapCell* heapCell)
     ASSERT(!m_isCheckingForDefaultMarkViolation);
     
     auto validateCell = [&] (JSCell* jsCell) {
+        jsCell->checkConsistency(heap());
+
         StructureID structureID = jsCell->structureID();
         
         // XXX
@@ -193,8 +195,6 @@ void SlotVisitor::appendJSCellOrAuxiliary(HeapCell* heapCell)
         if (structureID.isNuked())
             die("GC scan found object in bad state: structureID is nuked!\n");
         
-        jsCell->checkConsistency(heap());
-
         // This detects the worst of the badness.
         Integrity::auditStructureID(structureID);
     };

--- a/Source/JavaScriptCore/heap/SlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/SlotVisitor.cpp
@@ -360,6 +360,8 @@ ALWAYS_INLINE void SlotVisitor::visitChildren(const JSCell* cell)
             dataLog(" (subsequent)");
         dataLog("\n");
     }
+
+    cell->checkConsistency(heap());
     
     // Funny story: it's possible for the object to be black already, if we barrier the object at
     // about the same time that it's marked. That's fine. It's a gnarly and super-rare race. It's

--- a/Source/JavaScriptCore/heap/SlotVisitorInlines.h
+++ b/Source/JavaScriptCore/heap/SlotVisitorInlines.h
@@ -47,7 +47,9 @@ ALWAYS_INLINE void SlotVisitor::appendUnbarriered(JSCell* cell)
     
     if (!cell)
         return;
-    
+
+    cell->checkConsistency(heap());
+
     Dependency dependency;
     if (UNLIKELY(cell->isPreciseAllocation())) {
         if (LIKELY(cell->preciseAllocation().isMarked())) {
@@ -85,7 +87,9 @@ ALWAYS_INLINE void SlotVisitor::appendHiddenUnbarriered(JSCell* cell)
     
     if (!cell)
         return;
-    
+
+    cell->checkConsistency(heap());
+
     Dependency dependency;
     if (UNLIKELY(cell->isPreciseAllocation())) {
         if (LIKELY(cell->preciseAllocation().isMarked()))

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -84,7 +84,7 @@ void initialize()
         WriteBarrierCounters::initialize();
 #endif
         WTF::setDataFile(OSLogPrintStream::open("com.apple.JavaScriptCore", "DataLog", OS_LOG_TYPE_ERROR));;
-        dataLogLn("JSC::initialize() hello");
+        dataLogLn("JSC::initialize() MarkedBlock instrumentation enabled");
 
         {
             Options::AllowUnfinalizedAccessScope scope;

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -84,7 +84,7 @@ void initialize()
         WriteBarrierCounters::initialize();
 #endif
         WTF::setDataFile(OSLogPrintStream::open("com.apple.JavaScriptCore", "DataLog", OS_LOG_TYPE_ERROR));;
-        dataLogLn("JSC::initialize() MarkedBlock instrumentation v2 enabled");
+        dataLogLn("JSC::initialize() MarkedBlock instrumentation v3 enabled");
 
         {
             Options::AllowUnfinalizedAccessScope scope;

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -84,7 +84,7 @@ void initialize()
         WriteBarrierCounters::initialize();
 #endif
         WTF::setDataFile(OSLogPrintStream::open("com.apple.JavaScriptCore", "DataLog", OS_LOG_TYPE_ERROR));;
-        dataLogLn("JSC::initialize() MarkedBlock instrumentation enabled");
+        dataLogLn("JSC::initialize() MarkedBlock instrumentation v2 enabled");
 
         {
             Options::AllowUnfinalizedAccessScope scope;

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -56,6 +56,10 @@
 #endif
 #endif
 
+#if PLATFORM(COCOA)
+#include <wtf/darwin/OSLogPrintStream.h> // FIXME: rdar://136782494
+#endif
+
 #if ENABLE(LLVM_PROFILE_GENERATION)
 extern "C" char __llvm_profile_filename[] = "/private/tmp/WebKitPGO/JavaScriptCore_%m_pid%p%c.profraw";
 #endif
@@ -79,6 +83,9 @@ void initialize()
 #if ENABLE(WRITE_BARRIER_PROFILING)
         WriteBarrierCounters::initialize();
 #endif
+        WTF::setDataFile(OSLogPrintStream::open("com.apple.JavaScriptCore", "DataLog", OS_LOG_TYPE_ERROR));;
+        dataLogLn("JSC::initialize() hello");
+
         {
             Options::AllowUnfinalizedAccessScope scope;
             JITOperationList::initialize();

--- a/Source/JavaScriptCore/runtime/JSCell.h
+++ b/Source/JavaScriptCore/runtime/JSCell.h
@@ -261,7 +261,7 @@ public:
     void setPerCellBit(bool);
     bool perCellBit() const;
 
-    void checkConsistency(Heap*) const;
+    void checkConsistency(Heap*, bool knownBad = false) const;
 protected:
 
     void finishCreation(VM&);

--- a/Source/JavaScriptCore/runtime/JSCell.h
+++ b/Source/JavaScriptCore/runtime/JSCell.h
@@ -260,6 +260,8 @@ public:
 
     void setPerCellBit(bool);
     bool perCellBit() const;
+
+    void checkConsistency(Heap*) const;
 protected:
 
     void finishCreation(VM&);

--- a/Source/JavaScriptCore/runtime/JSCellInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCellInlines.h
@@ -487,10 +487,10 @@ inline bool isWebAssemblyInstance(const JSCell* cell)
     return cell->type() == WebAssemblyInstanceType;
 }
 
-inline void JSCell::checkConsistency(Heap* heap) const
+inline void JSCell::checkConsistency(Heap* heap, bool knownBad) const
 {
     if (!isPreciseAllocation())
-        markedBlock().checkConsistency(heap, const_cast<JSCell*>(this));
+        markedBlock().checkConsistency(heap, const_cast<JSCell*>(this), knownBad);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSCellInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCellInlines.h
@@ -486,6 +486,12 @@ inline bool isWebAssemblyInstance(const JSCell* cell)
     return cell->type() == WebAssemblyInstanceType;
 }
 
+inline void JSCell::checkConsistency(Heap* heap) const
+{
+    if (!isPreciseAllocation())
+        markedBlock().checkConsistency(heap, const_cast<JSCell*>(this));
+}
+
 } // namespace JSC
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/JSCellInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCellInlines.h
@@ -47,6 +47,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "JSString.h"
 #include "LocalAllocatorInlines.h"
 #include "MarkedBlock.h"
+#include "MarkedBlockInlines.h"
 #include "SlotVisitorInlines.h"
 #include "Structure.h"
 #include "Symbol.h"

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -750,6 +750,8 @@ void Options::notifyOptionsChanged()
 {
     AllowUnfinalizedAccessScope scope;
 
+    Options::scribbleFreeCells() = true;
+
     unsigned thresholdForGlobalLexicalBindingEpoch = Options::thresholdForGlobalLexicalBindingEpoch();
     if (thresholdForGlobalLexicalBindingEpoch == 0 || thresholdForGlobalLexicalBindingEpoch == 1)
         Options::thresholdForGlobalLexicalBindingEpoch() = UINT_MAX;

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -604,7 +604,8 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useWasmSIMD, true, Normal, "Allow the new simd instructions and types from the wasm simd spec."_s) \
     v(Bool, useWasmRelaxedSIMD, false, Normal, "Allow the relaxed simd instructions and types from the wasm relaxed simd spec."_s) \
     v(Bool, useWasmTailCalls, true, Normal, "Allow the new instructions from the wasm tail calls spec."_s) \
-    v(Unsigned, aboutToMarkSlowCrash, 0, Normal, nullptr) \
+    v(Unsigned, markedBlockDumpInfoCount, 0, Normal, nullptr) /* FIXME: rdar://136782494 */ \
+
 
 
 enum OptionEquivalence {

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -604,7 +604,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useWasmSIMD, true, Normal, "Allow the new simd instructions and types from the wasm simd spec."_s) \
     v(Bool, useWasmRelaxedSIMD, false, Normal, "Allow the relaxed simd instructions and types from the wasm relaxed simd spec."_s) \
     v(Bool, useWasmTailCalls, true, Normal, "Allow the new instructions from the wasm tail calls spec."_s) \
-
+    v(Unsigned, aboutToMarkSlowCrash, 0, Normal, nullptr) \
 
 
 enum OptionEquivalence {

--- a/Source/JavaScriptCore/tools/HeapVerifier.h
+++ b/Source/JavaScriptCore/tools/HeapVerifier.h
@@ -100,7 +100,7 @@ private:
     }
 
     CellList* cellListForGathering(Phase);
-    bool verifyCellList(Phase, CellList&);
+    JSCell* verifyCellList(Phase, CellList&);
     static bool validateJSCell(VM* expectedVM, JSCell*, CellProfile*, CellList*, const ScopedLambda<void()>& printHeaderIfNeeded, const char* prefix = "");
 
     void printVerificationHeader();


### PR DESCRIPTION
#### 8c8689189e8e02bbc78c1674ef1fdbc59e9f15c8
<pre>
[DEBUG-ONLY] MarkedBlock instrumentation
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/JavaScriptCore/heap/BlockDirectory.cpp:
(JSC::BlockDirectory::removeBlock):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::runBeginPhase):
(JSC::Heap::runEndPhase):
* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::Header::~Header):
(JSC::MarkedBlock::aboutToMarkSlow):
(JSC::MarkedBlock::dumpInfoAndCrashForInvalidHandle):
* Source/JavaScriptCore/heap/MarkedBlock.h:
* Source/JavaScriptCore/heap/MarkedBlockInlines.h:
(JSC::MarkedBlock::checkConsistency):
* Source/JavaScriptCore/heap/MarkedSpace.cpp:
(JSC::MarkedSpace::checkConsistency):
* Source/JavaScriptCore/heap/MarkedSpace.h:
* Source/JavaScriptCore/heap/SlotVisitor.cpp:
(JSC::SlotVisitor::visitChildren):
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/JavaScriptCore/runtime/JSCell.h:
* Source/JavaScriptCore/runtime/JSCellInlines.h:
(JSC::JSCell::checkConsistency const):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::notifyOptionsChanged):
</pre>
----------------------------------------------------------------------
#### 1df2f6917968258295c22058df811db2dfcfbc80
<pre>
[JSC] Simplify aboutToMarkSlow instrumentation
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef701a91dbad36fe6ffc2552cddac3ac131804b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76596 "10 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29502 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81126 "Hash ef701a91 for PR 36568 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27872 "Hash ef701a91 for PR 36568 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78713 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3924 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/81126 "Hash ef701a91 for PR 36568 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/27872 "Hash ef701a91 for PR 36568 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79663 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49965 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65767 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/81126 "Hash ef701a91 for PR 36568 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47365 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23260 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26196 "Hash ef701a91 for PR 36568 does not build (failure)") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69779 "Found unexpected failure with change (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68487 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23591 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82572 "Hash ef701a91 for PR 36568 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75873 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2616 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/82572 "Hash ef701a91 for PR 36568 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4125 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65739 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/82572 "Hash ef701a91 for PR 36568 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11547 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9632 "Passed tests") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98127 "Hash ef701a91 for PR 36568 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3919 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/98127 "Hash ef701a91 for PR 36568 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3942 "Built successfully") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7372 "Hash ef701a91 for PR 36568 does not build (failure)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5700 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->