### PR TITLE
Add URLPatternComponent class

### DIFF
--- a/LayoutTests/fast/urlpattern/urlpattern-component-expected.txt
+++ b/LayoutTests/fast/urlpattern/urlpattern-component-expected.txt
@@ -2190,89 +2190,13 @@ PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
 Testing: {"pattern":[{"protocol":"(cafÃ©)"}],"expected_obj":"error"}
-Component: protocol
-PASS urlPatternComponent is "(cafÃ©)"
-Component: username
-PASS urlPatternComponent is "*"
-Component: password
-PASS urlPatternComponent is "*"
-Component: hostname
-PASS urlPatternComponent is "*"
-Component: port
-PASS urlPatternComponent is "*"
-Component: password
-PASS urlPatternComponent is "*"
-Component: pathname
-PASS urlPatternComponent is "*"
-Component: search
-WARN: shouldBeEqualToString() expects string arguments
-WARN: shouldBe() expects function or string arguments
-FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
-Component: hash
-PASS urlPatternComponent is "*"
+PASS var pattern = new URLPattern(...errorEntry.pattern) threw exception TypeError: Current codepoint is not ascii.
 Testing: {"pattern":[{"username":"(cafÃ©)"}],"expected_obj":"error"}
-Component: protocol
-PASS urlPatternComponent is "*"
-Component: username
-PASS urlPatternComponent is "(cafÃ©)"
-Component: password
-PASS urlPatternComponent is "*"
-Component: hostname
-PASS urlPatternComponent is "*"
-Component: port
-PASS urlPatternComponent is "*"
-Component: password
-PASS urlPatternComponent is "*"
-Component: pathname
-PASS urlPatternComponent is "*"
-Component: search
-WARN: shouldBeEqualToString() expects string arguments
-WARN: shouldBe() expects function or string arguments
-FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
-Component: hash
-PASS urlPatternComponent is "*"
+PASS var pattern = new URLPattern(...errorEntry.pattern) threw exception TypeError: Current codepoint is not ascii.
 Testing: {"pattern":[{"password":"(cafÃ©)"}],"expected_obj":"error"}
-Component: protocol
-PASS urlPatternComponent is "*"
-Component: username
-PASS urlPatternComponent is "*"
-Component: password
-PASS urlPatternComponent is "(cafÃ©)"
-Component: hostname
-PASS urlPatternComponent is "*"
-Component: port
-PASS urlPatternComponent is "*"
-Component: password
-PASS urlPatternComponent is "(cafÃ©)"
-Component: pathname
-PASS urlPatternComponent is "*"
-Component: search
-WARN: shouldBeEqualToString() expects string arguments
-WARN: shouldBe() expects function or string arguments
-FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
-Component: hash
-PASS urlPatternComponent is "*"
+PASS var pattern = new URLPattern(...errorEntry.pattern) threw exception TypeError: Current codepoint is not ascii.
 Testing: {"pattern":[{"hostname":"(cafÃ©)"}],"expected_obj":"error"}
-Component: protocol
-PASS urlPatternComponent is "*"
-Component: username
-PASS urlPatternComponent is "*"
-Component: password
-PASS urlPatternComponent is "*"
-Component: hostname
-PASS urlPatternComponent is "(cafÃ©)"
-Component: port
-PASS urlPatternComponent is "*"
-Component: password
-PASS urlPatternComponent is "*"
-Component: pathname
-PASS urlPatternComponent is "*"
-Component: search
-WARN: shouldBeEqualToString() expects string arguments
-WARN: shouldBe() expects function or string arguments
-FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
-Component: hash
-PASS urlPatternComponent is "*"
+PASS var pattern = new URLPattern(...errorEntry.pattern) threw exception TypeError: Current codepoint is not ascii.
 Testing: {"pattern":[{"pathname":"(cafÃ©)"}],"expected_obj":"error"}
 Component: protocol
 PASS urlPatternComponent is "*"
@@ -2295,47 +2219,9 @@ FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type
 Component: hash
 PASS urlPatternComponent is "*"
 Testing: {"pattern":[{"search":"(cafÃ©)"}],"expected_obj":"error"}
-Component: protocol
-PASS urlPatternComponent is "*"
-Component: username
-PASS urlPatternComponent is "*"
-Component: password
-PASS urlPatternComponent is "*"
-Component: hostname
-PASS urlPatternComponent is "*"
-Component: port
-PASS urlPatternComponent is "*"
-Component: password
-PASS urlPatternComponent is "*"
-Component: pathname
-PASS urlPatternComponent is "*"
-Component: search
-WARN: shouldBeEqualToString() expects string arguments
-WARN: shouldBe() expects function or string arguments
-FAIL urlPatternComponent should be undefined (of type undefined). Was (cafÃ©) (of type string).
-Component: hash
-PASS urlPatternComponent is "*"
+PASS var pattern = new URLPattern(...errorEntry.pattern) threw exception TypeError: Current codepoint is not ascii.
 Testing: {"pattern":[{"hash":"(cafÃ©)"}],"expected_obj":"error"}
