### PR TITLE
[css-masonry] Update Intrinsic Sizing Rows 003 Mix1 Expected / Ref Test Case

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1771,7 +1771,6 @@ imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/mas
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/grid-placement/masonry-grid-placement-named-lines-002.html [ ImageOnlyFailure ]
 
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-fr.html [ ImageOnlyFailure ]
-webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1.html [ ImageOnlyFailure ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-columns-item-placement-auto-flow-next-001.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1-expected.html
@@ -8,6 +8,7 @@
   <meta charset="utf-8">
   <title>Reference: Masonry layout min-content sizing</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";
@@ -21,6 +22,7 @@ grid {
   padding: 1px 0 2px 0;
   vertical-align: top;
   height: min-content;
+  font-family: Ahem;
 }
 
 item {
@@ -32,28 +34,54 @@ item {
   visibility: hidden;
   width: 0;
 }
+
+grid > item:nth-child(1) {
+  background-color: #89CFF0;
+}
+
+grid > item:nth-child(2) {
+  background-color: #FF6F61;
+}
+
+grid > item:nth-child(3) {
+  background-color: #FDF3E7;
+}
+
+grid > item:nth-child(4) {
+  background-color: #F4C542;
+}
+
+grid > item:nth-child(5) {
+  background-color: #333333;
+}
+
+grid > item:nth-child(6) {
+  background-color: #B2C8A5;
+}
 </style>
 
 <body>
 
 <section>
-<grid>
+<grid style="grid-template-columns: 15px auto">
   <item style="height:2ch">1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="grid-column: span 2">5 5</item>
+  <item>5 5</item>
 
+  <item class="hidden" style="grid-column: 2; grid-row: 3; height:2ch">0</item>
   <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
-<grid>
-  <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item>4</item>
-  <item style="grid-column: span 2">5 5</item>
+<grid style="grid-template-columns: 15px auto">
+  <item style="height: 3ch">1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item style="height: 3ch">4</item>
+  <item style="height: 2ch">5 5</item>
 
+  <item class="hidden" style="grid-row: 3; grid-column: 2; height: 2ch;">0</item>
   <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
@@ -70,8 +98,8 @@ item {
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
   <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
 
@@ -81,8 +109,8 @@ item {
 
 <grid>
   <item style="grid-row: 4">1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
   <item style="grid-area: 2/1/4/2">5 5</item>
   <item style="height:5ch; grid-area: 1/2/4/3">6</item>
@@ -93,48 +121,38 @@ item {
 
 <grid>
   <item style="grid-row: 4">1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5 5</item>
+  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
   <item style="height:5ch; grid-area: 1/2/4/3">6</item>
 
   <item class="hidden" style="grid-area: 2/1">0 0</item>
   <item class="hidden" style="grid-area: 3/1">0 0</item>
 </grid>
 
-<grid>
-  <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item>4</item>
-  <item style="grid-area: 1/3/5/4">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/3">0 0</item>
-  <item class="hidden" style="grid-area: 3/3">0 0</item>
+<grid style="grid-template-columns: 30px auto">
+  <item style="height: 3ch;">1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item style="height: 3ch;">4</item>
+  <item style="grid-column: 2; grid-row: span 4;">5 5</item>
 </grid>
 
-<grid>
-  <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item>4</item>
-  <item style="height:6ch; grid-area: 1/3/5/4">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/3">0 0</item>
-  <item class="hidden" style="grid-area: 4/3">0 0</item>
+<grid style="grid-template-columns: 30px auto">
+  <item style="height: 3ch;">1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item style="height: 3ch;">4</item>
+  <item style="height:6ch; grid-row:span 4;">5 5</item>
 </grid>
 
-<grid>
-  <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item>4</item>
-  <item style="height:6ch; grid-area: 1/3/4/4">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/3">0 0</item>
-  <item class="hidden" style="grid-area: 4/3">0 0</item>
-  <item class="hidden" style="height:6ch; grid-area: 2/3/5/4">0 0</item>
+<grid style="grid-template-columns: 30px auto">
+  <item style="height: 3ch;">1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item style="height: 3ch;">4</item>
+  <item style="height:6ch; grid-row:span 3;">5 5</item>
 </grid>
 </section>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1-ref.html
@@ -8,6 +8,7 @@
   <meta charset="utf-8">
   <title>Reference: Masonry layout min-content sizing</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";
@@ -21,6 +22,7 @@ grid {
   padding: 1px 0 2px 0;
   vertical-align: top;
   height: min-content;
+  font-family: Ahem;
 }
 
 item {
@@ -32,28 +34,54 @@ item {
   visibility: hidden;
   width: 0;
 }
+
+grid > item:nth-child(1) {
+  background-color: #89CFF0;
+}
+
+grid > item:nth-child(2) {
+  background-color: #FF6F61;
+}
+
+grid > item:nth-child(3) {
+  background-color: #FDF3E7;
+}
+
+grid > item:nth-child(4) {
+  background-color: #F4C542;
+}
+
+grid > item:nth-child(5) {
+  background-color: #333333;
+}
+
+grid > item:nth-child(6) {
+  background-color: #B2C8A5;
+}
 </style>
 
 <body>
 
 <section>
-<grid>
+<grid style="grid-template-columns: 15px auto">
   <item style="height:2ch">1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="grid-column: span 2">5 5</item>
+  <item>5 5</item>
 
+  <item class="hidden" style="grid-column: 2; grid-row: 3; height:2ch">0</item>
   <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
-<grid>
-  <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item>4</item>
-  <item style="grid-column: span 2">5 5</item>
+<grid style="grid-template-columns: 15px auto">
+  <item style="height: 3ch">1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item style="height: 3ch">4</item>
+  <item style="height: 2ch">5 5</item>
 
+  <item class="hidden" style="grid-row: 3; grid-column: 2; height: 2ch;">0</item>
   <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
 
@@ -70,8 +98,8 @@ item {
 
 <grid>
   <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
   <item style="height:4ch; grid-area: 2/1/4/auto">5 5</item>
 
@@ -81,8 +109,8 @@ item {
 
 <grid>
   <item style="grid-row: 4">1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
   <item style="grid-area: 2/1/4/2">5 5</item>
   <item style="height:5ch; grid-area: 1/2/4/3">6</item>
@@ -93,48 +121,38 @@ item {
 
 <grid>
   <item style="grid-row: 4">1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item>2 2</item>
+  <item>3 3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5 5</item>
+  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
   <item style="height:5ch; grid-area: 1/2/4/3">6</item>
 
   <item class="hidden" style="grid-area: 2/1">0 0</item>
   <item class="hidden" style="grid-area: 3/1">0 0</item>
 </grid>
 
-<grid>
-  <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item>4</item>
-  <item style="grid-area: 1/3/5/4">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/3">0 0</item>
-  <item class="hidden" style="grid-area: 3/3">0 0</item>
+<grid style="grid-template-columns: 30px auto">
+  <item style="height: 3ch;">1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item style="height: 3ch;">4</item>
+  <item style="grid-column: 2; grid-row: span 4;">5 5</item>
 </grid>
 
-<grid>
-  <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item>4</item>
-  <item style="height:6ch; grid-area: 1/3/5/4">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/3">0 0</item>
-  <item class="hidden" style="grid-area: 4/3">0 0</item>
+<grid style="grid-template-columns: 30px auto">
+  <item style="height: 3ch;">1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item style="height: 3ch;">4</item>
+  <item style="height:6ch; grid-row:span 4;">5 5</item>
 </grid>
 
-<grid>
-  <item>1</item>
-  <item style="grid-column: span 2">2 2</item>
-  <item style="grid-column: span 2">3 3</item>
-  <item>4</item>
-  <item style="height:6ch; grid-area: 1/3/4/4">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/3">0 0</item>
-  <item class="hidden" style="grid-area: 4/3">0 0</item>
-  <item class="hidden" style="height:6ch; grid-area: 2/3/5/4">0 0</item>
+<grid style="grid-template-columns: 30px auto">
+  <item style="height: 3ch;">1</item>
+  <item>2 2</item>
+  <item>3 3</item>
+  <item style="height: 3ch;">4</item>
+  <item style="height:6ch; grid-row:span 3;">5 5</item>
 </grid>
 </section>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1.html
@@ -9,6 +9,7 @@
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
   <link rel="match" href="masonry-intrinsic-sizing-rows-003-ref.html">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";
@@ -22,12 +23,37 @@ grid {
   padding: 1px 0 2px 0;
   vertical-align: top;
   height: min-content;
+  font-family: Ahem;
 }
 
 item {
   /* allow for differing min-content and max-content sizes */
   writing-mode: vertical-rl;
   text-orientation: sideways;
+}
+
+grid > item:nth-child(1) {
+  background-color: #89CFF0;
+}
+
+grid > item:nth-child(2) {
+  background-color: #FF6F61;
+}
+
+grid > item:nth-child(3) {
+  background-color: #FDF3E7;
+}
+
+grid > item:nth-child(4) {
+  background-color: #F4C542;
+}
+
+grid > item:nth-child(5) {
+  background-color: #333333;
+}
+
+grid > item:nth-child(6) {
+  background-color: #B2C8A5;
 }
 </style>
 


### PR DESCRIPTION
#### a8303551d4dbf037322efb12adb3ac702f3bdb3e
<pre>
[css-masonry] Update Intrinsic Sizing Rows 003 Mix1 Expected / Ref Test Case
<a href="https://bugs.webkit.org/show_bug.cgi?id=283060">https://bugs.webkit.org/show_bug.cgi?id=283060</a>
<a href="https://rdar.apple.com/problem/139810909">rdar://problem/139810909</a>

Reviewed by Sammy Gill.

Use Ahem font and add colors to work around font sizing issues.

* Grid 1
Remove spans.
Add extra hidden item to correctly handle min-content size.
Add sizing for grid template columns, so the 5th item is correctly placed.

* Grid 2
Remove spans.
Add extra hidden item to correctly handle min-content size.
Add sizing for grid template columns, so the 5th item is correctly placed.

* Grid 4-5
Remove spans that were causing width issues.

* Grid 6
Remove spans that were causing width issues.
Remove extra 5 not found in the main test case.

* Grid 7 - 9
Remove spans that were causing width issues.
Remove hidden items that were adding an extra column
Add sizing for grid template columns; the grid appears to overflow without it.
Add height of 3ch to the first item, so the first row is correctly sized.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-003-mix1.html:

Canonical link: <a href="https://commits.webkit.org/286740@main">https://commits.webkit.org/286740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43bfc9137ba20d788add1acfb1759845cbd25332

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28252 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4304 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60327 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18401 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40639 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47670 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/23568 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26578 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68791 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82956 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2917 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68601 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4507 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66046 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/67852 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16906 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11834 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9917 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4299 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4319 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/7754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6078 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->