### PR TITLE
[TZone] Add caching to unannotated subclass allocation path

### DIFF
--- a/Source/bmalloc/bmalloc/Map.h
+++ b/Source/bmalloc/bmalloc/Map.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+BALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #include "BInline.h"
 #include "Sizes.h"
 #include "Vector.h"
@@ -174,3 +176,5 @@ void Map<Key, Value, Hash, allowDeleting>::rehash()
 template<typename Key, typename Value, typename Hash, enum AllowDeleting allowDeleting> const unsigned Map<Key, Value, Hash, allowDeleting>::minCapacity;
 
 } // namespace bmalloc
+
+BALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/bmalloc/bmalloc/TZoneHeap.h
+++ b/Source/bmalloc/bmalloc/TZoneHeap.h
@@ -80,7 +80,7 @@ struct TZoneHeapBase {
 
     static pas_heap_ref& provideHeap()
     {
-        static bmalloc_type type = BMALLOC_TYPE_INITIALIZER(roundUpToMulipleOf8(sizeof(LibPasBmallocHeapType)), roundUpToMulipleOf8(alignof(LibPasBmallocHeapType)), __PRETTY_FUNCTION__);
+        static const bmalloc_type type = BMALLOC_TYPE_INITIALIZER(roundUpToMulipleOf8(sizeof(LibPasBmallocHeapType)), roundUpToMulipleOf8(alignof(LibPasBmallocHeapType)), __PRETTY_FUNCTION__);
         static pas_heap_ref* heap = nullptr;
 
         if (!heap)
@@ -93,11 +93,7 @@ struct TZoneHeapBase {
     {
         bmalloc_type type = BMALLOC_TYPE_INITIALIZER((unsigned)roundUpToMulipleOf8(differentSize), roundUpToMulipleOf8(alignof(LibPasBmallocHeapType)), __PRETTY_FUNCTION__);
 
-        TZONE_LOG_DEBUG("Unannotated TZone type %s:%d\n", __FILE__, __LINE__);
-        TZONE_LOG_DEBUG("  Super Class: %s\n", __PRETTY_FUNCTION__);
-
-        //  &&&& Should we figure out a way to cache this different sized heap?
-        return *TZoneHeapManager::singleton().heapRefForTZoneType(&type);
+        return *TZoneHeapManager::singleton().heapRefForTZoneTypeDifferentSize(&type);
     }
 };
 


### PR DESCRIPTION
#### 4f65486bf9555e0ebb199e1facd0c09851912daa
<pre>
[TZone] Add caching to unannotated subclass allocation path
<a href="https://bugs.webkit.org/show_bug.cgi?id=283083">https://bugs.webkit.org/show_bug.cgi?id=283083</a>
<a href="https://rdar.apple.com/problem/139827893">rdar://problem/139827893</a>

Reviewed by Yusuke Suzuki.

Added a new Map to cache the heaps created for unannotated subclasses of a TZone annotated super classes.
When a type has a TZone annotation via one of the WTF_MAKE_TZONE_ALLOCATED_* macros, a templated helper class
is created that static records the size and alignment of the annotated class.  When another class inherits
from such a class, that inheritance uses its super classes templated helpers to perform its allocations.
If the size of the subclass is larger, due to added member variables, it cannot reuse the super classes
normal helper because the derived class falls into a different TZone size class.  There is a seldom used
additional helper when the allocation size doesn&apos;t the static recorded size of the annotated super class.
Added a global cache in TZoneHeapManager that caches the heaps created for such unannotated derived classes.

Moved the log reporting out of the helper class code and put it in the newly created method,
heapRefForTZoneTypeDifferentSize, for creating and caching these heap.
Also made the TZone type description created for an annotated class to be const to save _DATA space in the
executable.

* Source/bmalloc/bmalloc/Map.h:
* Source/bmalloc/bmalloc/TZoneHeap.h:
(bmalloc::api::TZoneHeapBase::provideHeap):
* Source/bmalloc/bmalloc/TZoneHeapManager.cpp:
(bmalloc::api::TZoneHeapManager::tzoneBucketForKey):
(bmalloc::api::TZoneHeapManager::heapRefForTZoneType):
(bmalloc::api::TZoneHeapManager::TZoneHeapManager::heapRefForTZoneTypeDifferentSize):
* Source/bmalloc/bmalloc/TZoneHeapManager.h:
(bmalloc::api::TZoneHeapManager::TZoneTypeAndSize::TZoneTypeAndSize):
(bmalloc::api::TZoneHeapManager::TZoneTypeAndSize::key const):
(bmalloc::api::TZoneHeapManager::TZoneTypeAndSize::hash):
(bmalloc::api::TZoneHeapManager::TZoneTypeAndSize::operator== const):
(bmalloc::api::TZoneHeapManager::TZoneTypeAndSize::operator&lt; const):
(bmalloc::api::TZoneHeapManager::TZoneTypeAndSize::operator bool const):
(bmalloc::api::TZoneHeapManager::differentSizeMutex):

Canonical link: <a href="https://commits.webkit.org/286582@main">https://commits.webkit.org/286582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9b152343bcf885337acc919ea44cd579bd2e636

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80937 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27690 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3742 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/18028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79481 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/49824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/65618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/40243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/47219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/23107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26012 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69597 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/68345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/23439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82387 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75691 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3790 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/2479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3943 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/65587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/67443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/16818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/11404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/97945 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11826 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3737 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/21429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/3760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/7190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5518 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->