### PR TITLE
[JSC] Add InLine / OutOfLine variants for load property handlers

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -447,8 +447,10 @@ private:
     Vector<std::unique_ptr<OptimizingCallLinkInfo>, 16> m_callLinkInfos;
 };
 
-MacroAssemblerCodeRef<JITThunkPtrTag> getByIdLoadOwnPropertyHandler(VM&);
-MacroAssemblerCodeRef<JITThunkPtrTag> getByIdLoadPrototypePropertyHandler(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> getByIdLoadOwnInLinePropertyHandler(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> getByIdLoadOwnOutOfLinePropertyHandler(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> getByIdLoadPrototypeInLinePropertyHandler(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> getByIdLoadPrototypeOutOfLinePropertyHandler(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> getByIdMissHandler(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> getByIdCustomAccessorHandler(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> getByIdCustomValueHandler(VM&);

--- a/Source/JavaScriptCore/jit/JITThunks.h
+++ b/Source/JavaScriptCore/jit/JITThunks.h
@@ -72,8 +72,10 @@ class NativeExecutable;
     macro(PolymorphicTopTierThunk, polymorphicTopTierThunk) \
     macro(PolymorphicTopTierThunkForClosure, polymorphicTopTierThunkForClosure) \
     macro(ReturnFromBaseline, returnFromBaselineGenerator) \
-    macro(GetByIdLoadOwnPropertyHandler, getByIdLoadOwnPropertyHandler) \
-    macro(GetByIdLoadPrototypePropertyHandler, getByIdLoadPrototypePropertyHandler) \
+    macro(GetByIdLoadOwnInLinePropertyHandler, getByIdLoadOwnInLinePropertyHandler) \
+    macro(GetByIdLoadOwnOutOfLinePropertyHandler, getByIdLoadOwnOutOfLinePropertyHandler) \
+    macro(GetByIdLoadPrototypeInLinePropertyHandler, getByIdLoadPrototypeInLinePropertyHandler) \
+    macro(GetByIdLoadPrototypeOutOfLinePropertyHandler, getByIdLoadPrototypeOutOfLinePropertyHandler) \
     macro(GetByIdMissHandler, getByIdMissHandler) \
     macro(GetByIdCustomAccessorHandler, getByIdCustomAccessorHandler) \
     macro(GetByIdCustomValueHandler, getByIdCustomValueHandler) \


### PR DESCRIPTION
#### 30b00bb45bceffdbb354729ea014eebda5fd78c9
<pre>
[JSC] Add InLine / OutOfLine variants for load property handlers
<a href="https://bugs.webkit.org/show_bug.cgi?id=283067">https://bugs.webkit.org/show_bug.cgi?id=283067</a>
<a href="https://rdar.apple.com/139815865">rdar://139815865</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::loadProperty):
(JSC::loadHandlerImpl):
(JSC::getByIdLoadHandlerImpl):
(JSC::getByIdLoadOwnInLinePropertyHandler):
(JSC::getByIdLoadOwnOutOfLinePropertyHandler):
(JSC::getByIdLoadPrototypeInLinePropertyHandler):
(JSC::getByIdLoadPrototypeOutOfLinePropertyHandler):
(JSC::getByValLoadHandlerImpl):
(JSC::InlineCacheCompiler::compileOneAccessCaseHandler):
(JSC::getByIdLoadOwnPropertyHandler): Deleted.
(JSC::getByIdLoadPrototypePropertyHandler): Deleted.
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:
* Source/JavaScriptCore/jit/JITThunks.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30b00bb45bceffdbb354729ea014eebda5fd78c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80864 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27622 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3676 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59874 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17996 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40206 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23050 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25944 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69529 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68302 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82318 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75626 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2443 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68088 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3876 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67396 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11362 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9466 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97880 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3670 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21415 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3693 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7122 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->