### PR TITLE
[WebGPU] Unused external textures result in struct size mismatches

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-283071-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-283071-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-283071.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-283071.html
@@ -1,0 +1,25458 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  requiredFeatures: [
+    'depth-clip-control',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxDynamicStorageBuffersPerPipelineLayout: 4,
+    maxDynamicUniformBuffersPerPipelineLayout: 8,
+    maxUniformBufferBindingSize: 16398468,
+    maxStorageBufferBindingSize: 158210384,
+  },
+});
+let veryExplicitBindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 46, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 48,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 83,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 119,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 162,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 977, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+  ],
+});
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let texture0 = device0.createTexture({
+  size: [260, 1, 41],
+  mipLevelCount: 2,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler0 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat'});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 646});
+let textureView0 = texture0.createView({mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 9});
+let sampler1 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+await gc();
+let commandEncoder0 = device0.createCommandEncoder();
+let texture1 = device0.createTexture({
+  size: [260, 1, 1],
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let buffer0 = device0.createBuffer({
+  size: 14479,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture2 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 1},
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView1 = texture1.createView({dimension: '2d-array', aspect: 'all'});
+let computePassEncoder0 = commandEncoder0.beginComputePass({});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(282).fill(18), /* required buffer size: 282 */
+{offset: 282}, {width: 49, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\ue267\u{1fd77}\u4c56\u0e6e\u{1fe32}\u0e03\u022e';
+} catch {}
+let texture3 = device0.createTexture({
+  label: '\u0aa2\u7139\u963e\uff43\u0abc\u91b3',
+  size: [260, 1, 27],
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let buffer1 = device0.createBuffer({size: 5236, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let textureView2 = texture1.createView({format: 'bgra8unorm', mipLevelCount: 1});
+let textureView3 = texture1.createView({dimension: '2d-array', arrayLayerCount: 1});
+try {
+buffer1.unmap();
+} catch {}
+let buffer2 = device0.createBuffer({size: 3665, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let textureView4 = texture2.createView({dimension: '2d-array'});
+try {
+device0.queue.writeBuffer(buffer0, 1840, new BigUint64Array(1922), 118, 0);
+} catch {}
+try {
+device0.label = '\udbd5\u0840\u{1fda0}\u{1fe53}\u0dea\u5f71';
+} catch {}
+let veryExplicitBindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 46, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 48,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 83,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 119,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 162,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 977, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+  ],
+});
+let sampler2 = device0.createSampler({addressModeU: 'mirror-repeat', lodMaxClamp: 84.92});
+let veryExplicitBindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\uf4c2\ud06f',
+  entries: [
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 46, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 48,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 83,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 119,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 162,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 977, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+  ],
+});
+let buffer3 = device0.createBuffer({size: 410, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 153, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(35).fill(21), /* required buffer size: 35 */
+{offset: 35}, {width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+adapter0.label = '\ud928\u53d9\u{1f77c}\ufec8\u{1f657}\u0eb0\u6ca6\u0250';
+} catch {}
+try {
+globalThis.someLabel = device0.queue.label;
+} catch {}
+let textureView5 = texture2.createView({dimension: '2d-array', baseArrayLayer: 0});
+try {
+device0.queue.submit([]);
+} catch {}
+let canvas0 = document.createElement('canvas');
+let buffer4 = device0.createBuffer({size: 4409, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX});
+let commandEncoder1 = device0.createCommandEncoder({});
+let textureView6 = texture0.createView({mipLevelCount: 1, arrayLayerCount: 5});
+let texture4 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 3},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+buffer2.unmap();
+} catch {}
+try {
+commandEncoder1.copyBufferToTexture({
+  /* bytesInLastRow: 576 widthInBlocks: 144 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 340 */
+  offset: 340,
+  rowsPerImage: 748,
+  buffer: buffer2,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 144, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder1.clearBuffer(buffer0, 3472, 1276);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder1.copyBufferToBuffer(buffer1, 1520, buffer0, 908, 776);
+} catch {}
+try {
+commandEncoder1.copyBufferToTexture({
+  /* bytesInLastRow: 56 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3168 */
+  offset: 3168,
+  bytesPerRow: 768,
+  buffer: buffer1,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData0 = new ImageData(28, 20);
+let shaderModule0 = device0.createShaderModule({
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+var<workgroup> vw4: atomic<u32>;
+
+var<workgroup> vw1: atomic<u32>;
+
+var<private> vp0 = modf(vec3f(0.00149, 0.3699, -0.3550));
+
+@group(0) @binding(41) var<storage, read_write> buffer5: array<array<array<f16, 1>, 52>>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn fn1() -> mat2x2h {
+  var out: mat2x2h;
+  var vf2: vec4h = faceForward(vec4h(unconst_f16(4248.2), unconst_f16(1438.6), unconst_f16(4601.6), unconst_f16(3495.5)), vec4h(vp0.fract.bgbb), vec4h(unconst_f16(7817.8), unconst_f16(13256.0), unconst_f16(5158.1), unconst_f16(2363.4)));
+  var vf3: f16 = vf2[u32(unconst_u32(63))];
+  vf2 += vec4h(f16(exp2(f32(unconst_f32(0.2838)))));
+  let ptr6: ptr<private, f32> = &vp1;
+  let vf4: vec2f = saturate(vec2f(unconst_f32(-0.09638), unconst_f32(0.3192)));
+  vf3 += vf2.z;
+  return out;
+}
+
+@group(0) @binding(83) var<uniform> buffer6: u32;
+
+struct T2 {
+  @align(4) @size(4) f0: f16,
+}
+
+@group(0) @binding(162) var tex0: texture_2d_array<u32>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(48) var st0: texture_storage_2d<bgra8unorm, read>;
+
+var<workgroup> vw0: u32;
+
+var<private> vp1: f32 = f32(-0.09603);
+
+struct T1 {
+  f0: f32,
+  @size(48) f1: array<mat4x2f, 1>,
+}
+
+@group(0) @binding(119) var<uniform> buffer7: i32;
+
+var<workgroup> vw3: atomic<u32>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn fn0(a0: ptr<private, T1>, a1: array<u32, 10>) {
+  let ptr0: ptr<private, mat4x2f> = &(*a0).f1[u32(unconst_u32(85))];
+  vp0 = modf(vec3f(bitcast<f32>(buffer6)));
+  atomicMin(&vw3, u32(unconst_u32(8)));
+  var vf0: vec2u = textureDimensions(tex0);
+  vp1 = f32(buffer5[arrayLength(&buffer5)][51][u32(unconst_u32(44))]);
+  vp0 = modf(unpack2x16snorm(u32(unconst_u32(36))).rgr);
+  let ptr1: ptr<storage, f16, read_write> = &buffer5[arrayLength(&buffer5)][51][u32(unconst_u32(417))];
+  let ptr2: ptr<workgroup, f32> = &vw2;
+  let ptr3: ptr<workgroup, f32> = &(*&vw2);
+  vw2 = bitcast<f32>(a1[9]);
+  let ptr4: ptr<storage, f16, read_write> = &(*&buffer5)[textureDimensions(tex0, i32(unconst_i32(-36))).r][51][0];
+  atomicMin(&vw4, u32(unconst_u32(16)));
+  let ptr5: ptr<private, mat4x2f> = &(*a0).f1[0];
+  let vf1: vec4f = select(vec4f(unconst_f32(0.1450), unconst_f32(0.02401), unconst_f32(0.2292), unconst_f32(0.01985)), vec4f(unconst_f32(0.1990), unconst_f32(0.1398), unconst_f32(0.01456), unconst_f32(0.2311)), bool(unconst_bool(true)));
+  _ = tex0;
+  _ = buffer6;
+  _ = buffer5;
+}
+
+alias vec3b = vec3<bool>;
+
+struct T0 {
+  @size(64) f0: mat2x3h,
+  @size(72) f1: array<atomic<u32>>,
+}
+
+var<workgroup> vw2: f32;
+
+@vertex
+fn vertex0(@location(13) @interpolate(perspective) a0: vec4h) -> @builtin(position) vec4f {
+  var out: vec4f;
+  fn1();
+  var vf5 = fn1();
+  vp1 -= f32((*&buffer7));
+  var vf6: vec2f = sinh(vec2f(unconst_f32(0.08419), unconst_f32(0.3194)));
+  var vf7 = fn1();
+  vp0.whole += vec3f(a0.ywz);
+  vf5 = mat2x2h(vec2h(vf6), vec2h(vf6));
+  vf7 = mat2x2h(vec2h(atan(vec2f(unconst_f32(-0.1854), unconst_f32(0.2206)))), vec2h(atan(vec2f(unconst_f32(-0.1854), unconst_f32(0.2206)))));
+  var vf8: vec4h = exp(vec4h(unconst_f16(4407.0), unconst_f16(1790.1), unconst_f16(1132.0), unconst_f16(13660.6)));
+  var vf9 = fn1();
+  let vf10: vec2h = exp2(bitcast<vec2h>((*&buffer6)));
+  vf8 += vf10.xyxy;
+  let ptr7: ptr<function, vec4h> = &vf8;
+  var vf11: f16 = a0[u32(unconst_u32(36))];
+  var vf12 = fn1();
+  vf12 -= mat2x2h(vf7[u32(unconst_u32(99))][u32(unconst_u32(429))], vf7[u32(unconst_u32(99))][u32(unconst_u32(429))], vf7[u32(unconst_u32(99))][u32(unconst_u32(429))], vf7[u32(unconst_u32(99))][u32(unconst_u32(429))]);
+  let vf13: f16 = vf9[u32(unconst_u32(258))][u32(unconst_u32(16))];
+  vf7 = mat2x2h(f16((*&buffer7)), f16((*&buffer7)), f16((*&buffer7)), f16((*&buffer7)));
+  fn1();
+  var vf14 = fn1();
+  vf14 -= mat2x2h(vec2h(vp0.fract.yy), vec2h(vp0.fract.gb));
+  return out;
+  _ = buffer6;
+  _ = buffer7;
+}
+
+@fragment
+fn fragment0() -> @location(200) @interpolate(flat, center) vec2u {
+  var out: vec2u;
+  fn1();
+  fn1();
+  out -= vec2u(u32((*&buffer5)[arrayLength(&(*&buffer5))][u32(unconst_u32(4))][0]));
+  fn1();
+  fn1();
+  let ptr8: ptr<storage, array<array<array<f16, 1>, 52>>, read_write> = &(*&buffer5);
+  fn1();
+  vp0 = modf(vec3f(f32((*&buffer5)[arrayLength(&(*&buffer5)) - 1][51][0])));
+  out = vec2u(u32((*ptr8)[u32(unconst_u32(224))][51][0]));
+  buffer5[u32(unconst_u32(122))][u32(unconst_u32(71))][u32(unconst_u32(485))] *= buffer5[u32(unconst_u32(0))][u32(unconst_u32(28))][0];
+  return out;
+  _ = buffer5;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  buffer5[u32(unconst_u32(228))][u32(unconst_u32(630))][u32(unconst_u32(60))] += (*&buffer5)[arrayLength(&(*&buffer5))][51][0];
+  atomicSub(&vw3, u32((*&buffer5)[arrayLength(&(*&buffer5))][51][u32(unconst_u32(67))]));
+  vw0 = pack2x16float(vec2f(unconst_f32(0.1662), unconst_f32(0.3817)));
+  atomicCompareExchangeWeak(&vw4, unconst_u32(212), unconst_u32(37));
+  let ptr9: ptr<storage, array<array<f16, 1>, 52>, read_write> = &(*&buffer5)[arrayLength(&(*&buffer5))];
+  let ptr10: ptr<storage, f16, read_write> = &buffer5[u32(unconst_u32(84))][51][u32((*ptr9)[bitcast<u32>(vp1)][0])];
+  var vf15: vec4i = extractBits(vec4i(unconst_i32(54), unconst_i32(79), unconst_i32(4), unconst_i32(136)), u32(unconst_u32(10)), u32((*&buffer5)[u32(unconst_u32(490))][51][0]));
+  let ptr11: ptr<storage, f16, read_write> = &buffer5[arrayLength(&buffer5)][u32(unconst_u32(75))][0];
+  let ptr12: ptr<storage, array<f16, 1>, read_write> = &(*&buffer5)[u32(unconst_u32(17))][u32(unconst_u32(146))];
+  buffer5[u32(unconst_u32(23))][u32(unconst_u32(33))][u32(unconst_u32(37))] = (*&buffer5)[arrayLength(&(*&buffer5))][u32(any(vec2<bool>(unconst_bool(true), unconst_bool(false))))][0];
+  let ptr13: ptr<storage, array<f16, 1>, read_write> = &(*&buffer5)[u32(unconst_u32(97))][u32(unconst_u32(618))];
+  vw2 = bitcast<f32>(atomicExchange(&vw1, u32(unconst_u32(157))));
+  atomicSub(&vw4, textureDimensions(st0).r);
+  vf15 &= vec4i(i32(buffer5[u32(unconst_u32(78))][u32(unconst_u32(257))][0]));
+  _ = buffer5;
+  _ = st0;
+}`,
+});
+let texture5 = device0.createTexture({
+  size: [32, 1, 1],
+  mipLevelCount: 1,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+document.body.append(canvas0);
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout2]});
+let texture6 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder1 = commandEncoder1.beginComputePass({});
+let sampler3 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 59.47,
+  compare: 'not-equal',
+});
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(343).fill(25), /* required buffer size: 343 */
+{offset: 343, rowsPerImage: 23}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise0 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+let commandEncoder2 = device0.createCommandEncoder();
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 1126});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(52).fill(252), /* required buffer size: 52 */
+{offset: 52}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer8 = device0.createBuffer({
+  size: 19152,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder3 = device0.createCommandEncoder({});
+let textureView7 = texture3.createView({format: 'bgra8unorm', baseArrayLayer: 4, arrayLayerCount: 1});
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'smpteSt4281', transfer: 'linear'} });
+let shaderModule1 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+requires pointer_composite_access;
+
+enable f16;
+
+var<workgroup> vw7: atomic<i32>;
+
+@id(52916) override override7: f16;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(41) var<storage, read_write> buffer9: array<array<mat2x2h, 13>>;
+
+var<workgroup> vw8: mat2x3h;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct FragmentOutput0 {
+  @location(4) f0: i32,
+  @location(3) @interpolate(flat) f1: vec2f,
+  @location(0) @interpolate(flat) f2: vec2u,
+}
+
+struct T1 {
+  f0: i32,
+}
+
+@id(2225) override override6: f32;
+
+override override8: u32 = 113;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(119) var<uniform> buffer11: f32;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw6: T0;
+
+alias vec3b = vec3<bool>;
+
+@group(0) @binding(977) var<uniform> buffer12: VertexOutput0;
+
+override override3: i32;
+
+@id(7102) override override4: f32;
+
+@id(36514) override override5: f16;
+
+struct T3 {
+  @size(56) f0: T0,
+}
+
+struct T0 {
+  @align(8) @size(8) f0: vec2h,
+}
+
+struct VertexOutput0 {
+  @builtin(position) f0: vec4f,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct S0 {
+  @location(3) f0: vec4i,
+  @location(13) @interpolate(linear) f1: vec4f,
+}
+
+var<workgroup> vw5: atomic<i32>;
+
+var<private> vp2: vec4f = vec4f(0.02604, 0.1695, 0.08719, 0.04203);
+
+override override0: i32;
+
+@id(51503) override override1: f32;
+
+@id(9084) override override2 = false;
+
+struct T2 {
+  @size(64) f0: array<mat3x4f, 1>,
+}
+
+@vertex
+fn vertex1(@location(7) a0: vec4u, @location(4) @interpolate(perspective, centroid) a1: vec2f, @location(1) a2: u32, @location(15) @interpolate(flat, centroid) a3: i32, a4: S0, @location(5) a5: vec4i, @location(8) a6: u32, @location(12) a7: vec4h) -> VertexOutput0 {
+  var out: VertexOutput0;
+  var vf16: vec4i = sign(vec4i(unconst_i32(168), unconst_i32(272), unconst_i32(7), unconst_i32(181)));
+  var vf17: f32 = a4.f1[u32(unconst_u32(143))];
+  vf16 *= vec4i(bitcast<i32>((*&buffer11)));
+  var vf18: u32 = pack4xU8(vec4u(unconst_u32(62), unconst_u32(321), unconst_u32(157), unconst_u32(24)));
+  let vf19: u32 = pack4x8unorm(vec4f(unconst_f32(0.1444), unconst_f32(0.3916), unconst_f32(-0.06930), unconst_f32(0.2668)));
+  let vf20: f32 = a4.f1[u32(unconst_u32(51))];
+  vp2 = unpack4x8unorm(a2);
+  vf16 -= bitcast<vec4i>((*&buffer12).f0);
+  out.f0 = bitcast<vec4f>(countOneBits(vec4u(unconst_u32(153), unconst_u32(75), unconst_u32(1), unconst_u32(123))));
+  var vf21: i32 = override0;
+  return out;
+  _ = override0;
+  _ = buffer12;
+  _ = buffer11;
+}
+
+@fragment
+fn fragment1(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  let ptr14: ptr<storage, array<mat2x2h, 13>, read_write> = &(*&buffer9)[u32(unconst_u32(9))];
+  var vf22: vec2h = buffer9[arrayLength(&buffer9)][u32(override2)][u32(unconst_u32(72))];
+  out.f1 = vec2f((*&buffer11));
+  return out;
+  _ = override2;
+  _ = buffer9;
+  _ = buffer11;
+}
+
+@compute @workgroup_size(3, 1, 3)
+fn compute1(@builtin(local_invocation_index) a0: u32) {
+  var vf23: f16 = (*&vw8)[u32(unconst_u32(77))][u32(unconst_u32(271))];
+  let ptr15: ptr<storage, array<mat2x2h, 13>, read_write> = &(*&buffer9)[arrayLength(&(*&buffer9))];
+  var vf24: f32 = override6;
+  let ptr16: ptr<storage, array<mat2x2h, 13>, read_write> = &buffer9[arrayLength(&buffer9)];
+  var vf25: f32 = vp2[u32(unconst_u32(37))];
+  var vf26: f16 = buffer9[u32(unconst_u32(330))][12][u32(unconst_u32(181))][u32(unconst_u32(30))];
+  atomicSub(&vw5, i32(unconst_i32(176)));
+  buffer9[u32(unconst_u32(1))][u32(unconst_u32(214))] -= mat2x2h(f16(atomicExchange(&(*&vw5), i32(unconst_i32(16)))), f16(atomicExchange(&(*&vw5), i32(unconst_i32(16)))), f16(atomicExchange(&(*&vw5), i32(unconst_i32(16)))), f16(atomicExchange(&(*&vw5), i32(unconst_i32(16)))));
+  vf24 *= bitcast<f32>(buffer9[u32(unconst_u32(402))][12][unconst_i32(1)]);
+  let ptr17: ptr<storage, array<mat2x2h, 13>, read_write> = &(*&buffer9)[arrayLength(&(*&buffer9))];
+  let vf27: f32 = distance(vec3f(unconst_f32(0.1407), unconst_f32(0.1003), unconst_f32(0.07046)), vec3f(unconst_f32(0.3413), unconst_f32(0.03731), unconst_f32(0.1192)));
+  let ptr18: ptr<storage, array<mat2x2h, 13>, read_write> = &buffer9[arrayLength(&buffer9)];
+  let ptr19: ptr<storage, mat2x2h, read_write> = &buffer9[arrayLength(&buffer9)][12];
+  let ptr20: ptr<storage, array<mat2x2h, 13>, read_write> = &(*ptr16);
+  var vf28: i32 = override0;
+  vf24 -= min(vec2f(unconst_f32(0.1984), unconst_f32(0.4949)), vec2f(unconst_f32(0.05321), unconst_f32(-0.09404))).g;
+  vf28 &= vec3i((*&vw8)[unconst_i32(0)])[2];
+  vf23 = f16(sign(bitcast<f32>(buffer9[u32(unconst_u32(171))][12][unconst_i32(1)])));
+  let ptr21: ptr<function, f16> = &vf23;
+  var vf29: i32 = atomicExchange(&(*&vw5), i32(unconst_i32(20)));
+  vp2 = vec4f((*&buffer9)[arrayLength(&(*&buffer9)) - 1][12][unconst_i32(1)].xxyx);
+  buffer9[u32(unconst_u32(26))][u32(unconst_u32(27))] = mat2x2h(buffer9[u32(unconst_u32(130))][u32(unconst_u32(126))][u32(unconst_u32(360))], buffer9[u32(unconst_u32(130))][u32(unconst_u32(126))][u32(unconst_u32(360))]);
+  var vf30: vec3h = vw8[u32(unconst_u32(310))];
+  _ = override6;
+  _ = override0;
+  _ = buffer9;
+}`,
+});
+let textureView8 = texture1.createView({dimension: '2d-array'});
+let computePassEncoder2 = commandEncoder2.beginComputePass({});
+try {
+commandEncoder3.copyBufferToTexture({
+  /* bytesInLastRow: 148 widthInBlocks: 37 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1044 */
+  offset: 1044,
+  buffer: buffer2,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 37, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let textureView9 = texture4.createView({format: 'rg16uint', mipLevelCount: 1});
+let sampler4 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat'});
+let commandEncoder4 = device0.createCommandEncoder({});
+try {
+commandEncoder3.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 904 */
+  offset: 904,
+  bytesPerRow: 23040,
+  buffer: buffer2,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder4.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 260 widthInBlocks: 65 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 92 */
+  offset: 92,
+  bytesPerRow: 2048,
+  buffer: buffer4,
+}, {width: 65, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder3.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 51, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 65, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder();
+let texture7 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 7},
+  mipLevelCount: 2,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder3 = commandEncoder4.beginComputePass({});
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder3.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 208 */
+  offset: 208,
+  bytesPerRow: 43264,
+  buffer: buffer1,
+}, {
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+adapter0.label = '\u{1fddd}\u0044\ucbb0\u0e26\u{1f61b}\u7921\u{1ff9f}\u001f';
+} catch {}
+let buffer13 = device0.createBuffer({size: 1059, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView10 = texture3.createView({dimension: '2d', baseArrayLayer: 5});
+let sampler5 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 37.39,
+  compare: 'greater',
+});
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder3.copyBufferToBuffer(buffer1, 1036, buffer13, 16, 4);
+} catch {}
+try {
+  await promise0;
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout2]});
+let texture8 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 2},
+  sampleCount: 1,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView11 = texture2.createView({dimension: '2d-array', baseMipLevel: 0, baseArrayLayer: 0});
+let computePassEncoder4 = commandEncoder3.beginComputePass();
+let commandEncoder6 = device0.createCommandEncoder({});
+try {
+commandEncoder6.resolveQuerySet(querySet0, 354, 39, buffer8, 1536);
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder({});
+let computePassEncoder5 = commandEncoder7.beginComputePass({});
+let pipeline0 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule1, constants: {2_225: 0, override0: 0}}});
+let promise1 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout3,
+  multisample: {count: 1, mask: 0x3cd1b79d},
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'not-equal', failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilReadMask: 433260104,
+    stencilWriteMask: 508907491,
+    depthBias: -1859616777,
+    depthBiasSlopeScale: 83.24805900767325,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex1',
+    constants: {override0: 0},
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 212, shaderLocation: 15},
+          {format: 'uint16x4', offset: 488, shaderLocation: 8},
+          {format: 'sint16x2', offset: 240, shaderLocation: 3},
+          {format: 'uint32x2', offset: 464, shaderLocation: 7},
+          {format: 'float32', offset: 196, shaderLocation: 4},
+          {format: 'uint8x2', offset: 498, shaderLocation: 1},
+          {format: 'sint16x2', offset: 260, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 84, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 8, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front'},
+});
+document.body.append(canvas0);
+let imageData1 = new ImageData(8, 60);
+let videoFrame1 = new VideoFrame(videoFrame0, {timestamp: 0});
+let buffer14 = device0.createBuffer({
+  size: 23121,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let textureView12 = texture7.createView({dimension: '2d', format: 'rg16uint', mipLevelCount: 1});
+let computePassEncoder6 = commandEncoder6.beginComputePass({label: '\u294b\u09f5'});
+try {
+computePassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder5.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6364 */
+  offset: 6364,
+  buffer: buffer14,
+}, {
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder5.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder5.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 43, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 236 widthInBlocks: 59 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2572 */
+  offset: 2572,
+  bytesPerRow: 69120,
+  buffer: buffer0,
+}, {width: 59, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 208, new Int16Array(29002), 339, 100);
+} catch {}
+let veryExplicitBindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 304,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture9 = device0.createTexture({
+  size: [260, 1, 13],
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder7 = commandEncoder5.beginComputePass({});
+try {
+device0.queue.writeBuffer(buffer8, 3484, new Float32Array(2135));
+} catch {}
+let autogeneratedBindGroupLayout0 = pipeline0.getBindGroupLayout(0);
+let commandEncoder8 = device0.createCommandEncoder({});
+let commandEncoder9 = device0.createCommandEncoder({});
+let computePassEncoder8 = commandEncoder9.beginComputePass({});
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+  await buffer13.mapAsync(GPUMapMode.READ, 32, 12);
+} catch {}
+try {
+commandEncoder8.resolveQuerySet(querySet0, 36, 5, buffer3, 0);
+} catch {}
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'smpteRp431', transfer: 'bt2020_12bit'} });
+let textureView13 = texture3.createView({dimension: '2d', baseArrayLayer: 12});
+let computePassEncoder9 = commandEncoder8.beginComputePass({});
+let imageData2 = new ImageData(88, 68);
+let autogeneratedBindGroupLayout1 = pipeline0.getBindGroupLayout(0);
+let bindGroup0 = device0.createBindGroup({
+  label: '\u{1fd52}\u0108\u{1fdd0}\u0fb6\u{1f89b}\u{1fc68}\u{1f8b3}\u{1fe41}\u0c5e',
+  layout: autogeneratedBindGroupLayout0,
+  entries: [{binding: 41, resource: {buffer: buffer8, offset: 2560}}],
+});
+let commandEncoder10 = device0.createCommandEncoder({});
+let commandBuffer0 = commandEncoder10.finish();
+let texture10 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer15 = device0.createBuffer({
+  size: 15658,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView14 = texture4.createView({baseMipLevel: 0, mipLevelCount: 1});
+let sampler6 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.79,
+  maxAnisotropy: 1,
+});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame2});
+let buffer16 = device0.createBuffer({size: 115, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder9.setPipeline(pipeline0);
+} catch {}
+let buffer17 = device0.createBuffer({
+  size: 28356,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder11 = device0.createCommandEncoder({});
+let textureView15 = texture0.createView({mipLevelCount: 1, baseArrayLayer: 11, arrayLayerCount: 5});
+let textureView16 = texture9.createView({baseArrayLayer: 0});
+let computePassEncoder10 = commandEncoder11.beginComputePass({});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let textureView17 = texture9.createView({});
+let texture11 = device0.createTexture({
+  label: '\u{1fa99}\u{1fe38}\u0fbe\uc3fb\u6785\u015e\u7df7\u{1f663}\u{1f66c}\u{1fe5e}',
+  size: {width: 130, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+try {
+computePassEncoder0.setPipeline(pipeline0);
+} catch {}
+let buffer18 = device0.createBuffer({
+  size: 3069,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+try {
+texture10.destroy();
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+try {
+adapter0.label = '\uf606\u{1f73a}\u06c9\u3f9c\u4f93';
+} catch {}
+let commandEncoder12 = device0.createCommandEncoder({});
+let texture12 = device0.createTexture({size: [65, 1, 19], mipLevelCount: 1, format: 'rg32uint', usage: GPUTextureUsage.STORAGE_BINDING});
+let textureView18 = texture7.createView({aspect: 'all', mipLevelCount: 1, arrayLayerCount: 2});
+let computePassEncoder11 = commandEncoder12.beginComputePass();
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+document.body.append(canvas0);
+canvas0.width = 2965;
+let shaderModule2 = device0.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+var<workgroup> vw13: array<T4, 1>;
+
+struct T2 {
+  f0: array<u32>,
+}
+
+fn fn0() -> T0 {
+  var out: T0;
+  let vf31: u32 = pack2x16unorm(vec2f(unconst_f32(0.1872), unconst_f32(0.05178)));
+  let vf32: f32 = sqrt(f32(unconst_f32(0.03640)));
+  let vf33: vec3f = smoothstep(vec3f(unconst_f32(0.2423), unconst_f32(0.4328), unconst_f32(0.2494)), vec3f(unconst_f32(0.1344), unconst_f32(0.1352), unconst_f32(-0.1930)), vec3f(unconst_f32(0.06070), unconst_f32(-0.2300), unconst_f32(0.03539)));
+  let vf34: u32 = pack4xU8Clamp(vec4u(unconst_u32(189), unconst_u32(320), unconst_u32(36), unconst_u32(176)));
+  let vf35: vec2u = select(vec2u(unconst_u32(57), unconst_u32(8)), vec2u(unconst_u32(128), unconst_u32(55)), vec2<bool>(unconst_bool(false), unconst_bool(false)));
+  let vf36: u32 = pack4x8snorm(vec4f(unconst_f32(0.09730), unconst_f32(0.3488), unconst_f32(0.3052), unconst_f32(0.4587)));
+  var vf37: f32 = vf32;
+  let ptr22: ptr<uniform, i32> = &buffer20;
+  let vf38: u32 = vf34;
+  var vf39: vec3f = vf33;
+  vf39 *= vec3f(f32(pack4xU8(vec4u(unconst_u32(34), unconst_u32(173), unconst_u32(103), unconst_u32(20)))));
+  var vf40: vec4f = unpack4x8unorm(u32(unconst_u32(106)));
+  let vf41: mat2x2f = transpose(mat2x2f());
+  var vf42: mat2x2f = transpose(mat2x2f());
+  let vf43: vec2u = select(vec2u(unconst_u32(5), unconst_u32(198)), vec2u(unconst_u32(219), unconst_u32(38)), vec2<bool>(unconst_bool(true), unconst_bool(false)));
+  return out;
+  _ = buffer20;
+}
+
+var<workgroup> vw15: mat2x2f;
+
+var<workgroup> vw9: mat2x3f;
+
+fn fn1() -> mat4x2h {
+  var out: mat4x2h;
+  let ptr23: ptr<workgroup, array<T0, 1>> = &vw11[u32(unconst_u32(67))][0][u32(unconst_u32(141))];
+  let ptr24: ptr<workgroup, T0> = &vw11[u32(unconst_u32(418))][0][u32(unconst_u32(60))][u32(unconst_u32(58))];
+  vw14 += atomicLoad(&buffer19[u32(unconst_u32(100))][u32(unconst_u32(93))][0][u32(unconst_u32(303))]);
+  return out;
+  _ = buffer19;
+}
+
+var<workgroup> vw14: i32;
+
+struct T3 {
+  f0: array<atomic<i32>, 1>,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  @align(4) @size(4) f0: f16,
+}
+
+var<workgroup> vw10: f16;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw12: mat4x2f;
+
+var<workgroup> vw11: array<array<array<array<T0, 1>, 1>, 1>, 1>;
+
+var<workgroup> vw16: T1;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(83) var<uniform> buffer20: i32;
+
+struct T4 {
+  @size(56) f0: array<mat2x4h, 1>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(41) var<storage, read_write> buffer19: array<array<array<array<atomic<i32>, 2>, 1>, 13>>;
+
+struct T1 {
+  f0: vec4h,
+  @size(16) f1: vec2i,
+  @size(32) f2: vec4i,
+  @size(8) f3: i32,
+}
+
+@compute @workgroup_size(2, 2, 1)
+fn compute2(@builtin(local_invocation_id) a0: vec3u) {
+  workgroupBarrier();
+  let ptr25: ptr<uniform, i32> = &buffer20;
+  let ptr26: ptr<storage, atomic<i32>, read_write> = &buffer19[u32(unconst_u32(46))][12][0][1];
+  let ptr27: ptr<workgroup, T0> = &vw11[u32(unconst_u32(45))][u32(unconst_u32(700))][0][u32(unconst_u32(29))];
+  atomicCompareExchangeWeak(&buffer19[u32(unconst_u32(157))][u32(unconst_u32(390))][u32(unconst_u32(255))][1], unconst_i32(98), unconst_i32(24));
+  let vf44: i32 = atomicExchange(&buffer19[arrayLength(&buffer19)][12][u32(unconst_u32(296))][u32(unconst_u32(313))], i32(unconst_i32(79)));
+  atomicExchange(&buffer19[u32(unconst_u32(62))][u32((*&vw13)[u32(unconst_u32(110))].f0[u32(unconst_u32(54))][unconst_i32(0)][3])][u32(unconst_u32(45))][u32((*&vw15)[u32(unconst_u32(373))][u32(unconst_u32(79))])], i32(unconst_i32(45)));
+  vw14 = atomicLoad(&(*&buffer19)[arrayLength(&(*&buffer19))][u32(unconst_u32(147))][0][1]);
+  var vf45 = fn1();
+  var vf46 = fn1();
+  vw10 = (*&vw11)[0][0][0][0].f0;
+  vw11[0][u32(unconst_u32(425))][u32(unconst_u32(1))][u32(unconst_u32(56))].f0 = (*&vw11)[0][u32(unconst_u32(1))][u32(unconst_u32(377))][0].f0;
+  var vf47: i32 = atomicExchange(&(*&buffer19)[u32(unconst_u32(197))][u32(unconst_u32(40))][u32(atomicLoad(&buffer19[bitcast<u32>(atomicExchange(&(*&buffer19)[u32(unconst_u32(7))][12][0][1], i32(unconst_i32(165))))][u32(unconst_u32(140))][0][1]))][1], i32(unconst_i32(111)));
+  vf45 -= mat4x2h(f16(atomicLoad(&(*&buffer19)[arrayLength(&(*&buffer19))][u32(unconst_u32(1))][u32(unconst_u32(81))][u32(unconst_u32(208))])), f16(atomicLoad(&(*&buffer19)[arrayLength(&(*&buffer19))][u32(unconst_u32(1))][u32(unconst_u32(81))][u32(unconst_u32(208))])), f16(atomicLoad(&(*&buffer19)[arrayLength(&(*&buffer19))][u32(unconst_u32(1))][u32(unconst_u32(81))][u32(unconst_u32(208))])), f16(atomicLoad(&(*&buffer19)[arrayLength(&(*&buffer19))][u32(unconst_u32(1))][u32(unconst_u32(81))][u32(unconst_u32(208))])), f16(atomicLoad(&(*&buffer19)[arrayLength(&(*&buffer19))][u32(unconst_u32(1))][u32(unconst_u32(81))][u32(unconst_u32(208))])), f16(atomicLoad(&(*&buffer19)[arrayLength(&(*&buffer19))][u32(unconst_u32(1))][u32(unconst_u32(81))][u32(unconst_u32(208))])), f16(atomicLoad(&(*&buffer19)[arrayLength(&(*&buffer19))][u32(unconst_u32(1))][u32(unconst_u32(81))][u32(unconst_u32(208))])), f16(atomicLoad(&(*&buffer19)[arrayLength(&(*&buffer19))][u32(unconst_u32(1))][u32(unconst_u32(81))][u32(unconst_u32(208))])));
+  var vf48 = fn1();
+  vw16 = T1(vec4h(f16(vw12[u32(unconst_u32(46))][u32(unconst_u32(6))])), vec2i(bitcast<i32>(vw12[u32(unconst_u32(46))][u32(unconst_u32(6))])), vec4i(bitcast<i32>(vw12[u32(unconst_u32(46))][u32(unconst_u32(6))])), bitcast<i32>(vw12[u32(unconst_u32(46))][u32(unconst_u32(6))]));
+  fn1();
+  let ptr28: ptr<workgroup, f16> = &vw11[u32(unconst_u32(52))][0][0][u32(unconst_u32(71))].f0;
+  _ = buffer20;
+  _ = buffer19;
+}`,
+});
+let buffer23 = device0.createBuffer({size: 1908, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder13 = device0.createCommandEncoder({});
+let texture13 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 91},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture14 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder12 = commandEncoder13.beginComputePass();
+try {
+computePassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup1 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 304, resource: {buffer: buffer8, offset: 256, size: 2620}}],
+});
+let texture15 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 190},
+  mipLevelCount: 1,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView19 = texture9.createView({format: 'r32sint', arrayLayerCount: 1});
+try {
+computePassEncoder8.setPipeline(pipeline0);
+} catch {}
+let pipeline1 = await promise1;
+let bindGroup2 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 46, resource: externalTexture0},
+    {binding: 162, resource: textureView0},
+    {binding: 977, resource: {buffer: buffer18, offset: 256, size: 893}},
+    {binding: 119, resource: {buffer: buffer16, offset: 0, size: 34}},
+    {binding: 41, resource: {buffer: buffer17, offset: 256}},
+    {binding: 48, resource: textureView2},
+    {binding: 83, resource: {buffer: buffer16, offset: 0, size: 43}},
+  ],
+});
+let textureView20 = texture0.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 2});
+let textureView21 = texture8.createView({dimension: '2d-array', arrayLayerCount: 1});
+let sampler7 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 99.80});
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder10.pushDebugGroup('\u051d');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 41, resource: {buffer: buffer15, offset: 768, size: 4256}}],
+});
+let buffer24 = device0.createBuffer({
+  size: 37092,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let sampler8 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 66.52,
+  lodMaxClamp: 77.20,
+});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+await gc();
+let commandEncoder14 = device0.createCommandEncoder({});
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 744});
+let texture16 = device0.createTexture({
+  size: [130, 1, 94],
+  mipLevelCount: 2,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder13 = commandEncoder14.beginComputePass({});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline0);
+} catch {}
+let imageData3 = new ImageData(88, 16);
+let buffer25 = device0.createBuffer({size: 33862, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView22 = texture13.createView({});
+let sampler9 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 13,
+});
+let externalTexture1 = device0.importExternalTexture({source: videoFrame1});
+let autogeneratedBindGroupLayout2 = pipeline0.getBindGroupLayout(0);
+let commandEncoder15 = device0.createCommandEncoder({});
+let textureView23 = texture0.createView({
+  label: '\u4a47\ufd72\ue57e\u4083\u05cd\u4712',
+  dimension: '2d',
+  aspect: 'all',
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+});
+let sampler10 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', lodMaxClamp: 67.99});
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder10.popDebugGroup();
+} catch {}
+let bindGroup4 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 46, resource: externalTexture0},
+    {binding: 48, resource: textureView2},
+    {binding: 977, resource: {buffer: buffer15, offset: 1792, size: 2104}},
+    {binding: 162, resource: textureView15},
+    {binding: 119, resource: {buffer: buffer18, offset: 0, size: 224}},
+    {binding: 41, resource: {buffer: buffer17, offset: 15616}},
+    {binding: 83, resource: {buffer: buffer18, offset: 0, size: 1008}},
+  ],
+});
+let texture17 = device0.createTexture({
+  size: [4, 4, 619],
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+commandEncoder15.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3960 */
+  offset: 3960,
+  buffer: buffer15,
+}, {
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer0, 420, 1648);
+} catch {}
+document.body.append(canvas0);
+let buffer26 = device0.createBuffer({
+  size: 38237,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView24 = texture1.createView({dimension: '2d-array'});
+let computePassEncoder14 = commandEncoder15.beginComputePass();
+try {
+computePassEncoder12.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 2572, new BigUint64Array(4072), 217, 72);
+} catch {}
+let buffer27 = device0.createBuffer({
+  size: 11391,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let textureView25 = texture17.createView({});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame1});
+let imageData4 = new ImageData(12, 20);
+let textureView26 = texture1.createView({dimension: '2d-array'});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup1);
+} catch {}
+let recycledExplicitBindGroupLayout0 = pipeline1.getBindGroupLayout(0);
+let sampler11 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', magFilter: 'linear', lodMaxClamp: 97.14});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer28 = device0.createBuffer({size: 11394, usage: GPUBufferUsage.MAP_WRITE});
+try {
+computePassEncoder14.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 34},
+  aspect: 'all',
+}, new Uint8Array(5_090).fill(233), /* required buffer size: 5_090 */
+{offset: 262, bytesPerRow: 142, rowsPerImage: 1}, {width: 19, height: 0, depthOrArrayLayers: 35});
+} catch {}
+let buffer29 = device0.createBuffer({
+  size: 15859,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder16 = device0.createCommandEncoder({});
+let textureView27 = texture12.createView({dimension: '2d', aspect: 'all', mipLevelCount: 1, baseArrayLayer: 2});
+let computePassEncoder15 = commandEncoder16.beginComputePass({});
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+await gc();
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'film', transfer: 'iec6196624'} });
+let bindGroup5 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 41, resource: {buffer: buffer15, offset: 512, size: 3296}}],
+});
+let commandEncoder17 = device0.createCommandEncoder({});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup1, new Uint32Array(24), 0, 0);
+} catch {}
+let arrayBuffer0 = buffer13.getMappedRange(32, 0);
+let bindGroup6 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 304, resource: {buffer: buffer15, offset: 2304, size: 8576}}],
+});
+let buffer30 = device0.createBuffer({
+  size: 4201,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView28 = texture0.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 8});
+let computePassEncoder16 = commandEncoder17.beginComputePass();
+try {
+computePassEncoder12.setBindGroup(0, bindGroup3, new Uint32Array(124), 3, 0);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+let texture18 = device0.createTexture({
+  size: [260, 1, 66],
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup1, new Uint32Array(740), 47, 0);
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline0);
+} catch {}
+let arrayBuffer1 = buffer13.getMappedRange(40, 0);
+let veryExplicitBindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 304,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup7 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 41, resource: {buffer: buffer0, offset: 2560, size: 240}}],
+});
+let commandEncoder18 = device0.createCommandEncoder({});
+let texture19 = device0.createTexture({
+  size: [260, 1, 1],
+  sampleCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder17 = commandEncoder18.beginComputePass({});
+let sampler12 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 80.76,
+  maxAnisotropy: 16,
+});
+let veryExplicitBindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 46, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 48,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 83,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 119,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 162,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 977, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+  ],
+});
+let buffer31 = device0.createBuffer({
+  size: 19880,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder19 = device0.createCommandEncoder({});
+let textureView29 = texture18.createView({dimension: '2d', baseArrayLayer: 3});
+let sampler13 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 81.87});
+try {
+device0.queue.writeBuffer(buffer30, 892, new BigUint64Array(36722), 5536, 260);
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder({});
+let textureView30 = texture19.createView({baseMipLevel: 0});
+let texture20 = device0.createTexture({
+  size: [130, 1, 1],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder18 = commandEncoder19.beginComputePass({label: '\u036e\uee07\uda63'});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup1, new Uint32Array(6011), 233, 0);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+let bindGroup8 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 977, resource: {buffer: buffer29, offset: 3840, size: 2424}},
+    {binding: 41, resource: {buffer: buffer15, offset: 2048, size: 3076}},
+    {binding: 119, resource: {buffer: buffer0, offset: 1536, size: 2397}},
+    {binding: 46, resource: externalTexture2},
+    {binding: 162, resource: textureView6},
+    {binding: 48, resource: textureView13},
+    {binding: 83, resource: {buffer: buffer16, offset: 0, size: 71}},
+  ],
+});
+let commandEncoder21 = device0.createCommandEncoder();
+try {
+computePassEncoder17.setPipeline(pipeline0);
+} catch {}
+let pipeline2 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule2, constants: {}}});
+document.body.prepend(canvas0);
+try {
+adapter0.label = '\ue330\u0b3e\u0e3e\u3f71\u0ad5\uf3f6\u00c9';
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder({});
+let computePassEncoder19 = commandEncoder20.beginComputePass({});
+try {
+computePassEncoder19.setPipeline(pipeline2);
+} catch {}
+let recycledExplicitBindGroupLayout1 = pipeline2.getBindGroupLayout(0);
+let texture21 = device0.createTexture({
+  size: [65, 1, 5],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder20 = commandEncoder21.beginComputePass();
+let renderPassEncoder0 = commandEncoder22.beginRenderPass({
+  colorAttachments: [{
+  view: textureView19,
+  depthSlice: 9,
+  clearValue: { r: 948.0, g: -421.8, b: 795.0, a: 188.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+renderPassEncoder0.setViewport(35.963630107544546, 0.5054367622022802, 5.099500217636296, 0.12090872823504582, 0.6910554199066361, 0.9483929743325423);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer30, 'uint32', 712, 701);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let texture22 = device0.createTexture({
+  size: [65],
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder20.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer30);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(29_517).fill(105), /* required buffer size: 29_517 */
+{offset: 29, bytesPerRow: 152, rowsPerImage: 194}, {width: 22, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let veryExplicitBindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 46, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 48,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 83,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 119,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 162,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 977, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+  ],
+});
+let buffer32 = device0.createBuffer({
+  size: 1388,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder23 = device0.createCommandEncoder({});
+let commandBuffer1 = commandEncoder23.finish();
+let texture23 = device0.createTexture({
+  size: [32],
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup7, new Uint32Array(0), 0, 0);
+} catch {}
+try {
+renderPassEncoder0.setViewport(139.07218673675152, 0.3762035525467745, 38.442692275355, 0.601428241722398, 0.04564407750037125, 0.551335021729981);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let textureView31 = texture23.createView({arrayLayerCount: 1});
+let texture24 = device0.createTexture({
+  size: {width: 32, height: 1, depthOrArrayLayers: 19},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler14 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 71.94,
+});
+try {
+device0.queue.writeBuffer(buffer0, 4572, new Int16Array(13752), 163, 1120);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder();
+let texture25 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 104},
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+computePassEncoder3.setBindGroup(0, bindGroup1, new Uint32Array(639), 113, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer26, 0, 1_056);
+} catch {}
+try {
+commandEncoder24.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 32 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2984 */
+  offset: 2952,
+  rowsPerImage: 18,
+  buffer: buffer26,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 32, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let img0 = await imageWithData(11, 2, '#10101010', '#20202020');
+let bindGroup9 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 119, resource: {buffer: buffer32, offset: 256}},
+    {binding: 162, resource: textureView0},
+    {binding: 46, resource: externalTexture1},
+    {binding: 41, resource: {buffer: buffer15, offset: 0, size: 3980}},
+    {binding: 83, resource: {buffer: buffer17, offset: 8704, size: 4490}},
+    {binding: 977, resource: {buffer: buffer26, offset: 7168, size: 817}},
+    {binding: 48, resource: textureView13},
+  ],
+});
+let buffer33 = device0.createBuffer({size: 8874, usage: GPUBufferUsage.COPY_DST});
+let texture26 = device0.createTexture({
+  size: {width: 32, height: 1, depthOrArrayLayers: 14},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture27 = device0.createTexture({
+  size: [32, 1, 45],
+  mipLevelCount: 2,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder0.setIndexBuffer(buffer31, 'uint16', 3_618, 5_419);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer30);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 32, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView32 = texture26.createView({dimension: '3d', format: 'r32float', mipLevelCount: 1});
+let computePassEncoder21 = commandEncoder24.beginComputePass({});
+try {
+renderPassEncoder0.beginOcclusionQuery(337);
+} catch {}
+try {
+computePassEncoder17.pushDebugGroup('\u0413');
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+try {
+adapter0.label = '\u6334\u7779\u02c7';
+} catch {}
+let recycledExplicitBindGroupLayout2 = pipeline2.getBindGroupLayout(0);
+let bindGroup10 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 83, resource: {buffer: buffer31, offset: 6656}},
+    {binding: 48, resource: textureView13},
+    {binding: 977, resource: {buffer: buffer18, offset: 512, size: 80}},
+    {binding: 46, resource: externalTexture1},
+    {binding: 162, resource: textureView15},
+    {binding: 119, resource: {buffer: buffer32, offset: 0, size: 501}},
+    {binding: 41, resource: {buffer: buffer8, offset: 8192, size: 2220}},
+  ],
+});
+try {
+computePassEncoder20.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer24, 'uint16', 1_274, 591);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+let commandEncoder25 = device0.createCommandEncoder({});
+let sampler15 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat'});
+try {
+buffer14.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(2).fill(242), /* required buffer size: 2 */
+{offset: 2, bytesPerRow: 126}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout3 = pipeline0.getBindGroupLayout(0);
+let buffer34 = device0.createBuffer({
+  size: 12659,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture28 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder21.setPipeline(pipeline2);
+} catch {}
+let bindGroup11 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [
+    {binding: 41, resource: {buffer: buffer17, offset: 0}},
+    {binding: 46, resource: externalTexture2},
+    {binding: 977, resource: {buffer: buffer18, offset: 768, size: 763}},
+    {binding: 48, resource: textureView13},
+    {binding: 119, resource: {buffer: buffer17, offset: 1280}},
+    {binding: 162, resource: textureView18},
+    {binding: 83, resource: {buffer: buffer15, offset: 3328, size: 4012}},
+  ],
+});
+let computePassEncoder22 = commandEncoder25.beginComputePass();
+let sampler16 = device0.createSampler({addressModeW: 'repeat', minFilter: 'nearest', lodMaxClamp: 98.22, compare: 'greater'});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer17, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer30, 92, new Int16Array(14632), 291, 224);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder({});
+let texture29 = device0.createTexture({
+  label: '\u5a15\u{1fbbb}\uc403\u92cc\u{1f78b}\u5e92\u{1fbe2}\u8e35\u099f\u3a9b\u{1f937}',
+  size: [4, 4, 17],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView33 = texture16.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 13});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup8, new Uint32Array(1361), 737, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer17, 2_780);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let autogeneratedBindGroupLayout4 = pipeline0.getBindGroupLayout(0);
+let commandEncoder27 = device0.createCommandEncoder();
+let textureView34 = texture24.createView({baseMipLevel: 0, baseArrayLayer: 1, arrayLayerCount: 10});
+let computePassEncoder23 = commandEncoder26.beginComputePass({});
+try {
+computePassEncoder23.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup8, new Uint32Array(1614), 450, 0);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder27.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 77, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 51, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise2;
+} catch {}
+let img1 = await imageWithData(38, 75, '#10101010', '#20202020');
+let commandEncoder28 = device0.createCommandEncoder({});
+let texture30 = device0.createTexture({size: [260, 1, 125], format: 'rg16uint', usage: GPUTextureUsage.COPY_DST, viewFormats: ['rg16uint']});
+let computePassEncoder24 = commandEncoder28.beginComputePass();
+try {
+computePassEncoder17.setBindGroup(0, bindGroup3, new Uint32Array(2055), 232, 0);
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer26, 'uint32', 22_272, 601);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer34, 0, 189);
+} catch {}
+let promise3 = shaderModule0.getCompilationInfo();
+try {
+commandEncoder27.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1088 */
+  offset: 1088,
+  buffer: buffer33,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u0c07\u73e1\uc201\u{1f741}\u09cb\uf57f\u020e\u{1f6c9}';
+} catch {}
+let computePassEncoder25 = commandEncoder27.beginComputePass({});
+try {
+computePassEncoder25.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup3, []);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup8, new Uint32Array(771), 22, 0);
+} catch {}
+try {
+computePassEncoder12.pushDebugGroup('\u0e4d');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 2144, new Int16Array(612));
+} catch {}
+let recycledExplicitBindGroupLayout3 = pipeline1.getBindGroupLayout(0);
+let buffer35 = device0.createBuffer({
+  size: 14697,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture31 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler17 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.77,
+});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture1.label = '\u00f7\u04a5\u{1fc26}\u{1fb4a}\u{1fa58}\ub9fa\u71f3\u7be8\u021a\ue13c';
+} catch {}
+let autogeneratedBindGroupLayout5 = pipeline0.getBindGroupLayout(0);
+let buffer36 = device0.createBuffer({
+  size: 3095,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+});
+let commandEncoder29 = device0.createCommandEncoder();
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup8, new Uint32Array(498), 87, 0);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(35, 0, 29, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer35);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 728, new BigUint64Array(43467), 6837, 28);
+} catch {}
+let pipeline3 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule1, constants: {2_225: 0, override0: 0}}});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+globalThis.someLabel = device0.queue.label;
+} catch {}
+let texture32 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView35 = texture21.createView({dimension: '2d'});
+try {
+commandEncoder29.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1336 */
+  offset: 1336,
+  rowsPerImage: 125,
+  buffer: buffer14,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder9.insertDebugMarker('\u0e34');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+canvas0.height = 315;
+let buffer37 = device0.createBuffer({size: 1256, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+computePassEncoder25.setBindGroup(3, bindGroup7, new Uint32Array(3039), 353, 0);
+} catch {}
+try {
+commandEncoder29.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 936 */
+  offset: 936,
+  buffer: buffer27,
+}, {
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder29.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise4 = device0.createComputePipelineAsync({
+  layout: pipelineLayout1,
+  compute: {module: shaderModule1, entryPoint: 'compute1', constants: {override0: 0, 2_225: 0}},
+});
+let textureView36 = texture17.createView({aspect: 'all'});
+let computePassEncoder26 = commandEncoder29.beginComputePass({});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup5, new Uint32Array(1799), 295, 0);
+} catch {}
+try {
+  await promise3;
+} catch {}
+try {
+device0.label = '\ude1e\ub496\uab27';
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [
+    {binding: 46, resource: externalTexture0},
+    {binding: 41, resource: {buffer: buffer0, offset: 256, size: 680}},
+    {binding: 977, resource: {buffer: buffer31, offset: 3072}},
+    {binding: 162, resource: textureView6},
+    {binding: 83, resource: {buffer: buffer29, offset: 0, size: 4751}},
+    {binding: 119, resource: {buffer: buffer30, offset: 0, size: 1766}},
+    {binding: 48, resource: textureView13},
+  ],
+});
+let buffer38 = device0.createBuffer({size: 9620, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder26.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder0.setViewport(68.0417626917617, 0.3824840244657549, 26.950560709566123, 0.4024806173021096, 0.14410565727829572, 0.22918635418442562);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+try {
+computePassEncoder12.popDebugGroup();
+} catch {}
+try {
+globalThis.someLabel = autogeneratedBindGroupLayout4.label;
+} catch {}
+let recycledExplicitBindGroupLayout4 = pipeline2.getBindGroupLayout(0);
+let buffer39 = device0.createBuffer({
+  size: 15716,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+device0.queue.writeBuffer(buffer27, 1756, new BigUint64Array(29), 9, 0);
+} catch {}
+let recycledExplicitBindGroupLayout5 = pipeline2.getBindGroupLayout(0);
+let commandEncoder30 = device0.createCommandEncoder({});
+let renderPassEncoder1 = commandEncoder30.beginRenderPass({
+  colorAttachments: [{
+  view: textureView35,
+  clearValue: { r: 832.8, g: -301.9, b: -76.12, a: 233.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder26.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 60, new BigUint64Array(1641), 171, 52);
+} catch {}
+let buffer40 = device0.createBuffer({
+  size: 29006,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup1, new Uint32Array(3502), 891, 0);
+} catch {}
+document.body.append(canvas0);
+let bindGroup13 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [
+    {binding: 119, resource: {buffer: buffer34, offset: 512, size: 1220}},
+    {binding: 46, resource: externalTexture0},
+    {binding: 48, resource: textureView2},
+    {binding: 977, resource: {buffer: buffer0, offset: 4864, size: 2198}},
+    {binding: 162, resource: textureView18},
+    {binding: 41, resource: {buffer: buffer26, offset: 2048, size: 6648}},
+    {binding: 83, resource: {buffer: buffer14, offset: 3072, size: 1343}},
+  ],
+});
+let buffer41 = device0.createBuffer({
+  size: 23481,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder31 = device0.createCommandEncoder({label: '\ucf6f\u{1f71d}'});
+let texture33 = device0.createTexture({
+  size: [260, 1, 1],
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture34 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder27 = commandEncoder31.beginComputePass({});
+try {
+computePassEncoder27.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup7, new Uint32Array(985), 114, 0);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer42 = device0.createBuffer({
+  size: 19110,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder32 = device0.createCommandEncoder({});
+let texture35 = device0.createTexture({
+  label: '\u4814\uf771\u{1fe3c}\ubdeb',
+  size: {width: 32},
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView37 = texture16.createView({
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  baseArrayLayer: 10,
+  arrayLayerCount: 1,
+});
+let computePassEncoder28 = commandEncoder32.beginComputePass();
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup3, new Uint32Array(337), 34, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 2,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(51).fill(11), /* required buffer size: 51 */
+{offset: 51}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+let pipeline4 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule0, constants: {}}});
+let promise6 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout3,
+  fragment: {module: shaderModule0, constants: {}, targets: [{format: 'rg16uint', writeMask: GPUColorWrite.GREEN}]},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'greater-equal', passOp: 'zero'},
+    stencilBack: {compare: 'never', failOp: 'increment-clamp', depthFailOp: 'increment-clamp', passOp: 'increment-clamp'},
+    stencilReadMask: 1392974471,
+    stencilWriteMask: 972139829,
+    depthBias: 0,
+  },
+  vertex: {
+    module: shaderModule0,
+    buffers: [{arrayStride: 1036, attributes: [{format: 'float32', offset: 132, shaderLocation: 13}]}],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw'},
+});
+let textureView38 = texture3.createView({aspect: 'all', baseArrayLayer: 1, arrayLayerCount: 7});
+let sampler18 = device0.createSampler({addressModeV: 'clamp-to-edge', addressModeW: 'repeat', minFilter: 'nearest', lodMaxClamp: 91.41});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(1, bindGroup8, new Uint32Array(389), 84, 0);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer35);
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder33 = device0.createCommandEncoder({});
+try {
+computePassEncoder3.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(0, bindGroup1, new Uint32Array(396), 146, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer38, 'uint16', 3_504, 2_029);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 52, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(354).fill(188), /* required buffer size: 354 */
+{offset: 354}, {width: 37, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 7, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise5;
+} catch {}
+let veryExplicitBindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 216,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+    {binding: 346, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let computePassEncoder29 = commandEncoder33.beginComputePass();
+try {
+computePassEncoder29.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(7, 0, 79, 0);
+} catch {}
+try {
+renderPassEncoder0.setViewport(71.02327956334439, 0.8971640780232322, 15.30479229461446, 0.05612046739283739, 0.6215426624776692, 0.7398588022165641);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer30, 0, 1_398);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 45, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(38).fill(233), /* required buffer size: 38 */
+{offset: 38, rowsPerImage: 145}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder34 = device0.createCommandEncoder({label: '\ubc19\u0dcf\u003e\u03a6\u{1f739}\ueed3\ucd5d'});
+let computePassEncoder30 = commandEncoder34.beginComputePass();
+try {
+computePassEncoder27.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+commandEncoder0.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 756 */
+  offset: 756,
+  bytesPerRow: 29696,
+  rowsPerImage: 1867,
+  buffer: buffer39,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder17.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let canvas1 = document.createElement('canvas');
+let autogeneratedBindGroupLayout6 = pipeline3.getBindGroupLayout(0);
+let textureView39 = texture19.createView({baseArrayLayer: 0});
+try {
+computePassEncoder30.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+computePassEncoder27.end();
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer0, 'uint16', 4_962, 876);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer41, 0, 11_153);
+} catch {}
+try {
+commandEncoder0.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 54, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1276 */
+  offset: 1276,
+  buffer: buffer42,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext1 = canvas1.getContext('webgpu');
+let bindGroup14 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout0,
+  entries: [{binding: 41, resource: {buffer: buffer31, offset: 1280}}],
+});
+let texture36 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 9},
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder31 = commandEncoder31.beginComputePass({});
+try {
+renderPassEncoder0.setViewport(240.2146752035561, 0.22769357570076576, 3.5115948389947045, 0.21393594245760666, 0.06316081908095705, 0.8915122619028835);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer30, 'uint16', 1_028, 218);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+let commandEncoder35 = device0.createCommandEncoder({});
+let commandBuffer2 = commandEncoder0.finish();
+let renderPassEncoder2 = commandEncoder35.beginRenderPass({
+  colorAttachments: [{
+  view: textureView35,
+  clearValue: { r: 303.8, g: 717.0, b: -445.5, a: -1.435, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+});
+try {
+computePassEncoder29.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(152);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+try {
+computePassEncoder26.pushDebugGroup('\u0023');
+} catch {}
+try {
+computePassEncoder26.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+let recycledExplicitBindGroupLayout6 = pipeline1.getBindGroupLayout(0);
+let buffer43 = device0.createBuffer({size: 4877, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let sampler19 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup3, new Uint32Array(1262), 806, 0);
+} catch {}
+let recycledExplicitBindGroupLayout7 = pipeline4.getBindGroupLayout(0);
+let commandEncoder36 = device0.createCommandEncoder({});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup1, new Uint32Array(609), 9, 0);
+} catch {}
+try {
+commandEncoder36.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 136 */
+  offset: 136,
+  bytesPerRow: 3072,
+  buffer: buffer40,
+}, {
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder36.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 284 widthInBlocks: 71 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2252 */
+  offset: 2252,
+  bytesPerRow: 7424,
+  buffer: buffer36,
+}, {width: 71, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder36.insertDebugMarker('\u12b7');
+} catch {}
+await gc();
+let buffer44 = device0.createBuffer({
+  size: 48082,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+let commandEncoder37 = device0.createCommandEncoder();
+let computePassEncoder32 = commandEncoder37.beginComputePass();
+let sampler20 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', maxAnisotropy: 1});
+try {
+computePassEncoder32.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer44, 'uint16', 108, 4_701);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder();
+let textureView40 = texture36.createView({baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder33 = commandEncoder38.beginComputePass({});
+let renderPassEncoder3 = commandEncoder36.beginRenderPass({
+  colorAttachments: [{
+  view: textureView35,
+  clearValue: { r: 450.8, g: -457.8, b: -180.4, a: -5.937, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet2,
+});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+computePassEncoder29.setBindGroup(0, bindGroup8, new Uint32Array(4132), 908, 0);
+} catch {}
+let autogeneratedBindGroupLayout7 = pipeline3.getBindGroupLayout(0);
+let commandEncoder39 = device0.createCommandEncoder();
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup1, new Uint32Array(685), 32, 0);
+} catch {}
+try {
+commandEncoder39.copyBufferToTexture({
+  /* bytesInLastRow: 136 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 480 */
+  offset: 480,
+  bytesPerRow: 13312,
+  buffer: buffer36,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let texture37 = device0.createTexture({
+  size: [130],
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture38 = device0.createTexture({
+  size: {width: 4, height: 4, depthOrArrayLayers: 17},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'display-p3'});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup8, new Uint32Array(804), 49, 0);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup8, new Uint32Array(1618), 388, 0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer24, 5_416, 5_889);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+let veryExplicitBindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 216,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+    {binding: 346, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder40 = device0.createCommandEncoder();
+let textureView41 = texture7.createView({mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 2});
+let computePassEncoder34 = commandEncoder39.beginComputePass({});
+let renderPassEncoder4 = commandEncoder40.beginRenderPass({
+  colorAttachments: [{
+  view: textureView16,
+  depthSlice: 8,
+  clearValue: { r: -340.9, g: 812.4, b: -327.6, a: -669.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+});
+let sampler21 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 80.79,
+});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup1, new Uint32Array(2721), 1_100, 0);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2, undefined);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer41, 704, new DataView(new ArrayBuffer(18053)), 923, 10404);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 214},
+  aspect: 'all',
+}, new Uint8Array(36_280).fill(22), /* required buffer size: 36_280 */
+{offset: 320, bytesPerRow: 31, rowsPerImage: 40}, {width: 1, height: 0, depthOrArrayLayers: 30});
+} catch {}
+let imageData5 = new ImageData(48, 44);
+let veryExplicitBindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 79,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 101,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 243,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 270,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {binding: 299, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 326,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 601,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout8 = pipeline0.getBindGroupLayout(0);
+let buffer45 = device0.createBuffer({
+  size: 3479,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder41 = device0.createCommandEncoder({});
+let textureView42 = texture19.createView({arrayLayerCount: 1});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup6, new Uint32Array(678), 36, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer4, 1_508);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 2 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = buffer45.label;
+} catch {}
+let recycledExplicitBindGroupLayout8 = pipeline2.getBindGroupLayout(0);
+let buffer46 = device0.createBuffer({
+  size: 6117,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let textureView43 = texture4.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder35 = commandEncoder41.beginComputePass({});
+let sampler22 = device0.createSampler({addressModeV: 'mirror-repeat', lodMaxClamp: 84.85});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup3, new Uint32Array(1293), 69, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 44, new Int16Array(5514), 2096, 164);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView44 = texture27.createView({dimension: '2d', mipLevelCount: 1});
+try {
+computePassEncoder31.setBindGroup(2, bindGroup1, new Uint32Array(1815), 550, 0);
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup13, new Uint32Array(815), 212, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let autogeneratedBindGroupLayout9 = pipeline0.getBindGroupLayout(0);
+let bindGroup15 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 162, resource: textureView0},
+    {binding: 119, resource: {buffer: buffer41, offset: 2816, size: 1047}},
+    {binding: 48, resource: textureView2},
+    {binding: 83, resource: {buffer: buffer32, offset: 0}},
+    {binding: 977, resource: {buffer: buffer17, offset: 8960}},
+    {binding: 46, resource: externalTexture1},
+    {binding: 41, resource: {buffer: buffer45, offset: 1024, size: 388}},
+  ],
+});
+let texture39 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 1},
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let sampler23 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 67.30,
+  lodMaxClamp: 96.03,
+  compare: 'never',
+});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup7, new Uint32Array(331), 10, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup1, []);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup16 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout8,
+  entries: [
+    {binding: 83, resource: {buffer: buffer40, offset: 10240, size: 1096}},
+    {binding: 119, resource: {buffer: buffer15, offset: 256, size: 913}},
+    {binding: 46, resource: externalTexture2},
+    {binding: 977, resource: {buffer: buffer14, offset: 0, size: 2173}},
+    {binding: 48, resource: textureView13},
+    {binding: 41, resource: {buffer: buffer0, offset: 6144, size: 4880}},
+    {binding: 162, resource: textureView15},
+  ],
+});
+let buffer47 = device0.createBuffer({
+  size: 50685,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture40 = device0.createTexture({
+  size: {width: 4, height: 4, depthOrArrayLayers: 54},
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView45 = texture24.createView({aspect: 'stencil-only', baseMipLevel: 0, baseArrayLayer: 2, arrayLayerCount: 4});
+let sampler24 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  compare: 'less',
+});
+let texture41 = device0.createTexture({
+  size: [32],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder29); computePassEncoder29.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup5, new Uint32Array(793), 217, 0);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(42);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer46, 'uint32', 1_420, 3_878);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer38, 416, 962);
+} catch {}
+try {
+  await shaderModule2.getCompilationInfo();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer27, 1504, new Float32Array(6432), 558, 64);
+} catch {}
+let buffer48 = device0.createBuffer({
+  size: 3127,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder29); computePassEncoder29.dispatchWorkgroupsIndirect(buffer18, 48); };
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer48, 'uint16', 886, 323);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 5748, new Float32Array(1860));
+} catch {}
+let buffer49 = device0.createBuffer({size: 26986, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let commandEncoder42 = device0.createCommandEncoder({});
+let computePassEncoder36 = commandEncoder42.beginComputePass({});
+let sampler25 = device0.createSampler({addressModeV: 'mirror-repeat', magFilter: 'nearest', lodMaxClamp: 80.52});
+try {
+computePassEncoder36.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup3, new Uint32Array(751), 94, 0);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+canvas1.width = 48;
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 3134});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup5, new Uint32Array(1354), 32, 0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(5, buffer24, 0);
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout6]});
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 1374});
+let texture42 = device0.createTexture({
+  size: [130],
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler26 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup13, new Uint32Array(590), 4, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup7, new Uint32Array(1603), 305, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer24, 'uint32', 14_024, 3_653);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+let videoFrame4 = new VideoFrame(videoFrame3, {timestamp: 0});
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 1});
+let texture43 = device0.createTexture({
+  size: [65],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg32uint'],
+});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer24, 'uint32', 484, 8_907);
+} catch {}
+let buffer50 = device0.createBuffer({
+  size: 2347,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let sampler27 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', magFilter: 'nearest', compare: 'not-equal'});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup5, new Uint32Array(2459), 142, 0);
+} catch {}
+let commandEncoder43 = device0.createCommandEncoder();
+let texture44 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView46 = texture44.createView({baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder37 = commandEncoder43.beginComputePass({});
+let sampler28 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMinClamp: 92.87,
+  lodMaxClamp: 96.04,
+  compare: 'always',
+});
+try {
+computePassEncoder37.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer24, 0, 3_812);
+} catch {}
+try {
+buffer25.destroy();
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: imageData0,
+  origin: { x: 3, y: 4 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup17 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 270, resource: {buffer: buffer24, offset: 3584}},
+    {binding: 101, resource: sampler5},
+    {binding: 243, resource: textureView29},
+    {binding: 326, resource: {buffer: buffer42, offset: 256, size: 9160}},
+    {binding: 601, resource: {buffer: buffer15, offset: 2048, size: 4960}},
+    {binding: 79, resource: textureView42},
+    {binding: 299, resource: sampler13},
+  ],
+});
+let textureView47 = texture23.createView({baseMipLevel: 0, arrayLayerCount: 1});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup16, new Uint32Array(982), 334, 0);
+} catch {}
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup1, new Uint32Array(159), 16, 0);
+} catch {}
+try {
+commandEncoder27.copyBufferToBuffer(buffer32, 80, buffer14, 44, 92);
+} catch {}
+await gc();
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout2, recycledExplicitBindGroupLayout3]});
+let commandEncoder44 = device0.createCommandEncoder({});
+let textureView48 = texture26.createView({mipLevelCount: 1});
+let textureView49 = texture41.createView({});
+let renderPassEncoder5 = commandEncoder27.beginRenderPass({
+  colorAttachments: [{
+  view: textureView35,
+  clearValue: { r: -830.3, g: 109.8, b: -588.9, a: 560.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 235757330,
+});
+let externalTexture4 = device0.importExternalTexture({source: videoFrame2});
+try {
+{ clearResourceUsages(device0, computePassEncoder29); computePassEncoder29.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+commandEncoder44.copyBufferToTexture({
+  /* bytesInLastRow: 56 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3264 */
+  offset: 3264,
+  bytesPerRow: 5376,
+  buffer: buffer30,
+}, {
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(40).fill(238), /* required buffer size: 40 */
+{offset: 40}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout9,
+  entries: [{binding: 41, resource: {buffer: buffer27, offset: 768, size: 1124}}],
+});
+let textureView50 = texture18.createView({dimension: '2d', baseArrayLayer: 5});
+let texture45 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 924},
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView51 = texture13.createView({arrayLayerCount: 1});
+let computePassEncoder38 = commandEncoder44.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder29); computePassEncoder29.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup1, []);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let texture46 = device0.createTexture({
+  size: [4],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler29 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'never',
+});
+try {
+computePassEncoder32.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -418.5, g: 120.7, b: 717.3, a: -824.9, });
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer48, 'uint16', 348, 362);
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(28, 8);
+let recycledExplicitBindGroupLayout9 = pipeline1.getBindGroupLayout(0);
+let commandEncoder45 = device0.createCommandEncoder({});
+let computePassEncoder39 = commandEncoder45.beginComputePass({});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder29); computePassEncoder29.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup6, new Uint32Array(1743), 227, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer30, 'uint16', 168, 69);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(293).fill(101), /* required buffer size: 293 */
+{offset: 293, rowsPerImage: 61}, {width: 29, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer51 = device0.createBuffer({
+  size: 11334,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView52 = texture12.createView({dimension: '2d', format: 'rg32uint', baseMipLevel: 0, baseArrayLayer: 7});
+let sampler30 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 87.85,
+  compare: 'never',
+});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup1, new Uint32Array(1437), 1_392, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 1104, new Int16Array(1739), 271, 1216);
+} catch {}
+let texture47 = device0.createTexture({
+  size: {width: 4, height: 4, depthOrArrayLayers: 17},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder38.setBindGroup(3, bindGroup5, new Uint32Array(200), 2, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder29); computePassEncoder29.dispatchWorkgroupsIndirect(buffer29, 76); };
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup7, new Uint32Array(1810), 240, 0);
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas0.getContext('webgpu');
+let buffer52 = device0.createBuffer({
+  size: 16857,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let commandEncoder46 = device0.createCommandEncoder({});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup13, new Uint32Array(1872), 266, 0);
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(buffer42, 1652, buffer36, 40, 716);
+} catch {}
+try {
+commandEncoder46.copyTextureToBuffer({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 130 widthInBlocks: 130 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 628 */
+  offset: 628,
+  buffer: buffer27,
+}, {width: 130, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img1);
+let shaderModule3 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<private> vp6 = array(modf(vec2f(0.3660, 0.1810)));
+
+@id(25352) override override13: i32 = 146;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+override override9: f16 = 42.50;
+
+var<workgroup> vw18: mat2x4h;
+
+var<private> vp7: array<vec2<bool>, 5> = array(vec2<bool>(true, true), vec2<bool>(false, false), vec2<bool>(false, true), vec2<bool>(false, true), vec2<bool>(true, true));
+
+struct T0 {
+  f0: u32,
+  @size(48) f1: mat2x2f,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@id(899) override override14: i32;
+
+var<private> vp3: T1 = T1(i32(187));
+
+var<workgroup> vw19: T0;
+
+var<private> vp4: VertexOutput1 = VertexOutput1(vec2u(169, 12), vec4f(0.01080, -0.1137, 0.03544, 0.02156), vec4f(0.09192, 0.1013, 0.2207, 0.1751), vec2i(0, 42), vec4i(334, 4, 15, 157));
+
+@id(20770) override override12: f16 = 6065.0;
+
+struct T2 {
+  f0: atomic<i32>,
+}
+
+fn fn0(a0: ptr<function, T1>, a1: array<T0, 1>) -> f32 {
+  var out: f32;
+  let ptr29: ptr<private, vec2f> = &vp6[u32(unconst_u32(180))].fract;
+  let vf49: i32 = override14;
+  let vf50: vec3i = countOneBits(vec3i(unconst_i32(231), unconst_i32(-52), unconst_i32(114)));
+  let vf51: vec3h = reflect(vec3h(unconst_f16(9618.2), unconst_f16(8255.6), unconst_f16(2099.3)), vec3h(unconst_f16(8498.7), unconst_f16(1849.8), unconst_f16(11346.8)));
+  var vf52: u32 = a1[u32(unconst_u32(29))].f0;
+  vp5.fract = vec2f(vp4.f2[u32(unconst_u32(198))]);
+  let ptr30: ptr<private, vec2<bool>> = &vp7[u32(unconst_u32(104))];
+  let ptr31 = &vp6;
+  let ptr32: ptr<private, vec2f> = &vp5.whole;
+  vp3 = T1(bitcast<i32>(a1[u32(unconst_u32(128))].f1[u32(unconst_u32(188))][u32(unconst_u32(507))]));
+  vp7[u32(unconst_u32(540))] = vec2<bool>(countOneBits(vec3i(unconst_i32(86), unconst_i32(433), unconst_i32(595))).br);
+  vp4 = VertexOutput1(vec2u(log(vec3f(unconst_f32(0.04583), unconst_f32(0.04210), unconst_f32(0.1121))).xy), log(vec3f(unconst_f32(0.04583), unconst_f32(0.04210), unconst_f32(0.1121))).gbgb, log(vec3f(unconst_f32(0.04583), unconst_f32(0.04210), unconst_f32(0.1121))).ggrg, bitcast<vec2i>(log(vec3f(unconst_f32(0.04583), unconst_f32(0.04210), unconst_f32(0.1121))).gr), bitcast<vec4i>(log(vec3f(unconst_f32(0.04583), unconst_f32(0.04210), unconst_f32(0.1121))).zyzx));
+  vf52 <<= vec4u(vp4.f3)[2];
+  vp6[u32(unconst_u32(7))] = modf(a1[0].f1[unconst_i32(1)]);
+  var vf53: bool = override10;
+  let ptr33: ptr<private, array<vec2<bool>, 5>> = &vp7;
+  out -= (*ptr31)[u32(unconst_u32(140))].fract[1];
+  return out;
+  _ = override10;
+  _ = override14;
+}
+
+var<private> vp5 = modf(vec2f(0.1947, 0.1890));
+
+@group(0) @binding(83) var<uniform> buffer54: f32;
+
+override override10: bool;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@id(49136) override override11: i32 = 34;
+
+struct VertexOutput1 {
+  @location(1) f1: vec2u,
+  @location(6) f2: vec4f,
+  @builtin(position) f3: vec4f,
+  @location(10) @interpolate(flat, centroid) f4: vec2i,
+  @location(11) f5: vec4i,
+}
+
+struct T1 {
+  f0: i32,
+}
+
+var<workgroup> vw17: VertexOutput1;
+
+@vertex
+fn vertex2(@location(15) @interpolate(perspective, centroid) a0: vec2f, @location(0) a1: f16, @location(14) @interpolate(flat, center) a2: f16, @location(6) @interpolate(flat, centroid) a3: u32) -> VertexOutput1 {
+  var out: VertexOutput1;
+  let ptr34: ptr<private, vec2i> = &vp4.f4;
+  return out;
+}
+
+@fragment
+fn fragment2() -> @location(200) vec4u {
+  var out: vec4u;
+  let ptr35: ptr<private, vec2i> = &vp4.f4;
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute3() {
+  vp7[vec4u(trunc(vec4f(unconst_f32(-0.1061), unconst_f32(0.07637), unconst_f32(0.8393), unconst_f32(0.01269)))).z] = vec2<bool>(bool(firstLeadingBit(u32(unconst_u32(81)))));
+  vp4 = VertexOutput1(vec2u(bitcast<u32>((*&buffer54))), vec4f((*&buffer54)), vec4f((*&buffer54)), vec2i(i32((*&buffer54))), vec4i(bitcast<i32>((*&buffer54))));
+  vp5 = modf(bitcast<vec2f>((*&vw17).f4));
+  let vf54: i32 = override11;
+  let vf55: i32 = (*&vw17).f4[u32(unconst_u32(433))];
+  _ = override11;
+  _ = buffer54;
+}`,
+});
+let veryExplicitBindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 216,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+    {binding: 346, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout2]});
+let computePassEncoder40 = commandEncoder46.beginComputePass({});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer38, 0, 164);
+} catch {}
+try {
+computePassEncoder22.pushDebugGroup('\u0229');
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+struct T4 {
+  @size(960) f0: array<atomic<i32>>,
+}
+
+struct FragmentOutput3 {
+  @location(0) f0: vec2u,
+  @location(4) f1: vec4f,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(83) var<uniform> buffer58: u32;
+
+var<workgroup> vw25: mat4x3h;
+
+struct T0 {
+  f0: u32,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw26: mat4x2h;
+
+struct FragmentOutput1 {
+  @location(0) f0: vec4u,
+}
+
+struct T3 {
+  f0: array<mat2x3h, 1>,
+  @align(16) @size(16) f1: T0,
+  @align(8) @size(336) f2: array<T0>,
+}
+
+var<workgroup> vw21: atomic<i32>;
+
+struct T1 {
+  @size(64) f0: vec4i,
+}
+
+@group(0) @binding(119) var<uniform> buffer59: i32;
+
+var<workgroup> vw23: atomic<i32>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw22: FragmentOutput2;
+
+@group(0) @binding(41) var<storage, read_write> buffer57: array<array<array<array<array<f16, 13>, 1>, 1>, 4>>;
+
+var<workgroup> vw27: array<FragmentOutput3, 1>;
+
+struct T2 {
+  @size(960) f0: array<array<atomic<u32>, 7>>,
+}
+
+var<workgroup> vw20: atomic<i32>;
+
+var<workgroup> vw24: array<mat2x4f, 3>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct FragmentOutput2 {
+  @location(5) @interpolate(perspective) f0: vec2f,
+  @location(0) f1: vec4u,
+  @location(7) f2: vec4f,
+  @location(3) @interpolate(flat, center) f3: f32,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@fragment
+fn fragment3(@location(11) @interpolate(flat, centroid) a0: vec4i) -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  let ptr36: ptr<storage, f16, read_write> = &buffer57[arrayLength(&buffer57)][u32(unconst_u32(424))][u32(unconst_u32(498))][0][u32(unconst_u32(123))];
+  out.f0 = unpack4xU8(u32((*&buffer57)[u32(unconst_u32(451))][3][u32(unconst_u32(296))][0][12]));
+  out.f0 |= vec4u(u32(buffer57[u32(unconst_u32(31))][3][0][0][12]));
+  let ptr37: ptr<storage, array<f16, 13>, read_write> = &(*&buffer57)[arrayLength(&(*&buffer57))][3][u32(unconst_u32(382))][0];
+  let ptr38: ptr<storage, f16, read_write> = &(*&buffer57)[arrayLength(&(*&buffer57))][3][0][u32(unconst_u32(152))][12];
+  out = FragmentOutput1(unpack4xU8(u32(buffer57[u32(unconst_u32(300))][3][u32(unconst_u32(24))][u32(unconst_u32(81))][12])));
+  let ptr39: ptr<storage, array<f16, 13>, read_write> = &(*&buffer57)[u32(buffer57[arrayLength(&buffer57)][u32(unconst_u32(154))][u32((*&buffer57)[u32(unconst_u32(552))][3][u32(unconst_u32(59))][u32(unconst_u32(329))][12])][0][12])][3][0][0];
+  let ptr40: ptr<storage, f16, read_write> = &(*&buffer57)[u32(unconst_u32(478))][3][u32(unconst_u32(280))][0][12];
+  let ptr41: ptr<storage, f16, read_write> = &buffer57[u32((*&buffer57)[arrayLength(&(*&buffer57))][u32(unconst_u32(78))][0][u32(unconst_u32(74))][u32(unconst_u32(144))])][u32(unconst_u32(210))][u32(unconst_u32(425))][u32(unconst_u32(68))][u32(unconst_u32(26))];
+  let ptr42: ptr<storage, array<f16, 13>, read_write> = &(*&buffer57)[u32(unconst_u32(116))][u32(unconst_u32(162))][u32(unconst_u32(29))][0];
+  let ptr43: ptr<storage, array<f16, 13>, read_write> = &(*&buffer57)[arrayLength(&(*&buffer57))][3][0][u32(unconst_u32(155))];
+  let ptr44: ptr<storage, array<f16, 13>, read_write> = &buffer57[u32(unconst_u32(156))][u32(unconst_u32(57))][0][0];
+  let ptr45: ptr<storage, f16, read_write> = &(*ptr44)[u32(unconst_u32(236))];
+  let ptr46: ptr<storage, array<array<array<array<f16, 13>, 1>, 1>, 4>, read_write> = &(*&buffer57)[i32(unconst_i32(-18))];
+  out.f0 = unpack4xU8(bitcast<u32>(buffer59));
+  let ptr47: ptr<storage, f16, read_write> = &(*ptr46)[u32(unconst_u32(159))][u32(unconst_u32(128))][0][u32(unconst_u32(36))];
+  let ptr48: ptr<storage, array<f16, 13>, read_write> = &buffer57[u32(unconst_u32(275))][u32(unconst_u32(27))][u32((*&buffer57)[u32(unconst_u32(54))][3][0][0][12])][0];
+  return out;
+  _ = buffer59;
+  _ = buffer57;
+}
+
+@fragment
+fn fragment4(@builtin(sample_index) a0: u32) -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  out.f0 = vec2f(f32(buffer57[u32(unconst_u32(19))][u32(buffer57[u32(buffer57[arrayLength(&buffer57)][u32(unconst_u32(91))][0][u32(unconst_u32(225))][12])][u32((*&buffer57)[u32(unconst_u32(23))][u32(unconst_u32(474))][u32(unconst_u32(125))][u32(unconst_u32(61))][12])][u32(unconst_u32(138))][u32(unconst_u32(150))][12])][0][u32(unconst_u32(85))][u32(unconst_u32(38))]));
+  let ptr49: ptr<storage, array<f16, 13>, read_write> = &(*&buffer57)[arrayLength(&(*&buffer57))][3][u32(buffer57[arrayLength(&buffer57)][3][0][0][12])][u32(unconst_u32(165))];
+  let ptr50: ptr<storage, f16, read_write> = &buffer57[arrayLength(&buffer57)][3][u32(unconst_u32(45))][0][12];
+  out = FragmentOutput2(vec2f(f32(buffer57[arrayLength(&buffer57)][u32(unconst_u32(99))][0][u32(unconst_u32(40))][12])), vec4u(u32(buffer57[arrayLength(&buffer57)][u32(unconst_u32(99))][0][u32(unconst_u32(40))][12])), vec4f(f32(buffer57[arrayLength(&buffer57)][u32(unconst_u32(99))][0][u32(unconst_u32(40))][12])), f32(buffer57[arrayLength(&buffer57)][u32(unconst_u32(99))][0][u32(unconst_u32(40))][12]));
+  let ptr51: ptr<storage, array<f16, 13>, read_write> = &buffer57[u32(unconst_u32(314))][u32(unconst_u32(119))][0][u32(unconst_u32(2))];
+  let ptr52: ptr<storage, f16, read_write> = &(*&buffer57)[u32(unconst_u32(91))][u32(unconst_u32(185))][0][u32(unconst_u32(133))][12];
+  let ptr53: ptr<storage, array<array<f16, 13>, 1>, read_write> = &buffer57[u32(unconst_u32(35))][3][0];
+  out = FragmentOutput2(vec2f(f32(buffer57[u32(unconst_u32(257))][3][u32(unconst_u32(332))][0][12])), vec4u(u32(buffer57[u32(unconst_u32(257))][3][u32(unconst_u32(332))][0][12])), vec4f(f32(buffer57[u32(unconst_u32(257))][3][u32(unconst_u32(332))][0][12])), f32(buffer57[u32(unconst_u32(257))][3][u32(unconst_u32(332))][0][12]));
+  let ptr54: ptr<storage, f16, read_write> = &(*&buffer57)[u32(unconst_u32(62))][u32(unconst_u32(35))][u32(unconst_u32(110))][u32(unconst_u32(188))][12];
+  let ptr55: ptr<uniform, u32> = &buffer58;
+  out = FragmentOutput2(vec2f(f32(a0)), vec4u(a0), vec4f(f32(a0)), f32(a0));
+  let ptr56: ptr<storage, f16, read_write> = &buffer57[u32(unconst_u32(1))][3][u32(unconst_u32(283))][0][u32(unconst_u32(4))];
+  out = FragmentOutput2(vec2f(f32(buffer57[arrayLength(&buffer57)][u32(unconst_u32(21))][0][0][12])), unpack4xU8(u32(buffer57[arrayLength(&buffer57)][u32(unconst_u32(21))][0][0][12])), vec4f(f32(buffer57[arrayLength(&buffer57)][u32(unconst_u32(21))][0][0][12])), f32(buffer57[arrayLength(&buffer57)][u32(unconst_u32(21))][0][0][12]));
+  let ptr57: ptr<storage, f16, read_write> = &buffer57[u32(unconst_u32(65))][3][u32(unconst_u32(56))][u32(unconst_u32(120))][12];
+  out.f1 = unpack4xU8(u32(buffer57[arrayLength(&buffer57)][u32(unconst_u32(44))][u32(unconst_u32(75))][0][u32(unconst_u32(213))]));
+  let vf56: vec4i = unpack4xI8(u32(unconst_u32(141)));
+  let ptr58: ptr<storage, array<f16, 13>, read_write> = &(*&buffer57)[u32(unconst_u32(52))][u32(unconst_u32(77))][u32(unconst_u32(169))][0];
+  var vf57: f32 = smoothstep(f32(unconst_f32(0.3510)), f32(unconst_f32(0.05541)), f32(unconst_f32(0.02512)));
+  out.f0 = vec2f(f32(buffer57[arrayLength(&buffer57)][3][0][u32(unconst_u32(17))][12]));
+  let ptr59: ptr<storage, array<array<array<f16, 13>, 1>, 1>, read_write> = &(*&buffer57)[arrayLength(&(*&buffer57))][3];
+  buffer57[u32(unconst_u32(3))][u32(unconst_u32(30))][u32(unconst_u32(260))][0][12] = f16(vf56[u32(unconst_u32(60))]);
+  return out;
+  _ = buffer58;
+  _ = buffer57;
+}
+
+@fragment
+fn fragment5(@location(1) a0: vec2u, @location(10) @interpolate(flat, centroid) a1: vec2i) -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  out = FragmentOutput3(vec2u(u32(buffer57[arrayLength(&buffer57)][3][0][0][12])), vec4f(f32(buffer57[arrayLength(&buffer57)][3][0][0][12])));
+  let ptr60: ptr<storage, array<f16, 13>, read_write> = &buffer57[arrayLength(&buffer57)][u32(unconst_u32(21))][u32(unconst_u32(327))][0];
+  let ptr61: ptr<storage, array<array<array<f16, 13>, 1>, 1>, read_write> = &(*&buffer57)[arrayLength(&(*&buffer57))][u32(unconst_u32(282))];
+  out.f1 *= vec4f(f32(buffer57[arrayLength(&buffer57)][3][u32(buffer57[arrayLength(&buffer57)][u32(unconst_u32(48))][u32(unconst_u32(11))][0][u32(buffer57[u32(unconst_u32(34))][u32(unconst_u32(15))][u32(unconst_u32(395))][u32(unconst_u32(103))][u32(unconst_u32(19))])])][u32(unconst_u32(71))][u32(unconst_u32(309))]));
+  out.f1 = vec4f(f32(buffer57[arrayLength(&buffer57)][3][u32(unconst_u32(57))][0][12]));
+  let ptr62: ptr<storage, f16, read_write> = &(*ptr61)[0][u32(buffer57[u32(unconst_u32(100))][3][u32(unconst_u32(52))][0][12])][12];
+  out.f0 >>= vec2u(u32(buffer57[u32(unconst_u32(234))][3][0][0][12]));
+  discard;
+  let ptr63: ptr<storage, array<array<array<f16, 13>, 1>, 1>, read_write> = &buffer57[arrayLength(&buffer57)][3];
+  let ptr64: ptr<storage, f16, read_write> = &buffer57[u32(unconst_u32(64))][3][u32(unconst_u32(9))][0][u32(unconst_u32(652))];
+  let ptr65: ptr<storage, f16, read_write> = &(*&buffer57)[u32(unconst_u32(194))][3][u32(unconst_u32(171))][u32(buffer57[arrayLength(&buffer57)][3][0][u32(unconst_u32(7))][12])][u32(unconst_u32(120))];
+  let ptr66: ptr<storage, f16, read_write> = &(*&buffer57)[u32(unconst_u32(197))][u32(buffer57[u32(unconst_u32(727))][u32(unconst_u32(91))][0][u32(unconst_u32(272))][12])][0][u32(unconst_u32(4))][u32(unconst_u32(11))];
+  return out;
+  _ = buffer57;
+}`,
+});
+let bindGroup19 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [
+    {binding: 119, resource: {buffer: buffer18, offset: 768, size: 95}},
+    {binding: 46, resource: externalTexture3},
+    {binding: 977, resource: {buffer: buffer51, offset: 0, size: 741}},
+    {binding: 41, resource: {buffer: buffer42, offset: 4608, size: 748}},
+    {binding: 83, resource: {buffer: buffer0, offset: 1792, size: 1377}},
+    {binding: 162, resource: textureView18},
+    {binding: 48, resource: textureView10},
+  ],
+});
+let commandBuffer3 = commandEncoder33.finish({});
+let texture48 = device0.createTexture({
+  size: {width: 32},
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg16uint'],
+});
+try {
+computePassEncoder40.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer48);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let autogeneratedBindGroupLayout10 = pipeline0.getBindGroupLayout(0);
+let bindGroup20 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout7,
+  entries: [{binding: 346, resource: externalTexture3}, {binding: 216, resource: textureView31}],
+});
+try {
+renderPassEncoder5.setBlendConstant({ r: 248.9, g: -125.2, b: 54.15, a: 370.6, });
+} catch {}
+let bindGroup21 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 977, resource: {buffer: buffer0, offset: 4608, size: 940}},
+    {binding: 46, resource: externalTexture0},
+    {binding: 162, resource: textureView41},
+    {binding: 119, resource: {buffer: buffer0, offset: 1536, size: 1193}},
+    {binding: 83, resource: {buffer: buffer17, offset: 1280, size: 5549}},
+    {binding: 41, resource: {buffer: buffer24, offset: 256}},
+    {binding: 48, resource: textureView10},
+  ],
+});
+let texture49 = device0.createTexture({
+  size: [260, 1, 30],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView53 = texture18.createView({dimension: '2d', format: 'rg32sint', baseArrayLayer: 10});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer39, 12, 589);
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+let bindGroup22 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout4,
+  entries: [{binding: 41, resource: {buffer: buffer24, offset: 14592}}],
+});
+let textureView54 = texture30.createView({baseArrayLayer: 11, arrayLayerCount: 2});
+let sampler31 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat'});
+try {
+computePassEncoder40.setBindGroup(2, bindGroup19, new Uint32Array(1660), 334, 0);
+} catch {}
+let recycledExplicitBindGroupLayout10 = pipeline4.getBindGroupLayout(0);
+let bindGroup23 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout9,
+  entries: [{binding: 41, resource: {buffer: buffer45, offset: 0, size: 1488}}],
+});
+let commandEncoder47 = device0.createCommandEncoder({});
+let texture50 = device0.createTexture({
+  size: {width: 4, height: 4, depthOrArrayLayers: 17},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView55 = texture30.createView({baseArrayLayer: 1, arrayLayerCount: 24});
+let sampler32 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.69,
+  maxAnisotropy: 12,
+});
+let externalTexture5 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'srgb'});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup5, new Uint32Array(901), 136, 0);
+} catch {}
+try {
+renderPassEncoder4.end();
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let commandEncoder48 = device0.createCommandEncoder({});
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 682});
+let commandBuffer4 = commandEncoder40.finish({});
+let computePassEncoder41 = commandEncoder48.beginComputePass({});
+let renderPassEncoder6 = commandEncoder47.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: -117.4, g: -366.5, b: 263.5, a: 426.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView40,
+    depthClearValue: -1.6724247869821127,
+    depthReadOnly: true,
+    stencilClearValue: 61296,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'discard',
+  },
+  maxDrawCount: 50477088,
+});
+try {
+computePassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer39, 'uint16', 1_056, 614);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(7, buffer40, 8_068);
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+let commandEncoder49 = device0.createCommandEncoder({});
+let texture51 = device0.createTexture({
+  size: [65, 1, 6],
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder3.setBlendConstant({ r: 88.56, g: -336.7, b: 499.4, a: 561.5, });
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let bindGroup24 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout5,
+  entries: [{binding: 41, resource: {buffer: buffer40, offset: 2560, size: 9480}}],
+});
+let buffer62 = device0.createBuffer({
+  size: 18755,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder50 = device0.createCommandEncoder({});
+let texture52 = gpuCanvasContext1.getCurrentTexture();
+let textureView56 = texture35.createView({});
+let renderPassEncoder7 = commandEncoder49.beginRenderPass({
+  colorAttachments: [{
+  view: textureView19,
+  depthSlice: 10,
+  clearValue: { r: 179.5, g: 264.6, b: -457.9, a: 937.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder6.setPipeline(pipeline1);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+commandEncoder50.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3584 */
+  offset: 3584,
+  bytesPerRow: 52224,
+  rowsPerImage: 225,
+  buffer: buffer52,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData6 = new ImageData(36, 20);
+let veryExplicitBindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 73,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let computePassEncoder42 = commandEncoder50.beginComputePass({});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup1, new Uint32Array(4615), 1_016, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup13, new Uint32Array(1385), 134, 0);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(3, 0, 11, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer48, 232, 26);
+} catch {}
+try {
+  await shaderModule1.getCompilationInfo();
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+let buffer63 = device0.createBuffer({size: 8613, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let querySet7 = device0.createQuerySet({
+  label: '\u81a5\u0783\u39fb\ua657\u9a41\u8ede\u{1f8fe}\u0cdc\u{1fcea}\u01cf\u67f3',
+  type: 'occlusion',
+  count: 129,
+});
+let textureView57 = texture39.createView({baseMipLevel: 0});
+try {
+computePassEncoder42.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup20, new Uint32Array(1061), 56, 0);
+} catch {}
+let bindGroup25 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [{binding: 346, resource: externalTexture0}, {binding: 216, resource: textureView47}],
+});
+let commandEncoder51 = device0.createCommandEncoder({});
+let texture53 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 40},
+  mipLevelCount: 1,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder43 = commandEncoder51.beginComputePass({});
+let sampler33 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 9,
+});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup8, new Uint32Array(2781), 137, 0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer29, 'uint16', 1_990, 5_847);
+} catch {}
+let imageData7 = new ImageData(136, 32);
+let bindGroup26 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 41, resource: {buffer: buffer15, offset: 13056, size: 372}}],
+});
+let commandEncoder52 = device0.createCommandEncoder({});
+let textureView58 = texture53.createView({dimension: '2d'});
+let computePassEncoder44 = commandEncoder52.beginComputePass({});
+try {
+computePassEncoder44.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup6, new Uint32Array(563), 47, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer45, 'uint16', 170, 537);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(1, buffer38, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData8 = new ImageData(24, 48);
+let bindGroup27 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout9,
+  entries: [
+    {binding: 162, resource: textureView15},
+    {binding: 83, resource: {buffer: buffer47, offset: 10240, size: 8810}},
+    {binding: 48, resource: textureView2},
+    {binding: 41, resource: {buffer: buffer47, offset: 3840, size: 1824}},
+    {binding: 977, resource: {buffer: buffer45, offset: 0, size: 612}},
+    {binding: 119, resource: {buffer: buffer31, offset: 768}},
+    {binding: 46, resource: externalTexture3},
+  ],
+});
+let commandEncoder53 = device0.createCommandEncoder({});
+let texture54 = device0.createTexture({
+  size: [260, 1, 1],
+  mipLevelCount: 2,
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView59 = texture0.createView({mipLevelCount: 1, baseArrayLayer: 15, arrayLayerCount: 1});
+let computePassEncoder45 = commandEncoder53.beginComputePass({});
+try {
+computePassEncoder41.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(1, bindGroup25, new Uint32Array(1004), 112, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup18, new Uint32Array(1106), 376, 0);
+} catch {}
+try {
+renderPassEncoder3.setViewport(32.45934648870743, 0.9909408047114129, 3.1499594214205837, 0.0014661036112768415, 0.3896058777487563, 0.49755267516576407);
+} catch {}
+try {
+computePassEncoder22.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout11 = pipeline0.getBindGroupLayout(0);
+let texture55 = device0.createTexture({
+  size: [65, 1, 1],
+  sampleCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView60 = texture8.createView({label: '\ud533\u0190\u0046', arrayLayerCount: 1});
+try {
+computePassEncoder43.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup23, new Uint32Array(652), 65, 0);
+} catch {}
+try {
+renderPassEncoder3.setViewport(26.68134360848637, 0.3677713861040026, 9.717640611225454, 0.10176484673284922, 0.3175787436414891, 0.806037070051663);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer29, 'uint32', 2_468, 196);
+} catch {}
+let recycledExplicitBindGroupLayout11 = pipeline2.getBindGroupLayout(0);
+let commandEncoder54 = device0.createCommandEncoder({});
+let sampler34 = device0.createSampler({label: '\u{1f9fb}\u6024\u2844\ud1bf\u0a39'});
+try {
+computePassEncoder45.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder7.setViewport(97.91520925810956, 0.35745586288417885, 3.3630208184362944, 0.6120189327315642, 0.526841320742705, 0.5458248274374764);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(3, buffer35);
+} catch {}
+let buffer64 = device0.createBuffer({
+  size: 11420,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let texture56 = device0.createTexture({
+  size: {width: 4},
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+let computePassEncoder46 = commandEncoder54.beginComputePass({});
+try {
+computePassEncoder46.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer62, 'uint16', 5_618, 2_082);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer35, 0);
+} catch {}
+try {
+  await promise8;
+} catch {}
+let recycledExplicitBindGroupLayout12 = pipeline4.getBindGroupLayout(0);
+let bindGroup28 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [{binding: 346, resource: externalTexture1}, {binding: 216, resource: textureView31}],
+});
+let buffer65 = device0.createBuffer({
+  size: 4952,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture57 = device0.createTexture({size: [260], dimension: '1d', format: 'r32sint', usage: GPUTextureUsage.COPY_SRC});
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup19, new Uint32Array(5420), 720, 0);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(4, buffer41, 0, 6_431);
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'jedecP22Phosphors', transfer: 'gamma28curve'} });
+let texture58 = device0.createTexture({size: [8, 5, 1], format: 'astc-8x5-unorm', usage: GPUTextureUsage.COPY_DST, viewFormats: []});
+let textureView61 = texture47.createView({dimension: '2d', baseArrayLayer: 2});
+let buffer66 = device0.createBuffer({size: 9726, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+computePassEncoder30.setBindGroup(3, bindGroup16, new Uint32Array(109), 43, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder41); computePassEncoder41.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+let commandEncoder55 = device0.createCommandEncoder({});
+let textureView62 = texture41.createView({});
+let texture59 = device0.createTexture({
+  size: [4, 4, 17],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder8 = commandEncoder55.beginRenderPass({
+  colorAttachments: [{
+  view: textureView35,
+  clearValue: { r: 196.9, g: -45.84, b: -570.6, a: -125.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+let sampler35 = device0.createSampler({addressModeV: 'mirror-repeat', lodMinClamp: 96.80, lodMaxClamp: 99.37});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let pipeline5 = await device0.createComputePipelineAsync({layout: pipelineLayout4, compute: {module: shaderModule2, constants: {}}});
+let commandEncoder56 = device0.createCommandEncoder({});
+let textureView63 = texture25.createView({format: 'r16float'});
+let sampler36 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 53.86,
+  compare: 'less-equal',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder41); computePassEncoder41.dispatchWorkgroupsIndirect(buffer36, 980); };
+} catch {}
+try {
+commandEncoder56.copyBufferToTexture({
+  /* bytesInLastRow: 36 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 568 */
+  offset: 568,
+  bytesPerRow: 23296,
+  buffer: buffer27,
+}, {
+  texture: texture28,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u09b2\u{1fd5d}\u{1f639}\ueb1d';
+} catch {}
+let commandEncoder57 = device0.createCommandEncoder();
+let textureView64 = texture2.createView({dimension: '2d-array'});
+let renderPassEncoder9 = commandEncoder57.beginRenderPass({
+  colorAttachments: [{
+  view: textureView17,
+  depthSlice: 2,
+  clearValue: { r: 769.4, g: -160.4, b: 357.3, a: -45.50, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 185485318,
+});
+let sampler37 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 80.17,
+  lodMaxClamp: 81.73,
+});
+try {
+computePassEncoder15.setBindGroup(2, bindGroup19, new Uint32Array(258), 10, 0);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(93);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer36, 'uint16', 74, 1_382);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+commandEncoder56.copyBufferToBuffer(buffer47, 388, buffer64, 3104, 156);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise9;
+} catch {}
+try {
+sampler36.label = '\u04a5\u{1fb7e}\u0369\u02fa\ufa71\uec58\u{1ff9f}\ub1ec\u1861\u1504';
+} catch {}
+let commandEncoder58 = device0.createCommandEncoder({});
+let texture60 = device0.createTexture({
+  size: [32, 1, 594],
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture61 = device0.createTexture({
+  size: [260, 1, 19],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder47 = commandEncoder58.beginComputePass();
+try {
+computePassEncoder19.setBindGroup(2, bindGroup3, new Uint32Array(16), 0, 0);
+} catch {}
+try {
+renderPassEncoder8.setViewport(0.8853496514098852, 0.7558142414689836, 2.8120515233843664, 0.05583141676046508, 0.4983336861491027, 0.5649923813818502);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: img0,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'smpte240m', transfer: 'iec61966-2-1'} });
+let veryExplicitBindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 22,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 154,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup29 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout12,
+  entries: [
+    {binding: 83, resource: {buffer: buffer14, offset: 1024, size: 1079}},
+    {binding: 977, resource: {buffer: buffer45, offset: 0, size: 268}},
+    {binding: 46, resource: externalTexture5},
+    {binding: 162, resource: textureView15},
+    {binding: 48, resource: textureView10},
+    {binding: 119, resource: {buffer: buffer47, offset: 2048, size: 309}},
+    {binding: 41, resource: {buffer: buffer40, offset: 5376, size: 3664}},
+  ],
+});
+let textureView65 = texture48.createView({format: 'rg16uint', baseArrayLayer: 0});
+let computePassEncoder48 = commandEncoder56.beginComputePass();
+try {
+computePassEncoder17.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer29, 0, 534);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer35, 572, new BigUint64Array(5203), 1219, 740);
+} catch {}
+let commandEncoder59 = device0.createCommandEncoder({});
+let texture62 = device0.createTexture({
+  size: {width: 32, height: 1, depthOrArrayLayers: 7},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder49 = commandEncoder59.beginComputePass({});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(2, bindGroup25, new Uint32Array(2006), 125, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup25, new Uint32Array(1414), 157, 0);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(6, 0, 8, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 85},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise7;
+} catch {}
+let buffer67 = device0.createBuffer({size: 13310, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 2434});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+computePassEncoder41.end();
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup3, new Uint32Array(728), 258, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(0, buffer30, 0, 1_630);
+} catch {}
+try {
+commandEncoder48.clearBuffer(buffer32, 24);
+} catch {}
+let recycledExplicitBindGroupLayout13 = pipeline2.getBindGroupLayout(0);
+let bindGroup30 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout11,
+  entries: [
+    {binding: 41, resource: {buffer: buffer26, offset: 3584, size: 5680}},
+    {binding: 162, resource: textureView6},
+    {binding: 48, resource: textureView2},
+    {binding: 46, resource: externalTexture1},
+    {binding: 83, resource: {buffer: buffer17, offset: 11776}},
+    {binding: 119, resource: {buffer: buffer64, offset: 512}},
+    {binding: 977, resource: {buffer: buffer14, offset: 256, size: 7833}},
+  ],
+});
+let textureView66 = texture51.createView({arrayLayerCount: 4});
+let renderPassEncoder10 = commandEncoder48.beginRenderPass({colorAttachments: [{view: textureView19, depthSlice: 4, loadOp: 'clear', storeOp: 'store'}]});
+let sampler38 = device0.createSampler({addressModeW: 'repeat', mipmapFilter: 'linear', lodMaxClamp: 98.99});
+try {
+computePassEncoder48.setPipeline(pipeline2);
+} catch {}
+try {
+buffer44.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 67, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(47).fill(37), /* required buffer size: 47 */
+{offset: 47}, {width: 28, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder60 = device0.createCommandEncoder({});
+let texture63 = device0.createTexture({
+  size: [260, 1, 27],
+  mipLevelCount: 2,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture64 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder49.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(20);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer65, 'uint16', 358, 265);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer38);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let recycledExplicitBindGroupLayout14 = pipeline2.getBindGroupLayout(0);
+let textureView67 = texture29.createView({baseArrayLayer: 1, arrayLayerCount: 1});
+let renderPassEncoder11 = commandEncoder60.beginRenderPass({
+  colorAttachments: [{
+  view: textureView17,
+  depthSlice: 7,
+  clearValue: { r: -447.6, g: 282.9, b: -163.5, a: -601.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+});
+try {
+renderPassEncoder0.setIndexBuffer(buffer0, 'uint16', 6_886, 1_172);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer52, 0);
+} catch {}
+let imageData9 = new ImageData(20, 28);
+try {
+adapter0.label = '\u0cab\udcee\u06b0\ud9d1\uf3e9\u000e';
+} catch {}
+let textureView68 = texture35.createView({aspect: 'all', baseMipLevel: 0});
+try {
+{ clearResourceUsages(device0, computePassEncoder39); computePassEncoder39.dispatchWorkgroupsIndirect(buffer8, 200); };
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer46, 'uint16', 214, 1_753);
+} catch {}
+let promise11 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout0,
+  multisample: {mask: 0xc067dad},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment4',
+  targets: [{format: 'rg32uint', writeMask: GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule0,
+    constants: {},
+    buffers: [{arrayStride: 480, attributes: [{format: 'float32x2', offset: 4, shaderLocation: 13}]}],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let imageData10 = new ImageData(60, 52);
+let autogeneratedBindGroupLayout12 = pipeline3.getBindGroupLayout(0);
+let bindGroup31 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout14,
+  entries: [
+    {binding: 119, resource: {buffer: buffer34, offset: 2304, size: 402}},
+    {binding: 46, resource: externalTexture3},
+    {binding: 48, resource: textureView10},
+    {binding: 162, resource: textureView15},
+    {binding: 977, resource: {buffer: buffer41, offset: 3072, size: 4878}},
+    {binding: 41, resource: {buffer: buffer50, offset: 512, size: 152}},
+    {binding: 83, resource: {buffer: buffer40, offset: 13312, size: 700}},
+  ],
+});
+let textureView69 = texture41.createView({});
+try {
+renderPassEncoder1.end();
+} catch {}
+let pipeline6 = device0.createRenderPipeline({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment3',
+  constants: {},
+  targets: [{format: 'rg32uint', writeMask: GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule3,
+    buffers: [
+      {
+        arrayStride: 348,
+        attributes: [
+          {format: 'uint16x2', offset: 32, shaderLocation: 6},
+          {format: 'float16x2', offset: 12, shaderLocation: 14},
+          {format: 'float32x3', offset: 24, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 64, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'back'},
+});
+let commandBuffer5 = commandEncoder30.finish();
+let texture65 = device0.createTexture({
+  size: {width: 4, height: 4, depthOrArrayLayers: 17},
+  format: 'etc2-rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder39); computePassEncoder39.dispatchWorkgroupsIndirect(buffer46, 3_668); };
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup25, new Uint32Array(277), 72, 0);
+} catch {}
+try {
+renderPassEncoder9.setViewport(148.56894815748498, 0.9964172529370187, 45.852948606047036, 0.0034040277663062862, 0.23103756441580958, 0.2609383071695112);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline1);
+} catch {}
+let buffer68 = device0.createBuffer({size: 8092, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let texture66 = device0.createTexture({
+  size: [260, 1, 1],
+  mipLevelCount: 2,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView70 = texture4.createView({mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder33.setBindGroup(1, bindGroup13);
+} catch {}
+document.body.append(img1);
+await gc();
+let bindGroup32 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout5,
+  entries: [{binding: 41, resource: {buffer: buffer68, offset: 1024, size: 268}}],
+});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup31, []);
+} catch {}
+try {
+computePassEncoder38.setBindGroup(0, bindGroup29, new Uint32Array(444), 59, 0);
+} catch {}
+let recycledExplicitBindGroupLayout15 = pipeline4.getBindGroupLayout(0);
+let externalTexture6 = device0.importExternalTexture({source: videoFrame4});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder39); computePassEncoder39.dispatchWorkgroupsIndirect(buffer39, 1_848); };
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint16', 38, 4);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer17, 2_240, 2_631);
+} catch {}
+let buffer69 = device0.createBuffer({size: 2197, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let commandEncoder61 = device0.createCommandEncoder({});
+let computePassEncoder50 = commandEncoder61.beginComputePass({});
+let sampler39 = device0.createSampler({
+  label: '\u0135\u896d\ubb56\u{1ffbd}\u0fe9\u{1fefb}\u0d81\u624e\u0662',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+});
+let autogeneratedBindGroupLayout13 = pipeline3.getBindGroupLayout(0);
+let commandEncoder62 = device0.createCommandEncoder({});
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 303});
+let commandBuffer6 = commandEncoder62.finish();
+let textureView71 = texture63.createView({aspect: 'all', format: 'r32sint', mipLevelCount: 1, baseArrayLayer: 6, arrayLayerCount: 2});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup26, []);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+struct S1 {
+  @location(2) @interpolate(flat, sample) f0: vec4i,
+  @location(6) f1: vec4h,
+  @builtin(vertex_index) f2: u32,
+  @location(10) @interpolate(linear, sample) f3: vec4h,
+  @location(8) f4: vec2f,
+  @location(11) f5: f32,
+  @builtin(instance_index) f6: u32,
+  @location(3) @interpolate(flat) f7: vec4u,
+  @location(14) f8: i32,
+  @location(1) @interpolate(flat, center) f9: vec2u,
+}
+
+struct T0 {
+  f0: vec2h,
+}
+
+struct T1 {
+  @size(16) f0: T0,
+  @size(256) f1: vec2u,
+  @align(16) @size(672) f2: T0,
+}
+
+var<workgroup> vw32: array<mat2x2f, 9>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw29: array<u32, 58>;
+
+fn fn0(a0: array<T0, 26>) -> vec4<bool> {
+  var out: vec4<bool>;
+  let ptr67: ptr<storage, array<f16, 1>, read_write> = &(*&buffer70)[arrayLength(&(*&buffer70))][u32(unconst_u32(296))][1][u32(unconst_u32(76))][u32(unconst_u32(476))][u32(unconst_u32(39))];
+  out = vec4<bool>(bool((*&buffer70)[arrayLength(&(*&buffer70))][u32(unconst_u32(182))][u32(unconst_u32(23))][12][0][0][0]));
+  let ptr68: ptr<storage, array<array<f16, 1>, 1>, read_write> = &buffer70[u32(unconst_u32(6))][1][1][12][u32(buffer70[u32(unconst_u32(15))][u32(unconst_u32(309))][u32(unconst_u32(354))][12][u32(unconst_u32(118))][0][u32(unconst_u32(133))])];
+  buffer70[u32(unconst_u32(113))][u32(unconst_u32(224))][u32((*&buffer70)[u32(unconst_u32(460))][u32(unconst_u32(9))][u32(unconst_u32(35))][12][0][0][0])][u32(unconst_u32(178))][0][u32(unconst_u32(83))][u32(unconst_u32(107))] = buffer70[arrayLength(&buffer70)][1][u32(unconst_u32(630))][12][u32((*&buffer70)[arrayLength(&(*&buffer70))][u32(unconst_u32(251))][1][u32(unconst_u32(188))][u32(unconst_u32(81))][0][0])][u32(unconst_u32(125))][0];
+  buffer70[u32(unconst_u32(167))][u32(unconst_u32(103))][u32(unconst_u32(146))][u32(unconst_u32(57))][u32(unconst_u32(226))][u32(unconst_u32(121))][u32(unconst_u32(191))] += buffer70[u32(unconst_u32(214))][u32(unconst_u32(101))][1][u32((*&buffer70)[arrayLength(&(*&buffer70))][u32(unconst_u32(33))][1][12][0][0][0])][u32(unconst_u32(397))][u32(buffer70[u32(unconst_u32(30))][u32(unconst_u32(55))][u32(unconst_u32(1))][12][u32(unconst_u32(299))][0][0])][u32(unconst_u32(15))];
+  let ptr69: ptr<storage, array<array<f16, 1>, 1>, read_write> = &(*&buffer70)[u32(unconst_u32(78))][1][1][u32(unconst_u32(139))][u32(unconst_u32(257))];
+  out = vec4<bool>(bool(buffer70[arrayLength(&buffer70)][1][1][u32(unconst_u32(135))][u32(unconst_u32(248))][0][0]));
+  let ptr70: ptr<storage, f16, read_write> = &(*ptr67)[u32(unconst_u32(128))];
+  let ptr71: ptr<storage, array<f16, 1>, read_write> = &buffer70[arrayLength(&buffer70)][u32(unconst_u32(91))][1][u32(unconst_u32(19))][u32(unconst_u32(25))][0];
+  let ptr72: ptr<storage, array<f16, 1>, read_write> = &buffer70[u32(unconst_u32(316))][1][1][12][0][0];
+  let ptr73: ptr<storage, f16, read_write> = &buffer70[u32(unconst_u32(48))][u32(unconst_u32(51))][1][12][u32(unconst_u32(398))][0][0];
+  buffer70[u32(buffer70[arrayLength(&buffer70)][1][1][12][u32(unconst_u32(2))][u32(unconst_u32(202))][0])][u32(unconst_u32(127))][u32((*&buffer70)[u32(unconst_u32(99))][1][1][u32(unconst_u32(145))][0][u32(unconst_u32(91))][u32(unconst_u32(153))])][u32((*ptr67)[u32(unconst_u32(38))])][u32(unconst_u32(496))][0][u32(unconst_u32(169))] = (*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(166))][u32(unconst_u32(99))][u32(unconst_u32(168))][0][0];
+  let ptr74: ptr<storage, array<f16, 1>, read_write> = &(*ptr67);
+  return out;
+  _ = buffer70;
+}
+
+var<workgroup> vw28: array<array<T0, 1>, 6>;
+
+struct T3 {
+  @size(32) f0: array<array<array<vec4i, 1>, 1>, 1>,
+  @size(28) f1: vec2h,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw31: mat4x3h;
+
+@group(0) @binding(977) var<uniform> buffer73: VertexOutput2;
+
+@group(0) @binding(41) var<storage, read_write> buffer70: array<array<array<array<array<array<array<f16, 1>, 1>, 1>, 13>, 2>, 2>>;
+
+struct T2 {
+  @align(8) @size(8) f0: T0,
+}
+
+struct VertexOutput2 {
+  @builtin(position) f6: vec4f,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw30: atomic<u32>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct FragmentOutput4 {
+  @location(2) @interpolate(flat, centroid) f0: vec2i,
+  @location(0) @interpolate(flat, center) f1: u32,
+}
+
+@group(0) @binding(48) var st5: texture_storage_2d<bgra8unorm, read>;
+
+@vertex
+fn vertex3(a0: S1, @location(4) a1: vec2h, @location(9) @interpolate(perspective) a2: vec2f, @location(13) @interpolate(flat) a3: vec4i) -> VertexOutput2 {
+  var out: VertexOutput2;
+  let vf58: u32 = a0.f7[u32(unconst_u32(87))];
+  let ptr75: ptr<uniform, VertexOutput2> = &buffer73;
+  let vf59: vec2u = a0.f9;
+  out.f6 = textureLoad(st5, vec2i(unconst_i32(18), unconst_i32(-137)));
+  out.f6 = vec4f(f32(a0.f2));
+  let vf60: S1 = a0;
+  let vf61: vec4h = vf60.f1;
+  out.f6 *= vec4f((*&buffer73).f6[u32(unconst_u32(130))]);
+  var vf62: vec4h = atan(vec4h(unconst_f16(1135.3), unconst_f16(10624.7), unconst_f16(22100.3), unconst_f16(13278.5)));
+  vf62 = vec4h(a0.f3[u32(unconst_u32(42))]);
+  var vf63: vec2u = vf59;
+  var vf64: f32 = buffer73.f6[u32(unconst_u32(71))];
+  vf63 |= a0.f9;
+  vf64 = (*ptr75).f6.x;
+  out = VertexOutput2(vec4f(vf60.f1));
+  out = VertexOutput2(vec4f(f32(a0.f8)));
+  let vf65: f32 = buffer73.f6[u32(unconst_u32(133))];
+  let vf66: vec4i = a0.f0;
+  vf64 = fma(vec4f(unconst_f32(0.2585), unconst_f32(0.06357), unconst_f32(0.6901), unconst_f32(0.1715)), vec4f(unconst_f32(0.1112), unconst_f32(0.03435), unconst_f32(0.07826), unconst_f32(0.00067)), vec4f(unconst_f32(0.09567), unconst_f32(0.04222), unconst_f32(0.05719), unconst_f32(0.01370))).b;
+  return out;
+  _ = st5;
+  _ = buffer73;
+}
+
+@fragment
+fn fragment6() -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  out.f0 = vec2i(i32(buffer70[u32(unconst_u32(92))][1][u32(unconst_u32(306))][12][0][u32(unconst_u32(286))][0]));
+  fn0(array<T0, 26>(T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0])), T0(vec2h((*&buffer70)[u32(unconst_u32(43))][u32(unconst_u32(234))][1][12][0][u32(unconst_u32(282))][0]))));
+  return out;
+  _ = buffer70;
+}
+
+@compute @workgroup_size(2, 4, 1)
+fn compute4(@builtin(local_invocation_id) a0: vec3u) {
+  vw29[57] = u32(buffer70[arrayLength(&buffer70)][1][u32(unconst_u32(1000))][12][u32((*&buffer70)[u32(unconst_u32(0))][u32(unconst_u32(218))][1][u32(unconst_u32(264))][0][0][0])][u32(unconst_u32(5))][u32(unconst_u32(165))]);
+  fn0(array<T0, 26>(T0(), T0(vec2h(unconst_f16(3574.2), unconst_f16(7485.9))), T0(), T0(), T0(), T0(vec2h(unconst_f16(13107.8), unconst_f16(163.9))), T0(vec2h(unconst_f16(249.6), unconst_f16(5159.3))), T0(), T0(), T0(vec2h(unconst_f16(-13345.6), unconst_f16(23262.7))), T0(vec2h(unconst_f16(1716.6), unconst_f16(19910.5))), T0(vec2h(unconst_f16(204.4), unconst_f16(4549.5))), T0(), T0(), T0(), T0(), T0(), T0(vec2h(unconst_f16(93.28), unconst_f16(14394.4))), T0(), T0(vec2h(unconst_f16(4753.7), unconst_f16(30843.6))), T0(), T0(vec2h(unconst_f16(28377.8), unconst_f16(5477.1))), T0(), T0(), T0(), T0(vec2h(unconst_f16(312.3), unconst_f16(665.5)))));
+  let ptr76: ptr<storage, array<f16, 1>, read_write> = &(*&buffer70)[u32(unconst_u32(147))][u32(unconst_u32(115))][1][u32(unconst_u32(109))][0][0];
+  let ptr77: ptr<storage, array<array<array<f16, 1>, 1>, 1>, read_write> = &(*&buffer70)[u32(unconst_u32(255))][1][1][u32(unconst_u32(121))];
+  vw29[u32(unconst_u32(79))] &= u32(buffer70[arrayLength(&buffer70)][1][u32(unconst_u32(14))][u32(unconst_u32(37))][0][0][0]);
+  vw28[u32((*ptr77)[0][0][0])][u32(unconst_u32(254))] = T0(bitcast<vec2h>(arrayLength(&(*&buffer70))));
+  let ptr78: ptr<storage, f16, read_write> = &buffer70[arrayLength(&buffer70)][u32(unconst_u32(150))][1][u32(unconst_u32(182))][0][u32(unconst_u32(326))][u32(unconst_u32(33))];
+  let vf67: array<u32, 58> = workgroupUniformLoad(&vw29);
+  var vf68 = fn0(array<T0, 26>(T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0), T0((*&vw28)[u32(unconst_u32(33))][u32((*&vw31)[u32(unconst_u32(148))][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(178))][1][u32(unconst_u32(435))][u32(unconst_u32(195))][u32(unconst_u32(59))][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(398))][u32(unconst_u32(147))][u32(unconst_u32(67))][0][u32(unconst_u32(12))])])])].f0)));
+  vw32[8] += mat2x2f(f32((*&buffer70)[u32(unconst_u32(168))][u32(unconst_u32(164))][u32(unconst_u32(83))][12][u32(unconst_u32(100))][u32(unconst_u32(70))][0]), f32((*&buffer70)[u32(unconst_u32(168))][u32(unconst_u32(164))][u32(unconst_u32(83))][12][u32(unconst_u32(100))][u32(unconst_u32(70))][0]), f32((*&buffer70)[u32(unconst_u32(168))][u32(unconst_u32(164))][u32(unconst_u32(83))][12][u32(unconst_u32(100))][u32(unconst_u32(70))][0]), f32((*&buffer70)[u32(unconst_u32(168))][u32(unconst_u32(164))][u32(unconst_u32(83))][12][u32(unconst_u32(100))][u32(unconst_u32(70))][0]));
+  let ptr79: ptr<storage, array<array<array<f16, 1>, 1>, 1>, read_write> = &(*&buffer70)[u32(unconst_u32(96))][u32(unconst_u32(216))][1][12];
+  fn0(array<T0, 26>(T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0), T0((*&vw28)[5][0].f0)));
+  fn0(array<T0, 26>(T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0])), T0(vec2h(buffer70[u32(unconst_u32(189))][u32(unconst_u32(283))][u32(unconst_u32(60))][u32(unconst_u32(107))][u32(unconst_u32(146))][u32(unconst_u32(59))][0]))));
+  var vf69 = fn0(array<T0, 26>(T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0])), T0(vec2h(buffer70[u32(unconst_u32(599))][u32(unconst_u32(472))][1][12][0][0][0]))));
+  let ptr80: ptr<storage, array<f16, 1>, read_write> = &buffer70[u32(unconst_u32(184))][u32(unconst_u32(544))][1][u32(unconst_u32(1))][u32(unconst_u32(16))][u32((*&buffer70)[u32(unconst_u32(97))][u32(unconst_u32(35))][1][u32(unconst_u32(103))][0][0][0])];
+  let ptr81: ptr<storage, array<array<array<f16, 1>, 1>, 1>, read_write> = &(*&buffer70)[arrayLength(&(*&buffer70))][u32(unconst_u32(2))][1][u32(unconst_u32(230))];
+  fn0(array<T0, 26>(T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0), T0((*&vw28)[u32(unconst_u32(14))][0].f0)));
+  let ptr82: ptr<storage, f16, read_write> = &(*&buffer70)[arrayLength(&(*&buffer70))][u32(unconst_u32(90))][u32(unconst_u32(6))][bitcast<u32>((*&vw28)[5][0].f0)][u32(unconst_u32(308))][0][u32(unconst_u32(27))];
+  let ptr83: ptr<storage, array<f16, 1>, read_write> = &(*&buffer70)[arrayLength(&(*&buffer70))][1][u32((*&buffer70)[arrayLength(&(*&buffer70))][1][u32(unconst_u32(157))][u32(unconst_u32(127))][0][u32(buffer70[arrayLength(&buffer70)][u32(unconst_u32(63))][1][u32(unconst_u32(303))][0][u32(unconst_u32(741))][0])][u32(unconst_u32(88))])][u32(unconst_u32(214))][u32(unconst_u32(104))][u32(unconst_u32(26))];
+  _ = buffer70;
+}`,
+});
+let bindGroup33 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 119, resource: {buffer: buffer41, offset: 1280, size: 2449}},
+    {binding: 41, resource: {buffer: buffer27, offset: 2816, size: 860}},
+    {binding: 48, resource: textureView10},
+    {binding: 977, resource: {buffer: buffer41, offset: 7680, size: 353}},
+    {binding: 83, resource: {buffer: buffer64, offset: 256}},
+    {binding: 46, resource: externalTexture4},
+    {binding: 162, resource: textureView6},
+  ],
+});
+let commandEncoder63 = device0.createCommandEncoder({});
+let texture67 = device0.createTexture({
+  size: [65, 1, 1],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView72 = texture66.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder51 = commandEncoder63.beginComputePass({});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthStencilFormat: 'stencil8', stencilReadOnly: false});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer48, 'uint32', 1_212, 786);
+} catch {}
+try {
+renderBundleEncoder0.setIndexBuffer(buffer38, 'uint16', 1_526, 398);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise10;
+} catch {}
+document.body.append(img0);
+let buffer74 = device0.createBuffer({
+  size: 910,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder64 = device0.createCommandEncoder({});
+let texture68 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 336},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderPassEncoder12 = commandEncoder64.beginRenderPass({
+  colorAttachments: [{
+  view: textureView35,
+  clearValue: { r: 495.2, g: -158.6, b: 302.3, a: 29.24, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder46.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+computePassEncoder17.setBindGroup(3, bindGroup29, new Uint32Array(3264), 590, 0);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer52, 'uint16', 2_230, 894);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(0, buffer17, 16_780);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(1, bindGroup24, new Uint32Array(707), 15, 0);
+} catch {}
+try {
+renderBundleEncoder0.setIndexBuffer(buffer30, 'uint32', 1_356, 915);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(5, buffer52, 2_076, 225);
+} catch {}
+try {
+renderBundleEncoder0.insertDebugMarker('\u{1f7b6}');
+} catch {}
+let recycledExplicitBindGroupLayout16 = pipeline5.getBindGroupLayout(0);
+let textureView73 = texture65.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 6});
+let textureView74 = texture53.createView({baseArrayLayer: 4, arrayLayerCount: 1});
+let sampler40 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 98.24});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup31, new Uint32Array(2555), 575, 0);
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(0, undefined);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(6, buffer8, 584, 6_728);
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let imageData11 = new ImageData(4, 28);
+let texture69 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 117},
+  format: 'depth24plus',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer29);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(5, buffer35, 304, 8_005);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer51, 2248, new Int16Array(131), 16, 0);
+} catch {}
+let recycledExplicitBindGroupLayout17 = pipeline5.getBindGroupLayout(0);
+let buffer75 = device0.createBuffer({
+  size: 18415,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let textureView75 = texture69.createView({dimension: '2d', baseArrayLayer: 25});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['rg32uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+computePassEncoder44.setBindGroup(0, bindGroup6, new Uint32Array(2547), 185, 0);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(1, bindGroup29);
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+let pipeline7 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule3, constants: {49_136: 0}}});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+await gc();
+let commandEncoder65 = device0.createCommandEncoder();
+let textureView76 = texture38.createView({dimension: 'cube', baseArrayLayer: 1});
+let computePassEncoder52 = commandEncoder65.beginComputePass();
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer44, 'uint32', 4_928, 6_351);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer3, 0, 6);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(0, bindGroup32);
+} catch {}
+let buffer76 = device0.createBuffer({
+  size: 3175,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder66 = device0.createCommandEncoder({label: '\u{1fbd6}\u835f\uf241\u{1fe72}'});
+let texture70 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 16},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView77 = texture22.createView({});
+let renderBundle0 = renderBundleEncoder1.finish({});
+try {
+computePassEncoder52.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, undefined, 0, 240_593_499);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(1, bindGroup6, []);
+} catch {}
+try {
+  await promise12;
+} catch {}
+let autogeneratedBindGroupLayout14 = pipeline3.getBindGroupLayout(0);
+let bindGroup34 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout11,
+  entries: [{binding: 73, resource: {buffer: buffer51, offset: 512, size: 6220}}],
+});
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 690});
+let computePassEncoder53 = commandEncoder66.beginComputePass({});
+let sampler41 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', mipmapFilter: 'nearest', lodMaxClamp: 58.08});
+try {
+computePassEncoder45.setBindGroup(2, bindGroup5, new Uint32Array(2694), 70, 0);
+} catch {}
+try {
+computePassEncoder39.end();
+} catch {}
+try {
+computePassEncoder53.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(74, 0, 15, 0);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(2, undefined, 407_198_888, 1_292_778_677);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(buffer63, 2544, buffer49, 2112, 6068);
+} catch {}
+let bindGroup35 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout7,
+  entries: [{binding: 41, resource: {buffer: buffer62, offset: 1280, size: 1556}}],
+});
+let commandEncoder67 = device0.createCommandEncoder();
+let sampler42 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 81.49,
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder0.beginOcclusionQuery(148);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: imageData10,
+  origin: { x: 14, y: 3 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 17},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout18 = pipeline2.getBindGroupLayout(0);
+let buffer77 = device0.createBuffer({
+  size: 16825,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 1283});
+let sampler43 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 73.36});
+try {
+{ clearResourceUsages(device0, computePassEncoder36); computePassEncoder36.dispatchWorkgroupsIndirect(buffer41, 1_012); };
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder0.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(5, buffer26, 1_756);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup36 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 83, resource: {buffer: buffer77, offset: 768, size: 416}},
+    {binding: 977, resource: {buffer: buffer15, offset: 3840, size: 3993}},
+    {binding: 48, resource: textureView13},
+    {binding: 41, resource: {buffer: buffer39, offset: 3072}},
+    {binding: 119, resource: {buffer: buffer47, offset: 15616, size: 4450}},
+    {binding: 46, resource: externalTexture3},
+    {binding: 162, resource: textureView15},
+  ],
+});
+let commandBuffer7 = commandEncoder67.finish({});
+let texture71 = device0.createTexture({
+  size: [130, 1, 1],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture72 = device0.createTexture({size: [260, 1, 1], mipLevelCount: 1, format: 'r32uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder54 = commandEncoder45.beginComputePass({});
+try {
+renderPassEncoder2.setIndexBuffer(buffer36, 'uint16', 382, 426);
+} catch {}
+try {
+renderBundleEncoder0.setPipeline(pipeline1);
+} catch {}
+try {
+buffer37.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+let autogeneratedBindGroupLayout15 = pipeline0.getBindGroupLayout(0);
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout2]});
+let buffer78 = device0.createBuffer({size: 1942, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture73 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 110},
+  mipLevelCount: 4,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder26.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup20, new Uint32Array(612), 82, 0);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(1, bindGroup28);
+} catch {}
+let bindGroup37 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout16,
+  entries: [
+    {binding: 119, resource: {buffer: buffer0, offset: 768, size: 419}},
+    {binding: 162, resource: textureView15},
+    {binding: 41, resource: {buffer: buffer26, offset: 3840, size: 18060}},
+    {binding: 977, resource: {buffer: buffer26, offset: 0, size: 2500}},
+    {binding: 48, resource: textureView13},
+    {binding: 46, resource: externalTexture2},
+    {binding: 83, resource: {buffer: buffer26, offset: 768, size: 1756}},
+  ],
+});
+let commandEncoder68 = device0.createCommandEncoder();
+let texture74 = device0.createTexture({
+  size: {width: 260},
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder55 = commandEncoder68.beginComputePass({});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup23, new Uint32Array(4655), 1_102, 0);
+} catch {}
+try {
+computePassEncoder36.end();
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer48, 'uint32', 728, 1_081);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(6, buffer74);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(2, bindGroup35, []);
+} catch {}
+try {
+commandEncoder42.copyBufferToTexture({
+  /* bytesInLastRow: 104 widthInBlocks: 26 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 844 */
+  offset: 844,
+  bytesPerRow: 18432,
+  buffer: buffer43,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 26, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandBuffer8 = commandEncoder42.finish({});
+let textureView78 = texture62.createView({format: 'r32sint', arrayLayerCount: 2});
+try {
+computePassEncoder2.setBindGroup(2, bindGroup34);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup23, new Uint32Array(1247), 98, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint32', 284, 870);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer34, 0, 7_961);
+} catch {}
+try {
+computePassEncoder45.pushDebugGroup('\u{1ff1b}');
+} catch {}
+try {
+computePassEncoder45.popDebugGroup();
+} catch {}
+try {
+renderPassEncoder12.insertDebugMarker('\u{1fa84}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 2},
+  aspect: 'all',
+}, new Uint8Array(23_077).fill(170), /* required buffer size: 23_077 */
+{offset: 499, bytesPerRow: 142, rowsPerImage: 53}, {width: 0, height: 0, depthOrArrayLayers: 4});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let recycledExplicitBindGroupLayout19 = pipeline5.getBindGroupLayout(0);
+let commandEncoder69 = device0.createCommandEncoder({});
+let textureView79 = texture58.createView({dimension: '2d-array', baseMipLevel: 0});
+try {
+renderPassEncoder5.setVertexBuffer(3, buffer8, 620, 2_707);
+} catch {}
+try {
+renderBundleEncoder0.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder69.copyBufferToBuffer(buffer77, 10348, buffer18, 40, 1372);
+} catch {}
+try {
+commandEncoder69.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 32 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 640 */
+  offset: 608,
+  bytesPerRow: 16384,
+  buffer: buffer76,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, {width: 32, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let imageBitmap0 = await createImageBitmap(imageData1);
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'bt709', transfer: 'bt2020_12bit'} });
+let texture75 = device0.createTexture({
+  size: {width: 32, height: 1, depthOrArrayLayers: 85},
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler44 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 90.23});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup25, []);
+} catch {}
+try {
+computePassEncoder35.setBindGroup(1, bindGroup26, new Uint32Array(1985), 74, 0);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+document.body.append(img0);
+let veryExplicitBindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [{binding: 104, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let bindGroup38 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout11,
+  entries: [{binding: 41, resource: {buffer: buffer51, offset: 5376, size: 808}}],
+});
+let commandEncoder70 = device0.createCommandEncoder({});
+let texture76 = device0.createTexture({
+  size: [65, 1, 18],
+  mipLevelCount: 2,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView80 = texture61.createView({mipLevelCount: 1});
+let computePassEncoder56 = commandEncoder69.beginComputePass();
+let sampler45 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup3, new Uint32Array(1678), 295, 0);
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup24, new Uint32Array(3833), 351, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer48, 'uint32', 636, 402);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(4, buffer26);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(2, buffer38, 1_308, 793);
+} catch {}
+try {
+commandEncoder70.copyBufferToBuffer(buffer78, 212, buffer14, 8604, 140);
+} catch {}
+let recycledExplicitBindGroupLayout20 = pipeline2.getBindGroupLayout(0);
+let bindGroup39 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout16,
+  entries: [
+    {binding: 48, resource: textureView10},
+    {binding: 83, resource: {buffer: buffer45, offset: 1024, size: 88}},
+    {binding: 977, resource: {buffer: buffer14, offset: 2048, size: 2796}},
+    {binding: 119, resource: {buffer: buffer41, offset: 1792, size: 2736}},
+    {binding: 46, resource: externalTexture6},
+    {binding: 162, resource: textureView0},
+    {binding: 41, resource: {buffer: buffer40, offset: 4608, size: 1292}},
+  ],
+});
+let commandEncoder71 = device0.createCommandEncoder({});
+let texture77 = device0.createTexture({
+  size: {width: 4, height: 4, depthOrArrayLayers: 98},
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView81 = texture59.createView({dimension: 'cube-array', baseArrayLayer: 4, arrayLayerCount: 6});
+let sampler46 = device0.createSampler({addressModeU: 'repeat', lodMaxClamp: 79.32, compare: 'equal'});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup32, new Uint32Array(3812), 664, 0);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(2, buffer39);
+} catch {}
+try {
+renderBundleEncoder0.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(2, buffer29);
+} catch {}
+try {
+commandEncoder71.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 4400 */
+  offset: 4400,
+  bytesPerRow: 17664,
+  buffer: buffer41,
+}, {
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 4, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout21 = pipeline1.getBindGroupLayout(0);
+let buffer79 = device0.createBuffer({size: 1726, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let texture78 = device0.createTexture({
+  size: [32, 1, 24],
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2, buffer38, 1_912, 86);
+} catch {}
+try {
+renderBundleEncoder0.setIndexBuffer(buffer36, 'uint16', 636, 661);
+} catch {}
+try {
+commandEncoder70.copyBufferToBuffer(buffer23, 956, buffer44, 17268, 92);
+} catch {}
+let imageBitmap1 = await createImageBitmap(videoFrame0);
+let videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'bt2020', transfer: 'bt1361ExtendedColourGamut'} });
+let veryExplicitBindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 304,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup40 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout6,
+  entries: [{binding: 41, resource: {buffer: buffer68, offset: 0}}],
+});
+let computePassEncoder57 = commandEncoder71.beginComputePass({});
+let sampler47 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 54.73,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder45.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle0, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -51.45, g: -784.2, b: -888.4, a: 649.2, });
+} catch {}
+try {
+renderBundleEncoder0.setIndexBuffer(buffer44, 'uint32', 8_224, 2_665);
+} catch {}
+let autogeneratedBindGroupLayout16 = pipeline0.getBindGroupLayout(0);
+let commandEncoder72 = device0.createCommandEncoder({});
+let computePassEncoder58 = commandEncoder72.beginComputePass({});
+try {
+computePassEncoder58.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(0, bindGroup29, new Uint32Array(371), 36, 0);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(4, buffer8, 0);
+} catch {}
+try {
+commandEncoder70.copyBufferToTexture({
+  /* bytesInLastRow: 152 widthInBlocks: 38 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 24 */
+  offset: 24,
+  buffer: buffer32,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 38, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder70.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5024 */
+  offset: 5024,
+  buffer: buffer44,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData12 = new ImageData(16, 36);
+let recycledExplicitBindGroupLayout22 = pipeline2.getBindGroupLayout(0);
+let buffer80 = device0.createBuffer({
+  size: 1598,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture79 = gpuCanvasContext0.getCurrentTexture();
+let renderPassEncoder13 = commandEncoder70.beginRenderPass({colorAttachments: [{view: textureView17, depthSlice: 6, loadOp: 'clear', storeOp: 'discard'}]});
+let renderBundle1 = renderBundleEncoder0.finish({});
+try {
+computePassEncoder45.setBindGroup(3, bindGroup34, []);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer26, 0, 3_270);
+} catch {}
+try {
+renderPassEncoder5.insertDebugMarker('\u27b8');
+} catch {}
+document.body.prepend(img0);
+let bindGroup41 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout14,
+  entries: [
+    {binding: 41, resource: {buffer: buffer39, offset: 2048}},
+    {binding: 46, resource: externalTexture5},
+    {binding: 119, resource: {buffer: buffer32, offset: 0}},
+    {binding: 977, resource: {buffer: buffer45, offset: 0, size: 145}},
+    {binding: 83, resource: {buffer: buffer0, offset: 512, size: 203}},
+    {binding: 162, resource: textureView15},
+    {binding: 48, resource: textureView13},
+  ],
+});
+let pipelineLayout8 = device0.createPipelineLayout({
+  bindGroupLayouts: [autogeneratedBindGroupLayout6, autogeneratedBindGroupLayout4, veryExplicitBindGroupLayout6],
+});
+let commandEncoder73 = device0.createCommandEncoder({});
+try {
+computePassEncoder55.setBindGroup(3, bindGroup3, new Uint32Array(314), 126, 0);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 732, new Int16Array(2776), 370, 212);
+} catch {}
+document.body.append(canvas0);
+try {
+globalThis.someLabel = externalTexture6.label;
+} catch {}
+let recycledExplicitBindGroupLayout23 = pipeline6.getBindGroupLayout(0);
+let commandEncoder74 = device0.createCommandEncoder();
+let texture80 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 124},
+  sampleCount: 1,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder59 = commandEncoder73.beginComputePass({});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthStencilFormat: 'stencil8'});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup20, new Uint32Array(2416), 319, 0);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup31, new Uint32Array(3133), 1_460, 0);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(5, buffer29, 856, 3_730);
+} catch {}
+try {
+commandEncoder74.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 244 */
+  offset: 244,
+  bytesPerRow: 17408,
+  buffer: buffer35,
+}, {
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline8 = device0.createRenderPipeline({
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment1',
+  targets: [{format: 'rg32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule3,
+    buffers: [
+      {
+        arrayStride: 52,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 0, shaderLocation: 0},
+          {format: 'uint8x4', offset: 0, shaderLocation: 6},
+          {format: 'snorm16x2', offset: 4, shaderLocation: 15},
+          {format: 'float32x3', offset: 4, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+document.body.append(img0);
+let imageBitmap2 = await createImageBitmap(videoFrame7);
+let imageData13 = new ImageData(144, 12);
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup34);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer1, 'uint32', 572, 359);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer49, 26448, new DataView(new ArrayBuffer(12447)), 3858, 520);
+} catch {}
+let imageBitmap3 = await createImageBitmap(offscreenCanvas0);
+let bindGroup42 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout6,
+  entries: [
+    {binding: 46, resource: externalTexture6},
+    {binding: 977, resource: {buffer: buffer68, offset: 768}},
+    {binding: 119, resource: {buffer: buffer30, offset: 0, size: 249}},
+    {binding: 48, resource: textureView10},
+    {binding: 83, resource: {buffer: buffer38, offset: 256}},
+    {binding: 41, resource: {buffer: buffer39, offset: 5888}},
+    {binding: 162, resource: textureView72},
+  ],
+});
+let texture81 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 1},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32uint'],
+});
+try {
+computePassEncoder53.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(0, bindGroup7, new Uint32Array(186), 10, 0);
+} catch {}
+try {
+renderBundleEncoder2.setPipeline(pipeline1);
+} catch {}
+let recycledExplicitBindGroupLayout24 = pipeline8.getBindGroupLayout(0);
+let buffer81 = device0.createBuffer({
+  size: 6340,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthStencilFormat: 'stencil8', depthReadOnly: true});
+let sampler48 = device0.createSampler({
+  label: '\u95ee\u06c2\uf4b8\u00f5\u{1fe1a}\u{1ff6e}\u{1f871}\u0ee3',
+  magFilter: 'linear',
+  minFilter: 'linear',
+});
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup34, new Uint32Array(1640), 167, 0);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(7, buffer74);
+} catch {}
+try {
+commandEncoder74.resolveQuerySet(querySet10, 13, 15, buffer29, 256);
+} catch {}
+try {
+device0.queue.submit([commandBuffer7, commandBuffer8]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: imageData0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout25 = pipeline4.getBindGroupLayout(0);
+let bindGroup43 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 41, resource: {buffer: buffer62, offset: 2816, size: 5336}}],
+});
+let commandEncoder75 = device0.createCommandEncoder({});
+try {
+renderPassEncoder12.executeBundles([renderBundle0, renderBundle0, renderBundle0, renderBundle0]);
+} catch {}
+try {
+commandEncoder74.copyTextureToTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 91, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 43, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout9 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout8]});
+let commandEncoder76 = device0.createCommandEncoder({});
+let texture82 = device0.createTexture({
+  size: [130, 1, 1],
+  mipLevelCount: 3,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup32, new Uint32Array(2471), 239, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(1076);
+} catch {}
+try {
+renderPassEncoder8.draw(0, 41, 2, 1_303_105_808);
+} catch {}
+try {
+renderBundleEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder74.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder77 = device0.createCommandEncoder({});
+let textureView82 = texture41.createView({});
+let computePassEncoder60 = commandEncoder75.beginComputePass();
+let renderPassEncoder14 = commandEncoder77.beginRenderPass({
+  colorAttachments: [{
+  view: textureView35,
+  clearValue: { r: 812.0, g: 763.3, b: 301.8, a: 854.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 101062376,
+});
+let renderBundle2 = renderBundleEncoder3.finish();
+let sampler49 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', lodMaxClamp: 88.40});
+try {
+computePassEncoder43.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup40);
+} catch {}
+try {
+renderPassEncoder8.draw(0, 378, 0, 74_699_299);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer18, 144);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer31, 'uint32', 1_504, 883);
+} catch {}
+try {
+commandEncoder76.copyBufferToTexture({
+  /* bytesInLastRow: 132 widthInBlocks: 33 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2004 */
+  offset: 2004,
+  buffer: buffer35,
+}, {
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: imageData10,
+  origin: { x: 13, y: 15 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder78 = device0.createCommandEncoder({});
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 841});
+let renderPassEncoder15 = commandEncoder76.beginRenderPass({
+  colorAttachments: [{
+  view: textureView16,
+  depthSlice: 7,
+  clearValue: { r: -639.8, g: 353.3, b: -734.5, a: -780.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet4,
+});
+let renderBundle3 = renderBundleEncoder2.finish({});
+let sampler50 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 63.57,
+});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup39, new Uint32Array(2521), 89, 0);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.draw(0, 23, 0, 39_484_134);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer77, 7_036);
+} catch {}
+try {
+buffer45.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let recycledExplicitBindGroupLayout26 = pipeline7.getBindGroupLayout(0);
+let texture83 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 62},
+  mipLevelCount: 2,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView83 = texture65.createView({baseMipLevel: 0, arrayLayerCount: 1});
+let computePassEncoder61 = commandEncoder74.beginComputePass();
+try {
+computePassEncoder33.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup13, new Uint32Array(2722), 156, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer24, 'uint16', 1_082, 9_608);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer52);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder78.copyBufferToTexture({
+  /* bytesInLastRow: 260 widthInBlocks: 260 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 900 */
+  offset: 900,
+  bytesPerRow: 16640,
+  buffer: buffer76,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 260, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'all',
+}, new Uint8Array(19_552).fill(121), /* required buffer size: 19_552 */
+{offset: 112, bytesPerRow: 36, rowsPerImage: 54}, {width: 1, height: 0, depthOrArrayLayers: 11});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: imageData6,
+  origin: { x: 2, y: 1 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas1);
+await gc();
+let veryExplicitBindGroupLayout15 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 73,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup44 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout4,
+  entries: [{binding: 41, resource: {buffer: buffer45, offset: 1024, size: 180}}],
+});
+let textureView84 = texture65.createView({dimension: 'cube-array', baseArrayLayer: 2, arrayLayerCount: 6});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup16, new Uint32Array(383), 5, 0);
+} catch {}
+try {
+renderPassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer42, 'uint16', 11_242, 773);
+} catch {}
+try {
+commandEncoder55.copyBufferToBuffer(buffer2, 676, buffer42, 1236, 412);
+} catch {}
+let commandBuffer9 = commandEncoder55.finish();
+let textureView85 = texture77.createView({dimension: '3d', format: 'rg32uint'});
+let computePassEncoder62 = commandEncoder78.beginComputePass();
+let sampler51 = device0.createSampler({magFilter: 'linear', lodMaxClamp: 86.94});
+try {
+computePassEncoder62.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+buffer79.unmap();
+} catch {}
+let textureView86 = texture50.createView({dimension: 'cube-array', baseArrayLayer: 1, arrayLayerCount: 6});
+let textureView87 = texture82.createView({aspect: 'stencil-only', mipLevelCount: 1});
+let sampler52 = device0.createSampler({addressModeU: 'mirror-repeat', minFilter: 'nearest', lodMaxClamp: 94.31});
+try {
+computePassEncoder57.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(4, 0, 16, 0);
+} catch {}
+try {
+renderPassEncoder12.insertDebugMarker('\u07bc');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let videoFrame9 = videoFrame5.clone();
+let textureView88 = texture33.createView({});
+let sampler53 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.44,
+  lodMaxClamp: 71.38,
+});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(1, bindGroup5, new Uint32Array(2002), 283, 0);
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(74, 0, 25, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(242).fill(130), /* required buffer size: 242 */
+{offset: 238, rowsPerImage: 72}, {width: 4, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let texture84 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView89 = texture6.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder22.setBindGroup(3, bindGroup40, []);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer8, 'uint16', 2_106, 504);
+} catch {}
+let bindGroup45 = device0.createBindGroup({layout: veryExplicitBindGroupLayout13, entries: [{binding: 104, resource: externalTexture0}]});
+let commandEncoder79 = device0.createCommandEncoder({});
+let texture85 = device0.createTexture({
+  size: [130, 1, 1],
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder10.setVertexBuffer(0, buffer38);
+} catch {}
+try {
+device0.queue.submit([commandBuffer9]);
+} catch {}
+let computePassEncoder63 = commandEncoder79.beginComputePass();
+let sampler54 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 77.79,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder47.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+computePassEncoder49.setBindGroup(1, bindGroup38, new Uint32Array(1233), 16, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder47); computePassEncoder47.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder35); computePassEncoder35.dispatchWorkgroupsIndirect(buffer24, 15_156); };
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(48).fill(128), /* required buffer size: 48 */
+{offset: 48}, {width: 130, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder8.setBindGroup(2, bindGroup44, new Uint32Array(4449), 1_390, 0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup16, new Uint32Array(1705), 55, 0);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer30, 0);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup46 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout6,
+  entries: [
+    {binding: 162, resource: textureView41},
+    {binding: 46, resource: externalTexture6},
+    {binding: 48, resource: textureView10},
+    {binding: 977, resource: {buffer: buffer47, offset: 13824, size: 1911}},
+    {binding: 83, resource: {buffer: buffer40, offset: 1280, size: 3767}},
+    {binding: 41, resource: {buffer: buffer65, offset: 0}},
+    {binding: 119, resource: {buffer: buffer51, offset: 2560, size: 1230}},
+  ],
+});
+let buffer82 = device0.createBuffer({
+  size: 3864,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder80 = device0.createCommandEncoder({});
+let renderPassEncoder16 = commandEncoder80.beginRenderPass({
+  colorAttachments: [{view: textureView21, loadOp: 'load', storeOp: 'discard'}],
+  depthStencilAttachment: {
+    view: textureView40,
+    depthClearValue: 1.33953519617544,
+    stencilClearValue: 10190,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'store',
+  },
+  maxDrawCount: 164935865,
+});
+try {
+computePassEncoder46.setBindGroup(2, bindGroup3, []);
+} catch {}
+try {
+computePassEncoder21.setBindGroup(0, bindGroup46, new Uint32Array(1651), 433, 0);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline1);
+} catch {}
+let pipeline9 = device0.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule3, constants: {49_136: 0}}});
+let bindGroup47 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout25,
+  entries: [
+    {binding: 48, resource: textureView13},
+    {binding: 46, resource: externalTexture0},
+    {binding: 83, resource: {buffer: buffer26, offset: 3840, size: 3155}},
+    {binding: 41, resource: {buffer: buffer81, offset: 0, size: 940}},
+    {binding: 119, resource: {buffer: buffer64, offset: 3328}},
+    {binding: 977, resource: {buffer: buffer31, offset: 1536}},
+    {binding: 162, resource: textureView72},
+  ],
+});
+let buffer83 = device0.createBuffer({
+  size: 2011,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder81 = device0.createCommandEncoder({});
+let texture86 = device0.createTexture({
+  size: {width: 65},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView90 = texture73.createView({dimension: '2d', aspect: 'all', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 37});
+let renderPassEncoder17 = commandEncoder81.beginRenderPass({
+  colorAttachments: [{
+  view: textureView35,
+  clearValue: { r: 176.9, g: -890.9, b: 896.3, a: 47.40, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder47); computePassEncoder47.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer75, 'uint16', 1_996, 511);
+} catch {}
+let commandEncoder82 = device0.createCommandEncoder({});
+let texture87 = device0.createTexture({
+  size: [4, 4, 17],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView91 = texture27.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 6});
+let renderPassEncoder18 = commandEncoder82.beginRenderPass({
+  colorAttachments: [{
+  view: textureView19,
+  depthSlice: 9,
+  clearValue: { r: 147.3, g: 114.8, b: -774.2, a: -954.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup40);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder35); computePassEncoder35.dispatchWorkgroupsIndirect(buffer46, 872); };
+} catch {}
+let commandEncoder83 = device0.createCommandEncoder({});
+let texture88 = device0.createTexture({
+  size: {width: 32, height: 1, depthOrArrayLayers: 9},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder64 = commandEncoder83.beginComputePass();
+let sampler55 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 96.16,
+});
+try {
+computePassEncoder47.end();
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup20, new Uint32Array(822), 273, 0);
+} catch {}
+try {
+renderPassEncoder18.setBlendConstant({ r: -913.5, g: -216.0, b: -191.6, a: 233.4, });
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(0, buffer3, 0);
+} catch {}
+try {
+commandEncoder58.resolveQuerySet(querySet2, 13, 7, buffer80, 256);
+} catch {}
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'bt470m', transfer: 'log'} });
+let veryExplicitBindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 49,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 95,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 101,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 258,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 315,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder84 = device0.createCommandEncoder({});
+let texture89 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView92 = texture53.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 10, arrayLayerCount: 1});
+let renderPassEncoder19 = commandEncoder58.beginRenderPass({
+  colorAttachments: [{
+  view: textureView57,
+  clearValue: { r: -689.4, g: -919.6, b: -661.3, a: -915.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView46, depthReadOnly: false, stencilLoadOp: 'load', stencilStoreOp: 'store'},
+  occlusionQuerySet: querySet11,
+  maxDrawCount: 138074735,
+});
+try {
+computePassEncoder42.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+computePassEncoder35.end();
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer30, 'uint32', 1_312, 652);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(5, buffer29, 0);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let imageData14 = new ImageData(48, 72);
+let commandBuffer10 = commandEncoder41.finish();
+let computePassEncoder65 = commandEncoder84.beginComputePass({});
+try {
+computePassEncoder65.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer38, 'uint16', 128, 985);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+document.body.append(img0);
+let shaderModule6 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+var<workgroup> vw33: atomic<u32>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct VertexOutput3 {
+  @builtin(position) f7: vec4f,
+  @location(15) f8: i32,
+  @location(2) f9: vec4h,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw35: FragmentOutput5;
+
+struct FragmentOutput5 {
+  @location(6) @interpolate(flat) f0: u32,
+  @location(7) f1: vec4u,
+  @location(5) @interpolate(perspective) f2: vec4f,
+  @location(0) @interpolate(flat) f3: vec4u,
+}
+
+@group(0) @binding(31) var tex6: texture_3d<f32>;
+
+var<workgroup> vw34: array<f16, 1>;
+
+fn fn0() -> VertexOutput3 {
+  var out: VertexOutput3;
+  let ptr84: ptr<private, mat3x2f> = &vp8;
+  var vf70: f32 = (*ptr84)[u32(unconst_u32(329))][u32(unconst_u32(38))];
+  out.f8 *= bitcast<vec2i>(vp8[unconst_i32(1)]).x;
+  let vf71: vec2f = (*ptr84)[u32(unconst_u32(120))];
+  let vf72: f32 = length(vec4f(unconst_f32(0.04913), unconst_f32(0.6309), unconst_f32(0.02155), unconst_f32(0.2926)));
+  let ptr85: ptr<private, mat3x2f> = &vp8;
+  var vf73: vec2f = vp8[u32(vf70)];
+  out.f9 -= vec4h(f16((*ptr85)[u32(unconst_u32(553))][u32(unconst_u32(122))]));
+  return out;
+}
+
+struct T0 {
+  @align(64) @size(64) f0: array<atomic<u32>>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<private> vp8: mat3x2f = mat3x2f(0.4490, -0.04327, 0.1575, 0.01037, 0.02968, 0.08791);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@vertex
+fn vertex4(@location(15) a0: u32, @location(13) a1: vec4u, @location(9) @interpolate(flat, center) a2: vec2u, @location(3) @interpolate(linear) a3: vec2f, @location(10) a4: vec2f, @location(12) a5: vec2h) -> VertexOutput3 {
+  var out: VertexOutput3;
+  out = VertexOutput3(vec4f(transpose(mat4x3h())[unconst_i32(1)]), vec4i(transpose(mat4x3h())[unconst_i32(1)])[2], transpose(mat4x3h())[unconst_i32(2)]);
+  let vf74: vec2u = countLeadingZeros(textureDimensions(tex6, i32(unconst_i32(140))).xx);
+  out.f7 *= unpack4x8unorm(a0);
+  let vf75: vec2u = vf74;
+  out.f9 = bitcast<vec4h>(a2);
+  let vf76: vec2f = vp8[u32(unconst_u32(3))];
+  out.f7 = vec4f(firstLeadingBit(vec2i(unconst_i32(397), unconst_i32(199))).yyyx);
+  let vf77: f16 = saturate(f16(unconst_f16(15691.5)));
+  out.f8 &= i32(a5[u32(unconst_u32(182))]);
+  out.f8 += bitcast<vec2i>(a2).x;
+  var vf78: vec2f = unpack2x16float(u32(unconst_u32(28)));
+  out.f9 = vec4h(f16(a1[u32(unconst_u32(1))]));
+  var vf79: vec2u = countLeadingZeros(vec2u(unconst_u32(53), unconst_u32(234)));
+  vf79 = vec2u(bitcast<u32>(a3[u32(unconst_u32(94))]));
+  let vf80: vec3u = textureDimensions(tex6, i32(unconst_i32(381)));
+  out.f7 = vec4f(a4[u32(unconst_u32(175))]);
+  out.f7 = unpack4x8unorm(a0);
+  vp8 += mat3x2f(vec2f(textureDimensions(tex6, i32(unconst_i32(-12))).zx), bitcast<vec2f>(textureDimensions(tex6, i32(unconst_i32(-12))).gr), bitcast<vec2f>(textureDimensions(tex6, i32(unconst_i32(-12))).xx));
+  var vf81: u32 = pack4xI8(vec4i(unconst_i32(171), unconst_i32(-12), unconst_i32(110), unconst_i32(295)));
+  let ptr86: ptr<function, vec2u> = &vf79;
+  let vf82: vec4f = cos(vec4f(unconst_f32(0.04810), unconst_f32(0.6873), unconst_f32(0.1220), unconst_f32(0.01529)));
+  vf78 += vec2f(exp(f32(unconst_f32(0.1255))));
+  return out;
+  _ = tex6;
+}
+
+@fragment
+fn fragment7() -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  fn0();
+  fn0();
+  let vf83: vec3u = abs(vec3u(unconst_u32(215), unconst_u32(318), unconst_u32(260)));
+  var vf84: u32 = vf83[u32(ceil(f32(unconst_f32(0.06852))))];
+  let ptr87: ptr<function, u32> = &vf84;
+  let vf85: vec3h = step(vec3h(unconst_f16(5416.9), unconst_f16(3108.9), unconst_f16(30997.5)), vec3h(unconst_f16(7534.1), unconst_f16(52615.7), unconst_f16(2029.3)));
+  let vf86: vec3h = step(vec3h(unconst_f16(8548.1), unconst_f16(15992.8), unconst_f16(42.64)), vec3h(unconst_f16(-51647.8), unconst_f16(2044.1), unconst_f16(1462.5)));
+  out.f3 >>= unpack4xU8(vf83[u32(unconst_u32(229))]);
+  var vf87: vec3u = abs(vec3u(unconst_u32(203), unconst_u32(191), unconst_u32(111)));
+  var vf88 = fn0();
+  let ptr88: ptr<function, i32> = &vf88.f8;
+  out.f1 <<= bitcast<vec4u>(vf88.f7);
+  vp8 = mat3x2f(vf88.f7[u32(unconst_u32(282))], vf88.f7[u32(unconst_u32(282))], vf88.f7[u32(unconst_u32(282))], vf88.f7[u32(unconst_u32(282))], vf88.f7[u32(unconst_u32(282))], vf88.f7[u32(unconst_u32(282))]);
+  var vf89 = fn0();
+  out.f0 |= u32(vp8[unconst_i32(1)].x);
+  return out;
+}
+
+@compute @workgroup_size(1, 2, 1)
+fn compute5() {
+  vw35 = FragmentOutput5(vw35.f1[u32(unconst_u32(174))], unpack4xU8(vw35.f1[u32(unconst_u32(174))]), vec4f(f32(vw35.f1[u32(unconst_u32(174))])), vec4u(vw35.f1[u32(unconst_u32(174))]));
+  atomicExchange(&vw33, u32(unconst_u32(833)));
+  vp8 = mat3x2f(f32(vw34[0]), f32(vw34[0]), f32(vw34[0]), f32(vw34[0]), f32(vw34[0]), f32(vw34[0]));
+  vp8 = mat3x2f(bitcast<f32>((*&vw35).f0), bitcast<f32>((*&vw35).f0), bitcast<f32>((*&vw35).f0), f32((*&vw35).f0), f32((*&vw35).f0), bitcast<f32>((*&vw35).f0));
+  atomicSub(&vw33, u32(unconst_u32(91)));
+  let ptr89: ptr<workgroup, vec4u> = &(*&vw35).f1;
+  var vf90: vec4h = round(vec4h(unconst_f16(2999.0), unconst_f16(15046.3), unconst_f16(15423.7), unconst_f16(4982.0)));
+  var vf91: f32 = vp8[u32(unconst_u32(83))][u32(unconst_u32(77))];
+  let vf92: f32 = vp8[u32(unconst_u32(438))][u32(unconst_u32(106))];
+  atomicAdd(&vw33, u32(unconst_u32(109)));
+  vw34[bitcast<u32>(vf92)] = cosh(vec3h(unconst_f16(3993.5), unconst_f16(17062.1), unconst_f16(7958.8))).y;
+  fn0();
+}`,
+});
+let bindGroup48 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout14,
+  entries: [
+    {binding: 977, resource: {buffer: buffer42, offset: 5632, size: 886}},
+    {binding: 162, resource: textureView41},
+    {binding: 83, resource: {buffer: buffer75, offset: 0, size: 12594}},
+    {binding: 41, resource: {buffer: buffer51, offset: 512, size: 10152}},
+    {binding: 48, resource: textureView2},
+    {binding: 119, resource: {buffer: buffer15, offset: 7680, size: 921}},
+    {binding: 46, resource: externalTexture3},
+  ],
+});
+let querySet13 = device0.createQuerySet({type: 'occlusion', count: 28});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({colorFormats: ['rg32uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder64.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup48);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup24, new Uint32Array(2115), 453, 0);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline8);
+} catch {}
+try {
+buffer68.unmap();
+} catch {}
+let veryExplicitBindGroupLayout17 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 22,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 154,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let buffer84 = device0.createBuffer({size: 1269, usage: GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let commandEncoder85 = device0.createCommandEncoder({});
+let computePassEncoder66 = commandEncoder85.beginComputePass({});
+let sampler56 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 9.836,
+});
+try {
+computePassEncoder66.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer8, 'uint32', 3_876, 3_380);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(5, buffer81, 484, 2_843);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: imageData2,
+  origin: { x: 14, y: 34 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let commandEncoder86 = device0.createCommandEncoder({});
+let computePassEncoder67 = commandEncoder86.beginComputePass({});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup45, new Uint32Array(1603), 109, 0);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(0, buffer38, 0, 316);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(2, buffer8, 0, 9_495);
+} catch {}
+try {
+  await buffer78.mapAsync(GPUMapMode.WRITE, 24, 640);
+} catch {}
+let canvas2 = document.createElement('canvas');
+let imageData15 = new ImageData(8, 76);
+let texture90 = device0.createTexture({size: [130], dimension: '1d', format: 'rg32uint', usage: GPUTextureUsage.COPY_DST, viewFormats: []});
+let texture91 = gpuCanvasContext2.getCurrentTexture();
+let renderBundle4 = renderBundleEncoder4.finish({});
+let sampler57 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 88.60,
+  compare: 'greater',
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup40, new Uint32Array(367), 42, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup19, new Uint32Array(1470), 60, 0);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(374);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(3, buffer8);
+} catch {}
+let gpuCanvasContext3 = canvas2.getContext('webgpu');
+document.body.append(canvas1);
+let shaderModule7 = device0.createShaderModule({
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires pointer_composite_access;
+
+@group(0) @binding(41) var<storage, read_write> buffer85: array<array<T0, 2>>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct FragmentOutput6 {
+  @location(0) @interpolate(flat, sample) f0: vec4u,
+}
+
+@group(0) @binding(119) var<uniform> buffer87: i32;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(162) var tex7: texture_2d_array<u32>;
+
+fn fn1(a0: vec2i) -> T0 {
+  var out: T0;
+  var vf94 = fn0();
+  let ptr91: ptr<uniform, vec4u> = &(*&buffer88).f0;
+  fn0();
+  var vf95 = fn0();
+  out.f0 -= vec2h(extractBits(vec4u(unconst_u32(230), unconst_u32(99), unconst_u32(741), unconst_u32(86)), u32(unconst_u32(66)), u32(unconst_u32(23))).zx);
+  var vf96 = fn0();
+  vf94 = mat3x4h(f16(buffer86), f16(buffer86), f16(buffer86), f16(buffer86), f16(buffer86), f16(buffer86), f16(buffer86), f16(buffer86), f16(buffer86), f16(buffer86), f16(buffer86), f16(buffer86));
+  return out;
+  _ = buffer88;
+  _ = buffer86;
+}
+
+@group(0) @binding(977) var<uniform> buffer88: FragmentOutput6;
+
+struct T1 {
+  f0: i32,
+}
+
+struct T2 {
+  @size(16) f0: atomic<i32>,
+  @size(40) f1: array<vec2u>,
+}
+
+struct VertexOutput4 {
+  @invariant @builtin(position) f10: vec4f,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+alias vec3b = vec3<bool>;
+
+@group(0) @binding(83) var<uniform> buffer86: f32;
+
+var<workgroup> vw36: atomic<u32>;
+
+fn fn0() -> mat3x4h {
+  var out: mat3x4h;
+  let vf93: vec2i = countOneBits(vec2i(unconst_i32(24), unconst_i32(279)));
+  let ptr90: ptr<uniform, f32> = &(*&buffer86);
+  return out;
+  _ = buffer86;
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T0 {
+  @size(52) f0: vec2h,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(48) var st7: texture_storage_2d<bgra8unorm, read>;
+
+@vertex @must_use
+fn vertex5(@builtin(vertex_index) a0: u32, @location(9) a1: vec2f, @location(4) @interpolate(perspective) a2: vec2h, @builtin(instance_index) a3: u32, @location(1) a4: vec2h, @location(2) @interpolate(flat) a5: vec2h, @location(0) @interpolate(flat, sample) a6: vec2u, @location(14) a7: vec4h, @location(11) @interpolate(flat) a8: vec2u) -> VertexOutput4 {
+  var out: VertexOutput4;
+  var vf97 = fn1(vec2i(a5));
+  vf97 = T0();
+  fn1(vec2i(dot(vec2i(unconst_i32(-66), unconst_i32(259)), vec2i(unconst_i32(75), unconst_i32(123)))));
+  out.f10 = vec4f(bitcast<f32>(buffer87));
+  vf97 = T0(vec2h(atan(vec4f(unconst_f32(0.01797), unconst_f32(0.03117), unconst_f32(0.1151), unconst_f32(0.03673))).yw));
+  out.f10 = vec4f(f32(a6[u32(unconst_u32(465))]));
+  var vf98: vec4f = textureLoad(st7, vec2i(unconst_i32(67), unconst_i32(-110)));
+  let vf99: f16 = vf97.f0[u32(unconst_u32(134))];
+  let vf100: f16 = a2[u32(unconst_u32(123))];
+  var vf101 = fn1(vec2i(a5));
+  fn0();
+  fn0();
+  var vf102 = fn0();
+  return out;
+  _ = buffer88;
+  _ = buffer87;
+  _ = st7;
+  _ = buffer86;
+}
+
+@fragment
+fn fragment8(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32) -> FragmentOutput6 {
+  var out: FragmentOutput6;
+  buffer85[u32(unconst_u32(279))][1] = buffer85[arrayLength(&buffer85)][u32(unconst_u32(4))];
+  out.f0 >>= vec4u(u32((*&buffer86)));
+  buffer85[u32(unconst_u32(24))][u32(unconst_u32(6))] = T0(abs(vec4h(unconst_f16(16.13), unconst_f16(19394.0), unconst_f16(9673.8), unconst_f16(38383.3))).ww);
+  out = FragmentOutput6(vec4u((*&buffer85)[u32(unconst_u32(31))][u32(unconst_u32(268))].f0.ggrr));
+  return out;
+  _ = buffer86;
+  _ = buffer85;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute6() {
+  let ptr92: ptr<storage, T0, read_write> = &(*&buffer85)[arrayLength(&(*&buffer85))][bitcast<u32>((*&buffer85)[u32(unconst_u32(225))][1].f0)];
+  let vf103: vec2u = textureDimensions(tex7, i32(unconst_i32(139)));
+  atomicOr(&vw36, pack2x16float(asinh(vec2f(unconst_f32(0.1267), unconst_f32(0.09906)))));
+  _ = buffer85;
+  _ = tex7;
+}`,
+});
+let commandEncoder87 = device0.createCommandEncoder({});
+let textureView93 = texture0.createView({baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 3});
+let computePassEncoder68 = commandEncoder87.beginComputePass({});
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(3, buffer49, 14_116, 166);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer49, 516, new BigUint64Array(16360), 10548, 168);
+} catch {}
+try {
+adapter0.label = '\u3764\u0e8d\uf403\ue005\u{1f92c}';
+} catch {}
+try {
+computePassEncoder38.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup31, new Uint32Array(1987), 47, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer48, 'uint32', 340, 456);
+} catch {}
+try {
+buffer82.unmap();
+} catch {}
+document.body.prepend(img0);
+let imageData16 = new ImageData(48, 56);
+let buffer89 = device0.createBuffer({size: 13596, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE});
+let sampler58 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.28,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder50.end();
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer0, 'uint16', 226, 2_742);
+} catch {}
+try {
+commandEncoder61.resolveQuerySet(querySet13, 1, 5, buffer50, 256);
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+document.body.append(canvas1);
+let recycledExplicitBindGroupLayout27 = pipeline7.getBindGroupLayout(0);
+let buffer90 = device0.createBuffer({size: 11826, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE, mappedAtCreation: false});
+let commandEncoder88 = device0.createCommandEncoder({});
+let computePassEncoder69 = commandEncoder61.beginComputePass();
+let sampler59 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 57.03,
+  lodMaxClamp: 58.51,
+});
+try {
+computePassEncoder68.setPipeline(pipeline7);
+} catch {}
+let buffer91 = device0.createBuffer({
+  label: '\ub5ba\u0634\u0829\ua050',
+  size: 597,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder89 = device0.createCommandEncoder();
+let textureView94 = texture69.createView({dimension: '2d', baseArrayLayer: 83});
+let computePassEncoder70 = commandEncoder89.beginComputePass({});
+let sampler60 = device0.createSampler({addressModeU: 'repeat', lodMaxClamp: 94.66});
+try {
+computePassEncoder64.setBindGroup(2, bindGroup26);
+} catch {}
+let textureView95 = texture71.createView({dimension: '2d-array', aspect: 'all'});
+let computePassEncoder71 = commandEncoder88.beginComputePass();
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(1_035).fill(84), /* required buffer size: 1_035 */
+{offset: 15, bytesPerRow: 34, rowsPerImage: 3}, {width: 1, height: 0, depthOrArrayLayers: 11});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: imageData9,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 140},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise13;
+} catch {}
+let bindGroup49 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout12,
+  entries: [{binding: 41, resource: {buffer: buffer76, offset: 1024, size: 168}}],
+});
+let commandEncoder90 = device0.createCommandEncoder({});
+let textureView96 = texture21.createView({arrayLayerCount: 1});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup46, new Uint32Array(1011), 145, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder21); computePassEncoder21.dispatchWorkgroupsIndirect(buffer79, 364); };
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant({ r: 469.2, g: 595.7, b: -9.069, a: 763.2, });
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer74);
+} catch {}
+let buffer92 = device0.createBuffer({
+  size: 12833,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup16, new Uint32Array(949), 87, 0);
+} catch {}
+try {
+computePassEncoder70.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer46, 'uint32', 5_792, 8);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(7, buffer26, 0, 896);
+} catch {}
+try {
+commandEncoder90.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder61.pushDebugGroup('\ufdb4');
+} catch {}
+document.body.append(img1);
+let imageBitmap4 = await createImageBitmap(imageData15);
+let bindGroup50 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [{binding: 216, resource: textureView47}, {binding: 346, resource: externalTexture5}],
+});
+let commandEncoder91 = device0.createCommandEncoder({});
+let renderPassEncoder20 = commandEncoder91.beginRenderPass({
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: -96.41, g: -810.4, b: 98.18, a: 945.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet13,
+});
+try {
+computePassEncoder69.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer48, 'uint32', 508, 31);
+} catch {}
+try {
+commandEncoder90.copyBufferToBuffer(buffer63, 508, buffer14, 572, 184);
+} catch {}
+try {
+computePassEncoder34.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+computePassEncoder13.setBindGroup(2, bindGroup49, new Uint32Array(470), 41, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder21); computePassEncoder21.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup13, new Uint32Array(1132), 349, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle4, renderBundle0, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(6, buffer35, 1_624, 52);
+} catch {}
+let pipeline10 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule7,
+  targets: [{format: 'rg32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule5,
+    buffers: [
+      {
+        arrayStride: 276,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 72, shaderLocation: 2},
+          {format: 'sint32x3', offset: 56, shaderLocation: 13},
+          {format: 'uint16x4', offset: 8, shaderLocation: 1},
+          {format: 'unorm10-10-10-2', offset: 56, shaderLocation: 9},
+          {format: 'sint32x2', offset: 4, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 6, shaderLocation: 11},
+          {format: 'uint8x4', offset: 52, shaderLocation: 3},
+          {format: 'float32x4', offset: 56, shaderLocation: 6},
+          {format: 'float16x2', offset: 116, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 24, shaderLocation: 10},
+          {format: 'float32x3', offset: 72, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front'},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let buffer93 = device0.createBuffer({
+  size: 8272,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 567});
+let texture92 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView97 = texture76.createView({mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 6});
+let renderPassEncoder21 = commandEncoder90.beginRenderPass({colorAttachments: [{view: textureView90, loadOp: 'load', storeOp: 'store'}]});
+try {
+computePassEncoder67.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup45, new Uint32Array(1199), 95, 0);
+} catch {}
+try {
+renderPassEncoder0.setViewport(213.1190211635933, 0.14646835971161076, 1.4522113751150052, 0.05062658122995512, 0.7740416450625984, 0.8488170958267286);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer44, 'uint16', 1_100, 2_481);
+} catch {}
+let imageData17 = new ImageData(36, 20);
+let videoFrame11 = videoFrame10.clone();
+try {
+adapter0.label = '\u{1ff95}\u96c1\u0ea6\u04ef\u4a6d';
+} catch {}
+let buffer94 = device0.createBuffer({size: 10319, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX});
+let texture93 = device0.createTexture({
+  size: [32, 1, 1],
+  dimension: '2d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView98 = texture77.createView({});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame6});
+try {
+computePassEncoder71.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer92, 'uint16', 1_958, 5_264);
+} catch {}
+let promise14 = shaderModule1.getCompilationInfo();
+try {
+  await promise14;
+} catch {}
+let textureView99 = texture78.createView({baseArrayLayer: 1, arrayLayerCount: 3});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+renderPassEncoder13.pushDebugGroup('\u02ab');
+} catch {}
+try {
+computePassEncoder9.setBindGroup(0, bindGroup8, new Uint32Array(2310), 301, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(72).fill(120), /* required buffer size: 72 */
+{offset: 72}, {width: 29, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'jedecP22Phosphors', transfer: 'bt2020_12bit'} });
+let bindGroup51 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout25,
+  entries: [
+    {binding: 162, resource: textureView59},
+    {binding: 41, resource: {buffer: buffer47, offset: 9472, size: 120}},
+    {binding: 119, resource: {buffer: buffer62, offset: 1792, size: 7067}},
+    {binding: 48, resource: textureView13},
+    {binding: 46, resource: externalTexture3},
+    {binding: 977, resource: {buffer: buffer32, offset: 0, size: 271}},
+    {binding: 83, resource: {buffer: buffer65, offset: 0}},
+  ],
+});
+let textureView100 = texture61.createView({mipLevelCount: 1});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup5, new Uint32Array(340), 63, 0);
+} catch {}
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer94, 'uint32', 1_628, 2_821);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer40);
+} catch {}
+let veryExplicitBindGroupLayout18 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 113,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+computePassEncoder62.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(1, bindGroup38, new Uint32Array(483), 85, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup29, new Uint32Array(492), 31, 0);
+} catch {}
+let commandEncoder92 = device0.createCommandEncoder({});
+let computePassEncoder72 = commandEncoder24.beginComputePass({});
+let renderPassEncoder22 = commandEncoder92.beginRenderPass({
+  colorAttachments: [{
+  view: textureView17,
+  depthSlice: 8,
+  clearValue: { r: -994.9, g: -26.43, b: -214.2, a: -38.23, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 104282420,
+});
+let sampler61 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'mirror-repeat', lodMaxClamp: 60.86});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup6, new Uint32Array(3134), 773, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup35, new Uint32Array(263), 32, 0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer26);
+} catch {}
+try {
+renderPassEncoder13.popDebugGroup();
+} catch {}
+let pipeline11 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout3,
+  multisample: {mask: 0x20618ee2},
+  fragment: {
+  module: shaderModule7,
+  constants: {},
+  targets: [{
+  format: 'rg32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule5,
+    buffers: [
+      {
+        arrayStride: 140,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 20, shaderLocation: 8},
+          {format: 'float32', offset: 16, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 56, shaderLocation: 10},
+          {format: 'sint32x3', offset: 4, shaderLocation: 13},
+          {format: 'sint16x2', offset: 28, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 28, shaderLocation: 9},
+          {format: 'float32x2', offset: 4, shaderLocation: 11},
+          {format: 'float16x2', offset: 4, shaderLocation: 6},
+          {format: 'uint8x4', offset: 8, shaderLocation: 3},
+          {format: 'uint32x2', offset: 8, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 0, attributes: [{format: 'sint32x2', offset: 40, shaderLocation: 14}]},
+    ],
+  },
+});
+let videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'bt470bg', transfer: 'bt709'} });
+try {
+globalThis.someLabel = texture51.label;
+} catch {}
+let recycledExplicitBindGroupLayout28 = pipeline1.getBindGroupLayout(0);
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup26, new Uint32Array(4596), 972, 0);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer91, 'uint16', 4, 140);
+} catch {}
+try {
+device0.queue.submit([commandBuffer10]);
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+let recycledExplicitBindGroupLayout29 = pipeline2.getBindGroupLayout(0);
+let bindGroup52 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [
+    {binding: 119, resource: {buffer: buffer75, offset: 8704, size: 1596}},
+    {binding: 162, resource: textureView72},
+    {binding: 46, resource: externalTexture1},
+    {binding: 83, resource: {buffer: buffer76, offset: 256, size: 194}},
+    {binding: 48, resource: textureView10},
+    {binding: 41, resource: {buffer: buffer8, offset: 3072}},
+    {binding: 977, resource: {buffer: buffer45, offset: 1024, size: 115}},
+  ],
+});
+let texture94 = device0.createTexture({size: [65], dimension: '1d', format: 'rg16uint', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline7);
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer74, 132, new Int16Array(637), 3, 32);
+} catch {}
+document.body.prepend(img0);
+let texture95 = device0.createTexture({
+  size: {width: 130},
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView101 = texture37.createView({aspect: 'all'});
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle0, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer74, 'uint16', 50, 196);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+adapter0.label = '\u4a49\u9ef1\u{1fe0d}\u2895\u2a0e\u780c';
+} catch {}
+let recycledExplicitBindGroupLayout30 = pipeline10.getBindGroupLayout(0);
+let bindGroup53 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout25,
+  entries: [
+    {binding: 48, resource: textureView13},
+    {binding: 46, resource: externalTexture1},
+    {binding: 41, resource: {buffer: buffer79, offset: 0, size: 504}},
+    {binding: 162, resource: textureView0},
+    {binding: 83, resource: {buffer: buffer38, offset: 3072}},
+    {binding: 977, resource: {buffer: buffer14, offset: 4096, size: 1718}},
+    {binding: 119, resource: {buffer: buffer16, offset: 0, size: 64}},
+  ],
+});
+let texture96 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 2},
+  mipLevelCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder18.setIndexBuffer(buffer24, 'uint16', 3_154, 2_403);
+} catch {}
+try {
+computePassEncoder51.pushDebugGroup('\u0144');
+} catch {}
+try {
+computePassEncoder33.insertDebugMarker('\ufe1d');
+} catch {}
+let autogeneratedBindGroupLayout17 = pipeline3.getBindGroupLayout(0);
+try {
+computePassEncoder38.setBindGroup(1, bindGroup46);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer24, 'uint32', 892, 3_168);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(2, buffer30, 0);
+} catch {}
+try {
+renderPassEncoder20.beginOcclusionQuery(3);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer91);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+computePassEncoder51.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup54 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout23,
+  entries: [
+    {binding: 162, resource: textureView93},
+    {binding: 83, resource: {buffer: buffer0, offset: 2048, size: 725}},
+    {binding: 41, resource: {buffer: buffer0, offset: 1280, size: 336}},
+    {binding: 977, resource: {buffer: buffer62, offset: 256, size: 380}},
+    {binding: 119, resource: {buffer: buffer93, offset: 256}},
+    {binding: 48, resource: textureView2},
+    {binding: 46, resource: externalTexture7},
+  ],
+});
+let commandEncoder93 = device0.createCommandEncoder({});
+let texture97 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 335},
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture98 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 3},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder73 = commandEncoder93.beginComputePass({});
+let sampler62 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.55,
+  lodMaxClamp: 87.50,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder73.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup25, new Uint32Array(232), 39, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: imageData1,
+  origin: { x: 1, y: 1 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame14 = new VideoFrame(img1, {timestamp: 0});
+try {
+adapter0.label = '\ud137\u086d\u{1fee4}\u{1fa4c}\ue004\u8587\u0307\u022b';
+} catch {}
+let veryExplicitBindGroupLayout19 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 113,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture99 = device0.createTexture({
+  size: {width: 32, height: 1, depthOrArrayLayers: 54},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup46);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup13, new Uint32Array(1617), 322, 0);
+} catch {}
+try {
+renderPassEncoder20.endOcclusionQuery();
+} catch {}
+try {
+  await promise15;
+} catch {}
+let buffer95 = device0.createBuffer({size: 14911, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView102 = texture11.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup49, new Uint32Array(189), 0, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup40);
+} catch {}
+document.body.prepend(canvas2);
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 136});
+let textureView103 = texture58.createView({dimension: '2d-array', aspect: 'all', format: 'astc-8x5-unorm'});
+let externalTexture8 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup50);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer52, 'uint16', 2_164, 381);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline8);
+} catch {}
+let veryExplicitBindGroupLayout20 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 304,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder94 = device0.createCommandEncoder({});
+let texture100 = device0.createTexture({
+  size: [32, 1, 1],
+  mipLevelCount: 1,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture101 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder74 = commandEncoder94.beginComputePass({});
+let sampler63 = device0.createSampler({addressModeU: 'repeat'});
+try {
+computePassEncoder43.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+computePassEncoder74.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup5, new Uint32Array(567), 43, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer75, 'uint16', 502, 503);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(3, buffer4, 468, 1);
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+struct VertexOutput6 {
+  @location(13) f14: vec2u,
+  @location(2) f15: vec4u,
+  @location(4) @interpolate(flat, sample) f16: u32,
+  @location(10) @interpolate(flat, centroid) f17: i32,
+  @location(5) f18: vec4f,
+  @location(9) f19: vec2u,
+  @location(14) f20: i32,
+  @location(8) f21: f16,
+  @builtin(position) f22: vec4f,
+}
+
+struct T0 {
+  f0: f32,
+  @size(48) f1: array<array<vec4f, 1>, 2>,
+}
+
+struct FragmentOutput7 {
+  @location(0) f0: i32,
+}
+
+struct FragmentOutput8 {
+  @location(0) @interpolate(flat) f0: vec2u,
+}
+
+struct VertexOutput5 {
+  @builtin(position) f11: vec4f,
+  @location(13) @interpolate(perspective) f12: vec4f,
+  @location(4) @interpolate(perspective, centroid) f13: vec4f,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw41: array<mat3x2h, 1>;
+
+@group(0) @binding(41) var<storage, read_write> buffer96: array<array<array<f16, 1>, 13>, 4>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T1 {
+  f0: u32,
+}
+
+@group(0) @binding(48) var st8: texture_storage_2d<bgra8unorm, read>;
+
+alias vec3b = vec3<bool>;
+
+var<workgroup> vw40: array<atomic<i32>, 1>;
+
+fn fn0() -> vec2h {
+  var out: vec2h;
+  out = bitcast<vec2h>((*&buffer97));
+  var vf104: u32 = pack4x8snorm(vec4f(unconst_f32(-0.08146), unconst_f32(0.1032), unconst_f32(0.1297), unconst_f32(0.1217)));
+  var vf105: vec3h = floor(vec3h(f16(buffer97)));
+  let vf106: u32 = pack4x8snorm(vec4f(countLeadingZeros(vec2i(unconst_i32(51), unconst_i32(133))).xxyy));
+  vf104 -= u32(vf105.b);
+  vf104 <<= bitcast<u32>(buffer97);
+  out = inverseSqrt(vec2h(unconst_f16(3559.1), unconst_f16(2685.2)));
+  let vf107: vec4f = tan(vec4f(unconst_f32(0.3967), unconst_f32(0.4071), unconst_f32(0.2186), unconst_f32(-0.2296)));
+  vf105 += vec3h(f16(vf106));
+  vf104 &= vf106;
+  vf104 >>= bitcast<u32>(vf107[u32(unconst_u32(0))]);
+  let vf108: f16 = vf105[u32(unconst_u32(515))];
+  var vf109: u32 = pack2x16snorm(vec2f(unconst_f32(0.00623), unconst_f32(0.01791)));
+  vf104 ^= bitcast<u32>(buffer97);
+  let ptr93: ptr<uniform, i32> = &buffer97;
+  vf109 <<= u32(vf107[u32(unconst_u32(310))]);
+  return out;
+  _ = buffer97;
+}
+
+var<workgroup> vw38: T0;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(119) var<uniform> buffer98: i32;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(83) var<uniform> buffer97: i32;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw37: T1;
+
+var<workgroup> vw39: atomic<u32>;
+
+@group(0) @binding(977) var<uniform> buffer99: VertexOutput5;
+
+@vertex
+fn vertex6(@location(0) a0: vec4f, @location(12) a1: f32, @location(3) @interpolate(flat, centroid) a2: vec2i, @location(4) a3: vec2h, @location(5) a4: f16, @location(14) a5: vec2h, @location(9) a6: f16, @location(2) a7: vec2u, @location(1) a8: vec4i) -> VertexOutput5 {
+  var out: VertexOutput5;
+  fn0();
+  let ptr94: ptr<uniform, vec4f> = &buffer99.f12;
+  out = VertexOutput5(bitcast<vec4f>(insertBits(vec2i(unconst_i32(39), unconst_i32(168)), vec2i(unconst_i32(44), unconst_i32(8)), u32(unconst_u32(99)), u32(unconst_u32(171))).yxxx), bitcast<vec4f>(insertBits(vec2i(unconst_i32(39), unconst_i32(168)), vec2i(unconst_i32(44), unconst_i32(8)), u32(unconst_u32(99)), u32(unconst_u32(171))).grgg), bitcast<vec4f>(insertBits(vec2i(unconst_i32(39), unconst_i32(168)), vec2i(unconst_i32(44), unconst_i32(8)), u32(unconst_u32(99)), u32(unconst_u32(171))).grgr));
+  out = (*&buffer99);
+  let vf110: f32 = buffer99.f12[u32(unconst_u32(154))];
+  var vf111 = fn0();
+  var vf112: vec4f = unpack4x8snorm(u32(unconst_u32(448)));
+  var vf113: f32 = vf110;
+  let vf114: f16 = a3[u32(unconst_u32(235))];
+  out.f11 -= vec4f(bitcast<f32>(a2[u32(unconst_u32(298))]));
+  var vf115 = fn0();
+  var vf116 = fn0();
+  fn0();
+  fn0();
+  return out;
+  _ = buffer99;
+  _ = buffer97;
+}
+
+@vertex
+fn vertex7(@location(1) @interpolate(flat) a0: f16) -> VertexOutput6 {
+  var out: VertexOutput6;
+  out.f18 += (*&buffer99).f11;
+  out.f14 = vec2u(u32((*&buffer99).f11[u32(unconst_u32(480))]));
+  out.f14 -= vec2u((*&buffer99).f11.bb);
+  var vf117: vec2u = countTrailingZeros(vec2u(unconst_u32(421), unconst_u32(36)));
+  let ptr95: ptr<uniform, vec4f> = &(*&buffer99).f13;
+  fn0();
+  var vf118: vec3f = smoothstep(vec3f((*&buffer99).f11[u32(unconst_u32(54))]), vec3f(unconst_f32(0.09054), unconst_f32(0.04345), unconst_f32(0.1826)), vec3f(unconst_f32(0.1074), unconst_f32(0.1065), unconst_f32(0.01637)));
+  out.f19 *= bitcast<vec2u>(tan(vec4h(unconst_f16(18867.7), unconst_f16(878.6), unconst_f16(2108.0), unconst_f16(27609.0))));
+  out.f19 ^= bitcast<vec2u>(clamp(vec4f(unconst_f32(0.1316), unconst_f32(0.1077), unconst_f32(0.00855), unconst_f32(0.1175)), vec4f(unconst_f32(0.1972), unconst_f32(-0.1313), unconst_f32(0.04242), unconst_f32(0.2063)), vec4f(unconst_f32(0.09611), unconst_f32(0.2148), unconst_f32(-0.1926), unconst_f32(0.07066))).rr);
+  out.f14 <<= countOneBits(vec3u(unconst_u32(585), unconst_u32(395), unconst_u32(159))).yy;
+  let vf119: vec4f = textureLoad(st8, vec2i(unconst_i32(233), unconst_i32(226)));
+  return out;
+  _ = buffer99;
+  _ = st8;
+  _ = buffer97;
+}
+
+@fragment
+fn fragment9() -> FragmentOutput7 {
+  var out: FragmentOutput7;
+  let ptr96: ptr<storage, array<f16, 1>, read_write> = &(*&buffer96)[u32(unconst_u32(229))][12];
+  out.f0 = i32(transpose(mat4x3h())[unconst_i32(2)].b);
+  let ptr97: ptr<storage, f16, read_write> = &(*&buffer96)[u32(unconst_u32(92))][12][0];
+  out.f0 ^= i32((*&buffer96)[u32(unconst_u32(174))][12][0]);
+  out.f0 = i32(buffer96[3][u32((*&buffer96)[u32(unconst_u32(160))][u32(unconst_u32(26))][u32(unconst_u32(85))])][u32(unconst_u32(240))]);
+  fn0();
+  buffer96[u32(unconst_u32(203))][u32(unconst_u32(142))][u32(unconst_u32(375))] -= buffer96[u32(unconst_u32(2))][12][0];
+  buffer96[u32(unconst_u32(81))][u32(unconst_u32(637))][u32(unconst_u32(7))] = (*&buffer96)[u32(unconst_u32(281))][u32(unconst_u32(46))][u32(unconst_u32(19))];
+  out = FragmentOutput7(i32(buffer96[u32((*&buffer96)[u32(unconst_u32(76))][u32(unconst_u32(88))][0])][u32(unconst_u32(148))][0]));
+  let ptr98: ptr<storage, array<f16, 1>, read_write> = &buffer96[u32(unconst_u32(297))][u32(unconst_u32(1))];
+  fn0();
+  fn0();
+  buffer96[u32(unconst_u32(197))][u32(unconst_u32(122))][u32(unconst_u32(135))] = vec3h(clamp(vec3i(unconst_i32(862), unconst_i32(430), unconst_i32(49)), vec3i(unconst_i32(299), unconst_i32(33), unconst_i32(32)), vec3i(unconst_i32(1000), unconst_i32(87), unconst_i32(607)))).x;
+  out.f0 = i32((*ptr98)[0]);
+  var vf120 = fn0();
+  vf120 -= bitcast<vec2h>(pack2x16snorm(vec2f(unconst_f32(0.02034), unconst_f32(0.1150))));
+  return out;
+  _ = buffer97;
+  _ = buffer96;
+}
+
+@fragment
+fn fragment10(@location(4) @interpolate(linear) a0: vec4f) -> FragmentOutput8 {
+  var out: FragmentOutput8;
+  fn0();
+  out.f0 = vec2u(u32((*&buffer96)[u32(unconst_u32(73))][u32(unconst_u32(70))][u32(unconst_u32(100))]));
+  var vf121: bool = any(vec2<bool>(unconst_bool(true), unconst_bool(true)));
+  let ptr99: ptr<function, bool> = &vf121;
+  fn0();
+  fn0();
+  fn0();
+  out.f0 = vec2u(pack2x16unorm(vec2f(unconst_f32(0.06830), unconst_f32(0.04178))));
+  buffer96[3][u32(unconst_u32(83))][u32(unconst_u32(645))] = (*&buffer96)[u32(unconst_u32(254))][12][u32(unconst_u32(95))];
+  vf121 = bool(buffer96[u32(unconst_u32(62))][u32(unconst_u32(41))][0]);
+  out.f0 |= vec2u(u32(a0[u32(unconst_u32(37))]));
+  let ptr100: ptr<storage, array<array<f16, 1>, 13>, read_write> = &(*&buffer96)[u32((*&buffer96)[3][u32(unconst_u32(86))][0])];
+  fn0();
+  var vf122 = fn0();
+  let ptr101: ptr<uniform, i32> = &buffer98;
+  vf122 -= vec2h(buffer96[u32(buffer96[u32(unconst_u32(38))][12][0])][12][0]);
+  var vf123 = fn0();
+  fn0();
+  return out;
+  _ = buffer98;
+  _ = buffer96;
+  _ = buffer97;
+}
+
+@compute @workgroup_size(1, 2, 1)
+fn compute7() {
+  fn0();
+  fn0();
+  atomicCompareExchangeWeak(&vw40[u32(unconst_u32(441))], unconst_i32(67), unconst_i32(-179));
+  fn0();
+  vw41[0] += mat3x2h((*&buffer96)[u32(unconst_u32(215))][u32(unconst_u32(51))][0], (*&buffer96)[u32(unconst_u32(215))][u32(unconst_u32(51))][0], (*&buffer96)[u32(unconst_u32(215))][u32(unconst_u32(51))][0], (*&buffer96)[u32(unconst_u32(215))][u32(unconst_u32(51))][0], (*&buffer96)[u32(unconst_u32(215))][u32(unconst_u32(51))][0], (*&buffer96)[u32(unconst_u32(215))][u32(unconst_u32(51))][0]);
+  buffer96[u32(unconst_u32(69))][u32(unconst_u32(164))][vec4u(vw38.f1[u32(unconst_u32(582))][0]).z] += (*&vw41)[0][unconst_i32(2)][0];
+  vw37 = T1(u32((*&buffer96)[3][12][pack2x16snorm(tan(vec2f(unconst_f32(0.04265), unconst_f32(0.01397))))]));
+  workgroupBarrier();
+  var vf124 = fn0();
+  fn0();
+  let vf125: i32 = atomicLoad(&(*&vw40)[0]);
+  fn0();
+  vw38 = T0(bitcast<f32>((*&vw41)[0][unconst_i32(1)]), array<array<vec4f, 1>, 2>(array<vec4f, 1>(vec4f((*&vw41)[0][unconst_i32(0)].grgg)), array<vec4f, 1>(vec4f((*&vw41)[0][unconst_i32(2)].yxxy))));
+  fn0();
+  var vf126 = fn0();
+  let ptr102: ptr<storage, f16, read_write> = &(*&buffer96)[u32(unconst_u32(63))][u32(unconst_u32(32))][0];
+  _ = buffer97;
+  _ = buffer96;
+}`,
+});
+let bindGroup55 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout11,
+  entries: [
+    {binding: 162, resource: textureView15},
+    {binding: 119, resource: {buffer: buffer76, offset: 256, size: 714}},
+    {binding: 48, resource: textureView13},
+    {binding: 46, resource: externalTexture6},
+    {binding: 41, resource: {buffer: buffer69, offset: 0, size: 228}},
+    {binding: 83, resource: {buffer: buffer64, offset: 3072}},
+    {binding: 977, resource: {buffer: buffer83, offset: 256, size: 107}},
+  ],
+});
+let commandEncoder95 = device0.createCommandEncoder({label: '\u090d\u{1ffcc}\u4ac5\uec09\u01a7\u2e5f\u{1fa0d}\ud800\u{1fbff}'});
+let computePassEncoder75 = commandEncoder95.beginComputePass({});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup48, new Uint32Array(259), 25, 0);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup44);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(5, buffer48);
+} catch {}
+let recycledExplicitBindGroupLayout31 = pipeline7.getBindGroupLayout(0);
+try {
+{ clearResourceUsages(device0, computePassEncoder28); computePassEncoder28.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroupsIndirect(buffer69, 296); };
+} catch {}
+try {
+computePassEncoder62.end();
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer77, 'uint32', 4_068, 1_260);
+} catch {}
+let pipeline12 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {mask: 0x49175a2d},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment6',
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule1,
+    constants: {override0: 0},
+    buffers: [
+      {
+        arrayStride: 32,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 0, shaderLocation: 12},
+          {format: 'sint32x2', offset: 0, shaderLocation: 3},
+          {format: 'uint32', offset: 4, shaderLocation: 7},
+          {format: 'sint32', offset: 0, shaderLocation: 15},
+          {format: 'uint8x2', offset: 2, shaderLocation: 8},
+          {format: 'uint16x2', offset: 20, shaderLocation: 1},
+          {format: 'sint8x2', offset: 2, shaderLocation: 5},
+          {format: 'float32x3', offset: 0, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 444,
+        stepMode: 'vertex',
+        attributes: [{format: 'float32x3', offset: 40, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'ccw'},
+});
+let commandBuffer11 = commandEncoder78.finish();
+let textureView104 = texture24.createView({aspect: 'stencil-only', baseArrayLayer: 6, arrayLayerCount: 2});
+try {
+computePassEncoder69.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+device0.queue.submit([commandBuffer11]);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(1, bindGroup40, new Uint32Array(1045), 387, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer64, 'uint16', 2_262, 4_135);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let sampler64 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 90.60,
+  compare: 'greater',
+});
+try {
+computePassEncoder65.setBindGroup(3, bindGroup23);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(7, buffer3, 28, 15);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(15).fill(29), /* required buffer size: 15 */
+{offset: 15}, {width: 54, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline13 = await promise4;
+let imageData18 = new ImageData(4, 8);
+let videoFrame15 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'film', transfer: 'smpteSt4281'} });
+let pipelineLayout10 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout9]});
+let querySet16 = device0.createQuerySet({type: 'occlusion', count: 197});
+let texture102 = device0.createTexture({
+  size: [65, 1, 16],
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup51);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(0, buffer17, 7_232);
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+let imageData19 = new ImageData(40, 16);
+let textureView105 = texture102.createView({arrayLayerCount: 1});
+let textureView106 = texture84.createView({aspect: 'stencil-only'});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup25, []);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup39, new Uint32Array(2316), 34, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 14},
+  aspect: 'all',
+}, new Uint8Array(358).fill(188), /* required buffer size: 358 */
+{offset: 33, bytesPerRow: 1, rowsPerImage: 65}, {width: 0, height: 0, depthOrArrayLayers: 6});
+} catch {}
+let videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'unspecified', transfer: 'bt2020_12bit'} });
+let commandEncoder96 = device0.createCommandEncoder({});
+let texture103 = device0.createTexture({
+  label: '\ua2af\ub41e\u{1fa2f}\ufbdf\udae4\u{1f84f}\u2764\u4ff8\u0875\ufad7\u039c',
+  size: {width: 32, height: 1, depthOrArrayLayers: 331},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let computePassEncoder76 = commandEncoder96.beginComputePass({});
+let externalTexture9 = device0.importExternalTexture({source: videoFrame6});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(7, buffer29, 6_784, 83);
+} catch {}
+await gc();
+let pipelineLayout11 = device0.createPipelineLayout({
+  bindGroupLayouts: [recycledExplicitBindGroupLayout14, autogeneratedBindGroupLayout1, recycledExplicitBindGroupLayout20],
+});
+let commandEncoder97 = device0.createCommandEncoder({});
+let texture104 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 1},
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder77 = commandEncoder97.beginComputePass({});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup51);
+} catch {}
+try {
+computePassEncoder76.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle0, renderBundle4, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(2, buffer81, 0);
+} catch {}
+try {
+device0.queue.label = '\u0b5f\uebf3\u10fb\u523e\ueadf\ued4e\u{1f6db}\u8d5e\uf976\u{1f6bb}';
+} catch {}
+let recycledExplicitBindGroupLayout32 = pipeline2.getBindGroupLayout(0);
+let texture105 = device0.createTexture({
+  size: [4, 4, 50],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let sampler65 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat'});
+try {
+renderPassEncoder5.setVertexBuffer(5, buffer81);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer33, 116, new BigUint64Array(484), 13, 60);
+} catch {}
+let autogeneratedBindGroupLayout18 = pipeline3.getBindGroupLayout(0);
+let buffer100 = device0.createBuffer({size: 6633, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let commandEncoder98 = device0.createCommandEncoder({});
+let texture106 = device0.createTexture({size: [260, 1, 10], format: 'r32uint', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup48, new Uint32Array(727), 28, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup39, new Uint32Array(493), 266, 0);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder98.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 336 */
+  offset: 336,
+  bytesPerRow: 31232,
+  buffer: buffer15,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup56 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout23,
+  entries: [
+    {binding: 48, resource: textureView13},
+    {binding: 977, resource: {buffer: buffer31, offset: 1536}},
+    {binding: 119, resource: {buffer: buffer76, offset: 0, size: 119}},
+    {binding: 46, resource: externalTexture7},
+    {binding: 162, resource: textureView6},
+    {binding: 41, resource: {buffer: buffer65, offset: 256}},
+    {binding: 83, resource: {buffer: buffer83, offset: 256, size: 514}},
+  ],
+});
+let buffer101 = device0.createBuffer({size: 19907, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture107 = device0.createTexture({size: [65, 1, 1], dimension: '2d', format: 'rg32uint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder78 = commandEncoder98.beginComputePass({});
+let externalTexture10 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'srgb'});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup45);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroupsIndirect(buffer15, 12); };
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer62, 'uint16', 240, 5_481);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: imageData16,
+  origin: { x: 2, y: 0 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img1);
+let texture108 = device0.createTexture({
+  size: [260, 1, 97],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder78.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(5, undefined, 0, 3_041_273_466);
+} catch {}
+let texture109 = device0.createTexture({
+  size: {width: 4, height: 4, depthOrArrayLayers: 8},
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView107 = texture92.createView({dimension: '2d-array', aspect: 'all', mipLevelCount: 1});
+try {
+computePassEncoder76.setBindGroup(0, bindGroup13, new Uint32Array(1524), 366, 0);
+} catch {}
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup46, new Uint32Array(2324), 322, 0);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(141);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer38, 'uint32', 504, 31);
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 19},
+  aspect: 'all',
+},
+{
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 69},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 33});
+} catch {}
+let textureView108 = texture65.createView({dimension: 'cube-array', baseArrayLayer: 5, arrayLayerCount: 6});
+let computePassEncoder79 = commandEncoder8.beginComputePass({});
+try {
+computePassEncoder43.setBindGroup(0, bindGroup44, new Uint32Array(2087), 84, 0);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer65, 'uint16', 1_422, 377);
+} catch {}
+try {
+computePassEncoder65.pushDebugGroup('\u8715');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer30, 80, new DataView(new ArrayBuffer(747)), 35, 20);
+} catch {}
+let buffer102 = device0.createBuffer({size: 15619, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let texture110 = device0.createTexture({
+  size: {width: 4, height: 4, depthOrArrayLayers: 23},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup16, new Uint32Array(447), 158, 0);
+} catch {}
+try {
+computePassEncoder79.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup13, new Uint32Array(1046), 65, 0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer91, 'uint16', 92, 64);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer81, 2_796, 1_390);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer74, 44, new BigUint64Array(4460), 1325, 0);
+} catch {}
+let veryExplicitBindGroupLayout21 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 304,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder99 = device0.createCommandEncoder({});
+let textureView109 = texture105.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder80 = commandEncoder99.beginComputePass({});
+let sampler66 = device0.createSampler({addressModeV: 'repeat', minFilter: 'linear', mipmapFilter: 'linear', lodMaxClamp: 74.57});
+let externalTexture11 = device0.importExternalTexture({source: videoFrame11});
+try {
+{ clearResourceUsages(device0, computePassEncoder28); computePassEncoder28.dispatchWorkgroups(1, 2); };
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer81, 'uint32', 2_204, 2);
+} catch {}
+let bindGroup57 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout31,
+  entries: [
+    {binding: 977, resource: {buffer: buffer18, offset: 1024, size: 103}},
+    {binding: 41, resource: {buffer: buffer76, offset: 0, size: 516}},
+    {binding: 48, resource: textureView10},
+    {binding: 46, resource: externalTexture9},
+    {binding: 83, resource: {buffer: buffer17, offset: 1280}},
+    {binding: 162, resource: textureView93},
+    {binding: 119, resource: {buffer: buffer83, offset: 0, size: 35}},
+  ],
+});
+try {
+computePassEncoder43.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+computePassEncoder24.setBindGroup(2, bindGroup31, new Uint32Array(722), 136, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(7, buffer17, 0, 182);
+} catch {}
+let veryExplicitBindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 31,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 498,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let bindGroup58 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout15,
+  entries: [{binding: 41, resource: {buffer: buffer50, offset: 0, size: 384}}],
+});
+let buffer103 = device0.createBuffer({size: 1306, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+try {
+renderPassEncoder21.setViewport(22.469953724614065, 0.5085762943752823, 55.91120529538336, 0.4490564397302011, 0.7597388478997826, 0.8601970798859485);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer24, 2_096);
+} catch {}
+try {
+computePassEncoder65.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(309).fill(137), /* required buffer size: 309 */
+{offset: 309}, {width: 130, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup59 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout27,
+  entries: [
+    {binding: 162, resource: textureView72},
+    {binding: 48, resource: textureView13},
+    {binding: 41, resource: {buffer: buffer50, offset: 0, size: 192}},
+    {binding: 83, resource: {buffer: buffer65, offset: 512}},
+    {binding: 977, resource: {buffer: buffer29, offset: 512, size: 2871}},
+    {binding: 119, resource: {buffer: buffer93, offset: 2560}},
+    {binding: 46, resource: externalTexture4},
+  ],
+});
+let commandEncoder100 = device0.createCommandEncoder({});
+let computePassEncoder81 = commandEncoder100.beginComputePass({});
+let sampler67 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'repeat'});
+try {
+computePassEncoder77.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline11);
+} catch {}
+try {
+buffer47.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+adapter0.label = '\u{1fe96}\udd5f\u27a0\u03c8\u003e\u0cb7';
+} catch {}
+let commandEncoder101 = device0.createCommandEncoder({});
+let textureView110 = texture31.createView({mipLevelCount: 1});
+try {
+computePassEncoder43.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+computePassEncoder3.setBindGroup(1, bindGroup25, new Uint32Array(3513), 893, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle4]);
+} catch {}
+try {
+  await buffer100.mapAsync(GPUMapMode.WRITE, 792, 468);
+} catch {}
+let autogeneratedBindGroupLayout19 = pipeline3.getBindGroupLayout(0);
+let sampler68 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 57.03,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder80.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer39, 'uint32', 14_512, 224);
+} catch {}
+try {
+commandEncoder101.copyTextureToTexture({
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder101.clearBuffer(buffer32);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(57).fill(117), /* required buffer size: 57 */
+{offset: 57}, {width: 4, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let computePassEncoder82 = commandEncoder101.beginComputePass({});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup48, new Uint32Array(2100), 1_307, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(1, buffer82, 184, 173);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(img0);
+await gc();
+let videoFrame17 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'unspecified', transfer: 'bt2020_10bit'} });
+let commandEncoder102 = device0.createCommandEncoder();
+let renderPassEncoder23 = commandEncoder102.beginRenderPass({
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: -250.3, g: -385.6, b: 614.1, a: -891.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet6,
+});
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup48);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer76, 1688, new BigUint64Array(8556), 803, 8);
+} catch {}
+let bindGroup60 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout8,
+  entries: [
+    {binding: 46, resource: externalTexture7},
+    {binding: 41, resource: {buffer: buffer80, offset: 0, size: 168}},
+    {binding: 83, resource: {buffer: buffer18, offset: 512, size: 2086}},
+    {binding: 48, resource: textureView2},
+    {binding: 977, resource: {buffer: buffer32, offset: 256}},
+    {binding: 119, resource: {buffer: buffer17, offset: 5888}},
+    {binding: 162, resource: textureView99},
+  ],
+});
+let buffer104 = device0.createBuffer({size: 6600, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder103 = device0.createCommandEncoder();
+let texture111 = device0.createTexture({size: [65, 1, 8], format: 'rg16uint', usage: GPUTextureUsage.COPY_DST, viewFormats: []});
+let renderPassEncoder24 = commandEncoder103.beginRenderPass({
+  colorAttachments: [{
+  view: textureView12,
+  clearValue: { r: 267.7, g: -246.7, b: 672.0, a: 118.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView87, depthReadOnly: false, stencilLoadOp: 'clear', stencilStoreOp: 'store'},
+  maxDrawCount: 202837901,
+});
+try {
+computePassEncoder81.setPipeline(pipeline7);
+} catch {}
+let bindGroup61 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout1,
+  entries: [
+    {binding: 48, resource: textureView13},
+    {binding: 83, resource: {buffer: buffer83, offset: 256, size: 798}},
+    {binding: 119, resource: {buffer: buffer65, offset: 0}},
+    {binding: 41, resource: {buffer: buffer17, offset: 16896}},
+    {binding: 977, resource: {buffer: buffer64, offset: 0}},
+    {binding: 162, resource: textureView41},
+    {binding: 46, resource: externalTexture7},
+  ],
+});
+let buffer105 = device0.createBuffer({
+  size: 14492,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let texture112 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 181},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['r32float'], stencilReadOnly: true});
+let sampler69 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.26,
+  lodMaxClamp: 58.35,
+  maxAnisotropy: 14,
+});
+try {
+renderPassEncoder21.setVertexBuffer(2, buffer35);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer90, 1488, new DataView(new ArrayBuffer(21652)), 1224, 256);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder64.setBindGroup(0, bindGroup39, new Uint32Array(4267), 638, 0);
+} catch {}
+try {
+computePassEncoder82.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(56);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(0, bindGroup48, []);
+} catch {}
+try {
+renderPassEncoder23.insertDebugMarker('\uc2d0');
+} catch {}
+let imageData20 = new ImageData(4, 96);
+let commandEncoder104 = device0.createCommandEncoder({});
+let renderBundle5 = renderBundleEncoder5.finish({});
+let sampler70 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.27,
+});
+try {
+computePassEncoder13.setBindGroup(3, bindGroup58);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline6);
+} catch {}
+let recycledExplicitBindGroupLayout33 = pipeline6.getBindGroupLayout(0);
+let bindGroup62 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout15,
+  entries: [{binding: 41, resource: {buffer: buffer44, offset: 1280, size: 4072}}],
+});
+let commandEncoder105 = device0.createCommandEncoder({});
+let computePassEncoder83 = commandEncoder104.beginComputePass();
+let externalTexture12 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder18.setBindGroup(2, bindGroup28, new Uint32Array(275), 3, 0);
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(3, buffer48, 0, 308);
+} catch {}
+try {
+commandEncoder105.copyBufferToTexture({
+  /* bytesInLastRow: 296 widthInBlocks: 37 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2368 */
+  offset: 2368,
+  rowsPerImage: 1049,
+  buffer: buffer67,
+}, {
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 37, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder105.resolveQuerySet(querySet9, 220, 3, buffer82, 0);
+} catch {}
+let recycledExplicitBindGroupLayout34 = pipeline6.getBindGroupLayout(0);
+let textureView111 = texture105.createView({mipLevelCount: 1});
+let computePassEncoder84 = commandEncoder105.beginComputePass({});
+try {
+computePassEncoder84.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(0, buffer91, 0, 133);
+} catch {}
+try {
+buffer93.unmap();
+} catch {}
+await gc();
+let texture113 = gpuCanvasContext0.getCurrentTexture();
+let sampler71 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 89.22,
+  maxAnisotropy: 1,
+});
+let externalTexture13 = device0.importExternalTexture({source: videoFrame1});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup25, new Uint32Array(856), 75, 0);
+} catch {}
+let buffer106 = device0.createBuffer({
+  size: 6153,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder106 = device0.createCommandEncoder();
+let textureView112 = texture31.createView({baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder73.setBindGroup(1, bindGroup50, new Uint32Array(3639), 310, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup44);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle0, renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer0, 'uint32', 636, 5_837);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer30, 192, new BigUint64Array(996), 188, 64);
+} catch {}
+let buffer107 = device0.createBuffer({
+  size: 4626,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup5, new Uint32Array(2394), 1_288, 0);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(6, buffer47);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(7, buffer93, 0);
+} catch {}
+let buffer108 = device0.createBuffer({
+  size: 3102,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture114 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 282},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder25 = commandEncoder106.beginRenderPass({
+  colorAttachments: [{
+  view: textureView32,
+  depthSlice: 6,
+  clearValue: { r: 13.34, g: -627.6, b: 967.0, a: -766.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['rg32uint'], depthReadOnly: true});
+let renderBundle6 = renderBundleEncoder6.finish({});
+try {
+computePassEncoder60.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup44);
+} catch {}
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: imageData9,
+  origin: { x: 4, y: 0 },
+  flipY: true,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 525},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData21 = new ImageData(4, 8);
+let bindGroup63 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout6,
+  entries: [{binding: 41, resource: {buffer: buffer47, offset: 1280, size: 6408}}],
+});
+try {
+computePassEncoder81.setBindGroup(2, bindGroup44);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(5, buffer49);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+try {
+globalThis.someLabel = commandEncoder101.label;
+} catch {}
+let buffer109 = device0.createBuffer({
+  size: 15532,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder107 = device0.createCommandEncoder({});
+let computePassEncoder85 = commandEncoder107.beginComputePass({});
+let sampler72 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder40.setBindGroup(1, bindGroup50, new Uint32Array(3506), 1_457, 0);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer39, 'uint16', 138, 4_014);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(2, buffer35, 0, 1_103);
+} catch {}
+try {
+computePassEncoder61.popDebugGroup();
+} catch {}
+let texture115 = device0.createTexture({
+  size: [4, 4, 9],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder78.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+computePassEncoder85.setPipeline(pipeline5);
+} catch {}
+try {
+buffer94.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer106, 168, new Float32Array(23123), 66, 352);
+} catch {}
+document.body.prepend(canvas1);
+let commandEncoder108 = device0.createCommandEncoder({});
+let renderPassEncoder26 = commandEncoder108.beginRenderPass({colorAttachments: [{view: textureView109, depthSlice: 31, loadOp: 'clear', storeOp: 'discard'}]});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['r32uint'], sampleCount: 1, depthReadOnly: true});
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup38, new Uint32Array(613), 18, 0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup58, new Uint32Array(1442), 73, 0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer24, 'uint16', 20_700, 8_164);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline12);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+document.body.prepend(canvas1);
+try {
+adapter0.label = '\uac5a\u31df\uaa32\uc46e\u93e8\u819e\uca29';
+} catch {}
+let recycledExplicitBindGroupLayout35 = pipeline1.getBindGroupLayout(0);
+let textureView113 = texture100.createView({});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['r32uint']});
+let renderBundle7 = renderBundleEncoder8.finish({});
+try {
+computePassEncoder70.setBindGroup(2, bindGroup50, new Uint32Array(1734), 401, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup45, new Uint32Array(3198), 234, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer52, 'uint32', 516, 3_061);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(3, buffer81, 1_472);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup25, new Uint32Array(705), 58, 0);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline12);
+} catch {}
+try {
+  await promise16;
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(6, 171);
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(2, buffer35);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer92, 1420, new Int16Array(14158), 1419, 800);
+} catch {}
+let recycledExplicitBindGroupLayout36 = pipeline9.getBindGroupLayout(0);
+let bindGroup64 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout10,
+  entries: [{binding: 41, resource: {buffer: buffer62, offset: 1792, size: 5656}}],
+});
+let texture116 = device0.createTexture({
+  size: [32, 1, 1],
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView114 = texture65.createView({dimension: 'cube-array', baseArrayLayer: 2, arrayLayerCount: 6});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup51);
+} catch {}
+try {
+renderPassEncoder15.setViewport(147.30081862607966, 0.8268363297552386, 85.65214684847814, 0.006706502090132152, 0.7805995909580276, 0.8728967219313655);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(1, buffer52, 900, 1_622);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup5, []);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer62, 'uint32', 7_168, 3_466);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(7, undefined, 218_385_533, 459_175_687);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let renderBundle8 = renderBundleEncoder7.finish({});
+try {
+computePassEncoder70.setBindGroup(0, bindGroup6, new Uint32Array(8), 1, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup48, new Uint32Array(453), 163, 0);
+} catch {}
+try {
+renderPassEncoder7.setViewport(217.6809420895609, 0.09057721616356262, 36.10955374395147, 0.014060923465540262, 0.6109619807821214, 0.7340429388281775);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer62, 'uint32', 4_388, 6_736);
+} catch {}
+let bindGroup65 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout9,
+  entries: [
+    {binding: 162, resource: textureView40},
+    {binding: 48, resource: textureView13},
+    {binding: 119, resource: {buffer: buffer92, offset: 1024, size: 1381}},
+    {binding: 41, resource: {buffer: buffer79, offset: 0, size: 440}},
+    {binding: 83, resource: {buffer: buffer14, offset: 7424, size: 220}},
+    {binding: 977, resource: {buffer: buffer108, offset: 0, size: 1187}},
+    {binding: 46, resource: externalTexture4},
+  ],
+});
+let externalTexture14 = device0.importExternalTexture({source: videoFrame16});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup45, new Uint32Array(221), 28, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer64, 'uint32', 6_860, 174);
+} catch {}
+try {
+computePassEncoder52.insertDebugMarker('\u61c1');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: imageData16,
+  origin: { x: 14, y: 7 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'smpte240m', transfer: 'bt2020_10bit'} });
+let veryExplicitBindGroupLayout23 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 22,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 154,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup66 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout6,
+  entries: [{binding: 41, resource: {buffer: buffer69, offset: 0, size: 292}}],
+});
+let buffer110 = device0.createBuffer({size: 519, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder109 = device0.createCommandEncoder({});
+let computePassEncoder86 = commandEncoder109.beginComputePass({});
+let sampler73 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 53.92,
+});
+try {
+computePassEncoder86.setBindGroup(1, bindGroup24, new Uint32Array(834), 192, 0);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline6);
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas1.getContext('webgpu');
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let commandEncoder110 = device0.createCommandEncoder({});
+let renderPassEncoder27 = commandEncoder110.beginRenderPass({
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: -632.2, g: -144.9, b: 628.8, a: 284.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet9,
+  maxDrawCount: 194029409,
+});
+let sampler74 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', compare: 'greater'});
+try {
+computePassEncoder85.setBindGroup(0, bindGroup51, new Uint32Array(2178), 210, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer64, 'uint32', 4_440, 2_421);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(6, undefined, 1_011_338_782, 383_336_623);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let texture117 = device0.createTexture({
+  size: [4, 4, 17],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder65); computePassEncoder65.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup19, new Uint32Array(2769), 1_027, 0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer32, 'uint32', 124, 108);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(4, buffer82);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let commandEncoder111 = device0.createCommandEncoder({});
+let texture118 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 3},
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView115 = texture57.createView({arrayLayerCount: 1});
+let computePassEncoder87 = commandEncoder111.beginComputePass();
+try {
+computePassEncoder72.setBindGroup(1, bindGroup44, new Uint32Array(771), 114, 0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup13, new Uint32Array(1186), 85, 0);
+} catch {}
+try {
+renderPassEncoder24.setViewport(16.67310082391109, 0.19131280074332435, 72.02535778736755, 0.10236979216973477, 0.8879261582798573, 0.9215144052185912);
+} catch {}
+await gc();
+try {
+device0.queue.label = '\u8922\u5e35\u2f3d\u7d60\u9bb2\ue98d';
+} catch {}
+let bindGroup67 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout5,
+  entries: [{binding: 41, resource: {buffer: buffer83, offset: 256, size: 596}}],
+});
+let commandEncoder112 = device0.createCommandEncoder({});
+let texture119 = device0.createTexture({
+  size: {width: 32, height: 1, depthOrArrayLayers: 30},
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup13, new Uint32Array(788), 23, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder65); computePassEncoder65.dispatchWorkgroupsIndirect(buffer92, 2_624); };
+} catch {}
+try {
+computePassEncoder87.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup63);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(0, buffer107, 0, 1_017);
+} catch {}
+try {
+commandEncoder112.copyBufferToBuffer(buffer44, 1140, buffer13, 360, 64);
+} catch {}
+try {
+commandEncoder112.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 120 */
+  offset: 120,
+  buffer: buffer26,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 9},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let imageBitmap5 = await createImageBitmap(videoFrame3);
+let commandEncoder113 = device0.createCommandEncoder({});
+let texture120 = device0.createTexture({
+  size: {width: 32, height: 1, depthOrArrayLayers: 171},
+  mipLevelCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder88 = commandEncoder112.beginComputePass();
+let renderPassEncoder28 = commandEncoder113.beginRenderPass({colorAttachments: [{view: textureView32, depthSlice: 9, loadOp: 'clear', storeOp: 'store'}]});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup62, new Uint32Array(776), 66, 0);
+} catch {}
+try {
+computePassEncoder88.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder20.draw(66, 0, 933_330_259, 9);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(0, buffer17, 21_684, 55);
+} catch {}
+let bindGroup68 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout23,
+  entries: [
+    {binding: 977, resource: {buffer: buffer105, offset: 1024}},
+    {binding: 83, resource: {buffer: buffer77, offset: 1024, size: 4557}},
+    {binding: 46, resource: externalTexture9},
+    {binding: 162, resource: textureView59},
+    {binding: 48, resource: textureView10},
+    {binding: 41, resource: {buffer: buffer106, offset: 2048, size: 784}},
+    {binding: 119, resource: {buffer: buffer68, offset: 1280}},
+  ],
+});
+let commandEncoder114 = device0.createCommandEncoder({label: '\ub180\u108c\u{1f876}\uc6fe\u1bcf\ubf02\u8421\u{1f753}'});
+let textureView116 = texture92.createView({dimension: '2d', mipLevelCount: 1});
+let computePassEncoder89 = commandEncoder114.beginComputePass();
+try {
+computePassEncoder89.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+renderPassEncoder20.drawIndirect(buffer105, 244);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer77, 'uint16', 6_496, 1_054);
+} catch {}
+try {
+computePassEncoder80.setBindGroup(2, bindGroup64);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(3, bindGroup39, new Uint32Array(1808), 219, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer77, 'uint16', 1_798, 317);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(24, 350);
+let videoFrame19 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'unspecified', transfer: 'hlg'} });
+let commandEncoder115 = device0.createCommandEncoder({});
+let computePassEncoder90 = commandEncoder115.beginComputePass();
+try {
+computePassEncoder61.setBindGroup(2, bindGroup31);
+} catch {}
+try {
+computePassEncoder90.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup31, new Uint32Array(305), 38, 0);
+} catch {}
+try {
+renderPassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(143);
+} catch {}
+try {
+renderPassEncoder5.draw(78, 4, 183_952_345);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline8);
+} catch {}
+try {
+buffer65.unmap();
+} catch {}
+try {
+commandEncoder91.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 16 */
+  offset: 16,
+  bytesPerRow: 39680,
+  buffer: buffer37,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup69 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout18,
+  entries: [
+    {binding: 119, resource: {buffer: buffer91, offset: 0, size: 334}},
+    {binding: 48, resource: textureView13},
+    {binding: 41, resource: {buffer: buffer24, offset: 11264, size: 404}},
+    {binding: 977, resource: {buffer: buffer42, offset: 8192, size: 2697}},
+    {binding: 162, resource: textureView99},
+    {binding: 83, resource: {buffer: buffer0, offset: 0, size: 5080}},
+    {binding: 46, resource: externalTexture5},
+  ],
+});
+let texture121 = gpuCanvasContext3.getCurrentTexture();
+try {
+computePassEncoder20.setBindGroup(1, bindGroup45, new Uint32Array(1365), 154, 0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup32, new Uint32Array(2883), 13, 0);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer106, 368);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder91.copyBufferToTexture({
+  /* bytesInLastRow: 88 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1120 */
+  offset: 1120,
+  bytesPerRow: 3840,
+  rowsPerImage: 11,
+  buffer: buffer2,
+}, {
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 68, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let texture122 = device0.createTexture({size: [65, 1, 1], format: 'stencil8', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder91 = commandEncoder91.beginComputePass();
+let sampler75 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat'});
+try {
+computePassEncoder64.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+renderPassEncoder7.setViewport(238.81848067625506, 0.441300093389713, 8.244549943350371, 0.508808544903306, 0.43396234047625937, 0.6077151355017594);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer29, 1_048);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer94, 'uint32', 1_480, 259);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView117 = texture86.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroupsIndirect(buffer43, 612); };
+} catch {}
+try {
+computePassEncoder91.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder5.draw(23, 0, 1_184_659_903, 3);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(0, 1, 0, -1_700_653_745, 1);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(3, buffer29, 2_396);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 404, new Int16Array(25275), 12132, 540);
+} catch {}
+try {
+adapter0.label = '\ue412\u1625';
+} catch {}
+try {
+globalThis.someLabel = textureView65.label;
+} catch {}
+let recycledExplicitBindGroupLayout37 = pipeline7.getBindGroupLayout(0);
+let bindGroup70 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout14,
+  entries: [
+    {binding: 48, resource: textureView13},
+    {binding: 41, resource: {buffer: buffer81, offset: 0}},
+    {binding: 46, resource: externalTexture9},
+    {binding: 162, resource: textureView107},
+    {binding: 977, resource: {buffer: buffer0, offset: 256, size: 203}},
+    {binding: 83, resource: {buffer: buffer82, offset: 0}},
+    {binding: 119, resource: {buffer: buffer34, offset: 1024, size: 3333}},
+  ],
+});
+let commandEncoder116 = device0.createCommandEncoder({});
+let computePassEncoder92 = commandEncoder116.beginComputePass({});
+let sampler76 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 80.26,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder88.setBindGroup(1, bindGroup43, new Uint32Array(9764), 1_260, 0);
+} catch {}
+try {
+computePassEncoder92.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(0, 0, 0, -1_569_855_282, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer24, 14_580);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 232},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise17;
+} catch {}
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 1586});
+let textureView118 = texture59.createView({dimension: 'cube-array', mipLevelCount: 1, arrayLayerCount: 6});
+let sampler77 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 77.27,
+});
+try {
+renderPassEncoder5.draw(38, 1, 1_780_704_761);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(0, 1, 0, -1_820_564_463);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer69, 136);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer75, 'uint32', 3_596, 719);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer40, 2716, new BigUint64Array(17003), 207, 56);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame20 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'smpte240m', transfer: 'bt709'} });
+let recycledExplicitBindGroupLayout38 = pipeline7.getBindGroupLayout(0);
+let buffer111 = device0.createBuffer({size: 2975, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+let textureView119 = texture106.createView({dimension: '2d', baseArrayLayer: 2});
+let sampler78 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat'});
+try {
+computePassEncoder54.setBindGroup(2, bindGroup49, new Uint32Array(642), 54, 0);
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(0, 0, 0, 320_761_590, 1);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer80, 168);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer30, 1_352);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer34, 1_976);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+renderPassEncoder9.pushDebugGroup('\u09d4');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 4, y: 0 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 83},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u{1fb1f}\u{1f77c}';
+} catch {}
+let bindGroup71 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout12,
+  entries: [{binding: 41, resource: {buffer: buffer79, offset: 256, size: 624}}],
+});
+let commandEncoder117 = device0.createCommandEncoder({});
+let computePassEncoder93 = commandEncoder117.beginComputePass({});
+try {
+computePassEncoder28.end();
+} catch {}
+try {
+computePassEncoder93.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder9.setViewport(55.75724254770358, 0.22971655627562448, 128.3495147532322, 0.17842695290167232, 0.8847189935444125, 0.910255103697778);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer51, 2_944);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(4, buffer30);
+} catch {}
+try {
+renderPassEncoder9.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 32},
+  aspect: 'all',
+}, new Uint8Array(154_542).fill(191), /* required buffer size: 154_542 */
+{offset: 129, bytesPerRow: 43, rowsPerImage: 63}, {width: 0, height: 0, depthOrArrayLayers: 58});
+} catch {}
+let recycledExplicitBindGroupLayout39 = pipeline7.getBindGroupLayout(0);
+let bindGroup72 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 304, resource: {buffer: buffer81, offset: 0}}],
+});
+let commandEncoder118 = device0.createCommandEncoder({});
+let renderPassEncoder29 = commandEncoder32.beginRenderPass({
+  colorAttachments: [{
+  view: textureView111,
+  depthSlice: 12,
+  clearValue: { r: -561.3, g: 391.9, b: -788.0, a: 108.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder17.executeBundles([renderBundle6, renderBundle6, renderBundle6, renderBundle6]);
+} catch {}
+let bindGroup73 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout20,
+  entries: [{binding: 304, resource: {buffer: buffer26, offset: 6144, size: 11604}}],
+});
+let commandEncoder119 = device0.createCommandEncoder();
+let sampler79 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', minFilter: 'nearest'});
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroupsIndirect(buffer18, 36); };
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 523.3, g: 271.0, b: 578.7, a: 559.1, });
+} catch {}
+let bindGroup74 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 46, resource: externalTexture8},
+    {binding: 977, resource: {buffer: buffer111, offset: 0, size: 240}},
+    {binding: 119, resource: {buffer: buffer45, offset: 256, size: 700}},
+    {binding: 162, resource: textureView72},
+    {binding: 83, resource: {buffer: buffer34, offset: 768, size: 4268}},
+    {binding: 48, resource: textureView13},
+    {binding: 41, resource: {buffer: buffer82, offset: 256}},
+  ],
+});
+let buffer112 = device0.createBuffer({
+  size: 2532,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder120 = device0.createCommandEncoder();
+let texture123 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler80 = device0.createSampler({});
+try {
+renderPassEncoder12.setIndexBuffer(buffer36, 'uint32', 248, 122);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline8);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: videoFrame20,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 55},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas2.width = 99;
+let commandEncoder121 = device0.createCommandEncoder();
+let texture124 = device0.createTexture({
+  size: [4, 4, 17],
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder94 = commandEncoder118.beginComputePass({});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+buffer94.unmap();
+} catch {}
+let recycledExplicitBindGroupLayout40 = pipeline5.getBindGroupLayout(0);
+let bindGroup75 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout14,
+  entries: [
+    {binding: 46, resource: externalTexture10},
+    {binding: 48, resource: textureView13},
+    {binding: 162, resource: textureView72},
+    {binding: 83, resource: {buffer: buffer64, offset: 1536}},
+    {binding: 977, resource: {buffer: buffer26, offset: 3584, size: 5137}},
+    {binding: 119, resource: {buffer: buffer31, offset: 5120}},
+    {binding: 41, resource: {buffer: buffer0, offset: 512, size: 3260}},
+  ],
+});
+let commandEncoder122 = device0.createCommandEncoder({});
+let texture125 = device0.createTexture({
+  size: [130],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder95 = commandEncoder119.beginComputePass({label: '\u{1f8ed}\udf67\u06c3\u8e0a'});
+let renderPassEncoder30 = commandEncoder120.beginRenderPass({
+  colorAttachments: [{
+  view: textureView48,
+  depthSlice: 4,
+  clearValue: { r: -765.5, g: -135.9, b: -922.3, a: -872.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 48763794,
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['rg32uint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle9 = renderBundleEncoder9.finish({});
+try {
+computePassEncoder95.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer83, 'uint32', 132, 875);
+} catch {}
+let buffer113 = device0.createBuffer({size: 8517, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder123 = device0.createCommandEncoder();
+let textureView120 = texture124.createView({dimension: 'cube', baseMipLevel: 0});
+let computePassEncoder96 = commandEncoder123.beginComputePass({});
+try {
+computePassEncoder86.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(3, bindGroup35, new Uint32Array(632), 40, 0);
+} catch {}
+try {
+computePassEncoder65.end();
+} catch {}
+try {
+computePassEncoder94.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup51);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup20, new Uint32Array(1002), 151, 0);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer110, 32, new Float32Array(5530), 104, 40);
+} catch {}
+let textureView121 = texture125.createView({aspect: 'all', format: 'r32float'});
+try {
+computePassEncoder43.setBindGroup(1, bindGroup64, []);
+} catch {}
+try {
+computePassEncoder32.setBindGroup(0, bindGroup19, new Uint32Array(1005), 962, 0);
+} catch {}
+try {
+computePassEncoder96.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(53);
+} catch {}
+try {
+renderPassEncoder12.setViewport(22.43774271483412, 0.625084270636933, 32.49860055047806, 0.1331866257132885, 0.46915022613094726, 0.550434722789368);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(4, buffer48);
+} catch {}
+try {
+commandEncoder84.copyBufferToBuffer(buffer69, 164, buffer4, 1320, 164);
+} catch {}
+try {
+commandEncoder84.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4500 */
+  offset: 4500,
+  bytesPerRow: 3328,
+  buffer: buffer109,
+}, {
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 43},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas2.getContext('webgpu');
+try {
+externalTexture0.label = '\u1d5c\u2ba5\u5161\u8d96\u{1fd93}\u99fe\uf365\u3fc5\u32bf\u97c9\ub362';
+} catch {}
+let bindGroup76 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 48, resource: textureView13},
+    {binding: 162, resource: textureView40},
+    {binding: 977, resource: {buffer: buffer15, offset: 4864, size: 2074}},
+    {binding: 119, resource: {buffer: buffer15, offset: 1280, size: 1349}},
+    {binding: 83, resource: {buffer: buffer14, offset: 19456, size: 381}},
+    {binding: 46, resource: externalTexture8},
+    {binding: 41, resource: {buffer: buffer62, offset: 7936, size: 1316}},
+  ],
+});
+let buffer114 = device0.createBuffer({size: 14608, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let commandEncoder124 = device0.createCommandEncoder({});
+let texture126 = device0.createTexture({
+  size: [4, 4, 17],
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView122 = texture19.createView({aspect: 'stencil-only'});
+let sampler81 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder69); computePassEncoder69.dispatchWorkgroupsIndirect(buffer64, 1_008); };
+} catch {}
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer62, 'uint16', 18_754, 0);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer42, 8248, new BigUint64Array(16786), 7711, 184);
+} catch {}
+document.body.prepend(img0);
+let bindGroup77 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout38,
+  entries: [
+    {binding: 48, resource: textureView13},
+    {binding: 162, resource: textureView66},
+    {binding: 119, resource: {buffer: buffer75, offset: 512, size: 6282}},
+    {binding: 41, resource: {buffer: buffer108, offset: 512, size: 1260}},
+    {binding: 977, resource: {buffer: buffer30, offset: 0, size: 1452}},
+    {binding: 46, resource: externalTexture7},
+    {binding: 83, resource: {buffer: buffer91, offset: 512, size: 13}},
+  ],
+});
+let sampler82 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 54.50,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup64, new Uint32Array(566), 100, 0);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(9);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer108, 'uint32', 96, 604);
+} catch {}
+try {
+commandEncoder124.copyBufferToBuffer(buffer100, 356, buffer93, 2272, 704);
+} catch {}
+await gc();
+let recycledExplicitBindGroupLayout41 = pipeline8.getBindGroupLayout(0);
+let bindGroup78 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout7,
+  entries: [{binding: 41, resource: {buffer: buffer81, offset: 1280}}],
+});
+let buffer115 = device0.createBuffer({
+  size: 6101,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView123 = texture126.createView({dimension: 'cube-array', baseArrayLayer: 2, arrayLayerCount: 6});
+let computePassEncoder97 = commandEncoder27.beginComputePass({});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup8, new Uint32Array(174), 0, 0);
+} catch {}
+try {
+computePassEncoder97.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer42, 'uint32', 3_540, 1_227);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline12);
+} catch {}
+let bindGroup79 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout15,
+  entries: [
+    {binding: 83, resource: {buffer: buffer26, offset: 0, size: 7541}},
+    {binding: 119, resource: {buffer: buffer38, offset: 1024}},
+    {binding: 41, resource: {buffer: buffer51, offset: 0, size: 10644}},
+    {binding: 162, resource: textureView41},
+    {binding: 48, resource: textureView13},
+    {binding: 46, resource: externalTexture13},
+    {binding: 977, resource: {buffer: buffer62, offset: 3584, size: 769}},
+  ],
+});
+let buffer116 = device0.createBuffer({
+  size: 7811,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandBuffer12 = commandEncoder84.finish();
+let renderPassEncoder31 = commandEncoder124.beginRenderPass({colorAttachments: [{view: textureView17, depthSlice: 5, loadOp: 'clear', storeOp: 'store'}]});
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+renderPassEncoder31.setViewport(14.158599523869167, 0.20041499947331165, 98.55450771550875, 0.019923230330906712, 0.19863310548893176, 0.24054825888536296);
+} catch {}
+let arrayBuffer2 = buffer100.getMappedRange(792, 76);
+try {
+commandEncoder121.copyBufferToBuffer(buffer26, 15888, buffer92, 4028, 216);
+} catch {}
+try {
+commandEncoder121.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 112},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder98 = commandEncoder121.beginComputePass({});
+try {
+computePassEncoder98.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(2, bindGroup62, new Uint32Array(55), 1, 0);
+} catch {}
+try {
+adapter0.label = '\u{1fbbb}\u{1f97f}\ue583';
+} catch {}
+let textureView124 = texture126.createView({dimension: 'cube-array', baseMipLevel: 0, baseArrayLayer: 1, arrayLayerCount: 6});
+let texture127 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView125 = texture120.createView({dimension: '2d', aspect: 'stencil-only', baseArrayLayer: 33});
+let renderPassEncoder32 = commandEncoder122.beginRenderPass({
+  colorAttachments: [{
+  view: textureView89,
+  clearValue: { r: 472.3, g: 169.2, b: 83.02, a: -350.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView40, stencilReadOnly: true},
+});
+try {
+computePassEncoder96.setBindGroup(2, bindGroup63, new Uint32Array(670), 58, 0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+let buffer117 = device0.createBuffer({size: 15628, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder125 = device0.createCommandEncoder({});
+let computePassEncoder99 = commandEncoder125.beginComputePass({});
+let sampler83 = device0.createSampler({addressModeU: 'repeat', minFilter: 'linear', compare: 'not-equal'});
+let externalTexture15 = device0.importExternalTexture({source: videoFrame7});
+try {
+computePassEncoder74.setBindGroup(2, bindGroup28, []);
+} catch {}
+try {
+computePassEncoder99.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer116, 'uint32', 84, 119);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(0).fill(116), /* required buffer size: 0 */
+{offset: 0}, {width: 76, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img1);
+let buffer118 = device0.createBuffer({
+  label: '\ueeab\u{1fe04}\u0b9d',
+  size: 6081,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder126 = device0.createCommandEncoder({});
+let textureView126 = texture63.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 11});
+let computePassEncoder100 = commandEncoder126.beginComputePass({});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup72);
+} catch {}
+try {
+computePassEncoder60.end();
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup71);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup73, new Uint32Array(588), 105, 0);
+} catch {}
+let buffer119 = device0.createBuffer({
+  size: 1148,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView127 = texture125.createView({aspect: 'all', format: 'r32float', mipLevelCount: 1});
+let renderPassEncoder33 = commandEncoder75.beginRenderPass({
+  colorAttachments: [{
+  view: textureView57,
+  clearValue: { r: 961.2, g: 881.3, b: 635.1, a: 821.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView46,
+    depthClearValue: -2.7785449299072074,
+    depthReadOnly: true,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'store',
+  },
+  occlusionQuerySet: querySet2,
+});
+try {
+computePassEncoder100.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup34, new Uint32Array(1924), 76, 0);
+} catch {}
+try {
+  await promise18;
+} catch {}
+let commandEncoder127 = device0.createCommandEncoder({});
+let texture128 = device0.createTexture({size: [260], dimension: '1d', format: 'r32uint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder101 = commandEncoder127.beginComputePass();
+let sampler84 = device0.createSampler({addressModeW: 'repeat', minFilter: 'linear', mipmapFilter: 'linear', lodMaxClamp: 90.18});
+let externalTexture16 = device0.importExternalTexture({source: videoFrame11});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup58);
+} catch {}
+try {
+computePassEncoder86.setBindGroup(2, bindGroup44, new Uint32Array(1207), 135, 0);
+} catch {}
+try {
+computePassEncoder101.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer38, 'uint16', 1_400, 1_915);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(5, buffer3, 0, 78);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.append(img1);
+let autogeneratedBindGroupLayout20 = pipeline3.getBindGroupLayout(0);
+let commandEncoder128 = device0.createCommandEncoder({});
+let computePassEncoder102 = commandEncoder128.beginComputePass();
+try {
+computePassEncoder54.setBindGroup(2, bindGroup40, []);
+} catch {}
+try {
+computePassEncoder37.setBindGroup(2, bindGroup38, new Uint32Array(512), 123, 0);
+} catch {}
+try {
+computePassEncoder102.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup19, new Uint32Array(1829), 491, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer62, 32, new DataView(new ArrayBuffer(2003)), 28, 388);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let shaderModule9 = device0.createShaderModule({
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires pointer_composite_access;
+
+@group(0) @binding(498) var st9: texture_storage_1d<r32uint, write>;
+
+var<workgroup> vw43: atomic<i32>;
+
+var<private> vp9: VertexOutput7 = VertexOutput7(u32(822), vec4f(0.1033, 0.2926, 0.1860, 0.1361));
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw44: atomic<i32>;
+
+fn fn2() -> FragmentOutput9 {
+  var out: FragmentOutput9;
+  let ptr111: ptr<private, vec4f> = &vp9.f24;
+  var vf140: vec2f = saturate(vec2f(unconst_f32(0.06773), unconst_f32(0.1300)));
+  return out;
+}
+
+var<private> vp10: mat4x2h = mat4x2h();
+
+@group(0) @binding(31) var tex9: texture_3d<f32>;
+
+var<workgroup> vw42: atomic<i32>;
+
+fn fn0() -> array<vec2f, 1> {
+  var out: array<vec2f, 1>;
+  let ptr103: ptr<workgroup, atomic<i32>> = &(*&vw44);
+  var vf127: f16 = vw45[u32(unconst_u32(68))][u32(unconst_u32(429))];
+  var vf128: f32 = length(f32(unconst_f32(0.08356)));
+  let vf129: vec2h = vp10[u32(unconst_u32(254))];
+  let ptr104: ptr<workgroup, atomic<i32>> = &vw42;
+  let ptr105: ptr<workgroup, mat4x2h> = &(*&vw45);
+  let ptr106: ptr<workgroup, mat4x2h> = &(*ptr105);
+  let vf130: i32 = atomicExchange(&vw43, i32(unconst_i32(166)));
+  atomicMin(&vw43, i32(unconst_i32(132)));
+  let vf131: vec2h = vf129;
+  vf128 = round(vec3f(unconst_f32(0.09747), unconst_f32(0.3458), unconst_f32(0.6608))).r;
+  return out;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  f0: array<u32>,
+}
+
+fn fn1() {
+  vp11 = VertexOutput7(bitcast<u32>(vp10[unconst_i32(0)]), vec4f(vp10[unconst_i32(2)].yxxx));
+  let vf132: f16 = dot(vec2h(unconst_f16(21742.6), unconst_f16(2488.6)), vec2h(unconst_f16(26156.9), unconst_f16(-16887.6)));
+  let ptr107: ptr<private, vec4f> = &vp11.f24;
+  vp9 = VertexOutput7(vec3u(sin(vec3h(unconst_f16(7053.9), unconst_f16(3479.4), unconst_f16(7585.6))))[1], vec4f(sin(vec3h(unconst_f16(7053.9), unconst_f16(3479.4), unconst_f16(7585.6))).rrrb));
+  vp9 = VertexOutput7(u32(dot(vec2h(unconst_f16(18437.8), unconst_f16(5863.8)), vec2h(unconst_f16(5258.1), unconst_f16(4444.0)))), vec4f(f32(dot(vec2h(unconst_f16(18437.8), unconst_f16(5863.8)), vec2h(unconst_f16(5258.1), unconst_f16(4444.0))))));
+  let vf133: f16 = smoothstep(f16(unconst_f16(11834.7)), f16(unconst_f16(1199.8)), f16(unconst_f16(4911.5)));
+  var vf134: f32 = vp9.f24[u32(vf133)];
+  vf134 = mix(vec2f(unconst_f32(0.05128), unconst_f32(0.08432)), vec2f(unconst_f32(0.04100), unconst_f32(0.08271)), vec2f(unconst_f32(-0.02148), unconst_f32(0.00306)))[1];
+  let vf135: u32 = textureNumLevels(tex9);
+  vf134 = f32(vf135);
+  var vf136: vec4f = textureLoad(tex9, vec3i(unconst_i32(6), unconst_i32(50), unconst_i32(490)), i32(unconst_i32(101)));
+  let ptr108: ptr<private, vec4f> = &vp9.f24;
+  vf136 *= mix(vec2f(unconst_f32(0.03001), unconst_f32(0.04086)), vec2f(f32(vf132)), vec2f(unconst_f32(0.09047), unconst_f32(-0.06971))).xxyy;
+  var vf137: vec2f = mix(vec2f(unconst_f32(0.2384), unconst_f32(0.06327)), vec2f(unconst_f32(0.1958), unconst_f32(0.08374)), vec2f(unconst_f32(0.2822), unconst_f32(-0.2852)));
+  let ptr109: ptr<private, vec4f> = &vp9.f24;
+  let ptr110: ptr<private, u32> = &vp9.f23;
+  vp9.f24 -= vec4f(vf136[u32(unconst_u32(29))]);
+  vp11.f23 = pack4xU8(insertBits(vec4u(unconst_u32(267), unconst_u32(45), unconst_u32(78), unconst_u32(102)), vec4u(unconst_u32(11), unconst_u32(93), unconst_u32(8), unconst_u32(518)), vp11.f23, u32(unconst_u32(106))));
+  let vf138: vec4u = insertBits(vec4u(unconst_u32(272), unconst_u32(345), unconst_u32(258), unconst_u32(10)), vec4u(unconst_u32(244), unconst_u32(271), unconst_u32(92), unconst_u32(118)), u32(unconst_u32(191)), u32(unconst_u32(220)));
+  vf136 = vf136;
+  let vf139: vec2h = vp10[u32(unconst_u32(217))];
+  _ = tex9;
+}
+
+struct FragmentOutput9 {
+  @location(5) @interpolate(flat, center) f0: vec4i,
+  @location(2) f1: i32,
+  @location(0) f2: vec2u,
+}
+
+var<workgroup> vw45: mat4x2h;
+
+struct VertexOutput7 {
+  @location(7) f23: u32,
+  @builtin(position) f24: vec4f,
+}
+
+var<private> vp11: VertexOutput7 = VertexOutput7(u32(18), vec4f(0.2896, 0.2350, 0.03798, 0.1378));
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@vertex
+fn vertex8(@location(4) a0: vec2u, @location(10) @interpolate(flat) a1: vec4u, @location(9) a2: vec2f, @location(1) a3: vec2f) -> VertexOutput7 {
+  var out: VertexOutput7;
+  out.f23 <<= unpack4xU8(u32(unconst_u32(50))).r;
+  out.f23 -= textureDimensions(tex9, i32(unconst_i32(171))).y;
+  fn1();
+  let vf141: u32 = pack4xU8(vec4u(unconst_u32(158), unconst_u32(390), unconst_u32(104), unconst_u32(343)));
+  var vf142: u32 = pack4xU8(vec4u(vp9.f24));
+  let vf143: f32 = vp11.f24[u32(unconst_u32(29))];
+  vf142 = bitcast<u32>(vp9.f24[u32(unconst_u32(86))]);
+  out.f24 += vec4f(a2[u32(unconst_u32(264))]);
+  return out;
+  _ = tex9;
+}
+
+@fragment
+fn fragment11() -> FragmentOutput9 {
+  var out: FragmentOutput9;
+  out.f2 *= vec2u(vp10[u32(unconst_u32(240))]);
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute8() {
+  fn0();
+  vw45 = (*&vw45);
+  atomicCompareExchangeWeak(&vw42, unconst_i32(-220), unconst_i32(272));
+  textureStore(st9, i32(unconst_i32(17)), vec4u(vec4u(unconst_u32(614), unconst_u32(243), unconst_u32(14), unconst_u32(90))));
+  var vf144: f16 = (*&vw45)[u32(unconst_u32(111))][u32(unconst_u32(594))];
+  _ = st9;
+}`,
+});
+let buffer120 = device0.createBuffer({size: 857, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let commandEncoder129 = device0.createCommandEncoder({});
+let texture129 = device0.createTexture({
+  size: {width: 4, height: 4, depthOrArrayLayers: 17},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder51.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(12, 0, 42, 0);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(1, buffer108, 208, 488);
+} catch {}
+let commandEncoder130 = device0.createCommandEncoder({});
+try {
+computePassEncoder15.setBindGroup(2, bindGroup3, new Uint32Array(479), 21, 0);
+} catch {}
+let canvas3 = document.createElement('canvas');
+let veryExplicitBindGroupLayout24 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 95,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 51, hasDynamicOffset: false },
+    },
+    {
+      binding: 384,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let textureView128 = texture50.createView({dimension: 'cube', baseArrayLayer: 1});
+let texture130 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 72},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView129 = texture129.createView({dimension: '2d-array', baseArrayLayer: 5, arrayLayerCount: 3});
+let computePassEncoder103 = commandEncoder130.beginComputePass();
+let renderPassEncoder34 = commandEncoder129.beginRenderPass({
+  colorAttachments: [{
+  view: textureView17,
+  depthSlice: 3,
+  clearValue: { r: -164.9, g: -583.0, b: 170.8, a: -990.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler85 = device0.createSampler({addressModeU: 'mirror-repeat', mipmapFilter: 'linear', lodMaxClamp: 63.26});
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup38);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(3, bindGroup39, new Uint32Array(3903), 1_343, 0);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline11);
+} catch {}
+let arrayBuffer3 = buffer100.getMappedRange(944, 116);
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let imageData22 = new ImageData(4, 48);
+try {
+device0.label = '\u93eb\u{1f83c}';
+} catch {}
+let buffer121 = device0.createBuffer({size: 330, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let commandEncoder131 = device0.createCommandEncoder({});
+let textureView130 = texture71.createView({});
+let sampler86 = device0.createSampler({addressModeV: 'repeat', lodMaxClamp: 95.38});
+try {
+computePassEncoder80.setBindGroup(2, bindGroup37, new Uint32Array(979), 45, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(51).fill(41), /* required buffer size: 51 */
+{offset: 51}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup80 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout17,
+  entries: [
+    {binding: 48, resource: textureView2},
+    {binding: 41, resource: {buffer: buffer27, offset: 2048, size: 1596}},
+    {binding: 977, resource: {buffer: buffer114, offset: 0}},
+    {binding: 46, resource: externalTexture6},
+    {binding: 162, resource: textureView72},
+    {binding: 119, resource: {buffer: buffer91, offset: 256, size: 217}},
+    {binding: 83, resource: {buffer: buffer30, offset: 1024, size: 378}},
+  ],
+});
+let texture131 = device0.createTexture({
+  label: '\uea61\u29ba\u1ec3\u{1fc90}\u{1f8e8}\u7351\uccd8\u0f1d\u3887\u{1fa88}\uf303',
+  size: {width: 260, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder78); computePassEncoder78.dispatchWorkgroupsIndirect(buffer46, 588); };
+} catch {}
+try {
+computePassEncoder69.end();
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(93);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer39, 492);
+} catch {}
+try {
+commandEncoder61.copyBufferToBuffer(buffer32, 216, buffer41, 12644, 168);
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+let recycledExplicitBindGroupLayout42 = pipeline5.getBindGroupLayout(0);
+let buffer122 = device0.createBuffer({size: 12179, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture132 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 98},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture133 = device0.createTexture({
+  size: {width: 260},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder35 = commandEncoder131.beginRenderPass({
+  colorAttachments: [{
+  view: textureView17,
+  depthSlice: 10,
+  clearValue: { r: -859.3, g: -132.4, b: -103.9, a: -412.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler87 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  compare: 'equal',
+});
+try {
+computePassEncoder103.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup18, new Uint32Array(2893), 1_012, 0);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder61.resolveQuerySet(querySet12, 131, 50, buffer17, 256);
+} catch {}
+let commandEncoder132 = device0.createCommandEncoder({});
+let querySet18 = device0.createQuerySet({type: 'occlusion', count: 195});
+let commandBuffer13 = commandEncoder61.finish();
+let texture134 = device0.createTexture({
+  size: [65, 1, 1],
+  sampleCount: 4,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture135 = device0.createTexture({
+  size: [130, 1, 26],
+  mipLevelCount: 2,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder104 = commandEncoder132.beginComputePass();
+try {
+renderPassEncoder27.setIndexBuffer(buffer91, 'uint32', 28, 26);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: videoFrame15,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 30},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let videoFrame21 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpteSt4281', transfer: 'smpte240m'} });
+let bindGroup81 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout22,
+  entries: [{binding: 498, resource: textureView47}, {binding: 31, resource: textureView105}],
+});
+let commandEncoder133 = device0.createCommandEncoder({});
+let texture136 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 1},
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder105 = commandEncoder133.beginComputePass({});
+try {
+computePassEncoder94.setBindGroup(1, bindGroup23, new Uint32Array(329), 54, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder76); computePassEncoder76.dispatchWorkgroupsIndirect(buffer43, 1_864); };
+} catch {}
+try {
+computePassEncoder104.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer31, 'uint32', 1_380, 686);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer12]);
+} catch {}
+let commandEncoder134 = device0.createCommandEncoder({});
+let textureView131 = texture131.createView({aspect: 'all', arrayLayerCount: 1});
+let computePassEncoder106 = commandEncoder134.beginComputePass({});
+let externalTexture17 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder105.setPipeline(pipeline3);
+} catch {}
+try {
+  await buffer28.mapAsync(GPUMapMode.WRITE, 0, 992);
+} catch {}
+let pipeline14 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout6,
+  multisample: {mask: 0x243d1877},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment11',
+  targets: [{format: 'rg32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {
+        arrayStride: 648,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x4', offset: 164, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front'},
+});
+document.body.prepend(canvas2);
+let texture137 = device0.createTexture({
+  size: [65, 1, 480],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture138 = device0.createTexture({
+  size: {width: 4, height: 4, depthOrArrayLayers: 400},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder66.setBindGroup(0, bindGroup46);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let veryExplicitBindGroupLayout25 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 79,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 101,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 243,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 270,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {binding: 299, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 326,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 601,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder135 = device0.createCommandEncoder();
+let textureView132 = texture102.createView({});
+let sampler88 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 93.29, compare: 'equal'});
+try {
+computePassEncoder93.setBindGroup(2, bindGroup64, new Uint32Array(1029), 211, 0);
+} catch {}
+try {
+computePassEncoder106.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle6, renderBundle6, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer108, 280, 149);
+} catch {}
+let commandEncoder136 = device0.createCommandEncoder({label: '\u{1f77e}\u06a5\u0b76\u32b5\uf013\u059b\u0fa9\u01ea\u0fe6'});
+let textureView133 = texture131.createView({});
+let computePassEncoder107 = commandEncoder135.beginComputePass({});
+let sampler89 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', mipmapFilter: 'linear', lodMaxClamp: 93.41});
+try {
+computePassEncoder86.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+computePassEncoder107.setBindGroup(1, bindGroup32, new Uint32Array(1011), 32, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder78); computePassEncoder78.dispatchWorkgroupsIndirect(buffer24, 7_036); };
+} catch {}
+try {
+computePassEncoder107.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5, buffer91, 0, 92);
+} catch {}
+try {
+commandEncoder136.copyBufferToTexture({
+  /* bytesInLastRow: 1008 widthInBlocks: 126 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 40 */
+  offset: 40,
+  bytesPerRow: 11264,
+  rowsPerImage: 733,
+  buffer: buffer117,
+}, {
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 40, y: 0, z: 15},
+  aspect: 'all',
+}, {width: 126, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(292).fill(190), /* required buffer size: 292 */
+{offset: 292}, {width: 130, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline15 = await device0.createComputePipelineAsync({layout: pipelineLayout7, compute: {module: shaderModule3}});
+document.body.append(canvas0);
+let texture139 = device0.createTexture({
+  size: [4, 4, 10],
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture140 = device0.createTexture({
+  size: [260, 1, 68],
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler90 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 79.07,
+  compare: 'equal',
+});
+try {
+computePassEncoder94.setBindGroup(0, bindGroup77, new Uint32Array(3461), 437, 0);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(1, bindGroup1, new Uint32Array(220), 109, 0);
+} catch {}
+let videoFrame22 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'film', transfer: 'bt709'} });
+let videoFrame23 = new VideoFrame(videoFrame12, {timestamp: 0});
+let buffer123 = device0.createBuffer({size: 11523, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder137 = device0.createCommandEncoder();
+let textureView134 = texture136.createView({aspect: 'all', baseArrayLayer: 0});
+let sampler91 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder101.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup43, new Uint32Array(2825), 1_609, 0);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(6, buffer49, 2_944, 3_622);
+} catch {}
+try {
+renderPassEncoder24.insertDebugMarker('\u3b6c');
+} catch {}
+try {
+device0.queue.submit([commandBuffer13]);
+} catch {}
+document.body.prepend(img1);
+let bindGroup82 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout23,
+  entries: [{binding: 154, resource: textureView48}, {binding: 22, resource: sampler16}],
+});
+let commandEncoder138 = device0.createCommandEncoder({});
+let textureView135 = texture136.createView({dimension: '2d', format: 'r32float'});
+let texture141 = device0.createTexture({size: {width: 4}, dimension: '1d', format: 'r32sint', usage: GPUTextureUsage.STORAGE_BINDING});
+let textureView136 = texture108.createView({});
+let computePassEncoder108 = commandEncoder138.beginComputePass();
+let renderPassEncoder36 = commandEncoder137.beginRenderPass({
+  colorAttachments: [{
+  view: textureView32,
+  depthSlice: 3,
+  clearValue: { r: 476.5, g: -951.0, b: -304.0, a: -843.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet7,
+  maxDrawCount: 215179074,
+});
+try {
+renderPassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder25.setBlendConstant({ r: -442.5, g: 120.1, b: 115.6, a: -550.5, });
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer42, 'uint16', 7_054, 776);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(2, undefined, 172_818_911);
+} catch {}
+try {
+commandEncoder81.copyBufferToBuffer(buffer68, 1380, buffer35, 7020, 1420);
+} catch {}
+try {
+renderPassEncoder15.pushDebugGroup('\ue222');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 0, y: 16 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup83 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout10,
+  entries: [
+    {binding: 48, resource: textureView2},
+    {binding: 119, resource: {buffer: buffer30, offset: 0, size: 1194}},
+    {binding: 162, resource: textureView6},
+    {binding: 977, resource: {buffer: buffer75, offset: 4352, size: 1472}},
+    {binding: 41, resource: {buffer: buffer40, offset: 5888, size: 2480}},
+    {binding: 83, resource: {buffer: buffer76, offset: 256, size: 94}},
+    {binding: 46, resource: externalTexture9},
+  ],
+});
+let textureView137 = texture137.createView({baseMipLevel: 0, baseArrayLayer: 0});
+let renderPassEncoder37 = commandEncoder136.beginRenderPass({
+  colorAttachments: [{
+  view: textureView57,
+  clearValue: { r: 790.3, g: 27.03, b: 804.3, a: -471.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView46,
+    depthClearValue: -6.691747068952887,
+    depthReadOnly: false,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'store',
+  },
+  maxDrawCount: 77328885,
+});
+try {
+computePassEncoder78.setBindGroup(2, bindGroup45, new Uint32Array(1124), 30, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder85); computePassEncoder85.dispatchWorkgroupsIndirect(buffer17, 7_060); };
+} catch {}
+try {
+computePassEncoder108.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup58, new Uint32Array(5171), 134, 0);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer112, 208, 97);
+} catch {}
+try {
+commandEncoder81.copyBufferToBuffer(buffer109, 5524, buffer93, 108, 68);
+} catch {}
+try {
+renderPassEncoder15.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(76).fill(95), /* required buffer size: 76 */
+{offset: 76}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let texture142 = device0.createTexture({
+  size: {width: 4, height: 4, depthOrArrayLayers: 37},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup35, new Uint32Array(667), 113, 0);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle9, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(2, buffer82, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer32, 168, new Int16Array(8261), 1196, 92);
+} catch {}
+let recycledExplicitBindGroupLayout43 = pipeline14.getBindGroupLayout(0);
+let computePassEncoder109 = commandEncoder81.beginComputePass({});
+let sampler92 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 99.58,
+  compare: 'never',
+});
+try {
+computePassEncoder82.setBindGroup(0, bindGroup5, new Uint32Array(1438), 50, 0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup45);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+let bindGroup84 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout22,
+  entries: [
+    {binding: 83, resource: {buffer: buffer34, offset: 0, size: 1056}},
+    {binding: 119, resource: {buffer: buffer91, offset: 0, size: 69}},
+    {binding: 48, resource: textureView10},
+    {binding: 41, resource: {buffer: buffer42, offset: 4608, size: 1896}},
+    {binding: 977, resource: {buffer: buffer45, offset: 256, size: 262}},
+    {binding: 162, resource: textureView0},
+    {binding: 46, resource: externalTexture10},
+  ],
+});
+let buffer124 = device0.createBuffer({size: 17784, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 394});
+let textureView138 = texture117.createView({aspect: 'stencil-only', baseMipLevel: 0, arrayLayerCount: 4});
+let sampler93 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.85,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder86.setBindGroup(2, bindGroup64);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup7, new Uint32Array(1329), 65, 0);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer119, 'uint16', 26, 558);
+} catch {}
+try {
+  await promise19;
+} catch {}
+let textureView139 = texture74.createView({aspect: 'all'});
+let externalTexture18 = device0.importExternalTexture({source: videoFrame1});
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroupsIndirect(buffer106, 60); };
+} catch {}
+try {
+computePassEncoder109.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup69);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer44, 'uint32', 1_992, 8_481);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(5, buffer39, 1_688, 236);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let texture143 = device0.createTexture({
+  size: [4, 4, 17],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler94 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 58.82,
+});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup81, new Uint32Array(3566), 19, 0);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup48, new Uint32Array(2341), 700, 0);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder6.setViewport(40.144918080574364, 0.5915340236688177, 13.936030226872772, 0.07492939042846826, 0.9436263385206477, 0.9678995421903122);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'opaque',
+});
+} catch {}
+let autogeneratedBindGroupLayout21 = pipeline12.getBindGroupLayout(0);
+let bindGroup85 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout33,
+  entries: [
+    {binding: 46, resource: externalTexture12},
+    {binding: 41, resource: {buffer: buffer50, offset: 256, size: 208}},
+    {binding: 48, resource: textureView2},
+    {binding: 977, resource: {buffer: buffer32, offset: 256}},
+    {binding: 119, resource: {buffer: buffer76, offset: 256, size: 816}},
+    {binding: 162, resource: textureView99},
+    {binding: 83, resource: {buffer: buffer30, offset: 0, size: 338}},
+  ],
+});
+let commandEncoder139 = device0.createCommandEncoder({});
+let texture144 = device0.createTexture({
+  size: {width: 32, height: 1, depthOrArrayLayers: 31},
+  mipLevelCount: 2,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView140 = texture48.createView({});
+let computePassEncoder110 = commandEncoder139.beginComputePass({});
+try {
+computePassEncoder24.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup83);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let arrayBuffer4 = buffer100.getMappedRange(1064, 140);
+let offscreenCanvas3 = new OffscreenCanvas(254, 74);
+let texture145 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 1},
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView141 = texture75.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroupsIndirect(buffer92, 1_792); };
+} catch {}
+try {
+computePassEncoder110.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle6, renderBundle0, renderBundle4, renderBundle4, renderBundle9]);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+let sampler95 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 89.82,
+});
+try {
+computePassEncoder20.setBindGroup(1, bindGroup65);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(2, bindGroup6, new Uint32Array(1219), 603, 0);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer77, 'uint16', 1_388, 9_592);
+} catch {}
+try {
+buffer48.unmap();
+} catch {}
+let buffer125 = device0.createBuffer({
+  size: 13992,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder14.setBlendConstant({ r: -470.7, g: -242.6, b: 629.2, a: 842.2, });
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer108, 'uint32', 220, 518);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline11);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(20).fill(103), /* required buffer size: 20 */
+{offset: 20, rowsPerImage: 7}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: imageData12,
+  origin: { x: 2, y: 14 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 11},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let commandEncoder140 = device0.createCommandEncoder({});
+let texture146 = device0.createTexture({
+  size: {width: 32, height: 1, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView142 = texture135.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 2});
+let computePassEncoder111 = commandEncoder140.beginComputePass({});
+try {
+computePassEncoder78.setBindGroup(0, bindGroup84);
+} catch {}
+try {
+computePassEncoder66.setBindGroup(2, bindGroup82, new Uint32Array(17), 1, 0);
+} catch {}
+try {
+computePassEncoder111.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer42, 'uint32', 80, 9_091);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(2_266).fill(239), /* required buffer size: 2_266 */
+{offset: 265, bytesPerRow: 87, rowsPerImage: 23}, {width: 0, height: 0, depthOrArrayLayers: 2});
+} catch {}
+await gc();
+try {
+renderPassEncoder16.setIndexBuffer(buffer38, 'uint32', 312, 4_355);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(4, buffer125);
+} catch {}
+try {
+buffer65.unmap();
+} catch {}
+document.body.append(img1);
+try {
+adapter0.label = '\u28d2\uf1a7';
+} catch {}
+try {
+sampler2.label = '\u94ed\u60ed\u7a0c\u6510';
+} catch {}
+let buffer126 = device0.createBuffer({size: 41980, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder141 = device0.createCommandEncoder();
+let textureView143 = texture24.createView({baseArrayLayer: 3, arrayLayerCount: 2});
+try {
+computePassEncoder89.setBindGroup(0, bindGroup83, new Uint32Array(532), 157, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer95, 4328, new DataView(new ArrayBuffer(11622)), 1359, 1664);
+} catch {}
+let bindGroup86 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [{binding: 346, resource: externalTexture11}, {binding: 216, resource: textureView101}],
+});
+let buffer127 = device0.createBuffer({
+  size: 13773,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder59.setBindGroup(0, bindGroup46, new Uint32Array(450), 14, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder89); computePassEncoder89.dispatchWorkgroupsIndirect(buffer30, 1_248); };
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup72, new Uint32Array(155), 18, 0);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+commandEncoder141.copyBufferToBuffer(buffer39, 20, buffer118, 1320, 200);
+} catch {}
+try {
+commandEncoder141.copyBufferToTexture({
+  /* bytesInLastRow: 130 widthInBlocks: 130 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1552 */
+  offset: 1552,
+  buffer: buffer122,
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 130, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder142 = device0.createCommandEncoder({});
+try {
+computePassEncoder76.end();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData23 = new ImageData(16, 28);
+let textureView144 = texture139.createView({dimension: '3d'});
+let texture147 = device0.createTexture({
+  size: {width: 32, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder38 = commandEncoder141.beginRenderPass({
+  colorAttachments: [{
+  view: textureView111,
+  depthSlice: 46,
+  clearValue: { r: 421.7, g: 357.1, b: -501.7, a: -179.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup18, new Uint32Array(247), 37, 0);
+} catch {}
+let gpuCanvasContext6 = canvas3.getContext('webgpu');
+let commandEncoder143 = device0.createCommandEncoder();
+let texture148 = device0.createTexture({size: [32, 1, 1], format: 'rg32sint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder112 = commandEncoder143.beginComputePass({});
+try {
+computePassEncoder112.setPipeline(pipeline5);
+} catch {}
+let imageData24 = new ImageData(8, 56);
+let renderPassEncoder39 = commandEncoder142.beginRenderPass({
+  colorAttachments: [{
+  view: textureView32,
+  depthSlice: 5,
+  clearValue: { r: 435.9, g: 65.72, b: -461.9, a: -619.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet11,
+  maxDrawCount: 103123856,
+});
+let sampler96 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 91.51,
+  lodMaxClamp: 94.49,
+});
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup38, new Uint32Array(1475), 272, 0);
+} catch {}
+try {
+renderPassEncoder30.setScissorRect(15, 0, 0, 0);
+} catch {}
+try {
+commandEncoder96.copyBufferToTexture({
+  /* bytesInLastRow: 72 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3256 */
+  offset: 3256,
+  bytesPerRow: 5888,
+  rowsPerImage: 298,
+  buffer: buffer115,
+}, {
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout26 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 61,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 68,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 144,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder144 = device0.createCommandEncoder();
+let textureView145 = texture123.createView({dimension: '2d-array'});
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup49);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(3, buffer41, 0, 4_474);
+} catch {}
+try {
+commandEncoder96.clearBuffer(buffer30, 292, 112);
+} catch {}
+let computePassEncoder113 = commandEncoder96.beginComputePass({});
+let renderPassEncoder40 = commandEncoder144.beginRenderPass({
+  colorAttachments: [{
+  view: textureView19,
+  depthSlice: 12,
+  clearValue: { r: -913.0, g: -43.04, b: -281.6, a: -228.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler97 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.28,
+  compare: 'equal',
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder94.dispatchWorkgroups(1);
+} catch {}
+try {
+computePassEncoder113.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup40, new Uint32Array(2674), 242, 0);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas3.getContext('webgpu');
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+document.body.append(canvas0);
+let commandEncoder145 = device0.createCommandEncoder({});
+let textureView146 = texture145.createView({});
+let computePassEncoder114 = commandEncoder145.beginComputePass();
+try {
+computePassEncoder30.setBindGroup(2, bindGroup67, new Uint32Array(45), 1, 0);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup58, new Uint32Array(1917), 76, 0);
+} catch {}
+try {
+  await buffer123.mapAsync(GPUMapMode.READ, 0, 3756);
+} catch {}
+let imageData25 = new ImageData(36, 8);
+let bindGroup87 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout15,
+  entries: [{binding: 73, resource: {buffer: buffer92, offset: 3840, size: 1068}}],
+});
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 408});
+let texture149 = device0.createTexture({
+  label: '\ucdb1\u6ac7\u0e81\u{1ff77}',
+  size: {width: 4, height: 4, depthOrArrayLayers: 17},
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler98 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 75.17,
+  maxAnisotropy: 10,
+});
+try {
+renderPassEncoder39.setBlendConstant({ r: 903.0, g: -250.2, b: -831.4, a: -669.1, });
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer116, 'uint16', 872, 194);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer29, 0, 872);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(149).fill(230), /* required buffer size: 149 */
+{offset: 149}, {width: 97, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler99 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 95.31,
+});
+try {
+computePassEncoder96.end();
+} catch {}
+let arrayBuffer5 = buffer28.getMappedRange(0, 308);
+try {
+commandEncoder123.clearBuffer(buffer4, 572, 868);
+} catch {}
+let buffer128 = device0.createBuffer({size: 29854, usage: GPUBufferUsage.QUERY_RESOLVE, mappedAtCreation: false});
+let texture150 = device0.createTexture({
+  label: '\uf163\u9279\u0ba5\u0a4c',
+  size: [260, 1, 1],
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder115 = commandEncoder123.beginComputePass({});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthStencilFormat: 'stencil8', stencilReadOnly: true});
+try {
+computePassEncoder44.setBindGroup(0, bindGroup29, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder114.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer93, 816, 4_088);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer44, 'uint16', 15_056, 22_855);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: imageData4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let bindGroup88 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout32,
+  entries: [
+    {binding: 83, resource: {buffer: buffer91, offset: 0, size: 89}},
+    {binding: 119, resource: {buffer: buffer119, offset: 0, size: 18}},
+    {binding: 162, resource: textureView0},
+    {binding: 41, resource: {buffer: buffer44, offset: 5888, size: 2560}},
+    {binding: 977, resource: {buffer: buffer51, offset: 1280, size: 3534}},
+    {binding: 46, resource: externalTexture1},
+    {binding: 48, resource: textureView13},
+  ],
+});
+let renderBundle10 = renderBundleEncoder10.finish({});
+let sampler100 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 82.59,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroupsIndirect(buffer36, 204); };
+} catch {}
+let commandEncoder146 = device0.createCommandEncoder({});
+let textureView147 = texture131.createView({});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup46);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder59); computePassEncoder59.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup84);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup38, new Uint32Array(4346), 4_346, 0);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(1, buffer113);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder116 = commandEncoder146.beginComputePass();
+let sampler101 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.73,
+  compare: 'greater',
+});
+let externalTexture19 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup76);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder78); computePassEncoder78.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder79.insertDebugMarker('\u07e1');
+} catch {}
+document.body.prepend(img1);
+let veryExplicitBindGroupLayout27 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 15,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 593,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let buffer129 = device0.createBuffer({size: 13989, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let sampler102 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 84.99,
+});
+try {
+computePassEncoder115.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+await gc();
+let bindGroup89 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout11,
+  entries: [{binding: 41, resource: {buffer: buffer81, offset: 256, size: 1288}}],
+});
+let texture151 = gpuCanvasContext5.getCurrentTexture();
+try {
+computePassEncoder113.setBindGroup(3, bindGroup40);
+} catch {}
+try {
+computePassEncoder94.end();
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(6, buffer38, 1_868);
+} catch {}
+let commandEncoder147 = device0.createCommandEncoder({});
+let commandBuffer14 = commandEncoder118.finish();
+let texture152 = device0.createTexture({
+  size: {width: 130},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder117 = commandEncoder147.beginComputePass({});
+try {
+computePassEncoder98.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder116.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(2, bindGroup8, new Uint32Array(845), 41, 0);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer24, 0, 11_167);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer107, 788, new DataView(new ArrayBuffer(35298)), 5879, 20);
+} catch {}
+let recycledExplicitBindGroupLayout44 = pipeline8.getBindGroupLayout(0);
+let buffer130 = device0.createBuffer({size: 17653, usage: GPUBufferUsage.MAP_WRITE});
+let texture153 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView148 = texture134.createView({aspect: 'depth-only', baseMipLevel: 0, arrayLayerCount: 1});
+try {
+computePassEncoder115.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup40);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(1, buffer109);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer107, 172, new BigUint64Array(3273), 751, 60);
+} catch {}
+await gc();
+let buffer131 = device0.createBuffer({size: 1144, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder33.setBindGroup(2, bindGroup34, new Uint32Array(501), 2, 0);
+} catch {}
+try {
+computePassEncoder85.end();
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer93, 'uint16', 4_286, 997);
+} catch {}
+try {
+commandEncoder107.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5128 */
+  offset: 5128,
+  bytesPerRow: 2816,
+  rowsPerImage: 954,
+  buffer: buffer66,
+}, {
+  texture: texture92,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder107.copyTextureToTexture({
+  texture: texture152,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture140,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer14]);
+} catch {}
+let texture154 = device0.createTexture({size: [130, 1, 1], mipLevelCount: 1, format: 'rg16uint', usage: GPUTextureUsage.COPY_DST});
+let textureView149 = texture20.createView({});
+let computePassEncoder118 = commandEncoder107.beginComputePass({});
+let arrayBuffer6 = buffer28.getMappedRange(312, 104);
+let videoFrame24 = new VideoFrame(imageBitmap1, {timestamp: 0});
+let buffer132 = device0.createBuffer({size: 13203, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let sampler103 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', minFilter: 'linear', lodMaxClamp: 69.48});
+try {
+computePassEncoder33.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+computePassEncoder118.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup65, new Uint32Array(313), 13, 0);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer29, 9_256, 2_411);
+} catch {}
+try {
+renderPassEncoder13.insertDebugMarker('\u0e1f');
+} catch {}
+let pipeline16 = device0.createComputePipeline({
+  layout: pipelineLayout6,
+  compute: {module: shaderModule1, entryPoint: 'compute1', constants: {override0: 0, 2_225: 0}},
+});
+let buffer133 = device0.createBuffer({
+  size: 6763,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder148 = device0.createCommandEncoder();
+let computePassEncoder119 = commandEncoder148.beginComputePass({});
+try {
+computePassEncoder59.setBindGroup(1, bindGroup66);
+} catch {}
+try {
+computePassEncoder77.setBindGroup(2, bindGroup50, new Uint32Array(1636), 197, 0);
+} catch {}
+try {
+computePassEncoder119.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup87);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer52, 'uint32', 2_380, 487);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder26.insertDebugMarker('\u{1fa66}');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let bindGroup90 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout21,
+  entries: [
+    {binding: 41, resource: {buffer: buffer89, offset: 512}},
+    {binding: 977, resource: {buffer: buffer47, offset: 6400, size: 2446}},
+    {binding: 119, resource: {buffer: buffer108, offset: 0, size: 12}},
+  ],
+});
+let textureView150 = texture54.createView({dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder114.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+computePassEncoder117.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup84);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline10);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageData26 = new ImageData(12, 96);
+let shaderModule10 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+requires pointer_composite_access;
+
+enable f16;
+
+struct FragmentOutput10 {
+  @location(0) f0: vec2u,
+  @location(4) f1: vec2i,
+}
+
+struct T2 {
+  f0: u32,
+}
+
+var<workgroup> vw46: atomic<u32>;
+
+alias vec3b = vec3<bool>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+override override15 = true;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(41) var<storage, read_write> buffer134: array<array<array<f16, 4>, 13>>;
+
+struct T0 {
+  @size(8) f0: array<atomic<i32>>,
+}
+
+var<private> vp14: T2 = T2();
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T1 {
+  f0: vec4i,
+  @size(40) f1: mat3x3h,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<private> vp12: mat3x2f = mat3x2f();
+
+var<private> vp13: f16 = f16(31576.3);
+
+@fragment
+fn fragment12() -> FragmentOutput10 {
+  var out: FragmentOutput10;
+  let ptr112: ptr<private, u32> = &vp14.f0;
+  let ptr113: ptr<storage, f16, read_write> = &(*&buffer134)[arrayLength(&(*&buffer134))][u32(unconst_u32(280))][3];
+  let vf145: u32 = pack2x16float(vec2f(unconst_f32(0.1518), unconst_f32(0.3707)));
+  vp14 = T2(vec2u(vp12[unconst_i32(2)])[1]);
+  vp14 = T2(pack2x16unorm(round(vec2f(unconst_f32(0.08393), unconst_f32(0.4384)))));
+  vp12 += mat3x2f(f32((*&buffer134)[u32(unconst_u32(24))][u32(unconst_u32(11))][3]), f32((*&buffer134)[u32(unconst_u32(24))][u32(unconst_u32(11))][3]), f32((*&buffer134)[u32(unconst_u32(24))][u32(unconst_u32(11))][3]), f32((*&buffer134)[u32(unconst_u32(24))][u32(unconst_u32(11))][3]), f32((*&buffer134)[u32(unconst_u32(24))][u32(unconst_u32(11))][3]), f32((*&buffer134)[u32(unconst_u32(24))][u32(unconst_u32(11))][3]));
+  vp14.f0 &= u32(buffer134[arrayLength(&buffer134)][u32(unconst_u32(348))][3]);
+  let ptr114: ptr<private, T2> = &vp14;
+  return out;
+  _ = buffer134;
+}`,
+});
+let commandEncoder149 = device0.createCommandEncoder({});
+let texture155 = device0.createTexture({
+  size: [260, 1, 14],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture156 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 40},
+  mipLevelCount: 2,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder120 = commandEncoder149.beginComputePass({});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup64);
+} catch {}
+try {
+computePassEncoder120.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup28, new Uint32Array(422), 3, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder150 = device0.createCommandEncoder({});
+let querySet21 = device0.createQuerySet({type: 'occlusion', count: 819});
+let textureView151 = texture87.createView({dimension: 'cube-array', mipLevelCount: 1, arrayLayerCount: 6});
+let renderPassEncoder41 = commandEncoder150.beginRenderPass({colorAttachments: [{view: textureView19, depthSlice: 4, loadOp: 'clear', storeOp: 'store'}]});
+try {
+{ clearResourceUsages(device0, computePassEncoder19); computePassEncoder19.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup34, []);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer46, 'uint32', 1_364, 1_699);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer3, 0);
+} catch {}
+let arrayBuffer7 = buffer100.getMappedRange(872, 8);
+let buffer139 = device0.createBuffer({
+  size: 10865,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let textureView152 = texture129.createView({label: '\u06f4\ub272', dimension: 'cube', baseArrayLayer: 6, arrayLayerCount: 6});
+try {
+computePassEncoder46.setBindGroup(2, bindGroup39, new Uint32Array(2631), 16, 0);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+renderPassEncoder40.setBlendConstant({ r: -310.0, g: -223.4, b: -184.9, a: -140.5, });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 6 },
+  flipY: true,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 93},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline17 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule9,
+  targets: [{format: 'rg32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex4',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 108,
+        attributes: [
+          {format: 'snorm16x4', offset: 8, shaderLocation: 10},
+          {format: 'uint32x2', offset: 4, shaderLocation: 9},
+          {format: 'float16x4', offset: 8, shaderLocation: 3},
+          {format: 'uint32x4', offset: 32, shaderLocation: 15},
+          {format: 'uint32x3', offset: 8, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 8,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x4', offset: 0, shaderLocation: 12}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front', unclippedDepth: true},
+});
+let texture157 = device0.createTexture({size: {width: 4}, dimension: '1d', format: 'r32uint', usage: GPUTextureUsage.COPY_SRC});
+try {
+renderPassEncoder34.setIndexBuffer(buffer131, 'uint32', 228, 16);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u5b62\u{1fe87}\u457a\u0135\u30b9\u3432';
+} catch {}
+let commandEncoder151 = device0.createCommandEncoder({});
+let computePassEncoder121 = commandEncoder151.beginComputePass({});
+let sampler104 = device0.createSampler({
+  label: '\u07ba\u84d8\u{1fd78}\u{1f7d3}\u020e\uda17\u0334\u{1fc55}\u0cd1\u{1fd33}',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.67,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder121.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer52, 'uint32', 3_824, 221);
+} catch {}
+try {
+  await buffer103.mapAsync(GPUMapMode.READ, 56, 140);
+} catch {}
+let recycledExplicitBindGroupLayout45 = pipeline14.getBindGroupLayout(0);
+let commandEncoder152 = device0.createCommandEncoder();
+let texture158 = device0.createTexture({
+  size: [32],
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup65, new Uint32Array(2056), 81, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder59); computePassEncoder59.dispatchWorkgroupsIndirect(buffer24, 7_592); };
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup43, new Uint32Array(1507), 459, 0);
+} catch {}
+try {
+renderPassEncoder34.end();
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(4, buffer108, 0);
+} catch {}
+try {
+commandEncoder129.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let commandEncoder153 = device0.createCommandEncoder();
+let textureView153 = texture62.createView({dimension: '2d'});
+let computePassEncoder122 = commandEncoder152.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder78.end();
+} catch {}
+try {
+computePassEncoder122.setPipeline(pipeline13);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(98).fill(25), /* required buffer size: 98 */
+{offset: 98, rowsPerImage: 46}, {width: 37, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: imageData25,
+  origin: { x: 2, y: 1 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder154 = device0.createCommandEncoder();
+let querySet22 = device0.createQuerySet({type: 'occlusion', count: 1761});
+let textureView154 = texture128.createView({arrayLayerCount: 1});
+let computePassEncoder123 = commandEncoder153.beginComputePass();
+let renderPassEncoder42 = commandEncoder98.beginRenderPass({
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: 864.5, g: 308.1, b: 287.0, a: 997.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup46, new Uint32Array(2129), 197, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup32, []);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(7, buffer91);
+} catch {}
+let arrayBuffer8 = buffer103.getMappedRange(72, 20);
+try {
+buffer76.unmap();
+} catch {}
+try {
+commandEncoder129.clearBuffer(buffer106, 452, 356);
+} catch {}
+let pipeline18 = await device0.createComputePipelineAsync({layout: pipelineLayout7, compute: {module: shaderModule5}});
+let buffer140 = device0.createBuffer({
+  size: 17717,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder155 = device0.createCommandEncoder({});
+let textureView155 = texture146.createView({dimension: '2d-array', aspect: 'stencil-only'});
+let computePassEncoder124 = commandEncoder155.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder124.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(0, buffer34);
+} catch {}
+try {
+commandEncoder154.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1508 */
+  offset: 1508,
+  bytesPerRow: 5632,
+  rowsPerImage: 267,
+  buffer: buffer111,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let recycledExplicitBindGroupLayout46 = pipeline4.getBindGroupLayout(0);
+let bindGroup91 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout9,
+  entries: [{binding: 41, resource: {buffer: buffer45, offset: 256, size: 684}}],
+});
+let buffer141 = device0.createBuffer({size: 5234, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let commandBuffer15 = commandEncoder129.finish();
+let texture159 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder125 = commandEncoder154.beginComputePass({label: '\u0761\u290e\u{1fa7a}\u0ad4\u5604\udf64\ud283'});
+try {
+computePassEncoder125.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle5]);
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(205, 130);
+let commandEncoder156 = device0.createCommandEncoder({});
+let textureView156 = texture81.createView({dimension: '2d', mipLevelCount: 1});
+try {
+computePassEncoder123.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer36, 'uint32', 580, 585);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(401).fill(197), /* required buffer size: 401 */
+{offset: 401, rowsPerImage: 116}, {width: 51, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline19 = device0.createComputePipeline({layout: pipelineLayout2, compute: {module: shaderModule2, constants: {}}});
+let recycledExplicitBindGroupLayout47 = pipeline10.getBindGroupLayout(0);
+let bindGroup92 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 162, resource: textureView72},
+    {binding: 977, resource: {buffer: buffer91, offset: 0, size: 58}},
+    {binding: 41, resource: {buffer: buffer107, offset: 1792, size: 180}},
+    {binding: 83, resource: {buffer: buffer32, offset: 0}},
+    {binding: 46, resource: externalTexture16},
+    {binding: 119, resource: {buffer: buffer93, offset: 1536}},
+    {binding: 48, resource: textureView2},
+  ],
+});
+let pipelineLayout12 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout25]});
+let commandEncoder157 = device0.createCommandEncoder({});
+let textureView157 = texture139.createView({});
+let computePassEncoder126 = commandEncoder156.beginComputePass();
+let renderPassEncoder43 = commandEncoder157.beginRenderPass({
+  colorAttachments: [{
+  view: textureView48,
+  depthSlice: 2,
+  clearValue: { r: -916.0, g: 161.9, b: 919.0, a: 804.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder111.setBindGroup(0, bindGroup51);
+} catch {}
+try {
+computePassEncoder111.setBindGroup(0, bindGroup51, new Uint32Array(3512), 379, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder19); computePassEncoder19.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer110, 168, new Float32Array(6756), 192, 16);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 38, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(340).fill(123), /* required buffer size: 340 */
+{offset: 340}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas4.getContext('webgl2');
+} catch {}
+let bindGroup93 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout7,
+  entries: [{binding: 41, resource: {buffer: buffer65, offset: 512}}],
+});
+let texture160 = device0.createTexture({size: [65, 1, 1], format: 'stencil8', usage: GPUTextureUsage.TEXTURE_BINDING, viewFormats: []});
+let sampler105 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 76.12,
+});
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer34, 0);
+} catch {}
+let commandEncoder158 = device0.createCommandEncoder();
+try {
+computePassEncoder93.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(1, bindGroup24, new Uint32Array(1338), 17, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder89); computePassEncoder89.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder89.end();
+} catch {}
+try {
+computePassEncoder126.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(7, undefined, 1_032_338_649);
+} catch {}
+try {
+commandEncoder114.clearBuffer(buffer32);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup94 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout44,
+  entries: [
+    {binding: 119, resource: {buffer: buffer92, offset: 2560, size: 1629}},
+    {binding: 977, resource: {buffer: buffer115, offset: 1280, size: 773}},
+    {binding: 162, resource: textureView155},
+    {binding: 41, resource: {buffer: buffer47, offset: 17920, size: 6404}},
+    {binding: 48, resource: textureView13},
+    {binding: 83, resource: {buffer: buffer76, offset: 0, size: 62}},
+    {binding: 46, resource: externalTexture2},
+  ],
+});
+let commandEncoder159 = device0.createCommandEncoder({});
+let commandBuffer16 = commandEncoder114.finish();
+let computePassEncoder127 = commandEncoder158.beginComputePass({});
+let renderPassEncoder44 = commandEncoder159.beginRenderPass({colorAttachments: [{view: textureView35, loadOp: 'load', storeOp: 'store'}]});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthStencilFormat: 'stencil8', depthReadOnly: true});
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup83);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup66, new Uint32Array(2944), 2_461, 0);
+} catch {}
+let commandEncoder160 = device0.createCommandEncoder();
+let computePassEncoder128 = commandEncoder160.beginComputePass({});
+try {
+renderBundleEncoder11.setPipeline(pipeline1);
+} catch {}
+let sampler106 = device0.createSampler({
+  addressModeU: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 55.08,
+  lodMaxClamp: 85.53,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder127.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer44, 'uint16', 326, 13_045);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(7, buffer121);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer65, 'uint32', 748, 311);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame25 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'jedecP22Phosphors', transfer: 'iec61966-2-1'} });
+let bindGroup95 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout17,
+  entries: [{binding: 22, resource: sampler29}, {binding: 154, resource: textureView105}],
+});
+let textureView158 = texture5.createView({dimension: '2d-array'});
+try {
+computePassEncoder128.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder36.beginOcclusionQuery(28);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup87);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.submit([commandBuffer16]);
+} catch {}
+let texture161 = device0.createTexture({
+  size: [4],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler107 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 98.76});
+try {
+renderPassEncoder19.beginOcclusionQuery(509);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer77, 'uint16', 4_478, 1_013);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer46, 'uint16', 848, 517);
+} catch {}
+try {
+renderBundleEncoder11.insertDebugMarker('\u4a9a');
+} catch {}
+try {
+device0.queue.submit([commandBuffer15]);
+} catch {}
+let imageBitmap6 = await createImageBitmap(videoFrame22);
+try {
+computePassEncoder126.label = '\u{1f8bc}\u0992\u0f88\u0898\ub53f';
+} catch {}
+let texture162 = gpuCanvasContext0.getCurrentTexture();
+try {
+{ clearResourceUsages(device0, computePassEncoder59); computePassEncoder59.dispatchWorkgroupsIndirect(buffer17, 1_024); };
+} catch {}
+try {
+computePassEncoder19.end();
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(1, buffer17, 0);
+} catch {}
+try {
+computePassEncoder90.pushDebugGroup('\u3223');
+} catch {}
+try {
+commandEncoder20.insertDebugMarker('\u04bf');
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipelineLayout13 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout8]});
+let buffer142 = device0.createBuffer({size: 7126, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let commandBuffer17 = commandEncoder20.finish();
+let texture163 = device0.createTexture({
+  size: [65, 1, 74],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundle11 = renderBundleEncoder11.finish();
+try {
+computePassEncoder1.setBindGroup(2, bindGroup5, new Uint32Array(2500), 167, 0);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline18);
+} catch {}
+let arrayBuffer9 = buffer103.getMappedRange(104, 8);
+try {
+device0.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 71},
+  aspect: 'all',
+}, new Uint8Array(61_322).fill(132), /* required buffer size: 61_322 */
+{offset: 72, bytesPerRow: 35, rowsPerImage: 70}, {width: 1, height: 0, depthOrArrayLayers: 26});
+} catch {}
+try {
+adapter0.label = '\u00b9\u06de\u{1f9b9}\u0754\u{1f8a1}\u5f24\u968c\ufc72';
+} catch {}
+let buffer143 = device0.createBuffer({size: 2765, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let commandEncoder161 = device0.createCommandEncoder({});
+let textureView159 = texture88.createView({mipLevelCount: 1});
+try {
+computePassEncoder24.setBindGroup(1, bindGroup72, new Uint32Array(4844), 184, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder58); computePassEncoder58.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle0, renderBundle9]);
+} catch {}
+try {
+buffer130.unmap();
+} catch {}
+try {
+commandEncoder161.resolveQuerySet(querySet6, 102, 54, buffer112, 0);
+} catch {}
+try {
+adapter0.label = '\u090e\u5a02\u{1fb8b}\u{1fd12}\ud56c\u0b55\u0acf';
+} catch {}
+let commandEncoder162 = device0.createCommandEncoder();
+let renderPassEncoder45 = commandEncoder162.beginRenderPass({colorAttachments: [{view: textureView109, depthSlice: 36, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+computePassEncoder81.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(122);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(4, buffer52);
+} catch {}
+try {
+commandEncoder161.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 616 */
+  offset: 616,
+  buffer: buffer39,
+}, {
+  texture: texture129,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder77.pushDebugGroup('\u0b4a');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(17).fill(136), /* required buffer size: 17 */
+{offset: 17, rowsPerImage: 3}, {width: 260, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer144 = device0.createBuffer({size: 14343, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder163 = device0.createCommandEncoder({});
+let textureView160 = texture109.createView({});
+let computePassEncoder129 = commandEncoder161.beginComputePass({});
+let renderPassEncoder46 = commandEncoder163.beginRenderPass({
+  colorAttachments: [{
+  view: textureView48,
+  depthSlice: 7,
+  clearValue: { r: -468.1, g: -46.33, b: 198.4, a: 10.15, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer1, 'uint32', 720, 1_272);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(97).fill(232), /* required buffer size: 97 */
+{offset: 97}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let videoFrame26 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'film', transfer: 'pq'} });
+let recycledExplicitBindGroupLayout48 = pipeline1.getBindGroupLayout(0);
+let bindGroup96 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout4,
+  entries: [
+    {binding: 162, resource: textureView99},
+    {binding: 977, resource: {buffer: buffer114, offset: 2560}},
+    {binding: 119, resource: {buffer: buffer68, offset: 256}},
+    {binding: 48, resource: textureView2},
+    {binding: 46, resource: externalTexture13},
+    {binding: 83, resource: {buffer: buffer34, offset: 1536, size: 782}},
+    {binding: 41, resource: {buffer: buffer17, offset: 3328}},
+  ],
+});
+let pipelineLayout14 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout26]});
+let buffer145 = device0.createBuffer({size: 31631, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder164 = device0.createCommandEncoder({});
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup72, new Uint32Array(3694), 886, 0);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer36, 'uint32', 276, 107);
+} catch {}
+let pipeline20 = device0.createComputePipeline({layout: pipelineLayout10, compute: {module: shaderModule8, constants: {}}});
+let texture164 = device0.createTexture({
+  size: {width: 65},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView161 = texture76.createView({format: 'r32sint', baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 4});
+let sampler108 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder116.setBindGroup(2, bindGroup48, new Uint32Array(414), 190, 0);
+} catch {}
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+computePassEncoder129.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(6, buffer121);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer102, 856, new Float32Array(10025), 189, 1284);
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+let commandEncoder165 = device0.createCommandEncoder();
+let commandBuffer18 = commandEncoder2.finish();
+let texture165 = device0.createTexture({
+  size: {width: 32, height: 1, depthOrArrayLayers: 561},
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView162 = texture70.createView({baseMipLevel: 0, mipLevelCount: 1});
+try {
+renderPassEncoder36.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline12);
+} catch {}
+try {
+buffer127.unmap();
+} catch {}
+try {
+commandEncoder165.copyTextureToTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 88},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder104.pushDebugGroup('\u0000');
+} catch {}
+let shaderModule11 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(122) var<storage, read> buffer146: array<mat4x3h, 3>;
+
+var<workgroup> vw49: bool;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(1) @binding(73) var<storage, read> buffer147: array<array<mat2x4h, 20>>;
+
+struct VertexOutput8 {
+  @location(12) @interpolate(linear, sample) f25: f16,
+  @location(6) @interpolate(perspective, sample) f26: vec4h,
+  @location(10) f27: i32,
+  @location(11) f28: vec4h,
+  @location(5) f29: vec2u,
+  @location(9) @interpolate(flat) f30: i32,
+  @location(8) @interpolate(flat, sample) f31: vec4i,
+  @invariant @builtin(position) f32: vec4f,
+  @location(3) @interpolate(flat, sample) f33: vec4i,
+  @location(4) f34: u32,
+}
+
+struct T1 {
+  @align(4) @size(256) f0: array<array<array<f16, 1>, 1>, 16>,
+  @align(32) @size(256) f1: mat4x2f,
+  @size(768) f2: array<array<array<mat4x2h, 1>, 1>, 1>,
+}
+
+alias vec3b = vec3<bool>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw48: VertexOutput8;
+
+var<workgroup> vw47: atomic<i32>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T0 {
+  @align(16) @size(320) f0: array<u32>,
+}
+
+@vertex
+fn vertex9(@builtin(vertex_index) a0: u32, @location(15) a1: vec2f) -> VertexOutput8 {
+  var out: VertexOutput8;
+  var vf146: vec2f = refract(vec2f(unconst_f32(-0.1608), unconst_f32(0.1331)), vec2f(unconst_f32(0.1221), unconst_f32(0.04692)), f32(unconst_f32(0.2071)));
+  out.f31 = vec4i(buffer147[u32(unconst_u32(131))][19][u32(unconst_u32(361))]);
+  return out;
+  _ = buffer147;
+}
+
+@compute @workgroup_size(1, 3, 1)
+fn compute9() {
+  let ptr115: ptr<storage, mat4x3h, read> = &(*&buffer146)[u32(unconst_u32(116))];
+  vw48.f29 *= vec2u(u32((*&buffer146)[2][u32(unconst_u32(384))][u32(unconst_u32(140))]));
+  let ptr116: ptr<workgroup, vec4i> = &(*&vw48).f31;
+  let ptr117: ptr<workgroup, vec4h> = &(*&vw48).f26;
+  let vf147: u32 = (*&vw48).f29[u32(unconst_u32(6))];
+  vw48.f34 |= bitcast<u32>(tanh(bitcast<vec2h>(atomicLoad(&vw47))));
+  let ptr118: ptr<workgroup, vec4i> = &(*&vw48).f31;
+  atomicExchange(&vw47, vw48.f30);
+  vw49 = bool((*ptr118).x);
+  vw48.f27 ^= i32(abs(vec3u(unconst_u32(509), unconst_u32(190), unconst_u32(66)))[2]);
+  var vf148: vec4f = exp(vec4f(unconst_f32(0.1297), unconst_f32(0.1087), unconst_f32(0.00850), unconst_f32(0.1420)));
+  vw48 = VertexOutput8((*&vw48).f26[2], (*&vw48).f26, vec4i((*&vw48).f26).r, (*&vw48).f26, bitcast<vec2u>((*&vw48).f26), i32((*&vw48).f26.z), vec4i((*&vw48).f26), vec4f((*&vw48).f26), vec4i((*&vw48).f26), vec4u((*&vw48).f26)[3]);
+  let vf149: vec4f = ceil(vec4f(unconst_f32(0.04122), unconst_f32(0.1177), unconst_f32(0.1664), unconst_f32(0.1731)));
+  var vf150: i32 = atomicLoad(&vw47);
+  _ = buffer146;
+}`,
+});
+let commandEncoder166 = device0.createCommandEncoder();
+let textureView163 = texture46.createView({});
+let renderPassEncoder47 = commandEncoder164.beginRenderPass({
+  colorAttachments: [{
+  view: textureView19,
+  depthSlice: 7,
+  clearValue: { r: 214.2, g: 626.4, b: -465.8, a: 516.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder33.setBindGroup(2, bindGroup66);
+} catch {}
+try {
+computePassEncoder18.setBindGroup(3, bindGroup6, new Uint32Array(2322), 195, 0);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer39, 'uint32', 2_996, 668);
+} catch {}
+try {
+commandEncoder166.copyTextureToTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder165.clearBuffer(buffer76, 740, 136);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer89, 3232, new Float32Array(1310));
+} catch {}
+let recycledExplicitBindGroupLayout49 = pipeline20.getBindGroupLayout(0);
+let buffer148 = device0.createBuffer({size: 11259, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder167 = device0.createCommandEncoder({});
+try {
+renderPassEncoder37.setVertexBuffer(7, buffer93);
+} catch {}
+try {
+commandEncoder167.insertDebugMarker('\u461c');
+} catch {}
+try {
+  await promise20;
+} catch {}
+await gc();
+let recycledExplicitBindGroupLayout50 = pipeline4.getBindGroupLayout(0);
+let bindGroup97 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout15,
+  entries: [{binding: 73, resource: {buffer: buffer0, offset: 2304, size: 2612}}],
+});
+let commandEncoder168 = device0.createCommandEncoder();
+let renderPassEncoder48 = commandEncoder165.beginRenderPass({
+  colorAttachments: [{
+  view: textureView160,
+  depthSlice: 7,
+  clearValue: { r: 152.2, g: 559.2, b: -234.2, a: 527.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet15,
+});
+let sampler109 = device0.createSampler({addressModeU: 'mirror-repeat', lodMaxClamp: 73.02, compare: 'not-equal'});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup45, new Uint32Array(2988), 208, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder59); computePassEncoder59.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder26.end();
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(7, buffer39);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer89, 2768, new Float32Array(18319), 3897, 644);
+} catch {}
+let pipeline21 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule7}});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let bindGroup98 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout22,
+  entries: [{binding: 498, resource: textureView77}, {binding: 31, resource: textureView63}],
+});
+let commandEncoder169 = device0.createCommandEncoder({});
+let computePassEncoder130 = commandEncoder166.beginComputePass({});
+try {
+computePassEncoder130.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(2, bindGroup88, new Uint32Array(1073), 73, 0);
+} catch {}
+try {
+renderPassEncoder33.setBlendConstant({ r: -935.7, g: -616.5, b: 928.2, a: -17.80, });
+} catch {}
+document.body.append(canvas1);
+let bindGroup99 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout7,
+  entries: [{binding: 216, resource: textureView101}, {binding: 346, resource: externalTexture5}],
+});
+let buffer149 = device0.createBuffer({
+  size: 2244,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let commandEncoder170 = device0.createCommandEncoder();
+let commandBuffer19 = commandEncoder29.finish();
+let computePassEncoder131 = commandEncoder170.beginComputePass({});
+try {
+computePassEncoder131.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(3, bindGroup24, new Uint32Array(62), 8, 0);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(0, buffer4, 0, 433);
+} catch {}
+try {
+computePassEncoder90.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer18, commandBuffer19]);
+} catch {}
+let pipeline22 = device0.createRenderPipeline({
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule7,
+  targets: [{format: 'rg32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex6',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 436,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 92, shaderLocation: 9},
+          {format: 'snorm8x4', offset: 12, shaderLocation: 0},
+          {format: 'sint8x2', offset: 84, shaderLocation: 1},
+          {format: 'sint16x2', offset: 100, shaderLocation: 3},
+          {format: 'float32', offset: 48, shaderLocation: 4},
+          {format: 'unorm8x2', offset: 64, shaderLocation: 12},
+          {format: 'uint16x2', offset: 8, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 96, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 76, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw'},
+});
+let commandEncoder171 = device0.createCommandEncoder({});
+let computePassEncoder132 = commandEncoder169.beginComputePass({});
+let renderPassEncoder49 = commandEncoder168.beginRenderPass({
+  colorAttachments: [{
+  view: textureView89,
+  clearValue: { r: -255.2, g: 553.7, b: -758.4, a: -504.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView40,
+    depthClearValue: -7.172427202719824,
+    stencilClearValue: 54872,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'discard',
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet3,
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup43, new Uint32Array(1728), 17, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup13, new Uint32Array(712), 132, 0);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(1, buffer17, 0);
+} catch {}
+let arrayBuffer10 = buffer103.getMappedRange(112, 4);
+try {
+commandEncoder171.clearBuffer(buffer30, 1324, 108);
+} catch {}
+try {
+computePassEncoder77.popDebugGroup();
+} catch {}
+let pipeline23 = await device0.createComputePipelineAsync({layout: pipelineLayout11, compute: {module: shaderModule7}});
+await gc();
+let recycledExplicitBindGroupLayout51 = pipeline8.getBindGroupLayout(0);
+let querySet23 = device0.createQuerySet({type: 'occlusion', count: 401});
+let textureView164 = texture28.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder133 = commandEncoder167.beginComputePass();
+let renderPassEncoder50 = commandEncoder171.beginRenderPass({
+  colorAttachments: [{
+  view: textureView160,
+  depthSlice: 0,
+  clearValue: { r: -641.2, g: -295.9, b: 205.5, a: -389.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet21,
+  maxDrawCount: 123524089,
+});
+try {
+renderPassEncoder31.end();
+} catch {}
+try {
+renderPassEncoder18.setViewport(251.77291916081737, 0.7728694751512606, 1.878375092999148, 0.1610287353493098, 0.809542181156385, 0.8616746257189902);
+} catch {}
+try {
+commandEncoder124.copyBufferToBuffer(buffer14, 1140, buffer40, 4856, 1608);
+} catch {}
+let textureView165 = texture157.createView({});
+let computePassEncoder134 = commandEncoder124.beginComputePass({});
+let sampler110 = device0.createSampler({
+  label: '\ue4b5\u09b1',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 88.19,
+});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup73);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup87, new Uint32Array(53), 7, 0);
+} catch {}
+try {
+renderPassEncoder39.beginOcclusionQuery(266);
+} catch {}
+try {
+renderPassEncoder39.endOcclusionQuery();
+} catch {}
+canvas0.height = 52;
+try {
+globalThis.someLabel = commandEncoder18.label;
+} catch {}
+let commandEncoder172 = device0.createCommandEncoder({});
+try {
+renderPassEncoder23.beginOcclusionQuery(58);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline24 = device0.createRenderPipeline({
+  label: '\u89c9\ua4c4\u0bc1\uae37\u02a4\u46aa\u0e77\u0a93\uc1e4\u80f2',
+  layout: pipelineLayout6,
+  fragment: {module: shaderModule4, entryPoint: 'fragment5', targets: [{format: 'rg32uint'}]},
+  vertex: {
+    module: shaderModule3,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 184,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 12, shaderLocation: 15},
+          {format: 'uint32x4', offset: 32, shaderLocation: 6},
+          {format: 'float32x3', offset: 36, shaderLocation: 0},
+          {format: 'unorm16x2', offset: 36, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', cullMode: 'back', unclippedDepth: true},
+});
+await gc();
+let imageData27 = new ImageData(108, 12);
+let recycledExplicitBindGroupLayout52 = pipeline6.getBindGroupLayout(0);
+let bindGroup100 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout10,
+  entries: [{binding: 41, resource: {buffer: buffer15, offset: 768, size: 6828}}],
+});
+let pipelineLayout15 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout20]});
+let commandEncoder173 = device0.createCommandEncoder({});
+let texture166 = device0.createTexture({
+  size: [130, 1, 1],
+  sampleCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder135 = commandEncoder173.beginComputePass({});
+let renderPassEncoder51 = commandEncoder172.beginRenderPass({
+  colorAttachments: [{
+  view: textureView16,
+  depthSlice: 4,
+  clearValue: { r: 258.9, g: -895.8, b: -297.5, a: 166.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup80);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder56); computePassEncoder56.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder134.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 28},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let videoFrame27 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'bt709', transfer: 'smpteSt4281'} });
+try {
+adapter0.label = '\u6704\u01f4\u48f3\u{1f746}\ub5d7\u{1fcc7}\u{1fac3}\ued51\u52e9';
+} catch {}
+let recycledExplicitBindGroupLayout53 = pipeline10.getBindGroupLayout(0);
+let bindGroup101 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout49,
+  entries: [
+    {binding: 119, resource: {buffer: buffer62, offset: 2560, size: 4308}},
+    {binding: 46, resource: externalTexture9},
+    {binding: 83, resource: {buffer: buffer51, offset: 512, size: 1447}},
+    {binding: 162, resource: textureView0},
+    {binding: 41, resource: {buffer: buffer0, offset: 768, size: 476}},
+    {binding: 977, resource: {buffer: buffer17, offset: 1280}},
+    {binding: 48, resource: textureView10},
+  ],
+});
+try {
+computePassEncoder132.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(2, buffer8, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(39_257).fill(89), /* required buffer size: 39_257 */
+{offset: 377, bytesPerRow: 48, rowsPerImage: 162}, {width: 7, height: 0, depthOrArrayLayers: 6});
+} catch {}
+let commandEncoder174 = device0.createCommandEncoder({});
+let texture167 = device0.createTexture({
+  size: {width: 590, height: 6, depthOrArrayLayers: 59},
+  dimension: '2d',
+  format: 'astc-10x6-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup40);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer65, 'uint32', 1_424, 383);
+} catch {}
+try {
+commandEncoder174.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2120 */
+  offset: 2120,
+  buffer: buffer77,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame28 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'bt709', transfer: 'iec61966-2-1'} });
+let textureView166 = texture119.createView({format: 'r32uint'});
+let textureView167 = texture142.createView({mipLevelCount: 1});
+let renderPassEncoder52 = commandEncoder174.beginRenderPass({
+  label: '\ub86a\u351e\u{1f911}',
+  colorAttachments: [{
+  view: textureView48,
+  depthSlice: 11,
+  clearValue: { r: 750.8, g: 45.08, b: -54.94, a: -447.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: ['r32float'], sampleCount: 1});
+try {
+computePassEncoder133.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup77);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup49, new Uint32Array(666), 472, 0);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle8, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer121, 'uint16', 0, 8);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer50, 'uint32', 168, 372);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(2, buffer149, 628, 3);
+} catch {}
+try {
+device0.queue.submit([commandBuffer17]);
+} catch {}
+let imageData28 = new ImageData(16, 24);
+let commandEncoder175 = device0.createCommandEncoder({});
+let texture168 = device0.createTexture({
+  size: [130, 1, 207],
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler111 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 57.30,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder79.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+computePassEncoder135.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer127, 'uint16', 6_864, 561);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let textureView168 = texture140.createView({baseMipLevel: 0, baseArrayLayer: 0});
+let renderBundle12 = renderBundleEncoder12.finish({});
+try {
+computePassEncoder127.setBindGroup(0, bindGroup63, new Uint32Array(1324), 131, 0);
+} catch {}
+try {
+renderPassEncoder40.end();
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(5, buffer81, 72, 977);
+} catch {}
+try {
+buffer107.unmap();
+} catch {}
+let bindGroup102 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout6,
+  entries: [{binding: 41, resource: {buffer: buffer107, offset: 1536, size: 220}}],
+});
+let querySet24 = device0.createQuerySet({type: 'occlusion', count: 323});
+let texture169 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 2},
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView169 = texture133.createView({});
+let computePassEncoder136 = commandEncoder144.beginComputePass({});
+let sampler112 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.95,
+  maxAnisotropy: 19,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder58); computePassEncoder58.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+computePassEncoder136.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(3, bindGroup69);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: videoFrame23,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let querySet25 = device0.createQuerySet({type: 'occlusion', count: 161});
+let computePassEncoder137 = commandEncoder175.beginComputePass({});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup84, new Uint32Array(4021), 1_883, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder56); computePassEncoder56.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder137.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle7, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder42.setStencilReference(1345);
+} catch {}
+let texture170 = device0.createTexture({size: [4, 4, 67], sampleCount: 1, dimension: '3d', format: 'rg16uint', usage: GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder53.setBindGroup(1, bindGroup24, new Uint32Array(959), 8, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder56); computePassEncoder56.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+device0.queue.writeBuffer(buffer133, 172, new Int16Array(382), 64, 16);
+} catch {}
+await gc();
+let videoFrame29 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'smpte240m', transfer: 'iec6196624'} });
+let textureView170 = texture133.createView({});
+let sampler113 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'mirror-repeat'});
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup63);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(0, bindGroup16, new Uint32Array(2967), 960, 0);
+} catch {}
+try {
+renderPassEncoder37.setScissorRect(119, 0, 2, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer30, 'uint32', 460, 136);
+} catch {}
+try {
+computePassEncoder12.pushDebugGroup('\u0d19');
+} catch {}
+let imageData29 = new ImageData(8, 12);
+let recycledExplicitBindGroupLayout54 = pipeline6.getBindGroupLayout(0);
+let bindGroup103 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout12,
+  entries: [
+    {binding: 83, resource: {buffer: buffer116, offset: 1536, size: 877}},
+    {binding: 977, resource: {buffer: buffer68, offset: 0}},
+    {binding: 41, resource: {buffer: buffer142, offset: 256, size: 1468}},
+    {binding: 48, resource: textureView13},
+    {binding: 162, resource: textureView99},
+    {binding: 46, resource: externalTexture3},
+    {binding: 119, resource: {buffer: buffer111, offset: 0, size: 196}},
+  ],
+});
+let texture171 = device0.createTexture({
+  size: [65, 1, 69],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgb9e5ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup34, new Uint32Array(6499), 66, 0);
+} catch {}
+try {
+gpuCanvasContext3.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+let commandEncoder176 = device0.createCommandEncoder({});
+let computePassEncoder138 = commandEncoder176.beginComputePass({});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder138.setPipeline(pipeline7);
+} catch {}
+let bindGroup104 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout39,
+  entries: [
+    {binding: 46, resource: externalTexture7},
+    {binding: 83, resource: {buffer: buffer16, offset: 0, size: 10}},
+    {binding: 48, resource: textureView10},
+    {binding: 119, resource: {buffer: buffer105, offset: 8448}},
+    {binding: 162, resource: textureView15},
+    {binding: 41, resource: {buffer: buffer44, offset: 768, size: 14132}},
+    {binding: 977, resource: {buffer: buffer14, offset: 2560, size: 1782}},
+  ],
+});
+let commandEncoder177 = device0.createCommandEncoder({});
+try {
+computePassEncoder131.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder114); computePassEncoder114.dispatchWorkgroups(2, 2); };
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup71);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer114, 'uint32', 1_660, 35);
+} catch {}
+try {
+computePassEncoder104.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(59).fill(81), /* required buffer size: 59 */
+{offset: 59}, {width: 75, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer150 = device0.createBuffer({
+  size: 13598,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture172 = device0.createTexture({size: [4, 4, 17], format: 'r32float', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder139 = commandEncoder177.beginComputePass({});
+try {
+computePassEncoder80.setBindGroup(3, bindGroup82, new Uint32Array(1967), 40, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup97);
+} catch {}
+await gc();
+let texture173 = device0.createTexture({
+  label: '\uc162\u{1f6c1}\u0c69\u9dac\uc899\u{1fe83}\u0c23\u{1fe50}',
+  size: {width: 4, height: 4, depthOrArrayLayers: 17},
+  mipLevelCount: 1,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let sampler114 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.06,
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(3, bindGroup3, new Uint32Array(484), 40, 0);
+} catch {}
+try {
+renderPassEncoder32.end();
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer91, 'uint32', 112, 4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 448, new Int16Array(614), 220, 52);
+} catch {}
+let bindGroup105 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout27,
+  entries: [{binding: 15, resource: {buffer: buffer24, offset: 19968}}, {binding: 593, resource: textureView158}],
+});
+let renderPassEncoder53 = commandEncoder122.beginRenderPass({
+  colorAttachments: [{view: textureView113, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 121892529,
+});
+try {
+renderPassEncoder15.setScissorRect(22, 0, 3, 0);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(6, buffer81);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+await gc();
+let bindGroup106 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 83, resource: {buffer: buffer68, offset: 3328}},
+    {binding: 46, resource: externalTexture19},
+    {binding: 119, resource: {buffer: buffer115, offset: 1280, size: 350}},
+    {binding: 41, resource: {buffer: buffer108, offset: 512, size: 264}},
+    {binding: 977, resource: {buffer: buffer125, offset: 3328}},
+    {binding: 48, resource: textureView2},
+    {binding: 162, resource: textureView107},
+  ],
+});
+let sampler115 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 93.04});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup103, new Uint32Array(333), 21, 0);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(1, buffer4, 1_508);
+} catch {}
+try {
+buffer133.unmap();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+computePassEncoder130.setBindGroup(2, bindGroup99);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(308);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline1);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let recycledExplicitBindGroupLayout55 = pipeline22.getBindGroupLayout(0);
+let buffer151 = device0.createBuffer({
+  size: 3683,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder178 = device0.createCommandEncoder({});
+let textureView171 = texture128.createView({aspect: 'all', baseArrayLayer: 0});
+let computePassEncoder140 = commandEncoder178.beginComputePass({});
+let sampler116 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 97.75});
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder2.insertDebugMarker('\u05be');
+} catch {}
+document.body.append(canvas3);
+let commandEncoder179 = device0.createCommandEncoder({});
+let renderPassEncoder54 = commandEncoder179.beginRenderPass({
+  colorAttachments: [{
+  view: textureView48,
+  depthSlice: 13,
+  clearValue: { r: 551.5, g: 325.2, b: -876.0, a: 16.49, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 314747507,
+});
+let sampler117 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 59.25,
+});
+try {
+computePassEncoder101.setBindGroup(0, bindGroup51);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle7, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(1, buffer48, 0);
+} catch {}
+let querySet26 = device0.createQuerySet({type: 'occlusion', count: 240});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup45);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(7, buffer3, 48);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(21).fill(200), /* required buffer size: 21 */
+{offset: 21}, {width: 65, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup107 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout28,
+  entries: [
+    {binding: 46, resource: externalTexture7},
+    {binding: 48, resource: textureView13},
+    {binding: 162, resource: textureView107},
+    {binding: 977, resource: {buffer: buffer150, offset: 2816, size: 1064}},
+    {binding: 41, resource: {buffer: buffer31, offset: 4096}},
+    {binding: 119, resource: {buffer: buffer30, offset: 0, size: 1149}},
+    {binding: 83, resource: {buffer: buffer108, offset: 0, size: 490}},
+  ],
+});
+let commandEncoder180 = device0.createCommandEncoder();
+let sampler118 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.94,
+  maxAnisotropy: 8,
+});
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup44, new Uint32Array(370), 41, 0);
+} catch {}
+try {
+buffer84.unmap();
+} catch {}
+try {
+commandEncoder180.copyTextureToBuffer({
+  texture: texture93,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 4480 */
+  offset: 4480,
+  rowsPerImage: 99,
+  buffer: buffer49,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture127,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(91).fill(178), /* required buffer size: 91 */
+{offset: 91}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: videoFrame23,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 148},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture174 = device0.createTexture({size: [32, 1, 53], format: 'r32float', usage: GPUTextureUsage.STORAGE_BINDING});
+try {
+computePassEncoder48.setBindGroup(0, bindGroup65);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder58); computePassEncoder58.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder58); computePassEncoder58.dispatchWorkgroupsIndirect(buffer116, 1_064); };
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+document.body.prepend(canvas0);
+let computePassEncoder141 = commandEncoder180.beginComputePass({});
+try {
+computePassEncoder140.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle9, renderBundle9, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline12);
+} catch {}
+let bindGroup108 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout19,
+  entries: [{binding: 41, resource: {buffer: buffer83, offset: 256, size: 252}}],
+});
+try {
+computePassEncoder61.setBindGroup(0, bindGroup7, new Uint32Array(2007), 359, 0);
+} catch {}
+try {
+computePassEncoder141.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup66, []);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer74, 'uint32', 96, 14);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(2, buffer52, 1_588, 2_321);
+} catch {}
+document.body.prepend(img1);
+let shaderModule12 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+var<workgroup> vw52: mat3x4h;
+
+struct T1 {
+  @size(320) f0: array<vec4h>,
+}
+
+var<workgroup> vw56: array<FragmentOutput11, 1>;
+
+struct FragmentOutput11 {
+  @location(0) f0: vec4u,
+}
+
+@group(0) @binding(122) var<storage, read> buffer152: array<vec2h, 24>;
+
+@group(1) @binding(73) var<storage, read> buffer153: array<array<mat4x4f, 5>>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw51: FragmentOutput11;
+
+var<workgroup> vw54: vec4u;
+
+var<workgroup> vw50: array<vec2h, 9>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw55: VertexOutput9;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct VertexOutput9 {
+  @location(5) @interpolate(flat) f35: vec2u,
+  @location(12) f36: vec2u,
+  @location(13) f37: vec2i,
+  @location(11) @interpolate(flat) f38: vec2h,
+  @location(0) @interpolate(linear, center) f39: vec2f,
+  @location(3) f40: vec4i,
+  @builtin(position) f41: vec4f,
+  @location(1) @interpolate(flat, sample) f42: i32,
+}
+
+struct T0 {
+  @align(32) @size(96) f0: array<array<array<vec2h, 1>, 1>>,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn fn0(a0: VertexOutput9, a1: ptr<storage, array<mat2x4f>, read_write>, a2: array<array<bool, 13>, 1>, a3: ptr<storage, array<FragmentOutput11>, read>, a4: array<FragmentOutput11, 1>, a5: mat2x4h, a6: ptr<uniform, FragmentOutput11>, a7: mat2x4f, a8: ptr<function, FragmentOutput11>, a9: array<FragmentOutput11, 2>, a10: ptr<private, mat2x2h>, a11: ptr<workgroup, atomic<u32>>, a12: u32, a13: FragmentOutput11, a14: array<array<mat2x3h, 1>, 7>, a15: mat2x4h, a16: ptr<function, mat2x4f>, a17: array<bool, 1>, a18: array<array<FragmentOutput11, 1>, 2>, a19: ptr<private, FragmentOutput11>, a20: vec4i, a21: FragmentOutput11, a22: array<FragmentOutput11, 1>, a23: ptr<private, mat2x3f>, a24: ptr<private, FragmentOutput11>, a25: ptr<workgroup, array<array<f16, 37>, 1>>, a26: f32, a27: mat4x4f, a28: vec2u, a29: ptr<function, FragmentOutput11>, a30: FragmentOutput11, a31: mat4x2f, a32: ptr<workgroup, array<FragmentOutput11, 1>>, a33: ptr<function, mat3x2f>, a34: ptr<function, FragmentOutput11>, a35: bool, a36: ptr<storage, array<u32>, read_write>, a37: ptr<function, array<mat3x4h, 1>>, a38: ptr<storage, array<VertexOutput9>, read>, a39: ptr<workgroup, FragmentOutput11>, a40: ptr<storage, array<u32>, read_write>, a41: ptr<workgroup, i32>, a42: vec2f, a43: array<array<array<array<array<array<array<i32, 1>, 1>, 1>, 1>, 1>, 9>, 2>) -> mat4x4h {
+  var out: mat4x4h;
+  (*a10) = mat2x2h(f16(a43[1][u32(unconst_u32(64))][u32(unconst_u32(100))][u32(unconst_u32(286))][u32(a43[1][u32(unconst_u32(120))][0][u32(unconst_u32(166))][u32(unconst_u32(111))][u32(unconst_u32(27))][0])][0][u32(unconst_u32(202))]), f16(a43[1][u32(unconst_u32(64))][u32(unconst_u32(100))][u32(unconst_u32(286))][u32(a43[1][u32(unconst_u32(120))][0][u32(unconst_u32(166))][u32(unconst_u32(111))][u32(unconst_u32(27))][0])][0][u32(unconst_u32(202))]), f16(a43[1][u32(unconst_u32(64))][u32(unconst_u32(100))][u32(unconst_u32(286))][u32(a43[1][u32(unconst_u32(120))][0][u32(unconst_u32(166))][u32(unconst_u32(111))][u32(unconst_u32(27))][0])][0][u32(unconst_u32(202))]), f16(a43[1][u32(unconst_u32(64))][u32(unconst_u32(100))][u32(unconst_u32(286))][u32(a43[1][u32(unconst_u32(120))][0][u32(unconst_u32(166))][u32(unconst_u32(111))][u32(unconst_u32(27))][0])][0][u32(unconst_u32(202))]));
+  (*a16) -= mat2x4f(bitcast<f32>((*a36)[arrayLength(&(*a36))]), bitcast<f32>((*a36)[arrayLength(&(*a36))]), f32((*a36)[arrayLength(&(*a36))]), f32((*a36)[arrayLength(&(*a36))]), bitcast<f32>((*a36)[arrayLength(&(*a36))]), bitcast<f32>((*a36)[arrayLength(&(*a36))]), bitcast<f32>((*a36)[arrayLength(&(*a36))]), bitcast<f32>((*a36)[arrayLength(&(*a36))]));
+  (*a37)[u32(unconst_u32(205))] = mat3x4h(f16(a43[1][u32(unconst_u32(149))][u32(unconst_u32(92))][u32(unconst_u32(179))][0][0][0]), f16(a43[1][u32(unconst_u32(149))][u32(unconst_u32(92))][u32(unconst_u32(179))][0][0][0]), f16(a43[1][u32(unconst_u32(149))][u32(unconst_u32(92))][u32(unconst_u32(179))][0][0][0]), f16(a43[1][u32(unconst_u32(149))][u32(unconst_u32(92))][u32(unconst_u32(179))][0][0][0]), f16(a43[1][u32(unconst_u32(149))][u32(unconst_u32(92))][u32(unconst_u32(179))][0][0][0]), f16(a43[1][u32(unconst_u32(149))][u32(unconst_u32(92))][u32(unconst_u32(179))][0][0][0]), f16(a43[1][u32(unconst_u32(149))][u32(unconst_u32(92))][u32(unconst_u32(179))][0][0][0]), f16(a43[1][u32(unconst_u32(149))][u32(unconst_u32(92))][u32(unconst_u32(179))][0][0][0]), f16(a43[1][u32(unconst_u32(149))][u32(unconst_u32(92))][u32(unconst_u32(179))][0][0][0]), f16(a43[1][u32(unconst_u32(149))][u32(unconst_u32(92))][u32(unconst_u32(179))][0][0][0]), f16(a43[1][u32(unconst_u32(149))][u32(unconst_u32(92))][u32(unconst_u32(179))][0][0][0]), f16(a43[1][u32(unconst_u32(149))][u32(unconst_u32(92))][u32(unconst_u32(179))][0][0][0]));
+  var vf151: array<array<array<i32, 1>, 1>, 1> = a43[1][u32(a43[u32(unconst_u32(499))][u32(unconst_u32(71))][u32(unconst_u32(226))][0][0][0][0])][0][u32(unconst_u32(192))];
+  (*a19) = FragmentOutput11(vec4u((*a37)[u32(unconst_u32(70))][unconst_i32(2)]));
+  var vf152: vec4u = a21.f0;
+  let vf153: i32 = a43[u32(unconst_u32(45))][u32(unconst_u32(231))][u32(unconst_u32(364))][0][u32(unconst_u32(63))][0][0];
+  (*a41) = vec3i(a14[u32(unconst_u32(159))][0][unconst_i32(0)]).z;
+  (*a37)[u32(unconst_u32(591))] -= mat3x4h(bitcast<vec4h>((*a38)[arrayLength(&(*a38))].f36), bitcast<vec4h>((*a38)[arrayLength(&(*a38))].f36), bitcast<vec4h>((*a38)[arrayLength(&(*a38))].f36));
+  vf151[0][a18[1][0].f0.r][u32(unconst_u32(263))] = a43[1][8][u32(unconst_u32(400))][0][0][0][0];
+  let ptr119: ptr<storage, mat2x4f, read_write> = &(*a1)[u32(unconst_u32(263))];
+  var vf154: vec2f = a42;
+  vf152 <<= (*a34).f0;
+  return out;
+}
+
+alias vec3b = vec3<bool>;
+
+var<workgroup> vw53: FragmentOutput11;
+
+@vertex
+fn vertex10() -> VertexOutput9 {
+  var out: VertexOutput9;
+  out.f37 ^= vec2i(i32(pack4xU8Clamp(vec4u(unconst_u32(88), unconst_u32(66), unconst_u32(230), unconst_u32(59)))));
+  out.f40 -= vec4i(i32(buffer152[u32(unconst_u32(2))][u32(unconst_u32(133))]));
+  let ptr120: ptr<storage, array<vec2h, 24>, read> = &(*&buffer152);
+  out.f42 *= i32((*&buffer153)[arrayLength(&(*&buffer153))][u32(unconst_u32(153))][unconst_i32(1)].b);
+  out.f42 = vec4i(buffer153[arrayLength(&buffer153)][4][unconst_i32(0)]).r;
+  out.f36 >>= vec2u(buffer153[u32(unconst_u32(97))][4][unconst_i32(0)].ba);
+  let ptr121: ptr<storage, mat4x4f, read> = &(*&buffer153)[arrayLength(&(*&buffer153))][u32(unconst_u32(9))];
+  let ptr122: ptr<storage, vec2h, read> = &buffer152[u32(unconst_u32(53))];
+  let ptr123: ptr<storage, mat4x4f, read> = &buffer153[arrayLength(&buffer153)][4];
+  let ptr124: ptr<storage, array<mat4x4f, 5>, read> = &buffer153[u32(unconst_u32(27))];
+  let ptr125: ptr<storage, vec2h, read> = &(*ptr122);
+  var vf155: vec3f = tanh(vec3f(unconst_f32(0.1419), unconst_f32(0.09030), unconst_f32(0.3274)));
+  out.f38 = vec2h((*ptr120)[u32(unconst_u32(1))][u32(unconst_u32(0))]);
+  var vf156: vec4f = (*&buffer153)[u32(unconst_u32(20))][u32(unconst_u32(246))][u32(unconst_u32(45))];
+  out.f37 -= vec2i(buffer152[23]);
+  vf155 = vec3f(buffer153[u32(unconst_u32(464))][4][bitcast<u32>((*&buffer153)[u32(unconst_u32(589))][u32(unconst_u32(139))][u32(unconst_u32(13))][u32(unconst_u32(6))])][u32(unconst_u32(28))]);
+  out.f40 = bitcast<vec4i>((*&buffer153)[arrayLength(&(*&buffer153))][4][unconst_i32(3)]);
+  let vf157: vec4f = (*ptr124)[4][u32(unconst_u32(245))];
+  vf156 = vec4f((*ptr121)[u32(unconst_u32(95))][u32(unconst_u32(5))]);
+  let ptr126: ptr<storage, mat4x4f, read> = &(*ptr124)[u32(unconst_u32(1))];
+  return out;
+  _ = buffer153;
+  _ = buffer152;
+}
+
+@vertex
+fn vertex11(@location(4) a0: vec2f, @location(10) a1: i32, @location(8) @interpolate(perspective, sample) a2: vec2h) -> @builtin(position) vec4f {
+  var out: vec4f;
+  out = (*&buffer153)[arrayLength(&(*&buffer153))][4][unconst_i32(2)];
+  out += vec4f(f32((*&buffer152)[23][u32(unconst_u32(7))]));
+  out += buffer153[arrayLength(&buffer153)][u32(unconst_u32(58))][unconst_i32(1)];
+  out = (*&buffer153)[arrayLength(&(*&buffer153))][4][u32(unconst_u32(338))];
+  let ptr127: ptr<storage, mat4x4f, read> = &(*&buffer153)[arrayLength(&(*&buffer153))][4];
+  out = vec4f((*&buffer152)[23].rrrr);
+  out *= buffer153[arrayLength(&buffer153)][4][unconst_i32(3)];
+  out += vec4f(buffer152[u32(unconst_u32(67))].yxxy);
+  var vf158: f32 = (*&buffer153)[u32(unconst_u32(494))][4][u32(unconst_u32(23))][bitcast<u32>((*&buffer152)[u32(unconst_u32(60))])];
+  return out;
+  _ = buffer153;
+  _ = buffer152;
+}
+
+@vertex
+fn vertex12() -> @builtin(position) vec4f {
+  var out: vec4f;
+  out *= buffer153[arrayLength(&buffer153)][4][unconst_i32(0)];
+  out += vec4f(f32(buffer152[23][u32(unconst_u32(12))]));
+  out = (*&buffer153)[u32(unconst_u32(108))][4][unconst_i32(3)];
+  let ptr128: ptr<storage, mat4x4f, read> = &(*&buffer153)[arrayLength(&(*&buffer153))][4];
+  out = buffer153[arrayLength(&buffer153)][u32(unconst_u32(27))][unconst_i32(0)];
+  let ptr129: ptr<storage, mat4x4f, read> = &buffer153[arrayLength(&buffer153)][4];
+  out -= (*&buffer153)[arrayLength(&(*&buffer153)) - 1][4][unconst_i32(2)];
+  let ptr130: ptr<storage, mat4x4f, read> = &buffer153[arrayLength(&buffer153)][4];
+  out = (*&buffer153)[u32(unconst_u32(66))][u32(unconst_u32(169))][unconst_i32(3)];
+  var vf159: f32 = buffer153[u32(unconst_u32(166))][4][u32(unconst_u32(199))][u32(unconst_u32(9))];
+  vf159 = (*&buffer153)[u32(unconst_u32(135))][4][unconst_i32(2)][2];
+  let ptr131: ptr<storage, mat4x4f, read> = &(*ptr128);
+  out = (*ptr130)[u32(unconst_u32(472))];
+  out += vec4f((*&buffer152)[u32(unconst_u32(227))].gggr);
+  let ptr132: ptr<storage, mat4x4f, read> = &buffer153[arrayLength(&buffer153)][4];
+  return out;
+  _ = buffer152;
+  _ = buffer153;
+}
+
+@fragment
+fn fragment13() -> FragmentOutput11 {
+  var out: FragmentOutput11;
+  let vf160: u32 = arrayLength(&(*&buffer153));
+  out.f0 *= vec4u(tan(vec3h(unconst_f16(13560.9), unconst_f16(10973.4), unconst_f16(2734.0))).bggb);
+  var vf161: vec3f = cross(vec3f(unconst_f32(0.2189), unconst_f32(0.07016), unconst_f32(0.1710)), vec3f(unconst_f32(0.1481), unconst_f32(0.1602), unconst_f32(0.1968)));
+  out = FragmentOutput11(firstTrailingBit(vec2u(unconst_u32(87), unconst_u32(295))).xyyx);
+  out.f0 = firstTrailingBit(vec2u(unconst_u32(319), unconst_u32(148))).grrr;
+  let vf162: vec2f = unpack2x16snorm(u32(unconst_u32(74)));
+  var vf163: f32 = buffer153[arrayLength(&buffer153)][u32(unconst_u32(206))][u32(unconst_u32(0))][u32(unconst_u32(39))];
+  out.f0 &= bitcast<vec4u>((*&buffer153)[arrayLength(&(*&buffer153))][4][unconst_i32(2)]);
+  vf161 = cross(vec3f(unconst_f32(0.03282), unconst_f32(-0.1497), unconst_f32(-0.03475)), vec3f(buffer153[u32(unconst_u32(115))][4][u32(unconst_u32(154))][u32(unconst_u32(28))]));
+  out.f0 -= vec4u((*&buffer153)[arrayLength(&(*&buffer153)) - 1][4][unconst_i32(2)]);
+  vf163 = (*&buffer153)[arrayLength(&(*&buffer153)) - 1][4][unconst_i32(0)].b;
+  out.f0 = vec4u(u32(pow(f16(unconst_f16(-2909.6)), f16(unconst_f16(38568.0)))));
+  var vf164: f16 = buffer152[u32(unconst_u32(42))][u32(unconst_u32(45))];
+  let ptr133: ptr<storage, mat4x4f, read> = &(*&buffer153)[arrayLength(&(*&buffer153))][u32(unconst_u32(171))];
+  let ptr134: ptr<storage, mat4x4f, read> = &buffer153[u32(unconst_u32(575))][u32(unconst_u32(129))];
+  let vf165: u32 = pack2x16snorm(vec2f(unconst_f32(0.03752), unconst_f32(0.02716)));
+  var vf166: f32 = (*&buffer153)[u32(unconst_u32(176))][4][u32(unconst_u32(20))][u32(unconst_u32(48))];
+  let ptr135: ptr<storage, mat4x4f, read> = &(*ptr133);
+  out.f0 -= vec4u(u32(vf161[u32(unconst_u32(25))]));
+  var vf167: f32 = buffer153[u32(unconst_u32(76))][u32(unconst_u32(182))][u32(unconst_u32(117))][u32(unconst_u32(338))];
+  var vf168: f16 = buffer152[23][u32(unconst_u32(213))];
+  out.f0 *= vec4u(u32((*&buffer153)[u32(unconst_u32(49))][u32(unconst_u32(18))][u32(unconst_u32(24))][u32(unconst_u32(94))]));
+  return out;
+  _ = buffer153;
+  _ = buffer152;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute10() {
+  let vf169: array<FragmentOutput11, 1> = workgroupUniformLoad(&vw56);
+  let ptr136: ptr<workgroup, vec2u> = &(*&vw55).f35;
+  vw50[u32(unconst_u32(1))] = vw55.f38;
+  vw56[u32(unconst_u32(36))] = FragmentOutput11((*&vw53).f0);
+  let ptr137: ptr<workgroup, FragmentOutput11> = &(*&vw56)[0];
+  vw55 = workgroupUniformLoad(&vw55);
+  vw52 = mat3x4h(vec4h((*&vw53).f0), vec4h((*&vw53).f0), vec4h((*&vw53).f0));
+  let ptr138: ptr<workgroup, FragmentOutput11> = &(*&vw51);
+  vw52 = mat3x4h(f16((*&vw55).f41[u32((*&buffer152)[23][u32(unconst_u32(179))])]), f16((*&vw55).f41[u32((*&buffer152)[23][u32(unconst_u32(179))])]), f16((*&vw55).f41[u32((*&buffer152)[23][u32(unconst_u32(179))])]), f16((*&vw55).f41[u32((*&buffer152)[23][u32(unconst_u32(179))])]), f16((*&vw55).f41[u32((*&buffer152)[23][u32(unconst_u32(179))])]), f16((*&vw55).f41[u32((*&buffer152)[23][u32(unconst_u32(179))])]), f16((*&vw55).f41[u32((*&buffer152)[23][u32(unconst_u32(179))])]), f16((*&vw55).f41[u32((*&buffer152)[23][u32(unconst_u32(179))])]), f16((*&vw55).f41[u32((*&buffer152)[23][u32(unconst_u32(179))])]), f16((*&vw55).f41[u32((*&buffer152)[23][u32(unconst_u32(179))])]), f16((*&vw55).f41[u32((*&buffer152)[23][u32(unconst_u32(179))])]), f16((*&vw55).f41[u32((*&buffer152)[23][u32(unconst_u32(179))])]));
+  vw55.f42 = bitcast<vec4i>(vw56[u32(unconst_u32(302))].f0).x;
+  _ = buffer152;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute11() {
+  let vf170: u32 = pack4xI8Clamp(vec4i(unconst_i32(-69), unconst_i32(39), unconst_i32(205), unconst_i32(4)));
+  let ptr139: ptr<workgroup, vec2h> = &(*&vw50)[8];
+  vw53 = FragmentOutput11(vec4u(vw50[8].rgrr));
+  let ptr140: ptr<workgroup, vec2f> = &(*&vw55).f39;
+  var vf171: u32 = vf170;
+  let ptr141: ptr<workgroup, FragmentOutput11> = &vw56[pack4x8snorm(vw55.f41)];
+}`,
+});
+let autogeneratedBindGroupLayout22 = pipeline12.getBindGroupLayout(0);
+let bindGroup109 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout48,
+  entries: [
+    {binding: 977, resource: {buffer: buffer0, offset: 1024, size: 1597}},
+    {binding: 119, resource: {buffer: buffer112, offset: 0}},
+    {binding: 41, resource: {buffer: buffer140, offset: 1536, size: 1024}},
+    {binding: 48, resource: textureView13},
+    {binding: 83, resource: {buffer: buffer65, offset: 3840}},
+    {binding: 162, resource: textureView155},
+    {binding: 46, resource: externalTexture4},
+  ],
+});
+let buffer154 = device0.createBuffer({
+  size: 9352,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture175 = device0.createTexture({
+  size: {width: 32, height: 1, depthOrArrayLayers: 125},
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView172 = texture109.createView({});
+try {
+computePassEncoder103.setBindGroup(2, bindGroup81);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder56); computePassEncoder56.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder139.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer151, 0, 514);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let veryExplicitBindGroupLayout28 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 95,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 51, hasDynamicOffset: false },
+    },
+    {
+      binding: 384,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let bindGroup110 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout26,
+  entries: [
+    {binding: 83, resource: {buffer: buffer150, offset: 3328, size: 5070}},
+    {binding: 46, resource: externalTexture18},
+    {binding: 119, resource: {buffer: buffer34, offset: 512, size: 412}},
+    {binding: 48, resource: textureView13},
+    {binding: 162, resource: textureView138},
+    {binding: 977, resource: {buffer: buffer18, offset: 0, size: 83}},
+    {binding: 41, resource: {buffer: buffer27, offset: 2048, size: 276}},
+  ],
+});
+let buffer155 = device0.createBuffer({size: 14747, usage: GPUBufferUsage.MAP_WRITE});
+let sampler119 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMaxClamp: 61.73,
+  compare: 'always',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder48); computePassEncoder48.dispatchWorkgroupsIndirect(buffer142, 852); };
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(5, buffer81);
+} catch {}
+try {
+computePassEncoder42.setBindGroup(1, bindGroup28, new Uint32Array(148), 5, 0);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(4, buffer40);
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(7, 285);
+let autogeneratedBindGroupLayout23 = pipeline3.getBindGroupLayout(0);
+let bindGroup111 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout24,
+  entries: [
+    {binding: 119, resource: {buffer: buffer29, offset: 1792, size: 137}},
+    {binding: 162, resource: textureView40},
+    {binding: 48, resource: textureView10},
+    {binding: 46, resource: externalTexture10},
+    {binding: 41, resource: {buffer: buffer27, offset: 256, size: 1040}},
+    {binding: 83, resource: {buffer: buffer47, offset: 7424, size: 31722}},
+    {binding: 977, resource: {buffer: buffer76, offset: 256, size: 1664}},
+  ],
+});
+let commandEncoder181 = device0.createCommandEncoder({});
+let textureView173 = texture21.createView({dimension: '2d', mipLevelCount: 1});
+try {
+renderPassEncoder53.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(32);
+} catch {}
+document.body.append(img1);
+let imageData30 = new ImageData(64, 28);
+let computePassEncoder142 = commandEncoder181.beginComputePass({});
+try {
+computePassEncoder111.setBindGroup(0, bindGroup111);
+} catch {}
+try {
+computePassEncoder105.setBindGroup(2, bindGroup102, new Uint32Array(3678), 58, 0);
+} catch {}
+try {
+computePassEncoder142.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(42);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle2, renderBundle11]);
+} catch {}
+let texture176 = device0.createTexture({
+  size: [130],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView174 = texture35.createView({format: 'rg32uint', arrayLayerCount: 1});
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup76);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer114, 'uint16', 4_000, 2_711);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(7, buffer116, 2_348, 391);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: imageData1,
+  origin: { x: 2, y: 10 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 16, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder182 = device0.createCommandEncoder();
+let texture177 = device0.createTexture({size: {width: 32}, dimension: '1d', format: 'rg32sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView175 = texture21.createView({dimension: '2d-array', arrayLayerCount: 3});
+let computePassEncoder143 = commandEncoder182.beginComputePass({});
+try {
+computePassEncoder139.setBindGroup(2, bindGroup35);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder114); computePassEncoder114.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+gpuCanvasContext4.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+} catch {}
+document.body.prepend(canvas0);
+let videoFrame30 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'film', transfer: 'hlg'} });
+let bindGroup112 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 46, resource: externalTexture17},
+    {binding: 977, resource: {buffer: buffer125, offset: 256}},
+    {binding: 48, resource: textureView2},
+    {binding: 83, resource: {buffer: buffer92, offset: 1024, size: 1033}},
+    {binding: 119, resource: {buffer: buffer30, offset: 256, size: 419}},
+    {binding: 41, resource: {buffer: buffer79, offset: 0, size: 176}},
+    {binding: 162, resource: textureView66},
+  ],
+});
+try {
+computePassEncoder72.setBindGroup(3, bindGroup73);
+} catch {}
+try {
+computePassEncoder143.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup103, []);
+} catch {}
+try {
+buffer67.unmap();
+} catch {}
+let buffer156 = device0.createBuffer({size: 14770, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder183 = device0.createCommandEncoder({});
+let textureView176 = texture168.createView({aspect: 'all'});
+let computePassEncoder144 = commandEncoder183.beginComputePass({});
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(6, undefined, 205_661_023);
+} catch {}
+let arrayBuffer11 = buffer28.getMappedRange(416, 132);
+let promise21 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise21;
+} catch {}
+document.body.append(canvas2);
+let veryExplicitBindGroupLayout29 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 113,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder184 = device0.createCommandEncoder();
+let texture178 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 1238},
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder68.setBindGroup(2, bindGroup95);
+} catch {}
+try {
+renderPassEncoder50.setIndexBuffer(buffer132, 'uint16', 2_556, 2_633);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(3, buffer150, 0, 1_347);
+} catch {}
+try {
+commandEncoder184.copyTextureToTexture({
+  texture: texture163,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture140,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 63},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 4});
+} catch {}
+try {
+computePassEncoder86.insertDebugMarker('\uddff');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 5164, new Float32Array(33094), 149, 604);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas2);
+let buffer157 = device0.createBuffer({size: 3189, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+computePassEncoder72.setBindGroup(0, bindGroup83, new Uint32Array(1360), 208, 0);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup13);
+} catch {}
+let pipeline25 = device0.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let buffer158 = device0.createBuffer({size: 4941, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let sampler120 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 17.47,
+  lodMaxClamp: 66.52,
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder144.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setViewport(7.142148345334226, 0.44092162108579525, 30.80348779101455, 0.46353032952496226, 0.26310764136481446, 0.5832126517574736);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer44, 'uint32', 10_468, 1_766);
+} catch {}
+try {
+commandEncoder184.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2856 */
+  offset: 2856,
+  bytesPerRow: 10752,
+  rowsPerImage: 44,
+  buffer: buffer68,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder12.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let canvas4 = document.createElement('canvas');
+let videoFrame31 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'smpte432', transfer: 'bt709'} });
+let autogeneratedBindGroupLayout24 = pipeline0.getBindGroupLayout(0);
+let texture179 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 1},
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder145 = commandEncoder184.beginComputePass({});
+try {
+computePassEncoder87.setBindGroup(3, bindGroup24, new Uint32Array(1129), 26, 0);
+} catch {}
+try {
+computePassEncoder145.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(6, buffer149, 220, 159);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img1);
+let veryExplicitBindGroupLayout30 = device0.createBindGroupLayout({
+  entries: [{binding: 92, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let texture180 = gpuCanvasContext3.getCurrentTexture();
+let textureView177 = texture170.createView({});
+let sampler121 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 77.71,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder114.end();
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup46);
+} catch {}
+try {
+commandEncoder145.resolveQuerySet(querySet23, 12, 76, buffer50, 0);
+} catch {}
+let pipeline26 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule3}});
+let buffer159 = device0.createBuffer({
+  size: 21380,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder185 = device0.createCommandEncoder({});
+let texture181 = device0.createTexture({
+  size: [260, 1, 48],
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder55 = commandEncoder145.beginRenderPass({
+  colorAttachments: [{
+  view: textureView109,
+  depthSlice: 6,
+  clearValue: { r: 152.7, g: 64.20, b: 4.608, a: 666.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet18,
+  maxDrawCount: 231717621,
+});
+let sampler122 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', magFilter: 'nearest', lodMaxClamp: 75.02});
+try {
+computePassEncoder33.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer26, 'uint16', 2_174, 814);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline6);
+} catch {}
+let bindGroup113 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout43,
+  entries: [
+    {binding: 48, resource: textureView2},
+    {binding: 41, resource: {buffer: buffer119, offset: 0}},
+    {binding: 162, resource: textureView72},
+    {binding: 119, resource: {buffer: buffer68, offset: 3840}},
+    {binding: 977, resource: {buffer: buffer29, offset: 3072, size: 288}},
+    {binding: 83, resource: {buffer: buffer68, offset: 0}},
+    {binding: 46, resource: externalTexture6},
+  ],
+});
+let commandEncoder186 = device0.createCommandEncoder({});
+let texture182 = device0.createTexture({
+  size: {width: 260},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView178 = texture95.createView({baseArrayLayer: 0});
+let renderPassEncoder56 = commandEncoder185.beginRenderPass({
+  label: '\ubaa4\u3827',
+  colorAttachments: [{
+  view: textureView109,
+  depthSlice: 30,
+  clearValue: { r: 345.7, g: -598.8, b: -906.3, a: 186.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder56.end();
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer30, 'uint32', 492, 359);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let gpuCanvasContext8 = canvas4.getContext('webgpu');
+let commandEncoder187 = device0.createCommandEncoder({});
+let textureView179 = texture141.createView({});
+let computePassEncoder146 = commandEncoder186.beginComputePass({});
+try {
+computePassEncoder68.setBindGroup(0, bindGroup31, new Uint32Array(1818), 902, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder37); computePassEncoder37.dispatchWorkgroupsIndirect(buffer75, 6_144); };
+} catch {}
+try {
+computePassEncoder59.end();
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup50, new Uint32Array(2235), 206, 0);
+} catch {}
+let promise22 = shaderModule10.getCompilationInfo();
+try {
+commandEncoder69.copyBufferToTexture({
+  /* bytesInLastRow: 130 widthInBlocks: 130 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2990 */
+  offset: 2860,
+  buffer: buffer116,
+}, {
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 130, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let buffer160 = device0.createBuffer({
+  size: 14891,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder188 = device0.createCommandEncoder();
+let computePassEncoder147 = commandEncoder73.beginComputePass({});
+try {
+renderPassEncoder6.setVertexBuffer(4, buffer40, 0, 1_806);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+let commandEncoder189 = device0.createCommandEncoder({});
+let texture183 = device0.createTexture({
+  size: [4, 4, 37],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView180 = texture75.createView({});
+let computePassEncoder148 = commandEncoder188.beginComputePass({});
+try {
+computePassEncoder147.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder49.setBlendConstant({ r: 79.47, g: 960.4, b: 550.3, a: 911.4, });
+} catch {}
+try {
+commandEncoder187.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1968 */
+  offset: 1968,
+  bytesPerRow: 17408,
+  rowsPerImage: 728,
+  buffer: buffer107,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup114 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 41, resource: {buffer: buffer109, offset: 2816}}],
+});
+let commandEncoder190 = device0.createCommandEncoder({});
+let texture184 = gpuCanvasContext6.getCurrentTexture();
+let computePassEncoder149 = commandEncoder190.beginComputePass({});
+let renderPassEncoder57 = commandEncoder187.beginRenderPass({
+  colorAttachments: [{
+  view: textureView176,
+  depthSlice: 20,
+  clearValue: { r: -613.5, g: 871.8, b: 744.3, a: 31.97, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder133.setBindGroup(0, bindGroup84);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder72); computePassEncoder72.dispatchWorkgroupsIndirect(buffer154, 1_500); };
+} catch {}
+try {
+commandEncoder69.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2056 */
+  offset: 2056,
+  buffer: buffer126,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 4},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder69.insertDebugMarker('\u10ff');
+} catch {}
+try {
+adapter0.label = '\u0c99\u9614\u{1f9f4}\u525b\u5c1c';
+} catch {}
+let recycledExplicitBindGroupLayout56 = pipeline24.getBindGroupLayout(0);
+let bindGroup115 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [
+    {binding: 41, resource: {buffer: buffer119, offset: 0}},
+    {binding: 162, resource: textureView72},
+    {binding: 48, resource: textureView10},
+    {binding: 83, resource: {buffer: buffer115, offset: 0, size: 1360}},
+    {binding: 119, resource: {buffer: buffer108, offset: 256, size: 462}},
+    {binding: 977, resource: {buffer: buffer77, offset: 1792, size: 4170}},
+    {binding: 46, resource: externalTexture5},
+  ],
+});
+let texture185 = device0.createTexture({
+  size: {width: 260},
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder150 = commandEncoder69.beginComputePass({});
+try {
+renderPassEncoder21.setPipeline(pipeline17);
+} catch {}
+try {
+commandEncoder189.copyTextureToTexture({
+  texture: texture125,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture183,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder191 = device0.createCommandEncoder({});
+let texture186 = device0.createTexture({
+  size: [260],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder151 = commandEncoder191.beginComputePass();
+let renderPassEncoder58 = commandEncoder189.beginRenderPass({
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: -830.0, g: 678.9, b: -798.4, a: -593.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler123 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 88.59,
+  maxAnisotropy: 4,
+});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup18, new Uint32Array(2724), 645, 0);
+} catch {}
+try {
+renderPassEncoder44.setStencilReference(815);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer90, 1220, new Float32Array(4568), 12, 1836);
+} catch {}
+let imageData31 = new ImageData(164, 68);
+let autogeneratedBindGroupLayout25 = pipeline17.getBindGroupLayout(0);
+try {
+computePassEncoder55.setBindGroup(3, bindGroup66, new Uint32Array(2229), 394, 0);
+} catch {}
+try {
+computePassEncoder149.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup8, new Uint32Array(3106), 50, 0);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline12);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer124, 4192, new Float32Array(9763), 1921, 128);
+} catch {}
+let videoFrame32 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'smpte170m', transfer: 'bt709'} });
+let recycledExplicitBindGroupLayout57 = pipeline6.getBindGroupLayout(0);
+let bindGroup116 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout17,
+  entries: [{binding: 154, resource: textureView105}, {binding: 22, resource: sampler87}],
+});
+let buffer161 = device0.createBuffer({
+  size: 6733,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder192 = device0.createCommandEncoder({});
+let texture187 = device0.createTexture({
+  size: {width: 260},
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView181 = texture12.createView({dimension: '2d', baseArrayLayer: 0});
+try {
+computePassEncoder86.setBindGroup(0, bindGroup103, new Uint32Array(960), 522, 0);
+} catch {}
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer50, 'uint32', 1_164, 4);
+} catch {}
+document.body.append(canvas3);
+let bindGroup117 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 41, resource: {buffer: buffer151, offset: 0, size: 220}}],
+});
+let commandEncoder193 = device0.createCommandEncoder({});
+let texture188 = device0.createTexture({size: [65, 1, 366], dimension: '3d', format: 'r32sint', usage: GPUTextureUsage.STORAGE_BINDING});
+let textureView182 = texture2.createView({dimension: '2d-array'});
+let computePassEncoder152 = commandEncoder193.beginComputePass({});
+try {
+computePassEncoder115.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+computePassEncoder73.setBindGroup(1, bindGroup100, new Uint32Array(247), 29, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder133); computePassEncoder133.dispatchWorkgroupsIndirect(buffer127, 3_992); };
+} catch {}
+try {
+computePassEncoder133.end();
+} catch {}
+try {
+computePassEncoder146.setPipeline(pipeline13);
+} catch {}
+let gpuCanvasContext9 = offscreenCanvas5.getContext('webgpu');
+try {
+renderPassEncoder43.setBindGroup(1, bindGroup28, new Uint32Array(1947), 128, 0);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(92);
+} catch {}
+try {
+renderPassEncoder39.setScissorRect(1, 0, 1, 0);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(4, buffer125);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder194 = device0.createCommandEncoder({});
+let texture189 = device0.createTexture({
+  size: [4, 4, 17],
+  sampleCount: 1,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder153 = commandEncoder43.beginComputePass();
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], depthReadOnly: true, stencilReadOnly: true});
+let sampler124 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 12.22,
+  compare: 'greater',
+});
+try {
+computePassEncoder90.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder58); computePassEncoder58.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder68); computePassEncoder68.dispatchWorkgroupsIndirect(buffer93, 628); };
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(4, buffer133, 0, 1_138);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer50, 'uint16', 550, 252);
+} catch {}
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+try {
+commandEncoder167.copyTextureToBuffer({
+  texture: texture31,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1024 */
+  offset: 1024,
+  buffer: buffer27,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer101, 268, new Float32Array(7404), 2492, 268);
+} catch {}
+let commandEncoder195 = device0.createCommandEncoder({});
+let texture190 = device0.createTexture({
+  size: {width: 32, height: 1, depthOrArrayLayers: 8},
+  sampleCount: 1,
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder46.setBindGroup(2, bindGroup65);
+} catch {}
+try {
+computePassEncoder152.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup71);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle7, renderBundle7]);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer77, 'uint16', 208, 4_778);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder192.copyBufferToTexture({
+  /* bytesInLastRow: 104 widthInBlocks: 26 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1084 */
+  offset: 1084,
+  bytesPerRow: 34048,
+  buffer: buffer126,
+}, {
+  texture: texture28,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 26, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise22;
+} catch {}
+let commandEncoder196 = device0.createCommandEncoder();
+let computePassEncoder154 = commandEncoder196.beginComputePass({});
+let renderPassEncoder59 = commandEncoder192.beginRenderPass({
+  colorAttachments: [{
+  view: textureView32,
+  depthSlice: 0,
+  clearValue: { r: 34.20, g: -170.8, b: -432.2, a: 812.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 377075751,
+});
+let sampler125 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'clamp-to-edge', lodMaxClamp: 89.10});
+try {
+computePassEncoder92.setBindGroup(0, bindGroup72, new Uint32Array(87), 8, 0);
+} catch {}
+try {
+computePassEncoder68.end();
+} catch {}
+try {
+computePassEncoder154.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(2, buffer115);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup89, new Uint32Array(2087), 16, 0);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer50, 'uint16', 186, 210);
+} catch {}
+try {
+commandEncoder195.copyBufferToTexture({
+  /* bytesInLastRow: 504 widthInBlocks: 63 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1416 */
+  offset: 1416,
+  bytesPerRow: 12288,
+  buffer: buffer46,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 173, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 63, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 69},
+  aspect: 'all',
+}, new Uint8Array(1_340_100).fill(128), /* required buffer size: 1_340_100 */
+{offset: 300, bytesPerRow: 55, rowsPerImage: 58}, {width: 6, height: 0, depthOrArrayLayers: 421});
+} catch {}
+let shaderModule13 = device0.createShaderModule({
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+enable f16;
+
+struct FragmentOutput12 {
+  @location(1) f0: i32,
+  @location(0) f1: vec2i,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(0) @binding(593) var tex11: texture_2d_array<u32>;
+
+fn fn1() -> array<mat4x2f, 1> {
+  var out: array<mat4x2f, 1>;
+  out[u32(unconst_u32(554))] += mat4x2f(bitcast<f32>(textureNumLevels(tex11)), f32(textureNumLevels(tex11)), f32(textureNumLevels(tex11)), f32(textureNumLevels(tex11)), bitcast<f32>(textureNumLevels(tex11)), bitcast<f32>(textureNumLevels(tex11)), f32(textureNumLevels(tex11)), bitcast<f32>(textureNumLevels(tex11)));
+  vp15.whole = vec2f(abs(vec2i(unconst_i32(123), unconst_i32(97)))).g;
+  var vf181: vec4h = log2(vec4h(unconst_f16(15121.4), unconst_f16(1731.1), unconst_f16(8766.2), unconst_f16(-41907.9)));
+  vf181 = vec4h(f16(pack4xU8(vec4u(unconst_u32(221), unconst_u32(51), unconst_u32(72), unconst_u32(734)))));
+  var vf182: u32 = pack4xU8(vec4u(unconst_u32(427), unconst_u32(325), unconst_u32(115), unconst_u32(22)));
+  let vf183: f16 = length(vec3h(unconst_f16(8905.7), unconst_f16(22750.9), unconst_f16(12583.5)));
+  let ptr144: ptr<function, vec4h> = &vf181;
+  vf181 = vec4h(vf181[u32(unconst_u32(314))]);
+  var vf184: vec4u = clamp(vec4u(unconst_u32(78), unconst_u32(207), unconst_u32(288), unconst_u32(104)), vec4u(unconst_u32(49), unconst_u32(41), unconst_u32(129), unconst_u32(355)), vec4u(unconst_u32(162), unconst_u32(297), unconst_u32(69), unconst_u32(38)));
+  let vf185: i32 = dot4I8Packed(u32(unconst_u32(149)), u32(unconst_u32(122)));
+  var vf186: vec2u = textureDimensions(tex11);
+  vf181 = (*ptr144);
+  var vf187: vec2u = textureDimensions(tex11);
+  vf187 -= textureDimensions(tex11);
+  var vf188: vec4h = log2(vec4h(length(vec3h(unconst_f16(3089.3), unconst_f16(12518.9), unconst_f16(7037.6)))));
+  let vf189: vec2h = sinh(vec2h(unconst_f16(7321.6), unconst_f16(16222.6)));
+  vf186 *= bitcast<vec2u>(unpack4x8snorm(u32(unconst_u32(84))).wx);
+  var vf190: vec4f = ceil(vec4f(unconst_f32(0.1497), unconst_f32(0.1960), unconst_f32(0.5041), unconst_f32(0.02227)));
+  vp15 = modf(f32(pack4xU8(vec4u(unconst_u32(137), unconst_u32(251), unconst_u32(453), unconst_u32(77)))));
+  return out;
+  _ = tex11;
+}
+
+var<private> vp15 = modf(f32(0.2961));
+
+struct T0 {
+  @size(16) f0: i32,
+}
+
+var<workgroup> vw57: f16;
+
+var<workgroup> vw58: VertexOutput10;
+
+struct T3 {
+  @align(32) @size(128) f0: vec4f,
+  @align(64) @size(1088) f1: array<atomic<u32>>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(15) var<storage, read> buffer162: T1;
+
+fn fn0(a0: ptr<function, T0>) -> FragmentOutput12 {
+  var out: FragmentOutput12;
+  var vf172: vec3i = clamp(vec3i(unconst_i32(224), unconst_i32(46), unconst_i32(42)), vec3i(unconst_i32(72), unconst_i32(357), unconst_i32(391)), vec3i(unconst_i32(71), unconst_i32(25), unconst_i32(19)));
+  vf172 = bitcast<vec3i>(exp2(vec3f(unconst_f32(0.1286), unconst_f32(0.1318), unconst_f32(0.1680))));
+  out.f0 |= i32(ldexp(vec3h(unconst_f16(334.2), unconst_f16(9436.9), unconst_f16(6904.3)), vec3i(unconst_i32(15), unconst_i32(132), unconst_i32(539)))[2]);
+  var vf173: u32 = textureNumLayers(tex11);
+  let vf174: f32 = exp2(f32(unconst_f32(0.2566)));
+  let vf175: vec4u = min(vec4u(unconst_u32(11), unconst_u32(90), unconst_u32(201), unconst_u32(338)), vec4u(unconst_u32(59), unconst_u32(5), unconst_u32(87), unconst_u32(60)));
+  let ptr142: ptr<function, u32> = &vf173;
+  vf172 &= vec3i(textureLoad(tex11, vec2i(unconst_i32(58), unconst_i32(-193)), i32(unconst_i32(6)), (*a0).f0).xwy);
+  let ptr143: ptr<function, u32> = &vf173;
+  let vf176: vec4u = textureLoad(tex11, vec2i(unconst_i32(162), unconst_i32(59)), i32(unconst_i32(71)), i32(unconst_i32(1000)));
+  var vf177: vec4u = vf176;
+  let vf178: vec3u = countTrailingZeros(vec3u(u32(vp15.fract)));
+  let vf179: vec4h = sin(vec4h(unconst_f16(57357.6), unconst_f16(311.7), unconst_f16(2281.5), unconst_f16(-12962.2)));
+  let vf180: f32 = exp2(f32(unconst_f32(0.09278)));
+  return out;
+  _ = tex11;
+}
+
+struct VertexOutput10 {
+  @invariant @builtin(position) f43: vec4f,
+}
+
+struct T2 {
+  @align(64) @size(1216) f0: array<atomic<i32>>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T1 {
+  @align(64) @size(1216) f0: array<u32>,
+}
+
+fn fn2(a0: vec2i, a1: mat3x2h) {
+  vp15.whole = vp15.whole;
+  let vf191: vec4i = unpack4xI8(u32(unconst_u32(9)));
+  let vf192: i32 = a0[u32(unconst_u32(176))];
+  vp15.whole = f32(a0[u32(unconst_u32(122))]);
+  vp15.fract = bitcast<f32>(radians(vec2h(unconst_f16(3382.5), unconst_f16(1330.4))));
+  vp15 = modf(bitcast<f32>(a1[unconst_i32(2)]));
+  vp15.fract = f32(textureDimensions(tex11, i32(unconst_i32(17))).g);
+  var vf193: i32 = a0[u32(unconst_u32(77))];
+  var vf194: vec4u = textureLoad(tex11, vec2i(unconst_i32(67), unconst_i32(266)), bitcast<i32>(a1[unconst_i32(1)]), i32(unconst_i32(6)));
+  let ptr145 = &vp15;
+  let vf195: u32 = vf194[u32(unconst_u32(125))];
+  var vf196: vec2i = a0;
+  var vf197: vec2h = a1[u32(unconst_u32(359))];
+  let ptr146: ptr<private, f32> = &(*ptr145).whole;
+  var vf198: vec4u = countLeadingZeros(vec4u(unconst_u32(830), unconst_u32(404), unconst_u32(464), unconst_u32(496)));
+  var vf199: u32 = textureNumLayers(tex11);
+  let vf200: vec4i = vf191;
+  vf194 ^= unpack4xU8(bitcast<u32>(vp15.fract));
+  vf194 |= vec4u(bitcast<u32>(vf200[u32(unconst_u32(33))]));
+  var vf201: i32 = a0[u32(unconst_u32(71))];
+  _ = tex11;
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@vertex
+fn vertex13(@location(3) @interpolate(flat) a0: vec2i) -> VertexOutput10 {
+  var out: VertexOutput10;
+  let ptr147: ptr<storage, u32, read> = &(*&buffer162).f0[i32(unconst_i32(109))];
+  fn2(vec2i(textureDimensions(tex11, i32(unconst_i32(626)))), mat3x2h(vec2h(textureDimensions(tex11)), vec2h(textureDimensions(tex11)), vec2h(textureDimensions(tex11))));
+  let ptr148: ptr<storage, u32, read> = &(*&buffer162).f0[arrayLength(&(*&buffer162).f0) - 1];
+  let ptr149: ptr<storage, T1, read> = &buffer162;
+  let ptr150: ptr<storage, u32, read> = &(*&buffer162).f0[u32(unconst_u32(18))];
+  out.f43 = vec4f(f32(buffer162.f0[u32(unconst_u32(203))]));
+  out.f43 += vec4f(bitcast<f32>((*&buffer162).f0[arrayLength(&(*&buffer162).f0)]));
+  let ptr151: ptr<storage, u32, read> = &(*ptr147);
+  var vf202: u32 = pack4xI8Clamp(vec4i(unconst_i32(55), unconst_i32(-259), unconst_i32(70), unconst_i32(267)));
+  var vf203: u32 = arrayLength(&(*&buffer162).f0);
+  return out;
+  _ = tex11;
+  _ = buffer162;
+}
+
+@fragment
+fn fragment14() -> FragmentOutput12 {
+  var out: FragmentOutput12;
+  var vf204: vec3h = log2(vec3h(unconst_f16(4643.7), unconst_f16(1072.6), unconst_f16(12627.9)));
+  let vf205: i32 = dot4I8Packed(u32(unconst_u32(1)), u32(unconst_u32(608)));
+  fn2(vec2i(unconst_i32(22), unconst_i32(43)), mat3x2h(atan2(f16(unconst_f16(18435.1)), f16(min(f32(unconst_f32(-0.02586)), f32(unconst_f32(0.2332))))), atan2(f16(unconst_f16(18435.1)), f16(min(f32(unconst_f32(-0.02586)), f32(unconst_f32(0.2332))))), atan2(f16(unconst_f16(18435.1)), f16(min(f32(unconst_f32(-0.02586)), f32(unconst_f32(0.2332))))), atan2(f16(unconst_f16(18435.1)), f16(min(f32(unconst_f32(-0.02586)), f32(unconst_f32(0.2332))))), atan2(f16(unconst_f16(18435.1)), f16(min(f32(unconst_f32(-0.02586)), f32(unconst_f32(0.2332))))), atan2(f16(unconst_f16(18435.1)), f16(min(f32(unconst_f32(-0.02586)), f32(unconst_f32(0.2332)))))));
+  vp15 = modf(bitcast<f32>(dot4I8Packed(u32(unconst_u32(155)), u32(unconst_u32(67)))));
+  let vf206: f16 = atan2(f16(unconst_f16(12957.0)), f16(unconst_f16(22593.5)));
+  let vf207: i32 = dot4I8Packed(u32(unconst_u32(133)), u32(unconst_u32(67)));
+  return out;
+  _ = tex11;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute12() {
+  fn1();
+  vp15.whole += f32((*&vw57));
+  vw57 = f16(faceForward(vec2f(unconst_f32(0.1323), unconst_f32(-0.01411)), vec2f(unconst_f32(0.08338), unconst_f32(0.01238)), vec2f(unconst_f32(0.2951), unconst_f32(0.2014))).r);
+  vw58 = VertexOutput10(vec4f((*&vw58).f43[u32(unconst_u32(134))]));
+  let vf208: vec2f = quantizeToF16(vec2f(unconst_f32(-0.00127), unconst_f32(0.1942)));
+  vp15 = modf((*&vw58).f43[3]);
+  var vf209 = fn1();
+  _ = tex11;
+}`,
+});
+let bindGroup118 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout18,
+  entries: [{binding: 113, resource: {buffer: buffer31, offset: 1792}}],
+});
+let computePassEncoder155 = commandEncoder195.beginComputePass({});
+let renderBundle13 = renderBundleEncoder13.finish({});
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup95, new Uint32Array(2596), 187, 0);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer32, 'uint32', 84, 9);
+} catch {}
+try {
+commandEncoder167.copyBufferToTexture({
+  /* bytesInLastRow: 168 widthInBlocks: 42 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4 */
+  offset: 4,
+  rowsPerImage: 218,
+  buffer: buffer18,
+}, {
+  texture: texture66,
+  mipLevel: 1,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 42, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData32 = new ImageData(32, 80);
+let recycledExplicitBindGroupLayout58 = pipeline25.getBindGroupLayout(0);
+let commandEncoder197 = device0.createCommandEncoder();
+let computePassEncoder156 = commandEncoder194.beginComputePass({});
+let renderPassEncoder60 = commandEncoder197.beginRenderPass({
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: 975.4, g: -370.0, b: 659.5, a: -98.74, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let imageBitmap7 = await createImageBitmap(videoFrame8);
+let textureView183 = texture15.createView({format: 'rg32uint', baseArrayLayer: 63, arrayLayerCount: 70});
+let computePassEncoder157 = commandEncoder87.beginComputePass({});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup66, new Uint32Array(1475), 30, 0);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+renderPassEncoder52.insertDebugMarker('\u032b');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(131).fill(99), /* required buffer size: 131 */
+{offset: 131}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout59 = pipeline25.getBindGroupLayout(0);
+let commandEncoder198 = device0.createCommandEncoder({});
+let computePassEncoder158 = commandEncoder167.beginComputePass({});
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(0, buffer143, 212, 666);
+} catch {}
+try {
+commandEncoder198.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1232 */
+  offset: 1232,
+  bytesPerRow: 10752,
+  buffer: buffer122,
+}, {
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 15, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder75.pushDebugGroup('\uc590');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: videoFrame20,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 84},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise23;
+} catch {}
+let videoFrame33 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'unspecified', transfer: 'iec6196624'} });
+let buffer163 = device0.createBuffer({size: 12635, usage: GPUBufferUsage.COPY_DST});
+let textureView184 = texture87.createView({mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 9});
+try {
+computePassEncoder86.setBindGroup(2, bindGroup20, new Uint32Array(826), 68, 0);
+} catch {}
+try {
+computePassEncoder72.end();
+} catch {}
+try {
+computePassEncoder156.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(0, buffer107, 128, 1_660);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let pipelineLayout16 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout23]});
+let commandEncoder199 = device0.createCommandEncoder();
+let textureView185 = texture59.createView({dimension: 'cube-array', format: 'rg32uint', baseArrayLayer: 2, arrayLayerCount: 6});
+let computePassEncoder159 = commandEncoder199.beginComputePass();
+try {
+computePassEncoder98.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+computePassEncoder97.setBindGroup(3, bindGroup99, new Uint32Array(1473), 298, 0);
+} catch {}
+try {
+computePassEncoder151.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer77, 'uint16', 88, 4_685);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer44, 3436, new BigUint64Array(1598), 377, 92);
+} catch {}
+let commandEncoder200 = device0.createCommandEncoder({});
+let commandBuffer20 = commandEncoder198.finish();
+let renderPassEncoder61 = commandEncoder200.beginRenderPass({colorAttachments: [{view: textureView96, loadOp: 'clear', storeOp: 'store'}], maxDrawCount: 34846591});
+let sampler126 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 71.35,
+  compare: 'never',
+});
+try {
+computePassEncoder113.setBindGroup(0, bindGroup94, new Uint32Array(482), 32, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder86); computePassEncoder86.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(3, bindGroup82, new Uint32Array(385), 11, 0);
+} catch {}
+document.body.prepend(canvas1);
+let commandEncoder201 = device0.createCommandEncoder();
+let commandBuffer21 = commandEncoder201.finish();
+let texture191 = device0.createTexture({
+  size: [260, 1, 26],
+  mipLevelCount: 2,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView186 = texture83.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+let sampler127 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 84.76,
+  compare: 'greater-equal',
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder92.setBindGroup(0, bindGroup64, new Uint32Array(4271), 618, 0);
+} catch {}
+try {
+computePassEncoder148.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(3, bindGroup70);
+} catch {}
+try {
+renderPassEncoder60.executeBundles([renderBundle9, renderBundle0, renderBundle0, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(4, buffer151, 440, 465);
+} catch {}
+try {
+commandEncoder24.copyBufferToBuffer(buffer126, 1836, buffer92, 3612, 3164);
+} catch {}
+try {
+gpuCanvasContext3.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(121).fill(238), /* required buffer size: 121 */
+{offset: 121}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder202 = device0.createCommandEncoder({});
+let texture192 = device0.createTexture({
+  size: [130, 1, 20],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder62 = commandEncoder24.beginRenderPass({
+  colorAttachments: [{
+  view: textureView89,
+  clearValue: { r: 635.9, g: 324.4, b: 452.0, a: -357.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {view: textureView40, depthReadOnly: false, stencilClearValue: 19008, stencilReadOnly: true},
+  occlusionQuerySet: querySet18,
+});
+try {
+computePassEncoder155.setBindGroup(2, bindGroup77, new Uint32Array(577), 1, 0);
+} catch {}
+try {
+computePassEncoder58.end();
+} catch {}
+try {
+renderPassEncoder61.setIndexBuffer(buffer48, 'uint16', 720, 265);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(2, buffer115, 0, 411);
+} catch {}
+try {
+device0.queue.submit([commandBuffer21, commandBuffer20]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(173).fill(78), /* required buffer size: 173 */
+{offset: 173}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout60 = pipeline16.getBindGroupLayout(0);
+let buffer164 = device0.createBuffer({
+  size: 26947,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture193 = device0.createTexture({
+  size: [32, 1, 1],
+  dimension: '2d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+renderPassEncoder50.beginOcclusionQuery(11);
+} catch {}
+try {
+renderPassEncoder50.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(1, buffer113, 3_188);
+} catch {}
+try {
+commandEncoder72.copyTextureToTexture({
+  texture: texture163,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture140,
+  mipLevel: 0,
+  origin: {x: 82, y: 0, z: 27},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView187 = texture151.createView({});
+let computePassEncoder160 = commandEncoder72.beginComputePass();
+let renderPassEncoder63 = commandEncoder202.beginRenderPass({
+  colorAttachments: [{
+  view: textureView32,
+  depthSlice: 0,
+  clearValue: { r: 36.67, g: -109.4, b: -650.8, a: -971.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet1,
+});
+let sampler128 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 49.34,
+});
+try {
+computePassEncoder43.setBindGroup(0, bindGroup115);
+} catch {}
+try {
+computePassEncoder155.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder48.beginOcclusionQuery(14);
+} catch {}
+let veryExplicitBindGroupLayout31 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 132,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32sint', access: 'write-only', viewDimension: '2d' },
+    },
+  ],
+});
+let commandEncoder203 = device0.createCommandEncoder({});
+let renderPassEncoder64 = commandEncoder203.beginRenderPass({
+  label: '\u1b2a\ude94\u0f42\u4198\u3cdf\u3464\uebda',
+  colorAttachments: [{
+  view: textureView35,
+  clearValue: { r: -190.1, g: 269.5, b: 96.36, a: -774.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder32.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+computePassEncoder86.end();
+} catch {}
+try {
+computePassEncoder158.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder62.executeBundles([renderBundle10, renderBundle10]);
+} catch {}
+try {
+commandEncoder109.copyBufferToTexture({
+  /* bytesInLastRow: 72 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1800 */
+  offset: 1800,
+  buffer: buffer145,
+}, {
+  texture: texture193,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder109.copyTextureToBuffer({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 100 widthInBlocks: 25 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 948 */
+  offset: 948,
+  buffer: buffer129,
+}, {width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline27 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule1,
+  constants: {9_084: 0},
+  targets: [{format: 'rg32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule13,
+    buffers: [
+      {arrayStride: 80, stepMode: 'vertex', attributes: [{format: 'sint8x2', offset: 2, shaderLocation: 3}]},
+    ],
+  },
+});
+let commandEncoder204 = device0.createCommandEncoder({});
+let commandBuffer22 = commandEncoder109.finish();
+let textureView188 = texture173.createView({dimension: 'cube-array', format: 'rg16uint', baseArrayLayer: 1, arrayLayerCount: 6});
+let sampler129 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.67,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder153.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle4]);
+} catch {}
+let videoFrame34 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'smpte240m', transfer: 'bt2020_10bit'} });
+let commandEncoder205 = device0.createCommandEncoder({});
+let texture194 = gpuCanvasContext4.getCurrentTexture();
+let computePassEncoder161 = commandEncoder204.beginComputePass();
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder205.copyTextureToBuffer({
+  texture: texture185,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 424 widthInBlocks: 53 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1768 */
+  offset: 1768,
+  buffer: buffer27,
+}, {width: 53, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer154, 580, new DataView(new ArrayBuffer(8209)), 1087, 344);
+} catch {}
+let bindGroup119 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout15,
+  entries: [{binding: 73, resource: {buffer: buffer106, offset: 1792, size: 1148}}],
+});
+let texture195 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder38.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+computePassEncoder93.setBindGroup(3, bindGroup24, new Uint32Array(58), 7, 0);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(4, buffer150, 3_104);
+} catch {}
+try {
+commandEncoder205.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 376 */
+  offset: 376,
+  rowsPerImage: 680,
+  buffer: buffer26,
+}, {
+  texture: texture67,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+renderPassEncoder48.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder205.copyTextureToBuffer({
+  texture: texture126,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2324 */
+  offset: 2324,
+  bytesPerRow: 28160,
+  buffer: buffer95,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderPassEncoder35.pushDebugGroup('\u5f95');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline28 = await device0.createComputePipelineAsync({layout: pipelineLayout6, compute: {module: shaderModule3, constants: {49_136: 0}}});
+let bindGroup120 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout58,
+  entries: [
+    {binding: 162, resource: textureView99},
+    {binding: 46, resource: externalTexture7},
+    {binding: 48, resource: textureView10},
+    {binding: 41, resource: {buffer: buffer81, offset: 2304}},
+    {binding: 119, resource: {buffer: buffer30, offset: 2304, size: 176}},
+    {binding: 83, resource: {buffer: buffer115, offset: 768, size: 79}},
+    {binding: 977, resource: {buffer: buffer31, offset: 5376}},
+  ],
+});
+let commandEncoder206 = device0.createCommandEncoder();
+let texture196 = device0.createTexture({
+  size: [32, 1, 76],
+  dimension: '2d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let texture197 = gpuCanvasContext1.getCurrentTexture();
+let textureView189 = texture6.createView({mipLevelCount: 1});
+let externalTexture20 = device0.importExternalTexture({source: videoFrame12});
+try {
+computePassEncoder108.setPipeline(pipeline26);
+} catch {}
+try {
+commandEncoder206.copyBufferToBuffer(buffer23, 124, buffer115, 316, 296);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer33, 2752, new DataView(new ArrayBuffer(4419)), 686, 540);
+} catch {}
+let imageData33 = new ImageData(12, 8);
+let videoFrame35 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'bt2020', transfer: 'bt2020_12bit'} });
+let autogeneratedBindGroupLayout26 = pipeline27.getBindGroupLayout(0);
+let commandEncoder207 = device0.createCommandEncoder({});
+let computePassEncoder162 = commandEncoder206.beginComputePass();
+try {
+computePassEncoder150.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder63.executeBundles([renderBundle5]);
+} catch {}
+try {
+commandEncoder207.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2108 */
+  offset: 2108,
+  bytesPerRow: 16384,
+  rowsPerImage: 74,
+  buffer: buffer27,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer22]);
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(canvas1);
+let buffer165 = device0.createBuffer({
+  size: 39385,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let sampler130 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 72.25,
+});
+try {
+computePassEncoder159.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(1, bindGroup7, new Uint32Array(2279), 77, 0);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([renderBundle4, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer52, 'uint16', 636, 3_401);
+} catch {}
+try {
+commandEncoder205.clearBuffer(buffer4, 1296, 460);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise24;
+} catch {}
+let textureView190 = texture100.createView({dimension: '2d-array', baseArrayLayer: 0});
+let computePassEncoder163 = commandEncoder205.beginComputePass({});
+let renderPassEncoder65 = commandEncoder207.beginRenderPass({
+  colorAttachments: [{view: textureView16, depthSlice: 10, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet26,
+});
+try {
+computePassEncoder40.setBindGroup(3, bindGroup43, new Uint32Array(292), 24, 0);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(3, bindGroup40, new Uint32Array(737), 287, 0);
+} catch {}
+try {
+renderPassEncoder55.beginOcclusionQuery(45);
+} catch {}
+try {
+renderPassEncoder53.setViewport(19.572636955146656, 0.9769548711056624, 8.038823769585264, 0.0013226521886258852, 0.2076454579304462, 0.8586453367383838);
+} catch {}
+try {
+renderPassEncoder35.popDebugGroup();
+} catch {}
+let bindGroup121 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout23,
+  entries: [
+    {binding: 977, resource: {buffer: buffer141, offset: 1024, size: 457}},
+    {binding: 119, resource: {buffer: buffer18, offset: 1280, size: 319}},
+    {binding: 48, resource: textureView10},
+    {binding: 41, resource: {buffer: buffer159, offset: 256, size: 9948}},
+    {binding: 46, resource: externalTexture18},
+    {binding: 83, resource: {buffer: buffer68, offset: 0, size: 133}},
+    {binding: 162, resource: textureView138},
+  ],
+});
+try {
+renderPassEncoder41.setBindGroup(2, bindGroup102);
+} catch {}
+try {
+renderPassEncoder55.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer112, 'uint32', 876, 438);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline11);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup122 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout56,
+  entries: [
+    {binding: 119, resource: {buffer: buffer115, offset: 768, size: 161}},
+    {binding: 83, resource: {buffer: buffer75, offset: 512, size: 1551}},
+    {binding: 46, resource: externalTexture0},
+    {binding: 41, resource: {buffer: buffer82, offset: 3584}},
+    {binding: 162, resource: textureView72},
+    {binding: 48, resource: textureView13},
+    {binding: 977, resource: {buffer: buffer51, offset: 1536, size: 121}},
+  ],
+});
+let commandEncoder208 = device0.createCommandEncoder({});
+let textureView191 = texture170.createView({});
+let computePassEncoder164 = commandEncoder208.beginComputePass({});
+try {
+computePassEncoder42.insertDebugMarker('\u{1f662}');
+} catch {}
+try {
+renderPassEncoder63.insertDebugMarker('\u36fc');
+} catch {}
+let autogeneratedBindGroupLayout27 = pipeline17.getBindGroupLayout(0);
+let commandEncoder209 = device0.createCommandEncoder({label: '\u0f0e\u4e74\ub76b\u0f37\ub843\u06cc\u7e46\u97ac\u024d\u{1f7f6}'});
+let textureView192 = texture74.createView({format: 'rg32uint'});
+let computePassEncoder165 = commandEncoder209.beginComputePass();
+try {
+computePassEncoder151.setBindGroup(1, bindGroup28, new Uint32Array(9890), 386, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder48); computePassEncoder48.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder13.setViewport(170.02301933868796, 0.0867252944872059, 13.07738928978929, 0.9083179913996483, 0.4355760440834938, 0.980144990722812);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer30, 'uint16', 1_158, 305);
+} catch {}
+try {
+buffer109.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let promise25 = device0.queue.onSubmittedWorkDone();
+let shaderModule14 = device0.createShaderModule({
+  label: '\ue74b\u0254\u09be\u0827',
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T0 {
+  @align(64) @size(320) f0: array<mat4x3h>,
+}
+
+override override16: u32;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn fn2() -> FragmentOutput13 {
+  var out: FragmentOutput13;
+  out.f1 = vec4i(i32((*&buffer167)[0][31][4]));
+  var vf211 = fn0();
+  let ptr169: ptr<function, i32> = &vf211[u32(unconst_u32(149))][0][u32(unconst_u32(138))][u32(unconst_u32(64))];
+  out = FragmentOutput13(vec4u(u32(buffer167[u32(unconst_u32(1))][u32(unconst_u32(50))][4])), vec4i(i32(buffer167[u32(unconst_u32(1))][u32(unconst_u32(50))][4])), vec4f(f32(buffer167[u32(unconst_u32(1))][u32(unconst_u32(50))][4])));
+  let ptr170: ptr<storage, array<f16, 1>, read> = &(*&buffer166)[47];
+  let ptr171: ptr<storage, f16, read> = &(*ptr170)[u32(unconst_u32(78))];
+  out = FragmentOutput13(vec4u(u32((*&buffer167)[u32(unconst_u32(13))][u32(unconst_u32(12))][4])), vec4i(i32((*&buffer167)[u32(unconst_u32(13))][u32(unconst_u32(12))][4])), vec4f(f32((*&buffer167)[u32(unconst_u32(13))][u32(unconst_u32(12))][4])));
+  vf211[u32(unconst_u32(110))][u32(unconst_u32(437))][u32(unconst_u32(525))][u32(unconst_u32(178))] -= i32(unpack4x8unorm(u32(unconst_u32(6)))[1]);
+  let ptr172: ptr<storage, array<f16, 5>, read> = &(*&buffer167)[u32(unconst_u32(88))][u32(unconst_u32(198))];
+  out.f0 |= unpack4xU8(u32(buffer167[0][31][4]));
+  let ptr173: ptr<function, array<i32, 4>> = &vf211[u32(unconst_u32(56))][0][u32(unconst_u32(121))];
+  out.f2 = vec4f(f32((*ptr170)[0]));
+  let ptr174: ptr<storage, f16, read> = &buffer167[u32(unconst_u32(70))][u32(unconst_u32(143))][4];
+  vf211[u32(unconst_u32(76))][u32(unconst_u32(23))][u32(unconst_u32(633))][u32(unconst_u32(35))] = vf211[14][u32(unconst_u32(61))][u32(unconst_u32(412))][3];
+  out.f2 -= vec4f(f32(buffer167[u32(unconst_u32(130))][u32(unconst_u32(601))][4]));
+  var vf212: f16 = override18;
+  return out;
+  _ = override18;
+  _ = buffer166;
+  _ = buffer167;
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct FragmentOutput13 {
+  @location(6) @interpolate(flat) f0: vec4u,
+  @location(0) f1: vec4i,
+  @location(3) @interpolate(perspective, center) f2: vec4f,
+}
+
+@group(0) @binding(122) var<storage, read> buffer166: array<array<f16, 1>, 48>;
+
+@group(1) @binding(73) var<storage, read> buffer167: array<array<array<f16, 5>, 32>, 1>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@id(53822) override override17: f32;
+
+fn fn0() -> array<array<array<array<i32, 4>, 1>, 1>, 15> {
+  var out: array<array<array<array<i32, 4>, 1>, 1>, 15>;
+  let ptr152: ptr<storage, array<array<f16, 5>, 32>, read> = &(*&buffer167)[u32(buffer167[u32(unconst_u32(19))][u32(unconst_u32(561))][4])];
+  let ptr153: ptr<storage, array<array<f16, 5>, 32>, read> = &(*&buffer167)[0];
+  let ptr154: ptr<storage, f16, read> = &buffer167[u32(unconst_u32(122))][u32(unconst_u32(135))][4];
+  let ptr155: ptr<storage, array<f16, 1>, read> = &(*&buffer166)[u32(unconst_u32(49))];
+  out[14][u32(unconst_u32(61))][u32(unconst_u32(392))][u32(unconst_u32(38))] |= i32((*ptr154));
+  var vf210: vec4i = unpack4xI8(u32(unconst_u32(268)));
+  return out;
+  _ = buffer166;
+  _ = buffer167;
+}
+
+var<workgroup> vw59: vec2h;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn fn1(a0: array<vec4u, 4>) -> FragmentOutput13 {
+  var out: FragmentOutput13;
+  let ptr156: ptr<storage, array<f16, 5>, read> = &(*&buffer167)[u32(unconst_u32(286))][31];
+  let ptr157: ptr<storage, array<f16, 5>, read> = &buffer167[0][31];
+  let ptr158: ptr<storage, array<array<f16, 5>, 32>, read> = &buffer167[u32(unconst_u32(147))];
+  let ptr159: ptr<storage, array<f16, 5>, read> = &(*ptr158)[u32(unconst_u32(356))];
+  out.f0 = vec4u(u32(buffer167[u32(buffer167[0][u32(unconst_u32(23))][4])][31][4]));
+  out.f0 |= vec4u(u32((*&buffer167)[0][31][4]));
+  let ptr160: ptr<storage, array<array<f16, 5>, 32>, read> = &buffer167[0];
+  let ptr161: ptr<storage, f16, read> = &(*&buffer167)[0][u32(unconst_u32(413))][u32((*ptr158)[31][4])];
+  let ptr162: ptr<storage, array<array<f16, 5>, 32>, read> = &buffer167[0];
+  let ptr163: ptr<storage, array<f16, 5>, read> = &(*&buffer167)[u32(unconst_u32(277))][31];
+  out.f1 = vec4i(i32((*ptr162)[31][4]));
+  let ptr164: ptr<storage, f16, read> = &(*&buffer167)[u32(unconst_u32(96))][u32(unconst_u32(72))][4];
+  out.f0 += unpack4xU8(u32(buffer166[47][0]));
+  out.f0 |= unpack4xU8(u32((*ptr163)[4]));
+  out.f1 *= vec4i(i32(buffer166[47][0]));
+  out.f0 >>= unpack4xU8(u32(buffer166[u32(unconst_u32(51))][0]));
+  let ptr165: ptr<storage, f16, read> = &buffer166[u32(unconst_u32(33))][u32(unconst_u32(190))];
+  let ptr166: ptr<storage, array<f16, 5>, read> = &(*ptr163);
+  out = FragmentOutput13(vec4u(u32((*&buffer167)[u32(unconst_u32(847))][31][4])), vec4i(i32((*&buffer167)[u32(unconst_u32(847))][31][4])), vec4f(f32((*&buffer167)[u32(unconst_u32(847))][31][4])));
+  out.f1 *= vec4i(saturate(vec2f(unconst_f32(0.1976), unconst_f32(0.1813))).xyyx);
+  let ptr167: ptr<storage, f16, read> = &(*ptr158)[u32(unconst_u32(15))][u32((*ptr160)[u32(unconst_u32(277))][4])];
+  let ptr168: ptr<storage, f16, read> = &(*ptr158)[31][4];
+  return out;
+  _ = buffer166;
+  _ = buffer167;
+}
+
+override override18: f16;
+
+@fragment
+fn fragment15(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool) -> FragmentOutput13 {
+  var out: FragmentOutput13;
+  fn1(array<vec4u, 4>(vec4u(unconst_u32(75), unconst_u32(177), unconst_u32(77), unconst_u32(704)), vec4u(unconst_u32(94), unconst_u32(220), unconst_u32(237), unconst_u32(229)), vec4u(unconst_u32(58), unconst_u32(385), unconst_u32(49), unconst_u32(138)), vec4u(unconst_u32(211), unconst_u32(70), unconst_u32(117), unconst_u32(4))));
+  fn1(array<vec4u, 4>(vec4u(u32((*&buffer167)[u32(unconst_u32(152))][31][4])), unpack4xU8(u32((*&buffer167)[u32(unconst_u32(152))][31][4])), vec4u(u32((*&buffer167)[u32(unconst_u32(152))][31][4])), unpack4xU8(u32((*&buffer167)[u32(unconst_u32(152))][31][4]))));
+  out.f0 >>= vec4u(pack4xU8Clamp(vec4u(unconst_u32(26), unconst_u32(229), unconst_u32(279), unconst_u32(257))));
+  out.f0 = unpack4xU8(u32((*&buffer167)[0][u32(unconst_u32(41))][u32(unconst_u32(189))]));
+  out = FragmentOutput13(vec4u(u32(buffer167[u32(unconst_u32(33))][u32(unconst_u32(997))][u32(unconst_u32(340))])), vec4i(i32(buffer167[u32(unconst_u32(33))][u32(unconst_u32(997))][u32(unconst_u32(340))])), vec4f(f32(buffer167[u32(unconst_u32(33))][u32(unconst_u32(997))][u32(unconst_u32(340))])));
+  fn1(array<vec4u, 4>(vec4u(u32(buffer166[47][0])), unpack4xU8(u32(buffer166[47][0])), vec4u(u32(buffer166[47][0])), vec4u(u32(buffer166[47][0]))));
+  out.f2 += vec4f(f32(buffer167[u32(unconst_u32(170))][31][4]));
+  out.f2 = vec4f(f32(buffer167[u32(unconst_u32(316))][u32(unconst_u32(360))][4]));
+  out.f2 = vec4f(f32(buffer166[47][u32(unconst_u32(45))]));
+  out.f1 *= vec4i(i32((*&buffer166)[u32(unconst_u32(89))][0]));
+  out.f1 += vec4i(i32(buffer167[0][31][4]));
+  out.f2 += vec4f(f32((*&buffer167)[u32(unconst_u32(509))][u32(unconst_u32(474))][4]));
+  fn1(array<vec4u, 4>(vec4u(unconst_u32(48), unconst_u32(194), unconst_u32(29), unconst_u32(11)), vec4u(unconst_u32(37), unconst_u32(210), unconst_u32(25), unconst_u32(57)), vec4u(unconst_u32(256), unconst_u32(321), unconst_u32(392), unconst_u32(35)), vec4u(unconst_u32(29), unconst_u32(5), unconst_u32(411), unconst_u32(187))));
+  var vf213: vec4h = reflect(vec4h(unconst_f16(7801.7), unconst_f16(4462.0), unconst_f16(35491.3), unconst_f16(12049.9)), vec4h(unconst_f16(4397.2), unconst_f16(-23709.8), unconst_f16(10440.2), unconst_f16(13864.5)));
+  return out;
+  _ = buffer167;
+  _ = buffer166;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute13() {
+  vw59 = vec2h((*&buffer166)[u32(unconst_u32(565))][bitcast<u32>(vw59)]);
+  let ptr175: ptr<storage, array<array<f16, 1>, 48>, read> = &buffer166;
+  vw59 = vec2h((*&buffer166)[47][0]);
+  vw59 = vec2h(firstTrailingBit(vec3i(unconst_i32(76), unconst_i32(-477), unconst_i32(130))).gr);
+  vw59 = vec2h(buffer166[47][0]);
+  vw59 = (*&vw59);
+  vw59 = vec2h((*&buffer166)[u32(vw59[u32(unconst_u32(191))])][0]);
+  let ptr176: ptr<storage, f16, read> = &buffer166[u32(unconst_u32(178))][u32(unconst_u32(166))];
+  vw59 *= vec2h((*&buffer166)[47][0]);
+  let ptr177: ptr<storage, f16, read> = &buffer166[47][u32(override18)];
+  let ptr178: ptr<storage, array<array<f16, 1>, 48>, read> = &(*&buffer166);
+  let ptr179: ptr<storage, f16, read> = &buffer166[u32(unconst_u32(102))][0];
+  let ptr180: ptr<storage, f16, read> = &(*ptr179);
+  let ptr181: ptr<storage, array<f16, 1>, read> = &(*ptr178)[u32(unconst_u32(921))];
+  let ptr182: ptr<storage, array<f16, 1>, read> = &buffer166[47];
+  let ptr183: ptr<storage, f16, read> = &(*ptr175)[47][0];
+  let ptr184: ptr<storage, array<f16, 1>, read> = &(*ptr181);
+  vw59 = vec2h((*&buffer166)[47][0]);
+  vw59 += vec2h((*ptr175)[u32(unconst_u32(1000))][0]);
+  let ptr185: ptr<storage, f16, read> = &(*&buffer166)[u32(unconst_u32(46))][0];
+  var vf214: f32 = distance(vec4f(unconst_f32(0.07014), unconst_f32(0.3218), unconst_f32(0.06490), unconst_f32(0.08326)), vec4f(unconst_f32(-0.1318), unconst_f32(0.2578), unconst_f32(-0.1378), unconst_f32(0.2023)));
+  _ = override18;
+  _ = buffer166;
+}`,
+});
+let veryExplicitBindGroupLayout32 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 226,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let pipelineLayout17 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout10]});
+let commandEncoder210 = device0.createCommandEncoder({});
+let textureView193 = texture39.createView({dimension: '2d-array'});
+let computePassEncoder166 = commandEncoder210.beginComputePass({});
+document.body.prepend(canvas3);
+let buffer168 = device0.createBuffer({
+  size: 2578,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let textureView194 = texture151.createView({dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder118.setBindGroup(0, bindGroup58);
+} catch {}
+try {
+computePassEncoder144.setBindGroup(0, bindGroup86, new Uint32Array(113), 8, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder113); computePassEncoder113.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder164.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(2, bindGroup99, new Uint32Array(38), 8, 0);
+} catch {}
+try {
+renderPassEncoder23.setBlendConstant({ r: -901.9, g: 855.6, b: 31.23, a: -390.1, });
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer156, 'uint16', 2_132, 4_307);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let imageData34 = new ImageData(44, 12);
+let bindGroup123 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout15,
+  entries: [{binding: 41, resource: {buffer: buffer0, offset: 2048, size: 1372}}],
+});
+let pipelineLayout18 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout0]});
+let querySet27 = device0.createQuerySet({type: 'occlusion', count: 736});
+let sampler131 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'equal',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder143.setBindGroup(0, bindGroup65);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder48); computePassEncoder48.dispatchWorkgroupsIndirect(buffer77, 3_980); };
+} catch {}
+try {
+computePassEncoder157.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder41.setScissorRect(2, 0, 142, 0);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer91, 'uint16', 40, 17);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(6, buffer8, 0, 828);
+} catch {}
+try {
+commandEncoder36.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 728 */
+  offset: 728,
+  rowsPerImage: 71,
+  buffer: buffer117,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder36.clearBuffer(buffer65, 236);
+} catch {}
+try {
+computePassEncoder75.popDebugGroup();
+} catch {}
+document.body.append(img0);
+let commandBuffer23 = commandEncoder36.finish();
+let textureView195 = texture32.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder48); computePassEncoder48.dispatchWorkgroupsIndirect(buffer119, 200); };
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup116);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(3, buffer107, 256, 959);
+} catch {}
+let imageBitmap8 = await createImageBitmap(canvas2);
+let buffer169 = device0.createBuffer({
+  size: 7879,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView196 = texture151.createView({});
+let sampler132 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 62.82,
+  compare: 'not-equal',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup94);
+} catch {}
+try {
+computePassEncoder113.end();
+} catch {}
+try {
+computePassEncoder161.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer30, 'uint16', 554, 928);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer52, 0);
+} catch {}
+let recycledExplicitBindGroupLayout61 = pipeline10.getBindGroupLayout(0);
+let bindGroup124 = device0.createBindGroup({layout: autogeneratedBindGroupLayout25, entries: [{binding: 31, resource: textureView63}]});
+let renderPassEncoder66 = commandEncoder96.beginRenderPass({
+  colorAttachments: [{
+  view: textureView172,
+  depthSlice: 5,
+  clearValue: { r: 638.4, g: 889.9, b: 585.4, a: 429.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet18,
+});
+try {
+computePassEncoder165.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(3, bindGroup58, new Uint32Array(1250), 83, 0);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline12);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+try {
+computePassEncoder88.setBindGroup(0, bindGroup66);
+} catch {}
+try {
+renderPassEncoder50.setPipeline(pipeline12);
+} catch {}
+let commandEncoder211 = device0.createCommandEncoder();
+let computePassEncoder167 = commandEncoder211.beginComputePass({});
+let sampler133 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 99.84,
+});
+try {
+computePassEncoder127.setBindGroup(0, bindGroup99, new Uint32Array(1630), 401, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder115); computePassEncoder115.dispatchWorkgroupsIndirect(buffer16, 28); };
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer160, 'uint32', 7_172, 1_263);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline1);
+} catch {}
+try {
+  await promise25;
+} catch {}
+await gc();
+let veryExplicitBindGroupLayout33 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 273,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup125 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout1,
+  entries: [
+    {binding: 119, resource: {buffer: buffer92, offset: 512, size: 1792}},
+    {binding: 41, resource: {buffer: buffer156, offset: 1024, size: 1268}},
+    {binding: 162, resource: textureView59},
+    {binding: 977, resource: {buffer: buffer17, offset: 6400}},
+    {binding: 48, resource: textureView10},
+    {binding: 83, resource: {buffer: buffer91, offset: 0, size: 84}},
+    {binding: 46, resource: externalTexture14},
+  ],
+});
+let buffer170 = device0.createBuffer({
+  size: 21731,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder212 = device0.createCommandEncoder({});
+let texture198 = device0.createTexture({size: {width: 32}, dimension: '1d', format: 'r32float', usage: GPUTextureUsage.STORAGE_BINDING});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup80, new Uint32Array(6246), 3_560, 0);
+} catch {}
+try {
+computePassEncoder167.setPipeline(pipeline4);
+} catch {}
+let arrayBuffer12 = buffer123.getMappedRange(40, 8);
+try {
+commandEncoder212.copyTextureToTexture({
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer171 = device0.createBuffer({
+  size: 1038,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder213 = device0.createCommandEncoder({});
+let texture199 = gpuCanvasContext8.getCurrentTexture();
+let renderPassEncoder67 = commandEncoder213.beginRenderPass({
+  label: '\u5283\uc796\u{1fc90}\u51c5\u{1f9b6}\ufa32\ue69c',
+  colorAttachments: [{
+  view: textureView48,
+  depthSlice: 13,
+  clearValue: { r: 329.6, g: -651.3, b: 312.9, a: -521.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let externalTexture21 = device0.importExternalTexture({source: videoFrame19, colorSpace: 'srgb'});
+try {
+renderPassEncoder50.setIndexBuffer(buffer65, 'uint16', 124, 1_601);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(7, buffer118, 224);
+} catch {}
+try {
+commandEncoder212.copyTextureToTexture({
+  texture: texture93,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler134 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 90.83,
+});
+try {
+computePassEncoder87.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder46.setBindGroup(0, bindGroup111, new Uint32Array(2547), 295, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder111); computePassEncoder111.dispatchWorkgroupsIndirect(buffer77, 1_544); };
+} catch {}
+try {
+computePassEncoder111.end();
+} catch {}
+try {
+renderPassEncoder54.setViewport(8.274600306202803, 0.6820233438855676, 19.78456178583131, 0.030832809924088263, 0.5469763778392367, 0.6847735661517366);
+} catch {}
+try {
+commandEncoder212.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2864 */
+  offset: 2864,
+  buffer: buffer67,
+}, {
+  texture: texture139,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 3},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise26 = device0.queue.onSubmittedWorkDone();
+let pipeline29 = device0.createRenderPipeline({
+  layout: pipelineLayout9,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment8',
+  constants: {},
+  targets: [{format: 'rg32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex6',
+    buffers: [
+      {
+        arrayStride: 252,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 24, shaderLocation: 1},
+          {format: 'unorm16x2', offset: 56, shaderLocation: 4},
+          {format: 'uint16x4', offset: 16, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 80, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 14},
+          {format: 'unorm16x2', offset: 96, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 228,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 116, shaderLocation: 5},
+          {format: 'sint32x2', offset: 124, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 560,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x2', offset: 136, shaderLocation: 12}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32'},
+});
+let recycledExplicitBindGroupLayout62 = pipeline23.getBindGroupLayout(2);
+let buffer172 = device0.createBuffer({size: 11792, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture200 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder168 = commandEncoder140.beginComputePass({});
+try {
+computePassEncoder121.setBindGroup(0, bindGroup94, new Uint32Array(2394), 91, 0);
+} catch {}
+try {
+computePassEncoder168.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup94, []);
+} catch {}
+try {
+renderPassEncoder58.executeBundles([renderBundle0, renderBundle6, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder60.setViewport(12.558765138609436, 0.191306902702007, 12.69256725916793, 0.6924560918405206, 0.5943113610204787, 0.6798190352051052);
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer50, 'uint32', 1_088, 108);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 76, new DataView(new ArrayBuffer(3267)), 426, 708);
+} catch {}
+let pipeline30 = await promise11;
+let imageBitmap9 = await createImageBitmap(imageData10);
+let bindGroup126 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 270, resource: {buffer: buffer92, offset: 3584, size: 2300}},
+    {binding: 326, resource: {buffer: buffer83, offset: 0, size: 464}},
+    {binding: 79, resource: textureView42},
+    {binding: 601, resource: {buffer: buffer51, offset: 3328, size: 1532}},
+    {binding: 299, resource: sampler125},
+    {binding: 101, resource: sampler3},
+    {binding: 243, resource: textureView146},
+  ],
+});
+let texture201 = device0.createTexture({size: [260, 1, 1], format: 'rg32uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+computePassEncoder24.setBindGroup(1, bindGroup65);
+} catch {}
+try {
+computePassEncoder163.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(0, bindGroup45, new Uint32Array(263), 112, 0);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer108, 0, 795);
+} catch {}
+try {
+commandEncoder212.copyBufferToBuffer(buffer2, 428, buffer172, 2948, 100);
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let recycledExplicitBindGroupLayout63 = pipeline2.getBindGroupLayout(0);
+let commandEncoder214 = device0.createCommandEncoder({});
+let textureView197 = texture151.createView({dimension: '2d-array'});
+let texture202 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 72},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder68 = commandEncoder212.beginRenderPass({
+  colorAttachments: [{view: textureView48, depthSlice: 5, loadOp: 'load', storeOp: 'store'}],
+  maxDrawCount: 249439014,
+});
+try {
+computePassEncoder131.setBindGroup(1, bindGroup3, new Uint32Array(3486), 231, 0);
+} catch {}
+try {
+computePassEncoder166.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer131, 'uint32', 136, 82);
+} catch {}
+let buffer173 = device0.createBuffer({
+  size: 1563,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup72, new Uint32Array(621), 2, 0);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(1, bindGroup23, new Uint32Array(3191), 397, 0);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(7, buffer29, 4_232);
+} catch {}
+try {
+commandEncoder214.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1536 */
+  offset: 1536,
+  rowsPerImage: 383,
+  buffer: buffer68,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let recycledExplicitBindGroupLayout64 = pipeline14.getBindGroupLayout(0);
+let texture203 = device0.createTexture({
+  size: {width: 4},
+  dimension: '1d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture204 = device0.createTexture({size: {width: 4}, dimension: '1d', format: 'r32sint', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder169 = commandEncoder214.beginComputePass({});
+try {
+computePassEncoder120.setBindGroup(0, bindGroup76);
+} catch {}
+try {
+computePassEncoder160.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle11]);
+} catch {}
+try {
+buffer171.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer30, 84, new BigUint64Array(17979), 976, 32);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(7, buffer113, 0, 2_290);
+} catch {}
+let commandEncoder215 = device0.createCommandEncoder({});
+let computePassEncoder170 = commandEncoder215.beginComputePass({});
+let sampler135 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', compare: 'greater'});
+try {
+computePassEncoder170.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder50.beginOcclusionQuery(192);
+} catch {}
+try {
+renderPassEncoder50.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder59.setStencilReference(1420);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, undefined, 2_189_355_109, 542_002_300);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+externalTexture21.label = '\u299d\u{1f737}\u{1fbca}\ucfda\ud766\u041d';
+} catch {}
+try {
+computePassEncoder32.setBindGroup(3, bindGroup108);
+} catch {}
+try {
+computePassEncoder169.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup50);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer33, 980, new DataView(new ArrayBuffer(22953)), 3829, 1876);
+} catch {}
+let commandEncoder216 = device0.createCommandEncoder();
+let texture205 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 405},
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView198 = texture198.createView({});
+let computePassEncoder171 = commandEncoder216.beginComputePass({});
+let sampler136 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  compare: 'greater-equal',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer158, 1_400); };
+} catch {}
+try {
+renderPassEncoder66.executeBundles([renderBundle7, renderBundle8, renderBundle8, renderBundle8]);
+} catch {}
+let pipeline31 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule12,
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'not-equal', failOp: 'zero', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less', failOp: 'zero', depthFailOp: 'decrement-clamp', passOp: 'invert'},
+    stencilReadMask: 711176594,
+    stencilWriteMask: 2801054263,
+  },
+  vertex: {
+    module: shaderModule3,
+    buffers: [
+      {
+        arrayStride: 672,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 24, shaderLocation: 15},
+          {format: 'float32x2', offset: 56, shaderLocation: 0},
+          {format: 'uint32x3', offset: 412, shaderLocation: 6},
+          {format: 'snorm16x4', offset: 56, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32'},
+});
+let bindGroup127 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout3,
+  entries: [{binding: 41, resource: {buffer: buffer0, offset: 512, size: 1460}}],
+});
+let buffer174 = device0.createBuffer({
+  size: 53,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture206 = device0.createTexture({
+  size: [32, 1, 58],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler137 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.95,
+});
+try {
+computePassEncoder152.setBindGroup(0, bindGroup111);
+} catch {}
+try {
+computePassEncoder162.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder65.setIndexBuffer(buffer116, 'uint16', 450, 1_801);
+} catch {}
+try {
+renderPassEncoder59.insertDebugMarker('\u06ef');
+} catch {}
+let commandEncoder217 = device0.createCommandEncoder({});
+let texture207 = device0.createTexture({
+  size: [260, 1, 5],
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder118.setBindGroup(0, bindGroup51);
+} catch {}
+try {
+computePassEncoder171.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(2, bindGroup31);
+} catch {}
+try {
+commandEncoder217.insertDebugMarker('\u0550');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer35, 4968, new Int16Array(471), 36, 24);
+} catch {}
+let bindGroup128 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout16,
+  entries: [
+    {binding: 46, resource: externalTexture13},
+    {binding: 83, resource: {buffer: buffer16, offset: 0, size: 26}},
+    {binding: 977, resource: {buffer: buffer105, offset: 512, size: 1718}},
+    {binding: 41, resource: {buffer: buffer17, offset: 3328}},
+    {binding: 162, resource: textureView72},
+    {binding: 119, resource: {buffer: buffer92, offset: 0, size: 792}},
+    {binding: 48, resource: textureView10},
+  ],
+});
+let buffer175 = device0.createBuffer({size: 882, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let computePassEncoder172 = commandEncoder217.beginComputePass({});
+try {
+computePassEncoder155.setBindGroup(0, bindGroup103);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup82, new Uint32Array(132), 24, 0);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle0, renderBundle4, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: 917.2, g: -159.5, b: 403.9, a: 920.3, });
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer52, 'uint16', 7_450, 3_438);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+let recycledExplicitBindGroupLayout65 = pipeline11.getBindGroupLayout(0);
+try {
+computePassEncoder48.end();
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(2, bindGroup111);
+} catch {}
+try {
+commandEncoder56.copyTextureToTexture({
+  texture: texture182,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 36},
+  aspect: 'all',
+},
+{width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder56.resolveQuerySet(querySet26, 11, 86, buffer50, 0);
+} catch {}
+try {
+computePassEncoder83.pushDebugGroup('\u{1ff35}');
+} catch {}
+try {
+renderPassEncoder57.insertDebugMarker('\u0097');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let imageData35 = new ImageData(72, 16);
+let textureView199 = texture176.createView({aspect: 'all', baseMipLevel: 0});
+let computePassEncoder173 = commandEncoder56.beginComputePass({});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: ['rg32sint'], sampleCount: 4, depthReadOnly: true});
+let sampler138 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', maxAnisotropy: 1});
+try {
+computePassEncoder38.setBindGroup(3, bindGroup115);
+} catch {}
+try {
+computePassEncoder143.setBindGroup(2, bindGroup26, new Uint32Array(1100), 26, 0);
+} catch {}
+try {
+computePassEncoder173.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup34, new Uint32Array(592), 106, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer23]);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageData36 = new ImageData(24, 4);
+let texture208 = device0.createTexture({size: [4, 4, 146], dimension: '3d', format: 'r32uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView200 = texture28.createView({mipLevelCount: 1});
+try {
+computePassEncoder142.setBindGroup(2, bindGroup44, new Uint32Array(2455), 451, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer140, 1_148); };
+} catch {}
+try {
+computePassEncoder172.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(4, buffer165, 0);
+} catch {}
+let buffer176 = device0.createBuffer({
+  size: 17984,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], depthReadOnly: true, stencilReadOnly: false});
+try {
+computePassEncoder93.setBindGroup(0, bindGroup13, new Uint32Array(203), 70, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(1, bindGroup110, new Uint32Array(47), 0, 0);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer93, 'uint16', 308, 7_110);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup103, new Uint32Array(1344), 73, 0);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer39, 'uint32', 1_056, 3_642);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(2, buffer109, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let recycledExplicitBindGroupLayout66 = pipeline26.getBindGroupLayout(0);
+let bindGroup129 = device0.createBindGroup({layout: autogeneratedBindGroupLayout25, entries: [{binding: 31, resource: textureView132}]});
+let texture209 = device0.createTexture({
+  size: {width: 4, height: 4, depthOrArrayLayers: 17},
+  sampleCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler139 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'less-equal',
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder43.end();
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder37.setViewport(204.4789152273189, 0.8720885269951123, 54.24838791155488, 0.11464733235881365, 0.4807466250956661, 0.9221075055489012);
+} catch {}
+try {
+renderPassEncoder68.setIndexBuffer(buffer65, 'uint32', 776, 100);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(6, buffer121, 0);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(3, bindGroup88);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(3, bindGroup86, new Uint32Array(588), 144, 0);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer94, 'uint16', 276, 1_395);
+} catch {}
+try {
+computePassEncoder95.pushDebugGroup('\u{1fe3e}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer52, 2740, new DataView(new ArrayBuffer(3509)), 82, 1060);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame36 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'smpte432', transfer: 'smpteSt4281'} });
+let recycledExplicitBindGroupLayout67 = pipeline5.getBindGroupLayout(0);
+let bindGroup130 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout21,
+  entries: [
+    {binding: 119, resource: {buffer: buffer83, offset: 768, size: 232}},
+    {binding: 162, resource: textureView107},
+    {binding: 977, resource: {buffer: buffer68, offset: 1280}},
+    {binding: 48, resource: textureView13},
+    {binding: 46, resource: externalTexture6},
+    {binding: 41, resource: {buffer: buffer107, offset: 2560, size: 108}},
+    {binding: 83, resource: {buffer: buffer112, offset: 512}},
+  ],
+});
+let commandEncoder218 = device0.createCommandEncoder({});
+let querySet28 = device0.createQuerySet({type: 'occlusion', count: 411});
+try {
+computePassEncoder160.setBindGroup(0, bindGroup94);
+} catch {}
+try {
+computePassEncoder163.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(3, bindGroup76, new Uint32Array(258), 71, 0);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(1, buffer113, 0, 1_064);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup100, new Uint32Array(658), 80, 0);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer65, 'uint16', 108, 268);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(1, buffer161, 336);
+} catch {}
+try {
+buffer107.unmap();
+} catch {}
+try {
+  await promise26;
+} catch {}
+let commandEncoder219 = device0.createCommandEncoder({});
+let texture210 = device0.createTexture({
+  size: [32, 1, 8],
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder174 = commandEncoder218.beginComputePass();
+try {
+computePassEncoder174.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(0, bindGroup86, new Uint32Array(3009), 2_370, 0);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer65, 'uint32', 36, 742);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(4, undefined, 0);
+} catch {}
+let arrayBuffer13 = buffer28.getMappedRange(648, 0);
+try {
+commandEncoder51.resolveQuerySet(querySet11, 68, 6, buffer151, 256);
+} catch {}
+let veryExplicitBindGroupLayout34 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 8, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {
+      binding: 26,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {binding: 39, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {
+      binding: 60,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 136,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 402,
+      visibility: 0,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder220 = device0.createCommandEncoder({});
+let texture211 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r32uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder175 = commandEncoder220.beginComputePass({});
+let renderPassEncoder69 = commandEncoder219.beginRenderPass({
+  colorAttachments: [{
+  view: textureView90,
+  clearValue: { r: 930.6, g: 72.79, b: -850.7, a: -775.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet13,
+});
+let renderBundle14 = renderBundleEncoder15.finish();
+try {
+{ clearResourceUsages(device0, computePassEncoder160); computePassEncoder160.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup49);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(4, buffer149, 0, 664);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer168, 108, new Int16Array(774), 417, 92);
+} catch {}
+let buffer177 = device0.createBuffer({
+  size: 16484,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder221 = device0.createCommandEncoder();
+let textureView201 = texture6.createView({mipLevelCount: 1});
+try {
+computePassEncoder90.setBindGroup(1, bindGroup50);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer174, 'uint32', 8, 6);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(5, buffer52, 0);
+} catch {}
+try {
+commandEncoder51.copyTextureToBuffer({
+  texture: texture186,
+  mipLevel: 0,
+  origin: {x: 124, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 148 widthInBlocks: 37 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2584 */
+  offset: 2584,
+  rowsPerImage: 27,
+  buffer: buffer129,
+}, {width: 37, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let videoFrame37 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'film', transfer: 'smpte240m'} });
+let commandEncoder222 = device0.createCommandEncoder({});
+let commandBuffer24 = commandEncoder51.finish({});
+try {
+computePassEncoder152.setBindGroup(3, bindGroup73, new Uint32Array(723), 56, 0);
+} catch {}
+try {
+computePassEncoder175.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(0, bindGroup46, new Uint32Array(1645), 843, 0);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer8, 'uint32', 3_728, 68);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(2, buffer26, 16_340, 7_733);
+} catch {}
+let bindGroup131 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout16,
+  entries: [
+    {binding: 48, resource: textureView13},
+    {binding: 119, resource: {buffer: buffer177, offset: 2048}},
+    {binding: 41, resource: {buffer: buffer142, offset: 512, size: 1452}},
+    {binding: 46, resource: externalTexture10},
+    {binding: 83, resource: {buffer: buffer113, offset: 0, size: 774}},
+    {binding: 162, resource: textureView15},
+    {binding: 977, resource: {buffer: buffer38, offset: 4864, size: 101}},
+  ],
+});
+let buffer178 = device0.createBuffer({size: 8828, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder223 = device0.createCommandEncoder({});
+let texture212 = device0.createTexture({
+  size: [130, 1, 22],
+  dimension: '2d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView202 = texture160.createView({dimension: '2d-array', aspect: 'stencil-only'});
+try {
+renderPassEncoder60.setBindGroup(1, bindGroup108);
+} catch {}
+try {
+renderPassEncoder65.executeBundles([renderBundle14, renderBundle14]);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(2, buffer48, 140);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer77, 'uint16', 394, 2_895);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(0, buffer154, 2_488, 3_436);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: videoFrame15,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData37 = new ImageData(28, 4);
+let recycledExplicitBindGroupLayout68 = pipeline29.getBindGroupLayout(0);
+let bindGroup132 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [
+    {binding: 41, resource: {buffer: buffer125, offset: 512}},
+    {binding: 48, resource: textureView13},
+    {binding: 119, resource: {buffer: buffer91, offset: 0, size: 125}},
+    {binding: 46, resource: externalTexture0},
+    {binding: 83, resource: {buffer: buffer131, offset: 0}},
+    {binding: 162, resource: textureView41},
+    {binding: 977, resource: {buffer: buffer175, offset: 0, size: 342}},
+  ],
+});
+let textureView203 = texture184.createView({});
+try {
+computePassEncoder148.setBindGroup(1, bindGroup97);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(0, bindGroup29, new Uint32Array(1812), 344, 0);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer115, 'uint32', 984, 724);
+} catch {}
+try {
+computePassEncoder83.popDebugGroup();
+} catch {}
+let commandEncoder224 = device0.createCommandEncoder({});
+let computePassEncoder176 = commandEncoder222.beginComputePass({});
+let sampler140 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', minFilter: 'linear', lodMaxClamp: 79.85});
+try {
+computePassEncoder159.setBindGroup(0, bindGroup18, []);
+} catch {}
+try {
+computePassEncoder153.setBindGroup(1, bindGroup1, new Uint32Array(881), 68, 0);
+} catch {}
+try {
+renderPassEncoder55.beginOcclusionQuery(13);
+} catch {}
+try {
+renderPassEncoder55.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer115, 'uint16', 1_736, 1_022);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(3, buffer3, 12, 0);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup6, new Uint32Array(767), 153, 0);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer75, 'uint16', 718, 5_551);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(5, buffer8, 0, 800);
+} catch {}
+let videoFrame38 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'unspecified', transfer: 'bt709'} });
+let commandEncoder225 = device0.createCommandEncoder({});
+let textureView204 = texture44.createView({aspect: 'stencil-only', mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder177 = commandEncoder223.beginComputePass({});
+try {
+computePassEncoder128.setBindGroup(1, bindGroup97);
+} catch {}
+try {
+computePassEncoder115.end();
+} catch {}
+try {
+computePassEncoder176.setPipeline(pipeline15);
+} catch {}
+try {
+buffer128.unmap();
+} catch {}
+try {
+commandEncoder224.copyBufferToTexture({
+  /* bytesInLastRow: 472 widthInBlocks: 59 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 672 */
+  offset: 672,
+  bytesPerRow: 17152,
+  buffer: buffer75,
+}, {
+  texture: texture185,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 59, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 3,
+  origin: {x: 5, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(48_078).fill(154), /* required buffer size: 48_078 */
+{offset: 354, bytesPerRow: 212, rowsPerImage: 75}, {width: 3, height: 1, depthOrArrayLayers: 4});
+} catch {}
+let commandEncoder226 = device0.createCommandEncoder();
+let textureView205 = texture211.createView({label: '\u42c0\u7009\u03a3\u0d96\ue011\u4b17\u5b44\udcb5\u0857', baseMipLevel: 0, mipLevelCount: 1});
+let renderPassEncoder70 = commandEncoder226.beginRenderPass({
+  colorAttachments: [{
+  view: textureView189,
+  clearValue: { r: 292.9, g: -201.7, b: 945.5, a: -898.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView40,
+    depthClearValue: 5.283202148236612,
+    depthReadOnly: true,
+    stencilClearValue: 12245,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'discard',
+  },
+});
+try {
+computePassEncoder177.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder56.setVertexBuffer(7, buffer159);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup108, new Uint32Array(135), 14, 0);
+} catch {}
+try {
+commandEncoder221.resolveQuerySet(querySet23, 42, 101, buffer118, 768);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 11, y: 3 },
+  flipY: true,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 209},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout69 = pipeline13.getBindGroupLayout(0);
+let commandEncoder227 = device0.createCommandEncoder();
+let querySet29 = device0.createQuerySet({type: 'occlusion', count: 250});
+let textureView206 = texture17.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder178 = commandEncoder123.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder120); computePassEncoder120.dispatchWorkgroupsIndirect(buffer26, 1_776); };
+} catch {}
+try {
+computePassEncoder160.end();
+} catch {}
+try {
+computePassEncoder178.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(3, buffer49);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(3, bindGroup82, new Uint32Array(3294), 627, 0);
+} catch {}
+try {
+computePassEncoder95.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let videoFrame39 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'film', transfer: 'smpte170m'} });
+let texture213 = device0.createTexture({
+  size: [260, 1, 1],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder123.setBindGroup(0, bindGroup115);
+} catch {}
+try {
+renderPassEncoder55.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder64.setVertexBuffer(3, buffer173, 0, 252);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer45, 'uint16', 668, 417);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(6, buffer107);
+} catch {}
+try {
+commandEncoder224.resolveQuerySet(querySet8, 76, 268, buffer17, 1280);
+} catch {}
+let textureView207 = texture186.createView({});
+let computePassEncoder179 = commandEncoder221.beginComputePass({});
+let renderPassEncoder71 = commandEncoder72.beginRenderPass({
+  colorAttachments: [{view: textureView96, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet11,
+});
+try {
+computePassEncoder117.setBindGroup(0, bindGroup124);
+} catch {}
+try {
+computePassEncoder179.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(3, bindGroup5, new Uint32Array(11), 1, 0);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer29, 'uint32', 2_044, 2_064);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(3, bindGroup3, new Uint32Array(359), 35, 0);
+} catch {}
+try {
+commandEncoder224.resolveQuerySet(querySet22, 133, 191, buffer26, 8192);
+} catch {}
+try {
+gpuCanvasContext7.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT, alphaMode: 'opaque'});
+} catch {}
+let textureView208 = texture164.createView({});
+let computePassEncoder180 = commandEncoder224.beginComputePass({});
+let renderBundle15 = renderBundleEncoder14.finish();
+let sampler141 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMinClamp: 47.34, lodMaxClamp: 78.64});
+try {
+renderPassEncoder48.setBindGroup(1, bindGroup7, new Uint32Array(2547), 203, 0);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(0, buffer133, 176);
+} catch {}
+let sampler142 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 43.32,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder117.setBindGroup(0, bindGroup82);
+} catch {}
+try {
+computePassEncoder180.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup23, new Uint32Array(3933), 725, 0);
+} catch {}
+try {
+commandEncoder225.copyTextureToTexture({
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture189,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer144, 2484, new DataView(new ArrayBuffer(3127)), 13, 1844);
+} catch {}
+let bindGroup133 = device0.createBindGroup({layout: veryExplicitBindGroupLayout32, entries: [{binding: 226, resource: textureView105}]});
+let commandEncoder228 = device0.createCommandEncoder({});
+let querySet30 = device0.createQuerySet({label: '\u0b6e\ucc2f\ube7d\u0057\u{1fdc0}\u71ac\u{1faa2}\u2f98', type: 'occlusion', count: 91});
+try {
+renderPassEncoder47.setIndexBuffer(buffer29, 'uint32', 4_784, 4_737);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture154,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(55).fill(102), /* required buffer size: 55 */
+{offset: 55, rowsPerImage: 34}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let offscreenCanvas6 = new OffscreenCanvas(23, 103);
+let recycledExplicitBindGroupLayout70 = pipeline15.getBindGroupLayout(0);
+let commandEncoder229 = device0.createCommandEncoder({});
+try {
+computePassEncoder157.setBindGroup(1, bindGroup64, new Uint32Array(1657), 574, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder152); computePassEncoder152.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder228.copyBufferToBuffer(buffer37, 4, buffer62, 8168, 452);
+} catch {}
+let recycledExplicitBindGroupLayout71 = pipeline7.getBindGroupLayout(0);
+let commandEncoder230 = device0.createCommandEncoder();
+let textureView209 = texture209.createView({aspect: 'stencil-only', arrayLayerCount: 2});
+let computePassEncoder181 = commandEncoder229.beginComputePass({});
+let sampler143 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', magFilter: 'linear', minFilter: 'linear'});
+try {
+computePassEncoder181.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder64.setPipeline(pipeline29);
+} catch {}
+try {
+commandEncoder225.copyTextureToTexture({
+  texture: texture169,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture76,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise27 = device0.queue.onSubmittedWorkDone();
+let commandEncoder231 = device0.createCommandEncoder({});
+let texture214 = device0.createTexture({
+  size: [4, 4, 17],
+  dimension: '2d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView210 = texture189.createView({baseArrayLayer: 3, arrayLayerCount: 1});
+let renderPassEncoder72 = commandEncoder230.beginRenderPass({
+  colorAttachments: [{
+  view: textureView113,
+  clearValue: { r: -616.4, g: -869.9, b: -791.5, a: -515.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 442159343,
+});
+try {
+computePassEncoder162.setBindGroup(1, bindGroup45);
+} catch {}
+try {
+computePassEncoder101.setBindGroup(0, bindGroup37, new Uint32Array(1039), 120, 0);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(4, buffer116, 0);
+} catch {}
+try {
+buffer141.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: imageData9,
+  origin: { x: 2, y: 9 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup134 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout19,
+  entries: [{binding: 113, resource: {buffer: buffer0, offset: 1280, size: 852}}],
+});
+let buffer179 = device0.createBuffer({
+  size: 14874,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView211 = texture194.createView({baseArrayLayer: 0});
+let computePassEncoder182 = commandEncoder227.beginComputePass({});
+let renderPassEncoder73 = commandEncoder225.beginRenderPass({
+  colorAttachments: [{
+  view: textureView85,
+  depthSlice: 42,
+  clearValue: { r: 862.2, g: -965.0, b: -745.1, a: 487.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 76965161,
+});
+try {
+renderPassEncoder63.setBindGroup(0, bindGroup24, new Uint32Array(848), 49, 0);
+} catch {}
+try {
+commandEncoder228.copyBufferToBuffer(buffer66, 3552, buffer157, 728, 200);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer180 = device0.createBuffer({size: 5692, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder232 = device0.createCommandEncoder({});
+let querySet31 = device0.createQuerySet({type: 'occlusion', count: 452});
+let computePassEncoder183 = commandEncoder228.beginComputePass({});
+try {
+computePassEncoder151.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+computePassEncoder182.setPipeline(pipeline16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer159, 268, new Float32Array(7193), 108, 228);
+} catch {}
+let recycledExplicitBindGroupLayout72 = pipeline6.getBindGroupLayout(0);
+let texture215 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 1},
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder149.setBindGroup(0, bindGroup99);
+} catch {}
+try {
+computePassEncoder183.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(1, bindGroup5, new Uint32Array(511), 8, 0);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer115, 'uint32', 1_044, 1_575);
+} catch {}
+try {
+commandEncoder232.copyBufferToBuffer(buffer45, 1272, buffer178, 1180, 268);
+} catch {}
+let commandEncoder233 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder120); computePassEncoder120.dispatchWorkgroupsIndirect(buffer107, 140); };
+} catch {}
+try {
+commandEncoder231.copyBufferToTexture({
+  /* bytesInLastRow: 44 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1988 */
+  offset: 1988,
+  buffer: buffer179,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas2);
+let imageData38 = new ImageData(20, 20);
+let textureView212 = texture126.createView({baseArrayLayer: 6, arrayLayerCount: 1});
+let computePassEncoder184 = commandEncoder233.beginComputePass({});
+try {
+computePassEncoder184.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle5]);
+} catch {}
+try {
+commandEncoder231.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2304 */
+  offset: 2304,
+  buffer: buffer2,
+}, {
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder231.clearBuffer(buffer103, 44, 100);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: videoFrame14,
+  origin: { x: 2, y: 5 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 24},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer181 = device0.createBuffer({
+  size: 4444,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView213 = texture184.createView({});
+let computePassEncoder185 = commandEncoder232.beginComputePass({});
+let renderPassEncoder74 = commandEncoder231.beginRenderPass({
+  colorAttachments: [{
+  view: textureView160,
+  depthSlice: 7,
+  clearValue: { r: -567.0, g: -986.4, b: 162.3, a: 973.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet16,
+  maxDrawCount: 227524163,
+});
+let sampler144 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 43.65,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder83.setBindGroup(0, bindGroup99);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer171, 'uint32', 88, 20);
+} catch {}
+let pipeline32 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout12,
+  fragment: {
+  module: shaderModule3,
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'equal', depthFailOp: 'decrement-clamp', passOp: 'invert'},
+    stencilBack: {compare: 'greater-equal', failOp: 'decrement-clamp', depthFailOp: 'keep', passOp: 'decrement-wrap'},
+    stencilReadMask: 411107160,
+    stencilWriteMask: 1172853068,
+    depthBias: -1891463547,
+  },
+  vertex: {
+    module: shaderModule1,
+    constants: {override0: 0},
+    buffers: [
+      {
+        arrayStride: 872,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 36, shaderLocation: 3},
+          {format: 'sint8x2', offset: 162, shaderLocation: 15},
+          {format: 'uint8x4', offset: 24, shaderLocation: 7},
+          {format: 'unorm16x4', offset: 140, shaderLocation: 4},
+          {format: 'uint32x3', offset: 72, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 88, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 948,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 0, shaderLocation: 8},
+          {format: 'float32x3', offset: 40, shaderLocation: 12},
+          {format: 'sint32x3', offset: 12, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', cullMode: 'back', unclippedDepth: true},
+});
+let gpuCanvasContext10 = offscreenCanvas6.getContext('webgpu');
+let bindGroup135 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout46,
+  entries: [
+    {binding: 977, resource: {buffer: buffer83, offset: 768, size: 460}},
+    {binding: 46, resource: externalTexture20},
+    {binding: 48, resource: textureView2},
+    {binding: 162, resource: textureView107},
+    {binding: 119, resource: {buffer: buffer141, offset: 0, size: 493}},
+    {binding: 83, resource: {buffer: buffer82, offset: 1792}},
+    {binding: 41, resource: {buffer: buffer81, offset: 0}},
+  ],
+});
+let commandEncoder234 = device0.createCommandEncoder({});
+let renderPassEncoder75 = commandEncoder234.beginRenderPass({
+  colorAttachments: [{
+  view: textureView48,
+  depthSlice: 12,
+  clearValue: { r: 884.4, g: 869.6, b: 313.3, a: 667.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+});
+let sampler145 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.28,
+});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+document.body.append(img1);
+let bindGroup136 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout61,
+  entries: [
+    {binding: 977, resource: {buffer: buffer113, offset: 0, size: 3031}},
+    {binding: 41, resource: {buffer: buffer76, offset: 768, size: 560}},
+    {binding: 83, resource: {buffer: buffer119, offset: 0, size: 208}},
+    {binding: 162, resource: textureView202},
+    {binding: 48, resource: textureView2},
+    {binding: 119, resource: {buffer: buffer175, offset: 256, size: 93}},
+    {binding: 46, resource: externalTexture18},
+  ],
+});
+try {
+computePassEncoder138.setBindGroup(1, bindGroup40);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder121); computePassEncoder121.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder185.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(2, bindGroup87);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(7, buffer49, 0);
+} catch {}
+let pipeline33 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule10,
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {module: shaderModule12, entryPoint: 'vertex12', buffers: []},
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+  await promise27;
+} catch {}
+document.body.prepend(img1);
+let offscreenCanvas7 = new OffscreenCanvas(226, 79);
+let imageData39 = new ImageData(28, 20);
+let bindGroup137 = device0.createBindGroup({layout: veryExplicitBindGroupLayout32, entries: [{binding: 226, resource: textureView63}]});
+let texture216 = gpuCanvasContext1.getCurrentTexture();
+let arrayBuffer14 = buffer103.getMappedRange(96, 0);
+let gpuCanvasContext11 = offscreenCanvas7.getContext('webgpu');
+let sampler146 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 46.92,
+});
+try {
+computePassEncoder151.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder48.setBlendConstant({ r: 14.03, g: 670.4, b: -172.6, a: 58.67, });
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(5, undefined, 2_998_265_007, 21_988_293);
+} catch {}
+try {
+buffer148.unmap();
+} catch {}
+try {
+computePassEncoder98.setBindGroup(3, bindGroup98);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(2, bindGroup72);
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(3, bindGroup95, new Uint32Array(4626), 9, 0);
+} catch {}
+try {
+renderPassEncoder55.setIndexBuffer(buffer91, 'uint32', 32, 58);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(3, buffer121, 48, 5);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let commandEncoder235 = device0.createCommandEncoder({});
+let textureView214 = texture68.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let renderPassEncoder76 = commandEncoder235.beginRenderPass({
+  colorAttachments: [{
+  view: textureView85,
+  depthSlice: 25,
+  clearValue: { r: -667.0, g: 975.9, b: -153.6, a: 261.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 72864024,
+});
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let pipeline34 = device0.createComputePipeline({layout: pipelineLayout12, compute: {module: shaderModule6}});
+let img2 = await imageWithData(30, 41, '#10101010', '#20202020');
+let commandEncoder236 = device0.createCommandEncoder();
+try {
+renderPassEncoder21.setVertexBuffer(7, buffer159, 3_868, 13_318);
+} catch {}
+try {
+  await shaderModule7.getCompilationInfo();
+} catch {}
+try {
+buffer107.unmap();
+} catch {}
+let videoFrame40 = new VideoFrame(canvas2, {timestamp: 0});
+try {
+adapter0.label = '\u71c5\u5a3e\u6112\u6a8b\u0e2f\u05e0';
+} catch {}
+let commandEncoder237 = device0.createCommandEncoder({});
+let textureView215 = texture54.createView({dimension: '2d', baseMipLevel: 0, mipLevelCount: 1});
+let renderPassEncoder77 = commandEncoder237.beginRenderPass({
+  colorAttachments: [{
+  view: textureView85,
+  depthSlice: 95,
+  clearValue: { r: -586.3, g: -687.3, b: 798.8, a: 721.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 1165218982,
+});
+try {
+renderPassEncoder76.setBindGroup(2, bindGroup117);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(2, bindGroup136, new Uint32Array(2656), 261, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer24]);
+} catch {}
+let buffer182 = device0.createBuffer({
+  size: 10938,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder238 = device0.createCommandEncoder();
+let texture217 = device0.createTexture({size: [130, 1, 1], mipLevelCount: 3, format: 'stencil8', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder186 = commandEncoder238.beginComputePass({});
+try {
+renderPassEncoder37.executeBundles([renderBundle2, renderBundle10, renderBundle1, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder50.setIndexBuffer(buffer65, 'uint16', 136, 363);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(107).fill(213), /* required buffer size: 107 */
+{offset: 107}, {width: 41, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let veryExplicitBindGroupLayout35 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 32,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let bindGroup138 = device0.createBindGroup({
+  label: '\udb1b\u4282\u{1fb87}\u00a9',
+  layout: recycledExplicitBindGroupLayout24,
+  entries: [
+    {binding: 46, resource: externalTexture20},
+    {binding: 41, resource: {buffer: buffer175, offset: 0, size: 116}},
+    {binding: 119, resource: {buffer: buffer82, offset: 1792}},
+    {binding: 83, resource: {buffer: buffer156, offset: 1536, size: 205}},
+    {binding: 162, resource: textureView93},
+    {binding: 48, resource: textureView10},
+    {binding: 977, resource: {buffer: buffer65, offset: 512, size: 211}},
+  ],
+});
+let commandEncoder239 = device0.createCommandEncoder({});
+let texture218 = device0.createTexture({size: {width: 130}, dimension: '1d', format: 'rg16uint', usage: GPUTextureUsage.COPY_DST});
+let sampler147 = device0.createSampler({addressModeU: 'mirror-repeat', lodMinClamp: 23.97});
+try {
+renderPassEncoder72.setIndexBuffer(buffer116, 'uint32', 208, 594);
+} catch {}
+try {
+commandEncoder236.clearBuffer(buffer64);
+} catch {}
+try {
+commandEncoder236.insertDebugMarker('\u49ab');
+} catch {}
+try {
+globalThis.someLabel = device0.label;
+} catch {}
+let commandEncoder240 = device0.createCommandEncoder({});
+let texture219 = device0.createTexture({
+  size: [130, 1, 16],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder187 = commandEncoder236.beginComputePass();
+let sampler148 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 60.83,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder187.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(2, bindGroup110, new Uint32Array(5637), 657, 0);
+} catch {}
+try {
+commandEncoder239.copyBufferToTexture({
+  /* bytesInLastRow: 130 widthInBlocks: 130 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 124 */
+  offset: 124,
+  bytesPerRow: 18944,
+  buffer: buffer127,
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 130, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder241 = device0.createCommandEncoder({});
+let texture220 = device0.createTexture({
+  size: {width: 260},
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView216 = texture67.createView({mipLevelCount: 1});
+let computePassEncoder188 = commandEncoder239.beginComputePass({});
+try {
+computePassEncoder45.setBindGroup(1, bindGroup63);
+} catch {}
+try {
+computePassEncoder188.setPipeline(pipeline7);
+} catch {}
+let arrayBuffer15 = buffer28.getMappedRange(656, 24);
+try {
+computePassEncoder49.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+computePassEncoder170.setBindGroup(2, bindGroup119, new Uint32Array(161), 30, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder143); computePassEncoder143.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder186.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(1, bindGroup103);
+} catch {}
+try {
+renderPassEncoder69.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder67.setVertexBuffer(3, buffer4, 0);
+} catch {}
+try {
+buffer150.unmap();
+} catch {}
+try {
+computePassEncoder164.insertDebugMarker('\u0a47');
+} catch {}
+let commandEncoder242 = device0.createCommandEncoder({});
+let texture221 = device0.createTexture({
+  size: [65, 1, 1],
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder189 = commandEncoder241.beginComputePass({});
+try {
+computePassEncoder186.setBindGroup(3, bindGroup71);
+} catch {}
+try {
+computePassEncoder189.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder240.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 516 */
+  offset: 516,
+  bytesPerRow: 41216,
+  rowsPerImage: 218,
+  buffer: buffer140,
+}, {
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder242.copyTextureToTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture130,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline35 = device0.createComputePipeline({layout: pipelineLayout16, compute: {module: shaderModule6, constants: {}}});
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+let imageData40 = new ImageData(80, 4);
+let buffer183 = device0.createBuffer({size: 13593, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture222 = device0.createTexture({
+  size: [32, 1, 1],
+  dimension: '2d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView217 = texture221.createView({});
+let renderPassEncoder78 = commandEncoder242.beginRenderPass({
+  colorAttachments: [{view: textureView32, depthSlice: 1, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 159986665,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder118); computePassEncoder118.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder11.setViewport(76.72491868235309, 0.12440473637956817, 88.72622398661626, 0.04892627699134003, 0.47743265798156553, 0.7536040974237281);
+} catch {}
+try {
+commandEncoder240.copyBufferToTexture({
+  /* bytesInLastRow: 248 widthInBlocks: 62 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1224 */
+  offset: 1224,
+  bytesPerRow: 1280,
+  buffer: buffer173,
+}, {
+  texture: texture186,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 62, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img1);
+let bindGroup139 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout26,
+  entries: [
+    {binding: 68, resource: textureView132},
+    {binding: 144, resource: textureView150},
+    {binding: 61, resource: textureView75},
+  ],
+});
+let buffer184 = device0.createBuffer({size: 13812, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture223 = device0.createTexture({
+  size: [65],
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder26.setPipeline(pipeline33);
+} catch {}
+try {
+  await shaderModule10.getCompilationInfo();
+} catch {}
+try {
+commandEncoder240.resolveQuerySet(querySet10, 94, 4, buffer177, 2048);
+} catch {}
+try {
+commandEncoder240.insertDebugMarker('\u28ff');
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(86, 26);
+let bindGroup140 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout8,
+  entries: [
+    {binding: 119, resource: {buffer: buffer51, offset: 768, size: 1738}},
+    {binding: 83, resource: {buffer: buffer26, offset: 14080, size: 6487}},
+    {binding: 48, resource: textureView10},
+    {binding: 46, resource: externalTexture4},
+    {binding: 977, resource: {buffer: buffer119, offset: 0, size: 53}},
+    {binding: 162, resource: textureView158},
+    {binding: 41, resource: {buffer: buffer176, offset: 5120}},
+  ],
+});
+let computePassEncoder190 = commandEncoder240.beginComputePass({});
+try {
+renderPassEncoder58.setBindGroup(0, bindGroup48, new Uint32Array(598), 12, 0);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(2, buffer169, 0);
+} catch {}
+try {
+buffer105.unmap();
+} catch {}
+let promise28 = device0.queue.onSubmittedWorkDone();
+let pipeline36 = device0.createRenderPipeline({
+  layout: pipelineLayout11,
+  fragment: {
+  module: shaderModule5,
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule7,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 684,
+        attributes: [
+          {format: 'unorm8x2', offset: 182, shaderLocation: 9},
+          {format: 'uint16x2', offset: 68, shaderLocation: 11},
+          {format: 'float16x2', offset: 164, shaderLocation: 4},
+          {format: 'uint16x2', offset: 84, shaderLocation: 0},
+          {format: 'float16x4', offset: 128, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 112, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 120, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'front'},
+});
+let imageData41 = new ImageData(4, 44);
+let buffer185 = device0.createBuffer({size: 6769, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture224 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler149 = device0.createSampler({
+  label: '\u3843\u929b\uef65\uaed4\u5b18\u67e1\u6b04\u{1ff0c}\uf24c',
+  addressModeV: 'repeat',
+  lodMaxClamp: 20.68,
+});
+try {
+renderPassEncoder33.setBlendConstant({ r: -351.8, g: -170.4, b: -889.1, a: 21.07, });
+} catch {}
+try {
+renderPassEncoder77.setIndexBuffer(buffer156, 'uint16', 2_818, 612);
+} catch {}
+let arrayBuffer16 = buffer78.getMappedRange(112, 72);
+try {
+buffer111.unmap();
+} catch {}
+try {
+gpuCanvasContext3.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING, colorSpace: 'srgb'});
+} catch {}
+let veryExplicitBindGroupLayout36 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 61,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 68,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 144,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let bindGroup141 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout14,
+  entries: [
+    {binding: 119, resource: {buffer: buffer64, offset: 0, size: 1620}},
+    {binding: 48, resource: textureView13},
+    {binding: 41, resource: {buffer: buffer118, offset: 512, size: 124}},
+    {binding: 46, resource: externalTexture20},
+    {binding: 83, resource: {buffer: buffer17, offset: 4096, size: 837}},
+    {binding: 977, resource: {buffer: buffer156, offset: 1792, size: 2864}},
+    {binding: 162, resource: textureView155},
+  ],
+});
+let buffer186 = device0.createBuffer({
+  size: 13400,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder243 = device0.createCommandEncoder({});
+let texture225 = device0.createTexture({
+  size: {width: 260},
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder191 = commandEncoder243.beginComputePass({});
+try {
+computePassEncoder138.setBindGroup(0, bindGroup136, new Uint32Array(472), 51, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder120); computePassEncoder120.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder191.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup3, new Uint32Array(184), 2, 0);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(1454);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer30, 'uint16', 2_372, 41);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(4, undefined, 335_448_891, 546_784_503);
+} catch {}
+try {
+renderPassEncoder75.insertDebugMarker('\u{1f928}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer180, 580, new DataView(new ArrayBuffer(9368)), 350, 732);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img1);
+try {
+renderPassEncoder2.setViewport(15.610131603499015, 0.36852775962407314, 18.13612983206437, 0.30465421429214007, 0.25656902263220915, 0.9480988417197583);
+} catch {}
+let querySet32 = device0.createQuerySet({type: 'occlusion', count: 477});
+let textureView218 = texture215.createView({dimension: '2d-array', arrayLayerCount: 1});
+try {
+computePassEncoder190.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup44);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup49, new Uint32Array(770), 249, 0);
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer38, 'uint32', 2_844, 672);
+} catch {}
+let buffer187 = device0.createBuffer({size: 9689, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder244 = device0.createCommandEncoder({});
+let texture226 = gpuCanvasContext5.getCurrentTexture();
+try {
+computePassEncoder71.setBindGroup(1, bindGroup86);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle4]);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder244.copyBufferToBuffer(buffer185, 1028, buffer36, 712, 212);
+} catch {}
+try {
+commandEncoder244.copyBufferToTexture({
+  /* bytesInLastRow: 232 widthInBlocks: 29 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2032 */
+  offset: 2032,
+  buffer: buffer42,
+}, {
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 29, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture227 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView219 = texture45.createView({});
+let computePassEncoder192 = commandEncoder244.beginComputePass();
+try {
+renderPassEncoder16.setIndexBuffer(buffer64, 'uint32', 164, 2_002);
+} catch {}
+let pipeline37 = await promise6;
+try {
+externalTexture15.label = '\u0f62\ue9b1\uf65c\u4098\u797c\u6b52\u893e\u{1f96e}\u{1f6c2}\u{1fab7}\u077e';
+} catch {}
+let recycledExplicitBindGroupLayout73 = pipeline7.getBindGroupLayout(0);
+let sampler150 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.38,
+});
+try {
+computePassEncoder97.setBindGroup(2, bindGroup25, new Uint32Array(1612), 486, 0);
+} catch {}
+try {
+computePassEncoder192.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder55.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder71.setPipeline(pipeline14);
+} catch {}
+let textureView220 = texture6.createView({baseMipLevel: 1, mipLevelCount: 1});
+try {
+computePassEncoder120.setBindGroup(2, bindGroup50, new Uint32Array(91), 85, 0);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(3, bindGroup18, new Uint32Array(3255), 1_100, 0);
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer24, 'uint32', 2_920, 3_784);
+} catch {}
+let textureView221 = texture85.createView({dimension: '2d-array'});
+try {
+renderPassEncoder30.setVertexBuffer(5, buffer74, 0);
+} catch {}
+let arrayBuffer17 = buffer123.getMappedRange(8, 4);
+try {
+buffer111.unmap();
+} catch {}
+let shaderModule15 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+requires unrestricted_pointer_parameters;
+
+struct T0 {
+  @align(8) @size(8) f0: u32,
+  @size(16) f1: atomic<u32>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw62: array<atomic<u32>, 1>;
+
+struct S2 {
+  @location(6) f0: vec4u,
+  @builtin(vertex_index) f1: u32,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct VertexOutput11 {
+  @location(3) f44: vec4f,
+  @location(14) f45: vec4u,
+  @location(13) f46: vec2h,
+  @location(7) @interpolate(perspective, center) f47: vec2f,
+  @location(11) @interpolate(flat, sample) f48: vec4i,
+  @builtin(position) f49: vec4f,
+}
+
+var<workgroup> vw60: mat4x3h;
+
+var<workgroup> vw63: T0;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<private> vp17: mat2x4h = mat2x4h();
+
+var<private> vp16: VertexOutput11 = VertexOutput11(vec4f(0.3914, 0.00833, 0.4699, 0.1884), vec4u(371, 8, 53, 191), vec2h(3882.6, 15013.9), vec2f(0.08351, 0.1964), vec4i(244, 115, 339, -142), vec4f(0.02850, 0.02939, 0.07458, 0.1915));
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+alias vec3b = vec3<bool>;
+
+fn fn0() -> f32 {
+  var out: f32;
+  let ptr186: ptr<private, mat2x4h> = &vp17;
+  var vf215: vec3f = quantizeToF16(vec3f(unconst_f32(0.1622), unconst_f32(0.08743), unconst_f32(0.1210)));
+  var vf216: f32 = vf215[u32(unconst_u32(309))];
+  let ptr187: ptr<private, vec4f> = &vp16.f44;
+  return out;
+}
+
+var<workgroup> vw64: array<S2, 1>;
+
+var<workgroup> vw61: atomic<i32>;
+
+@vertex
+fn vertex14(@location(1) @interpolate(linear, center) a0: f32, @builtin(instance_index) a1: u32, a2: S2) -> VertexOutput11 {
+  var out: VertexOutput11;
+  out.f49 = fma(vec3f(unconst_f32(0.04581), unconst_f32(0.01244), unconst_f32(0.4087)), vec3f(unconst_f32(0.00407), unconst_f32(0.2953), unconst_f32(0.1323)), vec3f(unconst_f32(-0.2796), unconst_f32(0.1612), unconst_f32(1.000))).rbbb;
+  out.f44 = vec4f(atan(vec3h(unconst_f16(14793.9), unconst_f16(5209.8), unconst_f16(290.5))).grbb);
+  let vf217: f32 = vp16.f49[u32(unconst_u32(69))];
+  var vf218: f32 = min(f32(unconst_f32(0.7534)), f32(unconst_f32(0.2333)));
+  var vf219: f32 = vp16.f47[bitcast<u32>(sqrt(vec4f(unconst_f32(0.07168), unconst_f32(0.1165), unconst_f32(0.1459), unconst_f32(0.09729)))[3])];
+  var vf220: vec3h = atan(vec3h(unconst_f16(-8471.0), unconst_f16(1025.2), unconst_f16(14076.2)));
+  vf219 = f32(pack4xU8Clamp(a2.f0));
+  let ptr188: ptr<private, vec4f> = &vp16.f49;
+  vp16.f45 += vec4u(u32(length(vec3f(unconst_f32(0.05703), unconst_f32(0.2287), unconst_f32(0.08137)))));
+  let ptr189: ptr<function, f32> = &vf219;
+  return out;
+}
+
+@compute @workgroup_size(5, 2, 2)
+fn compute14(@builtin(local_invocation_id) a0: vec3u, @builtin(num_workgroups) a1: vec3u) {
+  vp17 = mat2x4h(vec4h(vp16.f49), vec4h(vp16.f49));
+}`,
+});
+let bindGroup142 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout20,
+  entries: [
+    {binding: 119, resource: {buffer: buffer158, offset: 256, size: 1668}},
+    {binding: 48, resource: textureView10},
+    {binding: 41, resource: {buffer: buffer40, offset: 19712, size: 384}},
+    {binding: 977, resource: {buffer: buffer158, offset: 0, size: 205}},
+    {binding: 83, resource: {buffer: buffer68, offset: 256}},
+    {binding: 162, resource: textureView107},
+    {binding: 46, resource: externalTexture19},
+  ],
+});
+let texture228 = device0.createTexture({
+  size: [32, 1, 5],
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder88.setBindGroup(1, bindGroup25);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let texture229 = device0.createTexture({size: [32, 1, 168], format: 'rg32uint', usage: GPUTextureUsage.COPY_SRC});
+try {
+renderPassEncoder13.setIndexBuffer(buffer131, 'uint32', 268, 38);
+} catch {}
+let imageData42 = new ImageData(180, 12);
+try {
+renderPassEncoder46.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderPassEncoder73.setVertexBuffer(6, buffer38, 0, 5_218);
+} catch {}
+try {
+  await promise28;
+} catch {}
+let buffer188 = device0.createBuffer({
+  size: 11390,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderPassEncoder75.setVertexBuffer(5, buffer150, 540, 475);
+} catch {}
+let gpuCanvasContext12 = offscreenCanvas8.getContext('webgpu');
+let commandEncoder245 = device0.createCommandEncoder({});
+try {
+renderPassEncoder23.setIndexBuffer(buffer131, 'uint16', 22, 5);
+} catch {}
+try {
+renderPassEncoder70.setVertexBuffer(5, buffer154, 1_736, 489);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let buffer189 = device0.createBuffer({size: 11768, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandBuffer25 = commandEncoder18.finish({});
+let texture230 = device0.createTexture({
+  size: [4, 4, 41],
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView222 = texture44.createView({
+  label: '\ud733\u{1f784}\u56e0\u{1ffea}\u0015\u0935\u0dcb\u3ff3\u32f8',
+  aspect: 'stencil-only',
+  mipLevelCount: 1,
+});
+let computePassEncoder193 = commandEncoder245.beginComputePass({});
+try {
+renderPassEncoder18.setVertexBuffer(6, undefined, 0, 665_483_174);
+} catch {}
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55); };
+} catch {}
+document.body.prepend(img0);
+let img3 = await imageWithData(62, 52, '#10101010', '#20202020');
+let bindGroup143 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout56,
+  entries: [
+    {binding: 162, resource: textureView99},
+    {binding: 977, resource: {buffer: buffer17, offset: 19712}},
+    {binding: 119, resource: {buffer: buffer156, offset: 1792, size: 595}},
+    {binding: 46, resource: externalTexture13},
+    {binding: 41, resource: {buffer: buffer27, offset: 768, size: 364}},
+    {binding: 83, resource: {buffer: buffer47, offset: 256, size: 2771}},
+    {binding: 48, resource: textureView10},
+  ],
+});
+let textureView223 = texture55.createView({mipLevelCount: 1});
+try {
+computePassEncoder193.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.submit([commandBuffer25]);
+} catch {}
+let buffer190 = device0.createBuffer({size: 37694, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder246 = device0.createCommandEncoder({});
+let computePassEncoder194 = commandEncoder246.beginComputePass({});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup32, new Uint32Array(2189), 155, 0);
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(492);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, buffer115, 1_224);
+} catch {}
+try {
+computePassEncoder34.pushDebugGroup('\u1838');
+} catch {}
+let promise29 = device0.createComputePipelineAsync({layout: pipelineLayout6, compute: {module: shaderModule1, constants: {2_225: 0, override0: 0}}});
+let commandEncoder247 = device0.createCommandEncoder({});
+let renderPassEncoder79 = commandEncoder247.beginRenderPass({
+  colorAttachments: [{view: textureView109, depthSlice: 11, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet30,
+  maxDrawCount: 155241376,
+});
+try {
+computePassEncoder194.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle2, renderBundle2, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(5, buffer164);
+} catch {}
+let bindGroup144 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout5,
+  entries: [{binding: 41, resource: {buffer: buffer154, offset: 0}}],
+});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({colorFormats: ['r32float']});
+let renderBundle16 = renderBundleEncoder16.finish({});
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup63, new Uint32Array(276), 9, 0);
+} catch {}
+try {
+renderPassEncoder61.setBlendConstant({ r: -594.8, g: -73.24, b: -683.9, a: -322.5, });
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline31);
+} catch {}
+try {
+computePassEncoder34.popDebugGroup();
+} catch {}
+let canvas5 = document.createElement('canvas');
+let bindGroup145 = device0.createBindGroup({
+  label: '\u02fc\u0fbd\u03e1\ua29a\ue79a\u6d52\u7d1c\u{1f776}',
+  layout: recycledExplicitBindGroupLayout25,
+  entries: [
+    {binding: 46, resource: externalTexture11},
+    {binding: 83, resource: {buffer: buffer119, offset: 0}},
+    {binding: 119, resource: {buffer: buffer113, offset: 1024, size: 1017}},
+    {binding: 977, resource: {buffer: buffer176, offset: 768}},
+    {binding: 48, resource: textureView13},
+    {binding: 162, resource: textureView41},
+    {binding: 41, resource: {buffer: buffer24, offset: 11520}},
+  ],
+});
+try {
+renderPassEncoder73.setBlendConstant({ r: 938.9, g: 922.9, b: 411.7, a: -65.75, });
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(3, buffer38);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let veryExplicitBindGroupLayout37 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 64,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let querySet33 = device0.createQuerySet({type: 'occlusion', count: 1660});
+let texture231 = device0.createTexture({
+  size: {width: 32, height: 1, depthOrArrayLayers: 380},
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView224 = texture127.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder98.setBindGroup(3, bindGroup133, new Uint32Array(1817), 29, 0);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup63, new Uint32Array(994), 27, 0);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(2, buffer151);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let bindGroup146 = device0.createBindGroup({
+  label: '\u0460\u3155\u07e5\u558f\u4325',
+  layout: recycledExplicitBindGroupLayout49,
+  entries: [
+    {binding: 48, resource: textureView10},
+    {binding: 119, resource: {buffer: buffer93, offset: 1536}},
+    {binding: 977, resource: {buffer: buffer51, offset: 256, size: 4693}},
+    {binding: 162, resource: textureView99},
+    {binding: 46, resource: externalTexture12},
+    {binding: 41, resource: {buffer: buffer164, offset: 6144, size: 1080}},
+    {binding: 83, resource: {buffer: buffer83, offset: 256, size: 110}},
+  ],
+});
+let textureView225 = texture69.createView({dimension: '2d', baseArrayLayer: 11});
+let textureView226 = texture117.createView({dimension: 'cube', aspect: 'stencil-only', baseArrayLayer: 1});
+let bindGroup147 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout23,
+  entries: [{binding: 41, resource: {buffer: buffer65, offset: 0}}],
+});
+let textureView227 = texture55.createView({arrayLayerCount: 1});
+try {
+computePassEncoder141.setBindGroup(0, bindGroup94, new Uint32Array(1590), 480, 0);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let veryExplicitBindGroupLayout38 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 132,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32sint', access: 'write-only', viewDimension: '2d' },
+    },
+  ],
+});
+let recycledAutogeneratedBindGroupLayout0 = pipeline23.getBindGroupLayout(1);
+let bindGroup148 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout26,
+  entries: [
+    {binding: 48, resource: textureView10},
+    {binding: 83, resource: {buffer: buffer31, offset: 512}},
+    {binding: 977, resource: {buffer: buffer51, offset: 2304, size: 347}},
+    {binding: 119, resource: {buffer: buffer34, offset: 4608, size: 1900}},
+    {binding: 41, resource: {buffer: buffer27, offset: 5888, size: 1108}},
+    {binding: 162, resource: textureView224},
+    {binding: 46, resource: externalTexture12},
+  ],
+});
+let commandEncoder248 = device0.createCommandEncoder();
+let computePassEncoder195 = commandEncoder248.beginComputePass();
+try {
+computePassEncoder182.setBindGroup(1, bindGroup123);
+} catch {}
+try {
+computePassEncoder195.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle16, renderBundle12]);
+} catch {}
+try {
+  await shaderModule13.getCompilationInfo();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 38},
+  aspect: 'all',
+}, new Uint8Array(328_072).fill(219), /* required buffer size: 328_072 */
+{offset: 136, bytesPerRow: 244, rowsPerImage: 24}, {width: 16, height: 0, depthOrArrayLayers: 57});
+} catch {}
+let pipeline38 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {module: shaderModule6, constants: {}, targets: [{format: 'rg16uint'}]},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'never', failOp: 'invert', depthFailOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less', failOp: 'decrement-clamp', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    stencilReadMask: 214139344,
+    stencilWriteMask: 2001156576,
+    depthBiasClamp: 851.9555238836834,
+  },
+  vertex: {
+    module: shaderModule3,
+    buffers: [
+      {
+        arrayStride: 372,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float16x2', offset: 104, shaderLocation: 15},
+          {format: 'float32x4', offset: 52, shaderLocation: 0},
+          {format: 'uint32x2', offset: 16, shaderLocation: 6},
+          {format: 'unorm8x2', offset: 42, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front', unclippedDepth: true},
+});
+let recycledExplicitBindGroupLayout74 = pipeline7.getBindGroupLayout(0);
+let texture232 = device0.createTexture({
+  size: [32, 1, 60],
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture233 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView228 = texture20.createView({dimension: '2d-array', baseMipLevel: 0});
+try {
+{ clearResourceUsages(device0, computePassEncoder138); computePassEncoder138.dispatchWorkgroups(2); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder155); computePassEncoder155.dispatchWorkgroupsIndirect(buffer173, 8); };
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(2, bindGroup82);
+} catch {}
+try {
+renderPassEncoder74.executeBundles([renderBundle7, renderBundle7, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder73.setVertexBuffer(4, buffer93, 1_856);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer129, 2500, new Int16Array(7875), 1203, 1304);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder5.label = '\u0e56\u5549\u76b5\u3137\u1faa\u{1f861}\u4331\u7400\u82ff\u{1fe59}';
+} catch {}
+let recycledExplicitBindGroupLayout75 = pipeline34.getBindGroupLayout(0);
+let commandEncoder249 = device0.createCommandEncoder({});
+let textureView229 = texture75.createView({});
+let computePassEncoder196 = commandEncoder249.beginComputePass({});
+let sampler151 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.47,
+  maxAnisotropy: 12,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder93); computePassEncoder93.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder121.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup110);
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(0, bindGroup28, new Uint32Array(2615), 43, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup149 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout51,
+  entries: [
+    {binding: 83, resource: {buffer: buffer140, offset: 11520, size: 90}},
+    {binding: 162, resource: textureView41},
+    {binding: 48, resource: textureView2},
+    {binding: 41, resource: {buffer: buffer156, offset: 2560, size: 6324}},
+    {binding: 977, resource: {buffer: buffer65, offset: 768}},
+    {binding: 46, resource: externalTexture5},
+    {binding: 119, resource: {buffer: buffer64, offset: 256}},
+  ],
+});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({colorFormats: ['r32uint'], depthReadOnly: true, stencilReadOnly: false});
+try {
+computePassEncoder103.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+renderPassEncoder79.setBindGroup(3, bindGroup76, []);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(3, bindGroup66, new Uint32Array(2696), 14, 0);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(1, buffer150, 0, 7_077);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup86, new Uint32Array(1259), 533, 0);
+} catch {}
+let videoFrame41 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'jedecP22Phosphors', transfer: 'smpteSt4281'} });
+let recycledExplicitBindGroupLayout76 = pipeline32.getBindGroupLayout(0);
+let buffer191 = device0.createBuffer({
+  size: 11590,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder250 = device0.createCommandEncoder({});
+let textureView230 = texture106.createView({format: 'r32uint', baseMipLevel: 0, baseArrayLayer: 3, arrayLayerCount: 1});
+let computePassEncoder197 = commandEncoder250.beginComputePass({});
+try {
+computePassEncoder197.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup108, new Uint32Array(2997), 1_644, 0);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let imageData43 = new ImageData(8, 32);
+let buffer192 = device0.createBuffer({
+  size: 11859,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder251 = device0.createCommandEncoder();
+try {
+{ clearResourceUsages(device0, computePassEncoder143); computePassEncoder143.dispatchWorkgroupsIndirect(buffer50, 760); };
+} catch {}
+try {
+computePassEncoder196.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder73.executeBundles([renderBundle0, renderBundle4, renderBundle9, renderBundle9, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer75, 'uint16', 1_200, 4_798);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup77, []);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let commandEncoder252 = device0.createCommandEncoder({});
+let computePassEncoder198 = commandEncoder251.beginComputePass();
+let sampler152 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 92.41,
+});
+try {
+computePassEncoder198.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup83);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer177, 'uint32', 1_336, 4_880);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup137);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup71, new Uint32Array(2579), 385, 0);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer160, 'uint16', 4_164, 353);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline33);
+} catch {}
+try {
+commandEncoder252.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 448 */
+  offset: 448,
+  rowsPerImage: 713,
+  buffer: buffer34,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet34 = device0.createQuerySet({type: 'occlusion', count: 82});
+let computePassEncoder199 = commandEncoder252.beginComputePass({});
+let sampler153 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeW: 'mirror-repeat'});
+try {
+renderPassEncoder11.executeBundles([renderBundle13, renderBundle13, renderBundle14, renderBundle14]);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup133, new Uint32Array(2898), 388, 0);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(3, undefined, 861_348_657, 1_808_034_885);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 149},
+  aspect: 'all',
+}, new Uint8Array(33_897).fill(8), /* required buffer size: 33_897 */
+{offset: 297, bytesPerRow: 40, rowsPerImage: 60}, {width: 1, height: 0, depthOrArrayLayers: 15});
+} catch {}
+let canvas6 = document.createElement('canvas');
+let commandEncoder253 = device0.createCommandEncoder();
+try {
+computePassEncoder15.setBindGroup(1, bindGroup69);
+} catch {}
+try {
+computePassEncoder119.setBindGroup(2, bindGroup62, new Uint32Array(792), 398, 0);
+} catch {}
+try {
+computePassEncoder138.end();
+} catch {}
+try {
+computePassEncoder199.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer165);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup70, new Uint32Array(2892), 154, 0);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline33);
+} catch {}
+let pipeline39 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule9,
+  targets: [{
+  format: 'rg32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex7',
+    constants: {},
+    buffers: [{arrayStride: 488, attributes: [{format: 'float32x4', offset: 104, shaderLocation: 1}]}],
+  },
+});
+let gpuCanvasContext13 = canvas5.getContext('webgpu');
+let buffer193 = device0.createBuffer({size: 35563, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let textureView231 = texture59.createView({dimension: 'cube-array', baseMipLevel: 0, baseArrayLayer: 2, arrayLayerCount: 6});
+let renderBundle17 = renderBundleEncoder17.finish({});
+let sampler154 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 62.48,
+  lodMaxClamp: 71.49,
+  maxAnisotropy: 18,
+});
+try {
+renderPassEncoder2.draw(180, 25, 420_635_702, 272);
+} catch {}
+try {
+renderPassEncoder61.setPipeline(pipeline30);
+} catch {}
+try {
+commandEncoder253.copyBufferToTexture({
+  /* bytesInLastRow: 92 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 472 */
+  offset: 472,
+  bytesPerRow: 3328,
+  buffer: buffer106,
+}, {
+  texture: texture164,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder176.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture154,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext14 = canvas6.getContext('webgpu');
+let commandEncoder254 = device0.createCommandEncoder({});
+let computePassEncoder200 = commandEncoder254.beginComputePass({});
+let sampler155 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 81.73,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder82.setBindGroup(1, bindGroup63);
+} catch {}
+try {
+computePassEncoder200.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup86);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(225, 228, 265, 4_486_859, 25);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer132, 1_584);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer116, 372);
+} catch {}
+try {
+renderPassEncoder71.setVertexBuffer(7, buffer8, 680, 18_472);
+} catch {}
+let canvas7 = document.createElement('canvas');
+let recycledExplicitBindGroupLayout77 = pipeline25.getBindGroupLayout(0);
+let commandEncoder255 = device0.createCommandEncoder({});
+let texture234 = device0.createTexture({
+  size: [130, 1, 40],
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView232 = texture145.createView({});
+let computePassEncoder201 = commandEncoder176.beginComputePass({});
+let renderPassEncoder80 = commandEncoder253.beginRenderPass({
+  label: '\u2a8e\u39fb\u0876\u065b\u038b\u{1fbd1}\u2a1a',
+  colorAttachments: [{
+  view: textureView113,
+  clearValue: { r: 154.8, g: -892.6, b: -673.7, a: 104.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 24053804,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder123); computePassEncoder123.dispatchWorkgroupsIndirect(buffer26, 3_312); };
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(3, bindGroup43, new Uint32Array(1012), 78, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer36, 324);
+} catch {}
+try {
+commandEncoder255.copyTextureToTexture({
+  texture: texture170,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture218,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer168, 572, new BigUint64Array(7001), 36, 12);
+} catch {}
+let recycledAutogeneratedBindGroupLayout1 = pipeline35.getBindGroupLayout(0);
+let bindGroup150 = device0.createBindGroup({layout: veryExplicitBindGroupLayout38, entries: [{binding: 132, resource: textureView29}]});
+let texture235 = device0.createTexture({
+  size: [260, 1, 42],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder202 = commandEncoder255.beginComputePass({});
+try {
+computePassEncoder118.setBindGroup(3, bindGroup127);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup147);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup115, new Uint32Array(70), 52, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(303, 166, 393_631_001, 239);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer29, 2_272);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(5, buffer3, 24, 23);
+} catch {}
+let arrayBuffer18 = buffer78.getMappedRange(24, 0);
+let recycledExplicitBindGroupLayout78 = pipeline28.getBindGroupLayout(0);
+let textureView233 = texture232.createView({});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], depthReadOnly: true});
+try {
+computePassEncoder201.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup66, new Uint32Array(1498), 602, 0);
+} catch {}
+try {
+renderPassEncoder49.setScissorRect(0, 0, 4, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(186, 87, 411_245_886, 147);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(703, 140, 111, 269_583_110, 14);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer116, 512);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer31, 'uint32', 3_348, 2_246);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer183, 1260, new DataView(new ArrayBuffer(5444)), 117, 296);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: imageData41,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let buffer194 = device0.createBuffer({
+  size: 8234,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture236 = device0.createTexture({
+  size: {width: 4, height: 4, depthOrArrayLayers: 419},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder93.setBindGroup(0, bindGroup121);
+} catch {}
+try {
+computePassEncoder194.setBindGroup(3, bindGroup97, new Uint32Array(1118), 182, 0);
+} catch {}
+try {
+computePassEncoder202.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder67.executeBundles([renderBundle12, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(140, 235, 424, 91_291_898, 32);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(2, bindGroup134);
+} catch {}
+await gc();
+let buffer195 = device0.createBuffer({size: 10074, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture237 = device0.createTexture({
+  size: [65, 1, 1],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder156.setBindGroup(0, bindGroup137);
+} catch {}
+try {
+renderPassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder9.setViewport(142.45958947196186, 0.6276704122871041, 84.37775442218062, 0.06249126358028417, 0.5691796933281743, 0.8565162905560206);
+} catch {}
+try {
+renderPassEncoder2.draw(81, 252, 66_810_092, 8);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer80, 80);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer50, 1_300);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup8, new Uint32Array(821), 33, 0);
+} catch {}
+try {
+externalTexture10.label = '\u{1f9de}\ue29b';
+} catch {}
+let texture238 = device0.createTexture({size: [260, 1, 1], dimension: '2d', format: 'r32uint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder203 = commandEncoder77.beginComputePass({});
+let sampler156 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.23,
+  compare: 'greater',
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder2.drawIndexed(522, 3, 687, 151_733_808, 267);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer105, 248);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer131, 60);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline37);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer161, 'uint16', 270, 13);
+} catch {}
+try {
+computePassEncoder61.setBindGroup(0, bindGroup65);
+} catch {}
+try {
+computePassEncoder103.setBindGroup(0, bindGroup7, new Uint32Array(5322), 128, 0);
+} catch {}
+try {
+computePassEncoder203.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(256, 584, 187, -1_076_832_944, 0);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer77, 'uint32', 3_832, 1_391);
+} catch {}
+let autogeneratedBindGroupLayout28 = pipeline39.getBindGroupLayout(0);
+let bindGroup151 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout27,
+  entries: [
+    {binding: 162, resource: textureView6},
+    {binding: 46, resource: externalTexture12},
+    {binding: 41, resource: {buffer: buffer170, offset: 768, size: 3760}},
+    {binding: 119, resource: {buffer: buffer114, offset: 3328}},
+    {binding: 83, resource: {buffer: buffer154, offset: 1280, size: 361}},
+    {binding: 48, resource: textureView13},
+    {binding: 977, resource: {buffer: buffer150, offset: 768, size: 145}},
+  ],
+});
+let texture239 = gpuCanvasContext3.getCurrentTexture();
+let textureView234 = texture157.createView({baseArrayLayer: 0});
+try {
+renderPassEncoder2.draw(82, 97, 309_886_151, 72);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer24, 300);
+} catch {}
+let promise30 = device0.queue.onSubmittedWorkDone();
+try {
+computePassEncoder191.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+renderPassEncoder2.draw(96, 92, 1_801_172_521, 55);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(513, 57, 607, 12_602_199, 36);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer8, 1_456);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer46, 524);
+} catch {}
+try {
+renderPassEncoder58.setIndexBuffer(buffer108, 'uint32', 808, 302);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup97);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup3, new Uint32Array(589), 122, 0);
+} catch {}
+try {
+buffer50.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(66).fill(7), /* required buffer size: 66 */
+{offset: 66}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+try {
+  await promise30;
+} catch {}
+document.body.prepend(canvas3);
+let veryExplicitBindGroupLayout39 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 95,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 51, hasDynamicOffset: false },
+    },
+    {
+      binding: 384,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let buffer196 = device0.createBuffer({size: 7990, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let renderBundle18 = renderBundleEncoder18.finish({});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(140, 12, 209, -1_272_265_872, 19);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer75, 2_900);
+} catch {}
+try {
+renderPassEncoder76.setPipeline(pipeline29);
+} catch {}
+document.body.append(img1);
+try {
+renderPassEncoder63.beginOcclusionQuery(162);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(140, 7, 114, 236_899_182, 96);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer106, 1_008);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer121, 'uint32', 12, 29);
+} catch {}
+try {
+buffer63.unmap();
+} catch {}
+let pipeline40 = await promise29;
+let veryExplicitBindGroupLayout40 = device0.createBindGroupLayout({
+  label: '\ua942\uf543\uc4e2\u0e81\u8ac7\u0fee',
+  entries: [
+    {
+      binding: 79,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 101,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 243,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 270,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {binding: 299, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 326,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 601,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let recycledExplicitBindGroupLayout79 = pipeline16.getBindGroupLayout(0);
+let bindGroup152 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout38,
+  entries: [
+    {binding: 162, resource: textureView138},
+    {binding: 48, resource: textureView13},
+    {binding: 119, resource: {buffer: buffer125, offset: 2816, size: 1423}},
+    {binding: 41, resource: {buffer: buffer154, offset: 3584, size: 420}},
+    {binding: 46, resource: externalTexture13},
+    {binding: 977, resource: {buffer: buffer77, offset: 3072, size: 2038}},
+    {binding: 83, resource: {buffer: buffer68, offset: 256}},
+  ],
+});
+let commandEncoder256 = device0.createCommandEncoder({});
+let computePassEncoder204 = commandEncoder256.beginComputePass({});
+try {
+renderPassEncoder66.setBindGroup(0, bindGroup102);
+} catch {}
+try {
+renderPassEncoder53.setViewport(28.0646728047676, 0.15384983116611262, 3.015929650870384, 0.6684654081476161, 0.8524937021795674, 0.9005451612591306);
+} catch {}
+try {
+renderPassEncoder2.draw(252, 127, 115_521_974, 3);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer43, 1_600);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer81, 1_004);
+} catch {}
+let recycledExplicitBindGroupLayout80 = pipeline22.getBindGroupLayout(0);
+let bindGroup153 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout24,
+  entries: [
+    {binding: 46, resource: externalTexture16},
+    {binding: 83, resource: {buffer: buffer0, offset: 1280, size: 9630}},
+    {binding: 119, resource: {buffer: buffer158, offset: 768, size: 2911}},
+    {binding: 41, resource: {buffer: buffer107, offset: 256, size: 264}},
+    {binding: 48, resource: textureView13},
+    {binding: 162, resource: textureView15},
+    {binding: 977, resource: {buffer: buffer173, offset: 0, size: 240}},
+  ],
+});
+let texture240 = device0.createTexture({
+  size: {width: 4, height: 4, depthOrArrayLayers: 20},
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler157 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 85.48,
+});
+try {
+computePassEncoder204.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder69.setBindGroup(3, bindGroup25, new Uint32Array(2884), 456, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(214, 235, 520_905_595, 16);
+} catch {}
+await gc();
+let canvas8 = document.createElement('canvas');
+try {
+computePassEncoder71.setBindGroup(0, bindGroup44, new Uint32Array(283), 79, 0);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup119, new Uint32Array(2848), 276, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(132, 538, 1_083_364_840, 58);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(12, 105, 556, 144_358_718, 287);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer104, 36);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer120, 'uint32', 440, 8);
+} catch {}
+let buffer197 = device0.createBuffer({size: 23823, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE, mappedAtCreation: false});
+try {
+computePassEncoder165.setBindGroup(0, bindGroup102, new Uint32Array(913), 209, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer173, 120);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 13},
+  aspect: 'all',
+}, new Uint8Array(1_368).fill(152), /* required buffer size: 1_368 */
+{offset: 18, bytesPerRow: 150, rowsPerImage: 1}, {width: 16, height: 0, depthOrArrayLayers: 10});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: imageData24,
+  origin: { x: 1, y: 2 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 75},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext15 = canvas8.getContext('webgpu');
+let recycledExplicitBindGroupLayout81 = pipeline13.getBindGroupLayout(0);
+try {
+computePassEncoder132.setBindGroup(0, bindGroup87, new Uint32Array(141), 22, 0);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup6, new Uint32Array(3047), 230, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer50, 136);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(5, buffer47, 5_340, 1_825);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(37).fill(36), /* required buffer size: 37 */
+{offset: 37}, {width: 260, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline41 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {count: 4},
+  fragment: {module: shaderModule14, entryPoint: 'fragment15', targets: [{format: 'rg32sint'}]},
+  vertex: {
+    module: shaderModule6,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 160,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 30, shaderLocation: 10},
+          {format: 'uint32x4', offset: 104, shaderLocation: 9},
+          {format: 'float32', offset: 4, shaderLocation: 3},
+          {format: 'unorm8x4', offset: 40, shaderLocation: 12},
+          {format: 'uint32x4', offset: 16, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 88,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 14, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData44 = new ImageData(48, 68);
+let textureView235 = texture177.createView({});
+try {
+computePassEncoder66.setBindGroup(1, bindGroup72);
+} catch {}
+try {
+renderPassEncoder2.draw(47, 14, 333_900_395, 69);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(554, 23, 1_364, 59_720_896, 240);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer16, 16);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline32);
+} catch {}
+try {
+computePassEncoder104.insertDebugMarker('\u4f96');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let texture241 = device0.createTexture({
+  size: {width: 32, height: 1, depthOrArrayLayers: 858},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView236 = texture38.createView({dimension: '2d', aspect: 'stencil-only', baseArrayLayer: 1});
+try {
+computePassEncoder112.setBindGroup(0, bindGroup76);
+} catch {}
+try {
+computePassEncoder120.end();
+} catch {}
+try {
+renderPassEncoder68.setBindGroup(3, bindGroup40, []);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(295, 85, 262, 282_966_285, 67);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer80, 420);
+} catch {}
+try {
+renderPassEncoder50.setIndexBuffer(buffer119, 'uint16', 96, 83);
+} catch {}
+let gpuCanvasContext16 = canvas7.getContext('webgpu');
+let bindGroup154 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout3,
+  entries: [{binding: 41, resource: {buffer: buffer169, offset: 768, size: 576}}],
+});
+let commandEncoder257 = device0.createCommandEncoder({});
+let renderPassEncoder81 = commandEncoder257.beginRenderPass({
+  colorAttachments: [{
+  view: textureView111,
+  depthSlice: 22,
+  clearValue: { r: 481.2, g: -58.92, b: -316.3, a: -758.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+computePassEncoder204.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer36, 844);
+} catch {}
+try {
+renderPassEncoder56.setVertexBuffer(4, buffer174, 4, 16);
+} catch {}
+try {
+commandEncoder149.copyTextureToTexture({
+  texture: texture229,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 1,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline42 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule13}});
+document.body.prepend(canvas7);
+let commandEncoder258 = device0.createCommandEncoder({});
+let commandBuffer26 = commandEncoder149.finish();
+let computePassEncoder205 = commandEncoder258.beginComputePass({});
+try {
+computePassEncoder151.setBindGroup(3, bindGroup129, new Uint32Array(231), 51, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder112); computePassEncoder112.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder2.draw(512, 213, 118_349_742, 86);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer39, 644);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer168, 'uint16', 1_106, 1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer94, 3516, new Float32Array(10108), 435, 184);
+} catch {}
+let buffer198 = device0.createBuffer({size: 244, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder141.setBindGroup(1, bindGroup7, []);
+} catch {}
+try {
+computePassEncoder13.setBindGroup(3, bindGroup62, new Uint32Array(1178), 901, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(19, 1, 1_407_547_927, 5);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(20, 11, 78, 1_635_878_010, 292);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer168, 864, new Int16Array(2751), 743, 0);
+} catch {}
+let autogeneratedBindGroupLayout29 = pipeline17.getBindGroupLayout(0);
+let bindGroup155 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout14,
+  entries: [{binding: 41, resource: {buffer: buffer50, offset: 256, size: 176}}],
+});
+let commandEncoder259 = device0.createCommandEncoder({});
+let computePassEncoder206 = commandEncoder259.beginComputePass();
+let sampler158 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 96.19});
+try {
+computePassEncoder205.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder81.setIndexBuffer(buffer30, 'uint16', 214, 37);
+} catch {}
+let arrayBuffer19 = buffer78.getMappedRange(32, 12);
+try {
+commandEncoder35.copyBufferToBuffer(buffer76, 232, buffer183, 2840, 592);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture153,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 51, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise31 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: imageData37,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup156 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [
+    {binding: 119, resource: {buffer: buffer42, offset: 1024, size: 4961}},
+    {binding: 977, resource: {buffer: buffer119, offset: 0}},
+    {binding: 46, resource: externalTexture11},
+    {binding: 48, resource: textureView10},
+    {binding: 83, resource: {buffer: buffer30, offset: 0, size: 844}},
+    {binding: 162, resource: textureView59},
+    {binding: 41, resource: {buffer: buffer65, offset: 0}},
+  ],
+});
+let buffer199 = device0.createBuffer({
+  size: 22110,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+let renderPassEncoder82 = commandEncoder35.beginRenderPass({
+  colorAttachments: [{
+  view: textureView217,
+  clearValue: { r: -440.7, g: 973.1, b: -868.1, a: 831.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder74.setBindGroup(3, bindGroup64, []);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle1, renderBundle1, renderBundle2]);
+} catch {}
+try {
+gpuCanvasContext9.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.RENDER_ATTACHMENT, alphaMode: 'opaque'});
+} catch {}
+let imageBitmap10 = await createImageBitmap(videoFrame34);
+let videoFrame42 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'smpte432', transfer: 'gamma28curve'} });
+let veryExplicitBindGroupLayout41 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 78,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer200 = device0.createBuffer({
+  label: '\uc03e\u6f38\u85a3',
+  size: 20754,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView237 = texture8.createView({dimension: '2d'});
+try {
+computePassEncoder82.setBindGroup(2, bindGroup67, []);
+} catch {}
+try {
+computePassEncoder206.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer115, 'uint32', 184, 495);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(4, buffer173, 0, 419);
+} catch {}
+try {
+gpuCanvasContext16.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+let autogeneratedBindGroupLayout30 = pipeline33.getBindGroupLayout(0);
+try {
+computePassEncoder137.setBindGroup(0, bindGroup44);
+} catch {}
+try {
+computePassEncoder195.setBindGroup(0, bindGroup139, new Uint32Array(2100), 305, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline43 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {module: shaderModule9, constants: {}, targets: [{format: 'rg32uint'}]},
+  vertex: {
+    module: shaderModule6,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 100, shaderLocation: 9},
+          {format: 'uint32x3', offset: 348, shaderLocation: 13},
+          {format: 'uint32', offset: 280, shaderLocation: 15},
+          {format: 'snorm16x2', offset: 12, shaderLocation: 12},
+          {format: 'float16x4', offset: 124, shaderLocation: 3},
+          {format: 'unorm10-10-10-2', offset: 840, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', cullMode: 'back'},
+});
+let imageData45 = new ImageData(80, 20);
+let autogeneratedBindGroupLayout31 = pipeline12.getBindGroupLayout(0);
+let commandEncoder260 = device0.createCommandEncoder({});
+let textureView238 = texture145.createView({});
+let computePassEncoder207 = commandEncoder260.beginComputePass({});
+try {
+computePassEncoder207.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder47.setScissorRect(0, 0, 123, 0);
+} catch {}
+let canvas9 = document.createElement('canvas');
+let buffer201 = device0.createBuffer({size: 17289, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let textureView239 = texture130.createView({mipLevelCount: 1});
+try {
+computePassEncoder128.setBindGroup(2, bindGroup127);
+} catch {}
+try {
+computePassEncoder180.setBindGroup(1, bindGroup134, new Uint32Array(3740), 58, 0);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(0, bindGroup154);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: -381.5, g: -801.8, b: -213.4, a: -49.56, });
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer36, 'uint32', 216, 1_286);
+} catch {}
+let bindGroup157 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout74,
+  entries: [
+    {binding: 162, resource: textureView99},
+    {binding: 83, resource: {buffer: buffer112, offset: 0}},
+    {binding: 48, resource: textureView10},
+    {binding: 119, resource: {buffer: buffer0, offset: 2560, size: 1210}},
+    {binding: 41, resource: {buffer: buffer50, offset: 0, size: 484}},
+    {binding: 46, resource: externalTexture20},
+    {binding: 977, resource: {buffer: buffer105, offset: 5120}},
+  ],
+});
+let buffer202 = device0.createBuffer({
+  size: 6120,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder261 = device0.createCommandEncoder({});
+let textureView240 = texture155.createView({dimension: '2d', mipLevelCount: 1});
+let computePassEncoder208 = commandEncoder261.beginComputePass({});
+let sampler159 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', minFilter: 'nearest', lodMaxClamp: 89.74});
+try {
+computePassEncoder204.setBindGroup(0, bindGroup29, new Uint32Array(1324), 242, 0);
+} catch {}
+try {
+renderPassEncoder63.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder23.setViewport(4.41113758189091, 0.12682012859284608, 12.066637240949321, 0.5032483074166761, 0.415343505390674, 0.5289550229703069);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(0, buffer182, 1_956, 2_443);
+} catch {}
+try {
+  await promise31;
+} catch {}
+await gc();
+let texture242 = device0.createTexture({
+  size: [130, 1, 1],
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder118.setBindGroup(2, bindGroup43, new Uint32Array(2203), 302, 0);
+} catch {}
+try {
+computePassEncoder152.end();
+} catch {}
+try {
+computePassEncoder126.setPipeline(pipeline9);
+} catch {}
+try {
+computePassEncoder208.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderPassEncoder23.setViewport(10.686284482340362, 0.5777678693599341, 30.596744981590817, 0.4087923455390426, 0.6898679035895575, 0.734532496254229);
+} catch {}
+try {
+renderPassEncoder24.drawIndexed(0, 126, 0, 802_823_296, 22_007_177);
+} catch {}
+try {
+renderPassEncoder24.drawIndexedIndirect(buffer202, 0);
+} catch {}
+try {
+renderPassEncoder24.drawIndirect(buffer191, 7_780);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer121, 'uint16', 100, 31);
+} catch {}
+try {
+  await buffer63.mapAsync(GPUMapMode.WRITE, 0, 824);
+} catch {}
+try {
+commandEncoder193.copyTextureToTexture({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 256},
+  aspect: 'all',
+},
+{
+  texture: texture28,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder193.resolveQuerySet(querySet14, 74, 45, buffer18, 1024);
+} catch {}
+await gc();
+let buffer203 = device0.createBuffer({
+  size: 4248,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder262 = device0.createCommandEncoder({});
+let computePassEncoder209 = commandEncoder193.beginComputePass({});
+try {
+computePassEncoder91.setBindGroup(3, bindGroup86, new Uint32Array(2529), 3, 0);
+} catch {}
+try {
+computePassEncoder112.end();
+} catch {}
+try {
+if (!arrayBuffer17.detached) { new Uint8Array(arrayBuffer17).fill(0x55); };
+} catch {}
+let commandEncoder263 = device0.createCommandEncoder({});
+try {
+computePassEncoder46.setPipeline(pipeline16);
+} catch {}
+try {
+computePassEncoder209.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(3, bindGroup77, new Uint32Array(1418), 107, 0);
+} catch {}
+try {
+renderPassEncoder24.end();
+} catch {}
+try {
+renderPassEncoder49.executeBundles([renderBundle3]);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 130, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame41,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture227,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder264 = device0.createCommandEncoder({});
+let computePassEncoder210 = commandEncoder262.beginComputePass({});
+let renderPassEncoder83 = commandEncoder263.beginRenderPass({
+  colorAttachments: [{
+  view: textureView195,
+  clearValue: { r: 515.3, g: 151.3, b: -316.1, a: 546.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView204,
+    depthClearValue: -5.868212774979213,
+    depthReadOnly: false,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'store',
+  },
+});
+let sampler160 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 58.24,
+});
+try {
+renderPassEncoder35.setBindGroup(1, bindGroup139);
+} catch {}
+try {
+renderPassEncoder58.executeBundles([renderBundle4, renderBundle6, renderBundle9, renderBundle9, renderBundle0, renderBundle0]);
+} catch {}
+try {
+commandEncoder103.resolveQuerySet(querySet15, 33, 0, buffer91, 0);
+} catch {}
+let pipelineLayout19 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout25]});
+let computePassEncoder211 = commandEncoder103.beginComputePass();
+try {
+computePassEncoder7.setBindGroup(2, bindGroup20, new Uint32Array(480), 10, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder101); computePassEncoder101.dispatchWorkgroupsIndirect(buffer64, 1_064); };
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup45, new Uint32Array(2587), 292, 0);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer44, 'uint32', 7_308, 9_327);
+} catch {}
+let buffer204 = device0.createBuffer({size: 6853, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let computePassEncoder212 = commandEncoder143.beginComputePass({});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({colorFormats: ['r32float'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle19 = renderBundleEncoder19.finish({});
+try {
+computePassEncoder195.setBindGroup(0, bindGroup31, new Uint32Array(2002), 754, 0);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup127, new Uint32Array(1969), 36, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let img4 = await imageWithData(15, 88, '#10101010', '#20202020');
+let buffer205 = device0.createBuffer({
+  size: 5837,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder213 = commandEncoder264.beginComputePass({});
+try {
+computePassEncoder124.setBindGroup(0, bindGroup121);
+} catch {}
+try {
+computePassEncoder180.setBindGroup(2, bindGroup18, new Uint32Array(3695), 563, 0);
+} catch {}
+try {
+computePassEncoder210.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer158, 'uint32', 560, 126);
+} catch {}
+try {
+renderPassEncoder67.insertDebugMarker('\u2231');
+} catch {}
+document.body.append(canvas3);
+let shaderModule16 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+var<workgroup> vw69: VertexOutput12;
+
+var<workgroup> vw68: mat3x4f;
+
+var<workgroup> vw66: array<atomic<i32>, 1>;
+
+@group(0) @binding(31) var tex13: texture_3d<f32>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw67: FragmentOutput14;
+
+fn fn0() -> FragmentOutput14 {
+  var out: FragmentOutput14;
+  let vf221: vec3f = sqrt(vec3f(unconst_f32(0.5319), unconst_f32(0.1898), unconst_f32(0.1254)));
+  var vf222: u32 = pack4xI8Clamp(vec4i(i32(pack4xI8Clamp(vec4i(unconst_i32(332), unconst_i32(51), unconst_i32(253), unconst_i32(68))))));
+  out.f0 <<= vec2u(pack2x16snorm(vec2f(unconst_f32(0.3427), unconst_f32(0.1068))));
+  var vf223: vec3u = extractBits(vec3u(unconst_u32(183), unconst_u32(109), unconst_u32(207)), u32(unconst_u32(109)), u32(unconst_u32(4)));
+  var vf224: u32 = pack4xI8Clamp(vec4i(i32(pack4xI8Clamp(vec4i(unconst_i32(35), unconst_i32(126), unconst_i32(193), unconst_i32(84))))));
+  out.f0 = vec2u(pack4xI8Clamp(vec4i(unconst_i32(142), unconst_i32(115), unconst_i32(158), unconst_i32(214))));
+  vf222 = extractBits(vec3u(unconst_u32(96), unconst_u32(11), unconst_u32(109)), u32(unconst_u32(192)), u32(unconst_u32(75)))[1];
+  vf223 = vf223;
+  var vf225: vec3u = extractBits(vec3u(unconst_u32(29), unconst_u32(35), unconst_u32(46)), u32(unconst_u32(480)), extractBits(vec3u(unconst_u32(144), unconst_u32(39), unconst_u32(441)), u32(unconst_u32(14)), u32(unconst_u32(97))).x);
+  out = FragmentOutput14(vec2u(pack4xI8Clamp(vec4i(unconst_i32(15), unconst_i32(55), unconst_i32(158), unconst_i32(79)))));
+  vf222 &= extractBits(vec3u(unconst_u32(137), unconst_u32(104), unconst_u32(147)), u32(unconst_u32(58)), u32(unconst_u32(69))).z;
+  var vf226: vec2f = pow(vec2f(unconst_f32(0.06716), unconst_f32(0.09183)), vec2f(unconst_f32(0.4906), unconst_f32(-0.2690)));
+  var vf227: u32 = pack4xI8Clamp(vec4i(unconst_i32(16), unconst_i32(51), unconst_i32(7), unconst_i32(50)));
+  vf223 ^= vec3u(vf224);
+  return out;
+}
+
+struct VertexOutput12 {
+  @location(0) f50: f32,
+  @builtin(position) f51: vec4f,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw72: array<array<bool, 1>, 14>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T0 {
+  @size(3104) f0: array<vec2i, 110>,
+}
+
+var<workgroup> vw71: FragmentOutput14;
+
+struct FragmentOutput14 {
+  @location(0) @interpolate(flat, center) f0: vec2u,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw70: mat4x3h;
+
+var<workgroup> vw65: atomic<u32>;
+
+@vertex
+fn vertex15() -> VertexOutput12 {
+  var out: VertexOutput12;
+  let vf228: vec4f = textureLoad(tex13, vec3i(unconst_i32(209), unconst_i32(114), unconst_i32(77)), i32(unconst_i32(134)));
+  let vf229: i32 = insertBits(i32(unconst_i32(70)), i32(unconst_i32(179)), u32(unconst_u32(169)), u32(unconst_u32(66)));
+  let vf230: vec4h = step(vec4h(unconst_f16(6197.0), unconst_f16(12872.0), unconst_f16(16121.8), unconst_f16(12748.6)), vec4h(f16(textureNumLevels(tex13))));
+  out = VertexOutput12(f32(textureNumLevels(tex13)), unpack4x8unorm(textureNumLevels(tex13)));
+  out.f51 -= vec4f(vf230);
+  var vf231: vec4h = step(vec4h(unconst_f16(13331.3), unconst_f16(3922.9), unconst_f16(8186.5), unconst_f16(4052.1)), vec4h(unconst_f16(181.1), unconst_f16(9604.3), unconst_f16(4678.2), unconst_f16(6252.2)));
+  out = VertexOutput12(f32(vf231[u32(unconst_u32(155))]), vec4f(f32(vf231[u32(unconst_u32(155))])));
+  out.f50 *= f32(textureDimensions(tex13, i32(unconst_i32(34))).g);
+  out = VertexOutput12(vf228[pack4x8snorm(atan(vec4f(unconst_f32(0.2902), unconst_f32(0.07883), unconst_f32(0.1497), unconst_f32(-0.02441))))], vec4f(vf228[pack4x8snorm(atan(vec4f(unconst_f32(0.2902), unconst_f32(0.07883), unconst_f32(0.1497), unconst_f32(-0.02441))))]));
+  let vf232: vec4f = atan(vec4f(step(vec4h(unconst_f16(12202.7), unconst_f16(20824.8), unconst_f16(11103.2), unconst_f16(8086.4)), vec4h(unconst_f16(13468.1), unconst_f16(16729.8), unconst_f16(10451.7), unconst_f16(26729.7)))));
+  let vf233: f16 = vf230[u32(unconst_u32(36))];
+  out.f51 += vec4f(f32(vf233));
+  out = VertexOutput12(f32(pack4xI8Clamp(vec4i(unconst_i32(-193), unconst_i32(128), unconst_i32(25), unconst_i32(-224)))), unpack4x8unorm(pack4xI8Clamp(vec4i(unconst_i32(-193), unconst_i32(128), unconst_i32(25), unconst_i32(-224)))));
+  out.f51 *= unpack4x8unorm(textureNumLevels(tex13));
+  return out;
+  _ = tex13;
+}
+
+@fragment
+fn fragment16() -> FragmentOutput14 {
+  var out: FragmentOutput14;
+  fn0();
+  let vf234: bool = any(bool(unconst_bool(false)));
+  var vf235: f16 = mix(f16(all(vec2<bool>(unconst_bool(false), unconst_bool(true)))), f16(unconst_f16(-5151.7)), f16(unconst_f16(2588.6)));
+  out.f0 -= vec2u(reflect(vec3f(unconst_f32(0.06426), unconst_f32(0.1236), unconst_f32(0.09158)), vec3f(unconst_f32(0.07881), unconst_f32(0.5084), unconst_f32(0.07848))).zy);
+  vf235 += f16(exp(f32(unconst_f32(0.09965))));
+  fn0();
+  out.f0 = vec2u(u32(vf234));
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute15() {
+  var vf236 = fn0();
+  var vf237: u32 = textureNumLevels(tex13);
+  vw70 -= mat4x3h(ceil(f16(unconst_f16(1961.9))), ceil(f16(unconst_f16(1961.9))), ceil(f16(unconst_f16(1961.9))), ceil(f16(unconst_f16(1961.9))), ceil(f16(unconst_f16(1961.9))), ceil(f16(unconst_f16(1961.9))), ceil(f16(unconst_f16(1961.9))), ceil(f16(unconst_f16(1961.9))), ceil(f16(unconst_f16(1961.9))), ceil(f16(unconst_f16(1961.9))), ceil(f16(unconst_f16(1961.9))), ceil(f16(unconst_f16(1961.9))));
+  atomicOr(&vw66[u32(unconst_u32(32))], i32(unconst_i32(218)));
+  vf236 = FragmentOutput14(vec2u(u32(vw69.f50)));
+  vw71.f0 -= vec2u(u32((*&vw72)[13][0]));
+  var vf238 = fn0();
+  fn0();
+  fn0();
+  let vf239: u32 = (*&vw71).f0[u32(unconst_u32(38))];
+  vw72[u32(unconst_u32(157))][u32(unconst_u32(74))] = bool(atomicLoad(&vw66[0]));
+  let ptr190: ptr<workgroup, FragmentOutput14> = &vw71;
+  vw72[u32(unconst_u32(187))][u32(unconst_u32(46))] = bool((*&vw67).f0[1]);
+  textureBarrier();
+  vf236 = FragmentOutput14(vec2u(workgroupUniformLoad(&vw70)[unconst_i32(1)].rg));
+  textureBarrier();
+  fn0();
+  vf237 &= (*ptr190).f0[u32(unconst_u32(128))];
+  vw68 = mat3x4f(f32(vw70[u32(unconst_u32(643))][u32(unconst_u32(6))]), f32(vw70[u32(unconst_u32(643))][u32(unconst_u32(6))]), f32(vw70[u32(unconst_u32(643))][u32(unconst_u32(6))]), f32(vw70[u32(unconst_u32(643))][u32(unconst_u32(6))]), f32(vw70[u32(unconst_u32(643))][u32(unconst_u32(6))]), f32(vw70[u32(unconst_u32(643))][u32(unconst_u32(6))]), f32(vw70[u32(unconst_u32(643))][u32(unconst_u32(6))]), f32(vw70[u32(unconst_u32(643))][u32(unconst_u32(6))]), f32(vw70[u32(unconst_u32(643))][u32(unconst_u32(6))]), f32(vw70[u32(unconst_u32(643))][u32(unconst_u32(6))]), f32(vw70[u32(unconst_u32(643))][u32(unconst_u32(6))]), f32(vw70[u32(unconst_u32(643))][u32(unconst_u32(6))]));
+  var vf240: f16 = vw70[u32(unconst_u32(132))][u32(unconst_u32(180))];
+  let ptr191: ptr<workgroup, atomic<i32>> = &vw66[0];
+  let vf241: i32 = atomicExchange(&(*&vw66)[0], i32(unconst_i32(190)));
+  fn0();
+  _ = tex13;
+}`,
+});
+let veryExplicitBindGroupLayout42 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 61,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 68,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 144,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder265 = device0.createCommandEncoder({});
+let texture243 = device0.createTexture({
+  size: [260, 1, 64],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder214 = commandEncoder265.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder204); computePassEncoder204.dispatchWorkgroupsIndirect(buffer18, 484); };
+} catch {}
+try {
+computePassEncoder211.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup103, new Uint32Array(4179), 59, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer39, 'uint32', 1_228, 8_669);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer93, 1952, new DataView(new ArrayBuffer(6889)), 56, 1264);
+} catch {}
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+document.body.prepend(canvas2);
+let querySet35 = device0.createQuerySet({type: 'occlusion', count: 157});
+try {
+computePassEncoder153.setBindGroup(2, bindGroup39, new Uint32Array(1295), 39, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder191); computePassEncoder191.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup50, new Uint32Array(747), 222, 0);
+} catch {}
+let sampler161 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat'});
+try {
+computePassEncoder213.setPipeline(pipeline25);
+} catch {}
+let recycledExplicitBindGroupLayout82 = pipeline28.getBindGroupLayout(0);
+let bindGroup158 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout18,
+  entries: [{binding: 113, resource: {buffer: buffer40, offset: 5376, size: 10952}}],
+});
+let textureView241 = texture154.createView({dimension: '2d-array', aspect: 'all'});
+try {
+computePassEncoder123.setBindGroup(2, bindGroup71, []);
+} catch {}
+try {
+computePassEncoder165.setBindGroup(3, bindGroup58, new Uint32Array(625), 261, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder49); computePassEncoder49.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder101.end();
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer83, 'uint32', 1_888, 21);
+} catch {}
+let gpuCanvasContext17 = canvas9.getContext('webgpu');
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let shaderModule17 = device0.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+var<workgroup> vw73: VertexOutput13;
+
+@group(1) @binding(73) var<storage, read> buffer207: array<array<mat2x4f, 10>>;
+
+fn fn0(a0: VertexOutput13) {
+  let ptr192: ptr<private, u32> = &vp18[0].f4;
+  let ptr193: ptr<storage, u32, read> = &buffer206.f8;
+  vp18[u32(unconst_u32(12))].f6 &= vp18[u32(unconst_u32(0))].f2;
+  let ptr194: ptr<private, vec4i> = &vp18[0].f5;
+  let vf242: f32 = exp(f32(unconst_f32(0.1204)));
+  let ptr195: ptr<private, u32> = &vp18[u32(unconst_u32(210))].f8;
+  let ptr196: ptr<private, vec4u> = &vp18[u32(unconst_u32(240))].f0;
+  vp18[u32(unconst_u32(223))] = S3(unpack4xU8(u32(determinant(mat3x3f()))), vec4i(i32(determinant(mat3x3f()))), u32(determinant(mat3x3f())), vec2f(determinant(mat3x3f())), bitcast<u32>(determinant(mat3x3f())), vec4i(i32(determinant(mat3x3f()))), u32(determinant(mat3x3f())), determinant(mat3x3f()), u32(determinant(mat3x3f())));
+  vp18[u32(unconst_u32(6))] = S3(vec4u(buffer206.f5), buffer206.f5, u32(buffer206.f5[1]), vec2f(buffer206.f5.rb), pack4xI8Clamp(buffer206.f5), buffer206.f5, pack4xU8Clamp(bitcast<vec4u>(buffer206.f5)), bitcast<f32>(buffer206.f5.w), u32(buffer206.f5[3]));
+  var vf243: f16 = cosh(f16(unconst_f16(19174.3)));
+  var vf244: f32 = vp18[0].f3[u32(unconst_u32(362))];
+  let vf245: f32 = buffer206.f3[u32(unconst_u32(25))];
+  vp18[u32(unconst_u32(209))] = S3(unpack4xU8(buffer206.f4), vec4i(bitcast<i32>(buffer206.f4)), buffer206.f4, vec2f(bitcast<f32>(buffer206.f4)), buffer206.f4, vec4i(i32(buffer206.f4)), buffer206.f4, bitcast<f32>(buffer206.f4), buffer206.f4);
+  let vf246: vec4h = clamp(vec4h(unconst_f16(19567.3), unconst_f16(4021.9), unconst_f16(1269.3), unconst_f16(1952.7)), vec4h(unconst_f16(8322.6), unconst_f16(32892.4), unconst_f16(3535.6), unconst_f16(14426.5)), vec4h(unconst_f16(418.0), unconst_f16(912.0), unconst_f16(9084.2), unconst_f16(20409.3)));
+  var vf247: f32 = determinant(mat3x3f());
+  _ = buffer206;
+}
+
+var<private> vp18: array<S3, 1> = array(S3(vec4u(72, 71, 92, 71), vec4i(270, 97, -24, 158), u32(47), vec2f(0.2465, 0.03414), u32(865), vec4i(306, 45, 336, 287), u32(15), f32(0.07001), u32(169)));
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(122) var<storage, read> buffer206: S3;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T1 {
+  @size(320) f0: array<mat2x3f>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T0 {
+  @align(32) @size(320) f0: array<atomic<i32>>,
+}
+
+struct S3 {
+  @location(6) @interpolate(flat) f0: vec4u,
+  @location(10) @interpolate(flat, center) f1: vec4i,
+  @location(8) f2: u32,
+  @location(7) f3: vec2f,
+  @builtin(vertex_index) f4: u32,
+  @location(5) @interpolate(flat) f5: vec4i,
+  @builtin(instance_index) f6: u32,
+  @location(9) @interpolate(flat) f7: f32,
+  @location(4) @interpolate(flat) f8: u32,
+}
+
+var<workgroup> vw76: array<atomic<u32>, 1>;
+
+struct VertexOutput13 {
+  @builtin(position) f52: vec4f,
+}
+
+var<workgroup> vw75: array<array<array<f16, 1>, 1>, 1>;
+
+var<workgroup> vw74: vec4f;
+
+@vertex
+fn vertex16(@location(13) @interpolate(flat) a0: vec2i, a1: S3) -> VertexOutput13 {
+  var out: VertexOutput13;
+  let ptr197: ptr<private, u32> = &vp18[u32(unconst_u32(35))].f8;
+  let ptr198: ptr<storage, u32, read> = &(*&buffer206).f4;
+  let ptr199: ptr<private, u32> = &vp18[u32(unconst_u32(90))].f8;
+  let ptr200: ptr<private, u32> = &vp18[0].f4;
+  let ptr201: ptr<private, vec4u> = &vp18[0].f0;
+  out.f52 += vec4f(f32(vp18[0].f6));
+  let vf248: f32 = abs(f32(unconst_f32(0.01406)));
+  out.f52 = vec4f(buffer207[arrayLength(&buffer207)][u32(unconst_u32(141))][u32(unconst_u32(21))][u32(unconst_u32(56))]);
+  let ptr202: ptr<storage, u32, read> = &buffer206.f2;
+  out.f52 -= vec4f(bitcast<f32>(vp18[u32(unconst_u32(67))].f8));
+  return out;
+  _ = buffer207;
+  _ = buffer206;
+}`,
+});
+let recycledExplicitBindGroupLayout83 = pipeline24.getBindGroupLayout(0);
+let buffer208 = device0.createBuffer({
+  size: 11629,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture244 = device0.createTexture({
+  size: [260, 1, 74],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder215 = commandEncoder127.beginComputePass();
+try {
+renderPassEncoder37.setIndexBuffer(buffer74, 'uint16', 156, 14);
+} catch {}
+try {
+renderPassEncoder72.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(3, buffer121);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let arrayBuffer20 = buffer100.getMappedRange(1208, 0);
+try {
+device0.queue.writeBuffer(buffer170, 1104, new DataView(new ArrayBuffer(6958)), 139, 224);
+} catch {}
+let bindGroup159 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 101, resource: sampler106},
+    {binding: 243, resource: textureView238},
+    {binding: 601, resource: {buffer: buffer108, offset: 256, size: 168}},
+    {binding: 79, resource: textureView122},
+    {binding: 299, resource: sampler61},
+    {binding: 270, resource: {buffer: buffer31, offset: 7936}},
+    {binding: 326, resource: {buffer: buffer125, offset: 2560, size: 1020}},
+  ],
+});
+let buffer209 = device0.createBuffer({size: 5361, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder266 = device0.createCommandEncoder({});
+let texture245 = device0.createTexture({
+  size: [32],
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder216 = commandEncoder266.beginComputePass({});
+let sampler162 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder216.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer26, 'uint16', 1_596, 3_068);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer35, 1468, new Int16Array(5278), 563, 2016);
+} catch {}
+document.body.append(img3);
+let textureView242 = texture44.createView({dimension: '2d-array', aspect: 'stencil-only', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder182.setBindGroup(2, bindGroup1, new Uint32Array(1263), 502, 0);
+} catch {}
+try {
+computePassEncoder143.end();
+} catch {}
+try {
+computePassEncoder212.setPipeline(pipeline23);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let buffer210 = device0.createBuffer({
+  size: 14893,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture246 = device0.createTexture({
+  size: {width: 32},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView243 = texture237.createView({aspect: 'stencil-only', baseArrayLayer: 0});
+let renderPassEncoder84 = commandEncoder182.beginRenderPass({
+  colorAttachments: [{
+  view: textureView221,
+  clearValue: { r: 648.1, g: -797.5, b: 533.5, a: -433.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder169.setBindGroup(1, bindGroup129, new Uint32Array(413), 79, 0);
+} catch {}
+try {
+computePassEncoder215.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(0, bindGroup123, new Uint32Array(686), 144, 0);
+} catch {}
+try {
+renderPassEncoder73.setPipeline(pipeline10);
+} catch {}
+let pipelineLayout20 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout3]});
+let buffer211 = device0.createBuffer({size: 1866, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView244 = texture215.createView({baseArrayLayer: 0});
+try {
+computePassEncoder214.setPipeline(pipeline28);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: imageData34,
+  origin: { x: 23, y: 1 },
+  flipY: true,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 217},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas7);
+let bindGroup160 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout71,
+  entries: [
+    {binding: 41, resource: {buffer: buffer45, offset: 256, size: 416}},
+    {binding: 119, resource: {buffer: buffer193, offset: 3840, size: 1568}},
+    {binding: 48, resource: textureView2},
+    {binding: 83, resource: {buffer: buffer45, offset: 0, size: 674}},
+    {binding: 977, resource: {buffer: buffer182, offset: 256, size: 3005}},
+    {binding: 46, resource: externalTexture9},
+    {binding: 162, resource: textureView18},
+  ],
+});
+let commandEncoder267 = device0.createCommandEncoder({});
+let commandBuffer27 = commandEncoder267.finish({});
+let texture247 = device0.createTexture({size: [32, 1, 1], format: 'rg32sint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+try {
+computePassEncoder194.setBindGroup(1, bindGroup24, new Uint32Array(1956), 1_956, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder118); computePassEncoder118.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(0, bindGroup20, new Uint32Array(1854), 288, 0);
+} catch {}
+try {
+renderPassEncoder79.setPipeline(pipeline12);
+} catch {}
+let arrayBuffer21 = buffer103.getMappedRange(56, 0);
+try {
+device0.queue.writeBuffer(buffer200, 2156, new DataView(new ArrayBuffer(28842)), 131, 1408);
+} catch {}
+try {
+adapter0.label = '\uefda\u{1fc12}\u622e\u321f\u0ca6\u21f1\u89fd\u{1fe94}\u0189\uabce\u5cf8';
+} catch {}
+let texture248 = device0.createTexture({
+  size: [4, 4, 17],
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView245 = texture51.createView({format: 'rg16uint', baseMipLevel: 0, baseArrayLayer: 1, arrayLayerCount: 1});
+try {
+device0.queue.writeBuffer(buffer118, 1160, new BigUint64Array(11255), 749, 264);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(288).fill(144), /* required buffer size: 288 */
+{offset: 288}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule18 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+@group(0) @binding(162) var tex14: texture_2d_array<u32>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(119) var<uniform> buffer213: i32;
+
+@id(16942) override override19: f32;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T1 {
+  f0: i32,
+}
+
+fn fn0() -> T1 {
+  var out: T1;
+  var vf249: bool = all(bool(unconst_bool(true)));
+  out = T1(bitcast<i32>(floor(vec2f(unconst_f32(0.6122), unconst_f32(0.06850))).g));
+  var vf250: vec2f = floor(vec2f(unconst_f32(-0.3740), unconst_f32(-0.01122)));
+  var vf251: vec3f = round(vec3f(bitcast<f32>(countTrailingZeros(u32(unconst_u32(210))))));
+  out = T1(vec2i(floor(vec2f(unconst_f32(0.3712), unconst_f32(0.1031))))[1]);
+  vf251 += cross(vec3f(unconst_f32(0.1745), unconst_f32(0.06441), unconst_f32(0.02739)), vec3f(unconst_f32(0.1390), unconst_f32(0.1410), unconst_f32(0.08555)));
+  out.f0 = i32(floor(cross(vec3f(unconst_f32(-0.3042), unconst_f32(0.1147), unconst_f32(0.1480)), vec3f(unconst_f32(0.08228), unconst_f32(0.04753), unconst_f32(0.05131))).bg).y);
+  vf251 -= reflect(vec4f(unconst_f32(-0.06578), unconst_f32(-0.08448), unconst_f32(0.00144), unconst_f32(-0.08182)), vec4f(unconst_f32(0.2971), unconst_f32(0.01151), unconst_f32(0.3579), unconst_f32(0.02416))).bar;
+  var vf252: vec2f = floor(vec2f(unconst_f32(0.2501), unconst_f32(0.1218)));
+  return out;
+}
+
+struct T0 {
+  @size(56) f0: mat4x4h,
+}
+
+var<workgroup> vw77: T1;
+
+@group(0) @binding(83) var<uniform> buffer212: vec2h;
+
+fn fn1(a0: ptr<storage, array<mat4x2f>, read_write>, a1: T1, a2: ptr<workgroup, T1>) -> mat4x4h {
+  var out: mat4x4h;
+  var vf253: vec2f = (*a0)[arrayLength(&(*a0))][u32(unconst_u32(173))];
+  out = mat4x4h(round(vec4h(unconst_f16(4475.6), unconst_f16(4303.9), unconst_f16(8527.5), unconst_f16(26889.2))), round(vec4h(unconst_f16(4475.6), unconst_f16(4303.9), unconst_f16(8527.5), unconst_f16(26889.2))), round(vec4h(unconst_f16(4475.6), unconst_f16(4303.9), unconst_f16(8527.5), unconst_f16(26889.2))), round(vec4h(unconst_f16(4475.6), unconst_f16(4303.9), unconst_f16(8527.5), unconst_f16(26889.2))));
+  (*a0)[u32(unconst_u32(777))] = mat4x2f(f32(clamp(f16(unconst_f16(16937.6)), f16(unconst_f16(2611.5)), f16(unconst_f16(2793.7)))), f32(clamp(f16(unconst_f16(16937.6)), f16(unconst_f16(2611.5)), f16(unconst_f16(2793.7)))), f32(clamp(f16(unconst_f16(16937.6)), f16(unconst_f16(2611.5)), f16(unconst_f16(2793.7)))), f32(clamp(f16(unconst_f16(16937.6)), f16(unconst_f16(2611.5)), f16(unconst_f16(2793.7)))), f32(clamp(f16(unconst_f16(16937.6)), f16(unconst_f16(2611.5)), f16(unconst_f16(2793.7)))), f32(clamp(f16(unconst_f16(16937.6)), f16(unconst_f16(2611.5)), f16(unconst_f16(2793.7)))), f32(clamp(f16(unconst_f16(16937.6)), f16(unconst_f16(2611.5)), f16(unconst_f16(2793.7)))), f32(clamp(f16(unconst_f16(16937.6)), f16(unconst_f16(2611.5)), f16(unconst_f16(2793.7)))));
+  var vf254: u32 = pack4xI8Clamp(vec4i(unconst_i32(-48), unconst_i32(196), unconst_i32(-335), unconst_i32(33)));
+  let vf255: f16 = (*&buffer212)[bitcast<u32>(atan(vec4f(unconst_f32(0.7680), unconst_f32(-0.3485), unconst_f32(0.1801), unconst_f32(0.00129)))[3])];
+  (*a2) = T1(bitcast<i32>(buffer212));
+  (*a0)[u32(unconst_u32(267))] = mat4x2f(bitcast<f32>(a1.f0), f32(a1.f0), f32(a1.f0), bitcast<f32>(a1.f0), bitcast<f32>(a1.f0), f32(a1.f0), bitcast<f32>(a1.f0), f32(a1.f0));
+  let ptr203: ptr<storage, mat4x2f, read_write> = &(*a0)[arrayLength(&(*a0))];
+  let ptr204: ptr<storage, mat4x2f, read_write> = &(*ptr203);
+  vf253 *= exp(vec2f(unconst_f32(0.3128), unconst_f32(0.2011)));
+  vf254 >>= bitcast<u32>((*a0)[arrayLength(&(*a0))][unconst_i32(3)][1]);
+  let ptr205: ptr<storage, mat4x2f, read_write> = &(*a0)[i32(unconst_i32(256))];
+  (*a0)[u32(unconst_u32(47))] = mat4x2f((*ptr205)[u32(unconst_u32(256))], (*ptr205)[u32(unconst_u32(256))], (*ptr205)[u32(unconst_u32(256))], (*ptr205)[u32(unconst_u32(256))]);
+  let vf256: f16 = buffer212[u32(unconst_u32(182))];
+  out = mat4x4h((*&buffer212)[u32(unconst_u32(15))], (*&buffer212)[u32(unconst_u32(15))], (*&buffer212)[u32(unconst_u32(15))], (*&buffer212)[u32(unconst_u32(15))], (*&buffer212)[u32(unconst_u32(15))], (*&buffer212)[u32(unconst_u32(15))], (*&buffer212)[u32(unconst_u32(15))], (*&buffer212)[u32(unconst_u32(15))], (*&buffer212)[u32(unconst_u32(15))], (*&buffer212)[u32(unconst_u32(15))], (*&buffer212)[u32(unconst_u32(15))], (*&buffer212)[u32(unconst_u32(15))], (*&buffer212)[u32(unconst_u32(15))], (*&buffer212)[u32(unconst_u32(15))], (*&buffer212)[u32(unconst_u32(15))], (*&buffer212)[u32(unconst_u32(15))]);
+  var vf257: vec2f = unpack2x16unorm(u32(unconst_u32(80)));
+  let vf258: i32 = a1.f0;
+  let vf259: vec2f = (*a0)[u32(unconst_u32(155))][u32((*ptr203)[u32(unconst_u32(25))][u32(unconst_u32(142))])];
+  return out;
+  _ = buffer212;
+}
+
+@group(0) @binding(48) var st13: texture_storage_2d<bgra8unorm, read>;
+
+@group(0) @binding(46) var et9: texture_external;
+
+var<workgroup> vw78: mat4x2h;
+
+struct VertexOutput14 {
+  @builtin(position) f53: vec4f,
+}
+
+@group(1) @binding(273) var<storage, read_write> buffer215: array<array<vec4f, 60>>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(977) var<uniform> buffer214: VertexOutput14;
+
+@vertex
+fn vertex17(@location(9) a0: vec4f) -> VertexOutput14 {
+  var out: VertexOutput14;
+  out = VertexOutput14(vec4f(reflect(vec4h(unconst_f16(21586.6), unconst_f16(-20928.8), unconst_f16(3730.8), unconst_f16(-29559.6)), vec4h(unconst_f16(2973.4), unconst_f16(9671.7), unconst_f16(10052.7), unconst_f16(23355.5)))));
+  let ptr206: ptr<uniform, i32> = &buffer213;
+  var vf260: f32 = fract(f32(unconst_f32(0.00815)));
+  let ptr207: ptr<uniform, vec4f> = &(*&buffer214).f53;
+  out.f53 -= vec4f(firstLeadingBit(vec3i(unconst_i32(190), unconst_i32(211), unconst_i32(37))).zxxy);
+  out = VertexOutput14(vec4f(a0[u32(unconst_u32(211))]));
+  out.f53 = a0;
+  out.f53 = vec4f(round(vec3h(unconst_f16(3030.8), unconst_f16(22062.3), unconst_f16(2577.7))).xxxz);
+  var vf261: u32 = pack2x16float(vec2f(f32(pack2x16float(vec2f(unconst_f32(0.7623), unconst_f32(0.02951))))));
+  let vf262: vec3h = round(vec3h(f16((*ptr206))));
+  vf261 >>= bitcast<u32>(quantizeToF16(vec4f(unconst_f32(0.1332), unconst_f32(0.05022), unconst_f32(0.2261), unconst_f32(-0.4413))).z);
+  var vf263: f32 = a0[u32(unconst_u32(167))];
+  vf260 *= vf263;
+  return out;
+  _ = buffer213;
+  _ = buffer214;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute16() {
+  var vf264 = fn0();
+  let ptr208: ptr<storage, vec4f, read_write> = &buffer215[u32(unconst_u32(404))][59];
+  fn0();
+  var vf265: vec2u = textureDimensions(st13);
+  vf265 = vec2u((*&buffer212));
+  fn0();
+  vf265 += vec2u(u32((*&vw78)[u32(unconst_u32(782))][u32(unconst_u32(233))]));
+  buffer215[u32(unconst_u32(71))][u32(unconst_u32(665))] = vec4f(buffer212.xyyy);
+  var vf266 = fn0();
+  buffer215[u32(unconst_u32(243))][u32(unconst_u32(31))] = vec4f(bitcast<f32>((*&vw77).f0));
+  var vf267 = fn0();
+  buffer215[u32(unconst_u32(225))][u32(unconst_u32(53))] = vec4f(workgroupUniformLoad(&vw78)[unconst_i32(0)].rggr);
+  fn0();
+  let vf268: u32 = textureNumLevels(tex14);
+  vf265 = vec2u(arrayLength(&buffer215));
+  fn0();
+  vf267.f0 -= i32((*&buffer215)[u32(unconst_u32(303))][59][2]);
+  buffer215[u32(unconst_u32(179))][u32(unconst_u32(71))] += vec4f(f32(vf264.f0));
+  let ptr209: ptr<storage, vec4f, read_write> = &(*&buffer215)[u32(unconst_u32(444))][u32(unconst_u32(81))];
+  vw77.f0 &= bitcast<vec4i>(textureLoad(et9, vec2u(vf265[u32(unconst_u32(30))]))).w;
+  fn0();
+  _ = buffer215;
+  _ = buffer212;
+  _ = tex14;
+  _ = et9;
+  _ = st13;
+}`,
+});
+let buffer216 = device0.createBuffer({
+  size: 25587,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder268 = device0.createCommandEncoder({});
+let commandBuffer28 = commandEncoder268.finish();
+let textureView246 = texture75.createView({});
+try {
+computePassEncoder52.setBindGroup(1, bindGroup119);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer93, 'uint32', 588, 619);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(1, buffer173);
+} catch {}
+let pipelineLayout21 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout46]});
+let commandEncoder269 = device0.createCommandEncoder({});
+let textureView247 = texture233.createView({dimension: '2d-array', aspect: 'all', baseMipLevel: 0});
+let computePassEncoder217 = commandEncoder269.beginComputePass({});
+try {
+computePassEncoder118.end();
+} catch {}
+try {
+computePassEncoder217.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer31, 'uint32', 8_452, 2_077);
+} catch {}
+try {
+renderPassEncoder79.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(0, buffer165, 736, 2_363);
+} catch {}
+let buffer217 = device0.createBuffer({
+  size: 12654,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder174.setBindGroup(0, bindGroup86);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder124); computePassEncoder124.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(1, bindGroup63);
+} catch {}
+try {
+renderPassEncoder45.setViewport(1.6407532734079027, 1.621021390810594, 2.0322752938630146, 1.3915324024387203, 0.8523310051940324, 0.8600530024177462);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(2, buffer133, 384, 630);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(73_073).fill(202), /* required buffer size: 73_073 */
+{offset: 117, bytesPerRow: 122, rowsPerImage: 13}, {width: 2, height: 0, depthOrArrayLayers: 47});
+} catch {}
+let texture249 = device0.createTexture({
+  size: [65, 1, 6],
+  mipLevelCount: 4,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder218 = commandEncoder107.beginComputePass({});
+try {
+computePassEncoder87.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder87); computePassEncoder87.dispatchWorkgroupsIndirect(buffer106, 648); };
+} catch {}
+try {
+renderPassEncoder66.setBindGroup(2, bindGroup110, new Uint32Array(2093), 669, 0);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer74, 'uint16', 190, 75);
+} catch {}
+try {
+computePassEncoder66.insertDebugMarker('\u03fc');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer194, 132, new BigUint64Array(10042), 2988, 4);
+} catch {}
+let bindGroup161 = device0.createBindGroup({
+  label: '\u{1fd83}\u{1fab5}\u9904\u{1faf4}\u6650\u2071\u{1f7bc}\ubcd9\ud70a',
+  layout: recycledExplicitBindGroupLayout12,
+  entries: [
+    {binding: 41, resource: {buffer: buffer26, offset: 2816, size: 1480}},
+    {binding: 48, resource: textureView13},
+    {binding: 83, resource: {buffer: buffer41, offset: 3328, size: 650}},
+    {binding: 119, resource: {buffer: buffer196, offset: 768, size: 1352}},
+    {binding: 162, resource: textureView66},
+    {binding: 977, resource: {buffer: buffer40, offset: 7936, size: 348}},
+    {binding: 46, resource: externalTexture10},
+  ],
+});
+let commandEncoder270 = device0.createCommandEncoder({});
+let texture250 = device0.createTexture({
+  size: {width: 65},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder219 = commandEncoder270.beginComputePass({label: '\u0eb5\u{1f9d3}\u51b2'});
+try {
+computePassEncoder135.setBindGroup(0, bindGroup13, new Uint32Array(3999), 1_469, 0);
+} catch {}
+try {
+computePassEncoder219.setPipeline(pipeline35);
+} catch {}
+try {
+renderPassEncoder49.setScissorRect(31, 0, 8, 0);
+} catch {}
+try {
+renderPassEncoder76.setIndexBuffer(buffer1, 'uint32', 1_052, 527);
+} catch {}
+try {
+renderPassEncoder61.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(4, buffer181);
+} catch {}
+let videoFrame43 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'smpte432', transfer: 'gamma22curve'} });
+let textureView248 = texture108.createView({});
+try {
+computePassEncoder116.setBindGroup(0, bindGroup139, new Uint32Array(2453), 1_800, 0);
+} catch {}
+try {
+computePassEncoder123.end();
+} catch {}
+try {
+computePassEncoder218.setPipeline(pipeline34);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(1, bindGroup86);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(1, bindGroup71, new Uint32Array(22), 1, 0);
+} catch {}
+try {
+commandEncoder153.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 452 */
+  offset: 452,
+  buffer: buffer2,
+}, {
+  texture: texture194,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer28]);
+} catch {}
+let texture251 = device0.createTexture({
+  size: {width: 130},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder220 = commandEncoder153.beginComputePass();
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({colorFormats: ['rg32uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder63.setVertexBuffer(7, buffer200, 0);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer77, 'uint16', 962, 3_029);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(1, buffer154, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer27]);
+} catch {}
+let promise32 = device0.queue.onSubmittedWorkDone();
+try {
+computePassEncoder220.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder84.setIndexBuffer(buffer202, 'uint32', 192, 1_577);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(4, buffer93);
+} catch {}
+let arrayBuffer22 = buffer123.getMappedRange(464, 216);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 130, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture227,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView249 = texture201.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder155); computePassEncoder155.dispatchWorkgroupsIndirect(buffer76, 384); };
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup84);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer177, 'uint16', 638, 3_593);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(2, buffer182);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(2, bindGroup94, new Uint32Array(2482), 926, 0);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(3, buffer113, 832);
+} catch {}
+try {
+if (!arrayBuffer19.detached) { new Uint8Array(arrayBuffer19).fill(0x55); };
+} catch {}
+let commandEncoder271 = device0.createCommandEncoder({});
+let textureView250 = texture24.createView({aspect: 'stencil-only', baseArrayLayer: 3, arrayLayerCount: 3});
+let computePassEncoder221 = commandEncoder271.beginComputePass();
+try {
+computePassEncoder84.setBindGroup(3, bindGroup72, new Uint32Array(1262), 51, 0);
+} catch {}
+try {
+computePassEncoder49.end();
+} catch {}
+try {
+computePassEncoder221.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(0, bindGroup44);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(5, buffer177, 0, 7_038);
+} catch {}
+try {
+commandEncoder59.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 776 */
+  offset: 776,
+  bytesPerRow: 33280,
+  buffer: buffer18,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder193.pushDebugGroup('\u0bb1');
+} catch {}
+let pipeline44 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule6,
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'greater', failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'replace'},
+    stencilReadMask: 394869552,
+    stencilWriteMask: 1422229294,
+    depthBias: 0,
+    depthBiasClamp: 360.92880836745445,
+  },
+  vertex: {
+    module: shaderModule5,
+    buffers: [
+      {
+        arrayStride: 52,
+        attributes: [
+          {format: 'snorm8x4', offset: 0, shaderLocation: 11},
+          {format: 'float16x4', offset: 4, shaderLocation: 4},
+          {format: 'uint32x4', offset: 0, shaderLocation: 1},
+          {format: 'sint32x3', offset: 0, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 0, shaderLocation: 10},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 9},
+          {format: 'sint16x2', offset: 0, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 16, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 104,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 12, shaderLocation: 14},
+          {format: 'uint16x4', offset: 20, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+});
+let buffer218 = device0.createBuffer({size: 3003, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let textureView251 = texture227.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder222 = commandEncoder59.beginComputePass();
+let sampler163 = device0.createSampler({addressModeW: 'mirror-repeat', lodMaxClamp: 99.32, compare: 'less', maxAnisotropy: 1});
+try {
+computePassEncoder127.setBindGroup(0, bindGroup70, new Uint32Array(2225), 792, 0);
+} catch {}
+try {
+computePassEncoder222.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder83.setBindGroup(1, bindGroup111, new Uint32Array(1034), 137, 0);
+} catch {}
+try {
+renderPassEncoder61.setIndexBuffer(buffer94, 'uint32', 1_500, 268);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(0, bindGroup8, new Uint32Array(6966), 514, 0);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline27);
+} catch {}
+try {
+computePassEncoder130.insertDebugMarker('\u04b1');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 9, y: 12 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise32;
+} catch {}
+let buffer219 = device0.createBuffer({size: 92, usage: GPUBufferUsage.MAP_READ});
+let textureView252 = texture22.createView({});
+try {
+computePassEncoder136.setBindGroup(2, bindGroup86, new Uint32Array(2901), 60, 0);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(0, bindGroup87, new Uint32Array(318), 30, 0);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer158, 'uint32', 716, 1_066);
+} catch {}
+let commandEncoder272 = device0.createCommandEncoder({});
+let texture252 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView253 = texture231.createView({mipLevelCount: 1});
+let computePassEncoder223 = commandEncoder272.beginComputePass({});
+try {
+computePassEncoder77.setBindGroup(1, bindGroup141);
+} catch {}
+try {
+computePassEncoder223.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle11, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder9.setViewport(159.29301168666774, 0.507679386249088, 43.73959299853438, 0.38469467479043506, 0.6052261640207566, 0.9329095189509661);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer154, 'uint32', 124, 688);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder58.setViewport(52.80188431160731, 0.1378535540115916, 10.51076926873857, 0.24695969432340545, 0.1785787945371563, 0.20208211381318555);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(2, bindGroup26);
+} catch {}
+let canvas10 = document.createElement('canvas');
+let buffer220 = device0.createBuffer({size: 7677, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView254 = texture190.createView({label: '\u6207\u074f\u4b9a\ubbd5', baseArrayLayer: 2, arrayLayerCount: 1});
+let texture253 = device0.createTexture({
+  size: {width: 32},
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer150, 'uint32', 944, 2_194);
+} catch {}
+let gpuCanvasContext18 = canvas10.getContext('webgpu');
+document.body.prepend(canvas5);
+let buffer221 = device0.createBuffer({size: 14050, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let commandEncoder273 = device0.createCommandEncoder({});
+let textureView255 = texture179.createView({});
+let renderPassEncoder85 = commandEncoder273.beginRenderPass({
+  label: '\u13f2\u0a67\u{1f8c9}\uc066\u0d5f',
+  colorAttachments: [{
+  view: textureView111,
+  depthSlice: 15,
+  clearValue: { r: 420.8, g: 880.9, b: -637.0, a: -841.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet2,
+});
+try {
+computePassEncoder190.setBindGroup(0, bindGroup153, new Uint32Array(386), 42, 0);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle11, renderBundle11]);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(3, bindGroup87, new Uint32Array(1366), 348, 0);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer30, 'uint16', 154, 2_398);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(0, buffer208, 0);
+} catch {}
+let pipeline45 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x47fd9175},
+  fragment: {
+  module: shaderModule13,
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALPHA}],
+},
+  vertex: {
+    module: shaderModule7,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 204, shaderLocation: 0},
+          {format: 'float16x2', offset: 700, shaderLocation: 4},
+          {format: 'float32', offset: 988, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 620, shaderLocation: 14},
+          {format: 'snorm16x2', offset: 800, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 392, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 876, attributes: [{format: 'uint32x2', offset: 148, shaderLocation: 11}]},
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'ccw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let textureView256 = texture73.createView({mipLevelCount: 1, baseArrayLayer: 8, arrayLayerCount: 9});
+let externalTexture22 = device0.importExternalTexture({source: videoFrame14});
+try {
+buffer188.unmap();
+} catch {}
+try {
+computePassEncoder193.popDebugGroup();
+} catch {}
+try {
+computePassEncoder137.insertDebugMarker('\u{1f639}');
+} catch {}
+try {
+gpuCanvasContext18.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.STORAGE_BINDING, alphaMode: 'opaque'});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer49, 6856, new DataView(new ArrayBuffer(5879)), 247, 416);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(221).fill(211), /* required buffer size: 221 */
+{offset: 221, bytesPerRow: 165}, {width: 130, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout43 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 78,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup162 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout40,
+  entries: [
+    {binding: 101, resource: sampler76},
+    {binding: 79, resource: textureView30},
+    {binding: 601, resource: {buffer: buffer15, offset: 1280, size: 572}},
+    {binding: 243, resource: textureView238},
+    {binding: 326, resource: {buffer: buffer203, offset: 256}},
+    {binding: 270, resource: {buffer: buffer8, offset: 1024, size: 4776}},
+    {binding: 299, resource: sampler133},
+  ],
+});
+let buffer222 = device0.createBuffer({
+  size: 27919,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderBundle20 = renderBundleEncoder20.finish({});
+let sampler164 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 86.28, compare: 'less'});
+try {
+computePassEncoder164.setBindGroup(0, bindGroup99, new Uint32Array(692), 175, 0);
+} catch {}
+try {
+renderPassEncoder82.setBindGroup(0, bindGroup70);
+} catch {}
+try {
+renderPassEncoder75.executeBundles([renderBundle16]);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer150, 'uint16', 1_636, 2_519);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(7, buffer35);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer139, 340, new BigUint64Array(8956), 1949, 596);
+} catch {}
+let autogeneratedBindGroupLayout32 = pipeline27.getBindGroupLayout(0);
+let bindGroup163 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout12,
+  entries: [
+    {binding: 46, resource: externalTexture16},
+    {binding: 977, resource: {buffer: buffer140, offset: 0, size: 9522}},
+    {binding: 41, resource: {buffer: buffer79, offset: 0, size: 472}},
+    {binding: 48, resource: textureView13},
+    {binding: 119, resource: {buffer: buffer14, offset: 18176, size: 2612}},
+    {binding: 83, resource: {buffer: buffer154, offset: 1280}},
+    {binding: 162, resource: textureView15},
+  ],
+});
+let textureView257 = texture223.createView({});
+let sampler165 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.06,
+  maxAnisotropy: 17,
+});
+let externalTexture23 = device0.importExternalTexture({source: videoFrame2});
+try {
+{ clearResourceUsages(device0, computePassEncoder190); computePassEncoder190.dispatchWorkgroupsIndirect(buffer17, 3_796); };
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(0, buffer30, 0);
+} catch {}
+try {
+renderPassEncoder46.pushDebugGroup('\u077d');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 13},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout33 = pipeline3.getBindGroupLayout(0);
+let pipelineLayout22 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout41]});
+try {
+{ clearResourceUsages(device0, computePassEncoder191); computePassEncoder191.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder155.end();
+} catch {}
+try {
+renderPassEncoder12.setViewport(37.897927468108236, 0.5792749166466357, 19.481182504359985, 0.03128607172369858, 0.2164446940960748, 0.5001431535825042);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer178, 1808, new Int16Array(12164), 127, 1040);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(134).fill(242), /* required buffer size: 134 */
+{offset: 134, rowsPerImage: 31}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup164 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout15,
+  entries: [{binding: 41, resource: {buffer: buffer68, offset: 768, size: 776}}],
+});
+let commandEncoder274 = device0.createCommandEncoder();
+let textureView258 = texture206.createView({dimension: '2d', baseArrayLayer: 3});
+let computePassEncoder224 = commandEncoder274.beginComputePass({});
+try {
+renderPassEncoder10.setIndexBuffer(buffer120, 'uint16', 6, 4);
+} catch {}
+try {
+commandEncoder195.copyTextureToBuffer({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 2},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3336 */
+  offset: 3336,
+  rowsPerImage: 592,
+  buffer: buffer148,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas11 = document.createElement('canvas');
+let texture254 = device0.createTexture({size: [32, 1, 1], format: 'stencil8', usage: GPUTextureUsage.COPY_DST, viewFormats: []});
+try {
+renderPassEncoder71.setBindGroup(0, bindGroup62);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let gpuCanvasContext19 = canvas11.getContext('webgpu');
+let recycledExplicitBindGroupLayout84 = pipeline23.getBindGroupLayout(2);
+let querySet36 = device0.createQuerySet({type: 'occlusion', count: 902});
+let textureView259 = texture171.createView({mipLevelCount: 1});
+try {
+computePassEncoder105.setBindGroup(2, bindGroup44, []);
+} catch {}
+try {
+renderPassEncoder77.setIndexBuffer(buffer32, 'uint16', 24, 348);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(3, buffer82, 840, 662);
+} catch {}
+try {
+buffer217.unmap();
+} catch {}
+try {
+commandEncoder195.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3832 */
+  offset: 3832,
+  buffer: buffer154,
+}, {
+  texture: texture193,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder195.copyTextureToTexture({
+  texture: texture193,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture185,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise33 = device0.queue.onSubmittedWorkDone();
+let autogeneratedBindGroupLayout34 = pipeline33.getBindGroupLayout(1);
+let texture255 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 90},
+  sampleCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView260 = texture209.createView({baseArrayLayer: 1, arrayLayerCount: 1});
+let sampler166 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.90,
+  compare: 'less-equal',
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder220.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder76.setPipeline(pipeline39);
+} catch {}
+try {
+  await promise33;
+} catch {}
+let texture256 = device0.createTexture({size: [32, 1, 1], sampleCount: 1, format: 'rg32uint', usage: GPUTextureUsage.STORAGE_BINDING});
+let textureView261 = texture29.createView({baseArrayLayer: 1, arrayLayerCount: 11});
+let renderPassEncoder86 = commandEncoder195.beginRenderPass({
+  colorAttachments: [{
+  view: textureView89,
+  clearValue: { r: 285.0, g: -11.37, b: 500.1, a: -11.89, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView247, depthReadOnly: false, stencilClearValue: 57613, stencilReadOnly: true},
+});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup124);
+} catch {}
+try {
+computePassEncoder191.end();
+} catch {}
+try {
+renderPassEncoder77.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(3, undefined, 1_019_132_044, 257_164_501);
+} catch {}
+try {
+commandEncoder243.copyBufferToBuffer(buffer18, 164, buffer142, 296, 312);
+} catch {}
+try {
+renderPassEncoder46.popDebugGroup();
+} catch {}
+let pipeline46 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule9,
+  constants: {},
+  targets: [{
+  format: 'rg32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [{arrayStride: 48, attributes: [{format: 'snorm16x4', offset: 0, shaderLocation: 13}]}],
+  },
+});
+let recycledExplicitBindGroupLayout85 = pipeline5.getBindGroupLayout(0);
+let commandEncoder275 = device0.createCommandEncoder({});
+try {
+renderPassEncoder76.setBindGroup(3, bindGroup94);
+} catch {}
+try {
+commandEncoder243.copyBufferToTexture({
+  /* bytesInLastRow: 148 widthInBlocks: 37 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1752 */
+  offset: 1752,
+  bytesPerRow: 7168,
+  buffer: buffer122,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 37, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandBuffer29 = commandEncoder243.finish();
+let texture257 = device0.createTexture({
+  size: [65],
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderPassEncoder87 = commandEncoder275.beginRenderPass({
+  colorAttachments: [{
+  view: textureView186,
+  clearValue: { r: -596.4, g: -711.3, b: 373.3, a: -212.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet28,
+});
+let sampler167 = device0.createSampler({
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.87,
+  compare: 'never',
+  maxAnisotropy: 17,
+});
+let externalTexture24 = device0.importExternalTexture({source: videoFrame10});
+try {
+computePassEncoder109.setBindGroup(1, bindGroup100, new Uint32Array(244), 31, 0);
+} catch {}
+try {
+computePassEncoder121.end();
+} catch {}
+try {
+renderPassEncoder68.executeBundles([renderBundle19, renderBundle19]);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup165 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout10,
+  entries: [{binding: 41, resource: {buffer: buffer210, offset: 1280, size: 1464}}],
+});
+let textureView262 = texture63.createView({mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 6});
+let sampler168 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup3, []);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer29]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame44 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'bt709', transfer: 'gamma22curve'} });
+let autogeneratedBindGroupLayout35 = pipeline17.getBindGroupLayout(0);
+let computePassEncoder225 = commandEncoder151.beginComputePass();
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthStencilFormat: 'stencil8', depthReadOnly: true, stencilReadOnly: true});
+let renderBundle21 = renderBundleEncoder21.finish({});
+try {
+computePassEncoder224.setPipeline(pipeline19);
+} catch {}
+let arrayBuffer23 = buffer103.getMappedRange(64, 0);
+let commandEncoder276 = device0.createCommandEncoder({});
+let textureView263 = texture27.createView({dimension: '2d', aspect: 'all', mipLevelCount: 1, baseArrayLayer: 1});
+let computePassEncoder226 = commandEncoder276.beginComputePass({});
+let sampler169 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder53.setBindGroup(3, bindGroup88);
+} catch {}
+try {
+computePassEncoder226.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder55.beginOcclusionQuery(26);
+} catch {}
+try {
+renderPassEncoder76.setIndexBuffer(buffer81, 'uint16', 1_960, 737);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(35).fill(59), /* required buffer size: 35 */
+{offset: 35}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas4);
+await gc();
+let texture258 = device0.createTexture({
+  label: '\ud41e\uda21\ubbcf\ue75c\ub85b\u5f3b\u00e2\uf453\u{1f739}\u36e7',
+  size: [260, 1, 27],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView264 = texture108.createView({baseArrayLayer: 0});
+let sampler170 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 77.14,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder145.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder145); computePassEncoder145.dispatchWorkgroupsIndirect(buffer120, 48); };
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(3, bindGroup102, new Uint32Array(315), 36, 0);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([renderBundle2, renderBundle11, renderBundle2]);
+} catch {}
+let buffer223 = device0.createBuffer({
+  size: 8199,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder277 = device0.createCommandEncoder({});
+let computePassEncoder227 = commandEncoder277.beginComputePass({});
+let sampler171 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: videoFrame42,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout86 = pipeline36.getBindGroupLayout(2);
+let bindGroup166 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout17,
+  entries: [{binding: 41, resource: {buffer: buffer51, offset: 256, size: 2340}}],
+});
+let buffer224 = device0.createBuffer({size: 13698, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX, mappedAtCreation: false});
+let commandEncoder278 = device0.createCommandEncoder({});
+let sampler172 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.55,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder95.setBindGroup(2, bindGroup108);
+} catch {}
+try {
+commandEncoder278.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture259 = device0.createTexture({
+  size: [130],
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder228 = commandEncoder278.beginComputePass();
+try {
+renderPassEncoder42.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5, buffer4, 332, 41);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 260, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData17,
+  origin: { x: 21, y: 0 },
+  flipY: true,
+}, {
+  texture: texture227,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout87 = pipeline28.getBindGroupLayout(0);
+let bindGroup167 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout73,
+  entries: [
+    {binding: 83, resource: {buffer: buffer159, offset: 0}},
+    {binding: 977, resource: {buffer: buffer192, offset: 256, size: 5175}},
+    {binding: 119, resource: {buffer: buffer77, offset: 3072, size: 5685}},
+    {binding: 41, resource: {buffer: buffer177, offset: 1792}},
+    {binding: 162, resource: textureView155},
+    {binding: 48, resource: textureView13},
+    {binding: 46, resource: externalTexture13},
+  ],
+});
+let commandEncoder279 = device0.createCommandEncoder({});
+let textureView265 = texture38.createView({dimension: 'cube', aspect: 'stencil-only', baseArrayLayer: 1});
+let computePassEncoder229 = commandEncoder279.beginComputePass({});
+try {
+computePassEncoder174.setBindGroup(0, bindGroup77, new Uint32Array(1946), 430, 0);
+} catch {}
+try {
+computePassEncoder124.end();
+} catch {}
+try {
+computePassEncoder229.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder85.setBindGroup(2, bindGroup40, new Uint32Array(2926), 660, 0);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(1, undefined, 1_865_527_892, 3_926_919);
+} catch {}
+try {
+commandEncoder155.clearBuffer(buffer181);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer199, 4900, new BigUint64Array(5562), 1113, 236);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(80).fill(248), /* required buffer size: 80 */
+{offset: 80}, {width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture260 = device0.createTexture({size: [4, 4, 17], format: 'rgba16uint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let textureView266 = texture160.createView({baseMipLevel: 0});
+let computePassEncoder230 = commandEncoder155.beginComputePass({});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder127); computePassEncoder127.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(3, bindGroup127);
+} catch {}
+try {
+renderPassEncoder55.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(2185);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(1_655).fill(116), /* required buffer size: 1_655 */
+{offset: 407, bytesPerRow: 52, rowsPerImage: 8}, {width: 4, height: 0, depthOrArrayLayers: 4});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+await gc();
+let imageData46 = new ImageData(28, 16);
+let recycledExplicitBindGroupLayout88 = pipeline10.getBindGroupLayout(0);
+let commandEncoder280 = device0.createCommandEncoder({});
+let renderPassEncoder88 = commandEncoder280.beginRenderPass({
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: -225.9, g: -563.1, b: -562.7, a: -599.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 30719894,
+});
+try {
+computePassEncoder190.setBindGroup(3, bindGroup7, new Uint32Array(4413), 168, 0);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline19);
+} catch {}
+try {
+computePassEncoder225.setPipeline(pipeline9);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: imageData31,
+  origin: { x: 2, y: 12 },
+  flipY: true,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 40},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+bindGroup71.label = '\u0af6\ud82e\u0cb0\u5f4c\u0f2b\u3173\u0dd3\u01f9\u902b\u{1f87c}';
+} catch {}
+let commandEncoder281 = device0.createCommandEncoder();
+let querySet37 = device0.createQuerySet({type: 'occlusion', count: 1364});
+try {
+{ clearResourceUsages(device0, computePassEncoder135); computePassEncoder135.dispatchWorkgroups(1); };
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: videoFrame11,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout36 = pipeline12.getBindGroupLayout(0);
+let buffer225 = device0.createBuffer({
+  size: 65536,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder282 = device0.createCommandEncoder({});
+let textureView267 = texture62.createView({dimension: '2d'});
+let computePassEncoder231 = commandEncoder282.beginComputePass({});
+let sampler173 = device0.createSampler({magFilter: 'linear', minFilter: 'linear', mipmapFilter: 'linear', lodMaxClamp: 81.25, maxAnisotropy: 8});
+try {
+computePassEncoder190.setBindGroup(3, bindGroup7, []);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(4, buffer179, 0, 5_389);
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55); };
+} catch {}
+let veryExplicitBindGroupLayout44 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 113,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let computePassEncoder232 = commandEncoder281.beginComputePass({});
+try {
+computePassEncoder162.setBindGroup(0, bindGroup156, new Uint32Array(632), 105, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder162); computePassEncoder162.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder230.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder85.beginOcclusionQuery(73);
+} catch {}
+let texture261 = device0.createTexture({
+  size: {width: 260},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView268 = texture38.createView({dimension: '2d', aspect: 'stencil-only', baseArrayLayer: 2});
+try {
+computePassEncoder225.setBindGroup(0, bindGroup67);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder174); computePassEncoder174.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder190); computePassEncoder190.dispatchWorkgroupsIndirect(buffer36, 28); };
+} catch {}
+try {
+computePassEncoder231.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder85.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer154, 'uint16', 2_020, 331);
+} catch {}
+try {
+renderPassEncoder44.setPipeline(pipeline14);
+} catch {}
+try {
+buffer109.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+globalThis.someLabel = textureView129.label;
+} catch {}
+let buffer226 = device0.createBuffer({
+  size: 3738,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder283 = device0.createCommandEncoder({});
+let renderPassEncoder89 = commandEncoder283.beginRenderPass({
+  colorAttachments: [{view: textureView48, depthSlice: 3, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet33,
+  maxDrawCount: 2492665,
+});
+try {
+renderPassEncoder45.executeBundles([renderBundle8, renderBundle7, renderBundle17, renderBundle7, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline39);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder284 = device0.createCommandEncoder({});
+let texture262 = device0.createTexture({
+  size: {width: 32, height: 1, depthOrArrayLayers: 13},
+  format: 'rg32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler174 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 70.37,
+  maxAnisotropy: 13,
+});
+try {
+renderPassEncoder87.setVertexBuffer(0, buffer107, 0);
+} catch {}
+let arrayBuffer24 = buffer103.getMappedRange(136, 12);
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 43, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(25).fill(225), /* required buffer size: 25 */
+{offset: 25, bytesPerRow: 139}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline47 = device0.createRenderPipeline({
+  layout: pipelineLayout6,
+  multisample: {mask: 0x4ad4cacd},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment4',
+  targets: [{format: 'rg32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule5,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 8,
+        attributes: [
+          {format: 'unorm8x4', offset: 0, shaderLocation: 10},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 4},
+          {format: 'sint16x2', offset: 0, shaderLocation: 13},
+          {format: 'sint8x2', offset: 0, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 0, shaderLocation: 11},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 9},
+          {format: 'float16x4', offset: 0, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 180,
+        attributes: [
+          {format: 'uint32', offset: 40, shaderLocation: 3},
+          {format: 'sint16x4', offset: 24, shaderLocation: 2},
+          {format: 'uint32x2', offset: 0, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'none'},
+});
+let buffer227 = device0.createBuffer({
+  size: 19781,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder285 = device0.createCommandEncoder({});
+let textureView269 = texture112.createView({dimension: '3d'});
+let sampler175 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'always',
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder232.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle14, renderBundle14]);
+} catch {}
+try {
+renderPassEncoder76.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder83.setVertexBuffer(3, buffer188);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer203, 2452, new DataView(new ArrayBuffer(6740)), 1206, 192);
+} catch {}
+let bindGroup168 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout28,
+  entries: [
+    {binding: 95, resource: {buffer: buffer227, offset: 256, size: 1663}},
+    {binding: 384, resource: textureView203},
+  ],
+});
+let texture263 = device0.createTexture({
+  size: {width: 32, height: 1, depthOrArrayLayers: 8},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder233 = commandEncoder284.beginComputePass({});
+let renderPassEncoder90 = commandEncoder285.beginRenderPass({
+  colorAttachments: [{
+  view: textureView89,
+  clearValue: { r: 259.1, g: 860.2, b: -324.6, a: 789.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView247,
+    depthClearValue: -7.766602583413464,
+    depthReadOnly: false,
+    stencilClearValue: 52722,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'store',
+    stencilReadOnly: false,
+  },
+  maxDrawCount: 146334015,
+});
+let sampler176 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 84.68});
+try {
+{ clearResourceUsages(device0, computePassEncoder204); computePassEncoder204.dispatchWorkgroupsIndirect(buffer112, 332); };
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(0, bindGroup84, new Uint32Array(1122), 133, 0);
+} catch {}
+try {
+renderPassEncoder62.beginOcclusionQuery(1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder162); computePassEncoder162.dispatchWorkgroupsIndirect(buffer18, 316); };
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(3, bindGroup123, new Uint32Array(1231), 1, 0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup102, new Uint32Array(1244), 32, 0);
+} catch {}
+try {
+renderPassEncoder62.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder89.setVertexBuffer(7, buffer52, 0, 325);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule19 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(1) @binding(101) var tex18: texture_depth_2d;
+
+@group(0) @binding(593) var tex15: texture_2d_array<u32>;
+
+fn fn0(a0: array<mat2x2h, 1>) -> array<vec4<bool>, 1> {
+  var out: array<vec4<bool>, 1>;
+  var vf269: vec2u = textureDimensions(tex18, i32(unconst_i32(15)));
+  out[u32(unconst_u32(67))] = vec4<bool>(bool(textureNumLayers(tex15)));
+  let vf270: f32 = override20;
+  var vf271: f32 = override20;
+  let vf272: vec4u = unpack4xU8(u32(unconst_u32(218)));
+  vf271 -= bitcast<f32>(vf269[0]);
+  vf269 |= textureLoad(tex15, vec2i(cross(vec3h(unconst_f16(3176.6), unconst_f16(1977.7), unconst_f16(-1475.9)), vec3h(unconst_f16(3275.0), unconst_f16(9501.7), unconst_f16(3352.7))).gb), i32(unconst_i32(188)), i32(unconst_i32(191))).ba;
+  out[u32(unconst_u32(106))] = vec4<bool>(firstTrailingBit(vec2i(i32(clamp(f16(unconst_f16(-9611.1)), f16(unconst_f16(60000.0)), f16(unconst_f16(5734.6)))))).xxxx);
+  let vf273: vec2i = firstTrailingBit(vec2i(unconst_i32(-146), unconst_i32(97)));
+  vf271 = bitcast<vec4f>(textureLoad(tex15, vec2i(unconst_i32(268), unconst_i32(103)), i32(unconst_i32(61)), i32(unconst_i32(655))))[1];
+  vf271 = f32(vf272.z);
+  vf269 *= extractBits(vec3u(unconst_u32(229), unconst_u32(749), unconst_u32(221)), u32(unconst_u32(76)), u32(unconst_u32(571))).xy;
+  let vf274: f32 = override20;
+  let vf275: vec4u = textureLoad(tex15, vec2i(unconst_i32(280), unconst_i32(-244)), i32(unconst_i32(262)), i32(unconst_i32(487)));
+  let vf276: vec2u = textureDimensions(tex15, i32(unconst_i32(109)));
+  out[u32(unconst_u32(357))] = vec4<bool>(bool(a0[0][u32(unconst_u32(19))][u32(unconst_u32(17))]));
+  vf271 -= bitcast<f32>(vf273[0]);
+  let vf277: vec2u = textureDimensions(tex15);
+  return out;
+  _ = override20;
+  _ = tex18;
+  _ = tex15;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T0 {
+  @size(5952) f0: array<array<mat2x3f, 10>>,
+}
+
+var<workgroup> vw80: array<array<atomic<u32>, 1>, 1>;
+
+@id(37961) override override21: bool;
+
+var<workgroup> vw79: mat2x3f;
+
+@group(1) @binding(258) var<storage, read_write> buffer229: array<array<vec4f, 372>>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+override override20: f32;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@fragment
+fn fragment17() -> @location(200) @interpolate(perspective) vec4u {
+  var out: vec4u;
+  let ptr210: ptr<storage, vec4f, read_write> = &buffer229[arrayLength(&buffer229)][371];
+  let ptr211: ptr<storage, array<vec4f, 372>, read_write> = &(*&buffer229)[u32(unconst_u32(10))];
+  buffer229[u32(unconst_u32(214))][u32(unconst_u32(143))] = vec4f((*ptr211)[u32(unconst_u32(375))][u32(unconst_u32(52))]);
+  return out;
+  _ = buffer229;
+}
+
+@compute @workgroup_size(1, 2, 1)
+fn compute17() {
+  atomicXor(&vw80[u32(unconst_u32(55))][u32(tan(vec3h(f16(atomicExchange(&(*&vw80)[0][0], u32(buffer229[i32(unconst_i32(29))][371].r))))).b)], u32(unconst_u32(217)));
+  let ptr212: ptr<workgroup, array<array<atomic<u32>, 1>, 1>> = &vw80;
+  atomicSub(&vw80[u32(unconst_u32(198))][u32(unconst_u32(11))], u32(unconst_u32(203)));
+  var vf278 = fn0(array<mat2x2h, 1>(mat2x2h(f16(atomicLoad(&vw80[0][u32(unconst_u32(14))])), f16(atomicLoad(&vw80[0][u32(unconst_u32(14))])), f16(atomicLoad(&vw80[0][u32(unconst_u32(14))])), f16(atomicLoad(&vw80[0][u32(unconst_u32(14))])))));
+  vf278[u32(unconst_u32(478))] = vec4<bool>(bool(vw79[u32(unconst_u32(148))][u32(unconst_u32(4))]));
+  fn0(array<mat2x2h, 1>(mat2x2h(vec2h(refract(vec4f(unconst_f32(0.07299), unconst_f32(0.1395), unconst_f32(0.1024), unconst_f32(0.2100)), vec4f(unconst_f32(0.2811), unconst_f32(0.3749), unconst_f32(0.6258), unconst_f32(0.1295)), f32(unconst_f32(0.4750))).gg), vec2h(refract(vec4f(unconst_f32(0.07299), unconst_f32(0.1395), unconst_f32(0.1024), unconst_f32(0.2100)), vec4f(unconst_f32(0.2811), unconst_f32(0.3749), unconst_f32(0.6258), unconst_f32(0.1295)), f32(unconst_f32(0.4750))).zz))));
+  let ptr213: ptr<storage, vec4f, read_write> = &(*&buffer229)[u32(unconst_u32(108))][371];
+  let ptr214: ptr<storage, vec4f, read_write> = &(*&buffer229)[pack4xU8Clamp(bitcast<vec4u>((*&buffer229)[arrayLength(&(*&buffer229))][371]))][u32(unconst_u32(22))];
+  _ = override20;
+  _ = buffer229;
+  _ = tex15;
+  _ = tex18;
+}`,
+});
+let bindGroup169 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout5,
+  entries: [
+    {binding: 48, resource: textureView13},
+    {binding: 46, resource: externalTexture10},
+    {binding: 41, resource: {buffer: buffer208, offset: 5120, size: 184}},
+    {binding: 83, resource: {buffer: buffer158, offset: 256, size: 172}},
+    {binding: 162, resource: textureView158},
+    {binding: 119, resource: {buffer: buffer114, offset: 2560}},
+    {binding: 977, resource: {buffer: buffer140, offset: 0, size: 4815}},
+  ],
+});
+let buffer230 = device0.createBuffer({size: 3417, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+try {
+renderPassEncoder87.setBindGroup(3, bindGroup73);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer1, 'uint16', 508, 107);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let shaderModule20 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw83: atomic<u32>;
+
+struct T0 {
+  @size(88) f0: mat2x4h,
+}
+
+var<workgroup> vw82: array<array<VertexOutput15, 1>, 1>;
+
+struct VertexOutput15 {
+  @invariant @builtin(position) f54: vec4f,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw81: T0;
+
+fn fn0() -> T0 {
+  var out: T0;
+  let vf279: i32 = countTrailingZeros(i32(unconst_i32(60)));
+  var vf280: f16 = asin(f16(unconst_f16(6528.2)));
+  let vf281: i32 = dot4I8Packed(u32(unconst_u32(54)), u32(unconst_u32(19)));
+  let vf282: u32 = pack4xU8Clamp(vec4u(unconst_u32(188), unconst_u32(18), unconst_u32(91), unconst_u32(128)));
+  let vf283: f32 = length(vec4f(unconst_f32(0.2093), unconst_f32(0.2053), unconst_f32(0.2864), unconst_f32(0.07321)));
+  let vf284: vec4i = unpack4xI8(u32(unconst_u32(77)));
+  out.f0 += mat2x4h(f16(distance(vec2f(unconst_f32(0.00728), unconst_f32(0.1129)), vec2f(unconst_f32(0.03785), unconst_f32(-0.02323)))), f16(distance(vec2f(unconst_f32(0.00728), unconst_f32(0.1129)), vec2f(unconst_f32(0.03785), unconst_f32(-0.02323)))), f16(distance(vec2f(unconst_f32(0.00728), unconst_f32(0.1129)), vec2f(unconst_f32(0.03785), unconst_f32(-0.02323)))), f16(distance(vec2f(unconst_f32(0.00728), unconst_f32(0.1129)), vec2f(unconst_f32(0.03785), unconst_f32(-0.02323)))), f16(distance(vec2f(unconst_f32(0.00728), unconst_f32(0.1129)), vec2f(unconst_f32(0.03785), unconst_f32(-0.02323)))), f16(distance(vec2f(unconst_f32(0.00728), unconst_f32(0.1129)), vec2f(unconst_f32(0.03785), unconst_f32(-0.02323)))), f16(distance(vec2f(unconst_f32(0.00728), unconst_f32(0.1129)), vec2f(unconst_f32(0.03785), unconst_f32(-0.02323)))), f16(distance(vec2f(unconst_f32(0.00728), unconst_f32(0.1129)), vec2f(unconst_f32(0.03785), unconst_f32(-0.02323)))));
+  let vf285: vec2f = cosh(vec2f(unconst_f32(0.09892), unconst_f32(0.06129)));
+  let ptr215: ptr<function, f16> = &vf280;
+  out = T0(mat2x4h(asin(f16(unconst_f16(2825.3))), asin(f16(unconst_f16(2825.3))), asin(f16(unconst_f16(2825.3))), asin(f16(unconst_f16(2825.3))), asin(f16(unconst_f16(2825.3))), asin(f16(unconst_f16(2825.3))), asin(f16(unconst_f16(2825.3))), asin(f16(unconst_f16(2825.3)))));
+  let vf286: i32 = vf279;
+  let vf287: vec2h = reflect(vec2h(unconst_f16(19105.9), unconst_f16(-5678.5)), vec2h(vf285));
+  let vf288: f16 = asin(f16(vf285[u32(unconst_u32(79))]));
+  out.f0 -= mat2x4h(inverseSqrt(vec2h(unconst_f16(-5401.5), unconst_f16(19591.6))).gggg, inverseSqrt(vec2h(unconst_f16(-5401.5), unconst_f16(19591.6))).yyyx);
+  return out;
+}
+
+struct T1 {
+  @align(16) @size(80) f0: array<atomic<i32>>,
+}
+
+@group(0) @binding(64) var tex20: texture_2d_array<u32>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+alias vec3b = vec3<bool>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@vertex
+fn vertex18(@location(0) @interpolate(linear) a0: vec4f) -> VertexOutput15 {
+  var out: VertexOutput15;
+  out.f54 = vec4f(f32(reverseBits(i32(unconst_i32(417)))));
+  var vf289 = fn0();
+  let vf290: f32 = abs(f32(unconst_f32(0.1133)));
+  fn0();
+  out.f54 *= unpack4x8unorm(u32(unconst_u32(44)));
+  let vf291: mat2x3f = transpose(mat3x2f(unconst_f32(-0.08225), unconst_f32(0.1648), unconst_f32(-0.2477), unconst_f32(0.2097), unconst_f32(0.05156), unconst_f32(0.2405)));
+  var vf292: u32 = pack4xI8(vec4i(unconst_i32(118), unconst_i32(2), unconst_i32(125), unconst_i32(1)));
+  let vf293: vec3h = round(vec3h(unconst_f16(-11117.8), unconst_f16(-612.4), unconst_f16(2865.6)));
+  vf289 = T0(mat2x4h(f16(pack4xI8(vec4i(unconst_i32(595), unconst_i32(127), unconst_i32(151), unconst_i32(90)))), f16(pack4xI8(vec4i(unconst_i32(595), unconst_i32(127), unconst_i32(151), unconst_i32(90)))), f16(pack4xI8(vec4i(unconst_i32(595), unconst_i32(127), unconst_i32(151), unconst_i32(90)))), f16(pack4xI8(vec4i(unconst_i32(595), unconst_i32(127), unconst_i32(151), unconst_i32(90)))), f16(pack4xI8(vec4i(unconst_i32(595), unconst_i32(127), unconst_i32(151), unconst_i32(90)))), f16(pack4xI8(vec4i(unconst_i32(595), unconst_i32(127), unconst_i32(151), unconst_i32(90)))), f16(pack4xI8(vec4i(unconst_i32(595), unconst_i32(127), unconst_i32(151), unconst_i32(90)))), f16(pack4xI8(vec4i(unconst_i32(595), unconst_i32(127), unconst_i32(151), unconst_i32(90))))));
+  let vf294: vec4u = firstLeadingBit(vec4u(unconst_u32(71), unconst_u32(77), unconst_u32(238), unconst_u32(164)));
+  var vf295 = fn0();
+  var vf296: vec4f = unpack4x8unorm(u32(unconst_u32(33)));
+  let vf297: mat2x3f = transpose(mat3x2f());
+  let vf298: i32 = reverseBits(i32(quantizeToF16(f32(unconst_f32(0.07945)))));
+  let vf299: i32 = reverseBits(i32(unconst_i32(70)));
+  vf289 = T0(mat2x4h(vec4h(transpose(mat3x2f())[unconst_i32(0)].grbg), vec4h(transpose(mat3x2f())[unconst_i32(1)].gbbr)));
+  vf292 = bitcast<u32>(step(f32(unconst_f32(0.2505)), f32(unconst_f32(0.04645))));
+  vf295.f0 = mat2x4h(vf295.f0[u32(unconst_u32(14))], vf295.f0[u32(unconst_u32(14))]);
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute18() {
+  atomicCompareExchangeWeak(&vw83, unconst_u32(66), unconst_u32(242));
+  vw82[u32(unconst_u32(91))][u32(unconst_u32(112))].f54 = (*&vw82)[u32(unconst_u32(149))][0].f54;
+  var vf300: u32 = atomicExchange(&vw83, u32(unconst_u32(197)));
+  vw82[u32(unconst_u32(181))][u32(unconst_u32(47))] = VertexOutput15(unpack4x8snorm(textureNumLevels(tex20)));
+  let vf301: u32 = atomicLoad(&(*&vw83));
+  atomicMin(&vw83, u32(unconst_u32(401)));
+  let vf302: vec4f = atan2(vec4f(unconst_f32(0.3032), unconst_f32(0.1696), unconst_f32(0.09288), unconst_f32(-0.02941)), vec4f(unconst_f32(0.1812), unconst_f32(-0.07695), unconst_f32(0.6884), unconst_f32(0.04311)));
+  let vf303: f32 = (*&vw82)[0][0].f54[u32(unconst_u32(73))];
+  _ = tex20;
+}`,
+});
+let bindGroup170 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout4,
+  entries: [{binding: 41, resource: {buffer: buffer223, offset: 3840, size: 1584}}],
+});
+try {
+computePassEncoder228.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(533);
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let videoFrame45 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'bt709', transfer: 'pq'} });
+let buffer231 = device0.createBuffer({size: 10435, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT, mappedAtCreation: false});
+let texture264 = device0.createTexture({
+  size: [4],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView270 = texture69.createView({dimension: '2d', baseArrayLayer: 6});
+let sampler177 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', lodMaxClamp: 62.26});
+try {
+computePassEncoder233.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder77.setIndexBuffer(buffer132, 'uint32', 552, 674);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(71).fill(220), /* required buffer size: 71 */
+{offset: 71, rowsPerImage: 64}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 4, depthOrArrayLayers: 41}
+*/
+{
+  source: imageData40,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture230,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView271 = texture264.createView({});
+let texture265 = device0.createTexture({
+  size: [4, 4, 58],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder204); computePassEncoder204.dispatchWorkgroups(2, 1); };
+} catch {}
+try {
+computePassEncoder227.setPipeline(pipeline20);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline48 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule18, constants: {}}});
+let veryExplicitBindGroupLayout45 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 37, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 49,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 206,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 232,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+  ],
+});
+try {
+renderPassEncoder64.setBindGroup(0, bindGroup44, new Uint32Array(1147), 149, 0);
+} catch {}
+try {
+renderPassEncoder9.end();
+} catch {}
+try {
+commandEncoder57.copyBufferToTexture({
+  /* bytesInLastRow: 260 widthInBlocks: 260 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 20 */
+  offset: 20,
+  bytesPerRow: 11776,
+  buffer: buffer30,
+}, {
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 260, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext14.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture249,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(30).fill(156), /* required buffer size: 30 */
+{offset: 30}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout89 = pipeline26.getBindGroupLayout(0);
+let texture266 = device0.createTexture({
+  size: [130],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder234 = commandEncoder57.beginComputePass();
+try {
+computePassEncoder44.setBindGroup(2, bindGroup80);
+} catch {}
+try {
+computePassEncoder15.setBindGroup(0, bindGroup150, new Uint32Array(438), 182, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder135); computePassEncoder135.dispatchWorkgroupsIndirect(buffer80, 264); };
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup80);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer112, 'uint16', 54, 353);
+} catch {}
+let bindGroup171 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout3,
+  entries: [
+    {binding: 48, resource: textureView13},
+    {binding: 41, resource: {buffer: buffer83, offset: 256, size: 460}},
+    {binding: 119, resource: {buffer: buffer222, offset: 6144, size: 4128}},
+    {binding: 162, resource: textureView138},
+    {binding: 977, resource: {buffer: buffer226, offset: 768, size: 992}},
+    {binding: 83, resource: {buffer: buffer198, offset: 0}},
+    {binding: 46, resource: externalTexture1},
+  ],
+});
+let textureView272 = texture137.createView({baseArrayLayer: 0});
+let sampler178 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 90.12,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder147.setBindGroup(3, bindGroup99);
+} catch {}
+try {
+computePassEncoder201.setBindGroup(1, bindGroup99, new Uint32Array(7606), 477, 0);
+} catch {}
+try {
+computePassEncoder190.end();
+} catch {}
+try {
+computePassEncoder234.setPipeline(pipeline25);
+} catch {}
+try {
+buffer111.unmap();
+} catch {}
+try {
+commandEncoder240.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 56 */
+  offset: 56,
+  bytesPerRow: 4352,
+  rowsPerImage: 999,
+  buffer: buffer15,
+}, {
+  texture: texture210,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup172 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout21,
+  entries: [{binding: 304, resource: {buffer: buffer196, offset: 1280, size: 2844}}],
+});
+let querySet38 = device0.createQuerySet({type: 'occlusion', count: 41});
+let textureView273 = texture109.createView({});
+let computePassEncoder235 = commandEncoder240.beginComputePass();
+let sampler179 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 96.70,
+  compare: 'less',
+});
+try {
+computePassEncoder235.setPipeline(pipeline48);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([renderBundle8]);
+} catch {}
+let pipeline49 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x2dad4881},
+  fragment: {
+  module: shaderModule13,
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule0,
+    buffers: [{arrayStride: 556, attributes: [{format: 'unorm10-10-10-2', offset: 76, shaderLocation: 13}]}],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let textureView274 = texture7.createView({dimension: '2d', aspect: 'all', mipLevelCount: 1});
+try {
+renderPassEncoder59.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder75.setBindGroup(0, bindGroup156, new Uint32Array(4493), 1_202, 0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer116, 'uint16', 3_216, 304);
+} catch {}
+let arrayBuffer25 = buffer78.getMappedRange(200, 44);
+let videoFrame46 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'unspecified', transfer: 'logSqrt'} });
+try {
+globalThis.someLabel = externalTexture15.label;
+} catch {}
+let bindGroup173 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout20,
+  entries: [{binding: 304, resource: {buffer: buffer210, offset: 1280, size: 2080}}],
+});
+let buffer232 = device0.createBuffer({
+  size: 2133,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture267 = device0.createTexture({
+  size: {width: 260},
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture268 = device0.createTexture({
+  size: [260, 1, 1],
+  mipLevelCount: 3,
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler180 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 98.86});
+try {
+renderPassEncoder47.setBindGroup(0, bindGroup64);
+} catch {}
+let arrayBuffer26 = buffer78.getMappedRange(184, 0);
+try {
+buffer111.unmap();
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let recycledExplicitBindGroupLayout90 = pipeline30.getBindGroupLayout(0);
+let bindGroup174 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout19,
+  entries: [{binding: 113, resource: {buffer: buffer26, offset: 1792, size: 1356}}],
+});
+let buffer233 = device0.createBuffer({size: 8973, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let sampler181 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'clamp-to-edge', lodMaxClamp: 53.19});
+try {
+renderPassEncoder75.setScissorRect(6, 0, 2, 0);
+} catch {}
+let arrayBuffer27 = buffer103.getMappedRange(152, 0);
+await gc();
+let pipelineLayout23 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout53]});
+let buffer234 = device0.createBuffer({
+  size: 3594,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture269 = device0.createTexture({
+  size: [32, 1, 22],
+  mipLevelCount: 1,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder162.end();
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup25, new Uint32Array(2649), 30, 0);
+} catch {}
+try {
+renderPassEncoder66.beginOcclusionQuery(22);
+} catch {}
+try {
+buffer188.unmap();
+} catch {}
+let computePassEncoder236 = commandEncoder206.beginComputePass({});
+try {
+computePassEncoder186.setBindGroup(0, bindGroup62);
+} catch {}
+try {
+computePassEncoder236.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder66.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer42, 'uint16', 4_302, 1_236);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer65, 744, new Int16Array(10830), 4382, 20);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture186,
+  mipLevel: 0,
+  origin: {x: 94, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(632).fill(144), /* required buffer size: 632 */
+{offset: 632, rowsPerImage: 12}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise34 = device0.queue.onSubmittedWorkDone();
+let pipeline50 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule9,
+  constants: {},
+  targets: [{format: 'rg32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule1,
+    constants: {override0: 0},
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint8x2', offset: 46, shaderLocation: 15},
+          {format: 'uint32', offset: 184, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 36,
+        attributes: [
+          {format: 'sint32', offset: 8, shaderLocation: 3},
+          {format: 'uint32x4', offset: 0, shaderLocation: 8},
+          {format: 'uint32x2', offset: 4, shaderLocation: 7},
+          {format: 'float32x3', offset: 0, shaderLocation: 13},
+          {format: 'sint32', offset: 0, shaderLocation: 5},
+          {format: 'float32x3', offset: 0, shaderLocation: 4},
+          {format: 'float32x3', offset: 4, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', unclippedDepth: true},
+});
+try {
+  await promise34;
+} catch {}
+let textureView275 = texture126.createView({dimension: 'cube-array', mipLevelCount: 1, arrayLayerCount: 6});
+let texture270 = device0.createTexture({
+  size: {width: 4, height: 4, depthOrArrayLayers: 17},
+  dimension: '2d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView276 = texture181.createView({label: '\u84c6\u290a\u4c83\u0ac6\uc0f5', arrayLayerCount: 7});
+try {
+renderPassEncoder81.setVertexBuffer(4, buffer38, 0, 360);
+} catch {}
+let externalTexture25 = device0.importExternalTexture({source: videoFrame17, colorSpace: 'display-p3'});
+try {
+renderPassEncoder78.setBindGroup(2, bindGroup158, new Uint32Array(4792), 559, 0);
+} catch {}
+try {
+renderPassEncoder85.setVertexBuffer(4, buffer149, 232, 226);
+} catch {}
+offscreenCanvas0.width = 2;
+let videoFrame47 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'bt2020', transfer: 'gamma22curve'} });
+let recycledExplicitBindGroupLayout91 = pipeline34.getBindGroupLayout(0);
+let texture271 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 1},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder204); computePassEncoder204.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder89.setBindGroup(2, bindGroup168);
+} catch {}
+try {
+renderPassEncoder74.setStencilReference(1114);
+} catch {}
+try {
+  await buffer233.mapAsync(GPUMapMode.WRITE, 0, 1260);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let textureView277 = texture136.createView({dimension: '2d-array'});
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup82);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(1, buffer115, 540, 465);
+} catch {}
+let textureView278 = texture93.createView({aspect: 'all', mipLevelCount: 1});
+let sampler182 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 84.52});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup63);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(2, bindGroup116);
+} catch {}
+let bindGroup175 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout6,
+  entries: [
+    {binding: 977, resource: {buffer: buffer75, offset: 2816, size: 5435}},
+    {binding: 48, resource: textureView10},
+    {binding: 41, resource: {buffer: buffer8, offset: 2048, size: 692}},
+    {binding: 46, resource: externalTexture5},
+    {binding: 162, resource: textureView190},
+    {binding: 83, resource: {buffer: buffer210, offset: 2304, size: 3077}},
+    {binding: 119, resource: {buffer: buffer14, offset: 6400, size: 7344}},
+  ],
+});
+try {
+renderPassEncoder74.setBindGroup(1, bindGroup46);
+} catch {}
+try {
+renderPassEncoder63.beginOcclusionQuery(431);
+} catch {}
+try {
+renderPassEncoder71.setPipeline(pipeline27);
+} catch {}
+let promise35 = device0.queue.onSubmittedWorkDone();
+try {
+computePassEncoder174.end();
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(0, bindGroup124, new Uint32Array(535), 98, 0);
+} catch {}
+try {
+renderPassEncoder63.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder218.copyBufferToTexture({
+  /* bytesInLastRow: 96 widthInBlocks: 24 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1244 */
+  offset: 1244,
+  bytesPerRow: 32768,
+  buffer: buffer216,
+}, {
+  texture: texture268,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout92 = pipeline8.getBindGroupLayout(0);
+let buffer235 = device0.createBuffer({size: 4875, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let renderPassEncoder91 = commandEncoder218.beginRenderPass({
+  colorAttachments: [{
+  view: textureView35,
+  clearValue: { r: -319.0, g: -665.1, b: 880.0, a: 128.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 130, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData26,
+  origin: { x: 2, y: 2 },
+  flipY: false,
+}, {
+  texture: texture227,
+  mipLevel: 1,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline51 = device0.createRenderPipeline({
+  layout: 'auto',
+  multisample: {mask: 0x21105c4},
+  fragment: {
+  module: shaderModule12,
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'less-equal', failOp: 'invert', depthFailOp: 'decrement-wrap', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 79528085,
+    depthBias: -1614737191,
+    depthBiasSlopeScale: 241.48436845142987,
+  },
+  vertex: {
+    module: shaderModule6,
+    buffers: [
+      {
+        arrayStride: 12,
+        attributes: [
+          {format: 'unorm8x4', offset: 0, shaderLocation: 10},
+          {format: 'uint16x2', offset: 0, shaderLocation: 15},
+          {format: 'uint16x4', offset: 0, shaderLocation: 13},
+          {format: 'uint32x2', offset: 0, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 0, shaderLocation: 12},
+          {format: 'float32x2', offset: 0, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let videoFrame48 = new VideoFrame(canvas5, {timestamp: 0});
+let textureView279 = texture97.createView({});
+let sampler183 = device0.createSampler({addressModeW: 'repeat', magFilter: 'linear', minFilter: 'linear', lodMaxClamp: 78.67});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup165, new Uint32Array(1061), 80, 0);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let buffer236 = device0.createBuffer({size: 22061, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let textureView280 = texture206.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 3});
+try {
+computePassEncoder201.setBindGroup(1, bindGroup35);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture129,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(4_143).fill(136), /* required buffer size: 4_143 */
+{offset: 47, bytesPerRow: 32, rowsPerImage: 32}, {width: 0, height: 0, depthOrArrayLayers: 5});
+} catch {}
+let imageData47 = new ImageData(56, 8);
+let videoFrame49 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'bt470bg', transfer: 'smpteSt4281'} });
+try {
+renderPassEncoder71.setViewport(32.18129867930201, 0.4975489128495405, 24.550598971454402, 0.026137345701366388, 0.31930105792193575, 0.9369391977562074);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline12);
+} catch {}
+let pipeline52 = device0.createComputePipeline({layout: pipelineLayout9, compute: {module: shaderModule2}});
+let pipeline53 = device0.createRenderPipeline({
+  layout: 'auto',
+  multisample: {mask: 0x37aae3c7},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment11',
+  constants: {},
+  targets: [{format: 'rg32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule6,
+    buffers: [
+      {
+        arrayStride: 88,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 8, shaderLocation: 9},
+          {format: 'uint8x4', offset: 8, shaderLocation: 15},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 12},
+          {format: 'float32x3', offset: 48, shaderLocation: 10},
+          {format: 'unorm8x4', offset: 24, shaderLocation: 3},
+        ],
+      },
+      {arrayStride: 760, attributes: [{format: 'uint32x4', offset: 92, shaderLocation: 13}]},
+    ],
+  },
+});
+try {
+  await promise35;
+} catch {}
+let bindGroup176 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout7,
+  entries: [
+    {binding: 48, resource: textureView2},
+    {binding: 977, resource: {buffer: buffer14, offset: 1536, size: 1883}},
+    {binding: 162, resource: textureView6},
+    {binding: 83, resource: {buffer: buffer205, offset: 256, size: 1434}},
+    {binding: 41, resource: {buffer: buffer15, offset: 3072, size: 4320}},
+    {binding: 119, resource: {buffer: buffer176, offset: 0, size: 2885}},
+    {binding: 46, resource: externalTexture4},
+  ],
+});
+let texture272 = device0.createTexture({
+  size: [65, 1, 36],
+  mipLevelCount: 2,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder125.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder61); computePassEncoder61.dispatchWorkgroupsIndirect(buffer141, 752); };
+} catch {}
+try {
+renderPassEncoder63.beginOcclusionQuery(86);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+let img5 = await imageWithData(2, 19, '#10101010', '#20202020');
+let recycledExplicitBindGroupLayout93 = pipeline11.getBindGroupLayout(0);
+let textureView281 = texture78.createView({mipLevelCount: 1, arrayLayerCount: 8});
+try {
+renderPassEncoder74.setIndexBuffer(buffer91, 'uint32', 188, 112);
+} catch {}
+let autogeneratedBindGroupLayout37 = pipeline12.getBindGroupLayout(0);
+let buffer237 = device0.createBuffer({
+  size: 6513,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture273 = device0.createTexture({
+  size: [4, 4, 17],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView282 = texture92.createView({dimension: '2d-array', mipLevelCount: 1});
+let sampler184 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'clamp-to-edge', compare: 'greater'});
+let externalTexture26 = device0.importExternalTexture({source: videoFrame35, colorSpace: 'srgb'});
+try {
+computePassEncoder66.setBindGroup(2, bindGroup65, new Uint32Array(201), 28, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup110, new Uint32Array(514), 122, 0);
+} catch {}
+try {
+renderPassEncoder63.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer113, 'uint16', 2_982, 1_011);
+} catch {}
+try {
+renderPassEncoder61.setVertexBuffer(2, buffer115, 0, 259);
+} catch {}
+let texture274 = device0.createTexture({
+  size: {width: 260},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder154.setBindGroup(0, bindGroup8, new Uint32Array(3127), 799, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder127); computePassEncoder127.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup73, new Uint32Array(412), 36, 0);
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(0, 0, 2, 0);
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder85.setVertexBuffer(1, buffer154, 40);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+await gc();
+let bindGroup177 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 304, resource: {buffer: buffer217, offset: 512, size: 3948}}],
+});
+let texture275 = device0.createTexture({
+  size: [4, 4, 17],
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView283 = texture47.createView({dimension: '2d', aspect: 'stencil-only'});
+let sampler185 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 80.61,
+});
+try {
+computePassEncoder46.setBindGroup(3, bindGroup124);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder87); computePassEncoder87.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder55.setPipeline(pipeline33);
+} catch {}
+await gc();
+let recycledExplicitBindGroupLayout94 = pipeline1.getBindGroupLayout(0);
+let bindGroup178 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout33,
+  entries: [
+    {binding: 162, resource: textureView138},
+    {binding: 119, resource: {buffer: buffer93, offset: 0}},
+    {binding: 977, resource: {buffer: buffer209, offset: 512, size: 557}},
+    {binding: 48, resource: textureView13},
+    {binding: 83, resource: {buffer: buffer75, offset: 4608, size: 598}},
+    {binding: 46, resource: externalTexture24},
+    {binding: 41, resource: {buffer: buffer79, offset: 0, size: 104}},
+  ],
+});
+let texture276 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 6},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder67.setBindGroup(1, bindGroup110);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer50, 'uint16', 218, 46);
+} catch {}
+document.body.prepend(canvas2);
+let shaderModule21 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+requires unrestricted_pointer_parameters;
+
+var<workgroup> vw93: atomic<i32>;
+
+var<workgroup> vw89: atomic<i32>;
+
+var<private> vp21: array<array<FragmentOutput15, 1>, 1> = array<array<FragmentOutput15, 1>, 1>(array(FragmentOutput15(i32(2), vec4f(0.1468, 0.00494, 0.3769, 0.2388))));
+
+var<workgroup> vw90: atomic<i32>;
+
+var<workgroup> vw86: FragmentOutput15;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T2 {
+  @size(72) f0: array<atomic<i32>>,
+}
+
+var<workgroup> vw84: vec2h;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<private> vp22: array<FragmentOutput15, 1> = array<FragmentOutput15, 1>();
+
+var<workgroup> vw87: FragmentOutput15;
+
+var<workgroup> vw85: VertexOutput16;
+
+var<private> vp23: mat2x4h = mat2x4h();
+
+@group(0) @binding(113) var<storage, read> buffer238: array<array<array<array<vec2h, 2>, 9>, 1>>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn fn1() -> FragmentOutput15 {
+  var out: FragmentOutput15;
+  let ptr226: ptr<private, vec4f> = &vp21[0][0].f1;
+  out = FragmentOutput15(bitcast<i32>(vp20[u32(unconst_u32(209))]), vec4f(vp20[u32(unconst_u32(209))].grrg));
+  fn0();
+  vp22[u32(unconst_u32(443))].f0 |= bitcast<i32>(pack4xI8(vec4i(unconst_i32(687), unconst_i32(357), unconst_i32(264), unconst_i32(135))));
+  let ptr227: ptr<private, FragmentOutput15> = &vp19;
+  return out;
+}
+
+struct T0 {
+  @align(8) @size(72) f0: array<u32>,
+}
+
+struct VertexOutput16 {
+  @location(0) @interpolate(flat, centroid) f55: vec4u,
+  @builtin(position) f56: vec4f,
+}
+
+var<private> vp19: FragmentOutput15 = FragmentOutput15(i32(129), vec4f(0.4769, 0.2043, 0.03597, 0.1534));
+
+var<private> vp20: mat2x2h = mat2x2h(1673.3, 2235.7, 9385.7, 14123.5);
+
+fn fn2(a0: VertexOutput16) -> vec2f {
+  var out: vec2f;
+  let ptr228: ptr<workgroup, vec4f> = &(*&vw87).f1;
+  var vf310: i32 = atomicExchange(&vw90, i32(unconst_i32(32)));
+  let ptr229: ptr<private, vec4f> = &vp19.f1;
+  vw91 = VertexOutput16(vec4u((*&vw86).f1), (*&vw86).f1);
+  let ptr230: ptr<workgroup, vec4<bool>> = &vw92;
+  return out;
+}
+
+struct T1 {
+  f0: vec2f,
+  f1: vec2i,
+  @size(24) f2: u32,
+  @size(32) f3: array<array<atomic<u32>, 1>>,
+}
+
+var<workgroup> vw92: vec4<bool>;
+
+var<workgroup> vw91: VertexOutput16;
+
+fn fn0() -> FragmentOutput15 {
+  var out: FragmentOutput15;
+  vp23 = mat2x4h(vec4h(faceForward(vec3f(unconst_f32(0.2999), unconst_f32(0.09489), unconst_f32(0.1178)), vp21[u32(unconst_u32(64))][u32(unconst_u32(26))].f1.ara, vec3f(unconst_f32(0.2120), unconst_f32(0.2981), unconst_f32(0.08675))).bbbb), vec4h(faceForward(vec3f(unconst_f32(0.2999), unconst_f32(0.09489), unconst_f32(0.1178)), vp21[u32(unconst_u32(64))][u32(unconst_u32(26))].f1.ara, vec3f(unconst_f32(0.2120), unconst_f32(0.2981), unconst_f32(0.08675))).rgrg));
+  vp22[u32(unconst_u32(71))].f1 = vec4f(vp22[0].f1[u32(unconst_u32(186))]);
+  let ptr216: ptr<private, vec4f> = &vp21[bitcast<u32>(vp21[0][u32(unconst_u32(381))].f0)][u32(unconst_u32(433))].f1;
+  var vf304: vec3u = firstLeadingBit(vec3u(unconst_u32(101), unconst_u32(433), unconst_u32(52)));
+  let vf305: vec4h = vp23[u32(unconst_u32(83))];
+  let ptr217: ptr<private, i32> = &vp22[0].f0;
+  vp23 += mat2x4h(f16(vp21[0][u32(unconst_u32(39))].f0), f16(vp21[0][u32(unconst_u32(39))].f0), f16(vp21[0][u32(unconst_u32(39))].f0), f16(vp21[0][u32(unconst_u32(39))].f0), f16(vp21[0][u32(unconst_u32(39))].f0), f16(vp21[0][u32(unconst_u32(39))].f0), f16(vp21[0][u32(unconst_u32(39))].f0), f16(vp21[0][u32(unconst_u32(39))].f0));
+  var vf306: vec4f = sqrt(vec4f(unconst_f32(0.04858), unconst_f32(0.09058), unconst_f32(0.7989), unconst_f32(0.01113)));
+  let ptr218: ptr<private, FragmentOutput15> = &vp22[u32(unconst_u32(43))];
+  vp23 = mat2x4h(vec4h((*ptr218).f1), vec4h((*ptr218).f1));
+  let ptr219: ptr<private, i32> = &vp22[0].f0;
+  vp20 -= mat2x2h(step(f16(unconst_f16(1385.2)), f16(unconst_f16(5636.2))), step(f16(unconst_f16(1385.2)), f16(unconst_f16(5636.2))), step(f16(unconst_f16(1385.2)), f16(unconst_f16(5636.2))), step(f16(unconst_f16(1385.2)), f16(unconst_f16(5636.2))));
+  var vf307: u32 = dot(vec3u(unconst_u32(37), unconst_u32(488), unconst_u32(86)), vec3u(unconst_u32(175), unconst_u32(124), unconst_u32(5)));
+  vf304 &= vec3u(bitcast<u32>(vp21[0][0].f0));
+  let vf308: vec2h = vp20[pack4x8snorm(vp22[u32(unconst_u32(290))].f1)];
+  let ptr220: ptr<private, vec4f> = &vp22[0].f1;
+  let ptr221: ptr<private, FragmentOutput15> = &vp21[0][u32(unconst_u32(762))];
+  let ptr222: ptr<private, vec4f> = &(*ptr220);
+  let ptr223: ptr<private, vec4f> = &vp21[0][u32(unconst_u32(64))].f1;
+  let vf309: vec2f = unpack2x16unorm(bitcast<u32>((*ptr218).f1.z));
+  let ptr224: ptr<private, vec4f> = &vp21[0][0].f1;
+  vp20 += mat2x2h(f16(vp19.f1[u32(unconst_u32(68))]), f16(vp19.f1[u32(unconst_u32(68))]), f16(vp19.f1[u32(unconst_u32(68))]), f16(vp19.f1[u32(unconst_u32(68))]));
+  let ptr225: ptr<private, vec4f> = &vp22[0].f1;
+  return out;
+}
+
+var<workgroup> vw88: atomic<u32>;
+
+struct FragmentOutput15 {
+  @location(0) f0: i32,
+  @location(7) f1: vec4f,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@vertex
+fn vertex19(@location(15) @interpolate(perspective, sample) a0: f32) -> VertexOutput16 {
+  var out: VertexOutput16;
+  let ptr231: ptr<private, vec4f> = &vp21[0][0].f1;
+  vp19.f0 |= vec4i(vp22[0].f1)[2];
+  var vf311 = fn1();
+  return out;
+}
+
+@fragment
+fn fragment18() -> FragmentOutput15 {
+  var out: FragmentOutput15;
+  let vf312: f16 = buffer238[u32(unconst_u32(186))][0][8][u32(unconst_u32(141))][u32(unconst_u32(101))];
+  vp21[u32(unconst_u32(482))][u32(unconst_u32(211))] = FragmentOutput15(vp19.f0, vec4f(f32(vp19.f0)));
+  let ptr232: ptr<storage, vec2h, read> = &buffer238[arrayLength(&buffer238)][0][8][u32(unconst_u32(252))];
+  let ptr233: ptr<storage, array<array<vec2h, 2>, 9>, read> = &buffer238[u32(unconst_u32(127))][u32(unconst_u32(112))];
+  let ptr234: ptr<storage, vec2h, read> = &(*&buffer238)[arrayLength(&(*&buffer238))][0][8][u32(unconst_u32(30))];
+  let ptr235: ptr<private, FragmentOutput15> = &vp21[0][0];
+  return out;
+  _ = buffer238;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute19() {
+  let vf313: vec3h = exp(vec3h(unconst_f16(443.9), unconst_f16(693.3), unconst_f16(-9191.9)));
+  var vf314 = fn2(VertexOutput16());
+}`,
+});
+let buffer239 = device0.createBuffer({size: 15948, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let sampler186 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 76.56,
+  compare: 'equal',
+});
+try {
+renderPassEncoder51.executeBundles([renderBundle18, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder15.setViewport(173.83225241515032, 0.8839127764957984, 55.01751101918275, 0.04716398888514179, 0.14776807608586995, 0.3670807403464027);
+} catch {}
+try {
+buffer74.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup179 = device0.createBindGroup({
+  label: '\u{1fab7}\u5853\u77e0\u0eab\u9712\u09e7',
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 83, resource: {buffer: buffer141, offset: 768, size: 303}},
+    {binding: 41, resource: {buffer: buffer40, offset: 256, size: 2616}},
+    {binding: 46, resource: externalTexture23},
+    {binding: 977, resource: {buffer: buffer210, offset: 768, size: 2074}},
+    {binding: 119, resource: {buffer: buffer112, offset: 0, size: 942}},
+    {binding: 162, resource: textureView224},
+    {binding: 48, resource: textureView10},
+  ],
+});
+try {
+renderPassEncoder56.setBindGroup(2, bindGroup144, new Uint32Array(1192), 198, 0);
+} catch {}
+try {
+renderPassEncoder88.setVertexBuffer(5, buffer74);
+} catch {}
+try {
+renderPassEncoder55.insertDebugMarker('\u01bc');
+} catch {}
+let textureView284 = texture143.createView({dimension: 'cube-array', baseArrayLayer: 9, arrayLayerCount: 6});
+let sampler187 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder204.end();
+} catch {}
+try {
+renderPassEncoder83.setBindGroup(2, bindGroup31, new Uint32Array(93), 23, 0);
+} catch {}
+try {
+commandEncoder256.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3624 */
+  offset: 3624,
+  rowsPerImage: 1860,
+  buffer: buffer154,
+}, {
+  texture: texture67,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView285 = texture141.createView({});
+let computePassEncoder237 = commandEncoder256.beginComputePass({});
+let sampler188 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  lodMaxClamp: 99.74,
+  compare: 'less',
+});
+try {
+computePassEncoder196.setBindGroup(0, bindGroup91);
+} catch {}
+try {
+computePassEncoder232.setBindGroup(0, bindGroup49, new Uint32Array(1643), 61, 0);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+renderPassEncoder75.beginOcclusionQuery(38);
+} catch {}
+try {
+renderPassEncoder69.setIndexBuffer(buffer29, 'uint16', 5_618, 868);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 4, depthOrArrayLayers: 41}
+*/
+{
+  source: videoFrame43,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture230,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout46 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 73,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup180 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout8,
+  entries: [
+    {binding: 119, resource: {buffer: buffer200, offset: 768, size: 4119}},
+    {binding: 83, resource: {buffer: buffer15, offset: 1024, size: 128}},
+    {binding: 977, resource: {buffer: buffer237, offset: 256, size: 1613}},
+    {binding: 48, resource: textureView10},
+    {binding: 46, resource: externalTexture22},
+    {binding: 41, resource: {buffer: buffer170, offset: 512, size: 2568}},
+    {binding: 162, resource: textureView93},
+  ],
+});
+try {
+computePassEncoder237.setPipeline(pipeline35);
+} catch {}
+try {
+renderPassEncoder75.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer109, 564, 1_755);
+} catch {}
+let texture277 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder81.setBindGroup(0, bindGroup80, new Uint32Array(1717), 476, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: videoFrame13,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame50 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'smpteRp431', transfer: 'gamma22curve'} });
+try {
+renderPassEncoder88.setIndexBuffer(buffer75, 'uint32', 448, 1_184);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer225, 1520, new BigUint64Array(470));
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+await gc();
+let sampler189 = device0.createSampler({addressModeU: 'repeat', lodMaxClamp: 99.22});
+try {
+renderPassEncoder69.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder72.insertDebugMarker('\u088a');
+} catch {}
+let pipeline54 = device0.createRenderPipeline({
+  layout: pipelineLayout21,
+  multisample: {mask: 0x3d1be224},
+  fragment: {
+  module: shaderModule3,
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'equal', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'invert'},
+    stencilBack: {compare: 'never', failOp: 'increment-clamp', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilWriteMask: 711554793,
+    depthBias: -2003618255,
+    depthBiasSlopeScale: 0.0,
+  },
+  vertex: {
+    module: shaderModule18,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 16,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x4', offset: 0, shaderLocation: 9}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let textureView286 = texture267.createView({format: 'rgba32uint', arrayLayerCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder61); computePassEncoder61.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder135); computePassEncoder135.dispatchWorkgroupsIndirect(buffer109, 2_320); };
+} catch {}
+try {
+renderPassEncoder61.setIndexBuffer(buffer119, 'uint16', 50, 23);
+} catch {}
+await gc();
+let sampler190 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 92.01});
+try {
+computePassEncoder183.setBindGroup(3, bindGroup166, new Uint32Array(702), 28, 0);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(2, bindGroup177);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer210, 'uint32', 1_648, 5_086);
+} catch {}
+try {
+if (!arrayBuffer19.detached) { new Uint8Array(arrayBuffer19).fill(0x55); };
+} catch {}
+await gc();
+let bindGroup181 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout14,
+  entries: [{binding: 304, resource: {buffer: buffer109, offset: 1280, size: 3276}}],
+});
+let buffer240 = device0.createBuffer({size: 5190, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let texture278 = device0.createTexture({
+  size: {width: 4},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32sint'],
+});
+let textureView287 = texture21.createView({dimension: '2d', format: 'rg32uint'});
+let sampler191 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat'});
+try {
+computePassEncoder235.setBindGroup(2, bindGroup97);
+} catch {}
+try {
+computePassEncoder194.setBindGroup(1, bindGroup144, new Uint32Array(2542), 361, 0);
+} catch {}
+try {
+renderPassEncoder53.setViewport(12.04444152715579, 0.4868731080523321, 4.599711737454052, 0.07998141977513688, 0.5098646262803628, 0.8780535390912194);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder135); computePassEncoder135.dispatchWorkgroupsIndirect(buffer29, 748); };
+} catch {}
+try {
+computePassEncoder145.end();
+} catch {}
+try {
+renderPassEncoder72.setIndexBuffer(buffer237, 'uint16', 348, 289);
+} catch {}
+try {
+commandEncoder184.copyTextureToTexture({
+  texture: texture193,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture272,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture258,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+}, new Uint8Array(785_826).fill(134), /* required buffer size: 785_826 */
+{offset: 106, bytesPerRow: 265, rowsPerImage: 228}, {width: 260, height: 1, depthOrArrayLayers: 14});
+} catch {}
+let textureView288 = texture209.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 6});
+let computePassEncoder238 = commandEncoder184.beginComputePass({});
+let sampler192 = device0.createSampler({addressModeV: 'mirror-repeat', lodMaxClamp: 64.72});
+try {
+computePassEncoder238.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(0, bindGroup116);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(0, bindGroup38, new Uint32Array(3106), 158, 0);
+} catch {}
+try {
+renderPassEncoder83.setIndexBuffer(buffer158, 'uint16', 508, 109);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+  await buffer239.mapAsync(GPUMapMode.READ, 680);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame51 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {
+  fullRange: false,
+  matrix: 'bt2020-ncl',
+  primaries: 'jedecP22Phosphors',
+  transfer: 'bt1361ExtendedColourGamut',
+} });
+let buffer241 = device0.createBuffer({size: 29343, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let sampler193 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 95.27,
+});
+try {
+computePassEncoder182.setBindGroup(2, bindGroup165, new Uint32Array(2274), 189, 0);
+} catch {}
+let texture279 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler194 = device0.createSampler({addressModeU: 'repeat', lodMaxClamp: 73.57});
+try {
+computePassEncoder169.setBindGroup(1, bindGroup102, []);
+} catch {}
+try {
+computePassEncoder127.end();
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle14, renderBundle14, renderBundle18, renderBundle18, renderBundle18, renderBundle14]);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer181, 'uint16', 322, 124);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(1, buffer170, 328, 8_060);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer190, 2368, new DataView(new ArrayBuffer(10565)), 610, 3148);
+} catch {}
+let videoFrame52 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'film', transfer: 'bt2020_12bit'} });
+let veryExplicitBindGroupLayout47 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 31,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 498,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let textureView289 = texture212.createView({baseArrayLayer: 4, arrayLayerCount: 7});
+let computePassEncoder239 = commandEncoder158.beginComputePass({});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+computePassEncoder167.setBindGroup(0, bindGroup156, new Uint32Array(106), 43, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder93); computePassEncoder93.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder239.setPipeline(pipeline34);
+} catch {}
+try {
+renderPassEncoder70.setBindGroup(3, bindGroup137);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(185);
+} catch {}
+try {
+renderPassEncoder58.setIndexBuffer(buffer158, 'uint32', 376, 2_426);
+} catch {}
+let bindGroup182 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout25,
+  entries: [
+    {binding: 270, resource: {buffer: buffer194, offset: 0, size: 932}},
+    {binding: 326, resource: {buffer: buffer108, offset: 0, size: 432}},
+    {binding: 243, resource: textureView130},
+    {binding: 79, resource: textureView122},
+    {binding: 101, resource: sampler29},
+    {binding: 299, resource: sampler78},
+    {binding: 601, resource: {buffer: buffer42, offset: 1536, size: 516}},
+  ],
+});
+let texture280 = device0.createTexture({
+  size: {width: 32},
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView290 = texture22.createView({});
+try {
+computePassEncoder165.setBindGroup(1, bindGroup34, new Uint32Array(1553), 146, 0);
+} catch {}
+try {
+renderPassEncoder84.setPipeline(pipeline36);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(3, buffer154);
+} catch {}
+let recycledExplicitBindGroupLayout95 = pipeline8.getBindGroupLayout(0);
+let textureView291 = texture109.createView({arrayLayerCount: 1});
+try {
+computePassEncoder179.setBindGroup(2, bindGroup174);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder81); computePassEncoder81.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+renderPassEncoder91.setBindGroup(3, bindGroup172);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer174, 'uint16', 0, 12);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+buffer145.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer160, 1468, new Float32Array(195), 3, 76);
+} catch {}
+try {
+computePassEncoder226.setBindGroup(0, bindGroup182, new Uint32Array(1064), 192, 0);
+} catch {}
+try {
+renderPassEncoder65.executeBundles([renderBundle18, renderBundle14, renderBundle14]);
+} catch {}
+try {
+renderPassEncoder85.setIndexBuffer(buffer150, 'uint32', 3_068, 891);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.STORAGE_BINDING, viewFormats: []});
+} catch {}
+let sampler195 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 90.29,
+  maxAnisotropy: 11,
+});
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup111);
+} catch {}
+try {
+renderPassEncoder12.setViewport(53.9791182207301, 0.1122266769977468, 2.558766946364915, 0.09348178844721843, 0.14783957639436396, 0.8841607572606807);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer225, 'uint16', 6_982, 3_108);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(0, buffer151, 204);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer24.detached) { new Uint8Array(arrayBuffer24).fill(0x55); };
+} catch {}
+document.body.append(img2);
+let offscreenCanvas9 = new OffscreenCanvas(94, 6);
+try {
+offscreenCanvas9.getContext('webgl');
+} catch {}
+try {
+globalThis.someLabel = externalTexture2.label;
+} catch {}
+let sampler196 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.35,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder100.setBindGroup(3, bindGroup133, new Uint32Array(293), 15, 0);
+} catch {}
+try {
+computePassEncoder81.end();
+} catch {}
+try {
+renderPassEncoder85.setIndexBuffer(buffer199, 'uint16', 3_076, 123);
+} catch {}
+try {
+renderPassEncoder76.setVertexBuffer(4, buffer115, 0, 832);
+} catch {}
+let pipeline55 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {module: shaderModule0, targets: [{format: 'rg16uint'}]},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'equal', depthFailOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'greater', failOp: 'increment-clamp', depthFailOp: 'invert', passOp: 'invert'},
+    stencilReadMask: 18857200,
+    stencilWriteMask: 2234216142,
+    depthBiasClamp: 692.8027858047637,
+  },
+  vertex: {module: shaderModule16, entryPoint: 'vertex15', buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'back'},
+});
+let querySet39 = device0.createQuerySet({type: 'occlusion', count: 1000});
+let commandBuffer30 = commandEncoder100.finish();
+let texture281 = device0.createTexture({
+  size: {width: 4, height: 4, depthOrArrayLayers: 17},
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({colorFormats: ['rg32uint'], depthReadOnly: true});
+try {
+computePassEncoder179.setBindGroup(3, bindGroup144);
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder86.setIndexBuffer(buffer205, 'uint32', 188, 2_536);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(4, undefined, 2_174_645_511);
+} catch {}
+let querySet40 = device0.createQuerySet({type: 'occlusion', count: 685});
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup72);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer65, 'uint16', 348, 249);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline53);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup170, []);
+} catch {}
+try {
+renderPassEncoder10.pushDebugGroup('\ud194');
+} catch {}
+try {
+renderPassEncoder10.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer30]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer33, 1376, new DataView(new ArrayBuffer(7775)), 618, 392);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture253,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(495).fill(40), /* required buffer size: 495 */
+{offset: 495, rowsPerImage: 117}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder286 = device0.createCommandEncoder({});
+let textureView292 = texture172.createView({dimension: 'cube'});
+try {
+computePassEncoder231.setBindGroup(0, bindGroup155, new Uint32Array(881), 149, 0);
+} catch {}
+try {
+renderPassEncoder70.executeBundles([renderBundle11, renderBundle2, renderBundle2, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer227, 'uint16', 1_986, 422);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(2, bindGroup136);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(1, bindGroup178, new Uint32Array(948), 48, 0);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline53);
+} catch {}
+try {
+commandEncoder286.copyBufferToBuffer(buffer115, 2156, buffer76, 12, 440);
+} catch {}
+try {
+commandEncoder286.copyTextureToTexture({
+  texture: texture257,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture234,
+  mipLevel: 0,
+  origin: {x: 104, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline56 = device0.createComputePipeline({layout: pipelineLayout6, compute: {module: shaderModule15, entryPoint: 'compute14'}});
+let recycledExplicitBindGroupLayout96 = pipeline20.getBindGroupLayout(0);
+let bindGroup183 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout65,
+  entries: [
+    {binding: 162, resource: textureView282},
+    {binding: 977, resource: {buffer: buffer221, offset: 7168, size: 1501}},
+    {binding: 48, resource: textureView2},
+    {binding: 41, resource: {buffer: buffer176, offset: 1792}},
+    {binding: 83, resource: {buffer: buffer230, offset: 768, size: 23}},
+    {binding: 46, resource: externalTexture0},
+    {binding: 119, resource: {buffer: buffer65, offset: 0}},
+  ],
+});
+let computePassEncoder240 = commandEncoder286.beginComputePass({});
+try {
+renderPassEncoder71.setBindGroup(0, bindGroup182);
+} catch {}
+try {
+renderPassEncoder52.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(0, buffer161, 468, 614);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup7, new Uint32Array(2177), 719, 0);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer81, 'uint32', 1_436, 595);
+} catch {}
+let textureView293 = texture172.createView({dimension: 'cube', mipLevelCount: 1, baseArrayLayer: 2});
+try {
+renderPassEncoder33.setVertexBuffer(5, buffer161, 0, 270);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(1, buffer82, 0, 182);
+} catch {}
+let texture282 = device0.createTexture({
+  label: '\ud1c9\u7e6d\u2313\u049d\u0a60\u6a7c\ub06f\u9d7a\u7647',
+  size: [4, 4, 17],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder82.setBindGroup(3, bindGroup71);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup127);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(1, bindGroup116, new Uint32Array(949), 290, 0);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(6, buffer200);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup184 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout10,
+  entries: [{binding: 41, resource: {buffer: buffer44, offset: 1792, size: 4608}}],
+});
+let texture283 = device0.createTexture({
+  size: {width: 4, height: 4, depthOrArrayLayers: 17},
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderBundle22 = renderBundleEncoder22.finish({});
+let sampler197 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', minFilter: 'linear', lodMaxClamp: 82.99});
+try {
+computePassEncoder234.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext19.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline57 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment6',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule17,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 180,
+        attributes: [
+          {format: 'snorm16x4', offset: 0, shaderLocation: 7},
+          {format: 'sint8x4', offset: 36, shaderLocation: 5},
+          {format: 'unorm8x4', offset: 16, shaderLocation: 9},
+          {format: 'sint8x2', offset: 6, shaderLocation: 10},
+          {format: 'uint32x4', offset: 8, shaderLocation: 8},
+          {format: 'uint32x3', offset: 16, shaderLocation: 6},
+          {format: 'uint32x4', offset: 8, shaderLocation: 4},
+          {format: 'sint8x2', offset: 2, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let veryExplicitBindGroupLayout48 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 79,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 101,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 243,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 270,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {binding: 299, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 326,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 601,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture284 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 108},
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture27 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder159.setBindGroup(0, bindGroup72);
+} catch {}
+try {
+computePassEncoder218.setBindGroup(0, bindGroup87, new Uint32Array(6099), 353, 0);
+} catch {}
+try {
+computePassEncoder240.setPipeline(pipeline56);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup66);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup171, new Uint32Array(4236), 258, 0);
+} catch {}
+try {
+renderPassEncoder68.setIndexBuffer(buffer112, 'uint32', 488, 165);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(2, buffer150);
+} catch {}
+let buffer242 = device0.createBuffer({
+  size: 8570,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView294 = texture41.createView({format: 'r32sint'});
+try {
+computePassEncoder230.setBindGroup(0, bindGroup156);
+} catch {}
+try {
+computePassEncoder54.setBindGroup(1, bindGroup82, new Uint32Array(156), 3, 0);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer114, 'uint16', 5_568, 2_067);
+} catch {}
+document.body.append(img0);
+let textureView295 = texture258.createView({dimension: '2d', baseArrayLayer: 3});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup84);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(0, bindGroup88, new Uint32Array(451), 69, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle13, renderBundle14]);
+} catch {}
+try {
+renderPassEncoder18.setBlendConstant({ r: 337.9, g: -678.8, b: 681.8, a: -337.5, });
+} catch {}
+try {
+renderPassEncoder25.setViewport(23.732148720505457, 0.9332495998664786, 1.9548711276938295, 0.011335957466992553, 0.8080894820458524, 0.8319862664210946);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(0, buffer91, 0, 139);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 130, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData42,
+  origin: { x: 5, y: 1 },
+  flipY: false,
+}, {
+  texture: texture227,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 93, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture285 = gpuCanvasContext9.getCurrentTexture();
+try {
+computePassEncoder66.setBindGroup(0, bindGroup91, new Uint32Array(2018), 586, 0);
+} catch {}
+let textureView296 = texture88.createView({mipLevelCount: 1});
+try {
+buffer170.unmap();
+} catch {}
+let buffer243 = device0.createBuffer({
+  size: 6389,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+try {
+renderPassEncoder21.executeBundles([renderBundle22, renderBundle6, renderBundle0, renderBundle4, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer210, 'uint16', 1_854, 3_757);
+} catch {}
+let promise36 = shaderModule17.getCompilationInfo();
+let texture286 = device0.createTexture({
+  size: [130, 1, 1],
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder46); computePassEncoder46.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder89.setBindGroup(1, bindGroup141, new Uint32Array(2854), 411, 0);
+} catch {}
+try {
+renderPassEncoder41.setScissorRect(12, 0, 44, 0);
+} catch {}
+try {
+renderPassEncoder77.setIndexBuffer(buffer193, 'uint32', 7_784, 495);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline57);
+} catch {}
+let arrayBuffer28 = buffer28.getMappedRange(688, 44);
+try {
+buffer222.unmap();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup185 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout47,
+  entries: [{binding: 31, resource: textureView132}, {binding: 498, resource: textureView47}],
+});
+let buffer244 = device0.createBuffer({
+  size: 5615,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture287 = device0.createTexture({size: [260, 1, 1], mipLevelCount: 3, format: 'stencil8', usage: GPUTextureUsage.COPY_SRC});
+try {
+renderPassEncoder41.setIndexBuffer(buffer114, 'uint32', 232, 667);
+} catch {}
+let arrayBuffer29 = buffer233.getMappedRange(0, 128);
+try {
+device0.queue.writeTexture({
+  texture: texture183,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(215).fill(191), /* required buffer size: 215 */
+{offset: 215, rowsPerImage: 1}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData48 = new ImageData(32, 44);
+let bindGroup186 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout8,
+  entries: [
+    {binding: 41, resource: {buffer: buffer177, offset: 1792}},
+    {binding: 48, resource: textureView10},
+    {binding: 46, resource: externalTexture6},
+    {binding: 977, resource: {buffer: buffer158, offset: 2048, size: 242}},
+    {binding: 83, resource: {buffer: buffer160, offset: 5120, size: 4472}},
+    {binding: 162, resource: textureView138},
+    {binding: 119, resource: {buffer: buffer223, offset: 1024, size: 2240}},
+  ],
+});
+let texture288 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 25},
+  dimension: '2d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup136);
+} catch {}
+try {
+computePassEncoder224.setBindGroup(1, bindGroup18, new Uint32Array(992), 43, 0);
+} catch {}
+try {
+computePassEncoder135.end();
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline44);
+} catch {}
+let buffer245 = device0.createBuffer({
+  size: 9589,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderPassEncoder92 = commandEncoder173.beginRenderPass({
+  colorAttachments: [{
+  view: textureView217,
+  clearValue: { r: 954.3, g: -912.9, b: -741.5, a: 647.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 649007689,
+});
+try {
+computePassEncoder233.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+computePassEncoder132.setBindGroup(1, bindGroup155, new Uint32Array(567), 2, 0);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(3, bindGroup116, new Uint32Array(708), 79, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(36).fill(107), /* required buffer size: 36 */
+{offset: 36}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule22 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn fn1() -> VertexOutput17 {
+  var out: VertexOutput17;
+  let vf319: vec3h = atanh(vec3h(unconst_f16(3042.6), unconst_f16(3537.5), unconst_f16(13167.1)));
+  let vf320: u32 = pack4xU8(vec4u(unconst_u32(203), unconst_u32(180), unconst_u32(0), unconst_u32(26)));
+  out.f58 -= vec3f(mix(vec3h(unconst_f16(5700.6), unconst_f16(6180.0), unconst_f16(3681.8)), vec3h(unconst_f16(1248.9), unconst_f16(9354.3), unconst_f16(7963.3)), f16(unconst_f16(5544.8)))).x;
+  vp24[u32(unconst_u32(150))] = modf(vec2f(mix(vec3h(f16(pack4x8snorm(vec4f(unconst_f32(0.04095), unconst_f32(0.7421), unconst_f32(-0.06811), unconst_f32(0.1682))))), vec3h(unconst_f16(-25831.6), unconst_f16(8359.3), unconst_f16(12670.9)), f16(unconst_f16(15497.2))).yy));
+  var vf321: vec3h = atanh(vec3h(unconst_f16(722.5), unconst_f16(4493.5), unconst_f16(2135.5)));
+  let ptr243 = &vp24[u32(unconst_u32(279))];
+  out.f57 = unpack2x16float(u32(unconst_u32(190))).rggg;
+  vp24[u32(unconst_u32(40))].whole = vec2f(round(vec2h(unconst_f16(720.2), unconst_f16(14790.8))));
+  out.f58 += (*ptr243).fract.g;
+  out.f57 = vp24[0].whole.rgrr;
+  var vf322: vec3i = min(vec3i(unconst_i32(35), unconst_i32(147), unconst_i32(-113)), vec3i(unconst_i32(70), unconst_i32(427), unconst_i32(1)));
+  var vf323: u32 = pack4x8unorm(vec4f(unconst_f32(0.1380), unconst_f32(0.2387), unconst_f32(0.03157), unconst_f32(-0.1718)));
+  out = VertexOutput17(unpack2x16float(u32(unconst_u32(304))).grgg, unpack2x16float(u32(unconst_u32(304))).g);
+  vf321 = vec3h(vf321[u32(unconst_u32(100))]);
+  return out;
+}
+
+struct FragmentOutput17 {
+  @location(0) @interpolate(flat, center) f0: vec4i,
+  @location(1) @interpolate(linear) f1: vec4f,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct S5 {
+  @location(5) f0: f32,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct FragmentOutput16 {
+  @location(0) @interpolate(flat) f0: vec2i,
+  @location(1) @interpolate(flat) f1: vec4i,
+}
+
+var<private> vp24 = array(modf(vec2f(0.4845, -0.1482)));
+
+fn fn0(a0: ptr<workgroup, array<atomic<u32>, 1>>) -> array<mat3x2h, 1> {
+  var out: array<mat3x2h, 1>;
+  let ptr236 = &vp24[u32(unconst_u32(394))];
+  var vf315: vec3f = clamp(vec3f(unconst_f32(-0.05793), unconst_f32(0.1974), unconst_f32(0.01576)), clamp(vec3f(unconst_f32(0.1281), unconst_f32(0.01181), unconst_f32(0.08747)), vec3f(unconst_f32(0.03269), unconst_f32(-0.02526), unconst_f32(0.09054)), vec3f(unconst_f32(0.1855), unconst_f32(0.1283), unconst_f32(0.3200))), vec3f(unconst_f32(0.3816), unconst_f32(0.2352), unconst_f32(0.1749)));
+  let ptr237: ptr<workgroup, atomic<u32>> = &(*a0)[0];
+  let ptr238 = &vp24[u32(unconst_u32(462))];
+  let vf316: f32 = pow(f32(unconst_f32(0.1814)), f32(unconst_f32(-0.1739)));
+  let ptr239 = &vp24[u32(unconst_u32(22))];
+  let vf317: vec3h = sqrt(vec3h(unconst_f16(1317.1), unconst_f16(10434.2), unconst_f16(1581.3)));
+  atomicAdd(&(*a0)[u32(unconst_u32(51))], u32(unconst_u32(30)));
+  var vf318: f16 = acos(f16(unconst_f16(2460.1)));
+  let ptr240 = &vp24[u32(unconst_u32(260))];
+  let ptr241 = &(*ptr236);
+  vf318 += vec2h((*ptr241).fract).r;
+  let ptr242: ptr<private, vec2f> = &(*ptr241).whole;
+  vf318 *= vec3h(vf315).z;
+  atomicSub(&(*a0)[u32(unconst_u32(246))], u32(unconst_u32(61)));
+  return out;
+}
+
+struct T0 {
+  @size(8) f0: atomic<u32>,
+  @size(40) f1: array<atomic<u32>, 1>,
+  @size(120) f2: vec2h,
+}
+
+struct VertexOutput17 {
+  @builtin(position) f57: vec4f,
+  @location(3) @interpolate(perspective, centroid) f58: f32,
+}
+
+var<workgroup> vw94: array<FragmentOutput17, 1>;
+
+struct S4 {
+  @location(10) f0: vec2h,
+  @location(7) @interpolate(flat) f1: vec2u,
+  @location(0) @interpolate(linear) f2: vec2h,
+  @location(3) f3: vec4u,
+}
+
+@vertex
+fn vertex20(@builtin(vertex_index) a0: u32, a1: S4, @builtin(instance_index) a2: u32, @location(9) @interpolate(linear) a3: vec4f, a4: S5) -> VertexOutput17 {
+  var out: VertexOutput17;
+  out = VertexOutput17(vec4f(f32(sign(f16(unconst_f16(14234.5))))), f32(sign(f16(unconst_f16(14234.5)))));
+  out = VertexOutput17(radians(vec4f(unconst_f32(0.09553), unconst_f32(0.2212), unconst_f32(0.06187), unconst_f32(1.000))), radians(vec4f(unconst_f32(0.09553), unconst_f32(0.2212), unconst_f32(0.06187), unconst_f32(1.000)))[0]);
+  out.f58 *= unpack4x8unorm(u32(unconst_u32(37)))[3];
+  out.f58 = bitcast<f32>(a1.f3.r);
+  vp24[u32(unconst_u32(7))] = modf(vec2f(a1.f0));
+  out = VertexOutput17(vec4f(a1.f1.rrgr), bitcast<vec2f>(a1.f1).r);
+  vp24[u32(unconst_u32(24))] = modf(vec2f(f32(a1.f0[u32(unconst_u32(74))])));
+  out.f57 = vp24[0].fract.grgg;
+  out.f58 = vec2f(a1.f1).g;
+  let vf324: f16 = sign(f16(unconst_f16(34230.7)));
+  return out;
+}
+
+@fragment
+fn fragment19() -> FragmentOutput16 {
+  var out: FragmentOutput16;
+  let ptr244: ptr<private, vec2f> = &vp24[u32(unconst_u32(83))].whole;
+  vp24[u32(unconst_u32(195))].fract += vp24[u32(unconst_u32(66))].whole;
+  vp24[bitcast<u32>(acosh(vec2f(unconst_f32(0.1479), unconst_f32(0.3580))).g)] = modf(acos(vec3f(unconst_f32(0.01258), unconst_f32(0.5338), unconst_f32(0.2634))).zz);
+  vp24[u32(unconst_u32(59))].whole -= acos(vec3f(unconst_f32(0.1618), unconst_f32(0.2541), unconst_f32(0.04831))).gg;
+  var vf325: i32 = insertBits(i32(unconst_i32(521)), i32(unconst_i32(54)), u32(unconst_u32(21)), u32(unconst_u32(131)));
+  let vf326: vec3f = acos(vec3f(unconst_f32(-0.2471), unconst_f32(0.07122), unconst_f32(0.01856)));
+  vp24[u32(unconst_u32(12))].fract += vec2f(log2(vec3h(unconst_f16(5691.4), unconst_f16(17656.9), unconst_f16(3631.7))).gb);
+  vf325 = i32(log(vec3h(tanh(vec2f(log(vec3h(unconst_f16(35777.5), unconst_f16(5377.5), unconst_f16(11038.6))).zx)).xxx)).y);
+  out.f1 = vec4i(log(vec4h(unconst_f16(13636.9), unconst_f16(8092.3), unconst_f16(1740.3), unconst_f16(30323.9))));
+  let ptr245 = &vp24[0];
+  let vf327: vec4h = log(bitcast<vec4h>(vp24[0].whole));
+  let vf328: u32 = pack4xI8(vec4i(unconst_i32(236), unconst_i32(4), unconst_i32(-99), unconst_i32(-114)));
+  let vf329: vec2h = floor(vec2h(max(vec3f(unconst_f32(0.2734), unconst_f32(0.00620), unconst_f32(0.01490)), vec3f(unconst_f32(0.1065), unconst_f32(0.04998), unconst_f32(0.00494))).rg));
+  let ptr246 = &(*ptr245);
+  vp24[u32(vf327[0])].fract = vp24[0].whole;
+  return out;
+}
+
+@fragment
+fn fragment20() -> FragmentOutput17 {
+  var out: FragmentOutput17;
+  out.f1 -= vp24[0].whole.rrrg;
+  out = FragmentOutput17(vec4i(vp24[0].fract.grgr), vp24[0].fract.gggr);
+  let vf330: vec3h = sqrt(vec3h(unconst_f16(15062.9), unconst_f16(-7268.3), unconst_f16(6660.2)));
+  let ptr247: ptr<private, vec2f> = &vp24[0].whole;
+  discard;
+  out.f0 |= vec4i(log(vec3h(unconst_f16(-26586.9), unconst_f16(10647.7), unconst_f16(1861.2))).bgbr);
+  let vf331: f16 = vf330[u32(unconst_u32(17))];
+  let vf332: vec2h = normalize(vec2h(unconst_f16(15579.6), unconst_f16(3156.9)));
+  var vf333: vec4u = unpack4xU8(u32(unconst_u32(750)));
+  var vf334: i32 = countOneBits(i32(unconst_i32(138)));
+  out.f1 = unpack4x8snorm(insertBits(u32(unconst_u32(9)), u32(unconst_u32(64)), u32(unconst_u32(453)), u32(unconst_u32(620))));
+  var vf335: u32 = insertBits(u32(unconst_u32(308)), u32(unconst_u32(174)), u32(unconst_u32(41)), u32(unconst_u32(13)));
+  let vf336: u32 = vf333[u32(unconst_u32(176))];
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute20() {
+  vp24[u32(unconst_u32(0))] = modf(vw94[0].f1.zw);
+  let ptr248: ptr<workgroup, FragmentOutput17> = &(*&vw94)[u32(unconst_u32(407))];
+  vp24[u32(unconst_u32(12))].whole *= vec2f(bitcast<f32>((*ptr248).f0[u32(unconst_u32(33))]));
+  let ptr249: ptr<workgroup, array<FragmentOutput17, 1>> = &vw94;
+  vw94[u32(unconst_u32(100))].f1 = vec4f(bitcast<f32>((*ptr249)[0].f0[u32(unconst_u32(103))]));
+  vw94[u32((*&vw94)[u32(unconst_u32(45))].f1[u32(unconst_u32(158))])] = FragmentOutput17(vec4i((*ptr248).f0[u32(unconst_u32(280))]), vec4f(bitcast<f32>((*ptr248).f0[u32(unconst_u32(280))])));
+  let ptr250 = &vp24[u32(unconst_u32(19))];
+  vw94[u32(unconst_u32(115))].f1 += vec4f((*&vw94)[u32(unconst_u32(343))].f1[u32(unconst_u32(244))]);
+  vp24[u32(unconst_u32(50))].fract -= bitcast<vec2f>((*ptr249)[0].f0.gg);
+  let ptr251: ptr<workgroup, vec4f> = &(*ptr248).f1;
+  var vf337: i32 = (*&vw94)[0].f0[u32(unconst_u32(230))];
+  let ptr252: ptr<workgroup, FragmentOutput17> = &(*&vw94)[0];
+  let ptr253: ptr<workgroup, FragmentOutput17> = &(*&vw94)[u32(unconst_u32(288))];
+  vf337 = (*&vw94)[u32(unconst_u32(192))].f0[0];
+  vw94[0].f0 |= bitcast<vec4i>(vw94[u32(unconst_u32(123))].f1);
+}`,
+});
+let autogeneratedBindGroupLayout38 = pipeline17.getBindGroupLayout(0);
+let texture289 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 70},
+  format: 'r32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({colorFormats: ['r32float'], sampleCount: 1, depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder219.setBindGroup(1, bindGroup161);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup6, new Uint32Array(1879), 490, 0);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer245, 'uint16', 1_016, 1_224);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(3, bindGroup25);
+} catch {}
+let videoFrame53 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'smpteSt4281', transfer: 'logSqrt'} });
+let querySet41 = device0.createQuerySet({type: 'occlusion', count: 190});
+let textureView297 = texture207.createView({baseArrayLayer: 0});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({colorFormats: ['r32float'], depthReadOnly: true});
+try {
+renderPassEncoder56.executeBundles([renderBundle17]);
+} catch {}
+try {
+renderPassEncoder87.setBlendConstant({ r: -672.7, g: -126.5, b: -622.1, a: 650.9, });
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(2, bindGroup83, new Uint32Array(401), 130, 0);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer83, 'uint16', 296, 14);
+} catch {}
+let arrayBuffer30 = buffer63.getMappedRange(0, 140);
+let bindGroup187 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout20,
+  entries: [
+    {binding: 41, resource: {buffer: buffer62, offset: 2816, size: 440}},
+    {binding: 977, resource: {buffer: buffer32, offset: 0}},
+    {binding: 48, resource: textureView10},
+    {binding: 46, resource: externalTexture5},
+    {binding: 162, resource: textureView72},
+    {binding: 119, resource: {buffer: buffer230, offset: 768, size: 537}},
+    {binding: 83, resource: {buffer: buffer245, offset: 768, size: 1743}},
+  ],
+});
+try {
+renderPassEncoder88.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(0, buffer93, 400);
+} catch {}
+let arrayBuffer31 = buffer233.getMappedRange(128, 208);
+let bindGroup188 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout75,
+  entries: [
+    {binding: 119, resource: {buffer: buffer65, offset: 1792}},
+    {binding: 41, resource: {buffer: buffer177, offset: 512}},
+    {binding: 83, resource: {buffer: buffer205, offset: 0, size: 1308}},
+    {binding: 977, resource: {buffer: buffer193, offset: 8960, size: 1194}},
+    {binding: 46, resource: externalTexture9},
+    {binding: 162, resource: textureView0},
+    {binding: 48, resource: textureView13},
+  ],
+});
+try {
+computePassEncoder80.setBindGroup(2, bindGroup160);
+} catch {}
+try {
+renderPassEncoder87.setBindGroup(2, bindGroup154, new Uint32Array(2097), 120, 0);
+} catch {}
+try {
+renderPassEncoder92.executeBundles([renderBundle16]);
+} catch {}
+try {
+renderPassEncoder86.setVertexBuffer(5, buffer151, 308);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(62).fill(163), /* required buffer size: 62 */
+{offset: 62}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas6);
+let texture290 = gpuCanvasContext5.getCurrentTexture();
+try {
+computePassEncoder194.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder46); computePassEncoder46.dispatchWorkgroups(2); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder167); computePassEncoder167.dispatchWorkgroupsIndirect(buffer93, 4_228); };
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(43);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(4, buffer38, 0, 1_572);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(3, bindGroup87);
+} catch {}
+try {
+  await buffer183.mapAsync(GPUMapMode.READ, 0, 524);
+} catch {}
+let textureView298 = texture231.createView({});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], sampleCount: 1});
+let renderBundle23 = renderBundleEncoder25.finish({});
+try {
+computePassEncoder106.setBindGroup(0, bindGroup67, new Uint32Array(2683), 2_511, 0);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle19, renderBundle19, renderBundle16]);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(2, bindGroup115, new Uint32Array(848), 74, 0);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(3, buffer35);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: videoFrame33,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 110},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder167.end();
+} catch {}
+try {
+renderPassEncoder75.setVertexBuffer(3, buffer112, 0, 1_078);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer231, 'uint16', 2_332, 1_896);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(7, buffer125, 1_176, 409);
+} catch {}
+try {
+commandEncoder211.copyTextureToBuffer({
+  texture: texture140,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 304 widthInBlocks: 76 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9404 */
+  offset: 2236,
+  bytesPerRow: 1024,
+  rowsPerImage: 7,
+  buffer: buffer222,
+}, {width: 76, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+renderPassEncoder44.insertDebugMarker('\u{1fa68}');
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer203, 72, new Int16Array(5800), 750, 152);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup189 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout19,
+  entries: [{binding: 113, resource: {buffer: buffer92, offset: 9216, size: 144}}],
+});
+let texture291 = device0.createTexture({
+  label: '\u0d07\uac1e\u{1fa88}\u041e\u25e0',
+  size: {width: 130, height: 1, depthOrArrayLayers: 1},
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder93 = commandEncoder211.beginRenderPass({
+  colorAttachments: [{
+  view: textureView224,
+  clearValue: { r: 589.2, g: 659.8, b: -293.2, a: 818.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler198 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 90.29,
+});
+try {
+computePassEncoder212.setBindGroup(1, bindGroup165);
+} catch {}
+try {
+computePassEncoder93.end();
+} catch {}
+try {
+renderPassEncoder81.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(1, bindGroup129, new Uint32Array(50), 3, 0);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer231, 'uint32', 1_336, 4_034);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(4, buffer81, 1_556);
+} catch {}
+try {
+commandEncoder117.copyTextureToTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 71, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture278,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder117.resolveQuerySet(querySet26, 1, 65, buffer26, 2816);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture259,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(201).fill(53), /* required buffer size: 201 */
+{offset: 201, bytesPerRow: 191}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise37 = device0.queue.onSubmittedWorkDone();
+let videoFrame54 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'bt2020', transfer: 'smpteSt4281'} });
+let textureView299 = texture171.createView({mipLevelCount: 1});
+let computePassEncoder241 = commandEncoder117.beginComputePass({label: '\u{1f71a}\u4291\u0c15\u{1fa7c}\u{1fbc3}\u9f9c\u3c88\u05d1\u000c\u{1fb54}\u7a87'});
+try {
+computePassEncoder241.setPipeline(pipeline56);
+} catch {}
+try {
+renderPassEncoder69.setBindGroup(1, bindGroup134);
+} catch {}
+try {
+renderPassEncoder66.setBindGroup(3, bindGroup153, new Uint32Array(1323), 69, 0);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline33);
+} catch {}
+try {
+renderPassEncoder61.setVertexBuffer(7, buffer125);
+} catch {}
+try {
+computePassEncoder230.pushDebugGroup('\u{1faac}');
+} catch {}
+try {
+globalThis.someLabel = sampler14.label;
+} catch {}
+let renderBundle24 = renderBundleEncoder23.finish({});
+let sampler199 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'repeat', mipmapFilter: 'linear'});
+try {
+computePassEncoder209.setBindGroup(0, bindGroup160);
+} catch {}
+try {
+renderPassEncoder84.setBindGroup(2, bindGroup72);
+} catch {}
+try {
+renderPassEncoder46.executeBundles([renderBundle24, renderBundle19, renderBundle19, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder84.setIndexBuffer(buffer48, 'uint16', 402, 2_515);
+} catch {}
+document.body.prepend(canvas5);
+let buffer246 = device0.createBuffer({
+  size: 6368,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let renderBundle25 = renderBundleEncoder24.finish();
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup176, new Uint32Array(685), 73, 0);
+} catch {}
+try {
+renderPassEncoder71.executeBundles([renderBundle4, renderBundle0, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder77.setVertexBuffer(4, buffer40, 0);
+} catch {}
+document.body.prepend(canvas3);
+try {
+renderPassEncoder78.setIndexBuffer(buffer75, 'uint16', 3_134, 6_341);
+} catch {}
+let textureView300 = texture96.createView({dimension: '2d'});
+try {
+renderPassEncoder65.executeBundles([renderBundle14, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline32);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 130, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData27,
+  origin: { x: 4, y: 0 },
+  flipY: true,
+}, {
+  texture: texture286,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData49 = new ImageData(32, 28);
+let buffer247 = device0.createBuffer({size: 29894, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder175.setBindGroup(0, bindGroup69, new Uint32Array(24), 3, 0);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup158);
+} catch {}
+try {
+renderPassEncoder25.setStencilReference(1420);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer30, 'uint32', 1_948, 656);
+} catch {}
+try {
+renderPassEncoder61.setVertexBuffer(4, buffer177, 672, 3_389);
+} catch {}
+let recycledExplicitBindGroupLayout97 = pipeline36.getBindGroupLayout(0);
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthStencilFormat: 'stencil8', depthReadOnly: true});
+let renderBundle26 = renderBundleEncoder26.finish({});
+try {
+renderPassEncoder77.setBindGroup(2, bindGroup185);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline47);
+} catch {}
+try {
+buffer68.unmap();
+} catch {}
+let recycledExplicitBindGroupLayout98 = pipeline4.getBindGroupLayout(0);
+let buffer248 = device0.createBuffer({
+  size: 537,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture292 = device0.createTexture({size: [144, 654, 3], mipLevelCount: 2, format: 'astc-6x6-unorm', usage: GPUTextureUsage.COPY_DST});
+try {
+renderPassEncoder56.setBindGroup(0, bindGroup77, new Uint32Array(4317), 573, 0);
+} catch {}
+try {
+renderPassEncoder84.setIndexBuffer(buffer0, 'uint32', 404, 845);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline32);
+} catch {}
+try {
+  await buffer190.mapAsync(GPUMapMode.READ, 9624, 4816);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 260, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 1, y: 4 },
+  flipY: true,
+}, {
+  texture: texture227,
+  mipLevel: 0,
+  origin: {x: 40, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+document.body.append(canvas1);
+let autogeneratedBindGroupLayout39 = pipeline21.getBindGroupLayout(0);
+let bindGroup190 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [
+    {binding: 41, resource: {buffer: buffer17, offset: 4352}},
+    {binding: 119, resource: {buffer: buffer106, offset: 2560, size: 711}},
+    {binding: 977, resource: {buffer: buffer68, offset: 0}},
+    {binding: 46, resource: externalTexture4},
+    {binding: 48, resource: textureView2},
+    {binding: 83, resource: {buffer: buffer113, offset: 768, size: 1782}},
+    {binding: 162, resource: textureView276},
+  ],
+});
+let texture293 = device0.createTexture({
+  size: [1206, 210, 1],
+  format: 'astc-6x6-unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler200 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 73.08,
+});
+try {
+renderPassEncoder80.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderPassEncoder80.setBindGroup(0, bindGroup31, new Uint32Array(4215), 144, 0);
+} catch {}
+try {
+renderPassEncoder71.executeBundles([renderBundle22]);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer48, 'uint16', 1_902, 513);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup133);
+} catch {}
+try {
+renderPassEncoder51.executeBundles([renderBundle18, renderBundle18]);
+} catch {}
+let arrayBuffer32 = buffer123.getMappedRange(0, 0);
+let pipeline58 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {module: shaderModule9, targets: [{format: 'rg32uint'}]},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex4',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 820,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 16, shaderLocation: 9},
+          {format: 'float16x4', offset: 92, shaderLocation: 12},
+          {format: 'uint16x4', offset: 4, shaderLocation: 15},
+          {format: 'snorm16x2', offset: 96, shaderLocation: 10},
+          {format: 'uint8x2', offset: 4, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 84, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', unclippedDepth: true},
+});
+let imageData50 = new ImageData(56, 48);
+try {
+{ clearResourceUsages(device0, computePassEncoder87); computePassEncoder87.dispatchWorkgroupsIndirect(buffer150, 2_064); };
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(2, bindGroup18, []);
+} catch {}
+try {
+renderPassEncoder84.setVertexBuffer(1, buffer48);
+} catch {}
+document.body.prepend(img0);
+let recycledExplicitBindGroupLayout99 = pipeline7.getBindGroupLayout(0);
+let buffer249 = device0.createBuffer({size: 1816, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView301 = texture284.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 34});
+let textureView302 = texture210.createView({
+  label: '\u{1fe90}\u{1f9d8}\u{1fa58}\ud01b\u{1f75a}\u{1f97d}\u2896\u0f48\u0999\u{1f97a}',
+  aspect: 'all',
+  format: 'r32sint',
+  mipLevelCount: 1,
+});
+try {
+computePassEncoder126.setBindGroup(2, bindGroup170);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder230); computePassEncoder230.dispatchWorkgroupsIndirect(buffer170, 104); };
+} catch {}
+try {
+renderPassEncoder68.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(1, bindGroup117, new Uint32Array(1484), 53, 0);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle4, renderBundle0, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder35.setBlendConstant({ r: -859.4, g: -674.2, b: -6.389, a: -475.3, });
+} catch {}
+try {
+computePassEncoder230.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer181, 1504, new Int16Array(11499), 1744, 4);
+} catch {}
+let querySet42 = device0.createQuerySet({type: 'occlusion', count: 8});
+let texture294 = device0.createTexture({
+  size: [260],
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder46); computePassEncoder46.dispatchWorkgroupsIndirect(buffer168, 188); };
+} catch {}
+try {
+device0.queue.writeBuffer(buffer223, 8196, new Int16Array(5330), 1341, 0);
+} catch {}
+let texture295 = device0.createTexture({
+  size: [32, 1, 9],
+  mipLevelCount: 1,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let externalTexture28 = device0.importExternalTexture({source: videoFrame45});
+try {
+computePassEncoder87.setBindGroup(0, bindGroup65);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup124, new Uint32Array(471), 46, 0);
+} catch {}
+try {
+renderPassEncoder65.beginOcclusionQuery(76);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle23, renderBundle13]);
+} catch {}
+let arrayBuffer33 = buffer100.getMappedRange(896, 8);
+try {
+renderPassEncoder71.executeBundles([renderBundle22]);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(1, 0, 10, 0);
+} catch {}
+let buffer250 = device0.createBuffer({
+  size: 756,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let texture296 = device0.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 39},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder153.setBindGroup(2, bindGroup137);
+} catch {}
+try {
+computePassEncoder163.setBindGroup(0, bindGroup18, new Uint32Array(2182), 69, 0);
+} catch {}
+try {
+renderPassEncoder65.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer32, 'uint32', 76, 135);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 2, y: 45 },
+  flipY: false,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture297 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler201 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', lodMaxClamp: 88.97});
+try {
+computePassEncoder100.setBindGroup(3, bindGroup100, new Uint32Array(793), 374, 0);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(0, bindGroup172, new Uint32Array(114), 18, 0);
+} catch {}
+let recycledExplicitBindGroupLayout100 = pipeline16.getBindGroupLayout(0);
+let buffer251 = device0.createBuffer({
+  size: 9734,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture298 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 15},
+  mipLevelCount: 2,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView303 = texture251.createView({});
+try {
+renderPassEncoder48.setBindGroup(1, bindGroup171);
+} catch {}
+try {
+renderPassEncoder93.setBindGroup(3, bindGroup77, new Uint32Array(2117), 416, 0);
+} catch {}
+try {
+computePassEncoder61.insertDebugMarker('\u01f3');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture224,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(286).fill(79), /* required buffer size: 286 */
+{offset: 286}, {width: 260, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+globalThis.someLabel = textureView67.label;
+} catch {}
+let buffer252 = device0.createBuffer({
+  size: 12850,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView304 = texture96.createView({dimension: '2d', aspect: 'stencil-only', arrayLayerCount: 1});
+let sampler202 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+});
+try {
+computePassEncoder40.setBindGroup(2, bindGroup67);
+} catch {}
+try {
+renderPassEncoder77.setBindGroup(0, bindGroup171, new Uint32Array(117), 5, 0);
+} catch {}
+try {
+renderPassEncoder25.setScissorRect(1, 0, 1, 0);
+} catch {}
+try {
+renderPassEncoder59.setVertexBuffer(2, buffer173, 224);
+} catch {}
+try {
+buffer231.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 32, height: 1, depthOrArrayLayers: 594}
+*/
+{
+  source: videoFrame48,
+  origin: { x: 19, y: 0 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 266},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas3);
+let shaderModule23 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+alias vec3b = vec3<bool>;
+
+struct T0 {
+  f0: array<f32, 1>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct VertexOutput18 {
+  @invariant @builtin(position) f59: vec4f,
+}
+
+@group(0) @binding(498) var st14: texture_storage_1d<r32uint, write>;
+
+struct FragmentOutput18 {
+  @location(0) f0: vec2u,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@vertex
+fn vertex21(@location(0) a0: i32, @location(12) @interpolate(flat, center) a1: i32) -> VertexOutput18 {
+  var out: VertexOutput18;
+  out.f59 = unpack2x16snorm(u32(unconst_u32(99))).rrgg;
+  let vf338: vec4u = countTrailingZeros(vec4u(unconst_u32(43), unconst_u32(209), unconst_u32(129), unconst_u32(136)));
+  out = VertexOutput18(unpack4x8snorm(pack4xU8(vec4u(unconst_u32(68), unconst_u32(226), unconst_u32(460), unconst_u32(32)))));
+  out = VertexOutput18(vec4f(bitcast<f32>(a0)));
+  let vf339: vec4u = countTrailingZeros(vec4u(unconst_u32(460), unconst_u32(99), unconst_u32(40), unconst_u32(566)));
+  return out;
+}
+
+@fragment
+fn fragment21() -> FragmentOutput18 {
+  var out: FragmentOutput18;
+  var vf340: vec4u = max(vec4u(unconst_u32(11), unconst_u32(73), unconst_u32(122), unconst_u32(181)), vec4u(unconst_u32(94), unconst_u32(25), unconst_u32(37), unconst_u32(83)));
+  var vf341: f32 = log(f32(unconst_f32(0.04999)));
+  vf341 = bitcast<f32>(pack2x16snorm(vec2f(unconst_f32(0.05032), unconst_f32(0.02862))));
+  var vf342: f16 = log2(f16(unconst_f16(9493.2)));
+  var vf343: f32 = fract(bitcast<f32>(vf340[u32(unconst_u32(178))]));
+  var vf344: u32 = vf340[u32(unconst_u32(65))];
+  let vf345: vec4f = refract(vec4f(unconst_f32(0.1999), unconst_f32(0.2053), unconst_f32(0.02203), unconst_f32(0.3281)), vec4f(unconst_f32(0.01544), unconst_f32(0.02660), unconst_f32(0.1038), unconst_f32(0.3004)), f32(vf340[pack4x8unorm(refract(vec4f(unconst_f32(0.07285), unconst_f32(0.03919), unconst_f32(0.2614), unconst_f32(0.00525)), vec4f(unconst_f32(0.3151), unconst_f32(0.08253), unconst_f32(0.08211), unconst_f32(-0.08378)), f32(unconst_f32(0.1117))))]));
+  vf341 *= refract(vec4f(unconst_f32(0.09054), unconst_f32(0.3044), unconst_f32(0.00080), unconst_f32(0.04831)), vec4f(unconst_f32(0.03739), unconst_f32(0.2143), unconst_f32(-0.02647), unconst_f32(0.1120)), f32(unconst_f32(0.2428)))[2];
+  let ptr254: ptr<function, u32> = &vf344;
+  vf341 = log(f32(unconst_f32(0.1155)));
+  let ptr255: ptr<function, f16> = &vf342;
+  let ptr256: ptr<function, vec4u> = &vf340;
+  let ptr257: ptr<function, vec4u> = &vf340;
+  let vf346: u32 = (*ptr257)[u32(unconst_u32(446))];
+  vf340 = (*ptr256);
+  let vf347: vec4f = vf345;
+  vf341 = vf345[3];
+  let vf348: u32 = pack2x16snorm(vec2f(unconst_f32(0.02345), unconst_f32(0.02636)));
+  vf344 = pack4xU8(max(vec4u(unconst_u32(378), unconst_u32(393), unconst_u32(2), unconst_u32(35)), vec4u(unconst_u32(141), unconst_u32(30), unconst_u32(210), unconst_u32(147))));
+  out.f0 += (*ptr256).yz;
+  let ptr258: ptr<function, vec4u> = &(*ptr256);
+  var vf349: f16 = distance(f16(unconst_f16(13907.3)), f16(unconst_f16(10084.0)));
+  var vf350: f32 = log(f32(unconst_f32(0.01177)));
+  vf344 >>= u32(vf341);
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute21() {
+  var vf351: vec4f = atan(vec4f(f32(dot4U8Packed(u32(unconst_u32(66)), vec4u(normalize(vec4h(unpack4x8unorm(u32(unconst_u32(365)))))).x))));
+  var vf352: vec3f = clamp(vec3f(unconst_f32(0.1124), unconst_f32(0.1930), unconst_f32(0.04631)), vec3f(unconst_f32(0.3466), unconst_f32(-0.03329), unconst_f32(0.1798)), vec3f(unconst_f32(0.09850), unconst_f32(0.1571), unconst_f32(0.3154)));
+  let ptr259: ptr<function, vec3f> = &vf352;
+  let ptr260: ptr<function, vec3f> = &(*ptr259);
+  textureStore(st14, i32(unconst_i32(489)), vec4u(vec4u(unconst_u32(85), unconst_u32(6), unconst_u32(29), unconst_u32(2))));
+  textureStore(st14, i32(unconst_i32(6)), vec4u(vec4u(normalize(vec4h(unconst_f16(-1380.9), unconst_f16(8055.5), unconst_f16(1431.1), unconst_f16(-9866.3))))));
+  vf351 += vec4f(bitcast<f32>(dot4U8Packed(u32(unconst_u32(97)), u32(unconst_u32(8)))));
+  vf352 -= atan(vec4f(unconst_f32(0.1138), unconst_f32(0.2764), unconst_f32(-0.02413), unconst_f32(0.1456))).xxw;
+  var vf353: f32 = vf351[u32(unconst_u32(178))];
+  _ = st14;
+}`,
+});
+let autogeneratedBindGroupLayout40 = pipeline27.getBindGroupLayout(0);
+let textureView305 = texture37.createView({dimension: '1d', baseArrayLayer: 0});
+try {
+{ clearResourceUsages(device0, computePassEncoder154); computePassEncoder154.dispatchWorkgroupsIndirect(buffer237, 1_628); };
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(3, buffer194, 2_052);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(2, bindGroup161);
+} catch {}
+let recycledExplicitBindGroupLayout101 = pipeline26.getBindGroupLayout(0);
+let bindGroup191 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout20,
+  entries: [{binding: 41, resource: {buffer: buffer45, offset: 0, size: 272}}],
+});
+let buffer253 = device0.createBuffer({
+  size: 13908,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let externalTexture29 = device0.importExternalTexture({source: videoFrame39});
+try {
+renderPassEncoder0.setIndexBuffer(buffer62, 'uint16', 1_460, 1_134);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let bindGroup192 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout46,
+  entries: [
+    {binding: 41, resource: {buffer: buffer81, offset: 768}},
+    {binding: 48, resource: textureView13},
+    {binding: 119, resource: {buffer: buffer115, offset: 512, size: 118}},
+    {binding: 977, resource: {buffer: buffer62, offset: 5120, size: 6042}},
+    {binding: 46, resource: externalTexture28},
+    {binding: 83, resource: {buffer: buffer91, offset: 0, size: 7}},
+    {binding: 162, resource: textureView281},
+  ],
+});
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline37);
+} catch {}
+let buffer254 = device0.createBuffer({size: 2890, usage: GPUBufferUsage.MAP_READ});
+let texture299 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture300 = device0.createTexture({
+  size: [65, 1, 3],
+  mipLevelCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture301 = gpuCanvasContext16.getCurrentTexture();
+let textureView306 = texture85.createView({dimension: '2d-array', baseArrayLayer: 0});
+try {
+computePassEncoder175.setBindGroup(3, bindGroup1, new Uint32Array(2915), 1_015, 0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup178);
+} catch {}
+try {
+renderPassEncoder67.setBindGroup(2, bindGroup29, new Uint32Array(170), 25, 0);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer114, 'uint16', 10_202, 113);
+} catch {}
+try {
+renderPassEncoder56.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder92.setVertexBuffer(4, buffer174, 0);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let buffer255 = device0.createBuffer({
+  size: 3143,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture302 = device0.createTexture({
+  size: {width: 4, height: 4, depthOrArrayLayers: 17},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView307 = texture144.createView({dimension: '2d', mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder87); computePassEncoder87.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(4, buffer109, 0, 5_299);
+} catch {}
+try {
+globalThis.someLabel = veryExplicitBindGroupLayout12.label;
+} catch {}
+let bindGroup193 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout8,
+  entries: [{binding: 41, resource: {buffer: buffer197, offset: 6400, size: 3264}}],
+});
+try {
+renderPassEncoder56.setViewport(0.2550369282217506, 1.1267188740440792, 3.3748435576731097, 2.3251295430669883, 0.3179178992397452, 0.6390518867315133);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(6, undefined, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture299,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(64).fill(72), /* required buffer size: 64 */
+{offset: 64, rowsPerImage: 1}, {width: 49, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 65, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 15, y: 1 },
+  flipY: false,
+}, {
+  texture: texture221,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline59 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule23, constants: {}}});
+let recycledExplicitBindGroupLayout102 = pipeline11.getBindGroupLayout(0);
+let texture303 = device0.createTexture({
+  size: {width: 65, height: 1, depthOrArrayLayers: 18},
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView308 = texture148.createView({});
+let sampler203 = device0.createSampler({addressModeU: 'mirror-repeat', lodMaxClamp: 96.39});
+try {
+renderPassEncoder41.setVertexBuffer(7, undefined, 0, 1_069_115_188);
+} catch {}
+try {
+buffer216.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline60 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule20}});
+let textureView309 = texture243.createView({mipLevelCount: 1});
+let sampler204 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 56.91,
+  maxAnisotropy: 1,
+});
+try {
+  await shaderModule9.getCompilationInfo();
+} catch {}
+await gc();
+let bindGroup194 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout27,
+  entries: [
+    {binding: 162, resource: textureView190},
+    {binding: 41, resource: {buffer: buffer226, offset: 1536, size: 1272}},
+    {binding: 46, resource: externalTexture2},
+    {binding: 83, resource: {buffer: buffer106, offset: 512, size: 530}},
+    {binding: 48, resource: textureView13},
+    {binding: 977, resource: {buffer: buffer244, offset: 768, size: 325}},
+    {binding: 119, resource: {buffer: buffer198, offset: 0}},
+  ],
+});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup189);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder209); computePassEncoder209.dispatchWorkgroups(1); };
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 65, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture221,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout103 = pipeline11.getBindGroupLayout(0);
+let textureView310 = texture132.createView({baseMipLevel: 0});
+let sampler205 = device0.createSampler({
+  label: '\u{1fc22}\uf306\u39da\u65ca\u2f40\u0a62\u92e8',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 95.66,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder209); computePassEncoder209.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder81.executeBundles([renderBundle17, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder59.setBlendConstant({ r: 104.4, g: -573.8, b: 48.49, a: 405.6, });
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer1, 'uint32', 1_020, 512);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(1, buffer52, 2_380, 1_759);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let promise38 = device0.createComputePipelineAsync({layout: pipelineLayout23, compute: {module: shaderModule12, entryPoint: 'compute11'}});
+try {
+computePassEncoder140.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 4, depthOrArrayLayers: 41}
+*/
+{
+  source: videoFrame42,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture230,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas8);
+let bindGroup195 = device0.createBindGroup({layout: autogeneratedBindGroupLayout27, entries: [{binding: 31, resource: textureView105}]});
+let texture304 = device0.createTexture({
+  size: {width: 4, height: 4, depthOrArrayLayers: 17},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler206 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'always',
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup168, new Uint32Array(1083), 85, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 65, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData36,
+  origin: { x: 3, y: 0 },
+  flipY: true,
+}, {
+  texture: texture221,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet43 = device0.createQuerySet({type: 'occlusion', count: 2012});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({colorFormats: ['rg32uint'], sampleCount: 1});
+try {
+renderPassEncoder47.setBindGroup(1, bindGroup119, new Uint32Array(551), 53, 0);
+} catch {}
+try {
+renderPassEncoder62.setIndexBuffer(buffer160, 'uint16', 4_068, 1_528);
+} catch {}
+let texture305 = device0.createTexture({
+  size: {width: 130, height: 1, depthOrArrayLayers: 148},
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle27 = renderBundleEncoder27.finish();
+let sampler207 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+computePassEncoder54.setBindGroup(3, bindGroup25, new Uint32Array(4931), 288, 0);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(0, bindGroup63, new Uint32Array(401), 321, 0);
+} catch {}
+try {
+renderPassEncoder93.setPipeline(pipeline11);
+} catch {}
+try {
+buffer93.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer92, 236, new Int16Array(993), 50, 292);
+} catch {}
+let veryExplicitBindGroupLayout49 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 49,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 95,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 101,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 258,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 315,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+try {
+computePassEncoder46.end();
+} catch {}
+try {
+renderPassEncoder79.executeBundles([renderBundle17]);
+} catch {}
+try {
+renderPassEncoder85.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder88.setIndexBuffer(buffer45, 'uint16', 634, 789);
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer174, 8, buffer32, 120, 28);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture94,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(129).fill(125), /* required buffer size: 129 */
+{offset: 129}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData51 = new ImageData(20, 104);
+let videoFrame55 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'jedecP22Phosphors', transfer: 'bt1361ExtendedColourGamut'} });
+let veryExplicitBindGroupLayout50 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 216,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+    {binding: 346, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let bindGroup196 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout99,
+  entries: [
+    {binding: 41, resource: {buffer: buffer26, offset: 33024, size: 156}},
+    {binding: 48, resource: textureView2},
+    {binding: 162, resource: textureView210},
+    {binding: 46, resource: externalTexture17},
+    {binding: 83, resource: {buffer: buffer18, offset: 0, size: 624}},
+    {binding: 977, resource: {buffer: buffer234, offset: 512, size: 65}},
+    {binding: 119, resource: {buffer: buffer109, offset: 0}},
+  ],
+});
+let computePassEncoder242 = commandEncoder54.beginComputePass({});
+let externalTexture30 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder110.setBindGroup(0, bindGroup119);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder87); computePassEncoder87.dispatchWorkgroupsIndirect(buffer83, 616); };
+} catch {}
+try {
+computePassEncoder242.setPipeline(pipeline52);
+} catch {}
+let promise39 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise37;
+} catch {}
+document.body.prepend(canvas10);
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame23.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+videoFrame41.close();
+videoFrame42.close();
+videoFrame43.close();
+videoFrame45.close();
+videoFrame47.close();
+videoFrame48.close();
+videoFrame49.close();
+videoFrame50.close();
+videoFrame51.close();
+videoFrame52.close();
+videoFrame53.close();
+videoFrame54.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -217,7 +217,7 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
 
     if (m_shaderModule.usesExternalTextures()) {
         m_shaderModule.clearUsesExternalTextures();
-        m_stringBuilder.append("struct texture_external {\n"_s);
+        m_stringBuilder.append("struct __attribute__((packed)) texture_external {\n"_s);
         {
             IndentationScope scope(m_indent);
             m_stringBuilder.append(m_indent, "texture2d<float> FirstPlane;\n"_s,


### PR DESCRIPTION
#### 32ff5579026f4b0796e3d5ac473a9a7b316e3067
<pre>
[WebGPU] Unused external textures result in struct size mismatches
<a href="https://bugs.webkit.org/show_bug.cgi?id=283071">https://bugs.webkit.org/show_bug.cgi?id=283071</a>
<a href="https://rdar.apple.com/139732445">rdar://139732445</a>

Reviewed by Tadeu Zagallo.

In order to be able to place an unused texture_external instance directly
inside a struct, we need to pack it to single byte alignment otherwise there
is a size mismatch compared to a used texture_external which has its members
placed inline within the AB.

* LayoutTests/fast/webgpu/nocrash/fuzz-283071-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-283071.html: Added.
Add regression test.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):

Canonical link: <a href="https://commits.webkit.org/286594@main">https://commits.webkit.org/286594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8439e528d6773d8a2314cdfd3cf80ef4708065b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29238 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80849 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27608 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3662 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59856 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17979 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65556 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40196 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47155 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23046 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/25930 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68282 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82303 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2436 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68084 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3862 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67390 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16825 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11355 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9454 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3656 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3679 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7108 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5437 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->