### PR TITLE
AX: There are duplicate implementations of `columnHeaders()` for tables and table cells

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -786,6 +786,7 @@ public:
     virtual bool isExposable() const = 0;
     unsigned tableLevel() const;
     bool hasGridRole() const;
+    bool hasCellRole() const;
     bool supportsSelectedRows() const { return hasGridRole(); }
     virtual AccessibilityChildrenVector columns() = 0;
     virtual AccessibilityChildrenVector rows() = 0;
@@ -794,7 +795,7 @@ public:
     // All the cells in the table.
     virtual AccessibilityChildrenVector cells() = 0;
     virtual AXCoreObject* cellForColumnAndRow(unsigned column, unsigned row) = 0;
-    virtual AccessibilityChildrenVector columnHeaders() = 0;
+    AccessibilityChildrenVector columnHeaders();
     virtual AccessibilityChildrenVector rowHeaders() = 0;
     virtual AccessibilityChildrenVector visibleRows() = 0;
     AccessibilityChildrenVector selectedCells();

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -675,7 +675,7 @@ bool hasTableRole(Element& element)
     return hasAnyRole(element, { "grid"_s, "table"_s, "treegrid"_s });
 }
 
-bool hasCellRole(Element& element)
+bool hasCellARIARole(Element& element)
 {
     return hasAnyRole(element, { "gridcell"_s, "cell"_s, "columnheader"_s, "rowheader"_s });
 }
@@ -744,7 +744,7 @@ static bool isAccessibilityARIAGridRow(Element& element)
 
 static bool isAccessibilityARIAGridCell(Element& element)
 {
-    return hasCellRole(element);
+    return hasCellARIARole(element);
 }
 
 Ref<AccessibilityRenderObject> AXObjectCache::createObjectFromRenderer(RenderObject& renderer)
@@ -1948,7 +1948,7 @@ void AXObjectCache::onScrollbarFrameRectChange(const Scrollbar& scrollbar)
 
 void AXObjectCache::onSelectedChanged(Element& element)
 {
-    if (hasCellRole(element))
+    if (hasCellARIARole(element))
         postNotification(&element, AXSelectedCellsChanged);
     else if (is<HTMLOptionElement>(element))
         postNotification(&element, AXSelectedStateChanged);

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -933,7 +933,7 @@ private:
 bool hasRole(Element&, StringView role);
 bool hasAnyRole(Element&, Vector<StringView>&& roles);
 bool hasAnyRole(Element*, Vector<StringView>&& roles);
-bool hasCellRole(Element&);
+bool hasCellARIARole(Element&);
 bool hasPresentationRole(Element&);
 bool hasTableRole(Element&);
 bool isRowGroup(Element&);

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -142,7 +142,6 @@ public:
     unsigned rowCount() override { return 0; }
     AccessibilityChildrenVector cells() override { return AccessibilityChildrenVector(); }
     AccessibilityObject* cellForColumnAndRow(unsigned, unsigned) override { return nullptr; }
-    AccessibilityChildrenVector columnHeaders() override { return AccessibilityChildrenVector(); }
     AccessibilityChildrenVector rowHeaders() override { return AccessibilityChildrenVector(); }
     AccessibilityChildrenVector visibleRows() override { return AccessibilityChildrenVector(); }
     String cellScope() const final { return getAttribute(HTMLNames::scopeAttr); }

--- a/Source/WebCore/accessibility/AccessibilityTable.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTable.cpp
@@ -286,7 +286,7 @@ bool AccessibilityTable::isDataTable() const
                 }
 
                 // In this case, the developer explicitly assigned a "data" table attribute.
-                if (!cell->headers().isEmpty() || !cell->abbr().isEmpty() || !cell->axis().isEmpty() || !cell->scope().isEmpty() || hasCellRole(*cell))
+                if (!cell->headers().isEmpty() || !cell->abbr().isEmpty() || !cell->axis().isEmpty() || !cell->scope().isEmpty() || hasCellARIARole(*cell))
                     return true;
 
                 // If the author has used ARIA to specify a valid column or row index, assume they want us
@@ -808,21 +808,6 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityTable::rows()
     updateChildrenIfNecessary();
     
     return m_rows;
-}
-
-AXCoreObject::AccessibilityChildrenVector AccessibilityTable::columnHeaders()
-{
-    updateChildrenIfNecessary();
-
-    AccessibilityChildrenVector headers;
-    // Sometimes m_columns can be reset during the iteration, we cache it here to be safe.
-    AccessibilityChildrenVector columnsCopy = m_columns;
-    for (const auto& column : columnsCopy) {
-        if (auto* header = column->columnHeader())
-            headers.append(header);
-    }
-
-    return headers;
 }
 
 AXCoreObject::AccessibilityChildrenVector AccessibilityTable::rowHeaders()

--- a/Source/WebCore/accessibility/AccessibilityTable.h
+++ b/Source/WebCore/accessibility/AccessibilityTable.h
@@ -62,7 +62,6 @@ public:
     AccessibilityChildrenVector cells() final;
     AccessibilityObject* cellForColumnAndRow(unsigned column, unsigned row) final;
 
-    AccessibilityChildrenVector columnHeaders() final;
     AccessibilityChildrenVector rowHeaders() final;
     AccessibilityChildrenVector visibleRows() final;
 

--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -260,36 +260,6 @@ bool AccessibilityTableCell::supportsExpandedTextValue() const
     return isTableHeaderCell() && hasAttribute(abbrAttr);
 }
 
