### PR TITLE
Restrict dynamic_objc_cast to downcast.

### DIFF
--- a/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
+++ b/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
@@ -121,12 +121,13 @@ template<typename T> inline T *checked_objc_cast(id object)
 
 template<typename T, typename U> inline T *checked_objc_cast(U *object)
 {
+    static_assert(std::is_base_of_v<U, T>);
     if (!object)
         return nullptr;
 
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(is_objc<T>(object));
 
-    return reinterpret_cast<T*>(object);
+    return static_cast<T*>(object);
 }
 
 // Use dynamic_objc_cast<> instead of checked_objc_cast<> when actively checking NS types,
@@ -134,14 +135,32 @@ template<typename T, typename U> inline T *checked_objc_cast(U *object)
 
 // See RetainPtr.h for: template<typename T> T* dynamic_objc_cast(id object).
 
-template<typename T, typename U> RetainPtr<T> dynamic_objc_cast(RetainPtr<U>&& object)
+template<typename T, typename U, typename = std::enable_if_t<std::is_base_of_v<U, T>>> RetainPtr<T> dynamic_objc_cast(RetainPtr<U>&& object)
+{
+    static_assert(std::is_base_of_v<U, T>);
+    static_assert(!std::is_same_v<U, T>);
+    if (!is_objc<T>(object.get()))
+        return nullptr;
+    return adoptNS(static_cast<T*>(object.leakRef()));
+}
+
+template<typename T> RetainPtr<T> dynamic_objc_cast(RetainPtr<id>&& object)
 {
     if (!is_objc<T>(object.get()))
         return nullptr;
-    return WTFMove(object);
+    return adoptNS(reinterpret_cast<T*>(object.leakRef()));
 }
 
-template<typename T, typename U> RetainPtr<T> dynamic_objc_cast(const RetainPtr<U>& object)
+template<typename T, typename U, typename = std::enable_if_t<std::is_base_of_v<U, T>>> RetainPtr<T> dynamic_objc_cast(const RetainPtr<U>& object)
+{
+    static_assert(std::is_base_of_v<U, T>);
+    static_assert(!std::is_same_v<U, T>);
+    if (!is_objc<T>(object.get()))
+        return nullptr;
+    return static_cast<T*>(object.get());
+}
+
+template<typename T> RetainPtr<T> dynamic_objc_cast(const RetainPtr<id>& object)
 {
     if (!is_objc<T>(object.get()))
         return nullptr;
@@ -152,7 +171,7 @@ template<typename T> T *dynamic_objc_cast(NSObject *object)
 {
     if (!is_objc<T>(object))
         return nullptr;
-    return reinterpret_cast<T*>(object);
+    return static_cast<T*>(object);
 }
 
 template<typename T> T *dynamic_objc_cast(id object)

--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -251,7 +251,7 @@ public:
         new (&object) T(std::forward<Args>(args)...);
     }
 
-    id <WKObject> wrapper() const { return (__bridge id <WKObject>)m_wrapper; }
+    id wrapper() const { return (__bridge id)m_wrapper; }
 #endif
 
     void ref() const;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -143,7 +143,6 @@ void executeScript(const SourcePairs& scriptPairs, WKWebView *webView, API::Cont
             return;
         }
 
-        auto *world = executionWorld->wrapper();
         auto *frames = getFrames(mainFrame, parameters);
 
         for (_WKFrameTreeNode *frame in frames) {
@@ -159,7 +158,7 @@ void executeScript(const SourcePairs& scriptPairs, WKWebView *webView, API::Cont
                 NSString *javaScript = [NSString stringWithFormat:@"return (%@)(...arguments)", (NSString *)parameters.function.value()];
                 NSArray *arguments = parameters.arguments ? parseJSON(parameters.arguments.value(), JSONOptions::FragmentsAllowed) : @[ ];
 
-                [webView _callAsyncJavaScript:javaScript arguments:@{ @"arguments": arguments } inFrame:frameInfo inContentWorld:world completionHandler:makeBlockPtr([injectionResults, aggregator, frameInfo](id resultOfExecution, NSError *error) mutable {
+                [webView _callAsyncJavaScript:javaScript arguments:@{ @"arguments": arguments } inFrame:frameInfo inContentWorld:executionWorld->wrapper() completionHandler:makeBlockPtr([injectionResults, aggregator, frameInfo](id resultOfExecution, NSError *error) mutable {
                     injectionResults->results.append(toInjectionResultParameters(resultOfExecution, frameInfo, error.localizedDescription));
                 }).get()];
 

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
@@ -168,7 +168,8 @@ TEST(TypeCastsCocoa, checked_objc_cast)
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
             objectNS = adoptNS([[NSString alloc] initWithFormat:@"%s", helloWorldCString]);
             objectNSPtr = reinterpret_cast<uintptr_t>(objectNS.get());
-            EXPECT_EQ(objectNS.get(), checked_objc_cast<NSObject>(objectNS.get()));
+            NSObject* objPtr = objectNS.get();
+            EXPECT_EQ(objectNS.get(), objPtr);
         }
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectNSPtr));
     }
@@ -238,7 +239,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast)
 TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
 {
     @autoreleasepool {
-        RetainPtr<NSString> object;
+        RetainPtr<NSObject> object;
         auto objectCast = dynamic_objc_cast<NSString>(WTFMove(object));
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nil, object.get());
         EXPECT_EQ(nil, objectCast.get());
@@ -287,7 +288,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
         RetainPtr<NSArray> objectCastBad;
         uintptr_t objectPtr2;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
-            objectCastBad = dynamic_objc_cast<NSArray>(WTFMove(object));
+            objectCastBad = dynamic_objc_cast<NSArray>(object);
             objectPtr2 = reinterpret_cast<uintptr_t>(object.get());
         }
         EXPECT_EQ(objectPtr, objectPtr2);
@@ -303,7 +304,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
         }
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
 
-        auto objectCast = dynamic_objc_cast<NSObject>(WTFMove(object));
+        RetainPtr<NSObject> objectCast = WTFMove(object);
         uintptr_t objectCastPtr;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
             objectCastPtr = reinterpret_cast<uintptr_t>(objectCast.get());


### PR DESCRIPTION
#### 3073c97f61bc5d36032761637c77bed90fd12430
<pre>
Restrict dynamic_objc_cast to downcast.
<a href="https://bugs.webkit.org/show_bug.cgi?id=283039">https://bugs.webkit.org/show_bug.cgi?id=283039</a>

Reviewed by Geoffrey Garen.

Restrict dynamic_objc_cast&lt;T&gt;(U) to downcast only to match the semantics of downcast&lt;T&gt;(U).

* Source/WTF/wtf/cocoa/TypeCastsCocoa.h:
(WTF::checked_objc_cast):
(WTF::dynamic_objc_cast):
* Source/WebKit/Shared/API/APIObject.h:
(API::Object::wrapper const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::executeScript):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm:
(TestWebKitAPI::TEST(TypeCastsCocoa, checked_objc_cast)):
(TestWebKitAPI::TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)):

Canonical link: <a href="https://commits.webkit.org/291650@main">https://commits.webkit.org/291650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cd0ae245edbc5edd4c681266580253173fd4a90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98533 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44056 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95580 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21546 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71456 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28834 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51790 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9699 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2208 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43370 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86240 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79976 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100565 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92196 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20582 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80469 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20834 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80515 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79799 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24340 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1683 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13730 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15004 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20566 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25744 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/114846 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20253 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23713 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21994 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->