### PR TITLE
[scroll-animations] imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-playback-rate.html crashes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7411,8 +7411,6 @@ imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-subject-boun
 # webkit.org/b/281837 [scroll-animations] calc() values in `view-timeline-inset` lead to a failed assertion under `ViewTimeline::computeTimelineData()`
 imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-inset-animation.html [ Skip ]
 
-webkit.org/b/283047 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-playback-rate.html [ Skip ]
-
 # CSS @scope with shadow DOM
 imported/w3c/web-platform-tests/css/css-cascade/scope-visited.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-cascade/scope-shadow-sharing.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-playback-rate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-playback-rate-expected.txt
@@ -1,18 +1,16 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS Zero current time is not affected by playbackRate set while the animation is in idle state.
 PASS Zero current time is not affected by playbackRate set while the animation is in play-pending state.
 PASS Initial current time is scaled by playbackRate set while scroll-linked animation is in running state.
-TIMEOUT The current time is scaled by playbackRate set while the scroll-linked animation is in play state. Test timed out
-NOTRUN The playback rate set before scroll-linked animation started playing affects the rate of progress of the current time
-NOTRUN The playback rate affects the rate of progress of the current time when scrolling
-NOTRUN Setting the playback rate while play-pending does not scale current time.
-NOTRUN Setting the playback rate while playing scales current time.
-NOTRUN Setting the playback rate while playing scales the set current time.
-NOTRUN Negative initial playback rate should correctly modify initial current time.
-NOTRUN Reversing the playback rate while playing correctly impacts current time during future scrolls
-NOTRUN Zero initial playback rate should correctly modify initial current time.
-NOTRUN Setting a zero playback rate while running preserves the start time
-NOTRUN Reversing an animation with non-boundary aligned start time symmetrically adjusts the start time
+FAIL The current time is scaled by playbackRate set while the scroll-linked animation is in play state. assert_approx_equals: values do not match for "The current time is scaled by the playback rate." expected 40 +/- 0.125 but got 20
+PASS The playback rate set before scroll-linked animation started playing affects the rate of progress of the current time
+PASS The playback rate affects the rate of progress of the current time when scrolling
+PASS Setting the playback rate while play-pending does not scale current time.
+FAIL Setting the playback rate while playing scales current time. assert_approx_equals: values do not match for "undefined" expected 50 +/- 0.125 but got 25
+FAIL Setting the playback rate while playing scales the set current time. assert_approx_equals: values do not match for "undefined" expected 50 +/- 0.125 but got 25
+PASS Negative initial playback rate should correctly modify initial current time.
+PASS Reversing the playback rate while playing correctly impacts current time during future scrolls
+PASS Zero initial playback rate should correctly modify initial current time.
+FAIL Setting a zero playback rate while running preserves the start time assert_approx_equals: values do not match for "undefined" expected 0 +/- 0.125 but got 20
+FAIL Reversing an animation with non-boundary aligned start time symmetrically adjusts the start time assert_approx_equals: values do not match for "undefined" expected 60 +/- 0.125 but got -0
 

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1164,7 +1164,7 @@ ExceptionOr<void> WebAnimation::play(AutoRewind autoRewind)
     } else if (!playbackRate && !previousCurrentTime) {
         // If animation’s effective playback rate = 0 and animation’s current time is unresolved,
         // Set the animation’s hold time to zero.
-        m_holdTime = 0_s;
+        m_holdTime = zeroTime();
     }
 
     // 7. If has finite timeline and previous current time is unresolved:


### PR DESCRIPTION
#### 2b7c16d59dc043806c43a6e28d51a32be88251f4
<pre>
[scroll-animations] imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-playback-rate.html crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=283047">https://bugs.webkit.org/show_bug.cgi?id=283047</a>
<a href="https://rdar.apple.com/139801846">rdar://139801846</a>

Reviewed by Anne van Kesteren.

Make sure we use a 0 value that matches the associated timeline type by using `WebAnimation::zeroTime()`.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-playback-rate-expected.txt:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::play):

Canonical link: <a href="https://commits.webkit.org/286541@main">https://commits.webkit.org/286541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4024dd72d917ed188280c9bfa44abc40c096c4f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80799 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27560 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78404 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64462 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3614 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59822 "Found 79 new test failures: fast/css-custom-paint/out-of-memory-while-adding-worklet-module.html fast/css/focus-ring-exists-for-search-field.html fast/inline/list-marker-inside-container-with-margin.html fast/inline/min-content-width-with-hypens.html fast/inline/overflowing-content-with-hypens.html fast/mediastream/canvas-video-to-canvas.html fast/mediastream/captureStream/canvas3d.html fast/multicol/table-vertical-align.html fast/ruby/annotation-with-line-gap.html fast/ruby/ruby-run-break.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17948 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49720 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40164 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47118 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23002 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25882 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68245 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82254 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3660 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2390 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68038 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3814 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67350 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11319 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9419 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11804 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3608 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6415 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3631 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7060 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5389 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->