### PR TITLE
Implement `auto` value as a computed value for `user-select` and stop making it inherited

### DIFF
--- a/LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt
@@ -240,7 +240,7 @@ zoom: 1;
 -webkit-text-stroke-width: 0px;
 -webkit-user-drag: auto;
 -webkit-user-modify: read-only;
--webkit-user-select: text;
+-webkit-user-select: auto;
 
 Other attributes that the computed style class supports:
 

--- a/LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt
@@ -239,7 +239,7 @@ zoom: 1
 -webkit-text-stroke-width: 0px
 -webkit-user-drag: auto
 -webkit-user-modify: read-only
--webkit-user-select: text
+-webkit-user-select: auto
 background-position-x: 0%
 background-position-y: 0%
 border-spacing: 0px 0px

--- a/LayoutTests/media/modern-media-controls/airplay-placard/airplay-placard-text-section-expected.txt
+++ b/LayoutTests/media/modern-media-controls/airplay-placard/airplay-placard-text-section-expected.txt
@@ -4,9 +4,10 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS !!document.querySelector('.placard') became true
-PASS window.getComputedStyle(document.querySelector('.title')).webkitUserSelect is "none"
+PASS document.querySelector('.placard').querySelector('.title') == document.querySelector('.title') is true
+PASS document.querySelector('.placard').querySelector('.description') == document.querySelector('.description') is true
+PASS window.getComputedStyle(document.querySelector('.placard')).webkitUserSelect is "none"
 PASS window.getComputedStyle(document.querySelector('.title')).cursor is "default"
-PASS window.getComputedStyle(document.querySelector('.description')).webkitUserSelect is "none"
 PASS window.getComputedStyle(document.querySelector('.description')).cursor is "default"
 
 PASS successfullyParsed is true