-Component: protocol
-PASS urlPatternComponent is "*"
-Component: username
-PASS urlPatternComponent is "*"
-Component: password
-PASS urlPatternComponent is "*"
-Component: hostname
-PASS urlPatternComponent is "*"
-Component: port
-PASS urlPatternComponent is "*"
-Component: password
-PASS urlPatternComponent is "*"
-Component: pathname
-PASS urlPatternComponent is "*"
-Component: search
-WARN: shouldBeEqualToString() expects string arguments
-WARN: shouldBe() expects function or string arguments
-FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
-Component: hash
-PASS urlPatternComponent is "(cafÃ©)"
+PASS var pattern = new URLPattern(...errorEntry.pattern) threw exception TypeError: Current codepoint is not ascii.
 Testing: {"pattern":[{"protocol":":cafÃ©"}],"inputs":[{"protocol":"foo"}],"expected_match":{"protocol":{"input":"foo","groups":{"cafÃ©":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is ":cafÃ©"
@@ -2737,7 +2623,7 @@ Component: hash
 PASS urlPatternComponent is ":㐀"
 Testing: {"pattern":[{"protocol":"(.*)"}],"inputs":[{"protocol":"cafÃ©"}],"expected_obj":{"protocol":"*"},"expected_match":null}
 Component: protocol
-FAIL urlPatternComponent should be *. Was (.*).
+PASS urlPatternComponent is "*"
 Component: username
 PASS urlPatternComponent is "*"
 Component: password
@@ -2756,7 +2642,7 @@ Component: hash
 PASS urlPatternComponent is "*"
 Testing: {"pattern":[{"protocol":"(.*)"}],"inputs":[{"protocol":"cafe"}],"expected_obj":{"protocol":"*"},"expected_match":{"protocol":{"input":"cafe","groups":{"0":"cafe"}}}}
 Component: protocol
-FAIL urlPatternComponent should be *. Was (.*).
+PASS urlPatternComponent is "*"
 Component: username
 PASS urlPatternComponent is "*"
 Component: password
@@ -2796,7 +2682,7 @@ Testing: {"pattern":[{"username":"caf%C3%A9"}],"inputs":[{"username":"cafÃ©"}]
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
-PASS urlPatternComponent is "caf%C3%A9"
+FAIL urlPatternComponent should be caf%C3%A9. Was café.
 Component: password
 PASS urlPatternComponent is "*"
 Component: hostname
@@ -2834,7 +2720,7 @@ Testing: {"pattern":[{"username":"caf%c3%a9"}],"inputs":[{"username":"cafÃ©"}]
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
-PASS urlPatternComponent is "caf%c3%a9"
+FAIL urlPatternComponent should be caf%c3%a9. Was café.
 Component: password
 PASS urlPatternComponent is "*"
 Component: hostname
@@ -2855,13 +2741,13 @@ PASS urlPatternComponent is "*"
 Component: username
 PASS urlPatternComponent is "*"
 Component: password
-PASS urlPatternComponent is "caf%C3%A9"
+FAIL urlPatternComponent should be caf%C3%A9. Was café.
 Component: hostname
 PASS urlPatternComponent is "*"
 Component: port
 PASS urlPatternComponent is "*"
 Component: password
-PASS urlPatternComponent is "caf%C3%A9"
+FAIL urlPatternComponent should be caf%C3%A9. Was café.
 Component: pathname
 PASS urlPatternComponent is "*"
 Component: search
@@ -2893,13 +2779,13 @@ PASS urlPatternComponent is "*"
 Component: username
 PASS urlPatternComponent is "*"
 Component: password
-PASS urlPatternComponent is "caf%c3%a9"
+FAIL urlPatternComponent should be caf%c3%a9. Was café.
 Component: hostname
 PASS urlPatternComponent is "*"
 Component: port
 PASS urlPatternComponent is "*"
 Component: password
-PASS urlPatternComponent is "caf%c3%a9"
+FAIL urlPatternComponent should be caf%c3%a9. Was café.
 Component: pathname
 PASS urlPatternComponent is "*"
 Component: search
@@ -3002,26 +2888,7 @@ PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
 Testing: {"pattern":[{"protocol":"http","port":"80 "}],"inputs":[{"protocol":"http","port":"80"}],"expected_obj":"error"}
-Component: protocol
-PASS urlPatternComponent is "http"
-Component: username
-PASS urlPatternComponent is "*"
-Component: password
-PASS urlPatternComponent is "*"
-Component: hostname
-PASS urlPatternComponent is "*"
-Component: port
-FAIL urlPatternComponent should be 80 . Was .
-Component: password
-PASS urlPatternComponent is "*"
-Component: pathname
-PASS urlPatternComponent is "*"
-Component: search
-WARN: shouldBeEqualToString() expects string arguments
-WARN: shouldBe() expects function or string arguments
-FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
-Component: hash
-PASS urlPatternComponent is "*"
+FAIL var pattern = new URLPattern(...errorEntry.pattern) should throw an exception. Was undefined.
 Testing: {"pattern":[{"port":"80"}],"inputs":[{"protocol":"http","port":"80"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
@@ -3089,7 +2956,7 @@ PASS urlPatternComponent is "*"
 Component: hostname
 PASS urlPatternComponent is "*"
 Component: port
-FAIL urlPatternComponent should be *. Was (.*).
+PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
@@ -3437,7 +3304,7 @@ PASS urlPatternComponent is "*"
 Component: pathname
 PASS urlPatternComponent is "*"
 Component: search
-FAIL urlPatternComponent should be q=caf%C3%A9. Was q=cafÃ©.
+FAIL urlPatternComponent should be q=caf%C3%A9. Was q=caf%C3%83%C2%A9.
 Component: hash
 PASS urlPatternComponent is "*"
 Testing: {"pattern":[{"search":"q=caf%c3%a9"}],"inputs":[{"search":"q=cafÃ©"}],"expected_match":null}
@@ -3496,7 +3363,7 @@ PASS urlPatternComponent is "*"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
-FAIL urlPatternComponent should be caf%C3%A9. Was cafÃ©.
+FAIL urlPatternComponent should be caf%C3%A9. Was caf%C3%83%C2%A9.
 Testing: {"pattern":[{"hash":"caf%c3%a9"}],"inputs":[{"hash":"cafÃ©"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"

--- a/LayoutTests/fast/urlpattern/urlpattern-component.html
+++ b/LayoutTests/fast/urlpattern/urlpattern-component.html
@@ -2882,8 +2882,13 @@ const kComponents = [
 function executeURLPatternConstructor(jsonArray) {
   // Iterate through each object in the array
   jsonArray.forEach(entry => {
-
     debug("Testing: " + JSON.stringify(entry));
+
+    errorEntry = entry;
+    if (errorEntry.expected_obj === 'error' && !entry.pattern[0]['pathname']) {
+      shouldThrow("var pattern = new URLPattern(...errorEntry.pattern)");
+      return;
+    }
 
     const pattern = new URLPattern(...entry.pattern);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
@@ -115,20 +115,20 @@ FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}]
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
+PASS Pattern: [{"username":"(café)"}] Inputs: undefined
+PASS Pattern: [{"password":"(café)"}] Inputs: undefined
+PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
 FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+PASS Pattern: [{"search":"(café)"}] Inputs: undefined
+PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
+FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
+FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
+FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
+FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
+FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
 FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
 FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
@@ -143,15 +143,15 @@ FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation i
 FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
 FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] The operation is not supported.
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
+FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
 FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
 FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
@@ -161,7 +161,7 @@ FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","po
 FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
 FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: compiled pattern property 'port' expected "*" but got "(.*)"
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
@@ -179,10 +179,10 @@ FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] T
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
 FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
 FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] assert_equals: compiled pattern property 'search' expected "q=caf%C3%A9" but got "q=café"
+FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] The operation is not supported.
 FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
 FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] assert_equals: compiled pattern property 'hash' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
 FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
@@ -272,13 +272,13 @@ FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Not impl
 FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Not implemented.
 FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Not implemented.
 FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Not implemented.
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] assert_equals: compiled pattern property 'hostname' expected "[\\:\\:ab\\::num]" but got "[\\:\\:AB\\::num]"
-FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
 FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
@@ -299,20 +299,20 @@ FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operati
 FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
@@ -115,20 +115,20 @@ FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}]
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
+PASS Pattern: [{"username":"(café)"}] Inputs: undefined
+PASS Pattern: [{"password":"(café)"}] Inputs: undefined
+PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
 FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+PASS Pattern: [{"search":"(café)"}] Inputs: undefined
+PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
+FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
+FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
+FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
+FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
+FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
 FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
 FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
@@ -143,15 +143,15 @@ FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation i
 FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
 FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] The operation is not supported.
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
+FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
 FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
 FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
@@ -161,7 +161,7 @@ FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","po
 FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
 FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: compiled pattern property 'port' expected "*" but got "(.*)"
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
@@ -179,10 +179,10 @@ FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] T
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
 FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
 FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] assert_equals: compiled pattern property 'search' expected "q=caf%C3%A9" but got "q=café"
+FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] The operation is not supported.
 FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
 FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] assert_equals: compiled pattern property 'hash' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
 FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
@@ -272,13 +272,13 @@ FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Not impl
 FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Not implemented.
 FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Not implemented.
 FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Not implemented.
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] assert_equals: compiled pattern property 'hostname' expected "[\\:\\:ab\\::num]" but got "[\\:\\:AB\\::num]"
-FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
 FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
