### PR TITLE
REGRESSION (iOS 17.4): Notes pastes text copied from a text document in Safari as raw markup

### DIFF
--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -179,11 +179,16 @@ void Editor::writeSelectionToPasteboard(Pasteboard& pasteboard)
     content.contentOrigin = document->originIdentifierForPasteboard();
     content.canSmartCopyOrDelete = canSmartCopyOrDelete();
     if (!pasteboard.isStatic()) {
-        content.dataInWebArchiveFormat = selectionInWebArchiveFormat();
-        populateRichTextDataIfNeeded(content, document);
+        if (!document->isTextDocument()) {
+            content.dataInWebArchiveFormat = selectionInWebArchiveFormat();
+            populateRichTextDataIfNeeded(content, document);
+        }
         client()->getClientPasteboardData(selectedRange(), content.clientTypesAndData);
     }
-    content.dataInHTMLFormat = selectionInHTMLFormat();
+
+    if (!document->isTextDocument())
+        content.dataInHTMLFormat = selectionInHTMLFormat();
+
     content.dataInStringFormat = stringSelectionForPasteboardWithImageAltText();
 
     pasteboard.write(content);
@@ -196,11 +201,13 @@ void Editor::writeSelection(PasteboardWriterData& pasteboardWriterData)
     PasteboardWriterData::WebContent webContent;
     webContent.contentOrigin = document->originIdentifierForPasteboard();
     webContent.canSmartCopyOrDelete = canSmartCopyOrDelete();
-    webContent.dataInWebArchiveFormat = selectionInWebArchiveFormat();
-    populateRichTextDataIfNeeded(webContent, document);
-    webContent.dataInHTMLFormat = selectionInHTMLFormat();
-    webContent.dataInStringFormat = stringSelectionForPasteboardWithImageAltText();
+    if (!document->isTextDocument()) {
+        webContent.dataInWebArchiveFormat = selectionInWebArchiveFormat();
+        populateRichTextDataIfNeeded(webContent, document);
+        webContent.dataInHTMLFormat = selectionInHTMLFormat();
+    }
     client()->getClientPasteboardData(selectedRange(), webContent.clientTypesAndData);
+    webContent.dataInStringFormat = stringSelectionForPasteboardWithImageAltText();
 
     pasteboardWriterData.setWebContent(WTFMove(webContent));
 }

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1311,6 +1311,7 @@
 		F48D6C10224B377000E3E2FB /* PreferredContentMode.mm in Sources */ = {isa = PBXBuildFile; fileRef = F48D6C0F224B377000E3E2FB /* PreferredContentMode.mm */; };
 		F49153762901CEED004E2E97 /* CustomContentViewGestures.mm in Sources */ = {isa = PBXBuildFile; fileRef = F491536E2901CEED004E2E97 /* CustomContentViewGestures.mm */; };
 		F494B36A263120780060A310 /* TextServicesTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F494B369263120780060A310 /* TextServicesTests.mm */; };
+		F4A26ECC2CE59C0F0008F62A /* test.json in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4A26ECB2CE59C0F0008F62A /* test.json */; };
 		F4A2E64D284541BA0001FEEF /* FocusWebView.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4A2E64C284541BA0001FEEF /* FocusWebView.mm */; };
 		F4A715A82950C8D900B4D0D6 /* AdvancedPrivacyProtections.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4A715A72950C8D900B4D0D6 /* AdvancedPrivacyProtections.mm */; };
 		F4A7CE782662D6E800228685 /* TouchEventTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4A7CE772662D6E800228685 /* TouchEventTests.mm */; };
@@ -1987,6 +1988,7 @@
 				A17C46F52C98E54B0023F3C7 /* test-mse.webm in Copy Resources */,
 				A17C46F62C98E54B0023F3C7 /* test-without-audio-track.mp4 in Copy Resources */,
 				A17C48092C98E5C20023F3C7 /* test.jpg in Copy Resources */,
