### PR TITLE
Reduce use of IsDeprecatedTimerSmartPointerException in WebCore/

### DIFF
--- a/Source/WebCore/loader/TextTrackLoader.h
+++ b/Source/WebCore/loader/TextTrackLoader.h
@@ -33,19 +33,16 @@
 #include "Timer.h"
 #include "WebVTTParser.h"
 #include <memory>
+#include <wtf/CheckedPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
-class TextTrackLoader;
 class TextTrackLoaderClient;
 }
 
 namespace WTF {
 template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
 template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::TextTrackLoaderClient> : std::true_type { };
-
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::TextTrackLoader> : std::true_type { };
 }
 
 namespace WebCore {
@@ -66,9 +63,10 @@ public:
     virtual void newStyleSheetsAvailable(TextTrackLoader&) = 0;
 };
 
-class TextTrackLoader final : public CachedResourceClient, private WebVTTParserClient {
+class TextTrackLoader final : public CachedResourceClient, private WebVTTParserClient, public CanMakeCheckedPtr<TextTrackLoader> {
     WTF_MAKE_NONCOPYABLE(TextTrackLoader); 
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextTrackLoader);
 public:
     TextTrackLoader(TextTrackLoaderClient&, Document&);
     virtual ~TextTrackLoader();

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -1017,22 +1017,17 @@ unsigned CachedResource::decodedSize() const
 }
 
 inline CachedResourceCallback::CachedResourceCallback(CachedResource& resource, CachedResourceClient& client)
