### PR TITLE
REGRESSION(285552@main): TestWebKitAPI.WKWebExtensionAPICookies.SetCookieWithExpirationDat is flakey

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICookies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICookies.mm
@@ -627,7 +627,7 @@ TEST(WKWebExtensionAPICookies, SetCookieWithExpirationDate)
     auto *backgroundScript = Util::constructScript(@[
         @"const cookieName = 'token'",
         @"const testUrl = 'http://www.example.com/'",
-        @"const expirationDate = Math.floor(Date.now() / 1000) + 1",
+        @"const expirationDate = Math.floor(Date.now() / 1000) + 2",
 
         @"await browser.cookies.set({",
         @"  url: testUrl,",
@@ -646,7 +646,7 @@ TEST(WKWebExtensionAPICookies, SetCookieWithExpirationDate)
         @"browser.test.assertEq(cookie?.value, 'value', 'Cookie should be set successfully')",
         @"browser.test.assertEq(cookie?.expirationDate, expirationDate, 'expirationDate should be the same as it was set')",
 
-        @"await new Promise(resolve => setTimeout(resolve, 1500))",
+        @"await new Promise(resolve => setTimeout(resolve, 2500))",
 
         @"cookie = await browser.cookies.get({",
         @"  url: testUrl,",


### PR DESCRIPTION
#### df38ae2ba88029a4b1bc1a591026eced6a6d85bc
<pre>
REGRESSION(285552@main): TestWebKitAPI.WKWebExtensionAPICookies.SetCookieWithExpirationDat is flakey
<a href="https://bugs.webkit.org/show_bug.cgi?id=283110">https://bugs.webkit.org/show_bug.cgi?id=283110</a>
<a href="https://rdar.apple.com/139876570">rdar://139876570</a>

Reviewed by Timothy Hatcher.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICookies.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPICookies, SetCookieWithExpirationDate)): Expire cookie after 3 seconds
instead of 1 to make the test less race-y.

Canonical link: <a href="https://commits.webkit.org/286600@main">https://commits.webkit.org/286600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9730d1739bb36fe4e7ada0396e3cef76318da5a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80990 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27740 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78581 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3792 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59955 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18070 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40283 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47264 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23156 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26063 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68390 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82437 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2526 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68232 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3993 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65636 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67477 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16830 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11450 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9546 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3787 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3810 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7240 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5568 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->