### PR TITLE
requestVideoFrameCallback never calls its callback if the window is hidden.

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -145,9 +145,6 @@ media/media-source/media-source-vp8-webm-error-offscreen.html [ Pass ]
 
 webkit.org/b/269897 media/media-source/media-managedmse-poster.html [ Skip ]
 
-webkit.org/b/282969 media/media-video-fullrange.html [ Timeout Pass ]
-webkit.org/b/282969 media/media-video-videorange.html [ Timeout Pass ]
-
 fast/images/text-recognition [ Pass ]
 fast/images/text-recognition/ios [ Pass ]
 fast/images/text-recognition/mac [ Skip ]

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -154,13 +154,10 @@ MediaPlayerPrivateWebM::~MediaPlayerPrivateWebM()
 
     if (m_durationObserver)
         [m_synchronizer removeTimeObserver:m_durationObserver.get()];
-    if (m_videoFrameMetadataGatheringObserver)
-        [m_synchronizer removeTimeObserver:m_videoFrameMetadataGatheringObserver.get()];
     if (m_timeJumpedObserver)
         [m_synchronizer removeTimeObserver:m_timeJumpedObserver.get()];
 
     destroyLayer();
-    destroyDecompressionSession();
     destroyAudioRenderers();
     m_listener->invalidate();
 
