### PR TITLE
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF::Base64

### DIFF
--- a/Source/WTF/wtf/text/Base64.cpp
+++ b/Source/WTF/wtf/text/Base64.cpp
@@ -30,8 +30,6 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringCommon.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 constexpr const char nonAlphabet = -1;
@@ -39,7 +37,7 @@ constexpr const char nonAlphabet = -1;
 constexpr unsigned encodeMapSize = 64;
 constexpr unsigned decodeMapSize = 128;
 
-static const char base64EncMap[encodeMapSize] = {
+static constexpr std::array<char, encodeMapSize> base64EncMap {
     0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
     0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50,
     0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
@@ -50,7 +48,7 @@ static const char base64EncMap[encodeMapSize] = {
     0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x2B, 0x2F
 };
 
-static const char base64DecMap[decodeMapSize] = {
+static constexpr std::array<char, decodeMapSize> base64DecMap {
     nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet,
     nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet,
     nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet,
@@ -69,7 +67,7 @@ static const char base64DecMap[decodeMapSize] = {
     0x31, 0x32, 0x33, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet
 };
 
-static const char base64URLEncMap[encodeMapSize] = {
+static constexpr std::array<char, encodeMapSize> base64URLEncMap {
     0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
     0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50,
     0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
@@ -80,7 +78,7 @@ static const char base64URLEncMap[encodeMapSize] = {
     0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x2D, 0x5F
 };
 
-static const char base64URLDecMap[decodeMapSize] = {
+static constexpr std::array<char, decodeMapSize> base64URLDecMap {
     nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet,
     nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet,
     nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet,
@@ -325,7 +323,7 @@ static std::tuple<FromBase64ShouldThrowError, size_t, size_t> fromBase64SlowImpl
     if (!output.size())
         return { FromBase64ShouldThrowError::No, 0, 0 };
 
-    UChar chunk[4] = { 0, 0, 0, 0 };
+    std::array<UChar, 4> chunk { 0, 0, 0, 0 };
     size_t chunkLength = 0;
 
     for (size_t i = 0; i < length;) {
@@ -362,7 +360,7 @@ static std::tuple<FromBase64ShouldThrowError, size_t, size_t> fromBase64SlowImpl
             for (size_t j = chunkLength; j < 4; ++j)
                 chunk[j] = 'A';
 
-            auto decodedVector = base64Decode(StringView(std::span(chunk, 4)));
+            auto decodedVector = base64Decode(StringView(std::span { chunk }));
             if (!decodedVector)
                 return { FromBase64ShouldThrowError::Yes, read, write };
             auto decoded = decodedVector->span();
@@ -402,7 +400,7 @@ static std::tuple<FromBase64ShouldThrowError, size_t, size_t> fromBase64SlowImpl
         if (chunkLength != 4)
             continue;
 
-        auto decodedVector = base64Decode(StringView(std::span(chunk, chunkLength)));
+        auto decodedVector = base64Decode(StringView(std::span { chunk }));
         ASSERT(decodedVector);
         if (!decodedVector)
             return { FromBase64ShouldThrowError::Yes, read, write };
@@ -429,7 +427,7 @@ static std::tuple<FromBase64ShouldThrowError, size_t, size_t> fromBase64SlowImpl
         for (size_t j = chunkLength; j < 4; ++j)
             chunk[j] = 'A';
 
-        auto decodedVector = base64Decode(StringView(std::span(chunk, chunkLength)));
+        auto decodedVector = base64Decode(StringView(std::span { chunk }.first(chunkLength)));
         ASSERT(decodedVector);
         if (!decodedVector)
             return { FromBase64ShouldThrowError::Yes, read, write };
@@ -492,5 +490,3 @@ size_t maxLengthFromBase64(StringView string)
 }
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/text/Base64.h
+++ b/Source/WTF/wtf/text/Base64.h
@@ -31,8 +31,6 @@
 #include <wtf/OptionSet.h>
 #include <wtf/text/StringView.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 enum class Base64EncodeOption {
@@ -197,7 +195,7 @@ public:
 
     template<typename CharacterType> void writeTo(CharacterType* destination) const
     {
-        base64Encode(m_base64.input, std::span(destination, m_encodedLength), m_base64.options);
+        base64Encode(m_base64.input, unsafeMakeSpan(destination, m_encodedLength), m_base64.options);
     }
 
 private:
@@ -226,5 +224,3 @@ using WTF::base64URLEncoded;
 using WTF::isBase64OrBase64URLCharacter;
 using WTF::fromBase64;
 using WTF::maxLengthFromBase64;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### ace4a9dd693f17d7904aa4850cd607907fbe2ac3
<pre>
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF::Base64
<a href="https://bugs.webkit.org/show_bug.cgi?id=283030">https://bugs.webkit.org/show_bug.cgi?id=283030</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/text/Base64.cpp:
(WTF::fromBase64SlowImpl):
* Source/WTF/wtf/text/Base64.h:
(WTF::StringTypeAdapter&lt;Base64Specification&gt;::writeTo const):

Canonical link: <a href="https://commits.webkit.org/286535@main">https://commits.webkit.org/286535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22776d34427cc1fe3ab9e95281785abc27186510

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80744 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27510 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3564 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59785 "Found 84 new test failures: fast/css-custom-paint/out-of-memory-while-adding-worklet-module.html fast/css/focus-ring-exists-for-search-field.html fast/inline/list-marker-inside-container-with-margin.html fast/inline/min-content-width-with-hypens.html fast/inline/overflowing-content-with-hypens.html fast/mediastream/canvas-video-to-canvas.html fast/mediastream/captureStream/canvas3d.html fast/multicol/table-vertical-align.html fast/ruby/annotation-with-line-gap.html fast/ruby/ruby-run-break.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17920 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49680 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40129 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47077 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22963 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25832 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69417 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68207 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82203 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75514 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3610 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2357 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68007 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3764 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67323 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11275 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9386 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97768 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11797 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3558 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21393 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3581 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7010 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5339 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->