+				F4A26ECC2CE59C0F0008F62A /* test.json in Copy Resources */,
 				A17C46F72C98E54B0023F3C7 /* test.mp4 in Copy Resources */,
 				A17C480A2C98E5C20023F3C7 /* test.pages in Copy Resources */,
 				A17C46F82C98E54B0023F3C7 /* test.pdf in Copy Resources */,
@@ -3761,6 +3763,7 @@
 		F491DBAD281DE0980081705F /* image-controls.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "image-controls.html"; sourceTree = "<group>"; };
 		F494B369263120780060A310 /* TextServicesTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextServicesTests.mm; sourceTree = "<group>"; };
 		F49992C5248DABE400034167 /* overflow-hidden.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "overflow-hidden.html"; sourceTree = "<group>"; };
+		F4A26ECB2CE59C0F0008F62A /* test.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = test.json; sourceTree = "<group>"; };
 		F4A2E64C284541BA0001FEEF /* FocusWebView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FocusWebView.mm; sourceTree = "<group>"; };
 		F4A2E64E28455D230001FEEF /* open-in-new-tab.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "open-in-new-tab.html"; sourceTree = "<group>"; };
 		F4A32EC31F05F3780047C544 /* dragstart-change-selection-offscreen.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "dragstart-change-selection-offscreen.html"; sourceTree = "<group>"; };
@@ -5250,6 +5253,7 @@
 				31727A4A29F7338C00A7FB0F /* system-preview.html */,
 				313C3A0121E5677A00DBA86E /* SystemPreviewBlobNaming.html */,
 				F46D43AA26D7090300969E5E /* test.jpg */,
+				F4A26ECB2CE59C0F0008F62A /* test.json */,
 				49C64FD628349C19005BF0C2 /* test.pages */,
 				F45EB60327739F2B003571AE /* TestModalContainerControls.mlmodelc */,
 				2E9896141D8F092B00739892 /* text-and-password-inputs.html */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/test.json
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/test.json
@@ -1,0 +1,1 @@
+{"foo":0,"bar":null,"baz":[]}


### PR DESCRIPTION
#### 6c628b3ff9c4df5772477e8e085d6f0fad75f053
<pre>
REGRESSION (iOS 17.4): Notes pastes text copied from a text document in Safari as raw markup
<a href="https://bugs.webkit.org/show_bug.cgi?id=283093">https://bugs.webkit.org/show_bug.cgi?id=283093</a>
<a href="https://rdar.apple.com/124788252">rdar://124788252</a>

Reviewed by Richard Robinson.

When copying selected text in webpages after iOS 17.4, we no longer directly write rich text data to
the pasteboard — instead, we write web archive, HTML, and plain text to the pasteboard and let
UIKit/UIFoundation automatically coerce to `NSAttributedString` or rich text format, only if the
paste destination asks for it.

However, this is problematic in the case where the user is copying from a plain text document,
because UIKit will end up treating the main resource of the web archive as a plain text document as
well, and ultimately load an attributed string whose text is the raw markup of the text document
(instead of just the plain text).

While it&apos;s possible to fix this by addressing this (and teaching UIFoundation to load the web
archive properly), it&apos;s actually more efficient to elide this work altogether in the case where
we&apos;re copying from a simple text document, by only writing plain text data to the pasteboard in the
first place. This allows us to avoid spinning up `nsattributedstringagent` and performing what is
(usually) a synchronous load of web content.

* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::Editor::writeSelectionToPasteboard):
(WebCore::Editor::writeSelection):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyHTML.mm:
(TEST(CopyHTML, CopySelectedTextInTextDocument)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/test.json: Added.

Add an API test to exercise this change, by selecting text in a JSON file (loaded as plain text),
copying, and reading the copied contents as an attributed string.

Canonical link: <a href="https://commits.webkit.org/286583@main">https://commits.webkit.org/286583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab07a9bb6aaccf8d8f09cc5e4837d0e3dcd5e055

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80934 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27688 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3740 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59905 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18026 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65616 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40237 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47215 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23105 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26010 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68341 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82385 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2477 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3941 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65585 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67434 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16819 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11403 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9502 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3735 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6544 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3758 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7188 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5516 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->