### PR TITLE
Replace UncheckedKeyHashMap with HashMap in more places where it should not impact performance

### DIFF
--- a/Source/WTF/benchmarks/LockSpeedTest.cpp
+++ b/Source/WTF/benchmarks/LockSpeedTest.cpp
@@ -62,7 +62,7 @@ struct WithPadding {
     char buf[300]; // It's best if this isn't perfect to avoid false sharing.
 };
 
-UncheckedKeyHashMap<CString, Vector<double>> results;
+HashMap<CString, Vector<double>> results;
 
 void reportResult(const char* name, double value)
 {

--- a/Source/WTF/icu/unicode/dtitvinf.h
+++ b/Source/WTF/icu/unicode/dtitvinf.h
@@ -501,8 +501,8 @@ private:
     // default order
     UBool fFirstDateInPtnIsLaterDate;
 
-    // UncheckedKeyHashMap<UnicodeString, UnicodeString[kIPI_MAX_INDEX]>
-    // UncheckedKeyHashMap( skeleton, pattern[largest_different_field] )
+    // HashMap<UnicodeString, UnicodeString[kIPI_MAX_INDEX]>
+    // HashMap( skeleton, pattern[largest_different_field] )
     Hashtable* fIntervalPatterns;
 
 };// end class DateIntervalInfo

--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -411,7 +411,7 @@ private:
     };
 
     Lock m_lock;
-    UncheckedKeyHashMap<void*, std::unique_ptr<MallocSiteData>> m_addressMallocSiteData WTF_GUARDED_BY_LOCK(m_lock);
+    HashMap<void*, std::unique_ptr<MallocSiteData>> m_addressMallocSiteData WTF_GUARDED_BY_LOCK(m_lock);
 };
 
 MallocCallTracker& MallocCallTracker::singleton()
@@ -494,7 +494,7 @@ void MallocCallTracker::dumpStats()
         size_t totalUntrackedSize = 0;
         size_t totalUntrackedCount = 0;
 
