### PR TITLE
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF/

### DIFF
--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -251,7 +251,7 @@ WTF_EXTERN_C_BEGIN
 WTF_EXPORT_PRIVATE extern bool WTFSignpostIndirectLoggingEnabled;
 
 WTF_EXPORT_PRIVATE os_log_t WTFSignpostLogHandle();
-WTF_EXPORT_PRIVATE bool WTFSignpostHandleIndirectLog(os_log_t, pid_t, const char* line);
+WTF_EXPORT_PRIVATE bool WTFSignpostHandleIndirectLog(os_log_t, pid_t, std::span<const char> nullTerminatedLogString);
 
 WTF_EXPORT_PRIVATE uint64_t WTFCurrentContinuousTime(Seconds deltaFromNow);
 

--- a/Source/WTF/wtf/cf/VectorCF.h
+++ b/Source/WTF/wtf/cf/VectorCF.h
@@ -33,8 +33,6 @@
 #include <wtf/cf/TypeCastsCF.h>
 #include <wtf/text/WTFString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 template <typename A, typename... B>
@@ -164,12 +162,12 @@ template<typename MapLambdaType> Vector<typename LambdaTypeTraits<MapLambdaType>
 
 inline std::span<const uint8_t> span(CFDataRef data)
 {
-    return { static_cast<const uint8_t*>(CFDataGetBytePtr(data)), Checked<size_t>(CFDataGetLength(data)) };
+    return unsafeMakeSpan(static_cast<const uint8_t*>(CFDataGetBytePtr(data)), Checked<size_t>(CFDataGetLength(data)));
 }
 
 inline std::span<uint8_t> mutableSpan(CFMutableDataRef data)
 {
-    return { static_cast<uint8_t*>(CFDataGetMutableBytePtr(data)), Checked<size_t>(CFDataGetLength(data)) };
+    return unsafeMakeSpan(static_cast<uint8_t*>(CFDataGetMutableBytePtr(data)), Checked<size_t>(CFDataGetLength(data)));
 }
 
 inline RetainPtr<CFDataRef> toCFData(std::span<const uint8_t> span)
@@ -203,7 +201,5 @@ using WTF::makeVector;
 using WTF::mutableSpan;
 using WTF::span;
 using WTF::toCFData;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(CF)

--- a/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
+++ b/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
@@ -34,8 +34,6 @@
 #import <wtf/ResourceUsage.h>
 #import <wtf/spi/darwin/DispatchSPI.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 #define ENABLE_FMW_FOOTPRINT_COMPARISON 0
 
 extern "C" void cache_simulate_memory_warning_event(uint64_t);
@@ -66,7 +64,7 @@ static OSObjectPtr<dispatch_source_t>& timerEventSource()
 // One token for each of the memory pressure/memory warning notifications we listen for.
 // notifyutil -p org.WebKit.lowMemory[.begin/.end]
 // notifyutil -p org.WebKit.memoryWarning[.begin/.end]
-static int notifyTokens[6];
+static std::array<int, 6> notifyTokens;
 
 // Disable memory event reception for a minimum of s_minimumHoldOffTime
 // seconds after receiving an event. Don't let events fire any sooner than
@@ -246,5 +244,3 @@ std::optional<MemoryPressureHandler::ReliefLogger::MemoryUsage> MemoryPressureHa
 } // namespace WTF
 
 #undef LOG_CHANNEL_PREFIX
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/cocoa/SpanCocoa.h
+++ b/Source/WTF/wtf/cocoa/SpanCocoa.h
@@ -36,9 +36,7 @@ inline std::span<const uint8_t> span(NSData *data)
     if (!data)
         return { };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    return { static_cast<const uint8_t*>(data.bytes), data.length };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    return unsafeMakeSpan(static_cast<const uint8_t*>(data.bytes), data.length);
 }
 
 inline RetainPtr<NSData> toNSData(std::span<const uint8_t> span)


### PR DESCRIPTION
#### b62be076bbad66f31a14460afb6e5a91268d5094
<pre>
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF/
<a href="https://bugs.webkit.org/show_bug.cgi?id=283081">https://bugs.webkit.org/show_bug.cgi?id=283081</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/SystemTracing.h:
* Source/WTF/wtf/cf/VectorCF.h:
(WTF::span):
(WTF::mutableSpan):
* Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm:
* Source/WTF/wtf/cocoa/NSURLExtras.mm:
(WTF::dataWithUserTypedString):
(WTF::URLWithUserTypedString):
(WTF::URLWithUserTypedStringDeprecated):
(WTF::dataForURLComponentType):
(WTF::URLByRemovingComponentAndSubsequentCharacter):
(WTF::isUserVisibleURL):
* Source/WTF/wtf/cocoa/SpanCocoa.h:
(WTF::span):
* Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp:
(WTFSignpostHandleIndirectLog):
* Source/WTF/wtf/text/LineEnding.cpp:
(WTF::normalizeLineEndingsToLF):
(WTF::normalizeLineEndingsToCRLF):
* Source/WebKit/Shared/LogStream.cpp:
(WebKit::LogStream::logOnBehalfOfWebContent):

Canonical link: <a href="https://commits.webkit.org/286606@main">https://commits.webkit.org/286606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd6e3659c89823ffa67d0f365d26b5c37d3b9321

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80996 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27746 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3798 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59973 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18073 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40290 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47273 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23159 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26069 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69653 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68399 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23491 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82443 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75747 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3846 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2531 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68249 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3999 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65639 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/67495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11461 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9549 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98001 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11835 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3793 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6602 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21441 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3816 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7246 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5574 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->