### PR TITLE
[css-masonry] Update Intrinsic Sizing Rows 004 Mix1 Expected / Ref Test Case

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1770,8 +1770,6 @@ imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/mas
 
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/grid-placement/masonry-grid-placement-named-lines-002.html [ ImageOnlyFailure ]
 
-webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1.html [ ImageOnlyFailure ]
-
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-columns-item-placement-auto-flow-next-001.html [ Skip ]
 webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-005.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1-expected.html
@@ -7,6 +7,7 @@
   <meta charset="utf-8">
   <title>Reference: Masonry layout max-content sizing</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";
@@ -19,8 +20,9 @@ grid {
   border: 1px solid;
   padding: 1px 0 2px 0;
   vertical-align: top;
-  align-items: start;
   height: max-content;
+  font-family: Ahem;
+  font-size: 15px;
 }
 
 item {
@@ -33,6 +35,30 @@ item {
   opacity: 0.5;
   width: 1em;
 }
+
+grid > item:nth-child(1) {
+  background-color: #89CFF0;
+}
+
+grid > item:nth-child(2) {
+  background-color: #FF6F61;
+}
+
+grid > item:nth-child(3) {
+  background-color: #FDF3E7;
+}
+
+grid > item:nth-child(4) {
+  background-color: #F4C542;
+}
+
+grid > item:nth-child(5) {
+  background-color: #333333;
+}
+
+grid > item:nth-child(6) {
+  background-color: #B2C8A5;
+}
 </style>
 
 <body>
@@ -41,7 +67,7 @@ item {
 <grid>
   <item style="height:2ch">1</item>
   <item>2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item style="grid-column: span 2; min-height: 2ch">3 3</item>
   <item>4</item>
   <item>5 5</item>
 
@@ -49,11 +75,11 @@ item {
 </grid>
 
 <grid>
-  <item>1</item>
+  <item style="height: 3ch">1</item>
   <item>2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item style="grid-column: span 2; min-height: 2ch">3 3</item>
   <item>4</item>
-  <item>5 5</item>
+  <item style="height:2ch">5 5</item>
 
   <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
@@ -97,44 +123,34 @@ item {
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5 5</item>
+  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
   <item style="height:5ch; grid-area: 1/2/4/3">6</item>
 
   <item class="hidden" style="grid-area: 2/1">0 0</item>
   <item class="hidden" style="grid-area: 3/1">0 0</item>
 </grid>
 
-<grid>
-  <item>1</item>
+<grid style="grid-template-columns: 30px auto;">
+  <item style="height: 3ch">1</item>
   <item>2 2</item>
   <item>3 3</item>
-  <item>4</item>
-  <item style="grid-area: 1/2/5/3">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 3/2">0 0</item>
+  <item style="height: 3ch">4</item>
+  <item style="grid-row:span 4">5 5</item>
 </grid>
 
-<grid>
-  <item>1</item>
+<grid style="grid-template-columns: 30px auto;">
+  <item style="height: 3ch">1</item>
   <item>2 2</item>
   <item>3 3</item>
-  <item>4</item>
-  <item style="height:6ch; grid-area: 1/2/5/3">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 4/2">0 0</item>
+  <item style="height: 3ch">4</item>
+  <item style="height: 6ch; grid-row:span 4">5 5</item>
 </grid>
 
-<grid>
-  <item>1</item>
+<grid style="grid-template-columns: 30px auto;">
+  <item style="height: 3ch">1</item>
   <item>2 2</item>
   <item>3 3</item>
-  <item>4</item>
-  <item style="height:6ch; grid-area: 1/2/4/3">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 4/2">0 0</item>
-  <item class="hidden" style="height:6ch; grid-area: 2/2/5/3">0 0</item>
+  <item style="height: 3ch">4</item>
+  <item style="height: 6ch; grid-row:span 3">5 5</item>
 </grid>
 </section>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1-ref.html
@@ -7,6 +7,7 @@
   <meta charset="utf-8">
   <title>Reference: Masonry layout max-content sizing</title>
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";
@@ -19,8 +20,9 @@ grid {
   border: 1px solid;
   padding: 1px 0 2px 0;
   vertical-align: top;
-  align-items: start;
   height: max-content;
+  font-family: Ahem;
+  font-size: 15px;
 }
 
 item {
@@ -33,6 +35,30 @@ item {
   opacity: 0.5;
   width: 1em;
 }
+
+grid > item:nth-child(1) {
+  background-color: #89CFF0;
+}
+
+grid > item:nth-child(2) {
+  background-color: #FF6F61;
+}
+
+grid > item:nth-child(3) {
+  background-color: #FDF3E7;
+}
+
+grid > item:nth-child(4) {
+  background-color: #F4C542;
+}
+
+grid > item:nth-child(5) {
+  background-color: #333333;
+}
+
+grid > item:nth-child(6) {
+  background-color: #B2C8A5;
+}
 </style>
 
 <body>
@@ -41,7 +67,7 @@ item {
 <grid>
   <item style="height:2ch">1</item>
   <item>2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item style="grid-column: span 2; min-height: 2ch">3 3</item>
   <item>4</item>
   <item>5 5</item>
 
@@ -49,11 +75,11 @@ item {
 </grid>
 
 <grid>
-  <item>1</item>
+  <item style="height: 3ch">1</item>
   <item>2 2</item>
-  <item style="grid-column: span 2">3 3</item>
+  <item style="grid-column: span 2; min-height: 2ch">3 3</item>
   <item>4</item>
-  <item>5 5</item>
+  <item style="height:2ch">5 5</item>
 
   <item class="hidden" style="grid-area: 4/2">0 0</item>
 </grid>
@@ -97,44 +123,34 @@ item {
   <item>2 2</item>
   <item>3 3</item>
   <item>4</item>
-  <item style="height:3ch; grid-area: 2/1/4/2">5 5</item>
+  <item style="height:3ch; grid-area: 2/1/4/2">5</item>
   <item style="height:5ch; grid-area: 1/2/4/3">6</item>
 
   <item class="hidden" style="grid-area: 2/1">0 0</item>
   <item class="hidden" style="grid-area: 3/1">0 0</item>
 </grid>
 
-<grid>
-  <item>1</item>
+<grid style="grid-template-columns: 30px auto;">
+  <item style="height: 3ch">1</item>
   <item>2 2</item>
   <item>3 3</item>
-  <item>4</item>
-  <item style="grid-area: 1/2/5/3">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 3/2">0 0</item>
+  <item style="height: 3ch">4</item>
+  <item style="grid-row:span 4">5 5</item>
 </grid>
 
-<grid>
-  <item>1</item>
+<grid style="grid-template-columns: 30px auto;">
+  <item style="height: 3ch">1</item>
   <item>2 2</item>
   <item>3 3</item>
-  <item>4</item>
-  <item style="height:6ch; grid-area: 1/2/5/3">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 4/2">0 0</item>
+  <item style="height: 3ch">4</item>
+  <item style="height: 6ch; grid-row:span 4">5 5</item>
 </grid>
 
-<grid>
-  <item>1</item>
+<grid style="grid-template-columns: 30px auto;">
+  <item style="height: 3ch">1</item>
   <item>2 2</item>
   <item>3 3</item>
-  <item>4</item>
-  <item style="height:6ch; grid-area: 1/2/4/3">5 5</item>
-
-  <item class="hidden" style="grid-area: 1/2">0 0</item>
-  <item class="hidden" style="grid-area: 4/2">0 0</item>
-  <item class="hidden" style="height:6ch; grid-area: 2/2/5/3">0 0</item>
+  <item style="height: 3ch">4</item>
+  <item style="height: 6ch; grid-row:span 3">5 5</item>
 </grid>
 </section>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1.html
@@ -9,6 +9,7 @@
   <link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-grid-3">
   <link rel="match" href="masonry-intrinsic-sizing-rows-004-ref.html">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
 
 @import "support/masonry-intrinsic-sizing-visual.css";
@@ -22,12 +23,38 @@ grid {
   padding: 1px 0 2px 0;
   vertical-align: top;
   height: max-content;
+  font-family: Ahem;
+  font-size: 15px;
 }
 
 item {
   /* allow for differing min-content and max-content sizes */
   writing-mode: vertical-rl;
   text-orientation: sideways;
+}
+
+grid > item:nth-child(1) {
+  background-color: #89CFF0;
+}
+
+grid > item:nth-child(2) {
+  background-color: #FF6F61;
+}
+
+grid > item:nth-child(3) {
+  background-color: #FDF3E7;
+}
+
+grid > item:nth-child(4) {
+  background-color: #F4C542;
+}
+
+grid > item:nth-child(5) {
+  background-color: #333333;
+}
+
+grid > item:nth-child(6) {
+  background-color: #B2C8A5;
 }
 </style>
 


### PR DESCRIPTION
#### 7fb07870ad51fa511629e16e59e70fed3d075bbe
<pre>
[css-masonry] Update Intrinsic Sizing Rows 004 Mix1 Expected / Ref Test Case
<a href="https://bugs.webkit.org/show_bug.cgi?id=283068">https://bugs.webkit.org/show_bug.cgi?id=283068</a>
<a href="https://rdar.apple.com/problem/139815982">rdar://problem/139815982</a>

Reviewed by Sammy Gill.

Use Ahem font and add colors to work around font sizing issues.

* Grid 1

Row 3 needs to span at least 2ch, because item 1 in the test case has a height of 2ch.
Therefore, item &quot;3 3&quot; should set a similar height of 2ch.

* Grid 2

Row 1 needs a height of 3ch, because in the original test case &quot;2 2&quot; and &quot;3 3&quot; will be placed in this row during track sizing.

Row 3 needs to span at least 2ch, because item 5 in the test case has a height of 2ch.
Therefore, item &quot;3 3&quot; should set a similar height of 2ch.

Item 5 needs a height of 2ch, because it is set to that in the original test case.

* Grid 6

Remove extra 5 not found in original test case.

* Grid 7

Set the grid-template-columns, because the second column will be incorrectly computed without &quot;30px auto&quot;.
Row 1 need a height of 3ch.
Row 4 needs to be a max-content, which is 3ch.
Simplify item 5 to just a span of 4.

* Grid 8

Set the grid-template-columns, because the second column will be incorrectly computed without &quot;30px auto&quot;.
Row 1 need a height of 3ch.
Row 4 needs to be a max-content, which is 3ch.
Simplify item 5 to just a span of 4 and height of 6ch.

* Grid 9

Set the grid-template-columns, because the second column will be incorrectly computed without &quot;30px auto&quot;.
Row 1 need a height of 3ch.
Row 4 needs to be a max-content, which is 3ch.
Simplify item 5 to just a span of 3 and height of 6ch.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-rows-004-mix1.html:

Canonical link: <a href="https://commits.webkit.org/286779@main">https://commits.webkit.org/286779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99f3b14a89aa4537bcf7c8e25a0527141e93ca2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29958 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81593 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28322 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4374 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18440 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50322 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66133 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40679 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47724 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23631 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26648 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68840 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23959 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83027 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4423 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2968 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68645 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4578 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66106 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67897 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16941 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11881 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9970 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4369 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4389 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7824 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->