### PR TITLE
[Flatpak] Update to clang-19 in GNOME build environments

### DIFF
--- a/Tools/flatpak/flatpakutils.py
+++ b/Tools/flatpak/flatpakutils.py
@@ -468,6 +468,8 @@ class SDKBase:
         else:
             return True
 
+    def programs_lookup_paths(self):
+        return "/usr/bin"
 
 class WebKitSDK(SDKBase):
     # Our SDK branch matches with the FDO SDK branch. When updating the FDO SDK release branch
@@ -505,6 +507,9 @@ class WebKitSDK(SDKBase):
                                             self.flathub_repo, arch))
         self.packages.append(FlatpakPackage("org.freedesktop.Platform.GL.Debug.default", f"{self.branch}-extra",
                                             self.flathub_repo, arch))
+
+    def programs_lookup_paths(self):
+        return "/usr/lib/sdk/llvm18/bin:/usr/bin:/usr/lib/sdk/rust-stable/bin/"
 
     def check_remote(self):
         remote = "webkit-sdk"
@@ -546,7 +551,11 @@ class GnomeSDK(SDKBase):
         self.repos = FlatpakRepos([self.sdk_repo, self.flathub_repo])
         self.packages = [self.runtime, self.sdk]
         self.packages.append(FlatpakPackage('org.gnome.Sdk.Debug', self.branch, self.sdk_repo, arch))
+        self.packages.append(FlatpakPackage("org.freedesktop.Sdk.Extension.llvm19", self.fdo_branch,
+                                            self.flathub_repo, arch))
 
+    def programs_lookup_paths(self):
+        return "/usr/lib/sdk/llvm19/bin:/usr/bin"
 
 SUPPORTED_SDKS = {'webkit': WebKitSDK, 'gnome': GnomeSDK}
 
@@ -896,7 +905,7 @@ class WebkitFlatpak:
         sandbox_build_path = os.path.join(SANDBOX_SOURCE_ROOT, BUILD_ROOT_DIR_NAME, self.build_type)
         sandbox_environment = {
             "TEST_RUNNER_INJECTED_BUNDLE_FILENAME": os.path.join(sandbox_build_path, "lib/libTestRunnerInjectedBundle.so"),
-            "PATH": "/usr/lib/sdk/llvm18/bin:/usr/bin:/usr/lib/sdk/rust-stable/bin/",
+            "PATH": self.sdk.programs_lookup_paths(),
         }
 
         if not args:


### PR DESCRIPTION
#### 0d2833fc01b5ba8f307336bbce12543e8aad5d8a
<pre>
[Flatpak] Update to clang-19 in GNOME build environments
<a href="https://bugs.webkit.org/show_bug.cgi?id=283102">https://bugs.webkit.org/show_bug.cgi?id=283102</a>

Reviewed by Carlos Alberto Lopez Perez.

The WebKit SDK runtime remains on llvm18 because we&apos;re frozen in FDO SDK 23.08 branch there. The
GNOME runtime is based on 24.08 which has llvm19.

* Tools/flatpak/flatpakutils.py:
(SDKBase.programs_lookup_paths):
(WebKitSDK.programs_lookup_paths):
(GnomeSDK.__init__):
(GnomeSDK.programs_lookup_paths):
(WebkitFlatpak.run_in_sandbox):

Canonical link: <a href="https://commits.webkit.org/286586@main">https://commits.webkit.org/286586@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2aed984aa502cc46e7c73bda1b78c8fd1554de9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55462 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80951 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27703 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78544 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3755 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59922 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18037 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79494 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49835 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65631 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40251 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47230 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23120 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26026 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68356 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82400 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3803 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68134 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65600 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67448 "Found 1 new API test failure: /TestWebKit:WebKit.GetInjectedBundleInitializationUserDataCallback (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11415 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9517 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11827 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3750 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3773 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7203 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5531 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->