### PR TITLE
[TZone] Fix a couple of TZone annotations

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebProcessSyncClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebProcessSyncClient.cpp
@@ -31,8 +31,11 @@
 #include "WebPageProxyMessages.h"
 #include <WebCore/Page.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebProcessSyncClient);
 
 WebProcessSyncClient::WebProcessSyncClient(WebPage& webPage)
     : m_page(webPage)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebProcessSyncClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebProcessSyncClient.h
@@ -34,7 +34,7 @@ namespace WebKit {
 class WebPage;
 
 class WebProcessSyncClient :  public WebCore::ProcessSyncClient {
-    WTF_MAKE_TZONE_ALLOCATED(WebCryptoClient);
+    WTF_MAKE_TZONE_ALLOCATED(WebProcessSyncClient);
 public:
     WebProcessSyncClient(WebPage&);
     ~WebProcessSyncClient() = default;


### PR DESCRIPTION
#### 99f58d6bd884cf67dec4a7fee1d884e2886d3f58
<pre>
[TZone] Fix a couple of TZone annotations
<a href="https://bugs.webkit.org/show_bug.cgi?id=283080">https://bugs.webkit.org/show_bug.cgi?id=283080</a>
<a href="https://rdar.apple.com/139826390">rdar://139826390</a>

Reviewed by Yusuke Suzuki.

Fixed the TZone annotation in WebProcessSyncClient.h and added the corresponding IMPL annotation to WebProcessSyncClient.cpp

* Source/WebKit/WebProcess/WebCoreSupport/WebProcessSyncClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebProcessSyncClient.h:

Canonical link: <a href="https://commits.webkit.org/286735@main">https://commits.webkit.org/286735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa4b2c23b82e1259f8495f9d4ef2ecfaf68ca8e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29866 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81506 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28236 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4288 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18391 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50255 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/66066 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/40632 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47657 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26563 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/68784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82940 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4336 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/2912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/4501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66039 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67842 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16899 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4283 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4306 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/7747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->