### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/Modules

### DIFF
--- a/Source/WebCore/Modules/applepay/PaymentRequestValidator.mm
+++ b/Source/WebCore/Modules/applepay/PaymentRequestValidator.mm
@@ -35,8 +35,6 @@
 #import <wtf/text/MakeString.h>
 #import <wtf/unicode/icu/ICUHelpers.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 static ExceptionOr<void> validateCountryCode(const String&);
@@ -115,6 +113,7 @@ ExceptionOr<void> PaymentRequestValidator::validateTotal(const ApplePayLineItem&
     return { };
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 static ExceptionOr<void> validateCountryCode(const String& countryCode)
 {
     if (!countryCode)
@@ -127,6 +126,7 @@ static ExceptionOr<void> validateCountryCode(const String& countryCode)
 
     return Exception { ExceptionCode::TypeError, makeString("\""_s, countryCode, "\" is not a valid country code."_s) };
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static ExceptionOr<void> validateCurrencyCode(const String& currencyCode)
 {
@@ -182,7 +182,5 @@ static ExceptionOr<void> validateShippingMethods(const Vector<ApplePayShippingMe
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -44,8 +44,6 @@
 #include <wtf/URLParser.h>
 #include <wtf/text/MakeString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 static inline Ref<Blob> blobFromData(ScriptExecutionContext* context, Vector<uint8_t>&& data, const String& contentType)
@@ -140,6 +138,7 @@ FetchBodyConsumer::FetchBodyConsumer(FetchBodyConsumer&&) = default;
 FetchBodyConsumer::~FetchBodyConsumer() = default;
 FetchBodyConsumer& FetchBodyConsumer::operator=(FetchBodyConsumer&&) = default;
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 // https://fetch.spec.whatwg.org/#concept-body-package-data
 RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* context, const String& contentType, std::span<const uint8_t> data)
 {
@@ -221,6 +220,7 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
 
     return form;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static void resolveWithTypeAndData(Ref<DeferredPromise>&& promise, FetchBodyConsumer::Type type, const String& contentType, std::span<const uint8_t> data)
 {
@@ -514,5 +514,3 @@ FetchBodyConsumer FetchBodyConsumer::clone()
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
@@ -29,13 +29,12 @@
 #include "IDBKeyData.h"
 #include "IDBKeyPath.h"
 #include "KeyedCoding.h"
+#include <wtf/StdLibExtras.h>
 
 #if USE(GLIB)
 #include <glib.h>
 #include <wtf/glib/GRefPtr.h>
 #endif
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -208,7 +207,7 @@ template <typename T> static bool readLittleEndian(std::span<const uint8_t>& dat
 #else
 template <typename T> static void writeLittleEndian(Vector<uint8_t>& buffer, T value)
 {
-    buffer.append(std::span { reinterpret_cast<uint8_t*>(&value), sizeof(value) });
+    buffer.append(asByteSpan(value));
 }
 
 template <typename T> static bool readLittleEndian(std::span<const uint8_t>& data, T& value)
@@ -216,7 +215,7 @@ template <typename T> static bool readLittleEndian(std::span<const uint8_t>& dat
     if (data.size() < sizeof(value))
         return false;
 
-    value = *reinterpret_cast<const T*>(data.data());
+    value = reinterpretCastSpanStartTo<T>(data);
     data = data.subspan(sizeof(T));
 
     return true;
@@ -416,5 +415,3 @@ bool deserializeIDBKeyData(std::span<const uint8_t> data, IDBKeyData& result)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -55,8 +55,6 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 using namespace JSC;
 namespace IDBServer {
@@ -996,7 +994,7 @@ IDBError SQLiteIDBBackingStore::getOrEstablishDatabaseInfo(IDBDatabaseInfo& info
     m_sqliteDB->enableAutomaticWALTruncation();
 
     m_sqliteDB->setCollationFunction("IDBKEY"_s, [](int aLength, const void* a, int bLength, const void* b) {
-        return idbKeyCollate(std::span { static_cast<const uint8_t*>(a), static_cast<size_t>(aLength) }, std::span { static_cast<const uint8_t*>(b), static_cast<size_t>(bLength) });
+        return idbKeyCollate(unsafeMakeSpan(static_cast<const uint8_t*>(a), aLength), unsafeMakeSpan(static_cast<const uint8_t*>(b), bLength));
     });
 
     IDBError error = ensureValidRecordsTable();
@@ -2857,5 +2855,3 @@ void SQLiteIDBBackingStore::handleLowMemoryWarning()
 
 } // namespace IDBServer
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h
@@ -205,7 +205,7 @@ private:
     SQLiteStatementAutoResetScope cachedStatement(SQL, ASCIILiteral);
     SQLiteStatementAutoResetScope cachedStatementForGetAllObjectStoreRecords(const IDBGetAllRecordsData&);
 
-    std::unique_ptr<SQLiteStatement> m_cachedStatements[static_cast<int>(SQL::Invalid)];
+    std::array<std::unique_ptr<SQLiteStatement>, static_cast<size_t>(SQL::Invalid)> m_cachedStatements;
 
     IDBDatabaseIdentifier m_identifier;
     std::unique_ptr<IDBDatabaseInfo> m_databaseInfo;

--- a/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
@@ -29,8 +29,6 @@
 #include <unicode/utf16.h>
 #include <unicode/utf8.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 namespace URLPatternUtilities {
 
@@ -52,6 +50,7 @@ bool Token::isNull() const
     return false;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 // https://urlpattern.spec.whatwg.org/#get-the-next-code-point
 void Tokenizer::getNextCodePoint()
 {
@@ -63,6 +62,7 @@ void Tokenizer::getNextCodePoint()
         U16_NEXT_OR_FFFD(characters, m_nextIndex, m_input.length(), m_codepoint);
     }
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 // https://urlpattern.spec.whatwg.org/#seek-and-get-the-next-code-point
 void Tokenizer::seekNextCodePoint(size_t index)
@@ -276,5 +276,3 @@ ExceptionOr<Vector<Token>> Tokenizer::tokenize()
 
 } // namespace URLPatternUtilities
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/Modules/webdatabase/SQLTransaction.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLTransaction.cpp
@@ -51,8 +51,6 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 Ref<SQLTransaction> SQLTransaction::create(Ref<Database>&& database, RefPtr<SQLTransactionCallback>&& callback, RefPtr<VoidCallback>&& successCallback, RefPtr<SQLTransactionErrorCallback>&& errorCallback, RefPtr<SQLTransactionWrapper>&& wrapper, bool readOnly)
@@ -151,7 +149,7 @@ void SQLTransaction::enqueueStatement(std::unique_ptr<SQLStatement> statement)
 
 SQLTransaction::StateFunction SQLTransaction::stateFunctionFor(SQLTransactionState state)
 {
-    static const StateFunction stateFunctions[] = {
+    static constexpr std::array<StateFunction, 13> stateFunctions {
         &SQLTransaction::unreachableState,                // 0. illegal
         &SQLTransaction::unreachableState,                // 1. idle
         &SQLTransaction::unreachableState,                // 2. acquireLock
@@ -167,7 +165,7 @@ SQLTransaction::StateFunction SQLTransaction::stateFunctionFor(SQLTransactionSta
         &SQLTransaction::deliverSuccessCallback           // 12.
     };
 
-    ASSERT(std::size(stateFunctions) == static_cast<int>(SQLTransactionState::NumberOfStates));
+    ASSERT(stateFunctions.size() == static_cast<int>(SQLTransactionState::NumberOfStates));
     ASSERT(state < SQLTransactionState::NumberOfStates);
 
     return stateFunctions[static_cast<int>(state)];
@@ -678,5 +676,3 @@ ASCIILiteral SQLTransaction::debugStepName(void (SQLTransaction::*step)())
 #endif
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionBackend.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionBackend.cpp
@@ -338,8 +338,6 @@
 //     - This is how a transaction ends normally.
 //     - state CleanupAndTerminate calls doCleanup().
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 SQLTransactionBackend::SQLTransactionBackend(SQLTransaction& frontend)
@@ -403,7 +401,7 @@ void SQLTransactionBackend::doCleanup()
 
 SQLTransactionBackend::StateFunction SQLTransactionBackend::stateFunctionFor(SQLTransactionState state)
 {
-    static const StateFunction stateFunctions[] = {
+    static constexpr std::array<StateFunction, 13> stateFunctions {
         &SQLTransactionBackend::unreachableState,            // 0. end
         &SQLTransactionBackend::unreachableState,            // 1. idle
         &SQLTransactionBackend::acquireLock,                 // 2.
@@ -419,7 +417,7 @@ SQLTransactionBackend::StateFunction SQLTransactionBackend::stateFunctionFor(SQL
         &SQLTransactionBackend::unreachableState             // 12. deliverSuccessCallback
     };
 
-    ASSERT(std::size(stateFunctions) == static_cast<int>(SQLTransactionState::NumberOfStates));
+    ASSERT(stateFunctions.size() == static_cast<int>(SQLTransactionState::NumberOfStates));
     ASSERT(state < SQLTransactionState::NumberOfStates);
 
     return stateFunctions[static_cast<int>(state)];
@@ -522,5 +520,3 @@ void SQLTransactionBackend::unreachableState()
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionStateMachine.h
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionStateMachine.h
@@ -28,8 +28,6 @@
 #include "SQLTransactionState.h"
 #include <wtf/Forward.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 template<typename T>
@@ -54,9 +52,9 @@ protected:
     // s_sizeOfStateAuditTrail states that the state machine enters. The audit
     // trail is updated before entering each state. This is for debugging use
     // only.
-    static const int s_sizeOfStateAuditTrail = 20;
+    static constexpr size_t s_sizeOfStateAuditTrail = 20;
     int m_nextStateAuditEntry;
-    SQLTransactionState m_stateAuditTrail[s_sizeOfStateAuditTrail];
+    std::array<SQLTransactionState, s_sizeOfStateAuditTrail> m_stateAuditTrail;
 #endif
 };
 
@@ -73,7 +71,7 @@ SQLTransactionStateMachine<T>::SQLTransactionStateMachine()
 #endif
 {
 #ifndef NDEBUG
-    for (int i = 0; i < s_sizeOfStateAuditTrail; i++)
+    for (size_t i = 0; i < s_sizeOfStateAuditTrail; ++i)
         m_stateAuditTrail[i] = SQLTransactionState::NumberOfStates;
 #endif
 }
@@ -110,5 +108,3 @@ void SQLTransactionStateMachine<T>::runStateMachine()
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/Modules/websockets/WebSocketDeflater.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketDeflater.cpp
@@ -38,8 +38,6 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <zlib.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 static const int defaultMemLevel = 8;
@@ -69,12 +67,12 @@ WebSocketDeflater::~WebSocketDeflater()
         LOG(Network, "WebSocketDeflater %p Destructor deflateEnd() failed: %d is returned", this, result);
 }
 
-static void setStreamParameter(z_stream* stream, std::span<const uint8_t> inputData, uint8_t* outputData, size_t outputLength)
+static void setStreamParameter(z_stream* stream, std::span<const uint8_t> inputData, std::span<uint8_t> outputData)
 {
     stream->next_in = const_cast<uint8_t*>(inputData.data());
     stream->avail_in = inputData.size();
-    stream->next_out = outputData;
-    stream->avail_out = outputLength;
+    stream->next_out = outputData.data();
+    stream->avail_out = outputData.size();
 }
 
 bool WebSocketDeflater::addBytes(std::span<const uint8_t> data)
@@ -90,7 +88,7 @@ bool WebSocketDeflater::addBytes(std::span<const uint8_t> data)
         return false;
 
     m_buffer.grow(bufferSize.value());
-    setStreamParameter(m_stream.get(), data, m_buffer.data() + writePosition, maxLength);
+    setStreamParameter(m_stream.get(), data, m_buffer.mutableSpan().subspan(writePosition, maxLength));
     int result = deflate(m_stream.get(), Z_NO_FLUSH);
     if (result != Z_OK || m_stream->avail_in > 0)
         return false;
@@ -110,7 +108,7 @@ bool WebSocketDeflater::finish()
 
         m_buffer.grow(bufferSize.value());
         size_t availableCapacity = m_buffer.size() - writePosition;
-        setStreamParameter(m_stream.get(), { }, m_buffer.data() + writePosition, availableCapacity);
+        setStreamParameter(m_stream.get(), { }, m_buffer.mutableSpan().subspan(writePosition, availableCapacity));
         int result = deflate(m_stream.get(), Z_SYNC_FLUSH);
         if (m_stream->avail_out) {
             m_buffer.shrink(writePosition + availableCapacity - m_stream->avail_out);
@@ -171,7 +169,7 @@ bool WebSocketInflater::addBytes(std::span<const uint8_t> data)
         m_buffer.grow(bufferSize.value());
         size_t availableCapacity = m_buffer.size() - writePosition;
         size_t remainingLength = data.size() - consumedSoFar;
-        setStreamParameter(m_stream.get(), data.subspan(consumedSoFar, remainingLength), m_buffer.data() + writePosition, availableCapacity);
+        setStreamParameter(m_stream.get(), data.subspan(consumedSoFar, remainingLength), m_buffer.mutableSpan().subspan(writePosition, availableCapacity));
         int result = inflate(m_stream.get(), Z_NO_FLUSH);
         consumedSoFar += remainingLength - m_stream->avail_in;
         m_buffer.shrink(writePosition + availableCapacity - m_stream->avail_out);
@@ -207,7 +205,7 @@ bool WebSocketInflater::finish()
         m_buffer.grow(bufferSize.value());
         size_t availableCapacity = m_buffer.size() - writePosition;
         size_t remainingLength = strippedFields.size() - consumedSoFar;
-        setStreamParameter(m_stream.get(), std::span { strippedFields }.subspan(consumedSoFar), m_buffer.data() + writePosition, availableCapacity);
+        setStreamParameter(m_stream.get(), std::span { strippedFields }.subspan(consumedSoFar), m_buffer.mutableSpan().subspan(writePosition, availableCapacity));
         int result = inflate(m_stream.get(), Z_FINISH);
         consumedSoFar += remainingLength - m_stream->avail_in;
         m_buffer.shrink(writePosition + availableCapacity - m_stream->avail_out);
@@ -228,5 +226,3 @@ void WebSocketInflater::reset()
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp
@@ -38,8 +38,6 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringHash.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 void WebSocketExtensionDispatcher::reset()
@@ -97,7 +95,7 @@ bool WebSocketExtensionDispatcher::processHeaderValue(const String& headerValue)
     }
 
     const CString headerValueData = headerValue.utf8();
-    WebSocketExtensionParser parser(headerValueData.data(), headerValueData.data() + headerValueData.length());
+    WebSocketExtensionParser parser(headerValueData.span());
     while (!parser.finished()) {
         String extensionToken;
         HashMap<String, String> extensionParameters;
@@ -140,5 +138,3 @@ String WebSocketExtensionDispatcher::failureReason() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp
@@ -35,18 +35,16 @@
 #include <wtf/ASCIICType.h>
 #include <wtf/text/CString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 bool WebSocketExtensionParser::finished()
 {
-    return m_current >= m_end;
+    return m_data.empty();
 }
 
 bool WebSocketExtensionParser::parsedSuccessfully()
 {
-    return m_current == m_end;
+    return m_data.empty() && !m_didFailParsing;
 }
 
 static bool isSeparator(char character)
@@ -58,18 +56,20 @@ static bool isSeparator(char character)
 
 void WebSocketExtensionParser::skipSpaces()
 {
-    while (m_current < m_end && (*m_current == ' ' || *m_current == '\t'))
-        ++m_current;
+    while (!m_data.empty() && (m_data[0] == ' ' || m_data[0] == '\t'))
+        m_data = m_data.subspan(1);
 }
 
 bool WebSocketExtensionParser::consumeToken()
 {
     skipSpaces();
-    const char* start = m_current;
-    while (m_current < m_end && isASCIIPrintable(*m_current) && !isSeparator(*m_current))
-        ++m_current;
-    if (start < m_current) {
-        m_currentToken = String({ start, m_current });
+    auto start = m_data;
+    size_t tokenLength = 0;
+    while (tokenLength < m_data.size() && isASCIIPrintable(m_data[tokenLength]) && !isSeparator(m_data[tokenLength]))
+        ++tokenLength;
+    if (tokenLength) {
+        m_currentToken = String(start.first(tokenLength));
+        m_data = m_data.subspan(tokenLength);
         return true;
     }
     return false;
@@ -78,38 +78,41 @@ bool WebSocketExtensionParser::consumeToken()
 bool WebSocketExtensionParser::consumeQuotedString()
 {
     skipSpaces();
-    if (m_current >= m_end || *m_current != '"')
+    if (m_data.empty() || m_data[0] != '"')
         return false;
 
     Vector<char> buffer;
-    ++m_current;
-    while (m_current < m_end && *m_current != '"') {
-        if (*m_current == '\\' && ++m_current >= m_end)
-            return false;
-        buffer.append(*m_current);
-        ++m_current;
+    m_data = m_data.subspan(1);
+    while (!m_data.empty() && m_data[0] != '"') {
+        if (m_data[0] == '\\') {
+            m_data = m_data.subspan(1);
+            if (m_data.empty())
+                return false;
+        }
+        buffer.append(m_data[0]);
+        m_data = m_data.subspan(1);
     }
-    if (m_current >= m_end || *m_current != '"')
+    if (m_data.empty() || m_data[0] != '"')
         return false;
     m_currentToken = String::fromUTF8(buffer.span());
     if (m_currentToken.isNull())
         return false;
-    ++m_current;
+    m_data = m_data.subspan(1);
     return true;
 }
 
 bool WebSocketExtensionParser::consumeQuotedStringOrToken()
 {
-    // This is ok because consumeQuotedString() doesn't update m_current or
-    // makes it same as m_end on failure.
+    // This is ok because consumeQuotedString() doesn't update m_data or
+    // set m_didFailParsing to true on failure.
     return consumeQuotedString() || consumeToken();
 }
 
 bool WebSocketExtensionParser::consumeCharacter(char character)
 {
     skipSpaces();
-    if (m_current < m_end && *m_current == character) {
-        ++m_current;
+    if (!m_data.empty() && m_data[0] == character) {
+        m_data = m_data.subspan(1);
         return true;
     }
     return false;
@@ -118,31 +121,37 @@ bool WebSocketExtensionParser::consumeCharacter(char character)
 bool WebSocketExtensionParser::parseExtension(String& extensionToken, HashMap<String, String>& extensionParameters)
 {
     // Parse extension-token.
-    if (!consumeToken())
+    if (!consumeToken()) {
+        m_didFailParsing = true;
         return false;
+    }
 
     extensionToken = currentToken();
 
     // Parse extension-parameters if exists.
     while (consumeCharacter(';')) {
-        if (!consumeToken())
+        if (!consumeToken()) {
+            m_didFailParsing = true;
             return false;
+        }
 
         String parameterToken = currentToken();
         if (consumeCharacter('=')) {
             if (consumeQuotedStringOrToken())
                 extensionParameters.add(parameterToken, currentToken());
-            else
+            else {
+                m_didFailParsing = true;
                 return false;
+            }
         } else
             extensionParameters.add(parameterToken, String());
     }
-    if (!finished() && !consumeCharacter(','))
+    if (!finished() && !consumeCharacter(',')) {
+        m_didFailParsing = true;
         return false;
+    }
 
     return true;
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionParser.h
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionParser.h
@@ -38,9 +38,8 @@ namespace WebCore {
 
 class WebSocketExtensionParser {
 public:
-    explicit WebSocketExtensionParser(const char* start, const char* end)
-        : m_current(start)
-        , m_end(end)
+    explicit WebSocketExtensionParser(std::span<const uint8_t> data)
+        : m_data(data)
     {
     }
     bool finished();
@@ -59,9 +58,9 @@ private:
 
     void skipSpaces();
 
-    const char* m_current;
-    const char* m_end;
+    std::span<const uint8_t> m_data;
     String m_currentToken;
+    bool m_didFailParsing { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/websockets/WebSocketFrame.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketFrame.cpp
@@ -27,8 +27,6 @@
 #include <wtf/MathExtras.h>
 #include <wtf/text/MakeString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 // Constants for hybi-10 frame format.
@@ -49,6 +47,7 @@ bool WebSocketFrame::needsExtendedLengthField(size_t payloadLength)
     return payloadLength > maxPayloadLengthWithoutExtendedLengthField;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 WebSocketFrame::ParseFrameResult WebSocketFrame::parseFrame(uint8_t* data, size_t dataLength, WebSocketFrame& frame, const uint8_t*& frameEnd, String& errorString)
 {
     auto p = data;
@@ -121,6 +120,7 @@ WebSocketFrame::ParseFrameResult WebSocketFrame::parseFrame(uint8_t* data, size_
     frameEnd = p + maskingKeyLength + payloadLength;
     return FrameOK;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static void appendFramePayload(const WebSocketFrame& frame, Vector<uint8_t>& frameData)
 {
@@ -156,7 +156,7 @@ void WebSocketFrame::makeFrameData(Vector<uint8_t>& frameData)
         frameData.append(payload.size() & 0xFF);
     } else {
         frameData.at(1) |= payloadLengthWithEightByteExtendedLengthField;
-        uint8_t extendedPayloadLength[8];
+        std::array<uint8_t, 8> extendedPayloadLength;
         size_t remaining = payload.size();
         // Fill the length into extendedPayloadLength in the network byte order.
         for (int i = 0; i < 8; ++i) {
@@ -182,5 +182,3 @@ WebSocketFrame::WebSocketFrame(OpCode opCode, bool final, bool compress, bool ma
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### e92bf171d84d991d69c755f872a08a3d1e13d2ed
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/Modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=283061">https://bugs.webkit.org/show_bug.cgi?id=283061</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/Modules/applepay/PaymentRequestValidator.mm:
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
* Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp:
(WebCore::writeLittleEndian):
(WebCore::readLittleEndian):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::getOrEstablishDatabaseInfo):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h:
* Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp:
* Source/WebCore/Modules/webdatabase/SQLTransaction.cpp:
(WebCore::SQLTransaction::stateFunctionFor):
* Source/WebCore/Modules/webdatabase/SQLTransactionBackend.cpp:
(WebCore::SQLTransactionBackend::stateFunctionFor):
* Source/WebCore/Modules/webdatabase/SQLTransactionStateMachine.h:
(WebCore::SQLTransactionStateMachine&lt;T&gt;::SQLTransactionStateMachine):
* Source/WebCore/Modules/websockets/WebSocketDeflater.cpp:
(WebCore::setStreamParameter):
(WebCore::WebSocketDeflater::addBytes):
(WebCore::WebSocketDeflater::finish):
(WebCore::WebSocketInflater::addBytes):
(WebCore::WebSocketInflater::finish):
* Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp:
(WebCore::WebSocketExtensionDispatcher::processHeaderValue):
* Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp:
(WebCore::WebSocketExtensionParser::finished):
(WebCore::WebSocketExtensionParser::parsedSuccessfully):
(WebCore::WebSocketExtensionParser::skipSpaces):
(WebCore::WebSocketExtensionParser::consumeToken):
(WebCore::WebSocketExtensionParser::consumeQuotedString):
(WebCore::WebSocketExtensionParser::consumeQuotedStringOrToken):
(WebCore::WebSocketExtensionParser::consumeCharacter):
(WebCore::WebSocketExtensionParser::parseExtension):
* Source/WebCore/Modules/websockets/WebSocketExtensionParser.h:
(WebCore::WebSocketExtensionParser::WebSocketExtensionParser):
* Source/WebCore/Modules/websockets/WebSocketFrame.cpp:
(WebCore::WebSocketFrame::makeFrameData):

Canonical link: <a href="https://commits.webkit.org/286565@main">https://commits.webkit.org/286565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a46c682b391a34b25119db6268bb87e93757448

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80828 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27589 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78433 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3643 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59845 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17964 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65541 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40185 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47140 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23028 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25911 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68267 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82284 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3689 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2414 "Found 1 new test failure: imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.tentative.https.any.serviceworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68061 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3843 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65513 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67374 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11341 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9441 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11814 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3637 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6444 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3660 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7089 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5418 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->