### PR TITLE
[JSC] Set `JSValue` instead of `JSObject` as `JSAsyncFromSyncIterator` internal fields

### DIFF
--- a/Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.h
+++ b/Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.h
@@ -63,9 +63,10 @@ public:
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     static JSAsyncFromSyncIterator* createWithInitialValues(VM&, Structure*);
+    static JSAsyncFromSyncIterator* create(VM&, Structure*, JSValue syncIterator, JSValue nextMethod);
 
-    void setSyncIterator(VM& vm, JSObject* syncIterator) { internalField(Field::SyncIterator).set(vm, this, syncIterator); }
-    void setNextMethod(VM& vm, JSObject* nextMethod) { internalField(Field::NextMethod).set(vm, this, nextMethod); }
+    void setSyncIterator(VM& vm, JSValue syncIterator) { internalField(Field::SyncIterator).set(vm, this, syncIterator); }
+    void setNextMethod(VM& vm, JSValue nextMethod) { internalField(Field::NextMethod).set(vm, this, nextMethod); }
 
 private:
     JSAsyncFromSyncIterator(VM& vm, Structure* structure)
@@ -73,7 +74,7 @@ private:
     {
     }
 
-    void finishCreation(VM&);
+    void finishCreation(VM&, JSValue syncIterator, JSValue nextMethod);
     DECLARE_VISIT_CHILDREN;
 
 };


### PR DESCRIPTION
#### 5a2a5017b29bc7ab3f4bf6aafc21f00888a67cca
<pre>
[JSC] Set `JSValue` instead of `JSObject` as `JSAsyncFromSyncIterator` internal fields
<a href="https://bugs.webkit.org/show_bug.cgi?id=283096">https://bugs.webkit.org/show_bug.cgi?id=283096</a>

Reviewed by Yusuke Suzuki.

This patch changes to set `JSValue` instead of `JSObject` as
`JSAsyncFromSyncIterator` internal fields.

* Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.cpp:
(JSC::JSAsyncFromSyncIterator::createWithInitialValues):
(JSC::JSAsyncFromSyncIterator::create):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSAsyncFromSyncIterator::finishCreation): Deleted.
* Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.h:

Canonical link: <a href="https://commits.webkit.org/287025@main">https://commits.webkit.org/287025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7492be7e86286984690571182c8aa4333bb8342c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57043 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29266 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61088 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19013 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81076 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51079 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67400 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41394 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48441 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24543 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27609 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71153 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69536 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84020 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77245 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5375 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3633 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69308 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5531 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66934 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68562 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17114 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12561 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10742 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/99556 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5323 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21749 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5315 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8747 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7100 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->