### PR TITLE
text-autospace: Trim spacing between text runs placed on different lines

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3194,7 +3194,6 @@ imported/w3c/web-platform-tests/css/css-text/text-align/text-align-justify-tabs-
 imported/w3c/web-platform-tests/css/css-text/text-align/text-align-justify-tabs-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/text-align/text-align-justify-tabs-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/text-align/text-align-justify-tabs-004.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-break-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/text-justify/text-justify-word-separators.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-uppercase-dynamic.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/white-space/eol-spaces-bidi-004.html [ ImageOnlyFailure ]

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentCache.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentCache.h
@@ -48,6 +48,7 @@ public:
             bool requiresVisualReordering { false };
             // Note that <span>this is text</span> returns true as inline boxes are not considered 'content' here.
             bool hasTextAndLineBreakOnlyContent { false };
+            bool hasTextAutospace { false };
             size_t inlineBoxCount { 0 };
         };
         void set(InlineItemList&&, ContentAttributes);
@@ -59,6 +60,7 @@ public:
 
         bool requiresVisualReordering() const { return m_contentAttributes.requiresVisualReordering; }
         bool hasTextAndLineBreakOnlyContent() const { return m_contentAttributes.hasTextAndLineBreakOnlyContent; }
+        bool hasTextAutospace() const { return m_contentAttributes.hasTextAutospace; }
         bool hasInlineBoxes() const { return !!inlineBoxCount(); }
         size_t inlineBoxCount() const { return m_contentAttributes.inlineBoxCount; }
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -695,6 +695,11 @@ void LineBuilder::candidateContentForLine(LineCandidate& lineCandidate, size_t c
         }
         if (auto* inlineTextItem = dynamicDowncast<InlineTextItem>(inlineItem)) {
             auto logicalWidth = m_overflowingLogicalWidth ? *std::exchange(m_overflowingLogicalWidth, std::nullopt) : formattingContext().formattingUtils().inlineItemWidth(*inlineTextItem, currentLogicalRight, isFirstFormattedLine());
+            // if (!currentLogicalRight) {
+            if (!currentLogicalRight) {
+                if (auto trimmableSpacing = m_textSpacingContext.trimmableTextSpacings.find(index); trimmableSpacing != m_textSpacingContext.trimmableTextSpacings.end())
+                    logicalWidth -= trimmableSpacing->value;
+            }
             lineCandidate.inlineContent.appendInlineItem(*inlineTextItem, style, logicalWidth);
             // Word spacing does not make the run longer, but it produces an offset instead. See Line::appendTextContent as well.
             currentLogicalRight += logicalWidth + (inlineTextItem->isWordSeparator() ? style.fontCascade().wordSpacing() : 0.f);

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineTypes.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineTypes.h
@@ -36,7 +36,9 @@ using InlineBoxBoundaryTextSpacings = WTF::HashMap<size_t, float, DefaultHash<si
 using TrimmableTextSpacings = InlineBoxBoundaryTextSpacings;
 
 struct TextSpacingContext {
+    // InlineBoxBoundaryTextSpacings maps inline item indexes to spacing. It serves to identify start boxes that mark spacing between boxes boundaries. If we have start box with an entry here, this means that we have to add spacing between this start box and the previous box. We need to account for it during layout and to reproduce such spacing among 2 boxes during display. Therefore, this serve for identifying spacing between box boundaries such that we can both: add these spacing into layout/display and trim this spacing during line breaking if needed.
     InlineBoxBoundaryTextSpacings inlineBoxBoundaryTextSpacings;
+    // TrimmableTextSpacings map inline item indexes to spacing. Text content can be split into multiple different inline text items. This structure serves to identify spacing that was added to a text item because of its adjacency to another text item. Ex: if we have 2 text items A and B, and the last character of A and the first character of B require spacing to be added between them. This spacing is always added as a leading spacing to B. However, during line breaking, if B gets placed on a different line as A, they are no longer adjacent and we must trim such spacing. We don't use this map for actually adding the spacing, just for trimming it. Therefore this maps serves only to identify trimmable spacing between text runs. Maybe this can be called TrimmableTextSpacingBetweenTextItems or something.
     TrimmableTextSpacings trimmableTextSpacings;
 };
 

--- a/Source/WebCore/layout/formattingContexts/inline/RangeBasedLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/RangeBasedLineBuilder.cpp
@@ -110,7 +110,7 @@ bool RangeBasedLineBuilder::isEligibleForRangeInlineLayout(const InlineFormattin
         return false;
 
     // Check the nested text content.
-    if (!inlineItems.hasTextAndLineBreakOnlyContent() || inlineItems.requiresVisualReordering() || !placedFloats.isEmpty())
+    if (!inlineItems.hasTextAndLineBreakOnlyContent() || inlineItems.requiresVisualReordering() || !placedFloats.isEmpty() || inlineItems.hasTextAutospace())
         return false;
 
     if (!TextOnlySimpleLineBuilder::isEligibleForSimplifiedInlineLayoutByStyle(inlineFormattingContext.root().style()) || !TextOnlySimpleLineBuilder::isEligibleForSimplifiedInlineLayoutByStyle(inlineBox.style()))

--- a/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
@@ -445,7 +445,7 @@ bool TextOnlySimpleLineBuilder::isEligibleForSimplifiedTextOnlyInlineLayoutByCon
 {
     if (inlineItems.isEmpty())
         return false;
-    if (!inlineItems.hasTextAndLineBreakOnlyContent() || inlineItems.hasInlineBoxes() || inlineItems.requiresVisualReordering())
+    if (!inlineItems.hasTextAndLineBreakOnlyContent() || inlineItems.hasInlineBoxes() || inlineItems.requiresVisualReordering() || inlineItems.hasTextAutospace())
         return false;
     if (!placedFloats.isEmpty())
         return false;


### PR DESCRIPTION
#### db30cc63c7ac0e8a61e33b2dcf0b5089e46e3482
<pre>
text-autospace: Trim spacing between text runs placed on different lines
<a href="https://bugs.webkit.org/show_bug.cgi?id=283079">https://bugs.webkit.org/show_bug.cgi?id=283079</a>
<a href="https://rdar.apple.com/139824338">rdar://139824338</a>

Reviewed by Alan Baradlay.

Text content can be split into multiple different inline text items.
At this patch we use TrimmableTextSpacings in the TextSpacingContext to identify spacing that was added to a text item because of
its adjacency to another text item.

Ex: if we have 2 text items A and B, and the last character of A and the first character of B require spacing to be added between them.
This spacing is always added as a leading spacing to B. However, during line breaking, if B gets placed on a different line as A, they
are no longer adjacent and we must trim such spacing.

* LayoutTests/TestExpectations:
* Source/WebCore/layout/formattingContexts/inline/InlineContentCache.h:
(WebCore::Layout::InlineContentCache::InlineItems::hasTextAutospace const):
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::build):
(WebCore::Layout::handleTextSpacing):
(WebCore::Layout::InlineItemsBuilder::computeInlineTextItemWidths):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::candidateContentForLine):
* Source/WebCore/layout/formattingContexts/inline/InlineLineTypes.h:
* Source/WebCore/layout/formattingContexts/inline/RangeBasedLineBuilder.cpp:
(WebCore::Layout::RangeBasedLineBuilder::isEligibleForRangeInlineLayout):
* Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp:
(WebCore::Layout::TextOnlySimpleLineBuilder::isEligibleForSimplifiedTextOnlyInlineLayoutByContent):

Canonical link: <a href="https://commits.webkit.org/286630@main">https://commits.webkit.org/286630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee3c3b1c0e4f9d5328010ca7dda7f39a0c91a48c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81095 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27844 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3896 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60018 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18122 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65744 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40343 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47336 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23237 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26168 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68458 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82544 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3944 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/2589 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68300 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65716 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67548 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16854 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11521 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3891 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6700 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3914 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7344 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5672 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->