### PR TITLE
rewrite-compile-commands: handle compiler_commands.json with commands specified as array of arguments

### DIFF
--- a/Tools/Scripts/rewrite-compile-commands
+++ b/Tools/Scripts/rewrite-compile-commands
@@ -79,11 +79,18 @@ for entry in compile_commands:
                 include_file = os.path.join(d, include_path)
 
                 if os.path.exists(include_file):
-                    generated_compile_commands.append({
+                    renamed_entry = {
                         "directory": entry["directory"],
-                        "command": entry["command"].replace(entry_file, include_file),
                         "file": include_file,
-                    })
+                    }
+
+                    if "command" in entry:
+                        renamed_entry["command"] = entry["command"].replace(entry_file, include_file)
+                    else:
+                        renamed_arguments = [arg.replace(entry_file, include_file) for arg in entry["arguments"]]
+                        renamed_entry["arguments"] = renamed_arguments
+
+                    generated_compile_commands.append(renamed_entry)
                     break
 
 output_directory = os.path.dirname(args.output_file)


### PR DESCRIPTION
#### cf3127c02c78ff5b19895f6ff9b94b80ad424a71
<pre>
rewrite-compile-commands: handle compiler_commands.json with commands specified as array of arguments
<a href="https://rdar.apple.com/139827684">rdar://139827684</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=283082">https://bugs.webkit.org/show_bug.cgi?id=283082</a>

Reviewed by Alicia Boya Garcia.

rewrite-compile-commands assumes the compile commands are specified as one
single string, however Apple Clang specifies it as an array of arguments.
This is allowed per spec (<a href="https://clang.llvm.org/docs/JSONCompilationDatabase.html#format)">https://clang.llvm.org/docs/JSONCompilationDatabase.html#format)</a>

* Tools/Scripts/rewrite-compile-commands:

Canonical link: <a href="https://commits.webkit.org/286602@main">https://commits.webkit.org/286602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18cae3b9d5e8d98bec9d4ad806100457e36f1a3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29381 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81001 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27751 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78592 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3803 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/59965 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/18082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40293 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23163 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26074 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68397 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23495 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82448 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3851 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2533 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68244 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4004 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65643 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67489 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16832 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11457 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9553 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3798 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3821 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7251 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5579 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->