### PR TITLE
[JSC] Report extra memory allocated by JSC::Exception and JSC::JSWebAssemblyException

### DIFF
--- a/Source/JavaScriptCore/runtime/Exception.cpp
+++ b/Source/JavaScriptCore/runtime/Exception.cpp
@@ -65,6 +65,7 @@ void Exception::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_value);
     for (StackFrame& frame : thisObject->m_stack)
         frame.visitAggregate(visitor);
+    visitor.reportExtraMemoryVisited(thisObject->m_stack.sizeInBytes());
 }
 
 DEFINE_VISIT_CHILDREN(Exception);
@@ -85,6 +86,7 @@ void Exception::finishCreation(VM& vm, StackCaptureAction action)
     if (action == StackCaptureAction::CaptureStack)
         vm.interpreter.getStackTrace(this, stackTrace, 0, Options::exceptionStackTraceLimit());
     m_stack = WTFMove(stackTrace);
+    vm.heap.reportExtraMemoryAllocated(this, m_stack.sizeInBytes());
 }
 
 #if ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.cpp
@@ -54,6 +54,13 @@ JSWebAssemblyException::JSWebAssemblyException(VM& vm, Structure* structure, Ref
 {
 }
 
+void JSWebAssemblyException::finishCreation(VM& vm)
+{
+    Base::finishCreation(vm);
+    ASSERT(inherits(info()));
+    vm.heap.reportExtraMemoryAllocated(this, payload().byteSize());
+}
+
 template<typename Visitor>
 void JSWebAssemblyException::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
@@ -67,6 +74,7 @@ void JSWebAssemblyException::visitChildrenImpl(JSCell* cell, Visitor& visitor)
             visitor.append(std::bit_cast<WriteBarrier<Unknown>>(exception->payload()[offset]));
         offset += tagType.argumentType(i).kind == Wasm::TypeKind::V128 ? 2 : 1;
     }
+    visitor.reportExtraMemoryVisited(exception->payload().size());
 }
 
 DEFINE_VISIT_CHILDREN(JSWebAssemblyException);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.h
@@ -69,7 +69,7 @@ public:
 protected:
     JSWebAssemblyException(VM&, Structure*, Ref<const Wasm::Tag>&&, FixedVector<uint64_t>&&);
 
-    DECLARE_DEFAULT_FINISH_CREATION;
+    void finishCreation(VM&);
 
     Ref<const Wasm::Tag> m_tag;
     Payload m_payload;


### PR DESCRIPTION
#### c6956e26bf70f2cbf440ea72220975c3dcc4c99f
<pre>
[JSC] Report extra memory allocated by JSC::Exception and JSC::JSWebAssemblyException
<a href="https://bugs.webkit.org/show_bug.cgi?id=283108">https://bugs.webkit.org/show_bug.cgi?id=283108</a>

Reviewed by Justin Michaud.

JSTests/wasm/stress/cc-int-to-int-cross-module-with-exception.js would
exceed the memory footprint limit when run with --memory-limited. This
was due to it allocating a lot of exceptions, while the size of the
allocated exceptions reported to the GC was wildly underestimated.
This lead to the GC kicking in too late because it is unable to track the
true eden size.

This is resolved by calling Heap::reportExtraMemoryAllocated on
on the stacktrace and payload allocated by JSC::Exception and
JSC::JSWebAssemblyException respectively.

* Source/JavaScriptCore/runtime/Exception.cpp:
(JSC::Exception::finishCreation):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyException.cpp:
(JSC::JSWebAssemblyException::finishCreation):
(JSC::JSWebAssemblyException::visitChildrenImpl):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyException.h:

Canonical link: <a href="https://commits.webkit.org/289147@main">https://commits.webkit.org/289147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61594a627f48c66e98f54c7de0173b6dec2cf081

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90158 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36064 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4828 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66159 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23973 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77257 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46424 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3574 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31486 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35137 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77978 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74368 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91736 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/84056 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9040 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74747 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73069 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73869 "run-api-tests-without-change (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18345 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18155 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16606 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4369 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12300 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17757 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/106448 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12136 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25688 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15631 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13882 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->