### PR TITLE
[TZone] Add annotations for subclasses of AudioDSPKernel, CARingBuffer, PlatformAudioData & ImageDecoder

### DIFF
--- a/Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp
@@ -34,6 +34,7 @@
 #include "BiquadProcessor.h"
 #include "FloatConversion.h"
 #include <limits.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 #if CPU(X86_SSE2)
@@ -47,6 +48,8 @@
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BiquadDSPKernel);
 
 static bool hasConstantValue(float* values, int framesToProcess)
 {

--- a/Source/WebCore/Modules/webaudio/BiquadDSPKernel.h
+++ b/Source/WebCore/Modules/webaudio/BiquadDSPKernel.h
@@ -27,6 +27,7 @@
 #include "AudioDSPKernel.h"
 #include "Biquad.h"
 #include "BiquadProcessor.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -35,7 +36,8 @@ class BiquadProcessor;
 // BiquadDSPKernel is an AudioDSPKernel and is responsible for filtering one channel of a BiquadProcessor using a Biquad object.
 
 class BiquadDSPKernel final : public AudioDSPKernel {
-public:  
+    WTF_MAKE_TZONE_ALLOCATED(BiquadDSPKernel);
+public:
     explicit BiquadDSPKernel(BiquadProcessor* processor)
     : AudioDSPKernel(processor)
     {

--- a/Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp
@@ -31,10 +31,13 @@
 #include "AudioUtilities.h"
 #include "VectorMath.h"
 #include <algorithm>
+#include <wtf/TZoneMallocInlines.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DelayDSPKernel);
 
 static size_t bufferLengthForDelay(double maxDelayTime, double sampleRate)
 {

--- a/Source/WebCore/Modules/webaudio/DelayDSPKernel.h
+++ b/Source/WebCore/Modules/webaudio/DelayDSPKernel.h
@@ -27,13 +27,15 @@
 #include "AudioArray.h"
 #include "AudioDSPKernel.h"
 #include "DelayProcessor.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class DelayProcessor;
     
 class DelayDSPKernel final : public AudioDSPKernel {
-public:  
+    WTF_MAKE_TZONE_ALLOCATED(DelayDSPKernel);
+public:
     explicit DelayDSPKernel(DelayProcessor*);
     DelayDSPKernel(double maxDelayTime, float sampleRate);
     

--- a/Source/WebCore/Modules/webaudio/IIRDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/IIRDSPKernel.cpp
@@ -27,10 +27,13 @@
 
 #if ENABLE(WEB_AUDIO)
 #include "IIRDSPKernel.h"
+#include <wtf/TZoneMallocInlines.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IIRDSPKernel);
 
 IIRDSPKernel::IIRDSPKernel(IIRProcessor& processor)
     : AudioDSPKernel(&processor)

--- a/Source/WebCore/Modules/webaudio/IIRDSPKernel.h
+++ b/Source/WebCore/Modules/webaudio/IIRDSPKernel.h
@@ -28,10 +28,12 @@
 #include "AudioDSPKernel.h"
 #include "IIRFilter.h"
 #include "IIRProcessor.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class IIRDSPKernel final : public AudioDSPKernel {
+    WTF_MAKE_TZONE_ALLOCATED(IIRDSPKernel);
 public:
     explicit IIRDSPKernel(IIRProcessor&);
 

--- a/Source/WebCore/Modules/webaudio/IIRProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/IIRProcessor.cpp
@@ -29,8 +29,11 @@
 #include "IIRProcessor.h"
 
 #include "IIRDSPKernel.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IIRProcessor);
 
 IIRProcessor::IIRProcessor(float sampleRate, unsigned numberOfChannels, const Vector<double>& feedforward, const Vector<double>& feedback, bool isFilterStable)
     : AudioDSPKernelProcessor(sampleRate, numberOfChannels)

--- a/Source/WebCore/Modules/webaudio/IIRProcessor.h
+++ b/Source/WebCore/Modules/webaudio/IIRProcessor.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "AudioDSPKernelProcessor.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -33,6 +34,7 @@ namespace WebCore {
 class IIRDSPKernel;
 
 class IIRProcessor final : public AudioDSPKernelProcessor {
+    WTF_MAKE_TZONE_ALLOCATED(IIRProcessor);
 public:
     IIRProcessor(float sampleRate, unsigned numberOfChannels, const Vector<double>& feedforward, const Vector<double>& feedback, bool isFilterStable);
     ~IIRProcessor();

--- a/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp
@@ -33,11 +33,14 @@
 #include <JavaScriptCore/Float32Array.h>
 #include <algorithm>
 #include <wtf/MainThread.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Threading.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WaveShaperDSPKernel);
 
 WaveShaperDSPKernel::WaveShaperDSPKernel(WaveShaperProcessor* processor)
     : AudioDSPKernel(processor)

--- a/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.h
+++ b/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.h
@@ -30,12 +30,14 @@
 #include "UpSampler.h"
 #include "WaveShaperProcessor.h"
 #include <memory>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 // WaveShaperDSPKernel is an AudioDSPKernel and is responsible for non-linear distortion on one channel.
 
 class WaveShaperDSPKernel final : public AudioDSPKernel {
+    WTF_MAKE_TZONE_ALLOCATED(WaveShaperDSPKernel);
 public:
     explicit WaveShaperDSPKernel(WaveShaperProcessor*);
 

--- a/Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp
@@ -30,9 +30,12 @@
 
 #include "WaveShaperDSPKernel.h"
 #include <JavaScriptCore/Float32Array.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
-    
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WaveShaperProcessor);
+
 WaveShaperProcessor::WaveShaperProcessor(float sampleRate, size_t numberOfChannels)
     : AudioDSPKernelProcessor(sampleRate, numberOfChannels)
 {

--- a/Source/WebCore/Modules/webaudio/WaveShaperProcessor.h
+++ b/Source/WebCore/Modules/webaudio/WaveShaperProcessor.h
@@ -31,12 +31,14 @@
 #include <memory>
 #include <wtf/Lock.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 // WaveShaperProcessor is an AudioDSPKernelProcessor which uses WaveShaperDSPKernel objects to implement non-linear distortion effects.
 
 class WaveShaperProcessor final : public AudioDSPKernelProcessor {
+    WTF_MAKE_TZONE_ALLOCATED(WaveShaperProcessor);
 public:
     enum OverSampleType {
         OverSampleNone,

--- a/Source/WebCore/platform/audio/AudioDSPKernelProcessor.cpp
+++ b/Source/WebCore/platform/audio/AudioDSPKernelProcessor.cpp
@@ -35,8 +35,11 @@
 #include "AudioDSPKernelProcessor.h"
 
 #include "AudioDSPKernel.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioDSPKernelProcessor);
 
 // setNumberOfChannels() may later be called if the object is not yet in an "initialized" state.
 AudioDSPKernelProcessor::AudioDSPKernelProcessor(float sampleRate, unsigned numberOfChannels)

--- a/Source/WebCore/platform/audio/AudioDSPKernelProcessor.h
+++ b/Source/WebCore/platform/audio/AudioDSPKernelProcessor.h
@@ -33,6 +33,7 @@
 
 #include "AudioBus.h"
 #include "AudioProcessor.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -46,6 +47,7 @@ class AudioProcessor;
 // Despite this limitation it turns out to be a very common and useful type of processor.
 
 class AudioDSPKernelProcessor : public AudioProcessor {
+    WTF_MAKE_TZONE_ALLOCATED(AudioDSPKernelProcessor);
 public:
     // numberOfChannels may be later changed if object is not yet in an "initialized" state
     AudioDSPKernelProcessor(float sampleRate, unsigned numberOfChannels);

--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
@@ -41,6 +41,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CARingBuffer);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InProcessCARingBuffer);
 
 CARingBuffer::CARingBuffer(size_t bytesPerFrame, size_t frameCount, uint32_t numChannelStreams)
     : m_pointers(numChannelStreams)

--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.h
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.h
@@ -115,6 +115,7 @@ inline CARingBuffer::FetchMode CARingBuffer::fetchModeForMixing(AudioStreamDescr
 }
 
 class InProcessCARingBuffer final : public CARingBuffer {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(InProcessCARingBuffer, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT static std::unique_ptr<InProcessCARingBuffer> allocate(const WebCore::CAAudioStreamDescription& format, size_t frameCount);
     WEBCORE_EXPORT ~InProcessCARingBuffer();

--- a/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
+++ b/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
@@ -28,12 +28,15 @@
 
 #include "CAAudioStreamDescription.h"
 #include <wtf/CheckedArithmetic.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #include <pal/cf/CoreMediaSoftLink.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebAudioBufferList);
 
 WebAudioBufferList::WebAudioBufferList(const CAAudioStreamDescription& format)
     : m_bytesPerFrame(format.bytesPerFrame())

--- a/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h
+++ b/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h
@@ -28,6 +28,7 @@
 #include "PlatformAudioData.h"
 #include <wtf/IteratorRange.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 struct AudioBuffer;
@@ -40,6 +41,7 @@ namespace WebCore {
 class CAAudioStreamDescription;
 
 class WebAudioBufferList final : public PlatformAudioData {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(WebAudioBufferList, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT WebAudioBufferList(const CAAudioStreamDescription&);
     WEBCORE_EXPORT WebAudioBufferList(const CAAudioStreamDescription&, size_t sampleCount);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.h
@@ -31,6 +31,7 @@
 #include "ProcessIdentity.h"
 #include "SampleMap.h"
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -53,6 +54,7 @@ class PixelBufferConformerCV;
 class WebCoreDecompressionSession;
 
 class ImageDecoderAVFObjC : public ImageDecoder {
+    WTF_MAKE_TZONE_ALLOCATED(ImageDecoderAVFObjC);
 public:
     WEBCORE_EXPORT static RefPtr<ImageDecoderAVFObjC> create(const FragmentedSharedBuffer&, const String& mimeType, AlphaOption, GammaAndColorProfileOption, ProcessIdentity resourceOwner);
     virtual ~ImageDecoderAVFObjC();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
@@ -53,6 +53,7 @@
 #import <wtf/MainThread.h>
 #import <wtf/MediaTime.h>
 #import <wtf/NeverDestroyed.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/Vector.h>
 #import <wtf/cf/TypeCastsCF.h>
 
@@ -310,6 +311,8 @@ ImageDecoderAVFObjCSample* toSample(Iterator iter)
 }
 
 #pragma mark - ImageDecoderAVFObjC
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageDecoderAVFObjC);
 
 RefPtr<ImageDecoderAVFObjC> ImageDecoderAVFObjC::create(const FragmentedSharedBuffer& data, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption, ProcessIdentity resourceOwner)
 {

--- a/Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.mm
+++ b/Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.mm
@@ -33,9 +33,12 @@
 #import "WKBaseScrollView.h"
 #import "WKWebViewInternal.h"
 #import "_WKTouchEventGeneratorInternal.h"
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PointerTouchCompatibilitySimulator);
 
 bool PointerTouchCompatibilitySimulator::requiresPointerTouchCompatibility()
 {


### PR DESCRIPTION
#### 375c90ac39bfaf110f7d584ef76fc5ef96da08c7
<pre>
[TZone] Add annotations for subclasses of AudioDSPKernel, CARingBuffer, PlatformAudioData &amp; ImageDecoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=283097">https://bugs.webkit.org/show_bug.cgi?id=283097</a>
<a href="https://rdar.apple.com/139845268">rdar://139845268</a>

Reviewed by Yusuke Suzuki.

Added the missing TZone annotations to the subclasses of AudioDSPKernel, CARingBuffer, PlatformAudioData &amp; ImageDecoder.
When compiling for iOS, found that PointerTouchCompatibilitySimulator was missing the WTF_MAKE_TZONE_ALLOCATED_IMPL
macro in its .mm file.

* Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp:
* Source/WebCore/Modules/webaudio/BiquadDSPKernel.h:
* Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp:
* Source/WebCore/Modules/webaudio/DelayDSPKernel.h:
* Source/WebCore/Modules/webaudio/IIRDSPKernel.cpp:
* Source/WebCore/Modules/webaudio/IIRDSPKernel.h:
* Source/WebCore/Modules/webaudio/IIRProcessor.cpp:
* Source/WebCore/Modules/webaudio/IIRProcessor.h:
* Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp:
* Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.h:
* Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp:
* Source/WebCore/Modules/webaudio/WaveShaperProcessor.h:
* Source/WebCore/platform/audio/AudioDSPKernelProcessor.cpp:
* Source/WebCore/platform/audio/AudioDSPKernelProcessor.h:
* Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp:
* Source/WebCore/platform/audio/cocoa/CARingBuffer.h:
* Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp:
* Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h:
* Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm:
* Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.mm:

Canonical link: <a href="https://commits.webkit.org/286584@main">https://commits.webkit.org/286584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8782f1f9ed8fc5f01a156c90afbcd8ddbbfbe25e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29308 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80923 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27678 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78519 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64579 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3730 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59899 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18021 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65608 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40231 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47209 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23097 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26000 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68335 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82375 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2471 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68116 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67430 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16820 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11396 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9495 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3725 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6534 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3748 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7178 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5506 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->