### PR TITLE
AX: Implement NextParagraphEnd and PreviousParagraphStart off the main thread

### DIFF
--- a/LayoutTests/accessibility/ax-thread-text-apis/text-marker-paragraph-nav-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/text-marker-paragraph-nav-expected.txt
@@ -2,28 +2,57 @@ This tests that paragraph navigation is working correctly.
 
 Current character is: p
 Current paragraph is: paragraph test
+Pre paragraph start to next paragraph end: paragraph test
 Current character is: T
 Current paragraph is: Test Content
+Pre paragraph start to next paragraph end: Test Content
 Current character is: c
 Current paragraph is: c [ATTACHMENT]d
+Pre paragraph start to next paragraph end: c [ATTACHMENT]d
 Current character is: d
 Current paragraph is: c [ATTACHMENT]d
+Pre paragraph start to next paragraph end: c [ATTACHMENT]d
+test audio ￼file
 Current character is: t
 Current paragraph is: test audio [ATTACHMENT]file
+Pre paragraph start to next paragraph end: test audio [ATTACHMENT]file
 Current character is: c
 Current paragraph is: can't select
+Pre paragraph start to next paragraph end: can't select
 Current character is: 巧
 Current paragraph is: 巧克力 是食物吗?
+Pre paragraph start to next paragraph end: 巧克力 是食物吗?
 Current character is: ك
 Current paragraph is: كيف حالك؟
+Pre paragraph start to next paragraph end: كيف حالك؟
 Current character is: b
 Current paragraph is: both   spaces
+Pre paragraph start to next paragraph end: both   spaces
 Current character is: i
 Current paragraph is: line breaks
+Pre paragraph start to next paragraph end: line breaks
 Current character is: s
 Current paragraph is: some
+Pre paragraph start to next paragraph end: some
 Current character is: t
 Current paragraph is: text
+Pre paragraph start to next paragraph end: text
+Verify Paragraphs: Forward
+Paragraph: this is my first paragraph. Of text. it has some text.
+Paragraph:
+Paragraph:
+Paragraph: this is my second paragraph. Of text. it has some text.
+Paragraph: this is my third paragraph. Of text. it has some text.
+Verify Paragraphs: Backward
+Paragraph: this is my third paragraph. Of text. it has some text.
+Paragraph: this is my second paragraph. Of text. it has some text.
+Paragraph:
+Paragraph:
+Paragraph: this is my first paragraph. Of text. it has some text.
+Test going forward.
+End paragraph: text
+Test going backwards.
+Start paragraph: paragraph test
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/ax-thread-text-apis/text-marker-paragraph-nav.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/text-marker-paragraph-nav.html
@@ -53,98 +53,161 @@ this is my third paragraph. Of text. it has some text.<br><br>
 </div>
 
 <script>
+var output = "This tests that paragraph navigation is working correctly.\n\n";
 