@@ -299,20 +299,20 @@ FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operati
 FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
@@ -115,20 +115,20 @@ FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}]
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
+PASS Pattern: [{"username":"(café)"}] Inputs: undefined
+PASS Pattern: [{"password":"(café)"}] Inputs: undefined
+PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
 FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+PASS Pattern: [{"search":"(café)"}] Inputs: undefined
+PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
+FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
+FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
+FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
+FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
+FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
 FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
 FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
@@ -143,15 +143,15 @@ FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation i
 FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
 FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] The operation is not supported.
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
+FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
 FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
 FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
@@ -161,7 +161,7 @@ FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","po
 FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
 FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: compiled pattern property 'port' expected "*" but got "(.*)"
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
@@ -179,10 +179,10 @@ FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] T
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
 FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
 FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] assert_equals: compiled pattern property 'search' expected "q=caf%C3%A9" but got "q=café"
+FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] The operation is not supported.
 FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
 FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] assert_equals: compiled pattern property 'hash' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
 FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
@@ -272,13 +272,13 @@ FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Not impl
 FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Not implemented.
 FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Not implemented.
 FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Not implemented.
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] assert_equals: compiled pattern property 'hostname' expected "[\\:\\:ab\\::num]" but got "[\\:\\:AB\\::num]"
-FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
 FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
@@ -299,20 +299,20 @@ FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operati
 FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
@@ -115,20 +115,20 @@ FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}]
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
+PASS Pattern: [{"username":"(café)"}] Inputs: undefined
+PASS Pattern: [{"password":"(café)"}] Inputs: undefined
+PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
 FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+PASS Pattern: [{"search":"(café)"}] Inputs: undefined
+PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
+FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
+FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
+FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
+FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
+FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
 FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
 FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
@@ -143,15 +143,15 @@ FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation i
 FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
 FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] The operation is not supported.
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
+FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
 FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
 FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
@@ -161,7 +161,7 @@ FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","po
 FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
 FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: compiled pattern property 'port' expected "*" but got "(.*)"
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
@@ -179,10 +179,10 @@ FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] T
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
 FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
 FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] assert_equals: compiled pattern property 'search' expected "q=caf%C3%A9" but got "q=café"
+FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] The operation is not supported.
 FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
 FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] assert_equals: compiled pattern property 'hash' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
 FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
@@ -272,13 +272,13 @@ FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Not impl
 FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Not implemented.
 FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Not implemented.
 FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Not implemented.
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] assert_equals: compiled pattern property 'hostname' expected "[\\:\\:ab\\::num]" but got "[\\:\\:AB\\::num]"
-FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
 FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
@@ -299,20 +299,20 @@ FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operati
 FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
@@ -115,20 +115,20 @@ FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}]
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
+PASS Pattern: [{"username":"(café)"}] Inputs: undefined
+PASS Pattern: [{"password":"(café)"}] Inputs: undefined
+PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
 FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+PASS Pattern: [{"search":"(café)"}] Inputs: undefined
+PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
+FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
+FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
+FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
+FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
+FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
 FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
 FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
@@ -143,15 +143,15 @@ FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation i
 FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
 FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] The operation is not supported.
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
+FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
 FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
 FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
@@ -161,7 +161,7 @@ FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","po
 FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
 FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: compiled pattern property 'port' expected "*" but got "(.*)"
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
@@ -179,10 +179,10 @@ FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] T
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
 FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
 FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] assert_equals: compiled pattern property 'search' expected "q=caf%C3%A9" but got "q=café"
+FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] The operation is not supported.
 FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
 FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] assert_equals: compiled pattern property 'hash' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
 FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
@@ -272,13 +272,13 @@ FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Not impl
 FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Not implemented.
 FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Not implemented.
 FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Not implemented.
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] assert_equals: compiled pattern property 'hostname' expected "[\\:\\:ab\\::num]" but got "[\\:\\:AB\\::num]"
-FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
 FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
@@ -299,20 +299,20 @@ FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operati
 FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
@@ -115,20 +115,20 @@ FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}]
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
+PASS Pattern: [{"username":"(café)"}] Inputs: undefined
+PASS Pattern: [{"password":"(café)"}] Inputs: undefined
+PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
 FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+PASS Pattern: [{"search":"(café)"}] Inputs: undefined
+PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
+FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
+FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
+FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
+FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
+FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
 FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
 FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
@@ -143,15 +143,15 @@ FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation i
 FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
 FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] The operation is not supported.
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
+FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
 FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
 FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
@@ -161,7 +161,7 @@ FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","po
 FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
 FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: compiled pattern property 'port' expected "*" but got "(.*)"
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
@@ -179,10 +179,10 @@ FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] T
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
 FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
 FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] assert_equals: compiled pattern property 'search' expected "q=caf%C3%A9" but got "q=café"
+FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] The operation is not supported.
 FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
 FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] assert_equals: compiled pattern property 'hash' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
 FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
@@ -272,13 +272,13 @@ FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Not impl
 FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Not implemented.
 FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Not implemented.
 FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Not implemented.
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] assert_equals: compiled pattern property 'hostname' expected "[\\:\\:ab\\::num]" but got "[\\:\\:AB\\::num]"
-FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
 FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
@@ -299,20 +299,20 @@ FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operati
 FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
@@ -115,20 +115,20 @@ FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}]
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
+PASS Pattern: [{"username":"(café)"}] Inputs: undefined
+PASS Pattern: [{"password":"(café)"}] Inputs: undefined
+PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
 FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+PASS Pattern: [{"search":"(café)"}] Inputs: undefined
+PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
+FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
+FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
+FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
+FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
+FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
 FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
 FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
@@ -143,15 +143,15 @@ FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation i
 FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
 FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] The operation is not supported.
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
+FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
 FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
 FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
@@ -161,7 +161,7 @@ FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","po
 FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
 FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: compiled pattern property 'port' expected "*" but got "(.*)"
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
@@ -179,10 +179,10 @@ FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] T
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
 FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
 FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] assert_equals: compiled pattern property 'search' expected "q=caf%C3%A9" but got "q=café"
+FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] The operation is not supported.
 FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
 FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] assert_equals: compiled pattern property 'hash' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
 FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
@@ -272,13 +272,13 @@ FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Not impl
 FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Not implemented.
 FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Not implemented.
 FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Not implemented.
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] assert_equals: compiled pattern property 'hostname' expected "[\\:\\:ab\\::num]" but got "[\\:\\:AB\\::num]"
-FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
 FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
@@ -299,20 +299,20 @@ FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operati
 FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
@@ -115,20 +115,20 @@ FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/bar"}]
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"username":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"password":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
+PASS Pattern: [{"username":"(café)"}] Inputs: undefined
+PASS Pattern: [{"password":"(café)"}] Inputs: undefined
+PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
 FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"search":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hash":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] The operation is not supported.
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] The operation is not supported.
+PASS Pattern: [{"search":"(café)"}] Inputs: undefined
+PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
+FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
+FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
+FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
+FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] The operation is not supported.
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] The operation is not supported.
+FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
+FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
 FAIL Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}] The operation is not supported.
 FAIL Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}] The operation is not supported.
