### PR TITLE
Add Clients.openWindow support to MobileMiniBrowser

### DIFF
--- a/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/AppDelegate.m
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/AppDelegate.m
@@ -27,10 +27,11 @@
 
 #import "WebViewController.h"
 #import <WebKit/WKWebsiteDataStorePrivate.h>
+#import <WebKit/_WKWebsiteDataStoreDelegate.h>
 
 #import <WebKit/WebKit.h>
 
-@interface AppDelegate ()
+@interface AppDelegate () <_WKWebsiteDataStoreDelegate>
 @end
 
 @implementation AppDelegate
@@ -49,6 +50,7 @@
     [WKWebsiteDataStore _setWebPushActionHandler:^(_WKWebPushAction *action) {
         return dataStore;
     }];
+    dataStore._delegate = self;
 
     NSURL *url = launchOptions[UIApplicationLaunchOptionsURLKey];
     if (url)
@@ -100,5 +102,12 @@
     // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
 }
 
+- (void)websiteDataStore:(WKWebsiteDataStore *)dataStore openWindow:(NSURL *)url fromServiceWorkerOrigin:(WKSecurityOrigin *)serviceWorkerOrigin completionHandler:(void (^)(WKWebView *newWebView))completionHandler
+{
+    WebViewController *controller = (WebViewController *)self.window.rootViewController;
+    [controller addWebView];
+    [controller.currentWebView loadRequest:[NSURLRequest requestWithURL:url]];
+    completionHandler(controller.currentWebView);
+}
 
 @end


### PR DESCRIPTION
#### 8a70bbdcf0107a02fc8399f2f1b7696e76c26e73
<pre>
Add Clients.openWindow support to MobileMiniBrowser
<a href="https://bugs.webkit.org/show_bug.cgi?id=283122">https://bugs.webkit.org/show_bug.cgi?id=283122</a>
<a href="https://rdar.apple.com/139887510">rdar://139887510</a>

Reviewed by Brady Eidson.

To make it easier to debug issues with openWindow in a real browser, we should add the appropriate
data store delegate callback to handle an openWindow operation to MobileMiniBrowser.

* Tools/MobileMiniBrowser/MobileMiniBrowserFramework/AppDelegate.m:
(-[AppDelegate application:didFinishLaunchingWithOptions:]):
(-[AppDelegate websiteDataStore:openWindow:fromServiceWorkerOrigin:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/286612@main">https://commits.webkit.org/286612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba123e9f94d734b25f363884dc3d592e927fe5e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55511 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81002 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27752 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/59966 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18080 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49881 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65675 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40294 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47276 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23164 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26075 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68402 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82449 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3852 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2535 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68243 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65644 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67488 "Found 1 new API test failure: /TestWebKit:WebKit.GetInjectedBundleInitializationUserDataCallback (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16837 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11458 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9554 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3799 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3822 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7252 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5580 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->