### PR TITLE
AX: VoiceOver typing echo doesn't work in PDF form fields

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
@@ -36,6 +36,7 @@
 #include <WebCore/AXObjectCache.h>
 #include <WebCore/HTMLPlugInElement.h>
 #include <WebCore/WebAccessibilityObjectWrapperMac.h>
+#include <pal/spi/cocoa/NSAccessibilitySPI.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/ThreadSafeWeakPtr.h>
@@ -52,6 +53,10 @@
 
     _pdfDocument = document;
     _pluginElement = element;
+    // We are setting the presenter ID of the WKAccessibilityPDFDocumentObject to the hosting application's PID.
+    // This way VoiceOver can set AX observers on all the PDF AX nodes which are descendant of this element.
+    if ([self respondsToSelector:@selector(accessibilitySetPresenterProcessIdentifier:)])
+        [(id)self accessibilitySetPresenterProcessIdentifier:presentingApplicationPID()];
     return self;
 }
 


### PR DESCRIPTION
#### c4bcfc5ab5370240f1a989cf9406df823b49da81
<pre>
AX: VoiceOver typing echo doesn&apos;t work in PDF form fields
<a href="https://bugs.webkit.org/show_bug.cgi?id=283089">https://bugs.webkit.org/show_bug.cgi?id=283089</a>
<a href="https://rdar.apple.com/139835695">rdar://139835695</a>

Reviewed by Tyler Wilcock.

PDFs are hosted in a different process than Safari. With the current implementation all the PDF accessibility elements lack the Safari PID. Therefore, VoiceOver cannot add accessibility observers to these PDF accessibility elements.
This fix adds the application PID to WKAccessibilityPDFDocumentObject where all the descendant PDF AX nodes can inherit the same PID. This fixes the typing echo missing in PDF text fields when Isolated Tree Mode is disabled. Another fix will be submitted to fix typing echo and other VoiceOver issues in PDFs when ITM is enabled.

* Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm:
(-[WKAccessibilityPDFDocumentObject initWithPDFDocument:andElement:]):

Canonical link: <a href="https://commits.webkit.org/286623@main">https://commits.webkit.org/286623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3640dddc829d939dc4491a5e45a2382abcafca5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81033 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27782 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59987 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18099 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40314 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47297 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26105 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68423 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82479 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2558 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68263 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4035 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67510 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16848 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11483 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9571 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3829 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6638 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3852 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7282 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5610 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->