### PR TITLE
[WebAuthn] Adding a log message if the input is larger than expected for Yubikeys

### DIFF
--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp
@@ -27,7 +27,7 @@
 #include "CtapCcidDriver.h"
 
 #if ENABLE(WEB_AUTHN)
-
+#include "Logging.h"
 #include <WebCore/ApduCommand.h>
 #include <WebCore/ApduResponse.h>
 #include <wtf/RunLoop.h>
@@ -52,6 +52,9 @@ void CtapCcidDriver::transact(Vector<uint8_t>&& data, ResponseCallback&& callbac
     // For CTAP2, commands follow:
     // https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#nfc-command-framing
     if (protocol() == ProtocolVersion::kCtap) {
+
+        if (!isValidSize(data.size()))
+            RELEASE_LOG(WebAuthn, "CtapCcidDriver::transact Sending data larger than maxSize. msgSize=%ld", data.size());
         ApduCommand command;
         command.setCla(kCtapNfcApduCla);
         command.setIns(kCtapNfcApduIns);

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapDriver.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapDriver.h
@@ -49,10 +49,11 @@ public:
 
     WebCore::AuthenticatorTransport transport() const { return m_transport; }
     fido::ProtocolVersion protocol() const { return m_protocol; }
+    void setMaxMsgSize(std::optional<uint32_t> maxMsgSize) { m_maxMsgSize = maxMsgSize; }
+    bool isValidSize(size_t msgSize) { return !m_maxMsgSize || msgSize <= static_cast<size_t>(*m_maxMsgSize); }
 
     virtual void transact(Vector<uint8_t>&& data, ResponseCallback&&) = 0;
     virtual void cancel() { };
-
 protected:
     explicit CtapDriver(WebCore::AuthenticatorTransport transport)
         : m_transport(transport)
@@ -61,6 +62,7 @@ protected:
 private:
     fido::ProtocolVersion m_protocol { fido::ProtocolVersion::kCtap };
     WebCore::AuthenticatorTransport m_transport;
+    std::optional<uint32_t> m_maxMsgSize;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
@@ -28,7 +28,9 @@
 
 #if ENABLE(WEB_AUTHN)
 
+#include "Logging.h"
 #include <WebCore/FidoConstants.h>
+#include <wtf/Assertions.h>
 #include <wtf/RunLoop.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -176,6 +178,8 @@ CtapHidDriver::CtapHidDriver(Ref<HidConnection>&& connection)
 
 void CtapHidDriver::transact(Vector<uint8_t>&& data, ResponseCallback&& callback)
 {
+    if (!isValidSize(data.size()))
+        RELEASE_LOG(WebAuthn, "CtapHidDriver::transact Sending data larger than maxSize. msgSize=%ld", data.size());
     ASSERT(m_state == State::Idle);
     m_state = State::AllocateChannel;
     m_channelId = kHidBroadcastChannel;

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapNfcDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapNfcDriver.cpp
@@ -28,8 +28,10 @@
 
 #if ENABLE(WEB_AUTHN) && HAVE(NEAR_FIELD)
 
+#include "Logging.h"
 #include <WebCore/ApduCommand.h>
 #include <WebCore/ApduResponse.h>
+#include <wtf/Assertions.h>
 #include <wtf/RunLoop.h>
 
 namespace WebKit {
@@ -53,6 +55,8 @@ void CtapNfcDriver::transact(Vector<uint8_t>&& data, ResponseCallback&& callback
     // For CTAP2, commands follow:
     // https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#nfc-command-framing
     if (protocol() == ProtocolVersion::kCtap) {
+        if (!isValidSize(data.size()))
+            RELEASE_LOG(WebAuthn, "CtapNfcDriver::transact Sending data larger than maxSize. msgSize=%ld", data.size());
         ApduCommand command;
         command.setCla(kCtapNfcApduCla);
         command.setIns(kCtapNfcApduIns);
@@ -78,6 +82,7 @@ void CtapNfcDriver::transact(Vector<uint8_t>&& data, ResponseCallback&& callback
         respondAsync(WTFMove(callback), WTFMove(apduResponse->data()));
         return;
     }
+
 
     // For U2F, U2fAuthenticator would handle the APDU encoding.
     // https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-nfc-protocol-v1.2-ps-20170411.html#framing

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.cpp
@@ -73,6 +73,7 @@ void FidoService::continueAfterGetInfo(WeakPtr<CtapDriver>&& weakDriver, Vector<
 
     auto info = readCTAPGetInfoResponse(response);
     if (info && info->versions().find(ProtocolVersion::kCtap) != info->versions().end()) {
+        driver->setMaxMsgSize(info->maxMsgSize());
         observer()->authenticatorAdded(CtapAuthenticator::create(driver.releaseNonNull(), WTFMove(*info)));
         return;
     }


### PR DESCRIPTION
#### f493b67b3da63b355ea22430b8e625e23de1413c
<pre>
[WebAuthn] Adding a log message if the input is larger than expected for Yubikeys
<a href="https://bugs.webkit.org/show_bug.cgi?id=283057">https://bugs.webkit.org/show_bug.cgi?id=283057</a>
<a href="https://rdar.apple.com/139805499">rdar://139805499</a>

Reviewed by Pascoe.

This does not change any behavior but does add logs which should help debug issues.
Adjusting the requests to not exceed maxMsgSize are being worked on separately.

* Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp:
(WebKit::CtapCcidDriver::transact):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapDriver.h:
(WebKit::CtapDriver::setMaxMsgSize):
(WebKit::CtapDriver::isValidSize):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp:
(WebKit::CtapHidDriver::transact):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapNfcDriver.cpp:
(WebKit::CtapNfcDriver::transact):
* Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.cpp:
(WebKit::FidoService::continueAfterGetInfo):

Canonical link: <a href="https://commits.webkit.org/286561@main">https://commits.webkit.org/286561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b03360e842fa39d713b5daa07d6ea59f128f0f84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80833 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27594 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3648 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59844 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17971 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40184 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47143 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25916 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68270 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82289 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2418 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68068 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67379 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16804 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11340 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9443 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3642 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6449 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3665 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7094 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5423 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->