@@ -143,15 +143,15 @@ FAIL Pattern: [{"hostname":":㐀"}] Inputs: [{"hostname":"foo"}] The operation i
 FAIL Pattern: [{"pathname":"/:㐀"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"search":":㐀"}] Inputs: [{"search":"foo"}] The operation is not supported.
 FAIL Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
-FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] assert_equals: compiled pattern property 'protocol' expected "*" but got "(.*)"
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}] The operation is not supported.
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] The operation is not supported.
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
+FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
 FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] The operation is not supported.
+FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
 FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] The operation is not supported.
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
 FAIL Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
@@ -161,7 +161,7 @@ FAIL Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","po
 FAIL Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}] The operation is not supported.
 FAIL Pattern: [{"port":"80"}] Inputs: [{"port":"80"}] The operation is not supported.
-FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] assert_equals: compiled pattern property 'port' expected "*" but got "(.*)"
+FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
@@ -179,10 +179,10 @@ FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] T
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
 FAIL Pattern: [{"pathname":":name.html","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo.html"] assert_equals: compiled pattern property 'pathname' expected "/:name.html" but got ":name.html"
 FAIL Pattern: [{"search":"q=caf%C3%A9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
-FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] assert_equals: compiled pattern property 'search' expected "q=caf%C3%A9" but got "q=café"
+FAIL Pattern: [{"search":"q=café"}] Inputs: [{"search":"q=café"}] The operation is not supported.
 FAIL Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}] The operation is not supported.
 FAIL Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}] The operation is not supported.
-FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] assert_equals: compiled pattern property 'hash' expected "caf%C3%A9" but got "café"
+FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
 FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
@@ -272,13 +272,13 @@ FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Not impl
 FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Not implemented.
 FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Not implemented.
 FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Not implemented.
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] assert_equals: compiled pattern property 'hostname' expected "[\\:\\:ab\\::num]" but got "[\\:\\:AB\\::num]"
-FAIL Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] The operation is not supported.
+FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
+FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
 FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
@@ -299,20 +299,20 @@ FAIL Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}] The operati
 FAIL Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"hostname":"bad hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -1182,8 +1182,6 @@ TextStream& operator<<(TextStream& ts, const URL& url)
     return ts;
 }
 
-#if !PLATFORM(COCOA) && !USE(SOUP)
-
 static bool isIPv4Address(StringView string)
 {
     auto count = 0;
@@ -1216,7 +1214,7 @@ static bool isIPv4Address(StringView string)
     return (count == 4);
 }
 
-static bool isIPv6Address(StringView string)
+bool URL::isIPv6Address(StringView string)
 {
     enum SkipState { None, WillSkip, Skipping, Skipped, Final };
     auto skipState = None;
@@ -1267,6 +1265,8 @@ static bool isIPv6Address(StringView string)
 
     return (count == 8 && skipState == None) || skipState == Skipped || skipState == Final;
 }