-        UncheckedKeyHashMap<unsigned, std::unique_ptr<MallocSiteTotals>> callSiteToMallocData;
+        HashMap<unsigned, std::unique_ptr<MallocSiteTotals>> callSiteToMallocData;
         for (const auto& it : m_addressMallocSiteData) {
             auto result = callSiteToMallocData.ensure(it.value->stack.hash(), [] () {
                 // Intentionally using std::make_unique not to use FastMalloc for data structure tracking FastMalloc.

--- a/Source/WTF/wtf/Language.cpp
+++ b/Source/WTF/wtf/Language.cpp
@@ -60,7 +60,7 @@ static Vector<String>& preferredLanguagesOverride() WTF_REQUIRES_LOCK(languagesL
 }
 static std::optional<bool> cachedUserPrefersSimplifiedChinese WTF_GUARDED_BY_LOCK(languagesLock);
 
-typedef UncheckedKeyHashMap<void*, LanguageChangeObserverFunction> ObserverMap;
+using ObserverMap = HashMap<void*, LanguageChangeObserverFunction>;
 static ObserverMap& observerMap()
 {
     static LazyNeverDestroyed<ObserverMap> map;

--- a/Source/WTF/wtf/NaturalLoops.h
+++ b/Source/WTF/wtf/NaturalLoops.h
@@ -353,7 +353,7 @@ private:
     Graph& m_graph;
     
     // If we ever had a scalability problem in our natural loop finder, we could
-    // use some UncheckedKeyHashMap's here. But it just feels a heck of a lot less convenient.
+    // use some HashMap's here. But it just feels a heck of a lot less convenient.
     Vector<NaturalLoop<Graph>, 4> m_loops;
     
     typename Graph::template Map<InnerMostLoopIndices> m_innerMostLoopIndices;

--- a/Source/WTF/wtf/SortedArrayMap.h
+++ b/Source/WTF/wtf/SortedArrayMap.h
@@ -32,8 +32,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WTF {
 
-// SortedArrayMap is a map like UncheckedKeyHashMap, but it's read-only. It uses much less memory than UncheckedKeyHashMap.
-// It uses binary search instead of hashing, so can be outperformed by UncheckedKeyHashMap for large maps.
+// SortedArrayMap is a map like HashMap, but it's read-only. It uses much less memory than HashMap.
+// It uses binary search instead of hashing, so can be outperformed by HashMap for large maps.
 // The array passed to the constructor has std::pair elements: keys first and values second.
 // The array and the SortedArrayMap should typically both be global constant expressions.
 
@@ -58,10 +58,10 @@ public:
     constexpr SortedArrayMap(const ArrayType&);
     template<typename KeyArgument> bool contains(const KeyArgument&) const;
 
-    // FIXME: To match UncheckedKeyHashMap interface better, would be nice to get the default value from traits.
+    // FIXME: To match HashMap interface better, would be nice to get the default value from traits.
     template<typename KeyArgument> ValueType get(const KeyArgument&, const ValueType& defaultValue = { }) const;
 
-    // FIXME: Should add a function like this to UncheckedKeyHashMap so the two kinds of maps are more interchangable.
+    // FIXME: Should add a function like this to HashMap so the two kinds of maps are more interchangable.
     template<typename KeyArgument> const ValueType* tryGet(const KeyArgument&) const;
 
 private:

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -388,7 +388,7 @@ protected:
     // Use WordLock since WordLock does not depend on ThreadSpecific and this "Thread".
     WordLock m_mutex;
     StackBounds m_stack { StackBounds::emptyBounds() };
-    UncheckedKeyHashMap<ThreadGroup*, std::weak_ptr<ThreadGroup>> m_threadGroupMap;
+    HashMap<ThreadGroup*, std::weak_ptr<ThreadGroup>> m_threadGroupMap;
     PlatformThreadHandle m_handle;
     uint32_t m_uid { ++s_uid };
 #if OS(WINDOWS)

--- a/Source/WTF/wtf/TimingScope.cpp
+++ b/Source/WTF/wtf/TimingScope.cpp
@@ -59,7 +59,7 @@ public:
     }
 
 private:
-    UncheckedKeyHashMap<const char*, CallData> totals WTF_GUARDED_BY_LOCK(lock);
+    HashMap<const char*, CallData> totals WTF_GUARDED_BY_LOCK(lock);
     Lock lock;
 };
 

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -326,7 +326,7 @@ static void assertProtocolIsGood(StringView protocol)
 
 static Lock defaultPortForProtocolMapForTestingLock;
 
-using DefaultPortForProtocolMapForTesting = UncheckedKeyHashMap<String, uint16_t>;
+using DefaultPortForProtocolMapForTesting = HashMap<String, uint16_t>;
 static DefaultPortForProtocolMapForTesting*& defaultPortForProtocolMapForTesting() WTF_REQUIRES_LOCK(defaultPortForProtocolMapForTestingLock)
 {
     static DefaultPortForProtocolMapForTesting* defaultPortForProtocolMap;

--- a/Source/WTF/wtf/text/StringHash.h
+++ b/Source/WTF/wtf/text/StringHash.h
@@ -43,7 +43,7 @@ namespace WTF {
     }
 
     // The hash() functions on StringHash and ASCIICaseInsensitiveHash do not support
-    // null strings. get(), contains(), and add() on UncheckedKeyHashMap<String,..., StringHash>
+    // null strings. get(), contains(), and add() on HashMap<String,..., StringHash>
     // cause a null-pointer dereference when passed null strings.
 
     // FIXME: We should really figure out a way to put the computeHash function that's
@@ -238,7 +238,7 @@ namespace WTF {
     };
 
     // FIXME: Find a way to incorporate this functionality into ASCIICaseInsensitiveHash and allow
-    // a UncheckedKeyHashMap whose keys are type String to perform operations when given a key of type StringView.
+    // a HashMap whose keys are type String to perform operations when given a key of type StringView.
     struct ASCIICaseInsensitiveStringViewHashTranslator {
         static unsigned hash(StringView key)
         {

--- a/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
@@ -109,8 +109,8 @@ struct HashTranslatorTextEncodingName {
     }
 };
 
-using TextEncodingNameMap = UncheckedKeyHashMap<ASCIILiteral, ASCIILiteral, TextEncodingNameHash>;
-using TextCodecMap = UncheckedKeyHashMap<ASCIILiteral, NewTextCodecFunction>;
+using TextEncodingNameMap = HashMap<ASCIILiteral, ASCIILiteral, TextEncodingNameHash>;
+using TextCodecMap = HashMap<ASCIILiteral, NewTextCodecFunction>;
 
 static Lock encodingRegistryLock;
 

--- a/Source/WebCore/bridge/IdentifierRep.cpp
+++ b/Source/WebCore/bridge/IdentifierRep.cpp
@@ -48,7 +48,7 @@ static IdentifierSet& identifierSet()
     return identifierSet;
 }
     
-typedef UncheckedKeyHashMap<int, IdentifierRep*> IntIdentifierMap;
+using IntIdentifierMap = HashMap<int, IdentifierRep*>;
 
 static IntIdentifierMap& intIdentifierMap()
 {
@@ -82,7 +82,7 @@ IdentifierRep* IdentifierRep::get(int intID)
     return result.iterator->value;
 }
 
-typedef UncheckedKeyHashMap<RefPtr<StringImpl>, IdentifierRep*> StringIdentifierMap;
+using StringIdentifierMap = HashMap<RefPtr<StringImpl>, IdentifierRep*>;
 
 static StringIdentifierMap& stringIdentifierMap()
 {

--- a/Source/WebCore/bridge/objc/WebScriptObject.mm
+++ b/Source/WebCore/bridge/objc/WebScriptObject.mm
@@ -74,9 +74,9 @@ static Lock wrapperCacheLock;
 static CreateWrapperFunction createDOMWrapperFunction;
 static DisconnectWindowWrapperFunction disconnectWindowWrapperFunction;
 
-static UncheckedKeyHashMap<JSObject*, NSObject *>& wrapperCache() WTF_REQUIRES_LOCK(wrapperCacheLock)
+static HashMap<JSObject*, NSObject *>& wrapperCache() WTF_REQUIRES_LOCK(wrapperCacheLock)
 {
-    static NeverDestroyed<UncheckedKeyHashMap<JSObject*, NSObject *>> map;
+    static NeverDestroyed<HashMap<JSObject*, NSObject *>> map;
     return map;
 }
 

--- a/Source/WebCore/bridge/objc/objc_class.h
+++ b/Source/WebCore/bridge/objc/objc_class.h
@@ -50,8 +50,8 @@ public:
     
 private:
     ClassStructPtr _isa;
-    mutable UncheckedKeyHashMap<String, std::unique_ptr<Method>> m_methodCache;
-    mutable UncheckedKeyHashMap<String, std::unique_ptr<Field>> m_fieldCache;
+    mutable HashMap<String, std::unique_ptr<Method>> m_methodCache;
+    mutable HashMap<String, std::unique_ptr<Field>> m_fieldCache;
 };
 
 } // namespace Bindings

--- a/Source/WebCore/bridge/objc/objc_instance.mm
+++ b/Source/WebCore/bridge/objc/objc_instance.mm
@@ -69,9 +69,9 @@ static RetainPtr<NSString>& globalException()
 // FIXME: A new object can happen to be equal to the old one, so even pointer comparison is not safe. Maybe we can use NeverDestroyed<JSC::Weak>?
 static JSGlobalObject* s_exceptionEnvironment;
 
-static UncheckedKeyHashMap<CFTypeRef, ObjcInstance*>& wrapperCache()
+static HashMap<CFTypeRef, ObjcInstance*>& wrapperCache()
 {
-    static NeverDestroyed<UncheckedKeyHashMap<CFTypeRef, ObjcInstance*>> map;
+    static NeverDestroyed<HashMap<CFTypeRef, ObjcInstance*>> map;
     return map;
 }
 

--- a/Source/WebCore/bridge/runtime_root.h
+++ b/Source/WebCore/bridge/runtime_root.h
@@ -90,7 +90,7 @@ private:
     Strong<JSGlobalObject> m_globalObject;
 
     ProtectCountSet m_protectCountSet;
-    UncheckedKeyHashMap<RuntimeObject*, JSC::Weak<RuntimeObject>> m_runtimeObjects; // We use a map to implement a set.
+    HashMap<RuntimeObject*, JSC::Weak<RuntimeObject>> m_runtimeObjects; // We use a map to implement a set.
 
     HashSet<InvalidationCallback*> m_invalidationCallbacks;
 };

--- a/Source/WebCore/crypto/CryptoAlgorithmRegistry.h
+++ b/Source/WebCore/crypto/CryptoAlgorithmRegistry.h
@@ -62,8 +62,8 @@ private:
     void registerAlgorithm(const String& name, CryptoAlgorithmIdentifier, CryptoAlgorithmConstructor);
 
     Lock m_lock;
-    UncheckedKeyHashMap<String, CryptoAlgorithmIdentifier, ASCIICaseInsensitiveHash> m_identifiers WTF_GUARDED_BY_LOCK(m_lock);
-    UncheckedKeyHashMap<unsigned, std::pair<String, CryptoAlgorithmConstructor>> m_constructors WTF_GUARDED_BY_LOCK(m_lock);
+    HashMap<String, CryptoAlgorithmIdentifier, ASCIICaseInsensitiveHash> m_identifiers WTF_GUARDED_BY_LOCK(m_lock);
+    HashMap<unsigned, std::pair<String, CryptoAlgorithmConstructor>> m_constructors WTF_GUARDED_BY_LOCK(m_lock);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/SubtleCrypto.h
+++ b/Source/WebCore/crypto/SubtleCrypto.h
@@ -81,7 +81,7 @@ private:
     inline friend RefPtr<DeferredPromise> getPromise(DeferredPromise*, WeakPtr<SubtleCrypto>);
 
     Ref<WorkQueue> m_workQueue;
-    UncheckedKeyHashMap<DeferredPromise*, Ref<DeferredPromise>> m_pendingPromises;
+    HashMap<DeferredPromise*, Ref<DeferredPromise>> m_pendingPromises;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -48,16 +48,16 @@ namespace WebCore {
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(BroadcastChannel);
 
 static Lock allBroadcastChannelsLock;
-static UncheckedKeyHashMap<BroadcastChannelIdentifier, ThreadSafeWeakPtr<BroadcastChannel>>& allBroadcastChannels() WTF_REQUIRES_LOCK(allBroadcastChannelsLock)
+static HashMap<BroadcastChannelIdentifier, ThreadSafeWeakPtr<BroadcastChannel>>& allBroadcastChannels() WTF_REQUIRES_LOCK(allBroadcastChannelsLock)
 {
-    static NeverDestroyed<UncheckedKeyHashMap<BroadcastChannelIdentifier, ThreadSafeWeakPtr<BroadcastChannel>>> map;
+    static NeverDestroyed<HashMap<BroadcastChannelIdentifier, ThreadSafeWeakPtr<BroadcastChannel>>> map;
     return map;
 }
 
-static UncheckedKeyHashMap<BroadcastChannelIdentifier, ScriptExecutionContextIdentifier>& channelToContextIdentifier()
+static HashMap<BroadcastChannelIdentifier, ScriptExecutionContextIdentifier>& channelToContextIdentifier()
 {
     ASSERT(isMainThread());
-    static NeverDestroyed<UncheckedKeyHashMap<BroadcastChannelIdentifier, ScriptExecutionContextIdentifier>> map;
+    static NeverDestroyed<HashMap<BroadcastChannelIdentifier, ScriptExecutionContextIdentifier>> map;
     return map;
 }
 

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -142,7 +142,7 @@ public:
 
 private:
     ListHashSet<AtomString> m_keys;
-    UncheckedKeyHashMap<AtomString, UniqueRef<CapturedElement>> m_map;
+    HashMap<AtomString, UniqueRef<CapturedElement>> m_map;
 };
 
 struct ViewTransitionParams {

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -68,7 +68,7 @@ public:
     static URLRegistry& registry();
 
     Lock m_urlsPerContextLock;
-    UncheckedKeyHashMap<ScriptExecutionContextIdentifier, HashSet<URL>> m_urlsPerContext WTF_GUARDED_BY_LOCK(m_urlsPerContextLock);
+    HashMap<ScriptExecutionContextIdentifier, HashSet<URL>> m_urlsPerContext WTF_GUARDED_BY_LOCK(m_urlsPerContextLock);
 };
 
 void BlobURLRegistry::registerURL(const ScriptExecutionContext& context, const URL& publicURL, URLRegistrable& blob)

--- a/Source/WebCore/fileapi/FileReader.h
+++ b/Source/WebCore/fileapi/FileReader.h
@@ -109,7 +109,7 @@ private:
     std::unique_ptr<FileReaderLoader> m_loader;
     RefPtr<DOMException> m_error;
     MonotonicTime m_lastProgressNotificationTime { MonotonicTime::nan() };
-    UncheckedKeyHashMap<uint64_t, Function<void()>> m_pendingTasks;
+    HashMap<uint64_t, Function<void()>> m_pendingTasks;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/fileapi/ThreadableBlobRegistry.cpp
+++ b/Source/WebCore/fileapi/ThreadableBlobRegistry.cpp
@@ -54,7 +54,7 @@
 
 namespace WebCore {
 
-using BlobURLOriginMap = UncheckedKeyHashMap<String, RefPtr<SecurityOrigin>>;
+using BlobURLOriginMap = HashMap<String, RefPtr<SecurityOrigin>>;
 
 static BlobURLOriginMap& originMap()
 {

--- a/Source/WebCore/history/BackForwardCache.h
+++ b/Source/WebCore/history/BackForwardCache.h
@@ -88,7 +88,7 @@ private:
     void prune(PruningReason);
     void dump() const;
 
-    UncheckedKeyHashMap<BackForwardItemIdentifier, std::variant<PruningReason, UniqueRef<CachedPage>>> m_cachedPageMap;
+    HashMap<BackForwardItemIdentifier, std::variant<PruningReason, UniqueRef<CachedPage>>> m_cachedPageMap;
     ListHashSet<BackForwardItemIdentifier> m_items;
     unsigned m_maxSize {0};
 

--- a/Source/WebCore/html/track/InbandGenericTextTrack.h
+++ b/Source/WebCore/html/track/InbandGenericTextTrack.h
@@ -43,8 +43,8 @@ public:
     TextTrackCueGeneric* find(InbandGenericCueIdentifier);
 
 private:
-    using CueToDataMap = UncheckedKeyHashMap<TextTrackCue*, InbandGenericCueIdentifier>;
-    using CueDataToCueMap = UncheckedKeyHashMap<InbandGenericCueIdentifier, RefPtr<TextTrackCueGeneric>>;
+    using CueToDataMap = HashMap<TextTrackCue*, InbandGenericCueIdentifier>;
+    using CueDataToCueMap = HashMap<InbandGenericCueIdentifier, RefPtr<TextTrackCueGeneric>>;
 
     CueToDataMap m_cueToDataMap;
     CueDataToCueMap m_dataToCueMap;

--- a/Source/WebCore/inspector/DOMPatchSupport.cpp
+++ b/Source/WebCore/inspector/DOMPatchSupport.cpp
@@ -236,7 +236,7 @@ DOMPatchSupport::diff(const Vector<std::unique_ptr<Digest>>& oldList, const Vect
         newMap[newIndex].second = oldIndex;
     }
 
-    typedef UncheckedKeyHashMap<String, Vector<size_t>> DiffTable;
+    using DiffTable = HashMap<String, Vector<size_t>>;
     DiffTable newTable;
     DiffTable oldTable;
 
@@ -298,7 +298,7 @@ ExceptionOr<void> DOMPatchSupport::innerPatchChildren(ContainerNode& parentNode,
     Digest* oldBody = nullptr;
 
     // 1. First strip everything except for the nodes that retain. Collect pending merges.
-    UncheckedKeyHashMap<Digest*, Digest*> merges;
+    HashMap<Digest*, Digest*> merges;
     HashSet<size_t, IntHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>> usedNewOrdinals;
     for (size_t i = 0; i < oldList.size(); ++i) {
         if (oldMap[i].first) {

--- a/Source/WebCore/inspector/DOMPatchSupport.h
+++ b/Source/WebCore/inspector/DOMPatchSupport.h
@@ -52,7 +52,7 @@ private:
     struct Digest;
 
     using ResultMap = Vector<std::pair<Digest*, size_t>>;
-    using UnusedNodesMap = UncheckedKeyHashMap<String, Digest*>;
+    using UnusedNodesMap = HashMap<String, Digest*>;
 
     ExceptionOr<void> innerPatchNode(Digest& oldNode, Digest& newNode);
     std::pair<ResultMap, ResultMap> diff(const Vector<std::unique_ptr<Digest>>& oldChildren, const Vector<std::unique_ptr<Digest>>& newChildren);

--- a/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.h
+++ b/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.h
@@ -92,7 +92,7 @@ private:
 
     WeakPtr<Page> m_frontendPage;
     Vector<std::pair<String, EvaluationResultHandler>> m_queuedEvaluations;
-    UncheckedKeyHashMap<Ref<DOMPromise>, EvaluationResultHandler> m_pendingResponses;
+    HashMap<Ref<DOMPromise>, EvaluationResultHandler> m_pendingResponses;
     bool m_frontendLoaded { false };
     bool m_suspended { false };
 };

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -830,7 +830,7 @@ Ref<Inspector::Protocol::CSS::CSSStyle> InspectorStyle::styleWithProperties() co
 
     auto propertiesObject = JSON::ArrayOf<Inspector::Protocol::CSS::CSSProperty>::create();
     auto shorthandEntries = ArrayOf<Inspector::Protocol::CSS::ShorthandEntry>::create();
-    UncheckedKeyHashMap<String, RefPtr<Inspector::Protocol::CSS::CSSProperty>> propertyNameToPreviousActiveProperty;
+    HashMap<String, RefPtr<Inspector::Protocol::CSS::CSSProperty>> propertyNameToPreviousActiveProperty;
     HashSet<String> foundShorthands;
     String previousPriority;
     String previousStatus;
@@ -888,7 +888,7 @@ Ref<Inspector::Protocol::CSS::CSSStyle> InspectorStyle::styleWithProperties() co
 
                 // Canonicalize property names to treat non-prefixed and vendor-prefixed property names the same (opacity vs. -webkit-opacity).
                 String canonicalPropertyName = propertyId != CSSPropertyID::CSSPropertyInvalid && propertyId != CSSPropertyID::CSSPropertyCustom ? nameString(propertyId) : name;
-                UncheckedKeyHashMap<String, RefPtr<Inspector::Protocol::CSS::CSSProperty>>::iterator activeIt = propertyNameToPreviousActiveProperty.find(canonicalPropertyName);
+                HashMap<String, RefPtr<Inspector::Protocol::CSS::CSSProperty>>::iterator activeIt = propertyNameToPreviousActiveProperty.find(canonicalPropertyName);
                 if (activeIt != propertyNameToPreviousActiveProperty.end()) {
                     if (propertyEntry.parsedOk) {
                         auto newPriority = activeIt->value->getString("priority"_s);

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.h
@@ -118,7 +118,7 @@ private:
         String trackingAnimationId;
         ComputedEffectTiming lastComputedTiming;
     };
-    UncheckedKeyHashMap<StyleOriginatedAnimation*, UniqueRef<TrackedStyleOriginatedAnimationData>> m_trackedStyleOriginatedAnimationData;
+    HashMap<StyleOriginatedAnimation*, UniqueRef<TrackedStyleOriginatedAnimationData>> m_trackedStyleOriginatedAnimationData;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -160,10 +160,10 @@ private:
     class SetRuleHeaderTextAction;
     class AddRuleAction;
 
-    typedef UncheckedKeyHashMap<Inspector::Protocol::CSS::StyleSheetId, RefPtr<InspectorStyleSheet>> IdToInspectorStyleSheet;
-    typedef UncheckedKeyHashMap<CSSStyleSheet*, RefPtr<InspectorStyleSheet>> CSSStyleSheetToInspectorStyleSheet;
-    typedef UncheckedKeyHashMap<RefPtr<Document>, Vector<RefPtr<InspectorStyleSheet>>> DocumentToViaInspectorStyleSheet; // "via inspector" stylesheets
-    typedef HashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>> PseudoClassHashSet;
+    using IdToInspectorStyleSheet = HashMap<Inspector::Protocol::CSS::StyleSheetId, RefPtr<InspectorStyleSheet>>;
+    using CSSStyleSheetToInspectorStyleSheet = HashMap<CSSStyleSheet*, RefPtr<InspectorStyleSheet>>;
+    using DocumentToViaInspectorStyleSheet = HashMap<RefPtr<Document>, Vector<RefPtr<InspectorStyleSheet>>>; // "via inspector" stylesheets
+    using PseudoClassHashSet = HashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>>;
 
     InspectorStyleSheetForInlineStyle& asInspectorStyleSheet(StyledElement&);
     Element* elementForId(Inspector::Protocol::ErrorString&, Inspector::Protocol::DOM::NodeId);
@@ -196,10 +196,10 @@ private:
     Page& m_inspectedPage;
     IdToInspectorStyleSheet m_idToInspectorStyleSheet;
     CSSStyleSheetToInspectorStyleSheet m_cssStyleSheetToInspectorStyleSheet;
-    UncheckedKeyHashMap<Node*, Ref<InspectorStyleSheetForInlineStyle>> m_nodeToInspectorStyleSheet; // bogus "stylesheets" with elements' inline styles
+    HashMap<Node*, Ref<InspectorStyleSheetForInlineStyle>> m_nodeToInspectorStyleSheet; // bogus "stylesheets" with elements' inline styles
     DocumentToViaInspectorStyleSheet m_documentToInspectorStyleSheet;
-    UncheckedKeyHashMap<Document*, HashSet<CSSStyleSheet*>> m_documentToKnownCSSStyleSheets;
-    UncheckedKeyHashMap<Inspector::Protocol::DOM::NodeId, PseudoClassHashSet> m_nodeIdToForcedPseudoState;
+    HashMap<Document*, HashSet<CSSStyleSheet*>> m_documentToKnownCSSStyleSheets;
+    HashMap<Inspector::Protocol::DOM::NodeId, PseudoClassHashSet> m_nodeIdToForcedPseudoState;
     HashSet<Document*> m_documentsWithForcedPseudoStates;
 
     int m_lastStyleSheetId { 1 };

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -285,11 +285,11 @@ private:
     Page& m_inspectedPage;
     InspectorOverlay* m_overlay { nullptr };
     WeakHashMap<Node, Inspector::Protocol::DOM::NodeId, WeakPtrImplWithEventTargetData> m_nodeToId;
-    UncheckedKeyHashMap<Inspector::Protocol::DOM::NodeId, WeakPtr<Node, WeakPtrImplWithEventTargetData>> m_idToNode;
+    HashMap<Inspector::Protocol::DOM::NodeId, WeakPtr<Node, WeakPtrImplWithEventTargetData>> m_idToNode;
     HashSet<Inspector::Protocol::DOM::NodeId> m_childrenRequested;
     Inspector::Protocol::DOM::NodeId m_lastNodeId { 1 };
     RefPtr<Document> m_document;
-    typedef UncheckedKeyHashMap<String, Vector<RefPtr<Node>>> SearchResults;
+    using SearchResults = HashMap<String, Vector<RefPtr<Node>>>;
     SearchResults m_searchResults;
     std::unique_ptr<RevalidateStyleAttributeTask> m_revalidateStyleAttrTask;
     RefPtr<Node> m_nodeToFocus;
@@ -361,7 +361,7 @@ private:
     friend class EventFiredCallback;
 
     HashSet<const Event*> m_dispatchedEvents;
-    UncheckedKeyHashMap<Inspector::Protocol::DOM::EventListenerId, InspectorEventListener> m_eventListenerEntries;
+    HashMap<Inspector::Protocol::DOM::EventListenerId, InspectorEventListener> m_eventListenerEntries;
     Inspector::Protocol::DOM::EventListenerId m_lastEventListenerId { 1 };
 
     bool m_searchingForNode { false };

--- a/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h
@@ -87,11 +87,11 @@ private:
     std::unique_ptr<Inspector::LayerTreeFrontendDispatcher> m_frontendDispatcher;
     RefPtr<Inspector::LayerTreeBackendDispatcher> m_backendDispatcher;
 
-    UncheckedKeyHashMap<const RenderLayer*, Inspector::Protocol::LayerTree::LayerId> m_documentLayerToIdMap;
-    UncheckedKeyHashMap<Inspector::Protocol::LayerTree::LayerId, const RenderLayer*> m_idToLayer;
+    HashMap<const RenderLayer*, Inspector::Protocol::LayerTree::LayerId> m_documentLayerToIdMap;
+    HashMap<Inspector::Protocol::LayerTree::LayerId, const RenderLayer*> m_idToLayer;
 
     WeakHashMap<PseudoElement, Inspector::Protocol::LayerTree::PseudoElementId, WeakPtrImplWithEventTargetData> m_pseudoElementToIdMap;
-    UncheckedKeyHashMap<Inspector::Protocol::LayerTree::PseudoElementId, WeakPtr<PseudoElement, WeakPtrImplWithEventTargetData>> m_idToPseudoElement;
+    HashMap<Inspector::Protocol::LayerTree::PseudoElementId, WeakPtr<PseudoElement, WeakPtrImplWithEventTargetData>> m_idToPseudoElement;
 
     bool m_suppressLayerChangeEvents { false };
 };

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -175,7 +175,7 @@ private:
 
     WeakHashMap<Frame, String> m_frameToIdentifier;
     MemoryCompactRobinHoodHashMap<String, WeakPtr<Frame>> m_identifierToFrame;
-    UncheckedKeyHashMap<DocumentLoader*, String> m_loaderToIdentifier;
+    HashMap<DocumentLoader*, String> m_loaderToIdentifier;
     String m_userAgentOverride;
     AtomString m_emulatedMedia;
     String m_bootstrapScript;

--- a/Source/WebCore/inspector/agents/WebDebuggerAgent.h
+++ b/Source/WebCore/inspector/agents/WebDebuggerAgent.h
@@ -65,8 +65,8 @@ protected:
     InstrumentingAgents& m_instrumentingAgents;
 
 private:
-    UncheckedKeyHashMap<const RegisteredEventListener*, int> m_registeredEventListeners;
-    UncheckedKeyHashMap<const RegisteredEventListener*, int> m_dispatchedEventListeners;
+    HashMap<const RegisteredEventListener*, int> m_registeredEventListeners;
+    HashMap<const RegisteredEventListener*, int> m_dispatchedEventListeners;
     HashSet<int> m_postMessageTasks;
     int m_nextEventListenerIdentifier { 1 };
     int m_nextPostMessageIdentifier { 1 };

--- a/Source/WebCore/inspector/agents/page/PageDOMDebuggerAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageDOMDebuggerAgent.h
@@ -67,9 +67,9 @@ private:
 
     Ref<JSON::Object> buildPauseDataForDOMBreakpoint(Inspector::Protocol::DOMDebugger::DOMBreakpointType, Node& breakpointOwner);
 
-    UncheckedKeyHashMap<Node*, Ref<JSC::Breakpoint>> m_domSubtreeModifiedBreakpoints;
-    UncheckedKeyHashMap<Node*, Ref<JSC::Breakpoint>> m_domAttributeModifiedBreakpoints;
-    UncheckedKeyHashMap<Node*, Ref<JSC::Breakpoint>> m_domNodeRemovedBreakpoints;
+    HashMap<Node*, Ref<JSC::Breakpoint>> m_domSubtreeModifiedBreakpoints;
+    HashMap<Node*, Ref<JSC::Breakpoint>> m_domAttributeModifiedBreakpoints;
+    HashMap<Node*, Ref<JSC::Breakpoint>> m_domNodeRemovedBreakpoints;
 
     RefPtr<JSC::Breakpoint> m_pauseOnAllAnimationFramesBreakpoint;
 };

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -160,9 +160,9 @@ static void setAllDefersLoading(const ResourceLoaderMap& loaders, bool defers)
         loader->setDefersLoading(defers);
 }
 
-static UncheckedKeyHashMap<ScriptExecutionContextIdentifier, DocumentLoader*>& scriptExecutionContextIdentifierToLoaderMap()
+static HashMap<ScriptExecutionContextIdentifier, DocumentLoader*>& scriptExecutionContextIdentifierToLoaderMap()
 {
-    static NeverDestroyed<UncheckedKeyHashMap<ScriptExecutionContextIdentifier, DocumentLoader*>> map;
+    static NeverDestroyed<HashMap<ScriptExecutionContextIdentifier, DocumentLoader*>> map;
     return map.get();
 }
 

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -191,7 +191,7 @@ private:
     bool m_suppressNormalScrollRestorationDuringOngoingNavigation { false };
     RefPtr<NavigationAPIMethodTracker> m_ongoingAPIMethodTracker;
     RefPtr<NavigationAPIMethodTracker> m_upcomingNonTraverseMethodTracker;
-    UncheckedKeyHashMap<String, Ref<NavigationAPIMethodTracker>> m_upcomingTraverseMethodTrackers;
+    HashMap<String, Ref<NavigationAPIMethodTracker>> m_upcomingTraverseMethodTrackers;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1139,7 +1139,7 @@ struct FindReplacementRange {
 
 static void replaceRanges(Page& page, const Vector<FindReplacementRange>& ranges, const String& replacementText)
 {
-    UncheckedKeyHashMap<RefPtr<ContainerNode>, Vector<FindReplacementRange>> rangesByContainerNode;
+    HashMap<RefPtr<ContainerNode>, Vector<FindReplacementRange>> rangesByContainerNode;
     for (auto& range : ranges) {
         auto& rangeList = rangesByContainerNode.ensure(range.root, [] {
             return Vector<FindReplacementRange> { };
@@ -1157,7 +1157,7 @@ static void replaceRanges(Page& page, const Vector<FindReplacementRange>& ranges
         rangeList.insert(insertionIndex, range);
     }
 
-    UncheckedKeyHashMap<RefPtr<LocalFrame>, unsigned> frameToTraversalIndexMap;
+    HashMap<RefPtr<LocalFrame>, unsigned> frameToTraversalIndexMap;
     unsigned currentFrameTraversalIndex = 0;
     for (auto* frame = &page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
         if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame))

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1636,7 +1636,7 @@ private:
     Ref<BadgeClient> m_badgeClient;
     Ref<HistoryItemClient> m_historyItemClient;
 
-    UncheckedKeyHashMap<RegistrableDomain, uint64_t> m_noiseInjectionHashSalts;
+    HashMap<RegistrableDomain, uint64_t> m_noiseInjectionHashSalts;
 
 #if PLATFORM(IOS_FAMILY)
     String m_sceneIdentifier;

--- a/Source/WebCore/page/PageGroup.cpp
+++ b/Source/WebCore/page/PageGroup.cpp
@@ -71,7 +71,7 @@ PageGroup::PageGroup(Page& page)
 
 PageGroup::~PageGroup() = default;
 
-typedef UncheckedKeyHashMap<String, PageGroup*> PageGroupMap;
+using PageGroupMap = HashMap<String, PageGroup*>;
 static PageGroupMap* pageGroups = nullptr;
 
 PageGroup* PageGroup::pageGroup(const String& groupName)

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -341,7 +341,7 @@ void PrintContext::outputLinkedDestinations(GraphicsContext& graphicsContext, Do
         return;
 
     if (!m_linkedDestinations) {
-        m_linkedDestinations = makeUnique<UncheckedKeyHashMap<String, Ref<Element>>>();
+        m_linkedDestinations = makeUnique<HashMap<String, Ref<Element>>>();
         collectLinkedDestinations(document);
     }
 

--- a/Source/WebCore/page/PrintContext.h
+++ b/Source/WebCore/page/PrintContext.h
@@ -111,7 +111,7 @@ private:
     // Used to prevent misuses of begin() and end() (e.g., call end without begin).
     bool m_isPrinting { false };
 
-    std::unique_ptr<UncheckedKeyHashMap<String, Ref<Element>>> m_linkedDestinations;
+    std::unique_ptr<HashMap<String, Ref<Element>>> m_linkedDestinations;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -97,10 +97,10 @@ static inline OptionSet<AutoplayQuirk> allowedAutoplayQuirks(Document& document)
     return loader->allowedAutoplayQuirks();
 }
 
-static UncheckedKeyHashMap<RegistrableDomain, String>& updatableStorageAccessUserAgentStringQuirks()
+static HashMap<RegistrableDomain, String>& updatableStorageAccessUserAgentStringQuirks()
 {
     // FIXME: Make this a member of Quirks.
-    static MainThreadNeverDestroyed<UncheckedKeyHashMap<RegistrableDomain, String>> map;
+    static MainThreadNeverDestroyed<HashMap<RegistrableDomain, String>> map;
     return map.get();
 }
 

--- a/Source/WebCore/page/ResourceUsageThread.h
+++ b/Source/WebCore/page/ResourceUsageThread.h
@@ -81,7 +81,7 @@ private:
     RefPtr<Thread> m_thread;
     Lock m_observersLock;
     Condition m_condition;
-    UncheckedKeyHashMap<void*, std::pair<ResourceUsageCollectionMode, std::function<void(const ResourceUsageData&)>>> m_observers WTF_GUARDED_BY_LOCK(m_observersLock);
+    HashMap<void*, std::pair<ResourceUsageCollectionMode, std::function<void(const ResourceUsageData&)>>> m_observers WTF_GUARDED_BY_LOCK(m_observersLock);
     ResourceUsageCollectionMode m_collectionMode { None };
 
     // Platforms may need to access some data from the common VM.

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h
@@ -86,7 +86,7 @@ private:
 
     void inputNotificationTimerFired();
 
-    UncheckedKeyHashMap<CFTypeRef, std::unique_ptr<GameControllerGamepad>> m_gamepadMap;
+    HashMap<CFTypeRef, std::unique_ptr<GameControllerGamepad>> m_gamepadMap;
     Vector<WeakPtr<PlatformGamepad>> m_gamepadVector;
     WeakHashSet<PlatformGamepad> m_invisibleGamepads;
 

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
@@ -76,7 +76,7 @@ private:
     void inputNotificationTimerFired();
 
     Vector<WeakPtr<PlatformGamepad>> m_gamepadVector;
-    UncheckedKeyHashMap<uintptr_t, std::unique_ptr<GamepadLibWPE>> m_gamepadMap;
+    HashMap<uintptr_t, std::unique_ptr<GamepadLibWPE>> m_gamepadMap;
     bool m_initialGamepadsConnected { false };
 
     std::unique_ptr<struct wpe_gamepad_provider, void (*)(struct wpe_gamepad_provider*)> m_provider;

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepad.h
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepad.h
@@ -52,7 +52,7 @@ public:
 protected:
     HIDGamepad(HIDDevice&&, unsigned index);
 
-    UncheckedKeyHashMap<IOHIDElementCookie, std::unique_ptr<HIDGamepadElement>> m_elementMap;
+    HashMap<IOHIDElementCookie, std::unique_ptr<HIDGamepadElement>> m_elementMap;
     Vector<SharedGamepadValue> m_buttonValues;
     Vector<SharedGamepadValue> m_axisValues;
 

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h
@@ -82,7 +82,7 @@ private:
     unsigned indexForNewlyConnectedDevice();
 
     Vector<WeakPtr<PlatformGamepad>> m_gamepadVector;
-    UncheckedKeyHashMap<IOHIDDeviceRef, std::unique_ptr<HIDGamepad>> m_gamepadMap;
+    HashMap<IOHIDDeviceRef, std::unique_ptr<HIDGamepad>> m_gamepadMap;
 
     RetainPtr<IOHIDManagerRef> m_manager;
 

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h
@@ -72,7 +72,7 @@ private:
     void inputNotificationTimerFired();
 
     Vector<WeakPtr<PlatformGamepad>> m_gamepadVector;
-    UncheckedKeyHashMap<ManetteDevice*, std::unique_ptr<ManetteGamepad>> m_gamepadMap;
+    HashMap<ManetteDevice*, std::unique_ptr<ManetteGamepad>> m_gamepadMap;
     bool m_initialGamepadsConnected { false };
 
     GRefPtr<ManetteMonitor> m_monitor;

--- a/Source/WebCore/platform/mediastream/MediaPayload.h
+++ b/Source/WebCore/platform/mediastream/MediaPayload.h
@@ -53,7 +53,7 @@ public:
     bool nackpli { false };
     bool nack { false };
 
-    UncheckedKeyHashMap<String, unsigned> parameters;
+    HashMap<String, unsigned> parameters;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -305,7 +305,7 @@ private:
     Ref<RealtimeMediaSource> m_source;
     std::unique_ptr<MediaStreamTrackPrivateSourceObserverSourceProxy> m_sourceProxy;
     std::function<void(Function<void()>&&)> m_postTask;
-    UncheckedKeyHashMap<uint64_t, ApplyConstraintsHandler> m_applyConstraintsCallbacks;
+    HashMap<uint64_t, ApplyConstraintsHandler> m_applyConstraintsCallbacks;
     uint64_t m_applyConstraintsCallbacksIdentifier { 0 };
 };
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -388,7 +388,7 @@ private:
     HashSet<CheckedPtr<AudioSampleObserver>> m_audioSampleObservers WTF_GUARDED_BY_LOCK(m_audioSampleObserversLock);
 
     mutable Lock m_videoFrameObserversLock;
-    UncheckedKeyHashMap<VideoFrameObserver*, std::unique_ptr<VideoFrameAdaptor>> m_videoFrameObservers WTF_GUARDED_BY_LOCK(m_videoFrameObserversLock);
+    HashMap<VideoFrameObserver*, std::unique_ptr<VideoFrameAdaptor>> m_videoFrameObservers WTF_GUARDED_BY_LOCK(m_videoFrameObserversLock);
 
     CaptureDevice m_device;
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h
@@ -140,7 +140,7 @@ private:
         NodeAndFD nodeAndFd;
         String path;
     };
-    UncheckedKeyHashMap<String, std::unique_ptr<Session>> m_sessions;
+    HashMap<String, std::unique_ptr<Session>> m_sessions;
 
     GRefPtr<GDBusProxy> m_proxy;
     ResponseCallback m_currentResponseCallback;

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
@@ -59,7 +59,7 @@ private:
     GRefPtr<GstElement> m_bin;
     GRefPtr<GstElement> m_sink;
     Lock m_clientLock;
-    UncheckedKeyHashMap<int, GRefPtr<GstElement>> m_clients WTF_GUARDED_BY_LOCK(m_clientLock);
+    HashMap<int, GRefPtr<GstElement>> m_clients WTF_GUARDED_BY_LOCK(m_clientLock);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -333,10 +333,10 @@ static Vector<MockMediaDevice>& devices()
     return devices;
 }
 
-static UncheckedKeyHashMap<String, MockMediaDevice>& deviceMap()
+static HashMap<String, MockMediaDevice>& deviceMap()
 {
     static NeverDestroyed map = [] {
-        UncheckedKeyHashMap<String, MockMediaDevice> map;
+        HashMap<String, MockMediaDevice> map;
         for (auto& device : devices())
             map.add(device.persistentId, device);
         return map;

--- a/Source/WebCore/platform/network/curl/CookieJarDB.h
+++ b/Source/WebCore/platform/network/curl/CookieJarDB.h
@@ -105,7 +105,7 @@ private:
     bool hasCookies(const URL&);
 
     SQLiteDatabase m_database;
-    UncheckedKeyHashMap<String, std::unique_ptr<SQLiteStatement>> m_statements;
+    HashMap<String, std::unique_ptr<SQLiteStatement>> m_statements;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/curl/CurlRequestScheduler.h
+++ b/Source/WebCore/platform/network/curl/CurlRequestScheduler.h
@@ -72,7 +72,7 @@ private:
 
     Vector<Function<void()>> m_taskQueue;
     HashSet<CurlRequestSchedulerClient*> m_activeJobs;
-    UncheckedKeyHashMap<CURL*, CurlRequestSchedulerClient*> m_clientMaps;
+    HashMap<CURL*, CurlRequestSchedulerClient*> m_clientMaps;
 
     Lock m_multiHandleMutex;
     std::optional<CurlMultiHandle> m_curlMultiHandle;

--- a/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
+++ b/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
@@ -61,8 +61,8 @@ private:
     CurlStreamID m_currentStreamID = 1;
 
     Vector<Function<void()>> m_taskQueue;
-    UncheckedKeyHashMap<CurlStreamID, CurlStream::Client*> m_clientList;
-    UncheckedKeyHashMap<CurlStreamID, std::unique_ptr<CurlStream>> m_streamList;
+    HashMap<CurlStreamID, CurlStream::Client*> m_clientList;
+    HashMap<CurlStreamID, std::unique_ptr<CurlStream>> m_streamList;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/glib/DNSResolveQueueGLib.h
+++ b/Source/WebCore/platform/network/glib/DNSResolveQueueGLib.h
@@ -59,7 +59,7 @@ private:
     void updateIsUsingProxy() final;
     void platformResolve(const String&) final;
 
-    UncheckedKeyHashMap<uint64_t, GRefPtr<GCancellable>> m_requestCancellables;
+    HashMap<uint64_t, GRefPtr<GCancellable>> m_requestCancellables;
 };
 
 using DNSResolveQueuePlatform = DNSResolveQueueGLib;

--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.h
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.h
@@ -84,7 +84,7 @@ private:
     PAL::SessionID m_sessionID;
     bool m_ignoreTLSErrors { false };
     SoupNetworkProxySettings m_proxySettings;
-    UncheckedKeyHashMap<String, HostTLSCertificateSet, ASCIICaseInsensitiveHash> m_allowedCertificates;
+    HashMap<String, HostTLSCertificateSet, ASCIICaseInsensitiveHash> m_allowedCertificates;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/storage/StorageNamespaceProvider.h
+++ b/Source/WebCore/storage/StorageNamespaceProvider.h
@@ -70,7 +70,7 @@ private:
     virtual Ref<StorageNamespace> createTransientLocalStorageNamespace(SecurityOrigin&, unsigned quota, PAL::SessionID) = 0;
 
     RefPtr<StorageNamespace> m_localStorageNamespace;
-    UncheckedKeyHashMap<SecurityOriginData, RefPtr<StorageNamespace>> m_transientLocalStorageNamespaces;
+    HashMap<SecurityOriginData, RefPtr<StorageNamespace>> m_transientLocalStorageNamespaces;
 
     unsigned m_sessionStorageQuota { 0 };
 };


### PR DESCRIPTION
#### b819dda2e51c36103f8f83e0d74f76206ef2c30f
<pre>
Replace UncheckedKeyHashMap with HashMap in more places where it should not impact performance
<a href="https://bugs.webkit.org/show_bug.cgi?id=283033">https://bugs.webkit.org/show_bug.cgi?id=283033</a>

Reviewed by Darin Adler.

* Source/WTF/benchmarks/LockSpeedTest.cpp:
* Source/WTF/icu/unicode/dtitvinf.h:
* Source/WTF/wtf/FastMalloc.cpp:
(WTF::MallocCallTracker::dumpStats):
* Source/WTF/wtf/Language.cpp:
* Source/WTF/wtf/NaturalLoops.h:
* Source/WTF/wtf/SortedArrayMap.h:
* Source/WTF/wtf/Threading.h:
* Source/WTF/wtf/TimingScope.cpp:
* Source/WTF/wtf/URL.cpp:
* Source/WTF/wtf/text/StringHash.h:
* Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp:
* Source/WebCore/bridge/IdentifierRep.cpp:
* Source/WebCore/bridge/objc/WebScriptObject.mm:
* Source/WebCore/bridge/objc/objc_class.h:
* Source/WebCore/bridge/objc/objc_instance.mm:
* Source/WebCore/bridge/runtime_root.h:
* Source/WebCore/crypto/CryptoAlgorithmRegistry.h:
* Source/WebCore/crypto/SubtleCrypto.h:
* Source/WebCore/dom/BroadcastChannel.cpp:
(WebCore::WTF_REQUIRES_LOCK):
(WebCore::channelToContextIdentifier):
* Source/WebCore/dom/ViewTransition.h:
* Source/WebCore/fileapi/Blob.cpp:
* Source/WebCore/fileapi/FileReader.h:
* Source/WebCore/fileapi/ThreadableBlobRegistry.cpp:
* Source/WebCore/history/BackForwardCache.h:
* Source/WebCore/html/track/InbandGenericTextTrack.h:
* Source/WebCore/inspector/DOMPatchSupport.cpp:
(WebCore::DOMPatchSupport::diff):
(WebCore::DOMPatchSupport::innerPatchChildren):
* Source/WebCore/inspector/DOMPatchSupport.h:
* Source/WebCore/inspector/InspectorFrontendAPIDispatcher.h:
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::InspectorStyle::styleWithProperties const):
* Source/WebCore/inspector/agents/InspectorAnimationAgent.h:
* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.h:
* Source/WebCore/inspector/agents/InspectorLayerTreeAgent.h:
* Source/WebCore/inspector/agents/InspectorPageAgent.h:
* Source/WebCore/inspector/agents/WebDebuggerAgent.h:
* Source/WebCore/inspector/agents/page/PageDOMDebuggerAgent.h:
* Source/WebCore/loader/DocumentLoader.cpp:
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/Page.cpp:
(WebCore::replaceRanges):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageGroup.cpp:
* Source/WebCore/page/PrintContext.cpp:
(WebCore::PrintContext::outputLinkedDestinations):
* Source/WebCore/page/PrintContext.h:
* Source/WebCore/page/Quirks.cpp:
(WebCore::updatableStorageAccessUserAgentStringQuirks):
* Source/WebCore/page/ResourceUsageThread.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h:
* Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h:
* Source/WebCore/platform/gamepad/mac/HIDGamepad.h:
* Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h:
* Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h:
* Source/WebCore/platform/mediastream/MediaPayload.h:
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h:
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
(WebCore::deviceMap):
* Source/WebCore/platform/network/curl/CookieJarDB.h:
* Source/WebCore/platform/network/curl/CurlRequestScheduler.h:
* Source/WebCore/platform/network/curl/CurlStreamScheduler.h:
* Source/WebCore/platform/network/glib/DNSResolveQueueGLib.h:
* Source/WebCore/platform/network/soup/SoupNetworkSession.h:
* Source/WebCore/storage/StorageNamespaceProvider.h:

Canonical link: <a href="https://commits.webkit.org/286534@main">https://commits.webkit.org/286534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ef8c26022b287c0ddb109184f6f55fc8ff89c1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80753 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27518 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59789 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17924 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65485 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40133 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47086 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22971 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25840 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69425 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68215 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82211 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75522 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3618 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2362 "Found 1 new test failure: imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.tentative.https.any.serviceworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68012 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3772 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67324 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11281 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9392 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97776 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11798 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3566 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6373 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21395 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3589 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7018 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5347 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->