-    : m_resource(resource)
-    , m_client(client)
-    , m_timer(*this, &CachedResourceCallback::timerFired)
+    : m_timer([resource = CachedResourceHandle { resource }, client = WeakPtr { client }] {
+        if (client)
+            resource->didAddClient(*client);
+    })
 {
     m_timer.startOneShot(0_s);
 }
 
 inline void CachedResourceCallback::cancel()
 {
-    if (m_timer.isActive())
-        m_timer.stop();
-}
-
-void CachedResourceCallback::timerFired()
-{
-    CachedResourceHandle { m_resource.get() }->didAddClient(m_client);
+    m_timer.stop();
 }
 
 #if ENABLE(SHAREABLE_RESOURCE)

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -52,9 +52,6 @@ class CachedResourceCallback;
 namespace WTF {
 template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
 template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CachedResource> : std::true_type { };
-
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::CachedResourceCallback> : std::true_type { };
 }
 
 namespace WebCore {
@@ -452,14 +449,9 @@ class CachedResourceCallback {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     CachedResourceCallback(CachedResource&, CachedResourceClient&);
-
     void cancel();
 
 private:
-    void timerFired();
-
-    WeakRef<CachedResource> m_resource;
-    SingleThreadWeakRef<CachedResourceClient> m_client;
     Timer m_timer;
 };
 

--- a/Source/WebCore/page/AutoscrollController.h
+++ b/Source/WebCore/page/AutoscrollController.h
@@ -27,17 +27,9 @@
 
 #include "IntPoint.h"
 #include "Timer.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WallTime.h>
-
-namespace WebCore {
-class AutoscrollController;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::AutoscrollController> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -63,8 +55,9 @@ enum class AutoscrollType : uint8_t {
 constexpr Seconds autoscrollInterval { 50_ms };
 
 // AutscrollController handles autoscroll and pan scroll for EventHandler.
-class AutoscrollController {
+class AutoscrollController final : public CanMakeCheckedPtr<AutoscrollController> {
     WTF_MAKE_TZONE_ALLOCATED(AutoscrollController);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AutoscrollController);
 public:
     AutoscrollController();
     RenderBox* autoscrollRenderer() const;

--- a/Source/WebCore/page/ImageAnalysisQueue.cpp
+++ b/Source/WebCore/page/ImageAnalysisQueue.cpp
@@ -51,6 +51,11 @@ static constexpr Seconds resumeProcessingDelay = 100_ms;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageAnalysisQueue);
 
+Ref<ImageAnalysisQueue> ImageAnalysisQueue::create(Page& page)
+{
+    return adoptRef(*new ImageAnalysisQueue(page));
+}
+
 ImageAnalysisQueue::ImageAnalysisQueue(Page& page)
     : m_page(page)
     , m_resumeProcessingTimer(*this, &ImageAnalysisQueue::resumeProcessing)

--- a/Source/WebCore/page/ImageAnalysisQueue.h
+++ b/Source/WebCore/page/ImageAnalysisQueue.h
@@ -40,15 +40,6 @@ class HysteresisActivity;
 }
 
 namespace WebCore {
-class ImageAnalysisQueue;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::ImageAnalysisQueue> : std::true_type { };
-}
-
-namespace WebCore {
 
 class Document;
 class HTMLImageElement;
@@ -56,11 +47,11 @@ class Page;
 class Timer;
 class WeakPtrImplWithEventTargetData;
 
-class ImageAnalysisQueue {
+class ImageAnalysisQueue final : public RefCounted<ImageAnalysisQueue> {
     WTF_MAKE_TZONE_ALLOCATED(ImageAnalysisQueue);
 public:
-    ImageAnalysisQueue(Page&);
-    ~ImageAnalysisQueue();
+    static Ref<ImageAnalysisQueue> create(Page&);
+    WEBCORE_EXPORT ~ImageAnalysisQueue();
 
     WEBCORE_EXPORT void enqueueAllImagesIfNeeded(Document&, const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier);
     void clear();
@@ -71,6 +62,8 @@ public:
     WEBCORE_EXPORT void clearDidBecomeEmptyCallback();
 
 private:
+    explicit ImageAnalysisQueue(Page&);
+
     void resumeProcessingSoon();
     void resumeProcessing();
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -669,6 +669,7 @@ public:
 
 #if ENABLE(IMAGE_ANALYSIS)
     WEBCORE_EXPORT ImageAnalysisQueue& imageAnalysisQueue();
+    WEBCORE_EXPORT Ref<ImageAnalysisQueue> protectedImageAnalysisQueue();
     ImageAnalysisQueue* imageAnalysisQueueIfExists() { return m_imageAnalysisQueue.get(); }
 #endif
 
@@ -1551,7 +1552,7 @@ private:
     std::unique_ptr<ImageOverlayController> m_imageOverlayController;
 
 #if ENABLE(IMAGE_ANALYSIS)
-    std::unique_ptr<ImageAnalysisQueue> m_imageAnalysisQueue;
+    RefPtr<ImageAnalysisQueue> m_imageAnalysisQueue;
 #endif
 
     std::unique_ptr<WheelEventDeltaFilter> m_recentWheelEventDeltaFilter;

--- a/Source/WebCore/page/PerformanceMonitor.cpp
+++ b/Source/WebCore/page/PerformanceMonitor.cpp
@@ -84,6 +84,16 @@ PerformanceMonitor::PerformanceMonitor(Page& page)
     }
 }
 
+void PerformanceMonitor::ref() const
+{
+    m_page->ref();
+}
+
+void PerformanceMonitor::deref() const
+{
+    m_page->deref();
+}
+
 void PerformanceMonitor::didStartProvisionalLoad()
 {
     m_postLoadCPUTime = std::nullopt;

--- a/Source/WebCore/page/PerformanceMonitor.h
+++ b/Source/WebCore/page/PerformanceMonitor.h
@@ -31,15 +31,6 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
-class PerformanceMonitor;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::PerformanceMonitor> : std::true_type { };
-}
-
-namespace WebCore {
 
 class Page;
 
@@ -47,6 +38,9 @@ class PerformanceMonitor {
     WTF_MAKE_TZONE_ALLOCATED(PerformanceMonitor);
 public:
     explicit PerformanceMonitor(Page&);
+
+    void ref() const;
+    void deref() const;
 
     void didStartProvisionalLoad();
     void didFinishLoad();

--- a/Source/WebCore/page/ios/DOMTimerHoldingTank.h
+++ b/Source/WebCore/page/ios/DOMTimerHoldingTank.h
@@ -28,25 +28,18 @@
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
 
 #include "Timer.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
-class DOMTimerHoldingTank;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::DOMTimerHoldingTank> : std::true_type { };
-}
-
-namespace WebCore {
 
 class DOMTimer;
 
-class DOMTimerHoldingTank {
+class DOMTimerHoldingTank final : public CanMakeCheckedPtr<DOMTimerHoldingTank> {
     WTF_MAKE_TZONE_ALLOCATED(DOMTimerHoldingTank);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DOMTimerHoldingTank);
 public:
     DOMTimerHoldingTank();
     ~DOMTimerHoldingTank();

--- a/Source/WebCore/platform/CPUMonitor.h
+++ b/Source/WebCore/platform/CPUMonitor.h
@@ -26,24 +26,16 @@
 #pragma once
 
 #include "Timer.h"
-
 #include <wtf/CPUTime.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/Function.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
-class CPUMonitor;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::CPUMonitor> : std::true_type { };
-}
-
-namespace WebCore {
-
-class CPUMonitor {
+class CPUMonitor final : public CanMakeCheckedPtr<CPUMonitor> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(CPUMonitor, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CPUMonitor);
 public:
     using ExceededCPULimitHandler = Function<void(double)>;
     WEBCORE_EXPORT CPUMonitor(Seconds checkInterval, ExceededCPULimitHandler&&);

--- a/Source/WebCore/platform/CaretAnimator.h
+++ b/Source/WebCore/platform/CaretAnimator.h
@@ -29,6 +29,7 @@
 #include "LayoutRect.h"
 #include "RenderTheme.h"
 #include "Timer.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -82,8 +83,9 @@ public:
     virtual Node* caretNode() = 0;
 };
 
-class CaretAnimator {
+class CaretAnimator : public CanMakeCheckedPtr<CaretAnimator> {
     WTF_MAKE_TZONE_ALLOCATED(CaretAnimator);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CaretAnimator);
 public:
     struct PresentationProperties {
         enum class BlinkState : bool { 

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -436,7 +436,7 @@ void FindController::hideFindUI()
     resetMatchIndex();
 
 #if ENABLE(IMAGE_ANALYSIS)
-    if (auto imageAnalysisQueue = m_webPage->corePage()->imageAnalysisQueueIfExists())
+    if (RefPtr imageAnalysisQueue = m_webPage->corePage()->imageAnalysisQueueIfExists())
         imageAnalysisQueue->clearDidBecomeEmptyCallback();
 #endif
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9136,7 +9136,7 @@ void WebPage::updateWithTextRecognitionResult(const TextRecognitionResult& resul
 void WebPage::startVisualTranslation(const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier)
 {
     if (RefPtr document = m_mainFrame->coreLocalFrame()->document())
-        corePage()->imageAnalysisQueue().enqueueAllImagesIfNeeded(*document, sourceLanguageIdentifier, targetLanguageIdentifier);
+        corePage()->protectedImageAnalysisQueue()->enqueueAllImagesIfNeeded(*document, sourceLanguageIdentifier, targetLanguageIdentifier);
 }
 
 #endif // ENABLE(IMAGE_ANALYSIS)


### PR DESCRIPTION
#### d7f7e195648734524ab706a6802e90c9e4bc70ed
<pre>
Reduce use of IsDeprecatedTimerSmartPointerException in WebCore/
<a href="https://bugs.webkit.org/show_bug.cgi?id=283072">https://bugs.webkit.org/show_bug.cgi?id=283072</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/loader/TextTrackLoader.h:
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResourceCallback::CachedResourceCallback):
(WebCore::CachedResourceCallback::cancel):
(WebCore::CachedResourceCallback::timerFired): Deleted.
* Source/WebCore/loader/cache/CachedResource.h:
* Source/WebCore/page/AutoscrollController.h:
* Source/WebCore/page/ImageAnalysisQueue.cpp:
(WebCore::ImageAnalysisQueue::create):
* Source/WebCore/page/ImageAnalysisQueue.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::Page):
(WebCore::Page::analyzeImagesForFindInPage):
(WebCore::Page::didStartProvisionalLoad):
(WebCore::Page::didFinishLoad):
(WebCore::Page::setActivityState):
(WebCore::Page::didFinishLoadingImageForElement):
(WebCore::Page::imageAnalysisQueue):
(WebCore::Page::protectedImageAnalysisQueue):
(WebCore::Page::resetImageAnalysisQueue):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PerformanceMonitor.cpp:
(WebCore::PerformanceMonitor::ref const):
(WebCore::PerformanceMonitor::deref const):
* Source/WebCore/page/PerformanceMonitor.h:
* Source/WebCore/page/ios/DOMTimerHoldingTank.h:
* Source/WebCore/platform/CPUMonitor.h:
* Source/WebCore/platform/CaretAnimator.h:
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::hideFindUI):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::startVisualTranslation):

Canonical link: <a href="https://commits.webkit.org/286592@main">https://commits.webkit.org/286592@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1bc847bd4357d7257f6b9f3ca4be7e333feb6e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80870 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27635 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78471 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3681 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59875 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18000 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79422 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49781 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40207 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47165 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23057 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25954 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68291 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23390 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82323 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3727 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2446 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68094 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65541 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67404 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11366 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9469 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11831 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3675 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6491 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3698 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7127 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5456 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->