+
+#if !PLATFORM(COCOA) && !USE(SOUP)
 
 bool URL::hostIsIPAddress(StringView host)
 {

--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -221,6 +221,7 @@ public:
     WTF_EXPORT_PRIVATE void removeQueryAndFragmentIdentifier();
 
     WTF_EXPORT_PRIVATE static bool hostIsIPAddress(StringView);
+    WTF_EXPORT_PRIVATE static bool isIPv6Address(StringView);
 
     WTF_EXPORT_PRIVATE unsigned pathStart() const;
     unsigned pathEnd() const;

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -826,6 +826,7 @@ public:
     class Iterator;
     Iterator begin() const;
     Iterator end() const;
+    Iterator codePointAt(unsigned index) const;
 
 private:
     StringView m_stringView;
@@ -900,6 +901,7 @@ private:
 class StringView::CodePoints::Iterator {
     WTF_MAKE_FAST_ALLOCATED;
 public:
+    using iterator_category = std::forward_iterator_tag;
     Iterator(StringView, unsigned index);
 
     char32_t operator*() const;
@@ -1034,6 +1036,11 @@ inline auto StringView::CodePoints::begin() const -> Iterator
 inline auto StringView::CodePoints::end() const -> Iterator
 {
     return Iterator(m_stringView, m_stringView.length());
+}
+
+inline auto StringView::CodePoints::codePointAt(unsigned index) const -> Iterator
+{
+    return Iterator(m_stringView, index);
 }
 
 inline StringView::CodeUnits::CodeUnits(StringView stringView)

--- a/Source/WebCore/Modules/url-pattern/URLPattern.h
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ExceptionOr.h"
+#include "URLPatternComponent.h"
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -39,41 +40,47 @@ struct URLPatternOptions;
 struct URLPatternResult;
 enum class BaseURLStringType : bool { Pattern, URL };
 
+namespace URLPatternUtilities {
+class URLPatternComponent;
+}
+
 class URLPattern final : public RefCounted<URLPattern> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(URLPattern);
 public:
     using URLPatternInput = std::variant<String, URLPatternInit>;
 
-    static ExceptionOr<Ref<URLPattern>> create(URLPatternInput&&, String&& baseURL, URLPatternOptions&&);
-    static ExceptionOr<Ref<URLPattern>> create(std::optional<URLPatternInput>&&, URLPatternOptions&&);
+    static ExceptionOr<Ref<URLPattern>> create(ScriptExecutionContext&, URLPatternInput&&, String&& baseURL, URLPatternOptions&&);
+    static ExceptionOr<Ref<URLPattern>> create(ScriptExecutionContext&, std::optional<URLPatternInput>&&, URLPatternOptions&&);
     ~URLPattern();
 
     ExceptionOr<bool> test(std::optional<URLPatternInput>&&, String&& baseURL) const;
 
     ExceptionOr<std::optional<URLPatternResult>> exec(std::optional<URLPatternInput>&&, String&& baseURL) const;
 
-    const String& protocol() const { return m_protocol; }
-    const String& username() const { return m_username; }
-    const String& password() const { return m_password; }
-    const String& hostname() const { return m_hostname; }
-    const String& port() const { return m_port; }
+    const String& protocol() const { return m_protocolComponent.patternString(); }
+    const String& username() const { return m_usernameComponent.patternString(); }
+    const String& password() const { return m_passwordComponent.patternString(); }
+    const String& hostname() const { return m_hostnameComponent.patternString(); }
+    const String& port() const { return m_portComponent.patternString(); }
     const String& pathname() const { return m_pathname; }
-    const String& search() const { return m_search; }
-    const String& hash() const { return m_hash; }
+    const String& search() const { return m_searchComponent.patternString(); }
+    const String& hash() const { return m_hashComponent.patternString(); }
 
     bool hasRegExpGroups() const { return m_hasRegExpGroups; }
 
 private:
-    explicit URLPattern(URLPatternInit&& initInput);
+    URLPattern();
+    ExceptionOr<void> compileAllComponents(ScriptExecutionContext&, URLPatternInit&&, const URLPatternOptions&);
 
-    String m_protocol;
-    String m_username;
-    String m_password;
-    String m_hostname;
-    String m_port;
+    URLPatternUtilities::URLPatternComponent m_protocolComponent;
+    URLPatternUtilities::URLPatternComponent m_usernameComponent;
+    URLPatternUtilities::URLPatternComponent m_passwordComponent;
+    URLPatternUtilities::URLPatternComponent m_hostnameComponent;
+    // FIXME: Implement tracking pathname with URLPatternComponent
     String m_pathname;
-    String m_search;
-    String m_hash;
+    URLPatternUtilities::URLPatternComponent m_portComponent;
+    URLPatternUtilities::URLPatternComponent m_searchComponent;
+    URLPatternUtilities::URLPatternComponent m_hashComponent;
 
     bool m_hasRegExpGroups { false };
 };

--- a/Source/WebCore/Modules/url-pattern/URLPattern.idl
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.idl
@@ -34,8 +34,8 @@ typedef (USVString or URLPatternInit) URLPatternInput;
     EnabledBySetting=URLPatternAPIEnabled,
     Exposed=(Window,Worker)
 ] interface URLPattern {
-    constructor(URLPatternInit input, USVString baseURL, optional URLPatternOptions options);
-    constructor(optional URLPatternInput input, optional URLPatternOptions options);
+    [CallWith=CurrentScriptExecutionContext] constructor(URLPatternInit input, USVString baseURL, optional URLPatternOptions options);
+    [CallWith=CurrentScriptExecutionContext] constructor(optional URLPatternInput input, optional URLPatternOptions options);
 
     boolean test(optional URLPatternInput input, optional USVString baseURL);
   

--- a/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
@@ -174,7 +174,7 @@ ExceptionOr<String> canonicalizePort(StringView portValue, const std::optional<S
 }
 
 // https://urlpattern.spec.whatwg.org/#canonicalize-an-opaque-pathname
-static ExceptionOr<String> canonicalizeOpaquePathname(StringView value)
+ExceptionOr<String> canonicalizeOpaquePathname(StringView value)
 {
     URL dummyURL(dummyURLCharacters);
     dummyURL.setPath(value);
@@ -186,7 +186,7 @@ static ExceptionOr<String> canonicalizeOpaquePathname(StringView value)
 }
 
 // https://urlpattern.spec.whatwg.org/#canonicalize-a-pathname
-static ExceptionOr<String> canonicalizePathname(StringView pathnameValue)
+ExceptionOr<String> canonicalizePathname(StringView pathnameValue)
 {
     if (pathnameValue.isEmpty())
         return pathnameValue.toString();
@@ -279,6 +279,8 @@ ExceptionOr<String> callEncodingCallback(EncodingCallbackType type, StringView i
         return canonicalizePort(input, { }, BaseURLStringType::URL);
     case EncodingCallbackType::Path:
         return canonicalizePathname(input);
+    case EncodingCallbackType::OpaquePath:
+        return canonicalizeOpaquePathname(input);
     case EncodingCallbackType::Search:
         return canonicalizeSearch(input, BaseURLStringType::URL);
     case EncodingCallbackType::Hash:

--- a/Source/WebCore/Modules/url-pattern/URLPatternCanonical.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternCanonical.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 enum class BaseURLStringType : bool;
-enum class EncodingCallbackType : uint8_t { Protocol, Username, Password, Host, IPv6Host, Port, Path, Search, Hash };
+enum class EncodingCallbackType : uint8_t { Protocol, Username, Password, Host, IPv6Host, Port, Path, OpaquePath, Search, Hash };
 
 bool isAbsolutePathname(StringView input, BaseURLStringType inputType);
 ExceptionOr<String> canonicalizeProtocol(StringView, BaseURLStringType valueType);
@@ -40,6 +40,8 @@ ExceptionOr<String> canonicalizeHostname(StringView value, BaseURLStringType val
 ExceptionOr<String> canonicalizeIPv6Hostname(StringView value, BaseURLStringType valueType);
 ExceptionOr<String> canonicalizePort(StringView portValue, const std::optional<StringView> protocolValue, BaseURLStringType portValueType);
 ExceptionOr<String> processPathname(StringView pathnameValue, const StringView protocolValue, BaseURLStringType pathnameValueType);
+ExceptionOr<String> canonicalizePathname(StringView pathnameValue);
+ExceptionOr<String> canonicalizeOpaquePathname(StringView value);
 ExceptionOr<String> canonicalizeSearch(StringView value, BaseURLStringType valueType);
 ExceptionOr<String> canonicalizeHash(StringView value, BaseURLStringType valueType);
 ExceptionOr<String> callEncodingCallback(EncodingCallbackType, StringView input);

--- a/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "URLPatternComponent.h"
+
+#include "URLPatternCanonical.h"
+
+namespace WebCore {
+namespace URLPatternUtilities {
+
+URLPatternComponent::URLPatternComponent(String&& patternString, JSC::Strong<JSC::RegExp>&& regex, Vector<String>&& groupNameList, bool hasRegexpGroups)
+    : m_patternString(WTFMove(patternString))
+    , m_regularExpression(WTFMove(regex))
+    , m_groupNameList(WTFMove(groupNameList))
+    , m_hasRegexpGroups(hasRegexpGroups)
+{
+}
+
+ExceptionOr<URLPatternComponent> URLPatternComponent::compile(Ref<VM> vm, StringView input, EncodingCallbackType type, const URLPatternUtilities::URLPatternStringOptions& options)
+{
+    auto maybePartList = URLPatternUtilities::URLPatternParser::parse(input, options, type);
+    if (maybePartList.hasException())
+        return maybePartList.releaseException();
+    Vector<Part> partList = maybePartList.releaseReturnValue();
+
+    auto [regularExpressionString, nameList] = generateRegexAndNameList(partList, options);
+
+    OptionSet<Yarr::Flags> flags = { Yarr::Flags::UnicodeSets };
+    if (options.ignoreCase)
+        flags.add(Yarr::Flags::IgnoreCase);
+
+    RegExp* regularExpression = RegExp::create(vm, regularExpressionString, flags);
+    if (!regularExpression)
+        return Exception { ExceptionCode::TypeError, "Unable to create RegExp object regular expression from provided URLPattern string."_s };
+
+    String patternString = generatePatternString(partList, options);
+
+    bool hasRegexGroups = partList.containsIf([](auto& part) {
+        return part.type == PartType::Regexp;
+    });
+
+    return URLPatternComponent { WTFMove(patternString), JSC::Strong<JSC::RegExp> { vm, regularExpression }, WTFMove(nameList), hasRegexGroups };
+}
+
+}
+}

--- a/Source/WebCore/Modules/url-pattern/URLPatternComponent.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternComponent.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class EncodingCallbackType : uint8_t;
+
+namespace URLPatternUtilities {
+struct URLPatternStringOptions;
+
+class URLPatternComponent {
+public:
+    static ExceptionOr<URLPatternComponent> compile(Ref<JSC::VM>, StringView, EncodingCallbackType, const URLPatternStringOptions&);
+    const String& patternString() const { return m_patternString; }
+    URLPatternComponent() = default;
+
+private:
+    URLPatternComponent(String&&, JSC::Strong<JSC::RegExp>&&, Vector<String>&&, bool);
+
+    String m_patternString;
+    JSC::Strong<JSC::RegExp> m_regularExpression;
+    Vector<String> m_groupNameList;
+    bool m_hasRegexpGroups = false;
+};
+
+}
+}

--- a/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
@@ -26,21 +26,13 @@
 #include "config.h"
 #include "URLPatternTokenizer.h"
 
+#include "URLPatternParser.h"
 #include <unicode/utf16.h>
 #include <unicode/utf8.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
 namespace URLPatternUtilities {
-
-// https://urlpattern.spec.whatwg.org/#is-a-valid-name-code-point
-static bool isValidNameCodepoint(UChar codepoint, bool first)
-{
-    if (first)
-        return u_isIDStart(codepoint);
-
-    return u_isIDPart(codepoint);
-}
 
 bool Token::isNull() const
 {
@@ -161,7 +153,7 @@ ExceptionOr<Vector<Token>> Tokenizer::tokenize()
             while (namePosition < m_input.length()) {
                 seekNextCodePoint(namePosition);
 
-                bool isValidCodepoint = isValidNameCodepoint(m_codepoint, namePosition == nameStart);
+                bool isValidCodepoint = isValidNameCodepoint(m_codepoint, namePosition == nameStart ? IsFirst::Yes : IsFirst::No);
 
                 if (!isValidCodepoint)
                     break;

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp
@@ -28,6 +28,8 @@
 
 #if ENABLE(WEB_AUTHN)
 
+#include "AuthenticatorAssertionResponse.h"
+#include "AuthenticatorAttestationResponse.h"
 #include "AuthenticatorCoordinator.h"
 #include "AuthenticatorResponse.h"
 #include "BufferSource.h"
@@ -42,6 +44,7 @@
 #include "PublicKeyCredentialDescriptorJSON.h"
 #include "PublicKeyCredentialRequestOptionsJSON.h"
 #include "Settings.h"
+#include "WebAuthenticationUtils.h"
 #include <wtf/text/Base64.h>
 
 namespace WebCore {

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -222,6 +222,7 @@ JSTextTrackList.cpp
 JSTrustedTypePolicy.cpp
 JSTrustedTypePolicyFactory.cpp
 JSUndoManager.cpp
+JSURLPattern.cpp
 JSUserMessageHandlersNamespace.cpp
 JSVTTCue.cpp
 JSVTTRegion.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -371,6 +371,7 @@ Modules/streams/TransformStream.cpp
 Modules/streams/WritableStream.cpp
 Modules/url-pattern/URLPattern.cpp
 Modules/url-pattern/URLPatternCanonical.cpp
+Modules/url-pattern/URLPatternComponent.cpp
 Modules/url-pattern/URLPatternParser.cpp
 Modules/url-pattern/URLPatternTokenizer.cpp
 Modules/web-locks/WebLock.cpp


### PR DESCRIPTION
#### d3b30382f58c51f51d0762fde51c10e011be56d6
<pre>
Add URLPatternComponent class
<a href="https://bugs.webkit.org/show_bug.cgi?id=283073">https://bugs.webkit.org/show_bug.cgi?id=283073</a>
<a href="https://rdar.apple.com/139833314">rdar://139833314</a>

Reviewed by Sihui Liu.

Add preliminary support for URLPatternComponent, see <a href="https://urlpattern.spec.whatwg.org/#component">https://urlpattern.spec.whatwg.org/#component</a>

* LayoutTests/fast/urlpattern/urlpattern-component-expected.txt:
* LayoutTests/fast/urlpattern/urlpattern-component.html:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt:
* Source/WTF/wtf/URL.cpp:
(WTF::URL::isIPv6Address):
(WTF::isIPv6Address): Deleted.
* Source/WTF/wtf/URL.h:
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::CodePoints::codePointAt const):
* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
(WebCore::processBaseURLString):
(WebCore::URLPattern::create):
(WebCore::URLPattern::compileAllComponents):
(WebCore::escapePatternStringForCharacters): Deleted.
(WebCore::escapePatternString): Deleted.
(WebCore::URLPattern::URLPattern): Deleted.
* Source/WebCore/Modules/url-pattern/URLPattern.h:
* Source/WebCore/Modules/url-pattern/URLPattern.idl:
* Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp:
(WebCore::canonicalizeOpaquePathname):
(WebCore::canonicalizePathname):
(WebCore::callEncodingCallback):
* Source/WebCore/Modules/url-pattern/URLPatternCanonical.h:
* Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp: Added.
(WebCore::URLPatternUtilities::URLPatternComponent::URLPatternComponent):
(WebCore::URLPatternUtilities::URLPatternComponent::compile):
* Source/WebCore/Modules/url-pattern/URLPatternComponent.h: Copied from Source/WebCore/Modules/url-pattern/URLPatternCanonical.h.
(WebCore::URLPatternUtilities::URLPatternComponent::patternString const):
* Source/WebCore/Modules/url-pattern/URLPatternParser.cpp:
(WebCore::URLPatternUtilities::URLPatternParser::performParse):
(WebCore::URLPatternUtilities::URLPatternParser::addPart):
(WebCore::URLPatternUtilities::URLPatternParser::parse):
(WebCore::URLPatternUtilities::escapeRegexString):
(WebCore::URLPatternUtilities::convertModifierToString):
(WebCore::URLPatternUtilities::generateRegexAndNameList):
(WebCore::URLPatternUtilities::generatePatternString):
(WebCore::URLPatternUtilities::escapePatternStringForCharacters):
(WebCore::URLPatternUtilities::escapePatternString):
(WebCore::URLPatternUtilities::isValidNameCodepoint):
(): Deleted.
* Source/WebCore/Modules/url-pattern/URLPatternParser.h:
(WebCore::URLPatternUtilities::URLPatternParser::takePartList):
(WebCore::URLPatternUtilities::URLPatternParser::getPartList const): Deleted.
* Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp:
(WebCore::URLPatternUtilities::Tokenizer::tokenize):
(WebCore::URLPatternUtilities::isValidNameCodepoint): Deleted.
* Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/286965@main">https://commits.webkit.org/286965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9dea3cd60bdaa106334c22ddd5f09e8728f94c8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30576 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/82279 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28932 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65843 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4987 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60857 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18821 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66644 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41131 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24142 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27263 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/70842 "Found 4 new JSC stress test failures: stress/attribute-custom-accessor.js.ftl-eager, stress/get-by-val-hoist-above-structure.js.ftl-eager-no-cjit-b3o1, stress/get-by-val-hoist-above-structure.js.ftl-no-cjit-no-put-stack-validate, wasm.yaml/wasm/v8/regress/regress-824681.js.wasm-collect-continuously (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69319 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83657 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76931 "Found 2 new JSC stress test failures: stress/attribute-custom-accessor.js.ftl-eager, wasm.yaml/wasm/modules/wasm-imports-js-exports.js.wasm-aggressive-inline (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5034 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3422 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69084 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5191 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68336 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12340 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10444 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/99192 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12037 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4981 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21679 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4996 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8434 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->