### PR TITLE
Decrease use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF/

### DIFF
--- a/Source/WTF/wtf/persistence/PersistentCoders.cpp
+++ b/Source/WTF/wtf/persistence/PersistentCoders.cpp
@@ -31,8 +31,6 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF::Persistence {
 
 void Coder<AtomString>::encodeForPersistence(Encoder& encoder, const AtomString& atomString)
@@ -201,5 +199,3 @@ std::optional<Seconds> Coder<Seconds>::decodeForPersistence(Decoder& decoder)
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/persistence/PersistentDecoder.cpp
+++ b/Source/WTF/wtf/persistence/PersistentDecoder.cpp
@@ -26,9 +26,8 @@
 #include "config.h"
 #include <wtf/persistence/PersistentDecoder.h>
 
+#include <wtf/StdLibExtras.h>
 #include <wtf/persistence/PersistentEncoder.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WTF::Persistence {
 
@@ -45,24 +44,24 @@ bool Decoder::bufferIsLargeEnoughToContain(size_t size) const
     return size <= static_cast<size_t>(std::distance(m_bufferPosition, m_buffer.end()));
 }
 
-const uint8_t* Decoder::bufferPointerForDirectRead(size_t size)
+std::span<const uint8_t> Decoder::bufferPointerForDirectRead(size_t size)
 {
     if (!bufferIsLargeEnoughToContain(size))
-        return nullptr;
+        return { };
 
-    auto data = m_buffer.data() + currentOffset();
+    auto data = m_buffer.subspan(currentOffset(), size);
     m_bufferPosition += size;
 
-    Encoder::updateChecksumForData(m_sha1, { data, size });
+    Encoder::updateChecksumForData(m_sha1, data);
     return data;
 }
 
 bool Decoder::decodeFixedLengthData(std::span<uint8_t> span)
 {
     auto buffer = bufferPointerForDirectRead(span.size());
-    if (!buffer)
+    if (!buffer.data())
         return false;
-    memcpy(span.data(), buffer, span.size());
+    memcpySpan(span, buffer);
     return true;
 }
 
@@ -82,7 +81,7 @@ Decoder& Decoder::decodeNumber(std::optional<T>& optional)
         return *this;
 
     T value;
-    memcpy(&value, m_buffer.data() + currentOffset(), sizeof(T));
+    memcpySpan(asMutableByteSpan(value), m_buffer.subspan(currentOffset(), sizeof(T)));
     m_bufferPosition += sizeof(T);
 
     Encoder::updateChecksumForNumber(m_sha1, value);
@@ -153,5 +152,3 @@ bool Decoder::verifyChecksum()
 }
 
 } // namespace WTF::Persistence
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/persistence/PersistentDecoder.h
+++ b/Source/WTF/wtf/persistence/PersistentDecoder.h
@@ -88,7 +88,7 @@ public:
         return numElements <= std::numeric_limits<size_t>::max() / sizeof(T) && bufferIsLargeEnoughToContain(numElements * sizeof(T));
     }
 
-    WTF_EXPORT_PRIVATE WARN_UNUSED_RETURN const uint8_t* bufferPointerForDirectRead(size_t numBytes);
+    WTF_EXPORT_PRIVATE WARN_UNUSED_RETURN std::span<const uint8_t> bufferPointerForDirectRead(size_t numBytes);
 
 private:
     WTF_EXPORT_PRIVATE WARN_UNUSED_RETURN bool bufferIsLargeEnoughToContain(size_t) const;

--- a/Source/WTF/wtf/persistence/PersistentEncoder.h
+++ b/Source/WTF/wtf/persistence/PersistentEncoder.h
@@ -28,10 +28,9 @@
 #include <span>
 #include <wtf/EnumTraits.h>
 #include <wtf/SHA1.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
 #include <wtf/persistence/PersistentCoders.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WTF::Persistence {
 
@@ -84,7 +83,7 @@ private:
 
     template<typename Type> Encoder& encodeNumber(Type);
 
-    uint8_t* grow(size_t);
+    std::span<uint8_t> grow(size_t);
 
     template <typename Type> struct Salt;
 
@@ -108,10 +107,8 @@ template <typename Type>
 void Encoder::updateChecksumForNumber(SHA1& sha1, Type value)
 {
     auto typeSalt = Salt<Type>::value;
-    sha1.addBytes(std::span { reinterpret_cast<uint8_t*>(&typeSalt), sizeof(typeSalt) });
-    sha1.addBytes(std::span { reinterpret_cast<uint8_t*>(&value), sizeof(value) });
+    sha1.addBytes(asByteSpan(typeSalt));
+    sha1.addBytes(asByteSpan(value));
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/text/cf/AtomStringImplCF.cpp
+++ b/Source/WTF/wtf/text/cf/AtomStringImplCF.cpp
@@ -31,8 +31,6 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <wtf/text/CString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 RefPtr<AtomStringImpl> AtomStringImpl::add(CFStringRef string)
@@ -43,18 +41,16 @@ RefPtr<AtomStringImpl> AtomStringImpl::add(CFStringRef string)
     size_t length = CFStringGetLength(string);
 
     if (const LChar* ptr = byteCast<LChar>(CFStringGetCStringPtr(string, kCFStringEncodingISOLatin1)))
-        return add(std::span { ptr, length });
+        return add(unsafeMakeSpan(ptr, length));
 
     if (const UniChar* ptr = CFStringGetCharactersPtr(string))
-        return add(std::span { reinterpret_cast<const UChar*>(ptr), length });
+        return add(unsafeMakeSpan(reinterpret_cast<const UChar*>(ptr), length));
 
     Vector<UniChar, 1024> ucharBuffer(length);
     CFStringGetCharacters(string, CFRangeMake(0, length), ucharBuffer.data());
-    return add(std::span { reinterpret_cast<const UChar*>(ucharBuffer.data()), length });
+    return add(spanReinterpretCast<const UChar>(ucharBuffer.span()));
 }
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(CF)