-AXCoreObject::AccessibilityChildrenVector AccessibilityTableCell::columnHeaders()
-{
-    RefPtr parent = parentTable();
-    if (!parent)
-        return { };
-
-    // Choose columnHeaders as the place where the "headers" attribute is reported.
-    auto headers = relatedObjects(AXRelationType::Headers);
-    // If the headers attribute returned valid values, then do not further search for column headers.
-    if (!headers.isEmpty())
-        return headers;
-
-    auto rowRange = rowIndexRange();
-    auto colRange = columnIndexRange();
-
-    for (unsigned row = 0; row < rowRange.first; row++) {
-        RefPtr tableCell = parent->cellForColumnAndRow(colRange.first, row);
-        if (!tableCell || tableCell == this || headers.contains(tableCell))
-            continue;
-
-        ASSERT(is<AccessibilityObject>(tableCell));
-        if (tableCell->cellScope() == "colgroup"_s && isTableCellInSameColGroup(tableCell.get()))
-            headers.append(tableCell);
-        else if (tableCell->isColumnHeader())
-            headers.append(tableCell);
-    }
-
-    return headers;
-}
-
 AXCoreObject::AccessibilityChildrenVector AccessibilityTableCell::rowHeaders()
 {
     AccessibilityChildrenVector headers;

--- a/Source/WebCore/accessibility/AccessibilityTableCell.h
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.h
@@ -56,7 +56,6 @@ public:
     // Returns the start location and column span of the cell.
     std::pair<unsigned, unsigned> columnIndexRange() const final;
 
-    AccessibilityChildrenVector columnHeaders() override;
     AccessibilityChildrenVector rowHeaders() override;
 
     int axColumnIndex() const override;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -2027,44 +2027,6 @@ OptionSet<AXAncestorFlag> AXIsolatedObject::ancestorFlags() const
     );
 }
 
-AXCoreObject::AccessibilityChildrenVector AXIsolatedObject::columnHeaders()
-{
-    AccessibilityChildrenVector headers;
-    if (isTable()) {
-        auto columnsCopy = columns();
-        for (const auto& column : columnsCopy) {
-            if (auto* header = column->columnHeader())
-                headers.append(header);
-        }
-    } else if (isExposedTableCell()) {
-        auto* parent = exposedTableAncestor();
-        if (!parent)
-            return { };
-
-        // Choose columnHeaders as the place where the "headers" attribute is reported.
-        headers = relatedObjects(AXRelationType::Headers);
-        // If the headers attribute returned valid values, then do not further search for column headers.
-        if (!headers.isEmpty())
-            return headers;
-
-        auto rowRange = rowIndexRange();
-        auto colRange = columnIndexRange();
-
-        for (unsigned row = 0; row < rowRange.first; row++) {
-            auto* tableCell = parent->cellForColumnAndRow(colRange.first, row);
-            if (!tableCell || tableCell == this || headers.contains(tableCell))
-                continue;
-
-            if (tableCell->cellScope() == "colgroup"_s && isTableCellInSameColGroup(tableCell))
-                headers.append(tableCell);
-            else if (tableCell->isColumnHeader())
-                headers.append(tableCell);
-        }
-    }
-
-    return headers;
-}
-
 String AXIsolatedObject::innerHTML() const
 {
     return const_cast<AXIsolatedObject*>(this)->getOrRetrievePropertyValue<String>(AXPropertyName::InnerHTML);

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -178,7 +178,6 @@ private:
     unsigned rowCount() final { return static_cast<unsigned>(rows().size()); }
     AccessibilityChildrenVector cells() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXPropertyName::Cells)); }
     AXIsolatedObject* cellForColumnAndRow(unsigned, unsigned) final;
-    AccessibilityChildrenVector columnHeaders() final;
     AccessibilityChildrenVector rowHeaders() final;
     AccessibilityChildrenVector visibleRows() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXPropertyName::VisibleRows)); }
     AXIsolatedObject* headerContainer() final { return objectAttributeValue(AXPropertyName::HeaderContainer); }


### PR DESCRIPTION
#### b4a2029d94e856e89c613983d809a6898a25054c
<pre>
AX: There are duplicate implementations of `columnHeaders()` for tables and table cells
<a href="https://bugs.webkit.org/show_bug.cgi?id=283116">https://bugs.webkit.org/show_bug.cgi?id=283116</a>
<a href="https://rdar.apple.com/problem/139882739">rdar://problem/139882739</a>

Reviewed by Chris Fleizach.

The implementation of `columnHeaders` in AXIsolatedObject already does pseudo-polymorphism (branching based on isTable()
or isExposedTableCell()). This commit moves this implementation to AXCoreObject, and removes the duplicated implementations
in AccessibilityTable::columnHeaders() and AccessibilityTableCell::columnHeaders(). This is cleaner and slightly more
performant since we can remove virtual from AXCoreObject::columnHeaders.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::hasCellRole const):
(WebCore::AXCoreObject::columnHeaders):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::hasCellARIARole):
(WebCore::isAccessibilityARIAGridCell):
(WebCore::AXObjectCache::onSelectedChanged):
(WebCore::hasCellRole): Deleted.
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityTable.cpp:
(WebCore::AccessibilityTable::isDataTable const):
(WebCore::AccessibilityTable::columnHeaders): Deleted.
* Source/WebCore/accessibility/AccessibilityTable.h:
* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
(WebCore::AccessibilityTableCell::columnHeaders): Deleted.
* Source/WebCore/accessibility/AccessibilityTableCell.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::columnHeaders): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:

Canonical link: <a href="https://commits.webkit.org/286616@main">https://commits.webkit.org/286616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f791dbcf59fded697a57654b736108bf5e12551c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81005 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27739 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78580 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64640 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3791 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59971 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18069 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49872 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40299 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47267 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23157 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26062 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68393 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23489 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82436 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2528 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68236 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/3992 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65637 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67481 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16842 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11452 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9547 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3786 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6595 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3809 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7239 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5567 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->