### PR TITLE
[CSS] Improve :host selector combinations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-002-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-002.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:host</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#featureless">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id=host>
+</div>
+<script>
+  host.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      :host {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+      }
+      :not(:not(:host)):host {
+        background-color: green;
+      }
+    </style>
+  `;
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-003-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-003.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:host</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#featureless">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id=host>
+</div>
+<script>
+  host.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      :host {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+      }
+      :is(div, :host) {
+        background-color: green;
+      }
+    </style>
+  `;
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-004-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-004-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-004.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:host</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#featureless">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id=host>
+</div>
+<script>
+  host.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      :host {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+      }
+      :not(div, :not(:host)) {
+        background-color: green;
+      }
+    </style>
+  `;
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-005-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-005-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-005.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:host</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#featureless">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id=host>
+</div>
+<script>
+  host.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      :host {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+      }
+      :is(:host):host {
+        background-color: green;
+      }
+    </style>
+  `;
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-006-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-006-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-006.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:host</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#featureless">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id=host>
+</div>
+<script>
+  host.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      :host {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+      }
+      :not(:not(:host)):host {
+        background-color: green;
+      }
+    </style>
+  `;
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-not-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-not-001-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-not-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-not-001.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:host doesn't combine with tag selector</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#featureless">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div id=host>
+</div>
+<script>
+  host.attachShadow({mode: "open"}).innerHTML = `
+    <style>
+      :host {
+        width: 100px;
+        height: 100px;
+        background-color: green;
+      }
+      div:host {
+        background-color: red;
+      }
+      :not(div):host {
+        background-color: red;
+      }
+      :host:not(div) {
+        background-color: red;
+      }
+      :host:is(div) {
+        background-color: red;
+      }
+      :is(div):host {
+        background-color: red;
+      }
+      :host:not(:hover) {
+        background-color: red;
+      }
+      :host:not(:defined) {
+        background-color: red;
+      }
+    </style>
+  `;
+
+</script>


### PR DESCRIPTION
#### e7e15ba670eb8f999c3b375afe12a85ff9180ebe
<pre>
[CSS] Improve :host selector combinations
<a href="https://bugs.webkit.org/show_bug.cgi?id=283062">https://bugs.webkit.org/show_bug.cgi?id=283062</a>

Reviewed by NOBODY (OOPS!).

<a href="https://drafts.csswg.org/selectors/#featureless-elements">https://drafts.csswg.org/selectors/#featureless-elements</a>

:host only matches the shadow host.
For combination, the behavior is:
  * compound selectors, if all contained simple selectors are allowed to match it
  * selector lists, if at least one selector in the list is allowed to match it
  * logical combination pseudo-classes, if their argument selector is allowed to match it

Thus, should match:
  * :is(:host, whatever)
  * :not(:not(:host), whatever)
  * :host
  * any combination of those above

* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-003-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-003.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-004-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-004.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-005-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-005.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-006-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-multiple-006.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-not-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-not-001.html: Added.
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7e15ba670eb8f999c3b375afe12a85ff9180ebe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29387 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81008 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27757 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3809 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59969 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-scoping/host-not-001.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18081 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79548 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49886 "Exiting early after 10 failures. 60 tests run. 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65681 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40297 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47281 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-scoping/host-not-001.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23170 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-scoping/host-not-001.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26080 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68407 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23502 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-scoping/host-not-001.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82454 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3857 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2543 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-scoping/host-not-001.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68247 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-scoping/host-not-001.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4010 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65650 "Exiting early after 10 failures. 60 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67493 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11466 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9560 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-scoping/host-not-001.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3804 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6613 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3827 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7257 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5585 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->