### PR TITLE
[flatpak] Forward port GStreamer sticky events race fix

### DIFF
--- a/Tools/gstreamer/jhbuild.modules
+++ b/Tools/gstreamer/jhbuild.modules
@@ -97,7 +97,9 @@
             rename-tarball="gstreamer-${version}.tar.gz"
             module="gstreamer/tarball/${version}"
             version="1.22.7"
-            hash="sha256:5d38ad36449e755a11f8235eb80d68360c0ad4e8b422aebecad0e895d24f3834" />
+            hash="sha256:5d38ad36449e755a11f8235eb80d68360c0ad4e8b422aebecad0e895d24f3834">
+      <patch file="0001-pad-Never-push-sticky-events-in-response-to-a-FLUSH_.patch" strip="1"/>
+    </branch>
     <dependencies>
       <dep package="openh264"/>
     </dependencies>

--- a/Tools/gstreamer/patches/0001-pad-Never-push-sticky-events-in-response-to-a-FLUSH_.patch
+++ b/Tools/gstreamer/patches/0001-pad-Never-push-sticky-events-in-response-to-a-FLUSH_.patch
@@ -1,0 +1,81 @@
+From 59b714edc36c6d5887d54741cd628f38efe9e30c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alicia=20Boya=20Garc=C3=ADa?= <aboya@igalia.com>
+Date: Wed, 9 Oct 2024 13:35:33 -0400
+Subject: [PATCH] pad: Never push sticky events in response to a FLUSH_STOP
+
+FLUSH_STOP is meant to clear the flushing state of pads and elements
+downstream, not to process data. Hence, a FLUSH_STOP should not
+propagate sticky events. This is also consistent with how flushes are a
+special case for probes.
+
+Currently this is almost always the case, since a FLUSH_STOP is
+__usually__ preceded by a FLUSH_START, and events (sticky or not) are
+discarded while a pad has the FLUSHING flag active (set by FLUSH_START).
+
+However, it is currently assumed that a FLUSH_STOP not preceded by a
+FLUSH_START is correct behavior, and this will occur while autoplugging
+pipelines are constructed. This leaves us with an unhandled edge case!
+
+This patch explicitly disables sending sticky events when pushing a
+FLUSH_STOP, instead of relying on the flushing flag of the pad, which
+will break in the edge case of a FLUSH_STOP not preceded by a
+FLUSH_START.
+
+If sticky events are propagated in response to a FLUSH_STOP, the
+flushing thread can end up deadlocked in blocking code of a downstream
+pad, such as a blocking probe. Instead, those events should be
+propagated from the streaming thread of the pad when handling a
+non-flushing synchronized event or buffer.
+
+This fixes a deadlock found in WebKit with playbin3 when seeks occur
+before preroll, where the seeking thread ended up stuck in the blocking
+probe of playsink:
+https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1367
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/7632>
+---
+ subprojects/gstreamer/gst/gstpad.c | 17 ++++++++++++++---
+ 1 file changed, 14 insertions(+), 3 deletions(-)
+
+diff --git a/subprojects/gstreamer/gst/gstpad.c b/subprojects/gstreamer/gst/gstpad.c
+index d8bda692b2..7c159d2816 100644
+--- a/subprojects/gstreamer/gst/gstpad.c
++++ b/subprojects/gstreamer/gst/gstpad.c
+@@ -5580,8 +5580,12 @@ gst_pad_push_event_unchecked (GstPad * pad, GstEvent * event,
+   PROBE_PUSH (pad, type | GST_PAD_PROBE_TYPE_PUSH, event, probe_stopped);
+ 
+   /* recheck sticky events because the probe might have cause a relink */
++  /* Note: FLUSH_STOP is a serialized event, but must not propagate sticky
++   * events. FLUSH_STOP is only targeted at removing the flushing state from
++   * pads and elements, and not actually pushing data/events. */
+   if (GST_PAD_HAS_PENDING_EVENTS (pad) && GST_PAD_IS_SRC (pad)
+-      && (GST_EVENT_IS_SERIALIZED (event))) {
++      && (GST_EVENT_IS_SERIALIZED (event))
++      && GST_EVENT_TYPE (event) != GST_EVENT_FLUSH_STOP) {
+     PushStickyData data = { GST_FLOW_OK, FALSE, event };
+     GST_OBJECT_FLAG_UNSET (pad, GST_PAD_FLAG_PENDING_EVENTS);
+ 
+@@ -5740,11 +5744,18 @@ gst_pad_push_event (GstPad * pad, GstEvent * event)
+         break;
+     }
+   }
+-  if (GST_PAD_IS_SRC (pad) && serialized) {
++  if (GST_PAD_IS_SRC (pad) && serialized
++      && GST_EVENT_TYPE (event) != GST_EVENT_FLUSH_STOP) {
+     /* All serialized events on the srcpad trigger push of sticky events.
+      *
+      * Note that we do not do this for non-serialized sticky events since it
+-     * could potentially block. */
++     * could potentially block.
++     *
++     * We must NOT propagate sticky events in response to FLUSH_STOP either, as
++     * FLUSH_STOP is only targeted at removing the flushing state from pads and
++     * elements, and not actually pushing data/events. This also makes it
++     * consistent with the way flush events are handled in "blocking" pad
++     * probes. */
+     res = (check_sticky (pad, event) == GST_FLOW_OK);
+   }
+   if (!serialized || !sticky) {
+-- 
+2.47.0
+


### PR DESCRIPTION
#### f6cf69a241a3ebb0a49a5b400be36dc5c8db38c3
<pre>
[flatpak] Forward port GStreamer sticky events race fix
<a href="https://bugs.webkit.org/show_bug.cgi?id=283121">https://bugs.webkit.org/show_bug.cgi?id=283121</a>

Reviewed by NOBODY (OOPS!).

Applies <a href="https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/7632">https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/7632</a>
on top of stable GStreamer. That merge request fixes a long standing
race condition prone to occur in MSE.

* Tools/gstreamer/jhbuild.modules:
* Tools/gstreamer/patches/0001-pad-Never-push-sticky-events-in-response-to-a-FLUSH_.patch: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6cf69a241a3ebb0a49a5b400be36dc5c8db38c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/80997 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27747 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78588 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3799 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59963 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18075 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65671 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40291 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23160 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26070 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68395 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82444 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3847 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2534 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68239 "Found 4 new test failures: compositing/shared-backing/overlap-after-end-sharing.html imported/w3c/web-platform-tests/css/css-animations/translation-animation-subpixel-offset.html imported/w3c/web-platform-tests/css/css-view-transitions/navigation/root-element-transition-iframe-cross-origin.sub.html imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-match-early.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4000 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65640 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67484 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11462 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9550 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3794 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3817 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7247 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->