### PR TITLE
Update StringView::getCharacters() to take in a span

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlLocale.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocale.cpp
@@ -180,7 +180,7 @@ bool LocaleIDBuilder::setKeywordValue(ASCIILiteral key, StringView value)
 
     ASSERT(value.containsOnlyASCII());
     Vector<char, 32> rawValue(value.length() + 1);
-    value.getCharacters(byteCast<LChar>(rawValue.data()));
+    value.getCharacters(byteCast<LChar>(rawValue.mutableSpan()));
     rawValue[value.length()] = '\0';
 
     UErrorCode status = U_ZERO_ERROR;

--- a/Source/JavaScriptCore/runtime/JSString.cpp
+++ b/Source/JavaScriptCore/runtime/JSString.cpp
@@ -239,7 +239,7 @@ const String& JSRopeString::resolveRopeWithFunction(JSGlobalObject* nullOrGlobal
     }
     
     if (is8Bit()) {
-        LChar* buffer;
+        std::span<LChar> buffer;
         auto newImpl = StringImpl::tryCreateUninitialized(length(), buffer);
         if (!newImpl) {
             outOfMemory(nullOrGlobalObjectForOOM);
@@ -248,14 +248,14 @@ const String& JSRopeString::resolveRopeWithFunction(JSGlobalObject* nullOrGlobal
 
         size_t sizeToReport = newImpl->cost();
         uint8_t* stackLimit = bitwise_cast<uint8_t*>(vm.softStackLimit());
-        resolveRopeInternalNoSubstring(buffer, stackLimit);
+        resolveRopeInternalNoSubstring(buffer.data(), stackLimit);
         convertToNonRope(function(newImpl.releaseNonNull()));
         if constexpr (reportAllocation)
             vm.heap.reportExtraMemoryAllocated(this, sizeToReport);
         return valueInternal();
     }
     
-    UChar* buffer;
+    std::span<UChar> buffer;
     auto newImpl = StringImpl::tryCreateUninitialized(length(), buffer);
     if (!newImpl) {
         outOfMemory(nullOrGlobalObjectForOOM);
@@ -264,7 +264,7 @@ const String& JSRopeString::resolveRopeWithFunction(JSGlobalObject* nullOrGlobal
     
     size_t sizeToReport = newImpl->cost();
     uint8_t* stackLimit = bitwise_cast<uint8_t*>(vm.softStackLimit());
-    resolveRopeInternalNoSubstring(buffer, stackLimit);
+    resolveRopeInternalNoSubstring(buffer.data(), stackLimit);
     convertToNonRope(function(newImpl.releaseNonNull()));
     if constexpr (reportAllocation)
         vm.heap.reportExtraMemoryAllocated(this, sizeToReport);

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -145,7 +145,7 @@ ALWAYS_INLINE JSString* jsSpliceSubstringsWithSeparators(JSGlobalObject* globalO
         return jsEmptyString(vm);
 
     if (source.is8Bit() && allSeparators8Bit) {
-        LChar* buffer;
+        std::span<LChar> buffer;
         auto impl = StringImpl::tryCreateUninitialized(totalLength, buffer);
         if (!impl) {
             throwOutOfMemoryError(globalObject, scope);
@@ -157,12 +157,12 @@ ALWAYS_INLINE JSString* jsSpliceSubstringsWithSeparators(JSGlobalObject* globalO
         for (int i = 0; i < maxCount; i++) {
             if (i < rangeCount) {
                 auto substring = StringView { source }.substring(substringRanges[i].begin(), substringRanges[i].distance());
-                substring.getCharacters8(buffer + bufferPos.value());
+                substring.getCharacters8(buffer.subspan(bufferPos.value()));
                 bufferPos += substring.length();
             }
             if (i < separatorCount) {
                 StringView separator = separators[i];
-                separator.getCharacters8(buffer + bufferPos.value());
+                separator.getCharacters8(buffer.subspan(bufferPos.value()));
                 bufferPos += separator.length();
             }
         }
@@ -170,7 +170,7 @@ ALWAYS_INLINE JSString* jsSpliceSubstringsWithSeparators(JSGlobalObject* globalO
         RELEASE_AND_RETURN(scope, jsString(vm, impl.releaseNonNull()));
     }
 
-    UChar* buffer;
+    std::span<UChar> buffer;
     auto impl = StringImpl::tryCreateUninitialized(totalLength, buffer);
     if (!impl) {
         throwOutOfMemoryError(globalObject, scope);
@@ -182,12 +182,12 @@ ALWAYS_INLINE JSString* jsSpliceSubstringsWithSeparators(JSGlobalObject* globalO
     for (int i = 0; i < maxCount; i++) {
         if (i < rangeCount) {
             auto substring = StringView { source }.substring(substringRanges[i].begin(), substringRanges[i].distance());
-            substring.getCharacters(buffer + bufferPos.value());
+            substring.getCharacters(buffer.subspan(bufferPos.value()));
             bufferPos += substring.length();
         }
         if (i < separatorCount) {
             StringView separator = separators[i];
-            separator.getCharacters(buffer + bufferPos.value());
+            separator.getCharacters(buffer.subspan(bufferPos.value()));
             bufferPos += separator.length();
         }
     }

--- a/Source/WTF/wtf/HexNumber.h
+++ b/Source/WTF/wtf/HexNumber.h
@@ -81,7 +81,7 @@ public:
 
     unsigned length() const { return m_buffer.length; }
     bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(CharacterType* destination) const { StringImpl::copyCharacters(destination, m_buffer.span()); }
+    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { StringImpl::copyCharacters(destination.data(), m_buffer.span()); }
 
 private:
     const HexNumberBuffer& m_buffer;

--- a/Source/WTF/wtf/ObjectIdentifier.h
+++ b/Source/WTF/wtf/ObjectIdentifier.h
@@ -260,7 +260,7 @@ class ObjectIdentifierGenericBaseStringTypeAdapter<uint64_t> {
 public:
     unsigned length() const { return lengthOfIntegerAsString(m_identifier); }
     bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(CharacterType* destination) const { writeIntegerToBuffer(m_identifier, destination); }
+    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { writeIntegerToBuffer(m_identifier, destination.data()); }
 protected:
     explicit ObjectIdentifierGenericBaseStringTypeAdapter(uint64_t identifier)
         : m_identifier(identifier) { }

--- a/Source/WTF/wtf/UUID.h
+++ b/Source/WTF/wtf/UUID.h
@@ -211,7 +211,7 @@ public:
     bool is8Bit() const { return true; }
 
     template<typename CharacterType>
-    void writeTo(CharacterType* destination) const
+    void writeTo(std::span<CharacterType> destination) const
     {
         handle([&](auto&&... adapters) {
             stringTypeAdapterAccumulator(destination, std::forward<decltype(adapters)>(adapters)...);

--- a/Source/WTF/wtf/text/Base64.h
+++ b/Source/WTF/wtf/text/Base64.h
@@ -193,9 +193,9 @@ public:
     unsigned length() const { return m_encodedLength; }
     bool is8Bit() const { return true; }
 
-    template<typename CharacterType> void writeTo(CharacterType* destination) const
+    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const
     {
-        base64Encode(m_base64.input, unsafeMakeSpan(destination, m_encodedLength), m_base64.options);
+        base64Encode(m_base64.input, destination.first(m_encodedLength), m_base64.options);
     }
 
 private:

--- a/Source/WTF/wtf/text/StringBuilder.cpp
+++ b/Source/WTF/wtf/text/StringBuilder.cpp
@@ -135,18 +135,18 @@ void StringBuilder::reserveCapacity(unsigned newCapacity)
 }
 
 // Alterative extendBufferForAppending that can be called from the header without inlining.
-LChar* StringBuilder::extendBufferForAppendingLChar(unsigned requiredLength)
+std::span<LChar> StringBuilder::extendBufferForAppendingLChar(unsigned requiredLength)
 {
     return extendBufferForAppending<LChar>(requiredLength);
 }
 
-UChar* StringBuilder::extendBufferForAppendingWithUpconvert(unsigned requiredLength)
+std::span<UChar> StringBuilder::extendBufferForAppendingWithUpconvert(unsigned requiredLength)
 {
     if (is8Bit()) {
         allocateBuffer<UChar>(characters<LChar>(), expandedCapacity(capacity(), requiredLength));
         if (UNLIKELY(hasOverflowed()))
-            return nullptr;
-        return const_cast<UChar*>(m_buffer->span16().data()) + std::exchange(m_length, requiredLength);
+            return { };
+        return spanConstCast<UChar>(m_buffer->span16().subspan(std::exchange(m_length, requiredLength)));
     }
     return extendBufferForAppending<UChar>(requiredLength);
 }
@@ -160,8 +160,8 @@ void StringBuilder::append(std::span<const UChar> characters)
         return;
     }
     RELEASE_ASSERT(characters.size() < std::numeric_limits<uint32_t>::max());
-    if (auto destination = extendBufferForAppendingWithUpconvert(saturatedSum<uint32_t>(m_length, static_cast<uint32_t>(characters.size()))))
-        StringImpl::copyCharacters(destination, characters);
+    if (auto destination = extendBufferForAppendingWithUpconvert(saturatedSum<uint32_t>(m_length, static_cast<uint32_t>(characters.size()))); destination.data())
+        StringImpl::copyCharacters(destination.data(), characters);
 }
 
 void StringBuilder::append(std::span<const LChar> characters)
@@ -170,11 +170,11 @@ void StringBuilder::append(std::span<const LChar> characters)
         return;
     RELEASE_ASSERT(characters.size() < std::numeric_limits<uint32_t>::max());
     if (is8Bit()) {
-        if (auto destination = extendBufferForAppending<LChar>(saturatedSum<uint32_t>(m_length, static_cast<uint32_t>(characters.size()))))
-            StringImpl::copyCharacters(destination, characters);
+        if (auto destination = extendBufferForAppending<LChar>(saturatedSum<uint32_t>(m_length, static_cast<uint32_t>(characters.size()))); destination.data())
+            StringImpl::copyCharacters(destination.data(), characters);
     } else {
-        if (auto destination = extendBufferForAppending<UChar>(saturatedSum<uint32_t>(m_length, static_cast<uint32_t>(characters.size()))))
-            StringImpl::copyCharacters(destination, characters);
+        if (auto destination = extendBufferForAppending<UChar>(saturatedSum<uint32_t>(m_length, static_cast<uint32_t>(characters.size()))); destination.data())
+            StringImpl::copyCharacters(destination.data(), characters);
     }
 }
 

--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -108,10 +108,10 @@ private:
     template<typename CharacterType> void reallocateBuffer(unsigned requiredCapacity);
     void reallocateBuffer(unsigned requiredCapacity);
 
-    template<typename CharacterType> CharacterType* extendBufferForAppending(unsigned requiredLength);
-    template<typename CharacterType> CharacterType* extendBufferForAppendingSlowCase(unsigned requiredLength);
-    WTF_EXPORT_PRIVATE LChar* extendBufferForAppendingLChar(unsigned requiredLength);
-    WTF_EXPORT_PRIVATE UChar* extendBufferForAppendingWithUpconvert(unsigned requiredLength);
+    template<typename CharacterType> std::span<CharacterType> extendBufferForAppending(unsigned requiredLength);
+    template<typename CharacterType> std::span<CharacterType> extendBufferForAppendingSlowCase(unsigned requiredLength);
+    WTF_EXPORT_PRIVATE std::span<LChar> extendBufferForAppendingLChar(unsigned requiredLength);
+    WTF_EXPORT_PRIVATE std::span<UChar> extendBufferForAppendingWithUpconvert(unsigned requiredLength);
 
     WTF_EXPORT_PRIVATE void reifyString() const;
 
@@ -309,12 +309,12 @@ template<typename... StringTypeAdapters> void StringBuilder::appendFromAdapters(
         auto requiredLength = saturatedSum<uint32_t>(m_length, adapters.length()...);
         if (is8Bit() && are8Bit(adapters...)) {
             auto destination = extendBufferForAppendingLChar(requiredLength);
-            if (!destination)
+            if (!destination.data())
                 return;
             stringTypeAdapterAccumulator(destination, adapters...);
         } else {
             auto destination = extendBufferForAppendingWithUpconvert(requiredLength);
-            if (!destination)
+            if (!destination.data())
                 return;
             stringTypeAdapterAccumulator(destination, adapters...);
         }

--- a/Source/WTF/wtf/text/StringBuilderInternals.h
+++ b/Source/WTF/wtf/text/StringBuilderInternals.h
@@ -35,7 +35,7 @@ namespace WTF {
 // Allocate a new buffer, copying in currentCharacters (these may come from either m_string or m_buffer.
 template<typename AllocationCharacterType, typename CurrentCharacterType> void StringBuilder::allocateBuffer(const CurrentCharacterType* currentCharacters, unsigned requiredCapacity)
 {
-    AllocationCharacterType* bufferCharacters;
+    std::span<AllocationCharacterType> bufferCharacters;
     auto buffer = StringImpl::tryCreateUninitialized(requiredCapacity, bufferCharacters);
     if (UNLIKELY(!buffer)) {
         didOverflow();
@@ -43,7 +43,7 @@ template<typename AllocationCharacterType, typename CurrentCharacterType> void S
     }
 
     ASSERT(!hasOverflowed());
-    StringImpl::copyCharacters(bufferCharacters, { currentCharacters, m_length });
+    StringImpl::copyCharacters(bufferCharacters.data(), { currentCharacters, m_length });
 
     m_buffer = WTFMove(buffer);
     m_string = { };
@@ -73,24 +73,24 @@ template<typename CharacterType> void StringBuilder::reallocateBuffer(unsigned r
 // that capacity and return a pointer to the newly allocated storage so the caller can write characters there.
 // Returns nullptr if allocation fails, length overflows, or if total capacity is 0 so no buffer is needed.
 // The caller has the responsibility for checking that CharacterType is the type of the existing buffer.
-template<typename CharacterType> CharacterType* StringBuilder::extendBufferForAppending(unsigned requiredLength)
+template<typename CharacterType> std::span<CharacterType> StringBuilder::extendBufferForAppending(unsigned requiredLength)
 {
     if (m_buffer && requiredLength <= m_buffer->length()) {
         m_string = { };
-        return const_cast<CharacterType*>(m_buffer->span<CharacterType>().data()) + std::exchange(m_length, requiredLength);
+        return spanConstCast<CharacterType>(m_buffer->span<CharacterType>().subspan(std::exchange(m_length, requiredLength)));
     }
     return extendBufferForAppendingSlowCase<CharacterType>(requiredLength);
 }
 
 // Shared by the other extendBuffer functions.
-template<typename CharacterType> CharacterType* StringBuilder::extendBufferForAppendingSlowCase(unsigned requiredLength)
+template<typename CharacterType> std::span<CharacterType> StringBuilder::extendBufferForAppendingSlowCase(unsigned requiredLength)
 {
     if (!requiredLength || hasOverflowed())
-        return nullptr;
+        return { };
     reallocateBuffer(expandedCapacity(capacity(), requiredLength));
     if (UNLIKELY(hasOverflowed()))
-        return nullptr;
-    return const_cast<CharacterType*>(m_buffer->span<CharacterType>().data()) + std::exchange(m_length, requiredLength);
+        return { };
+    return spanConstCast<CharacterType>(m_buffer->span<CharacterType>().subspan(std::exchange(m_length, requiredLength)));
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/StringBuilderJSON.cpp
+++ b/Source/WTF/wtf/text/StringBuilderJSON.cpp
@@ -38,7 +38,7 @@ void StringBuilder::appendQuotedJSONString(const String& string)
     auto stringLengthValue = stringLength.value();
 
     if (is8Bit() && string.is8Bit()) {
-        if (auto* output = extendBufferForAppending<LChar>(saturatedSum<int32_t>(m_length, stringLengthValue))) {
+        if (auto* output = extendBufferForAppending<LChar>(saturatedSum<int32_t>(m_length, stringLengthValue)).data()) {
             auto* end = output + stringLengthValue;
             *output++ = '"';
             appendEscapedJSONStringContent(output, string.span8());
@@ -47,7 +47,7 @@ void StringBuilder::appendQuotedJSONString(const String& string)
                 shrink(m_length - (end - output));
         }
     } else {
-        if (auto* output = extendBufferForAppendingWithUpconvert(saturatedSum<int32_t>(m_length, stringLengthValue))) {
+        if (auto* output = extendBufferForAppendingWithUpconvert(saturatedSum<int32_t>(m_length, stringLengthValue)).data()) {
             auto* end = output + stringLengthValue;
             *output++ = '"';
             if (string.is8Bit())

--- a/Source/WTF/wtf/text/StringConcatenateNumbers.h
+++ b/Source/WTF/wtf/text/StringConcatenateNumbers.h
@@ -44,7 +44,7 @@ public:
     unsigned length() const { return lengthOfIntegerAsString(m_number); }
     bool is8Bit() const { return true; }
     template<typename CharacterType>
-    void writeTo(CharacterType* destination) const { writeIntegerToBuffer(m_number, destination); }
+    void writeTo(std::span<CharacterType> destination) const { writeIntegerToBuffer(m_number, destination.data()); }
 
 private:
     Integer m_number;
@@ -62,7 +62,7 @@ public:
     unsigned length() const { return lengthOfIntegerAsString(static_cast<UnderlyingType>(m_enum)); }
     bool is8Bit() const { return true; }
     template<typename CharacterType>
-    void writeTo(CharacterType* destination) const { writeIntegerToBuffer(static_cast<UnderlyingType>(m_enum), destination); }
+    void writeTo(std::span<CharacterType> destination) const { writeIntegerToBuffer(static_cast<UnderlyingType>(m_enum), destination.data()); }
 
 private:
     Enum m_enum;
@@ -78,7 +78,7 @@ public:
 
     unsigned length() const { return m_length; }
     bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(CharacterType* destination) const { StringImpl::copyCharacters(destination, span()); }
+    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { StringImpl::copyCharacters(destination.data(), span()); }
 
 private:
     std::span<const LChar> span() const { return byteCast<LChar>(std::span { m_buffer }).first(m_length); }
@@ -122,7 +122,7 @@ public:
 
     unsigned length() const { return m_number.length(); }
     bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(CharacterType* destination) const { StringImpl::copyCharacters(destination, m_number.span()); }
+    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { StringImpl::copyCharacters(destination.data(), m_number.span()); }
 
 private:
     const FormattedNumber& m_number;
@@ -156,7 +156,7 @@ public:
 
     unsigned length() const { return m_number.length(); }
     bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(CharacterType* destination) const { StringImpl::copyCharacters(destination, m_number.span()); }
+    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { StringImpl::copyCharacters(destination.data(), m_number.span()); }
 
 private:
     const FormattedCSSNumber& m_number;

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -133,9 +133,9 @@ public:
     template<size_t N = 32>
     UpconvertedCharactersWithSize<N> upconvertedCharacters() const;
 
-    template<typename CharacterType> void getCharacters(CharacterType*) const;
-    template<typename CharacterType> void getCharacters8(CharacterType*) const;
-    template<typename CharacterType> void getCharacters16(CharacterType*) const;
+    template<typename CharacterType> void getCharacters(std::span<CharacterType>) const;
+    template<typename CharacterType> void getCharacters8(std::span<CharacterType>) const;
+    template<typename CharacterType> void getCharacters16(std::span<CharacterType>) const;
 
     enum class CaseConvertType { Upper, Lower };
     WTF_EXPORT_PRIVATE void getCharactersWithASCIICase(CaseConvertType, LChar*) const;
@@ -608,17 +608,17 @@ template<bool isSpecialCharacter(UChar)> inline bool StringView::containsOnly() 
     return WTF::containsOnly<isSpecialCharacter>(span16());
 }
 
-template<typename CharacterType> inline void StringView::getCharacters8(CharacterType* destination) const
+template<typename CharacterType> inline void StringView::getCharacters8(std::span<CharacterType> destination) const
 {
-    StringImpl::copyCharacters(destination, span8());
+    StringImpl::copyCharacters(destination.data(), span8());
 }
 
-template<typename CharacterType> inline void StringView::getCharacters16(CharacterType* destination) const
+template<typename CharacterType> inline void StringView::getCharacters16(std::span<CharacterType> destination) const
 {
-    StringImpl::copyCharacters(destination, span16());
+    StringImpl::copyCharacters(destination.data(), span16());
 }
 
-template<typename CharacterType> inline void StringView::getCharacters(CharacterType* destination) const
+template<typename CharacterType> inline void StringView::getCharacters(std::span<CharacterType> destination) const
 {
     if (is8Bit())
         getCharacters8(destination);
@@ -726,7 +726,7 @@ public:
 
     unsigned length() const { return m_string.length(); }
     bool is8Bit() const { return m_string.is8Bit(); }
-    template<typename CharacterType> void writeTo(CharacterType* destination) { m_string.getCharacters(destination); }
+    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) { m_string.getCharacters(destination); }
 
 private:
     StringView m_string;
@@ -736,7 +736,7 @@ template<typename CharacterType, size_t inlineCapacity> void append(Vector<Chara
 {
     size_t oldSize = buffer.size();
     buffer.grow(oldSize + string.length());
-    string.getCharacters(buffer.mutableSpan().subspan(oldSize).data());
+    string.getCharacters(buffer.mutableSpan().subspan(oldSize));
 }
 
 ALWAYS_INLINE bool equal(StringView a, StringView b, unsigned length)

--- a/Source/WTF/wtf/text/cf/StringConcatenateCF.h
+++ b/Source/WTF/wtf/text/cf/StringConcatenateCF.h
@@ -36,7 +36,7 @@ public:
     StringTypeAdapter(CFStringRef);
     unsigned length() const { return m_string ? CFStringGetLength(m_string) : 0; }
     bool is8Bit() const { return !m_string || CFStringGetCStringPtr(m_string, kCFStringEncodingISOLatin1); }
-    template<typename CharacterType> void writeTo(CharacterType*) const;
+    template<typename CharacterType> void writeTo(std::span<CharacterType>) const;
 
 private:
     CFStringRef m_string;
@@ -47,16 +47,16 @@ inline StringTypeAdapter<CFStringRef>::StringTypeAdapter(CFStringRef string)
 {
 }
 
-template<> inline void StringTypeAdapter<CFStringRef>::writeTo<LChar>(LChar* destination) const
+template<> inline void StringTypeAdapter<CFStringRef>::writeTo<LChar>(std::span<LChar> destination) const
 {
     if (m_string)
-        std::memcpy(destination, CFStringGetCStringPtr(m_string, kCFStringEncodingISOLatin1), CFStringGetLength(m_string));
+        std::memcpy(destination.data(), CFStringGetCStringPtr(m_string, kCFStringEncodingISOLatin1), CFStringGetLength(m_string));
 }
 
-template<> inline void StringTypeAdapter<CFStringRef>::writeTo<UChar>(UChar* destination) const
+template<> inline void StringTypeAdapter<CFStringRef>::writeTo<UChar>(std::span<UChar> destination) const
 {
     if (m_string)
-        CFStringGetCharacters(m_string, CFRangeMake(0, CFStringGetLength(m_string)), reinterpret_cast<UniChar*>(destination));
+        CFStringGetCharacters(m_string, CFRangeMake(0, CFStringGetLength(m_string)), reinterpret_cast<UniChar*>(destination.data()));
 }
 
 #ifdef __OBJC__

--- a/Source/WTF/wtf/text/cocoa/ContextualizedNSString.mm
+++ b/Source/WTF/wtf/text/cocoa/ContextualizedNSString.mm
@@ -64,10 +64,10 @@
     auto contentsHigh = std::clamp(static_cast<unsigned>(range.location + range.length), context.length(), context.length() + contents.length());
     auto contentsSubstring = contents.substring(contentsLow - context.length(), contentsHigh - contentsLow);
     static_assert(std::is_same_v<std::make_unsigned_t<unichar>, std::make_unsigned_t<UChar>>);
-    contextSubstring.getCharacters(reinterpret_cast<UChar*>(buffer));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    contentsSubstring.getCharacters(reinterpret_cast<UChar*>(buffer) + contextSubstring.length());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    // FIXME: We don't actually know the size of buffer here.
+    auto bufferSpan = unsafeMakeSpan(reinterpret_cast<UChar*>(buffer), contextSubstring.length() + contentsSubstring.length());
+    contextSubstring.getCharacters(bufferSpan);
+    contentsSubstring.getCharacters(bufferSpan.subspan(contextSubstring.length()));
 }
 
 @end

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.cpp
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.cpp
@@ -106,7 +106,7 @@ void ThreadableWebSocketChannelClientWrapper::setSubprotocol(const String& subpr
 {
     unsigned length = subprotocol.length();
     m_subprotocol.resize(length);
-    StringView(subprotocol).getCharacters(m_subprotocol.data());
+    StringView(subprotocol).getCharacters(m_subprotocol.mutableSpan());
 }
 
 String ThreadableWebSocketChannelClientWrapper::extensions() const
@@ -120,7 +120,7 @@ void ThreadableWebSocketChannelClientWrapper::setExtensions(const String& extens
 {
     unsigned length = extensions.length();
     m_extensions.resize(length);
-    StringView(extensions).getCharacters(m_extensions.data());
+    StringView(extensions).getCharacters(m_extensions.mutableSpan());
 }
 
 ThreadableWebSocketChannel::SendResult ThreadableWebSocketChannelClientWrapper::sendRequestResult() const

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2792,7 +2792,7 @@ String CanvasRenderingContext2DBase::normalizeSpaces(const String& text)
 
     unsigned textLength = text.length();
     Vector<UChar> charVector(textLength);
-    StringView(text).getCharacters(charVector.data());
+    StringView(text).getCharacters(charVector.mutableSpan());
 
     charVector[i++] = ' ';
 

--- a/Source/WebCore/platform/ProcessQualified.h
+++ b/Source/WebCore/platform/ProcessQualified.h
@@ -165,12 +165,12 @@ class ProcessQualifiedStringTypeAdapter {
 public:
     unsigned length() const { return lengthOfIntegerAsString(m_processIdentifier) + lengthOfIntegerAsString(m_objectIdentifier) + 1; }
     bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(CharacterType* destination) const
+    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const
     {
         auto processIdentifierLength = lengthOfIntegerAsString(m_processIdentifier);
-        writeIntegerToBuffer(m_processIdentifier, destination);
-        *(destination + processIdentifierLength) = '-';
-        writeIntegerToBuffer(m_objectIdentifier, destination + processIdentifierLength + 1);
+        writeIntegerToBuffer(m_processIdentifier, destination.data());
+        destination[processIdentifierLength] = '-';
+        writeIntegerToBuffer(m_objectIdentifier, destination.subspan(processIdentifierLength + 1).data());
     }
 protected:
     explicit ProcessQualifiedStringTypeAdapter(uint64_t processIdentifier, uint64_t objectIdentifier)

--- a/Source/WebCore/platform/graphics/StringTruncator.cpp
+++ b/Source/WebCore/platform/graphics/StringTruncator.cpp
@@ -93,10 +93,10 @@ static unsigned centerTruncateToBuffer(const String& string, unsigned length, un
     unsigned truncatedLength = omitStart + shouldInsertEllipsis + (length - omitEnd);
     ASSERT(truncatedLength <= length);
 
-    StringView(string).left(omitStart).getCharacters(buffer.data());
+    StringView(string).left(omitStart).getCharacters(buffer);
     if (shouldInsertEllipsis)
         buffer[omitStart++] = horizontalEllipsis;
-    StringView(string).substring(omitEnd, length - omitEnd).getCharacters(&buffer[omitStart]);
+    StringView(string).substring(omitEnd, length - omitEnd).getCharacters(buffer.subspan(omitStart));
     return truncatedLength;
 }
 
@@ -123,7 +123,7 @@ static unsigned rightTruncateToBuffer(const String& string, unsigned length, uns
     unsigned keepLength = textBreakAtOrPreceding(it, keepCount);
     unsigned truncatedLength = shouldInsertEllipsis ? keepLength + 1 : keepLength;
 
-    StringView(string).left(keepLength).getCharacters(buffer.data());
+    StringView(string).left(keepLength).getCharacters(buffer);
     if (shouldInsertEllipsis)
         buffer[keepLength] = horizontalEllipsis;
 
@@ -137,7 +137,7 @@ static unsigned rightClipToCharacterBuffer(const String& string, unsigned length
 
     NonSharedCharacterBreakIterator it(StringView(string).left(length));
     unsigned keepLength = textBreakAtOrPreceding(it, keepCount);
-    StringView(string).left(keepLength).getCharacters(buffer.data());
+    StringView(string).left(keepLength).getCharacters(buffer);
 
     return keepLength;
 }
@@ -149,7 +149,7 @@ static unsigned rightClipToWordBuffer(const String& string, unsigned length, uns
 
     UBreakIterator* it = wordBreakIterator(StringView(string).left(length));
     unsigned keepLength = textBreakAtOrPreceding(it, keepCount);
-    StringView(string).left(keepLength).getCharacters(buffer.data());
+    StringView(string).left(keepLength).getCharacters(buffer);
 
 #if PLATFORM(IOS_FAMILY)
     // FIXME: We should guard this code behind an editing behavior. Then we can remove the PLATFORM(IOS_FAMILY)-guard.
@@ -186,10 +186,10 @@ static unsigned leftTruncateToBuffer(const String& string, unsigned length, unsi
 
     if (shouldInsertEllipsis) {
         buffer[0] = horizontalEllipsis;
-        StringView(string).substring(adjustedStartIndex, length - adjustedStartIndex + 1).getCharacters(&buffer[1]);
+        StringView(string).substring(adjustedStartIndex, length - adjustedStartIndex + 1).getCharacters(buffer.subspan(1));
         return length - adjustedStartIndex + 1;
     }
-    StringView(string).substring(adjustedStartIndex, length - adjustedStartIndex + 1).getCharacters(&buffer[0]);
+    StringView(string).substring(adjustedStartIndex, length - adjustedStartIndex + 1).getCharacters(buffer);
     return length - adjustedStartIndex;
 }
 
@@ -224,7 +224,7 @@ static String truncateString(const String& string, float maxWidth, const FontCas
         truncatedLength = centerTruncateToBuffer(string, length, keepCount, stringBuffer, shouldInsertEllipsis);
     } else {
         keepCount = length;
-        StringView(string).getCharacters(stringBuffer.data());
+        StringView(string).getCharacters(std::span<UChar> { stringBuffer });
         truncatedLength = length;
     }
 

--- a/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
@@ -311,7 +311,7 @@ RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription&
 
         LOGFONT logFont;
         logFont.lfCharSet = DEFAULT_CHARSET;
-        StringView(linkedFonts->at(linkedFontIndex)).getCharacters(ucharFrom(logFont.lfFaceName));
+        StringView(linkedFonts->at(linkedFontIndex)).getCharacters(spanReinterpretCast<UChar>(std::span<wchar_t> { logFont.lfFaceName }));
         logFont.lfFaceName[linkedFonts->at(linkedFontIndex).length()] = 0;
         EnumFontFamiliesEx(hdc, &logFont, linkedFontEnumProc, reinterpret_cast<LPARAM>(&hfont), 0);
         linkedFontIndex++;
@@ -503,7 +503,7 @@ GDIObject<HFONT> createGDIFont(const AtomString& family, LONG desiredWeight, boo
     LOGFONT logFont;
     logFont.lfCharSet = DEFAULT_CHARSET;
     StringView truncatedFamily = StringView(family).left(static_cast<unsigned>(LF_FACESIZE - 1));
-    truncatedFamily.getCharacters(ucharFrom(logFont.lfFaceName));
+    truncatedFamily.getCharacters(spanReinterpretCast<UChar>(std::span<wchar_t> { logFont.lfFaceName }));
     logFont.lfFaceName[truncatedFamily.length()] = 0;
     logFont.lfPitchAndFamily = 0;
 
@@ -608,7 +608,7 @@ Vector<FontSelectionCapabilities> FontCache::getFontSelectionCapabilitiesInFamil
     LOGFONT logFont;
     logFont.lfCharSet = DEFAULT_CHARSET;
     StringView truncatedFamily = StringView(familyName).left(static_cast<unsigned>(LF_FACESIZE - 1));
-    truncatedFamily.getCharacters(ucharFrom(logFont.lfFaceName));
+    truncatedFamily.getCharacters(spanReinterpretCast<UChar>(std::span<wchar_t> { logFont.lfFaceName }));
     logFont.lfFaceName[truncatedFamily.length()] = 0;
     logFont.lfPitchAndFamily = 0;
 

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -167,7 +167,7 @@ HGLOBAL createGlobalData(const String& str)
     HGLOBAL vm = ::GlobalAlloc(GPTR, (str.length() + 1) * sizeof(UChar));
     if (!vm)
         return 0;
-    UChar* buffer = static_cast<UChar*>(GlobalLock(vm));
+    auto buffer = unsafeMakeSpan(static_cast<UChar*>(GlobalLock(vm)), str.length() + 1);
     StringView(str).getCharacters(buffer);
     buffer[str.length()] = 0;
     GlobalUnlock(vm);

--- a/Source/WebCore/platform/win/PasteboardWin.cpp
+++ b/Source/WebCore/platform/win/PasteboardWin.cpp
@@ -49,6 +49,7 @@
 #include "WebCoreInstanceHandle.h"
 #include "markup.h"
 #include <pal/text/TextEncoding.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/URL.h>
 #include <wtf/WindowsExtras.h>
 #include <wtf/text/CString.h>
@@ -601,18 +602,18 @@ static String fileSystemPathFromURLOrTitle(const String& urlString, const String
 {
     static const size_t fsPathMaxLengthExcludingNullTerminator = MAX_PATH - 1;
     bool usedURL = false;
-    UChar fsPathBuffer[MAX_PATH];
+    std::array<UChar, MAX_PATH> fsPathBuffer;
     fsPathBuffer[0] = 0;
     int fsPathMaxLengthExcludingExtension = fsPathMaxLengthExcludingNullTerminator - extension.length();
 
     if (!title.isEmpty()) {
         size_t len = std::min<size_t>(title.length(), fsPathMaxLengthExcludingExtension);
-        StringView(title).left(len).getCharacters(fsPathBuffer);
+        StringView(title).left(len).getCharacters(std::span<UChar> { fsPathBuffer });
         fsPathBuffer[len] = 0;
-        pathRemoveBadFSCharacters(wcharFrom(fsPathBuffer), len);
+        pathRemoveBadFSCharacters(wcharFrom(fsPathBuffer.data()), len);
     }
 
-    if (!wcslen(wcharFrom(fsPathBuffer))) {
+    if (!wcslen(wcharFrom(fsPathBuffer.data()))) {
         URL url { urlString };
         usedURL = true;
         // The filename for any content based drag or file url should be the last element of 
@@ -622,24 +623,24 @@ static String fileSystemPathFromURLOrTitle(const String& urlString, const String
         auto lastComponent = url.lastPathComponent();
         if (url.protocolIsFile() || (!isLink && !lastComponent.isEmpty())) {
             len = std::min<DWORD>(fsPathMaxLengthExcludingExtension, lastComponent.length());
-            lastComponent.left(len).getCharacters(fsPathBuffer);
+            lastComponent.left(len).getCharacters(std::span<UChar> { fsPathBuffer });
         } else {
             len = std::min<DWORD>(fsPathMaxLengthExcludingExtension, urlString.length());
-            StringView(urlString).left(len).getCharacters(fsPathBuffer);
+            StringView(urlString).left(len).getCharacters(std::span<UChar> { fsPathBuffer });
         }
         fsPathBuffer[len] = 0;
-        pathRemoveBadFSCharacters(wcharFrom(fsPathBuffer), len);
+        pathRemoveBadFSCharacters(wcharFrom(fsPathBuffer.data()), len);
     }
 
     if (extension.isEmpty())
-        return String(wcharFrom(fsPathBuffer));
+        return String(wcharFrom(fsPathBuffer.data()));
 
     if (!isLink && usedURL) {
-        PathRenameExtension(wcharFrom(fsPathBuffer), extension.wideCharacters().data());
-        return String(wcharFrom(fsPathBuffer));
+        PathRenameExtension(wcharFrom(fsPathBuffer.data()), extension.wideCharacters().data());
+        return String(wcharFrom(fsPathBuffer.data()));
     }
 
-    return makeString(const_cast<const UChar*>(fsPathBuffer), extension);
+    return makeString(const_cast<const UChar*>(fsPathBuffer.data()), extension);
 }
 
 // writeFileToDataObject takes ownership of fileDescriptor and fileContent
@@ -723,7 +724,7 @@ void Pasteboard::writeURLToDataObject(const URL& kurl, const String& titleStr)
     fgd->fgd[0].nFileSizeLow = content.length();
 
     unsigned maxSize = std::min<unsigned>(fsPath.length(), std::size(fgd->fgd[0].cFileName));
-    StringView(fsPath).left(maxSize).getCharacters(ucharFrom(fgd->fgd[0].cFileName));
+    StringView(fsPath).left(maxSize).getCharacters(spanReinterpretCast<UChar>(std::span<wchar_t> { fgd->fgd[0].cFileName }));
     GlobalUnlock(urlFileDescriptor);
 
     char* fileContents = static_cast<char*>(GlobalLock(urlFileContent));
@@ -961,7 +962,7 @@ static HGLOBAL createGlobalImageFileDescriptor(const String& url, const String& 
     }
 
     int maxSize = std::min<int>(fsPath.length(), std::size(fgd->fgd[0].cFileName));
-    StringView(fsPath).left(maxSize).getCharacters(ucharFrom(fgd->fgd[0].cFileName));
+    StringView(fsPath).left(maxSize).getCharacters(spanReinterpretCast<UChar>(std::span<wchar_t> { fgd->fgd[0].cFileName }));
     GlobalUnlock(memObj);
 
     return memObj;

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -320,7 +320,7 @@ public:
     unsigned length() const { return m_string.length(); }
     bool is8Bit() const { return m_string.is8Bit(); }
     template<typename CharacterType>
-    void writeTo(CharacterType* destination) const
+    void writeTo(std::span<CharacterType> destination) const
     {
         StringView { m_string }.getCharacters(destination);
         WTF_STRINGTYPEADAPTER_COPIED_WTF_STRING();

--- a/Source/WebKit/Shared/API/c/WKString.cpp
+++ b/Source/WebKit/Shared/API/c/WKString.cpp
@@ -66,7 +66,7 @@ size_t WKStringGetCharacters(WKStringRef stringRef, WKChar* buffer, size_t buffe
     unsigned unsignedBufferLength = std::min<size_t>(bufferLength, std::numeric_limits<unsigned>::max());
     auto substring = WebKit::toImpl(stringRef)->stringView().left(unsignedBufferLength);
 
-    substring.getCharacters(reinterpret_cast<UChar*>(buffer));
+    substring.getCharacters(unsafeMakeSpan(reinterpret_cast<UChar*>(buffer), bufferLength));
     return substring.length();
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/MoveOnly.h
+++ b/Tools/TestWebKitAPI/Tests/WTF/MoveOnly.h
@@ -108,7 +108,7 @@ public:
 
     unsigned length() const { return StringTypeAdapter<unsigned>(m_moveOnly.value()).length(); }
     bool is8Bit() const { return StringTypeAdapter<unsigned>(m_moveOnly.value()).is8Bit(); }
-    template<typename CharacterType> void writeTo(CharacterType* destination) const
+    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const
     {
         StringTypeAdapter<unsigned>(m_moveOnly.value()).writeTo(destination);
     }

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -69,7 +69,7 @@ public:
     StringTypeAdapter(WKStringRef);
     unsigned length() const { return m_string ? WKStringGetLength(m_string) : 0; }
     bool is8Bit() const { return !m_string; }
-    template<typename CharacterType> void writeTo(CharacterType*) const;
+    template<typename CharacterType> void writeTo(std::span<CharacterType>) const;
 
 private:
     WKStringRef m_string;
@@ -80,14 +80,14 @@ inline StringTypeAdapter<WKStringRef>::StringTypeAdapter(WKStringRef string)
 {
 }
 
-template<> inline void StringTypeAdapter<WKStringRef>::writeTo<LChar>(LChar*) const
+template<> inline void StringTypeAdapter<WKStringRef>::writeTo<LChar>(std::span<LChar>) const
 {
 }
 
-template<> inline void StringTypeAdapter<WKStringRef>::writeTo<UChar>(UChar* destination) const
+template<> inline void StringTypeAdapter<WKStringRef>::writeTo<UChar>(std::span<UChar> destination) const
 {
     if (m_string)
-        WKStringGetCharacters(m_string, reinterpret_cast<WKChar*>(destination), WKStringGetLength(m_string));
+        WKStringGetCharacters(m_string, reinterpret_cast<WKChar*>(destination.data()), WKStringGetLength(m_string));
 }
 
 }


### PR DESCRIPTION
#### 7a039c8cf8011ef0a2a405b7a3ada7dbd0db6f43
<pre>
Update StringView::getCharacters() to take in a span
<a href="https://bugs.webkit.org/show_bug.cgi?id=283099">https://bugs.webkit.org/show_bug.cgi?id=283099</a>

Reviewed by Geoffrey Garen.

* Source/JavaScriptCore/API/OpaqueJSString.cpp:
(OpaqueJSString::characters):
* Source/JavaScriptCore/runtime/IntlLocale.cpp:
(JSC::LocaleIDBuilder::setKeywordValue):
* Source/JavaScriptCore/runtime/JSString.cpp:
(JSC::JSRopeString::resolveRopeInternalNoSubstring const):
(JSC::JSRopeString::resolveRopeToAtomString const):
(JSC::JSRopeString::resolveRopeToExistingAtomString const):
(JSC::JSRopeString::resolveRopeWithFunction const):
* Source/JavaScriptCore/runtime/JSString.h:
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::repeatCharacter):
(JSC::JSRopeString::resolveToBufferSlow):
(JSC::JSRopeString::resolveToBuffer):
(JSC::jsAtomString):
* Source/JavaScriptCore/runtime/JSStringJoiner.cpp:
(JSC::appendStringToData):
(JSC::appendStringToDataWithOneCharacterSeparatorRepeatedly):
(JSC::joinStrings):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::jsSpliceSubstrings):
(JSC::normalize):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::jsSpliceSubstringsWithSeparators):
* Source/WTF/wtf/HexNumber.h:
(WTF::StringTypeAdapter&lt;HexNumberBuffer&gt;::writeTo const):
* Source/WTF/wtf/ObjectIdentifier.h:
(WTF::ObjectIdentifierGenericBaseStringTypeAdapter&lt;uint64_t&gt;::writeTo const):
* Source/WTF/wtf/UUID.h:
(WTF::StringTypeAdapter&lt;UUID&gt;::writeTo const):
* Source/WTF/wtf/text/Base64.h:
(WTF::StringTypeAdapter&lt;Base64Specification&gt;::writeTo const):
* Source/WTF/wtf/text/MakeString.h:
(WTF::tryMakeStringImplFromAdaptersInternal):
(WTF::tryMakeAtomStringFromAdapters):
* Source/WTF/wtf/text/StringBuilder.cpp:
(WTF::StringBuilder::extendBufferForAppendingLChar):
(WTF::StringBuilder::extendBufferForAppendingWithUpconvert):
(WTF::StringBuilder::append):
* Source/WTF/wtf/text/StringBuilder.h:
(WTF::StringBuilder::appendFromAdapters):
* Source/WTF/wtf/text/StringBuilderInternals.h:
(WTF::StringBuilder::allocateBuffer):
(WTF::StringBuilder::extendBufferForAppending):
(WTF::StringBuilder::extendBufferForAppendingSlowCase):
* Source/WTF/wtf/text/StringBuilderJSON.cpp:
(WTF::StringBuilder::appendQuotedJSONString):
* Source/WTF/wtf/text/StringConcatenate.h:
(WTF::StringTypeAdapter&lt;std::tuple&lt;StringTypes::writeTo const):
(WTF::StringTypeAdapter&lt;PaddingSpecification&lt;UnderlyingElementType&gt;&gt;::writeTo const):
(WTF::stringTypeAdapterAccumulator):
* Source/WTF/wtf/text/StringConcatenateNumbers.h:
(WTF::StringTypeAdapter&lt;FormattedNumber&gt;::writeTo const):
(WTF::StringTypeAdapter&lt;FormattedCSSNumber&gt;::writeTo const):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::tryCreateUninitialized):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::getCharacters8 const):
(WTF::StringView::getCharacters16 const):
(WTF::StringView::getCharacters const):
(WTF::append):
* Source/WTF/wtf/text/cf/StringConcatenateCF.h:
(WTF::StringTypeAdapter&lt;CFStringRef&gt;::writeTo&lt;LChar&gt; const):
(WTF::StringTypeAdapter&lt;CFStringRef&gt;::writeTo&lt;UChar&gt; const):
* Source/WTF/wtf/text/cocoa/ContextualizedNSString.mm:
(-[WTFContextualizedNSString getCharacters:range:]):
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.cpp:
(WebCore::ThreadableWebSocketChannelClientWrapper::setSubprotocol):
(WebCore::ThreadableWebSocketChannelClientWrapper::setExtensions):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::normalizeSpaces):
* Source/WebCore/platform/ProcessQualified.h:
(WTF::ProcessQualifiedStringTypeAdapter::writeTo const):
* Source/WebCore/platform/graphics/StringTruncator.cpp:
(WebCore::centerTruncateToBuffer):
(WebCore::rightTruncateToBuffer):
(WebCore::rightClipToCharacterBuffer):
(WebCore::rightClipToWordBuffer):
(WebCore::leftTruncateToBuffer):
(WebCore::truncateString):
* Source/WebCore/platform/graphics/win/FontCacheWin.cpp:
(WebCore::FontCache::systemFallbackForCharacterCluster):
(WebCore::createGDIFont):
(WebCore::FontCache::getFontSelectionCapabilitiesInFamily):
* Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp:
(WebCore::createGlobalData):
* Source/WebCore/platform/win/PasteboardWin.cpp:
(WebCore::fileSystemPathFromURLOrTitle):
(WebCore::Pasteboard::writeURLToDataObject):
(WebCore::createGlobalImageFileDescriptor):
* Source/WebGPU/WGSL/Types.h:
* Source/WebKit/Shared/API/c/WKString.cpp:
(WKStringGetCharacters):
* Tools/TestWebKitAPI/Tests/WTF/MoveOnly.h:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTF::StringTypeAdapter&lt;WKStringRef&gt;::writeTo&lt;LChar&gt; const):
(WTF::StringTypeAdapter&lt;WKStringRef&gt;::writeTo&lt;UChar&gt; const):

Canonical link: <a href="https://commits.webkit.org/286694@main">https://commits.webkit.org/286694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47443acb61b2a32ae66ae68bfc15f8e8e3795c44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81321 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28064 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60173 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18261 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65925 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40492 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47521 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23419 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26388 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69971 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68638 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23749 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82765 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76065 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2757 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68455 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4317 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67707 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11684 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9767 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98319 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11885 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4111 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6922 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21505 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4134 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7564 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5892 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->