--- a/LayoutTests/media/modern-media-controls/airplay-placard/airplay-placard-text-section.html
+++ b/LayoutTests/media/modern-media-controls/airplay-placard/airplay-placard-text-section.html
@@ -13,9 +13,10 @@ mediaControls.placard = mediaControls.airplayPlacard;
 document.body.appendChild(mediaControls.element);
 
 shouldBecomeEqual("!!document.querySelector('.placard')", "true", () => {
-    shouldBeEqualToString("window.getComputedStyle(document.querySelector('.title')).webkitUserSelect", "none");
+    shouldBeTrue("document.querySelector('.placard').querySelector('.title') == document.querySelector('.title')");
+    shouldBeTrue("document.querySelector('.placard').querySelector('.description') == document.querySelector('.description')");
+    shouldBeEqualToString("window.getComputedStyle(document.querySelector('.placard')).webkitUserSelect", "none");
     shouldBeEqualToString("window.getComputedStyle(document.querySelector('.title')).cursor", "default");
-    shouldBeEqualToString("window.getComputedStyle(document.querySelector('.description')).webkitUserSelect", "none");
     shouldBeEqualToString("window.getComputedStyle(document.querySelector('.description')).cursor", "default");
 
     mediaControls.element.remove();

--- a/LayoutTests/media/modern-media-controls/pip-placard/pip-placard-text-section-expected.txt
+++ b/LayoutTests/media/modern-media-controls/pip-placard/pip-placard-text-section-expected.txt
@@ -3,7 +3,8 @@ Testing that text selection is turned off for PiPPlacard.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS window.getComputedStyle(document.querySelector('.description')).webkitUserSelect is "none"
+PASS document.querySelector('.placard').querySelector('.description') == document.querySelector('.description') is true
+PASS window.getComputedStyle(document.querySelector('.placard')).webkitUserSelect is "none"
 PASS window.getComputedStyle(document.querySelector('.description')).cursor is "default"
 
 PASS successfullyParsed is true

--- a/LayoutTests/media/modern-media-controls/pip-placard/pip-placard-text-section.html
+++ b/LayoutTests/media/modern-media-controls/pip-placard/pip-placard-text-section.html
@@ -14,7 +14,8 @@ document.body.appendChild(mediaControls.element);
 
 scheduler.frameDidFire = function()
 {
-    shouldBeEqualToString("window.getComputedStyle(document.querySelector('.description')).webkitUserSelect", "none");
+    shouldBeTrue("document.querySelector('.placard').querySelector('.description') == document.querySelector('.description')");
+    shouldBeEqualToString("window.getComputedStyle(document.querySelector('.placard')).webkitUserSelect", "none");
     shouldBeEqualToString("window.getComputedStyle(document.querySelector('.description')).cursor", "default");
 
     mediaControls.element.remove();

--- a/LayoutTests/media/modern-media-controls/status-label/status-label-text-selection-expected.txt
+++ b/LayoutTests/media/modern-media-controls/status-label/status-label-text-selection-expected.txt
@@ -3,7 +3,8 @@ Testing that text selection is turned off for StatusLabel.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS window.getComputedStyle(mediaControls.statusLabel.element).webkitUserSelect is "none"
+PASS mediaControls.bottomControlsBar.element == mediaControls.statusLabel.element.parentElement is true
+PASS window.getComputedStyle(mediaControls.bottomControlsBar.element).webkitUserSelect is "none"
 PASS window.getComputedStyle(mediaControls.statusLabel.element).cursor is "default"
 
 PASS successfullyParsed is true

--- a/LayoutTests/media/modern-media-controls/status-label/status-label-text-selection.html
+++ b/LayoutTests/media/modern-media-controls/status-label/status-label-text-selection.html
@@ -16,7 +16,8 @@ document.body.appendChild(mediaControls.element);
 
 scheduler.frameDidFire = function()
 {
-    shouldBeEqualToString("window.getComputedStyle(mediaControls.statusLabel.element).webkitUserSelect", "none");
+    shouldBeTrue("mediaControls.bottomControlsBar.element == mediaControls.statusLabel.element.parentElement");
+    shouldBeEqualToString("window.getComputedStyle(mediaControls.bottomControlsBar.element).webkitUserSelect", "none");
     shouldBeEqualToString("window.getComputedStyle(mediaControls.statusLabel.element).cursor", "default");
     mediaControls.element.remove();
     debug("");

--- a/LayoutTests/svg/css/getComputedStyle-basic-expected.txt
+++ b/LayoutTests/svg/css/getComputedStyle-basic-expected.txt
@@ -238,7 +238,7 @@ rect: style.getPropertyValue(-webkit-text-stroke-color) : rgb(0, 0, 0)
 rect: style.getPropertyValue(-webkit-text-stroke-width) : 0px
 rect: style.getPropertyValue(-webkit-user-drag) : auto
 rect: style.getPropertyValue(-webkit-user-modify) : read-only
-rect: style.getPropertyValue(-webkit-user-select) : text
+rect: style.getPropertyValue(-webkit-user-select) : auto
 g: style.getPropertyValue(align-content) : normal
 g: style.getPropertyValue(align-items) : normal
 g: style.getPropertyValue(align-self) : auto
@@ -479,5 +479,5 @@ g: style.getPropertyValue(-webkit-text-stroke-color) : rgb(0, 0, 0)
 g: style.getPropertyValue(-webkit-text-stroke-width) : 0px
 g: style.getPropertyValue(-webkit-user-drag) : auto
 g: style.getPropertyValue(-webkit-user-modify) : read-only
-g: style.getPropertyValue(-webkit-user-select) : text
+g: style.getPropertyValue(-webkit-user-select) : auto
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -8788,7 +8788,6 @@
             "status": "non-standard"
         },
         "-webkit-user-select": {
-            "inherited": true,
             "values": [
                 "auto",
                 "text",
@@ -8800,6 +8799,7 @@
                 "all"
             ],
             "codegen-properties": {
+                "auto-functions": true,
                 "parser-grammar": "<<values>>"
             },
             "status": {

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -4531,6 +4531,8 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertyWebkitUserDrag:
         return createConvertingToCSSValueID(style.userDrag());
     case CSSPropertyWebkitUserSelect:
+        if (style.hasAutoUserSelect())
+            return CSSPrimitiveValue::create(CSSValueAuto);
         return createConvertingToCSSValueID(style.userSelect());
     case CSSPropertyBorderBottomLeftRadius:
         return borderRadiusCornerValue(style.borderBottomLeftRadius(), style);

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1194,6 +1194,7 @@ static bool requiresPainting(const RenderStyle& style)
 static bool miscDataChangeRequiresRepaint(const StyleMiscNonInheritedData& first, const StyleMiscNonInheritedData& second, OptionSet<StyleDifferenceContextSensitiveProperty>&)
 {
     if (first.userDrag != second.userDrag
+        || first.userSelect != second.userSelect
         || first.objectFit != second.objectFit
         || first.objectPosition != second.objectPosition)
         return true;
@@ -1219,7 +1220,6 @@ static bool rareInheritedDataChangeRequiresRepaint(const StyleRareInheritedData&
 {
     return first.effectiveInert != second.effectiveInert
         || first.userModify != second.userModify
-        || first.userSelect != second.userSelect
         || first.appleColorFilter != second.appleColorFilter
         || first.imageRendering != second.imageRendering
         || first.accentColor != second.accentColor
@@ -1804,6 +1804,7 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
         // hasExplicitlySetWritingMode
         // usedAppearance
         // userDrag
+        // userSelect
     };
 
     auto conservativelyCollectChangedAnimatablePropertiesViaNonInheritedRareData = [&](auto& first, auto& second) {
@@ -2118,7 +2119,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
         // nbspMode
         // useTouchOverflowScrolling
         // textSizeAdjust
-        // userSelect
         // isInSubtreeWithBlendMode
         // usedTouchActions
         // eventListenerRegionTypes

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -855,6 +855,7 @@ public:
     inline UserModify usedUserModify() const;
     inline UserModify userModify() const;
     inline UserDrag userDrag() const;
+    inline bool hasAutoUserSelect() const;
     WEBCORE_EXPORT UserSelect usedUserSelect() const;
     inline UserSelect userSelect() const;
     inline TextOverflow textOverflow() const;
@@ -1476,7 +1477,9 @@ public:
     inline void setMarqueeLoopCount(int);
     inline void setUserModify(UserModify);
     inline void setUserDrag(UserDrag);
+    inline void setHasAutoUserSelect();
     inline void setUserSelect(UserSelect);
+    inline void setUsedUserSelect(UserSelect);
     inline void setTextOverflow(TextOverflow);
     inline void setWordBreak(WordBreak);
     inline void setOverflowWrap(OverflowWrap);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -276,6 +276,7 @@ inline bool RenderStyle::hasAutoOrphans() const { return m_rareInheritedData->ha
 inline bool RenderStyle::hasAutoSpecifiedZIndex() const { return m_nonInheritedData->boxData->hasAutoSpecifiedZIndex(); }
 inline bool RenderStyle::hasAutoTopAndBottom() const { return top().isAuto() && bottom().isAuto(); }
 inline bool RenderStyle::hasAutoUsedZIndex() const { return m_nonInheritedData->boxData->hasAutoUsedZIndex(); }
+inline bool RenderStyle::hasAutoUserSelect() const { return m_nonInheritedData->miscData->hasAutoUserSelect; }
 inline bool RenderStyle::hasAutoWidows() const { return m_rareInheritedData->hasAutoWidows; }
 inline bool RenderStyle::hasBackground() const { return visitedDependentColor(CSSPropertyBackgroundColor).isVisible() || hasBackgroundImage(); }
 inline bool RenderStyle::hasBackgroundImage() const { return backgroundLayers().hasImage(); }
@@ -746,7 +747,7 @@ inline TransformStyle3D RenderStyle::usedTransformStyle3D() const { return stati
 inline int RenderStyle::usedZIndex() const { return m_nonInheritedData->boxData->usedZIndex(); }
 inline UserDrag RenderStyle::userDrag() const { return static_cast<UserDrag>(m_nonInheritedData->miscData->userDrag); }
 inline UserModify RenderStyle::userModify() const { return static_cast<UserModify>(m_rareInheritedData->userModify); }
-inline UserSelect RenderStyle::userSelect() const { return static_cast<UserSelect>(m_rareInheritedData->userSelect); }
+inline UserSelect RenderStyle::userSelect() const { return static_cast<UserSelect>(m_nonInheritedData->miscData->userSelect); }
 inline VerticalAlign RenderStyle::verticalAlign() const { return m_nonInheritedData->boxData->verticalAlign(); }
 inline const Length& RenderStyle::verticalAlignLength() const { return m_nonInheritedData->boxData->verticalAlignLength(); }
 inline const Vector<Style::ScopedName>& RenderStyle::viewTransitionClasses() const { return m_nonInheritedData->rareData->viewTransitionClasses; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -335,7 +335,9 @@ inline void RenderStyle::setUseSmoothScrolling(bool value) { SET_NESTED(m_nonInh
 inline void RenderStyle::setUsedZIndex(int index) { SET_NESTED_PAIR(m_nonInheritedData, boxData, m_usedZIndex, index, m_hasAutoUsedZIndex, false); }
 inline void RenderStyle::setUserDrag(UserDrag value) { SET_NESTED(m_nonInheritedData, miscData, userDrag, static_cast<unsigned>(value)); }
 inline void RenderStyle::setUserModify(UserModify value) { SET(m_rareInheritedData, userModify, static_cast<unsigned>(value)); }
-inline void RenderStyle::setUserSelect(UserSelect value) { SET(m_rareInheritedData, userSelect, static_cast<unsigned>(value)); }
+inline void RenderStyle::setHasAutoUserSelect() { SET_NESTED_PAIR(m_nonInheritedData, miscData, hasAutoUserSelect, true, userSelect, static_cast<unsigned>(RenderStyle::initialUserSelect())); }
+inline void RenderStyle::setUserSelect(UserSelect value) { SET_NESTED_PAIR(m_nonInheritedData, miscData, userSelect, static_cast<unsigned>(value), hasAutoUserSelect, false); }
+inline void RenderStyle::setUsedUserSelect(UserSelect value) { SET_NESTED(m_nonInheritedData, miscData, userSelect, static_cast<unsigned>(value)); }
 inline void RenderStyle::setViewTransitionClasses(const Vector<Style::ScopedName>& value) { SET_NESTED(m_nonInheritedData, rareData, viewTransitionClasses, value); }
 inline void RenderStyle::setViewTransitionName(Style::ViewTransitionName value) { SET_NESTED(m_nonInheritedData, rareData, viewTransitionName, value); }
 inline void RenderStyle::setVisitedLinkBackgroundColor(const StyleColor& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, visitedLinkColor, background, value); }

--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp
@@ -68,6 +68,8 @@ StyleMiscNonInheritedData::StyleMiscNonInheritedData()
     , usedAppearance(static_cast<unsigned>(RenderStyle::initialAppearance()))
     , textOverflow(static_cast<unsigned>(RenderStyle::initialTextOverflow()))
     , userDrag(static_cast<unsigned>(RenderStyle::initialUserDrag()))
+    , userSelect(static_cast<unsigned>(RenderStyle::initialUserSelect()))
+    , hasAutoUserSelect(true)
     , objectFit(static_cast<unsigned>(RenderStyle::initialObjectFit()))
     , resize(static_cast<unsigned>(RenderStyle::initialResize()))
 {
@@ -111,6 +113,8 @@ StyleMiscNonInheritedData::StyleMiscNonInheritedData(const StyleMiscNonInherited
     , usedAppearance(o.usedAppearance)
     , textOverflow(o.textOverflow)
     , userDrag(o.userDrag)
+    , userSelect(o.userSelect)
+    , hasAutoUserSelect(o.hasAutoUserSelect)
     , objectFit(o.objectFit)
     , resize(o.resize)
 {
@@ -161,6 +165,8 @@ bool StyleMiscNonInheritedData::operator==(const StyleMiscNonInheritedData& o) c
         && usedAppearance == o.usedAppearance
         && textOverflow == o.textOverflow
         && userDrag == o.userDrag
+        && userSelect == o.userSelect
+        && hasAutoUserSelect == o.hasAutoUserSelect
         && objectFit == o.objectFit
         && resize == o.resize;
 }

--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
@@ -104,6 +104,8 @@ public:
     unsigned usedAppearance : appearanceBitWidth; // EAppearance
     unsigned textOverflow : 1; // Whether or not lines that spill out should be truncated with "..."
     unsigned userDrag : 2; // UserDrag
+    unsigned userSelect : 2; // UserSelect
+    unsigned hasAutoUserSelect : 1; // bool
     unsigned objectFit : 3; // ObjectFit
     unsigned resize : 3; // Resize
 

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -101,7 +101,6 @@ StyleRareInheritedData::StyleRareInheritedData()
     , overflowWrap(static_cast<unsigned>(RenderStyle::initialOverflowWrap()))
     , nbspMode(static_cast<unsigned>(NBSPMode::Normal))
     , lineBreak(static_cast<unsigned>(LineBreak::Auto))
-    , userSelect(static_cast<unsigned>(RenderStyle::initialUserSelect()))
     , hyphens(static_cast<unsigned>(Hyphens::Manual))
     , textCombine(static_cast<unsigned>(RenderStyle::initialTextCombine()))
     , textEmphasisFill(static_cast<unsigned>(TextEmphasisFill::Filled))
@@ -196,7 +195,6 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , overflowWrap(o.overflowWrap)
     , nbspMode(o.nbspMode)
     , lineBreak(o.lineBreak)
-    , userSelect(o.userSelect)
     , speakAs(o.speakAs)
     , hyphens(o.hyphens)
     , textCombine(o.textCombine)
@@ -315,7 +313,6 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
 #if ENABLE(TEXT_AUTOSIZING)
         && textSizeAdjust == o.textSizeAdjust
 #endif
-        && userSelect == o.userSelect
         && speakAs == o.speakAs
         && hyphens == o.hyphens
         && hyphenationLimitBefore == o.hyphenationLimitBefore

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -116,7 +116,6 @@ public:
     unsigned overflowWrap : 2; // OverflowWrap
     unsigned nbspMode : 1; // NBSPMode
     unsigned lineBreak : 3; // LineBreak
-    unsigned userSelect : 2; // UserSelect
     unsigned colorSpace : 1; // ColorSpace
     unsigned speakAs : 4 { 0 }; // OptionSet<SpeakAs>
     unsigned hyphens : 2; // Hyphens

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -565,6 +565,13 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
             style.setUsedZIndex(0);
     }
 
+    // Handle user-select: auto;
+    if (style.hasAutoUserSelect()) {
+        // FIXME: Make ::before & ::after use 'none' as used value.
+        // FIXME: Convert 'contain' parent value to 'text' once it's implemented.
+        style.setUsedUserSelect(m_parentStyle.userSelect());
+    }
+
     if (RefPtr element = m_element) {
         // Textarea considers overflow visible as auto.
         if (is<HTMLTextAreaElement>(*element)) {


### PR DESCRIPTION
#### a8f5d67d772e622c009d920a39722597e3b5ecc2
<pre>
Implement `auto` value as a computed value for `user-select` and stop making it inherited
<a href="https://bugs.webkit.org/show_bug.cgi?id=239514">https://bugs.webkit.org/show_bug.cgi?id=239514</a>
<a href="https://rdar.apple.com/92350088">rdar://92350088</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt:
* LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt:
* LayoutTests/media/modern-media-controls/airplay-placard/airplay-placard-text-section-expected.txt:
* LayoutTests/media/modern-media-controls/airplay-placard/airplay-placard-text-section.html:
* LayoutTests/media/modern-media-controls/pip-placard/pip-placard-text-section-expected.txt:
* LayoutTests/media/modern-media-controls/pip-placard/pip-placard-text-section.html:
* LayoutTests/media/modern-media-controls/status-label/status-label-text-selection-expected.txt:
* LayoutTests/media/modern-media-controls/status-label/status-label-text-selection.html:
* LayoutTests/svg/css/getComputedStyle-basic-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::miscDataChangeRequiresRepaint):
(WebCore::rareInheritedDataChangeRequiresRepaint):
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::hasAutoUserSelect const):
(WebCore::RenderStyle::userSelect const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setHasAutoUserSelect):
(WebCore::RenderStyle::setUserSelect):
* Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp:
(WebCore::StyleMiscNonInheritedData::StyleMiscNonInheritedData):
(WebCore::StyleMiscNonInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleMiscNonInheritedData.h:
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::StyleRareInheritedData):
(WebCore::StyleRareInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8f5d67d772e622c009d920a39722597e3b5ecc2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80780 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27542 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3596 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59808 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17935 "Found 1 new test failure: editing/selection/user-select-all-image-with-single-click.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79337 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49705 "Found 1 new test failure: editing/pasteboard/copy-content-with-user-select-none.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65501 "Found 1 new API test failure: TestWebKitAPI.CopyRTF.StripsUserSelectNone (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40151 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47103 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22987 "Found 1 new test failure: editing/pasteboard/copy-content-with-user-select-none.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25864 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68230 "Found 1 new API test failure: TestWebKitAPI.CopyRTF.StripsUserSelectNone (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23322 "Found 2 new test failures: editing/pasteboard/copy-content-with-user-select-none.html editing/selection/user-select-all-image-with-single-click.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82235 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3642 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2376 "Found 2 new test failures: editing/pasteboard/copy-content-with-user-select-none.html editing/selection/user-select-all-image-with-single-click.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68027 "Found 2 new test failures: editing/pasteboard/copy-content-with-user-select-none.html editing/selection/user-select-all-image-with-single-click.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65473 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67339 "Found 1 new API test failure: /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11304 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9404 "Found 2 new test failures: editing/pasteboard/copy-content-with-user-select-none.html editing/selection/user-select-all-image-with-single-click.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3590 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6397 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3613 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7042 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5371 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->