-    var output = "This tests that paragraph navigation is working correctly.\n\n";
+if (window.accessibilityController) {
+    // Check that we can get the paragraph range with span tag.
+    var text = accessibilityController.accessibleElementById("text1");
+    var textMarkerRange = text.textMarkerRangeForElement(text);
+    var startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
+    var currentMarker = advanceAndVerify(startMarker, 1, text);
+
+    // Check with contenteditable.
+    text = accessibilityController.accessibleElementById("text2");
+    textMarkerRange = text.textMarkerRangeForElement(text);
+    startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
+    currentMarker = advanceAndVerify(startMarker, 1, text);
+
+    // Check with replaced elements.
+    text = accessibilityController.accessibleElementById("text3");
+    textMarkerRange = text.textMarkerRangeForElement(text);
+    startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
+    currentMarker = advanceAndVerify(startMarker, 1, text);
+    currentMarker = advanceAndVerify(currentMarker, 3, text);
+
+    // Audio tag.
+    text = accessibilityController.accessibleElementById("text4");
+    textMarkerRange = text.textMarkerRangeForElement(text);
+    startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
+    currentMarker = advanceAndVerify(startMarker, 1, text);
+
+    // Check with user-select:none.
+    text = accessibilityController.accessibleElementById("text5");
+    textMarkerRange = text.textMarkerRangeForElement(text);
+    startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
+    currentMarker = advanceAndVerify(startMarker, 1, text);
     
-    if (window.accessibilityController) {
-        
-        // Check that we can get the paragraph range with span tag.
-        var text = accessibilityController.accessibleElementById("text1");
-        var textMarkerRange = text.textMarkerRangeForElement(text);
-        var startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
-        var currentMarker = advanceAndVerify(startMarker, 1, text);
+    // Multi-languages.
+    text = accessibilityController.accessibleElementById("text6");
+    textMarkerRange = text.textMarkerRangeForElement(text);
+    startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
+    currentMarker = advanceAndVerify(startMarker, 1, text);
+    
+    text = accessibilityController.accessibleElementById("text6a");
+    textMarkerRange = text.textMarkerRangeForElement(text);
+    startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
+    currentMarker = advanceAndVerify(startMarker, 1, text);
 
-        // Check with contenteditable.
-        text = accessibilityController.accessibleElementById("text2");
-        textMarkerRange = text.textMarkerRangeForElement(text);
-        startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
-        currentMarker = advanceAndVerify(startMarker, 1, text);
+    // Check the case with pre tag.
+    text = accessibilityController.accessibleElementById("text7");
+    textMarkerRange = text.textMarkerRangeForElement(text);
+    startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
+    currentMarker = advanceAndVerify(startMarker, 1, text);
+    currentMarker = advanceAndVerify(currentMarker, 15, text);
+    
+    // Check the case with br tag.
+    text = accessibilityController.accessibleElementById("text8");
+    textMarkerRange = text.textMarkerRangeForElement(text);
+    startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
+    currentMarker = advanceAndVerify(startMarker, 1, text);
+    currentMarker = advanceAndVerify(currentMarker, 5, text);
 
-        // Check with replaced elements.
-        text = accessibilityController.accessibleElementById("text3");
-        textMarkerRange = text.textMarkerRangeForElement(text);
-        startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
-        currentMarker = advanceAndVerify(startMarker, 1, text);
-        currentMarker = advanceAndVerify(currentMarker, 3, text);
+    text = accessibilityController.accessibleElementById("text9");
+    textMarkerRange = text.textMarkerRangeForElement(text);
+    startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
+    startMarker = text.nextTextMarker(startMarker);
+    var endMarker = text.endTextMarkerForTextMarkerRange(textMarkerRange);
+    verifyParagraphs(text, startMarker, 5);
 
-        // Audio tag.
-        text = accessibilityController.accessibleElementById("text4");
-        textMarkerRange = text.textMarkerRangeForElement(text);
-        startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
-        currentMarker = advanceAndVerify(startMarker, 1, text);
+    // Check the paragraph marker runs from start to end, and backwards.
+    // Make sure it won't hang.
+    verifyDocument(text);
 
-        // Check with user-select:none.
-        text = accessibilityController.accessibleElementById("text5");
-        textMarkerRange = text.textMarkerRangeForElement(text);
-        startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
-        currentMarker = advanceAndVerify(startMarker, 1, text);
-        
-        // Multi-languages.
-        text = accessibilityController.accessibleElementById("text6");
-        textMarkerRange = text.textMarkerRangeForElement(text);
-        startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
-        currentMarker = advanceAndVerify(startMarker, 1, text);
-        
-        text = accessibilityController.accessibleElementById("text6a");
-        textMarkerRange = text.textMarkerRangeForElement(text);
-        startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
-        currentMarker = advanceAndVerify(startMarker, 1, text);
-
-        // Check the case with pre tag.
-        text = accessibilityController.accessibleElementById("text7");
-        textMarkerRange = text.textMarkerRangeForElement(text);
-        startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
-        currentMarker = advanceAndVerify(startMarker, 1, text);
-        currentMarker = advanceAndVerify(currentMarker, 15, text);
-        
-        // Check the case with br tag.
-        text = accessibilityController.accessibleElementById("text8");
-        textMarkerRange = text.textMarkerRangeForElement(text);
-        startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
-        currentMarker = advanceAndVerify(startMarker, 1, text);
-        currentMarker = advanceAndVerify(currentMarker, 5, text);
-
-        // FIXME: add verifyParagraphs and verifyDocument from original test once nextParagraphEnd and previousParagraphStart APIs are implemented off the main thread
-        debug(output);
-        
-        function advanceAndVerify(currentMarker, offset, obj) {
-            var previousMarker = currentMarker;
-            for (var i = 0; i < offset; i++) {
-                previousMarker = currentMarker;
-                currentMarker = obj.nextTextMarker(previousMarker);
-            }
-            verifyParagraphRangeForTextMarker(previousMarker, currentMarker, obj);
-            return currentMarker;
+    debug(output);
+    
+    function advanceAndVerify(currentMarker, offset, obj) {
+        var previousMarker = currentMarker;
+        for (var i = 0; i < offset; i++) {
+            previousMarker = currentMarker;
+            currentMarker = obj.nextTextMarker(previousMarker);
         }
+        verifyParagraphRangeForTextMarker(previousMarker, currentMarker, obj);
+        return currentMarker;
+    }
+    
+    function replaceAttachmentInString(str) {
+        str =  str.replace(String.fromCharCode(65532), "[ATTACHMENT]");
+        return str;
+    }
+    
+    function verifyParagraphRangeForTextMarker(preMarker, textMarker, obj) {
+        var markerRange = obj.textMarkerRangeForMarkers(preMarker, textMarker);
+        var currentCharacter = replaceAttachmentInString(obj.stringForTextMarkerRange(markerRange));
+        output += `Current character is: ${currentCharacter}\n`;
         
-        function replaceAttachmentInString(str) {
-            str =  str.replace(String.fromCharCode(65532), "[ATTACHMENT]");
-            return str;
+        var paragraphRange = obj.paragraphTextMarkerRangeForTextMarker(textMarker);
+        var paragraph = replaceAttachmentInString(obj.stringForTextMarkerRange(paragraphRange));
+        output += `Current paragraph is: ${paragraph}\n`;
+
+        var preStart = obj.previousParagraphStartTextMarkerForTextMarker(textMarker);
+        var nextEnd = obj.nextParagraphEndTextMarkerForTextMarker(textMarker);
+        var preAndNextParagraphRange = obj.textMarkerRangeForMarkers(preStart, nextEnd);
+        var preAndNextParagraph = replaceAttachmentInString(obj.stringForTextMarkerRange(preAndNextParagraphRange));
+        output += `Pre paragraph start to next paragraph end: ${preAndNextParagraph}\n`;
+    }
+
+    function verifyParagraphs(obj, startMarker, paragraphCount) {
+        output += "Verify Paragraphs: Forward\n";
+        var current = startMarker;
+        var i = 0;
+        while(i < paragraphCount) {
+            current = obj.nextParagraphEndTextMarkerForTextMarker(current);
+            var currRange = obj.paragraphTextMarkerRangeForTextMarker(current);
+            var currParagraph = obj.stringForTextMarkerRange(currRange);
+            output += `Paragraph: ${currParagraph}\n`;
+            i++;
         }
+
+        // Backwards.
+        output += "Verify Paragraphs: Backward\n";
+        i = 0;
+        while(i < paragraphCount) {
+            current = obj.previousParagraphStartTextMarkerForTextMarker(current);
+            var currRange = obj.paragraphTextMarkerRangeForTextMarker(current);
+            var currParagraph = obj.stringForTextMarkerRange(currRange);
+            output += `Paragraph: ${currParagraph}\n`;
+            i++;
+        }
+    }
+    
+    function verifyDocument(obj) {
+        var start = obj.startTextMarker;
         
-        function verifyParagraphRangeForTextMarker(preMarker, textMarker, obj) {
-            var markerRange = obj.textMarkerRangeForMarkers(preMarker, textMarker);
-            var currentCharacter = replaceAttachmentInString(obj.stringForTextMarkerRange(markerRange));
-            output += `Current character is: ${currentCharacter}\n`;
-            
-            var paragraphRange = obj.paragraphTextMarkerRangeForTextMarker(textMarker);
-            var paragraph = replaceAttachmentInString(obj.stringForTextMarkerRange(paragraphRange));
-            output += `Current paragraph is: ${paragraph}\n`;
-            
-            // FIXME: Add "Pre paragraph start to next paragraph end" once nextParagraphEnd and previousParagraphStart are implemented off the main thread
+        // Going forward.
+        output += "Test going forward.\n";
+        var current = start;
+        var end = "text";
+        var currParagraph = "";
+        while(currParagraph != end) {
+            var currRange = obj.paragraphTextMarkerRangeForTextMarker(current);
+            currParagraph = obj.stringForTextMarkerRange(currRange);
+            current = obj.nextParagraphEndTextMarkerForTextMarker(current);
         }
+        output += `End paragraph: ${replaceAttachmentInString(currParagraph)}\n`;
+        
+        // Going backwards.
+        
+        output += "Test going backwards.\n";
+        var start = "paragraph test";
+        currParagraph = "";
+        while(currParagraph != start) {
+            var currentRange = obj.paragraphTextMarkerRangeForTextMarker(current);
+            currParagraph = obj.stringForTextMarkerRange(currentRange);
+            current = obj.previousParagraphStartTextMarkerForTextMarker(current);
+        }
+        output += `Start paragraph: ${replaceAttachmentInString(currParagraph)}\n`;
+    }
 }
-
 </script>
 
 </body>

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -193,8 +193,8 @@ public:
     AXTextMarker previousWordEnd(std::optional<AXID> stopAtID = std::nullopt) const { return findMarker(AXDirection::Previous, AXTextUnit::Word, AXTextUnitBoundary::End, stopAtID); }
     AXTextMarker previousSentenceStart(std::optional<AXID> stopAtID = std::nullopt) const { return findMarker(AXDirection::Previous, AXTextUnit::Sentence, AXTextUnitBoundary::Start, stopAtID); }
     AXTextMarker nextSentenceEnd(std::optional<AXID> stopAtID = std::nullopt) const { return findMarker(AXDirection::Next, AXTextUnit::Sentence, AXTextUnitBoundary::End, stopAtID); }
-    AXTextMarker previousParagraphStart(std::optional<AXID> stopAtID = std::nullopt) const { return findMarker(AXDirection::Previous, AXTextUnit::Paragraph, AXTextUnitBoundary::Start, stopAtID); }
-    AXTextMarker nextParagraphEnd(std::optional<AXID> stopAtID = std::nullopt) const { return findMarker(AXDirection::Next, AXTextUnit::Paragraph, AXTextUnitBoundary::End, stopAtID); }
+    AXTextMarker previousParagraphStart(std::optional<AXID> stopAtID = std::nullopt) const;
+    AXTextMarker nextParagraphEnd(std::optional<AXID> stopAtID = std::nullopt) const;
 
     // Creates a range for the line this marker points to.
     AXTextMarkerRange lineRange(LineRangeType) const;

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -3130,6 +3130,10 @@ enum class TextUnit {
             return inputMarker.nextSentenceEnd().platformData().autorelease();
         case TextUnit::PreviousSentenceStart:
             return inputMarker.previousSentenceStart().platformData().autorelease();
+        case TextUnit::NextParagraphEnd:
+            return inputMarker.nextParagraphEnd().platformData().autorelease();
+        case TextUnit::PreviousParagraphStart:
+            return inputMarker.previousParagraphStart().platformData().autorelease();
         default:
             // TODO: Not implemented!
             break;


### PR DESCRIPTION
#### 2be2f2d783081daf22256d444a61df63f215f86c
<pre>
AX: Implement NextParagraphEnd and PreviousParagraphStart off the main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=283112">https://bugs.webkit.org/show_bug.cgi?id=283112</a>
<a href="https://rdar.apple.com/139880052">rdar://139880052</a>

Reviewed by Tyler Wilcock.

This PR finishes moving paragraph navigation off the main thread by implementing the nextParagraphEnd
and previousParagraphStart APIs off of the main thread.

Several changes were made since 286004@main (AX: Implement TextUnit::Paragraph off the main thread),
including:
* Using the runIndex instead of the line index, so we can index relative to the current runs, not the
containing block.
* Adding logic to AXTextMarker::previousParagraphStart and AXTextMarker::nextParagraphEnd to mimic the
live tree behavior, notably, advancing when there are line breaks.
* Updating AXTextMarker::ParagraphRange to call findMarker directly, similar to the live tree.
* Refining the logic within findMarker to handle more edge cases. This includes removing the cumulative
offset, which is no longer used.

The text-marker-paragraph-nav.html test was also updated to test these APIs.

* LayoutTests/accessibility/ax-thread-text-apis/text-marker-paragraph-nav-expected.txt:
* LayoutTests/accessibility/ax-thread-text-apis/text-marker-paragraph-nav.html:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::findMarker const):
(WebCore::AXTextMarker::previousParagraphStart const):
(WebCore::AXTextMarker::nextParagraphEnd const):
(WebCore::AXTextMarker::paragraphRange const):
* Source/WebCore/accessibility/AXTextMarker.h:
(WebCore::AXTextMarker::previousParagraphStart const): Deleted.
(WebCore::AXTextMarker::nextParagraphEnd const): Deleted.
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper textMarkerForTextMarker:atUnit:]):

Canonical link: <a href="https://commits.webkit.org/286613@main">https://commits.webkit.org/286613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14ac491a628d9c272fc01db6af96a06713f7118c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80994 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27744 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64645 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59958 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18071 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65665 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40286 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47266 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23154 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26067 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68392 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82441 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2527 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68233 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3997 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65634 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67478 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16839 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11455 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9544 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3791 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6600 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3814 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7244 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->