@@ -188,7 +185,7 @@ MediaPlayer::SupportsType MediaPlayerPrivateWebM::supportsType(const MediaEngine
 {
     if (parameters.isMediaSource || parameters.isMediaStream || parameters.requiresRemotePlayback)
         return MediaPlayer::SupportsType::IsNotSupported;
-    
+
     return SourceBufferParserWebM::isContentTypeSupported(parameters.type);
 }
 
@@ -637,31 +634,16 @@ RefPtr<NativeImage> MediaPlayerPrivateWebM::nativeImageForCurrentTime()
 
 bool MediaPlayerPrivateWebM::updateLastPixelBuffer()
 {
-    if (m_videoRenderer) {
-        auto entry = m_videoRenderer->copyDisplayedPixelBuffer();
-        if (entry.pixelBuffer) {
-            INFO_LOG(LOGIDENTIFIER, "displayed pixelbuffer copied for time ", entry.presentationTimeStamp);
-            m_lastPixelBuffer = WTFMove(entry.pixelBuffer);
-            m_lastPixelBufferPresentationTimeStamp = entry.presentationTimeStamp;
-            return true;
-        }
-    }
-
-    if (!m_decompressionSession)
+    if (!m_videoRenderer)
         return false;
 
-    auto flags = !m_lastPixelBuffer ? WebCoreDecompressionSession::AllowLater : WebCoreDecompressionSession::ExactTime;
-    auto newPixelBuffer = m_decompressionSession->imageForTime(currentTime(), flags);
-    if (!newPixelBuffer)
+    auto entry = m_videoRenderer->copyDisplayedPixelBuffer();
+    if (!entry.pixelBuffer)
         return false;
 
-    m_lastPixelBuffer = WTFMove(newPixelBuffer);
-
-    if (m_resourceOwner) {
-        if (auto surface = CVPixelBufferGetIOSurface(m_lastPixelBuffer.get()))
-            IOSurface::setOwnershipIdentity(surface, m_resourceOwner);
-    }
-
+    INFO_LOG(LOGIDENTIFIER, "displayed pixelbuffer copied for time ", entry.presentationTimeStamp);
+    m_lastPixelBuffer = WTFMove(entry.pixelBuffer);
+    m_lastPixelBufferPresentationTimeStamp = entry.presentationTimeStamp;
     return true;
 }
 
@@ -764,6 +746,7 @@ void MediaPlayerPrivateWebM::setHasAvailableVideoFrame(bool hasAvailableVideoFra
     if (auto player = m_player.get())
         player->firstVideoFrameAvailable();
 
+    checkNewVideoFrameMetadata(currentTime());
     if (m_seekState == WaitingForAvailableFame)
         maybeCompleteSeek();
 
@@ -839,31 +822,29 @@ void MediaPlayerPrivateWebM::characteristicsChanged()
 bool MediaPlayerPrivateWebM::shouldEnsureLayerOrVideoRenderer() const
 {
     auto player = m_player.get();
-    return (m_videoRenderer && !CGRectIsEmpty(m_videoRenderer->bounds())) || (player && !player->presentationSize().isEmpty());
+    return ((m_sampleBufferDisplayLayer && !CGRectIsEmpty([m_sampleBufferDisplayLayer bounds])) || (player && !player->presentationSize().isEmpty()));
 }
 
 void MediaPlayerPrivateWebM::setPresentationSize(const IntSize& newSize)
 {
     if (m_hasVideo && !m_videoRenderer && !newSize.isEmpty())
-        updateDisplayLayerAndDecompressionSession();
+        updateDisplayLayer();
 }
 
 void MediaPlayerPrivateWebM::acceleratedRenderingStateChanged()
 {
     if (m_hasVideo)
-        updateDisplayLayerAndDecompressionSession();
+        updateDisplayLayer();
 }
 
-void MediaPlayerPrivateWebM::updateDisplayLayerAndDecompressionSession()
+void MediaPlayerPrivateWebM::updateDisplayLayer()
 {
     if (shouldEnsureLayerOrVideoRenderer()) {
-        auto needsRenderingModeChanged = destroyDecompressionSession();
+        auto needsRenderingModeChanged = !m_videoRenderer || m_videoRenderer->renderer() ? MediaPlayerEnums::NeedsRenderingModeChanged::No : MediaPlayerEnums::NeedsRenderingModeChanged::Yes;
         ensureLayerOrVideoRenderer(needsRenderingModeChanged);
         return;
     }
-
-    destroyLayerOrVideoRenderer();
-    ensureDecompressionSession();
+    destroyLayerOrVideoRendererAndCreateRenderlessVideoMediaSampleRenderer();
 }
 
 RetainPtr<PlatformLayer> MediaPlayerPrivateWebM::createVideoFullscreenLayer()
@@ -961,40 +942,11 @@ void MediaPlayerPrivateWebM::enqueueSample(Ref<MediaSample>&& sample, TrackID tr
         if (formatSize != m_naturalSize)
             setNaturalSize(formatSize);
 
-        if (m_decompressionSession)
-            m_decompressionSession->enqueueSample(platformSample.sample.cmSampleBuffer, !sample->isNonDisplaying());
-
         if (!m_videoRenderer)
             return;
 
         m_videoRenderer->enqueueSample(sample);
-        WebSampleBufferVideoRendering *renderer = m_videoRenderer->renderer();
-#if HAVE(AVSAMPLEBUFFERDISPLAYLAYER_READYFORDISPLAY)
-        if (AVSampleBufferDisplayLayer *displayLayer = m_videoRenderer->displayLayer()) {
-            // FIXME (117934497): Remove staging code once -[AVSampleBufferDisplayLayer isReadyForDisplay] is available in SDKs used by WebKit builders
-            if ([displayLayer respondsToSelector:@selector(isReadyForDisplay)])
-                return;
-        }
-#endif
-        if (m_hasAvailableVideoFrame || sample->isNonDisplaying())
-            return;
-
-        DEBUG_LOG(LOGIDENTIFIER, "adding buffer attachment");
-
-        [renderer prerollDecodeWithCompletionHandler:[this, weakThis = ThreadSafeWeakPtr { *this }, logSiteIdentifier = LOGIDENTIFIER] (BOOL success) mutable {
-            ensureOnMainThread([this, weakThis = WTFMove(weakThis), logSiteIdentifier, success] () {
-                RefPtr protectedThis = weakThis.get();
-                if (!protectedThis)
-                    return;
-
-                if (!success || !m_videoRenderer) {
-                    ERROR_LOG(logSiteIdentifier, "prerollDecodeWithCompletionHandler failed");
-                    return;
-                }
-
-                videoRendererReadyForDisplayChanged(m_videoRenderer->renderer(), true);
-            });
-        }];
+        registerNotifyWhenHasAvailableVideoFrame();
 
         return;
     }
@@ -1036,21 +988,16 @@ void MediaPlayerPrivateWebM::reenqueueMediaForTime(TrackBuffer& trackBuffer, Tra
 void MediaPlayerPrivateWebM::notifyClientWhenReadyForMoreSamples(TrackID trackId)
 {
     if (isEnabledVideoTrackID(trackId)) {
-        if (m_decompressionSession) {
-            m_decompressionSession->requestMediaDataWhenReady([weakThis = ThreadSafeWeakPtr { *this }, this, trackId] {
-                if (RefPtr protectedThis = weakThis.get())
-                    didBecomeReadyForMoreSamples(trackId);
-            });
-        }
-        if (m_videoRenderer) {
-            m_videoRenderer->requestMediaDataWhenReady([weakThis = ThreadSafeWeakPtr { *this }, this, trackId] {
-                if (RefPtr protectedThis = weakThis.get())
-                    didBecomeReadyForMoreSamples(trackId);
-            });
-        }
+        if (!m_videoRenderer)
+            return;
+
+        m_videoRenderer->requestMediaDataWhenReady([weakThis = ThreadSafeWeakPtr { *this }, this, trackId] {
+            if (RefPtr protectedThis = weakThis.get())
+                didBecomeReadyForMoreSamples(trackId);
+        });
         return;
     }
-    
+
     if (auto itAudioRenderer = m_audioRenderers.find(trackId); itAudioRenderer != m_audioRenderers.end()) {
         ThreadSafeWeakPtr weakThis { *this };
         [itAudioRenderer->second requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:^{
@@ -1079,9 +1026,6 @@ bool MediaPlayerPrivateWebM::isReadyForMoreSamples(TrackID trackId)
         if (m_displayLayerWasInterrupted)
             return false;
 #endif
-        if (m_decompressionSession)
-            return m_decompressionSession->isReadyForMoreMediaData();
-        
         return m_videoRenderer->isReadyForMoreMediaData();
     }
 
@@ -1096,8 +1040,6 @@ void MediaPlayerPrivateWebM::didBecomeReadyForMoreSamples(TrackID trackId)
     INFO_LOG(LOGIDENTIFIER, trackId);
 
     if (isEnabledVideoTrackID(trackId)) {
-        if (m_decompressionSession)
-            m_decompressionSession->stopRequestingMediaData();
         if (m_videoRenderer)
             m_videoRenderer->stopRequestingMediaData();
     } else if (auto itAudioRenderer = m_audioRenderers.find(trackId); itAudioRenderer != m_audioRenderers.end())
@@ -1214,7 +1156,7 @@ void MediaPlayerPrivateWebM::trackDidChangeSelected(VideoTrackPrivate& track, bo
 
     if (selected) {
         m_enabledVideoTrackID = trackId;
-        updateDisplayLayerAndDecompressionSession();
+        updateDisplayLayer();
         return;
     }
     
@@ -1223,8 +1165,6 @@ void MediaPlayerPrivateWebM::trackDidChangeSelected(VideoTrackPrivate& track, bo
         m_readyForMoreSamplesMap.erase(trackId);
         if (m_videoRenderer)
             m_videoRenderer->stopRequestingMediaData();
-        if (m_decompressionSession)
-            m_decompressionSession->stopRequestingMediaData();
     }
 }
 
@@ -1405,10 +1345,8 @@ void MediaPlayerPrivateWebM::flushIfNeeded()
         flushVideo();
 
     // We initiatively enqueue samples instead of waiting for the
-    // media data requests from m_decompressionSession and m_displayLayer.
+    // media data requests from m_displayLayer.
     // In addition, we need to enqueue a sync sample (IDR video frame) first.
-    if (m_decompressionSession)
-        m_decompressionSession->stopRequestingMediaData();
     if (m_videoRenderer)
         m_videoRenderer->stopRequestingMediaData();
 
@@ -1435,11 +1373,6 @@ void MediaPlayerPrivateWebM::flushVideo()
     DEBUG_LOG(LOGIDENTIFIER);
     if (m_videoRenderer)
         m_videoRenderer->flush();
-    
-    if (m_decompressionSession) {
-        m_decompressionSession->flush();
-        registerNotifyWhenHasAvailableVideoFrame();
-    }
     setHasAvailableVideoFrame(false);
 }
 
@@ -1479,28 +1412,6 @@ void MediaPlayerPrivateWebM::ensureLayer()
 
     if (RefPtr player = m_player.get())
         m_videoLayerManager->setVideoLayer(m_sampleBufferDisplayLayer.get(), player->presentationSize());
-}
-
-void MediaPlayerPrivateWebM::ensureDecompressionSession()
-{
-    if (m_decompressionSession)
-        return;
-    
-    m_decompressionSession = WebCoreDecompressionSession::createOpenGL();
-    m_decompressionSession->setTimebase([m_synchronizer timebase]);
-    m_decompressionSession->setResourceOwner(m_resourceOwner);
-    m_decompressionSession->setErrorListener([weakThis = WeakPtr { *this }](OSStatus) {
-        if (RefPtr protectedThis = weakThis.get()) {
-            protectedThis->setNetworkState(MediaPlayer::NetworkState::DecodeError);
-            protectedThis->setReadyState(MediaPlayer::ReadyState::HaveNothing);
-            protectedThis->m_errored = true;
-        }
-    });
-
-    registerNotifyWhenHasAvailableVideoFrame();
-    
-    if (auto player = m_player.get())
-        player->renderingModeChanged();
 }
 
 void MediaPlayerPrivateWebM::addAudioRenderer(TrackID trackId)
@@ -1573,17 +1484,6 @@ void MediaPlayerPrivateWebM::destroyLayer()
 
     m_videoLayerManager->didDestroyVideoLayer();
     m_sampleBufferDisplayLayer = nullptr;
-}
-
-MediaPlayerEnums::NeedsRenderingModeChanged MediaPlayerPrivateWebM::destroyDecompressionSession()
-{
-    if (!m_decompressionSession)
-        return MediaPlayerEnums::NeedsRenderingModeChanged::No;
-
-    m_decompressionSession->invalidate();
-    m_decompressionSession = nullptr;
-    setHasAvailableVideoFrame(false);
-    return MediaPlayerEnums::NeedsRenderingModeChanged::Yes;
 }
 
 void MediaPlayerPrivateWebM::ensureVideoRenderer()
@@ -1660,45 +1560,25 @@ void MediaPlayerPrivateWebM::clearTracks()
 
 void MediaPlayerPrivateWebM::registerNotifyWhenHasAvailableVideoFrame()
 {
-    if (!m_decompressionSession)
-        return;
-    
-    m_decompressionSession->notifyWhenHasAvailableVideoFrame([weakThis = WeakPtr { *this }, this] {
-        if (weakThis)
-            setHasAvailableVideoFrame(true);
+    m_videoRenderer->notifyWhenHasAvailableVideoFrame([weakThis = WeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->setHasAvailableVideoFrame(true);
     });
 }
 
 void MediaPlayerPrivateWebM::startVideoFrameMetadataGathering()
 {
-    if (m_videoFrameMetadataGatheringObserver)
-        return;
     ASSERT(m_synchronizer);
     m_isGatheringVideoFrameMetadata = true;
-    acceleratedRenderingStateChanged();
-
-    // FIXME: We should use a CADisplayLink to get updates on rendering, for now we emulate with addPeriodicTimeObserverForInterval.
-    m_videoFrameMetadataGatheringObserver = [m_synchronizer addPeriodicTimeObserverForInterval:PAL::CMTimeMake(1, 60) queue:dispatch_get_main_queue() usingBlock:[weakThis = WeakPtr { *this }, this](CMTime currentTime) {
-        ensureOnMainThread([weakThis, this, currentTime] {
-            if (weakThis)
-                checkNewVideoFrameMetadata(currentTime);
-        });
-    }];
 }
 
 void MediaPlayerPrivateWebM::stopVideoFrameMetadataGathering()
 {
     m_isGatheringVideoFrameMetadata = false;
-    acceleratedRenderingStateChanged();
     m_videoFrameMetadata = { };
-
-    ASSERT(m_videoFrameMetadataGatheringObserver);
-    if (m_videoFrameMetadataGatheringObserver)
-        [m_synchronizer removeTimeObserver:m_videoFrameMetadataGatheringObserver.get()];
-    m_videoFrameMetadataGatheringObserver = nil;
 }
 
-void MediaPlayerPrivateWebM::checkNewVideoFrameMetadata(CMTime currentCMTime)
+void MediaPlayerPrivateWebM::checkNewVideoFrameMetadata(MediaTime currentTime)
 {
     auto player = m_player.get();
     if (!player)
@@ -1707,7 +1587,6 @@ void MediaPlayerPrivateWebM::checkNewVideoFrameMetadata(CMTime currentCMTime)
     if (!updateLastPixelBuffer())
         return;
 
-    auto currentTime = PAL::toMediaTime(currentCMTime);
     auto presentationTime = m_lastPixelBufferPresentationTimeStamp;
     if (!presentationTime.isValid())
         presentationTime = currentTime;
@@ -1803,17 +1682,6 @@ void MediaPlayerPrivateWebM::audioRendererDidReceiveError(AVSampleBufferAudioRen
     m_errored = true;
 }
 
-void MediaPlayerPrivateWebM::videoRendererReadyForDisplayChanged(WebSampleBufferVideoRendering *renderer, bool isReadyForDisplay)
-{
-    if (!m_videoRenderer || renderer != m_videoRenderer->renderer() || !isReadyForDisplay)
-        return;
-
-    auto currentTime = PAL::CMTimebaseGetTime(renderer.timebase);
-    ALWAYS_LOG(LOGIDENTIFIER, "m_isSynchronizerSeeking:", m_isSynchronizerSeeking, " layer.basetime:", PAL::toMediaTime(currentTime));
-
-    setHasAvailableVideoFrame(true);
-}
-
 void MediaPlayerPrivateWebM::ensureLayerOrVideoRenderer(MediaPlayerEnums::NeedsRenderingModeChanged needsRenderingModeChanged)
 {
     switch (acceleratedVideoMode()) {
@@ -1883,7 +1751,7 @@ void MediaPlayerPrivateWebM::setShouldDisableHDR(bool shouldDisable)
 void MediaPlayerPrivateWebM::playerContentBoxRectChanged(const LayoutRect& newRect)
 {
     if (!layerOrVideoRenderer() && !newRect.isEmpty())
-        updateDisplayLayerAndDecompressionSession();
+        updateDisplayLayer();
 }
 
 void MediaPlayerPrivateWebM::setShouldMaintainAspectRatio(bool shouldMaintainAspectRatio)
@@ -1970,7 +1838,7 @@ void MediaPlayerPrivateWebM::updateSpatialTrackingLabel()
 }
 #endif
 
-void MediaPlayerPrivateWebM::destroyLayerOrVideoRenderer()
+void MediaPlayerPrivateWebM::destroyLayerOrVideoRendererAndCreateRenderlessVideoMediaSampleRenderer()
 {
     destroyLayer();
     destroyVideoRenderer();
@@ -2007,14 +1875,16 @@ void MediaPlayerPrivateWebM::configureLayerOrVideoRenderer(WebSampleBufferVideoR
 void MediaPlayerPrivateWebM::configureVideoRenderer(VideoMediaSampleRenderer& videoRenderer)
 {
     videoRenderer.setResourceOwner(m_resourceOwner);
-    m_listener->beginObservingVideoRenderer(videoRenderer.renderer());
+    if (auto renderer = videoRenderer.renderer())
+        m_listener->beginObservingVideoRenderer(renderer);
 }
 
 void MediaPlayerPrivateWebM::invalidateVideoRenderer(VideoMediaSampleRenderer& videoRenderer)
 {
     videoRenderer.flush();
     videoRenderer.stopRequestingMediaData();
-    m_listener->stopObservingVideoRenderer(videoRenderer.renderer());
+    if (auto renderer = videoRenderer.renderer())
+        m_listener->stopObservingVideoRenderer(renderer);
 
 }
 
@@ -2027,17 +1897,21 @@ void MediaPlayerPrivateWebM::setVideoRenderer(WebSampleBufferVideoRendering *ren
     }
 
     ALWAYS_LOG(LOGIDENTIFIER, "!!renderer = ", !!renderer);
-    ASSERT(!renderer || !m_decompressionSession || hasSelectedVideo());
 
+    // FIXME: VideoMediaSampleRenderer could be re-used, even as the renderer is changing.
     if (m_videoRenderer)
         invalidateVideoRenderer(*std::exchange(m_videoRenderer, nullptr));
-
-    if (!renderer)
-        return;
 
     m_videoRenderer = VideoMediaSampleRenderer::create(renderer);
     m_videoRenderer->setPrefersDecompressionSession(true);
     m_videoRenderer->setTimebase([m_synchronizer timebase]);
+    m_videoRenderer->notifyWhenDecodingErrorOccurred([weakThis = WeakPtr { *this }](OSStatus) {
+        if (RefPtr protectedThis = weakThis.get()) {
+            protectedThis->setNetworkState(MediaPlayer::NetworkState::DecodeError);
+            protectedThis->setReadyState(MediaPlayer::ReadyState::HaveNothing);
+            protectedThis->m_errored = true;
+        }
+    });
     configureVideoRenderer(*m_videoRenderer);
 }
 
@@ -2047,12 +1921,12 @@ void MediaPlayerPrivateWebM::stageVideoRenderer(WebSampleBufferVideoRendering *r
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, "!!renderer = ", !!renderer);
-    ASSERT(!renderer || !m_decompressionSession || hasSelectedVideo());
+    ASSERT(!renderer || hasSelectedVideo());
 
     if (m_expiringVideoRenderer)
         invalidateVideoRenderer(*std::exchange(m_expiringVideoRenderer, nullptr));
 
-    m_expiringVideoRenderer = WTFMove(m_videoRenderer);
+    m_expiringVideoRenderer = std::exchange(m_videoRenderer, { });
     m_videoRenderer = VideoMediaSampleRenderer::create(renderer);
     configureVideoRenderer(*m_videoRenderer);
     if (m_enabledVideoTrackID)
@@ -2101,7 +1975,7 @@ void MediaPlayerPrivateWebM::setVideoTarget(const PlatformVideoTarget& videoTarg
     if (!!videoTarget)
         m_usingLinearMediaPlayer = true;
     m_videoTarget = videoTarget;
-    updateDisplayLayerAndDecompressionSession();
+    updateDisplayLayer();
 }
 #endif
 
@@ -2111,7 +1985,7 @@ void MediaPlayerPrivateWebM::isInFullscreenOrPictureInPictureChanged(bool isInFu
     ALWAYS_LOG(LOGIDENTIFIER, isInFullscreenOrPictureInPicture);
     if (!m_usingLinearMediaPlayer)
         return;
-    updateDisplayLayerAndDecompressionSession();
+    updateDisplayLayer();
 #else
     UNUSED_PARAM(isInFullscreenOrPictureInPicture);
 #endif

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
@@ -71,7 +71,6 @@ public:
     void requestMediaDataWhenReady(Function<void()>&&);
     void stopRequestingMediaData();
     void notifyWhenHasAvailableVideoFrame(Function<void()>&&);
-    void decodedFrameWhenAvailable(Function<void(RetainPtr<CMSampleBufferRef>&&)>&&);
 
     RetainPtr<CVPixelBufferRef> decodeSampleSync(CMSampleBufferRef);
 

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
@@ -697,15 +697,6 @@ void WebCoreDecompressionSession::requestMediaDataWhenReady(Function<void()>&& n
     }
 }
 
-void WebCoreDecompressionSession::decodedFrameWhenAvailable(Function<void(RetainPtr<CMSampleBufferRef>&&)>&& callback)
-{
-    assertIsMainThread();
-    LOG(Media, "WebCoreDecompressionSession::decodedFrameWhenAvailable(%p), hasDecodedFrameWhenAvailable(%d)", this, !!callback);
-    m_newDecodedFrameCallback = WTFMove(callback);
-
-    m_deliverDecodedFrames = !!m_newDecodedFrameCallback;
-}
-
 void WebCoreDecompressionSession::stopRequestingMediaData()
 {
     assertIsMainThread();


### PR DESCRIPTION
#### 02de235c5862ad86b1220f437a2dfe031b10eb43
<pre>
requestVideoFrameCallback never calls its callback if the window is hidden.
<a href="https://bugs.webkit.org/show_bug.cgi?id=282797">https://bugs.webkit.org/show_bug.cgi?id=282797</a>
<a href="https://rdar.apple.com/139481527">rdar://139481527</a>

Reviewed by NOBODY (OOPS!).

Following-up on 286451@main, we continue duplicating the logic of maintaining a decoding queue from the
WebCoreDecompressionSession in VideoMediaSampleRenderer.
Rather than query if a sample has been presented by the AVSampleBufferDisplayLayer, we instead notify the MediaPlayerPrivate
when the sample has been decoded and added to the AVSBDL.

The need to use a separate WebCoreDecompressionSession whenever we do not have a render (such as the video being offscreen or a canvas being attached)
is no longer required thanks to the extended capabilities of the VideoMediaSampleRenderer which can now operates without a renderer being set.

This allows to greatly simplify the MediaPlayerPrivateWebM.

For now we restrict the changes to this player only, in a follow-up change we will use a similar approach with the MediaPlayerPrivateMediaSourceAVFObjC.

In additions the following changes were applied:
* Remove VideoMediaSampleRenderer::bounds() ; it can&apos;t be used with a renderer-less VideoMediaSampleRenderer.
* Always use a AVSampleBufferVideoRenderer on platforms supporting it when present.
  We can avoid the need to re-dispatch task on the main thread.
  On platforms not supporting it, we will enqueue compressed and decoded frames on the main thread instead.
  This will also allows the use with WK1 and compatible with web thread.
* Always use a decompression session if no renderer are available.
* When a AVSampleBufferVideoRenderer is used on two threads concurently, where on one thread we call stopRequestingMediaData and on the other we call enqueueMediaSample: a deadlock will occur.
  Workaround for <a href="https://rdar.apple.com/139910776">rdar://139910776</a>
* Access to m_decompressionSession was racy (could be deleted on the main thread while being used in the decoder queue
  For now, we don&apos;t allow disabling the decompression session if it&apos;s been setup already. pref can only be toggled until a sample has been submitted.

Re-enable tests that used to timeout.

* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
(WebCore::MediaPlayerPrivateWebM::decompressionSession const): Deleted.
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::~MediaPlayerPrivateWebM):
(WebCore::MediaPlayerPrivateWebM::supportsType):
(WebCore::MediaPlayerPrivateWebM::updateLastPixelBuffer):
(WebCore::MediaPlayerPrivateWebM::videoFrameForCurrentTime):
(WebCore::MediaPlayerPrivateWebM::setHasAvailableVideoFrame):
(WebCore::MediaPlayerPrivateWebM::setPresentationSize):
(WebCore::MediaPlayerPrivateWebM::acceleratedRenderingStateChanged):
(WebCore::MediaPlayerPrivateWebM::updateDisplayLayer):
(WebCore::MediaPlayerPrivateWebM::enqueueSample):
(WebCore::MediaPlayerPrivateWebM::notifyClientWhenReadyForMoreSamples):
(WebCore::MediaPlayerPrivateWebM::isReadyForMoreSamples):
(WebCore::MediaPlayerPrivateWebM::didBecomeReadyForMoreSamples):
(WebCore::MediaPlayerPrivateWebM::trackDidChangeSelected):
(WebCore::MediaPlayerPrivateWebM::flushIfNeeded):
(WebCore::MediaPlayerPrivateWebM::flushVideo):
(WebCore::MediaPlayerPrivateWebM::registerNotifyWhenHasAvailableVideoFrame):
(WebCore::MediaPlayerPrivateWebM::startVideoFrameMetadataGathering):
(WebCore::MediaPlayerPrivateWebM::stopVideoFrameMetadataGathering):
(WebCore::MediaPlayerPrivateWebM::checkNewVideoFrameMetadata):
(WebCore::MediaPlayerPrivateWebM::playerContentBoxRectChanged):
(WebCore::MediaPlayerPrivateWebM::destroyLayerOrVideoRendererAndCreateRenderlessVideoMediaSampleRenderer):
(WebCore::MediaPlayerPrivateWebM::configureVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::invalidateVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::setVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::stageVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::setVideoTarget):
(WebCore::MediaPlayerPrivateWebM::isInFullscreenOrPictureInPictureChanged):
(WebCore::MediaPlayerPrivateWebM::updateDisplayLayerAndDecompressionSession): Deleted.
(WebCore::MediaPlayerPrivateWebM::ensureDecompressionSession): Deleted.
(WebCore::MediaPlayerPrivateWebM::destroyDecompressionSession): Deleted.
(WebCore::MediaPlayerPrivateWebM::videoRendererReadyForDisplayChanged): Deleted.
(WebCore::MediaPlayerPrivateWebM::destroyLayerOrVideoRenderer): Deleted.
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
(WebCore::VideoMediaSampleRenderer::timebase const): Deleted.
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::VideoMediaSampleRenderer):
(WebCore::VideoMediaSampleRenderer::timebase const):
(WebCore::VideoMediaSampleRenderer::isReadyForMoreMediaData const):
(WebCore::VideoMediaSampleRenderer::maybeBecomeReadyForMoreMediaData):
(WebCore::VideoMediaSampleRenderer::setTimebase):
(WebCore::VideoMediaSampleRenderer::enqueueSample):
(WebCore::VideoMediaSampleRenderer::decodeNextSample):
(WebCore::VideoMediaSampleRenderer::shouldDecodeSample):
(WebCore::VideoMediaSampleRenderer::initializeDecompressionSession):
(WebCore::VideoMediaSampleRenderer::decodedFrameAvailable):
(WebCore::VideoMediaSampleRenderer::flushCompressedSampleQueue):
(WebCore::VideoMediaSampleRenderer::cancelTimer):
(WebCore::VideoMediaSampleRenderer::flushDecodedSampleQueue):
(WebCore::VideoMediaSampleRenderer::purgeDecodedSampleQueue):
(WebCore::VideoMediaSampleRenderer::resetReadyForMoreSample):
(WebCore::VideoMediaSampleRenderer::copyDisplayedPixelBuffer):
(WebCore::VideoMediaSampleRenderer::totalVideoFrames const):
(WebCore::VideoMediaSampleRenderer::droppedVideoFrames const):
(WebCore::VideoMediaSampleRenderer::corruptedVideoFrames const):
(WebCore::VideoMediaSampleRenderer::totalFrameDelay const):
(WebCore::VideoMediaSampleRenderer::notifyWhenHasAvailableVideoFrame):
(WebCore::VideoMediaSampleRenderer::notifyHasAvailableVideoFrame):
(WebCore::VideoMediaSampleRenderer::ensureDecodedSampleQueue): Deleted.
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h: Remove declaration for unused decodedFrameWhenAvailable method.
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm:
(WebCore::WebCoreDecompressionSession::decodeSample):
(WebCore::WebCoreDecompressionSession::decodedFrameWhenAvailable): Deleted. Method was unused.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02de235c5862ad86b1220f437a2dfe031b10eb43

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81853 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28565 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79400 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4614 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60547 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18586 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66326 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40846 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47918 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23825 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26888 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69030 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83271 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4663 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68817 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68074 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17004 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12067 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10159 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4610 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4629 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8064 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6388 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->