### PR TITLE
ifdef out bookkeeping to GC wasm code

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1274,6 +1274,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     wasm/WasmCallee.h
     wasm/WasmCalleeGroup.h
     wasm/WasmCallingConvention.h
+    wasm/WasmCallsiteCollection.h
     wasm/WasmCapabilities.h
     wasm/WasmCompilationContext.h
     wasm/WasmCompilationMode.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1189,6 +1189,7 @@
 		539BFBB022AD3CDC0023F4C0 /* JSWeakObjectRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 539BFBAF22AD3CDC0023F4C0 /* JSWeakObjectRef.h */; };
 		539DD7F523C1BBB500905F13 /* JSArrayIterator.h in Headers */ = {isa = PBXBuildFile; fileRef = 539DD7F423C1BBA900905F13 /* JSArrayIterator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		539FB8BA1C99DA7C00940FA1 /* JSArrayInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 539FB8B91C99DA7C00940FA1 /* JSArrayInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		53A3FF322CE41924009AABCF /* WasmCallsiteCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 53FB0D282CE40D11008A3331 /* WasmCallsiteCollection.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53B4BD121F68B32500D2BEA3 /* WasmOps.h in Headers */ = {isa = PBXBuildFile; fileRef = 533B15DE1DC7F463004D500A /* WasmOps.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53B601EC2034B8C5006BE667 /* JSCast.h in Headers */ = {isa = PBXBuildFile; fileRef = 53B601EB2034B8C5006BE667 /* JSCast.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53C2CE9C22FCC3D6008B2853 /* AirHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 53C2CE9B22FCC3D6008B2853 /* AirHelpers.h */; };
@@ -4315,6 +4316,8 @@
 		53F9DD762BEFD76D004A17B7 /* GCOwnedDataScope.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GCOwnedDataScope.h; sourceTree = "<group>"; };
 		53FA2AE01CF37F3F0022711D /* LLIntPrototypeLoadAdaptiveStructureWatchpoint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LLIntPrototypeLoadAdaptiveStructureWatchpoint.h; sourceTree = "<group>"; };
 		53FA2AE21CF380390022711D /* LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp; sourceTree = "<group>"; };
+		53FB0D282CE40D11008A3331 /* WasmCallsiteCollection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmCallsiteCollection.h; sourceTree = "<group>"; };
+		53FB0D292CE40D11008A3331 /* WasmCallsiteCollection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmCallsiteCollection.cpp; sourceTree = "<group>"; };
 		53FD04D11D7AB187003287D3 /* WasmCallingConvention.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmCallingConvention.cpp; sourceTree = "<group>"; };
 		53FD04D21D7AB187003287D3 /* WasmCallingConvention.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmCallingConvention.h; sourceTree = "<group>"; };
 		554C418529B14CA5003C9F71 /* WebAssemblyGCObjectBase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyGCObjectBase.cpp; path = js/WebAssemblyGCObjectBase.cpp; sourceTree = "<group>"; };
@@ -7743,6 +7746,8 @@
 				526AC4B51E977C5D003500E1 /* WasmCalleeGroup.h */,
 				53FD04D11D7AB187003287D3 /* WasmCallingConvention.cpp */,
 				53FD04D21D7AB187003287D3 /* WasmCallingConvention.h */,
+				53FB0D292CE40D11008A3331 /* WasmCallsiteCollection.cpp */,
+				53FB0D282CE40D11008A3331 /* WasmCallsiteCollection.h */,
 				E337B966224324E50093A820 /* WasmCapabilities.h */,
 				E32D51A62C6D0FD600B013D1 /* WasmCompilationContext.cpp */,
 				E32D51A52C6D0FD600B013D1 /* WasmCompilationContext.h */,
@@ -11913,6 +11918,7 @@
 				525C0DDA1E935847002184CD /* WasmCallee.h in Headers */,
 				526AC4B71E977C5D003500E1 /* WasmCalleeGroup.h in Headers */,
 				53FD04D41D7AB291003287D3 /* WasmCallingConvention.h in Headers */,
+				53A3FF322CE41924009AABCF /* WasmCallsiteCollection.h in Headers */,
 				E337B967224324EA0093A820 /* WasmCapabilities.h in Headers */,
 				E32D51AF2C6D0FF200B013D1 /* WasmCompilationContext.h in Headers */,
 				E3BD2B7622F275020011765C /* WasmCompilationMode.h in Headers */,
@@ -12563,7 +12569,7 @@
 		};
 		5D5D8ABF0E0D0B0300F9C692 /* Create /usr/local/bin/jsc symlink */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 8;
 			files = (
 			);
 			inputPaths = (
@@ -12764,7 +12770,7 @@
 		};
 		F4CDF3C927E9147500191928 /* Copy Profiling Data */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 12;
+			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1137,6 +1137,7 @@ wasm/WasmBranchHintsSectionParser.cpp
 wasm/WasmCallee.cpp
 wasm/WasmCalleeGroup.cpp
 wasm/WasmCallingConvention.cpp
+wasm/WasmCallsiteCollection.cpp
 wasm/WasmCompilationContext.cpp
 wasm/WasmCompilationMode.cpp
 wasm/WasmConstExprGenerator.cpp

--- a/Source/JavaScriptCore/heap/ConservativeRoots.h
+++ b/Source/JavaScriptCore/heap/ConservativeRoots.h
@@ -34,6 +34,7 @@ class HeapCell;
 class JITStubRoutineSet;
 
 class ConservativeRoots {
+    WTF_FORBID_HEAP_ALLOCATION;
 public:
     ConservativeRoots(Heap&);
     ~ConservativeRoots();

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -59,10 +59,15 @@ CalleeGroup::CalleeGroup(MemoryMode mode, const CalleeGroup& other)
     , m_mode(mode)
     , m_llintCallees(other.m_llintCallees)
     , m_jsEntrypointCallees(other.m_jsEntrypointCallees)
+#if ENABLE(WASM_CODE_RECLAIMATION)
     , m_callers(m_calleeCount)
+#endif
     , m_wasmIndirectCallEntryPoints(other.m_wasmIndirectCallEntryPoints)
     , m_wasmIndirectCallWasmCallees(other.m_wasmIndirectCallWasmCallees)
     , m_wasmToWasmExitStubs(other.m_wasmToWasmExitStubs)
+#if !ENABLE(WASM_CODE_RECLAIMATION)
+    , m_callsiteCollection(m_calleeCount)
+#endif
 {
     Locker locker { m_lock };
     setCompilationFinished();
@@ -72,7 +77,12 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
     : m_calleeCount(moduleInformation.internalFunctionCount())
     , m_mode(mode)
     , m_llintCallees(llintCallees)
+#if ENABLE(WASM_CODE_RECLAIMATION)
     , m_callers(m_calleeCount)
+#else
+    , m_callsiteCollection(m_calleeCount)
+#endif
+
 {
     RefPtr<CalleeGroup> protectedThis = this;
     m_plan = adoptRef(*new LLIntPlan(vm, moduleInformation, m_llintCallees->data(), createSharedTask<Plan::CallbackType>([this, protectedThis = WTFMove(protectedThis)] (Plan&) {
@@ -97,6 +107,9 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
         }
 
         m_wasmToWasmExitStubs = m_plan->takeWasmToWasmExitStubs();
+#if !ENABLE(WASM_CODE_RECLAIMATION)
+        m_callsiteCollection.addCalleeGroupCallsites(locker, *this, m_plan->takeWasmToWasmCallsites());
+#endif
         m_jsEntrypointCallees = static_cast<LLIntPlan*>(m_plan.get())->takeJSCallees();
 
         setCompilationFinished();
@@ -117,7 +130,11 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
     : m_calleeCount(moduleInformation.internalFunctionCount())
     , m_mode(mode)
     , m_ipintCallees(ipintCallees)
+#if ENABLE(WASM_CODE_RECLAIMATION)
     , m_callers(m_calleeCount)
+#else
+    , m_callsiteCollection(m_calleeCount)
+#endif
 {
     RefPtr<CalleeGroup> protectedThis = this;
     m_plan = adoptRef(*new IPIntPlan(vm, moduleInformation, m_ipintCallees->data(), createSharedTask<Plan::CallbackType>([this, protectedThis = WTFMove(protectedThis)] (Plan&) {
@@ -137,6 +154,9 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
         }
 
         m_wasmToWasmExitStubs = m_plan->takeWasmToWasmExitStubs();
+#if !ENABLE(WASM_CODE_RECLAIMATION)
+        m_callsiteCollection.addCalleeGroupCallsites(locker, *this, m_plan->takeWasmToWasmCallsites());
+#endif
         m_jsEntrypointCallees = static_cast<IPIntPlan*>(m_plan.get())->takeJSCallees();
 
         setCompilationFinished();
@@ -199,6 +219,7 @@ BBQCallee* CalleeGroup::tryGetBBQCalleeForLoopOSR(const AbstractLocker&, VM& vm,
         return nullptr;
 
     auto& maybeCallee = m_bbqCallees[functionIndex];
+#if ENABLE(WASM_CODE_RECLAIMATION)
     if (maybeCallee.isStrong())
         return maybeCallee.ptr();
 
@@ -211,8 +232,13 @@ BBQCallee* CalleeGroup::tryGetBBQCalleeForLoopOSR(const AbstractLocker&, VM& vm,
     BBQCallee* result = bbqCallee.get();
     vm.heap.reportWasmCalleePendingDestruction(bbqCallee.releaseNonNull());
     return result;
+#else
+    UNUSED_PARAM(vm);
+    return maybeCallee.get();
+#endif
 }
 
+#if ENABLE(WASM_CODE_RECLAIMATION)
 void CalleeGroup::releaseBBQCallee(const AbstractLocker&, FunctionCodeIndex functionIndex)
 {
     if (!Options::freeRetiredWasmCode())
@@ -230,7 +256,9 @@ void CalleeGroup::releaseBBQCallee(const AbstractLocker&, FunctionCodeIndex func
     bbqCallee->reportToVMsForDestruction();
 }
 #endif
+#endif
 
+#if ENABLE(WASM_CODE_RECLAIMATION)
 #if ENABLE(WEBASSEMBLY_OMGJIT) || ENABLE(WEBASSEMBLY_BBQJIT)
 void CalleeGroup::updateCallsitesToCallUs(const AbstractLocker& locker, CodeLocationLabel<WasmEntryPtrTag> entrypoint, FunctionCodeIndex functionIndex)
 {
@@ -349,7 +377,7 @@ void CalleeGroup::reportCallees(const AbstractLocker&, JITCallee* caller, const 
         );
     }
 }
-#endif
+#endif // ENABLE(WEBASSEMBLY_OMGJIT) || ENABLE(WEBASSEMBLY_BBQJIT)
 
 TriState CalleeGroup::calleeIsReferenced(const AbstractLocker&, Wasm::Callee* callee) const
 {
@@ -389,6 +417,7 @@ TriState CalleeGroup::calleeIsReferenced(const AbstractLocker&, Wasm::Callee* ca
         RELEASE_ASSERT_NOT_REACHED();
     }
 }
+#endif // ENABLE(WASM_CODE_RECLAIMATION)
 
 bool CalleeGroup::isSafeToRun(MemoryMode memoryMode)
 {

--- a/Source/JavaScriptCore/wasm/WasmCallsiteCollection.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallsiteCollection.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WasmCallsiteCollection.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "WasmCallee.h"
+#include "WasmCalleeGroup.h"
+#include "WasmMachineThreads.h"
+#include <wtf/DataLog.h>
+#include <wtf/Locker.h>
+#include <wtf/StdLibExtras.h>
+
+namespace JSC { namespace Wasm {
+
+#if ENABLE(WEBASSEMBLY_OMGJIT) || ENABLE(WEBASSEMBLY_BBQJIT)
+namespace WasmCallsiteCollectionInternal {
+static constexpr bool verbose = false;
+}
+#endif
+
+void CallsiteCollection::addCallsites(const AbstractLocker& calleeGroupLocker, CalleeGroup& calleeGroup, const FixedVector<UnlinkedWasmToWasmCall>& callsites)
+{
+    UNUSED_PARAM(calleeGroupLocker);
+    unsigned functionImportCount = calleeGroup.functionImportCount();
+    for (auto& callsite : callsites) {
+        unsigned calleeIndex = callsite.functionIndexSpace - functionImportCount;
+        m_callsites[calleeIndex].append(Callsite {
+            callsite.callLocation,
+            { }
+        });
+    }
+}
+
+void CallsiteCollection::addCalleeGroupCallsites(const AbstractLocker& calleeGroupLocker, CalleeGroup& calleeGroup, Vector<Vector<UnlinkedWasmToWasmCall>>&& callsitesList)
+{
+    UNUSED_PARAM(calleeGroupLocker);
+    unsigned functionImportCount = calleeGroup.functionImportCount();
+    for (auto& callsites : callsitesList) {
+        for (auto& callsite : callsites) {
+            unsigned calleeIndex = callsite.functionIndexSpace - functionImportCount;
+            m_callsites[calleeIndex].append(Callsite {
+                callsite.callLocation,
+                { }
+            });
+        }
+    }
+    m_calleeGroupCallsites = WTFMove(callsitesList);
+}
+
+#if ENABLE(WEBASSEMBLY_OMGJIT) || ENABLE(WEBASSEMBLY_BBQJIT)
+void CallsiteCollection::updateCallsitesToCallUs(const AbstractLocker& calleeGroupLocker, CalleeGroup& calleeGroup, CodeLocationLabel<WasmEntryPtrTag> entrypoint, uint32_t functionIndex, uint32_t functionIndexSpace)
+{
+    UNUSED_PARAM(calleeGroupLocker);
+    UNUSED_PARAM(functionIndexSpace);
+
+    for (auto& callsite : m_callsites[functionIndex])
+        callsite.m_target = MacroAssembler::prepareForAtomicRepatchNearCallConcurrently(callsite.m_callLocation, entrypoint);
+
+    // It's important to make sure we do this before we make any of the code we just compiled visible. If we didn't, we could end up
+    // where we are tiering up some function A to A' and we repatch some function B to call A' instead of A. Another CPU could see
+    // the updates to B but still not have reset its cache of A', which would lead to all kinds of badness.
+    resetInstructionCacheOnAllThreads();
+    WTF::storeStoreFence(); // This probably isn't necessary but it's good to be paranoid.
+
+    calleeGroup.m_wasmIndirectCallEntryPoints[functionIndex] = entrypoint;
+
+    for (auto& callsite : m_callsites[functionIndex]) {
+        dataLogLnIf(WasmCallsiteCollectionInternal::verbose, "Repatching call at: ", RawPointer(callsite.m_callLocation.dataLocation()), " to ", RawPointer(entrypoint.taggedPtr()));
+        MacroAssembler::repatchNearCall(callsite.m_callLocation, callsite.m_target);
+    }
+}
+#endif
+
+} } // namespace JSC::Wasm
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -185,7 +185,9 @@ void OMGPlan::work(CompilationEffort)
 
         m_calleeGroup->setOMGCallee(locker, m_functionIndex, callee.copyRef());
         ASSERT(m_calleeGroup->replacement(locker, callee->index()) == callee.ptr());
+#if ENABLE(WASM_CODE_RECLAIMATION)
         m_calleeGroup->reportCallees(locker, callee.ptr(), internalFunction->outgoingJITDirectCallees);
+#endif
 
         for (auto& call : callee->wasmToWasmCallsites()) {
             CodePtr<WasmEntryPtrTag> entrypoint;
@@ -203,8 +205,13 @@ void OMGPlan::work(CompilationEffort)
             MacroAssembler::repatchPointer(call.calleeLocation, CalleeBits::boxNativeCalleeIfExists(calleeCallee));
         }
 
+#if ENABLE(WASM_CODE_RECLAIMATION)
         m_calleeGroup->updateCallsitesToCallUs(locker, CodeLocationLabel<WasmEntryPtrTag>(entrypoint), m_functionIndex);
         ASSERT(*m_calleeGroup->entrypointLoadLocationFromFunctionIndexSpace(functionIndexSpace) == entrypoint);
+#else
+        m_calleeGroup->callsiteCollection().addCallsites(locker, m_calleeGroup.get(), callee->wasmToWasmCallsites());
+        m_calleeGroup->callsiteCollection().updateCallsitesToCallUs(locker, m_calleeGroup, CodeLocationLabel<WasmEntryPtrTag>(entrypoint), m_functionIndex, functionIndexSpace);
+#endif
 
         {
             WTF::storeStoreFence();
@@ -229,11 +236,13 @@ void OMGPlan::work(CompilationEffort)
     if (jsEntrypointCallee)
         jsEntrypointCallee->setReplacementTarget(entrypoint);
 
+#if ENABLE(WASM_CODE_RECLAIMATION)
     if (Options::freeRetiredWasmCode()) {
         WTF::storeStoreFence();
         Locker locker { m_calleeGroup->m_lock };
         m_calleeGroup->releaseBBQCallee(locker, m_functionIndex);
     }
+#endif
 
     dataLogLnIf(WasmOMGPlanInternal::verbose, "Finished OMG ", m_functionIndex);
     Locker locker { m_lock };

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
@@ -140,8 +140,10 @@ void OSREntryPlan::work(CompilationEffort)
     callee->setEntrypoint(WTFMove(omgEntrypoint), internalFunction->osrEntryScratchBufferSize, WTFMove(unlinkedCalls), WTFMove(internalFunction->stackmaps), WTFMove(internalFunction->exceptionHandlers), WTFMove(exceptionHandlerLocations));
     {
         Locker locker { m_calleeGroup->m_lock };
+#if ENABLE(WASM_CODE_RECLAIMATION)
         m_calleeGroup->recordOMGOSREntryCallee(locker, m_functionIndex, callee.get());
         m_calleeGroup->reportCallees(locker, callee.ptr(), internalFunction->outgoingJITDirectCallees);
+#endif
 
         for (auto& call : callee->wasmToWasmCallsites()) {
             CodePtr<WasmEntryPtrTag> entrypoint;

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -1198,7 +1198,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmLoopOSREnterBBQJIT, void, (Probe:
 
 ALWAYS_INLINE void assertCalleeIsReferenced(CallFrame* frame, JSWebAssemblyInstance* instance)
 {
-#if ASSERT_ENABLED
+#if ASSERT_ENABLED && ENABLE(WASM_CODE_RECLAIMATION)
     CalleeGroup& calleeGroup = *instance->calleeGroup();
     Wasm::Callee* callee = static_cast<Wasm::Callee*>(frame->callee().asNativeCallee());
     TriState status;

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -60,6 +60,7 @@ public:
     ALWAYS_INLINE ~RefPtr() { RefDerefTraits::derefIfNotNull(PtrTraits::exchange(m_ptr, nullptr)); }
 
     T* get() const { return PtrTraits::unwrap(m_ptr); }
+    T* ptr() const { return get(); }
 
     Ref<T> releaseNonNull() { ASSERT(m_ptr); Ref<T> tmp(adoptRef(*m_ptr)); m_ptr = nullptr; return tmp; }
 


### PR DESCRIPTION
#### f3fb9b07e5316590aebe5d7be10ea2d9dbb0ca4f
<pre>
ifdef out bookkeeping to GC wasm code
<a href="https://bugs.webkit.org/show_bug.cgi?id=283050">https://bugs.webkit.org/show_bug.cgi?id=283050</a>
<a href="https://rdar.apple.com/139208625">rdar://139208625</a>

Reviewed by Mark Lam.

There still seems to be some unaccounted for memory regression with 284867@main even
after the other fixes. Let&apos;s ifdef out the bookkeeping for now.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/heap/ConservativeRoots.h:
* Source/JavaScriptCore/runtime/NativeCallee.h:
(JSC::NativeCallee::category const): Deleted.
(JSC::NativeCallee::implementationVisibility const): Deleted.
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::work):
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::Callee::Callee):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::CalleeGroup):
(JSC::Wasm::CalleeGroup::tryGetBBQCalleeForLoopOSR):
* Source/JavaScriptCore/wasm/WasmCalleeGroup.h:
* Source/JavaScriptCore/wasm/WasmCallsiteCollection.cpp: Added.
(JSC::Wasm::CallsiteCollection::addCallsites):
(JSC::Wasm::CallsiteCollection::addCalleeGroupCallsites):
(JSC::Wasm::CallsiteCollection::updateCallsitesToCallUs):
* Source/JavaScriptCore/wasm/WasmCallsiteCollection.h: Copied from Source/JavaScriptCore/runtime/NativeCallee.h.
(JSC::Wasm::CallsiteCollection::CallsiteCollection):
(JSC::Wasm::CallsiteCollection::calleeGroupCallsites const):
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::work):
* Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp:
(JSC::Wasm::OSREntryPlan::work):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::assertCalleeIsReferenced):
* Source/WTF/wtf/RefPtr.h:
(WTF::RefPtr::ptr const):

Canonical link: <a href="https://commits.webkit.org/286543@main">https://commits.webkit.org/286543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ffe19068cad20b66fad1cf568a05ddf23ad9124

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80812 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/27573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3627 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/27573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49731 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/65526 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/40177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47129 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23013 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/25895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69480 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68256 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23347 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82268 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75577 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3673 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/2401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65498 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67363 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16789 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/11329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97831 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3621 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/21406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/3644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7073 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5402 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->