--- a/Source/WTF/wtf/text/cf/StringImplCF.cpp
+++ b/Source/WTF/wtf/text/cf/StringImplCF.cpp
@@ -30,8 +30,6 @@
 #include <wtf/RetainPtr.h>
 #include <wtf/Threading.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 namespace StringWrapperCFAllocator {
@@ -57,6 +55,7 @@ namespace StringWrapperCFAllocator {
         return CFSTR("WTF::String-based allocator");
     }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     static void* allocate(CFIndex size, CFOptionFlags, void*)
     {
         StringImpl* underlyingString = nullptr;
@@ -95,6 +94,7 @@ namespace StringWrapperCFAllocator {
             });
         }
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     static CFIndex preferredSize(CFIndex size, CFOptionFlags, void*)
     {
@@ -155,7 +155,5 @@ RetainPtr<CFStringRef> StringImpl::createCFString()
 // allocator, so it's probably not urgent optimize that case.
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(CF)

--- a/Source/WTF/wtf/text/cocoa/ContextualizedNSString.mm
+++ b/Source/WTF/wtf/text/cocoa/ContextualizedNSString.mm
@@ -29,8 +29,6 @@
 #import <algorithm>
 #import <wtf/text/StringView.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 @implementation WTFContextualizedNSString {
     StringView context;
     StringView contents;
@@ -67,9 +65,9 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     auto contentsSubstring = contents.substring(contentsLow - context.length(), contentsHigh - contentsLow);
     static_assert(std::is_same_v<std::make_unsigned_t<unichar>, std::make_unsigned_t<UChar>>);
     contextSubstring.getCharacters(reinterpret_cast<UChar*>(buffer));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     contentsSubstring.getCharacters(reinterpret_cast<UChar*>(buffer) + contextSubstring.length());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 @end
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/WebCorePersistentCoders.cpp
+++ b/Source/WebCore/platform/WebCorePersistentCoders.cpp
@@ -337,11 +337,11 @@ static std::optional<RetainPtr<CFDataRef>> decodeCFData(Decoder& decoder)
     if (UNLIKELY(!isInBounds<size_t>(*size)))
         return std::nullopt;
 
-    auto pointer = decoder.bufferPointerForDirectRead(static_cast<size_t>(*size));
-    if (!pointer)
+    auto buffer = decoder.bufferPointerForDirectRead(static_cast<size_t>(*size));
+    if (!buffer.data())
         return std::nullopt;
 
-    return adoptCF(CFDataCreate(nullptr, pointer, *size));
+    return toCFData(buffer);
 }
 
 static void encodeSecTrustRef(Encoder& encoder, SecTrustRef trust)


### PR DESCRIPTION
#### 5c846c99d1332f366820911b12c069b26a1745a1
<pre>
Decrease use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF/
<a href="https://bugs.webkit.org/show_bug.cgi?id=283035">https://bugs.webkit.org/show_bug.cgi?id=283035</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/persistence/PersistentCoders.cpp:
* Source/WTF/wtf/persistence/PersistentDecoder.cpp:
(WTF::Persistence::Decoder::bufferPointerForDirectRead):
(WTF::Persistence::Decoder::decodeFixedLengthData):
(WTF::Persistence::Decoder::decodeNumber):
* Source/WTF/wtf/persistence/PersistentDecoder.h:
* Source/WTF/wtf/persistence/PersistentEncoder.cpp:
(WTF::Persistence::Encoder::grow):
(WTF::Persistence::Encoder::updateChecksumForData):
(WTF::Persistence::Encoder::encodeFixedLengthData):
(WTF::Persistence::Encoder::encodeNumber):
(WTF::Persistence::Encoder::encodeChecksum):
* Source/WTF/wtf/persistence/PersistentEncoder.h:
(WTF::Persistence::Encoder::updateChecksumForNumber):
* Source/WTF/wtf/text/cf/AtomStringImplCF.cpp:
(WTF::AtomStringImpl::add):
* Source/WTF/wtf/text/cf/StringImplCF.cpp:
* Source/WTF/wtf/text/cocoa/ContextualizedNSString.mm:
(-[WTFContextualizedNSString getCharacters:range:]):
* Source/WebCore/platform/WebCorePersistentCoders.cpp:
(WTF::Persistence::decodeCFData):

Canonical link: <a href="https://commits.webkit.org/286554@main">https://commits.webkit.org/286554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97f2b4a0a170c2cef3ed597f59ca52d0d978faa7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80831 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27592 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78436 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3646 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/17968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79387 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/49753 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65545 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/40189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47151 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23032 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/25914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69499 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/68278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82287 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75596 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3692 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2415 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3846 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65517 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67377 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11345 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9444 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97850 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11806 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3640 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6447 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21409 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3663 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7092 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5421 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->