### PR TITLE
Further reduce use of IsDeprecatedTimerSmartPointerException in WebCore

### DIFF
--- a/Source/WebCore/PAL/pal/HysteresisActivity.h
+++ b/Source/WebCore/PAL/pal/HysteresisActivity.h
@@ -30,17 +30,8 @@
 #include <wtf/TZoneMallocInlines.h>
 
 namespace PAL {
-class HysteresisActivity;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<PAL::HysteresisActivity> : std::true_type { };
-}
-
-namespace PAL {
-
-static const Seconds defaultHysteresisDuration { 5_s };
+static constexpr Seconds defaultHysteresisDuration { 5_s };
 
 enum class HysteresisState : bool { Started, Stopped };
 
@@ -50,7 +41,7 @@ public:
     explicit HysteresisActivity(Function<void(HysteresisState)>&& callback = [](HysteresisState) { }, Seconds hysteresisSeconds = defaultHysteresisDuration)
         : m_callback(WTFMove(callback))
         , m_hysteresisSeconds(hysteresisSeconds)
-        , m_timer(RunLoop::main(), this, &HysteresisActivity::hysteresisTimerFired)
+        , m_timer(RunLoop::main(), [this] { m_callback(HysteresisState::Stopped); })
     {
     }
 
@@ -103,12 +94,6 @@ public:
     }
     
 private:
-    void hysteresisTimerFired()
-    {
-        m_timer.stop();
-        m_callback(HysteresisState::Stopped);
-    }
-
     Function<void(HysteresisState)> m_callback;
     Seconds m_hysteresisSeconds;
     RunLoop::Timer m_timer;

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4144,8 +4144,8 @@ void Editor::scanSelectionForTelephoneNumbers()
     m_detectedTelephoneNumberRanges.clear();
     
     auto notifyController = makeScopeExit([&] {
-        if (auto* page = document().page())
-            page->servicesOverlayController().selectedTelephoneNumberRangesChanged();
+        if (RefPtr page = document().page())
+            page->protectedServicesOverlayController()->selectedTelephoneNumberRangesChanged();
     });
 
     auto selection = document().selection().selection();

--- a/Source/WebCore/editing/SelectionGeometryGatherer.cpp
+++ b/Source/WebCore/editing/SelectionGeometryGatherer.cpp
@@ -76,7 +76,7 @@ SelectionGeometryGatherer::Notifier::~Notifier()
     if (!page)
         return;
 
-    page->servicesOverlayController().selectionRectsDidChange(m_gatherer.boundingRects(), m_gatherer.m_gapRects, m_gatherer.isTextOnly());
+    page->protectedServicesOverlayController()->selectionRectsDidChange(m_gatherer.boundingRects(), m_gatherer.m_gapRects, m_gatherer.isTextOnly());
     page->imageOverlayController().selectionQuadsDidChange(m_gatherer.m_renderView->frame(), m_gatherer.m_quads);
 }
 

--- a/Source/WebCore/html/parser/HTMLDocumentParser.h
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.h
@@ -141,7 +141,7 @@ private:
     std::unique_ptr<HTMLTreeBuilder> m_treeBuilder;
     std::unique_ptr<HTMLPreloadScanner> m_preloadScanner;
     std::unique_ptr<HTMLPreloadScanner> m_insertionPreloadScanner;
-    std::unique_ptr<HTMLParserScheduler> m_parserScheduler;
+    RefPtr<HTMLParserScheduler> m_parserScheduler;
     TextPosition m_textPosition;
 
     std::unique_ptr<HTMLResourcePreloader> m_preloader;

--- a/Source/WebCore/html/parser/HTMLParserScheduler.cpp
+++ b/Source/WebCore/html/parser/HTMLParserScheduler.cpp
@@ -75,9 +75,14 @@ PumpSession::PumpSession(unsigned& nestingLevel, Document* document)
 
 PumpSession::~PumpSession() = default;
 
+Ref<HTMLParserScheduler> HTMLParserScheduler::create(HTMLDocumentParser& parser)
+{
+    return adoptRef(*new HTMLParserScheduler(parser));
+}
+
 HTMLParserScheduler::HTMLParserScheduler(HTMLDocumentParser& parser)
-    : m_parser(parser)
-    , m_parserTimeLimit(parserTimeLimit(m_parser.document()->page()))
+    : m_parser(&parser)
+    , m_parserTimeLimit(parserTimeLimit(parser.document()->page()))
     , m_continueNextChunkTimer(*this, &HTMLParserScheduler::continueNextChunkTimerFired)
     , m_isSuspendedWithActiveTimer(false)
 #if ASSERT_ENABLED
@@ -86,22 +91,26 @@ HTMLParserScheduler::HTMLParserScheduler(HTMLDocumentParser& parser)
 {
 }
 
-HTMLParserScheduler::~HTMLParserScheduler()
+HTMLParserScheduler::~HTMLParserScheduler() = default;
+
+void HTMLParserScheduler::detach()
 {
     m_continueNextChunkTimer.stop();
+    m_parser = nullptr;
 }
 
 void HTMLParserScheduler::continueNextChunkTimerFired()
 {
     ASSERT(!m_suspended);
+    ASSERT(m_parser);
 
     // FIXME: The timer class should handle timer priorities instead of this code.
     // If a layout is scheduled, wait again to let the layout timer run first.
-    if (m_parser.document()->isLayoutPending()) {
+    if (m_parser->document()->isLayoutPending()) {
         m_continueNextChunkTimer.startOneShot(0_s);
         return;
     }
-    m_parser.resumeParsingAfterYield();
+    m_parser->resumeParsingAfterYield();
 }
 
 static bool parsingProgressedSinceLastYield(PumpSession& session)
@@ -118,7 +127,7 @@ bool HTMLParserScheduler::shouldYieldBeforeExecutingScript(const ScriptElement* 
 {
     // If we've never painted before and a layout is pending, yield prior to running
     // scripts to give the page a chance to paint earlier.
-    RefPtr<Document> document = m_parser.document();
+    RefPtr<Document> document = m_parser->document();
 
     session.didSeeScript = true;
 

--- a/Source/WebCore/html/parser/HTMLParserScheduler.h
+++ b/Source/WebCore/html/parser/HTMLParserScheduler.h
@@ -27,21 +27,14 @@
 
 #include "NestingLevelIncrementer.h"
 #include "Timer.h"
+#include <wtf/CheckedPtr.h>
+#include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 #if PLATFORM(IOS_FAMILY)
 #include "WebCoreThread.h"
 #endif
-
-namespace WebCore {
-class HTMLParserScheduler;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::HTMLParserScheduler> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -70,12 +63,14 @@ public:
     bool didSeeScript { false };
 };
 
-class HTMLParserScheduler {
+class HTMLParserScheduler final : public RefCounted<HTMLParserScheduler> {
     WTF_MAKE_TZONE_ALLOCATED(HTMLParserScheduler);
     WTF_MAKE_NONCOPYABLE(HTMLParserScheduler);
 public:
-    explicit HTMLParserScheduler(HTMLDocumentParser&);
+    static Ref<HTMLParserScheduler> create(HTMLDocumentParser&);
     ~HTMLParserScheduler();
+
+    void detach();
 
     bool shouldYieldBeforeToken(PumpSession& session)
     {
@@ -116,6 +111,8 @@ public:
     }
 
 private:
+    explicit HTMLParserScheduler(HTMLDocumentParser&);
+
     static const unsigned numberOfTokensBeforeCheckingForYield = 4096; // Performance optimization
 
     void continueNextChunkTimerFired();
@@ -129,7 +126,7 @@ private:
         return elapsedTime > m_parserTimeLimit;
     }
 
-    HTMLDocumentParser& m_parser;
+    CheckedPtr<HTMLDocumentParser> m_parser;
 
     Seconds m_parserTimeLimit;
     Timer m_continueNextChunkTimer;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -397,7 +397,7 @@ Page::Page(PageConfiguration&& pageConfiguration)
     , m_thermalMitigationNotifier(makeUnique<ThermalMitigationNotifier>([this](bool thermalMitigationEnabled) { handleThermalMitigationChange(thermalMitigationEnabled); }))
     , m_performanceLogging(makeUnique<PerformanceLogging>(*this))
 #if PLATFORM(MAC) && (ENABLE(SERVICE_CONTROLS) || ENABLE(TELEPHONE_NUMBER_DETECTION))
-    , m_servicesOverlayController(makeUnique<ServicesOverlayController>(*this))
+    , m_servicesOverlayController(makeUniqueRefWithoutRefCountedCheck<ServicesOverlayController>(*this))
 #endif
     , m_recentWheelEventDeltaFilter(WheelEventDeltaFilter::create())
     , m_pageOverlayController(makeUnique<PageOverlayController>(*this))
@@ -4251,7 +4251,7 @@ void Page::applicationDidBecomeActive()
 ScrollLatchingController& Page::scrollLatchingController()
 {
     if (!m_scrollLatchingController)
-        m_scrollLatchingController = makeUnique<ScrollLatchingController>();
+        m_scrollLatchingController = makeUniqueWithoutRefCountedCheck<ScrollLatchingController>(*this);
         
     return *m_scrollLatchingController;
 }
@@ -5320,5 +5320,12 @@ bool Page::isAlwaysOnLoggingAllowed() const
 {
     return m_sessionID.isAlwaysOnLoggingAllowed() || protectedSettings()->allowPrivacySensitiveOperationsInNonPersistentDataStores();
 }
+
+#if PLATFORM(MAC) && (ENABLE(SERVICE_CONTROLS) || ENABLE(TELEPHONE_NUMBER_DETECTION))
+Ref<ServicesOverlayController> Page::protectedServicesOverlayController()
+{
+    return m_servicesOverlayController.get();
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -662,7 +662,8 @@ public:
     PageOverlayController& pageOverlayController() { return *m_pageOverlayController; }
 
 #if PLATFORM(MAC) && (ENABLE(SERVICE_CONTROLS) || ENABLE(TELEPHONE_NUMBER_DETECTION))
-    ServicesOverlayController& servicesOverlayController() { return *m_servicesOverlayController; }
+    ServicesOverlayController& servicesOverlayController() { return m_servicesOverlayController.get(); }
+    Ref<ServicesOverlayController> protectedServicesOverlayController();
 #endif
     ImageOverlayController& imageOverlayController();
     ImageOverlayController* imageOverlayControllerIfExists() { return m_imageOverlayController.get(); }
@@ -1547,7 +1548,7 @@ private:
     std::unique_ptr<ScrollLatchingController> m_scrollLatchingController;
 #endif
 #if PLATFORM(MAC) && (ENABLE(SERVICE_CONTROLS) || ENABLE(TELEPHONE_NUMBER_DETECTION))
-    std::unique_ptr<ServicesOverlayController> m_servicesOverlayController;
+    UniqueRef<ServicesOverlayController> m_servicesOverlayController;
 #endif
     std::unique_ptr<ImageOverlayController> m_imageOverlayController;
 

--- a/Source/WebCore/page/mac/ServicesOverlayController.h
+++ b/Source/WebCore/page/mac/ServicesOverlayController.h
@@ -38,15 +38,6 @@
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
-class ServicesOverlayController;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::ServicesOverlayController> : std::true_type { };
-}
-
-namespace WebCore {
     
 class LayoutRect;
 class Page;
@@ -60,6 +51,9 @@ class ServicesOverlayController : private DataDetectorHighlightClient, private P
 public:
     explicit ServicesOverlayController(Page&);
     ~ServicesOverlayController();
+
+    void ref() const;
+    void deref() const;
 
     void selectedTelephoneNumberRangesChanged();
     void selectionRectsDidChange(const Vector<LayoutRect>&, const Vector<GapRects>&, bool isTextOnly);

--- a/Source/WebCore/page/mac/ServicesOverlayController.mm
+++ b/Source/WebCore/page/mac/ServicesOverlayController.mm
@@ -66,6 +66,16 @@ ServicesOverlayController::ServicesOverlayController(Page& page)
 
 ServicesOverlayController::~ServicesOverlayController() = default;
 
+void ServicesOverlayController::ref() const
+{
+    m_page->ref();
+}
+
+void ServicesOverlayController::deref() const
+{
+    m_page->deref();
+}
+
 void ServicesOverlayController::willMoveToPage(PageOverlay&, Page* page)
 {
     if (page)

--- a/Source/WebCore/page/mac/TextIndicatorWindow.h
+++ b/Source/WebCore/page/mac/TextIndicatorWindow.h
@@ -26,32 +26,24 @@
 #pragma once
 
 #import "TextIndicator.h"
+#import <wtf/CheckedPtr.h>
 #import <wtf/Noncopyable.h>
 #import <wtf/RefPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
-#include <wtf/TZoneMalloc.h>
+#import <wtf/TZoneMalloc.h>
 
 OBJC_CLASS NSView;
 OBJC_CLASS WebTextIndicatorLayer;
 
 namespace WebCore {
-class TextIndicatorWindow;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::TextIndicatorWindow> : std::true_type { };
-}
-
-namespace WebCore {
 
 #if PLATFORM(MAC)
 
-class TextIndicatorWindow {
+class TextIndicatorWindow final : public CanMakeCheckedPtr<TextIndicatorWindow> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(TextIndicatorWindow, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(TextIndicatorWindow);
-
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextIndicatorWindow);
 public:
     WEBCORE_EXPORT explicit TextIndicatorWindow(NSView *);
     WEBCORE_EXPORT ~TextIndicatorWindow();

--- a/Source/WebCore/page/scrolling/ScrollLatchingController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollLatchingController.cpp
@@ -44,12 +44,23 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollLatchingController);
 // See also ScrollTreeLatchingController.cpp
 static const Seconds resetLatchedStateTimeout { 100_ms };
 
-ScrollLatchingController::ScrollLatchingController()
-    : m_clearLatchingStateTimer(*this, &ScrollLatchingController::clearTimerFired)
+ScrollLatchingController::ScrollLatchingController(Page& page)
+    : m_page(page)
+    , m_clearLatchingStateTimer(*this, &ScrollLatchingController::clearTimerFired)
 {
 }
 
 ScrollLatchingController::~ScrollLatchingController() = default;
+
+void ScrollLatchingController::ref() const
+{
+    m_page->ref();
+}
+
+void ScrollLatchingController::deref() const
+{
+    m_page->deref();
+}
 
 void ScrollLatchingController::clear()
 {

--- a/Source/WebCore/page/scrolling/ScrollLatchingController.h
+++ b/Source/WebCore/page/scrolling/ScrollLatchingController.h
@@ -34,15 +34,8 @@
 
 #if ENABLE(WHEEL_EVENT_LATCHING)
 
-namespace WebCore {
-class ScrollLatchingController;
-}
-
 namespace WTF {
 class TextStream;
-
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::ScrollLatchingController> : std::true_type { };
 }
 
 namespace WebCore {
@@ -56,10 +49,13 @@ class WeakPtrImplWithEventTargetData;
 class ScrollLatchingController {
     WTF_MAKE_TZONE_ALLOCATED(ScrollLatchingController);
 public:
-    ScrollLatchingController();
+    explicit ScrollLatchingController(Page&);
     ~ScrollLatchingController();
 
     void clear();
+
+    void ref() const;
+    void deref() const;
 
     void receivedWheelEvent(const PlatformWheelEvent&);
     FloatSize cumulativeEventDelta() const { return m_cumulativeEventDelta; }
@@ -94,6 +90,7 @@ private:
 
     bool shouldLatchToScrollableArea(const LocalFrame&, ScrollableArea*, FloatSize) const;
 
+    WeakRef<Page> m_page;
     FloatSize m_cumulativeEventDelta;
     Vector<FrameState> m_frameStateStack;
     Timer m_clearLatchingStateTimer;

--- a/Source/WebCore/platform/CaretAnimator.h
+++ b/Source/WebCore/platform/CaretAnimator.h
@@ -43,15 +43,6 @@ class Node;
 class Page;
 class VisibleSelection;
 
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::CaretAnimator> : std::true_type { };
-}
-
-namespace WebCore {
-
 enum class CaretAnimatorType : uint8_t {
     Default,
     Dictation

--- a/Source/WebCore/platform/graphics/ca/TileGrid.h
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.h
@@ -30,6 +30,7 @@
 #include "PlatformCALayerClient.h"
 #include "TileGridIdentifier.h"
 #include "Timer.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Deque.h>
 #include <wtf/HashCountedSet.h>
 #include <wtf/HashMap.h>
@@ -41,15 +42,6 @@ typedef struct CGContext *CGContextRef;
 #endif
 
 namespace WebCore {
-class TileGrid;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::TileGrid> : std::true_type { };
-}
-
-namespace WebCore {
 
 class GraphicsContext;
 class PlatformCALayer;
@@ -57,9 +49,10 @@ class TileController;
 
 using TileIndex = IntPoint;
 
-class TileGrid : public PlatformCALayerClient {
+class TileGrid final : public PlatformCALayerClient, public CanMakeCheckedPtr<TileGrid> {
     WTF_MAKE_TZONE_ALLOCATED(TileGrid);
     WTF_MAKE_NONCOPYABLE(TileGrid);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TileGrid);
 public:
     explicit TileGrid(TileController&);
     ~TileGrid();
@@ -165,7 +158,7 @@ private:
     bool platformCALayerNeedsPlatformContext(const PlatformCALayer*) const override;
 
     TileGridIdentifier m_identifier;
-    TileController& m_controller;
+    CheckedRef<TileController> m_controller;
 #if USE(CA)
     Ref<PlatformCALayer> m_containerLayer;
 #endif

--- a/Source/WebCore/platform/graphics/cg/CGSubimageCacheWithTimer.h
+++ b/Source/WebCore/platform/graphics/cg/CGSubimageCacheWithTimer.h
@@ -29,6 +29,7 @@
 #include "Timer.h"
 
 #include <CoreGraphics/CoreGraphics.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashCountedSet.h>
 #include <wtf/HashSet.h>
 #include <wtf/HashTraits.h>
@@ -40,22 +41,13 @@
 #define CACHE_SUBIMAGES 1
 
 namespace WebCore {
-class CGSubimageCacheWithTimer;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::CGSubimageCacheWithTimer> : std::true_type { };
-}
-
-namespace WebCore {
 
 #if CACHE_SUBIMAGES
 
-class CGSubimageCacheWithTimer {
+class CGSubimageCacheWithTimer final : public CanMakeThreadSafeCheckedPtr<CGSubimageCacheWithTimer> {
     WTF_MAKE_TZONE_ALLOCATED(CGSubimageCacheWithTimer);
     WTF_MAKE_NONCOPYABLE(CGSubimageCacheWithTimer);
-
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CGSubimageCacheWithTimer);
 public:
     struct CacheEntry {
         RetainPtr<CGImageRef> image;

--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.h
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.h
@@ -30,7 +30,7 @@
 #include "IntRect.h"
 #include "ScrollbarsController.h"
 #include "Timer.h"
-
+#include <wtf/CheckedPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -40,21 +40,13 @@ OBJC_CLASS WebScrollerImpDelegate;
 typedef id ScrollerImpPair;
 
 namespace WebCore {
-class ScrollbarsControllerMac;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::ScrollbarsControllerMac> : std::true_type { };
-}
-
-namespace WebCore {
 
 class WheelEventTestMonitor;
 
-class ScrollbarsControllerMac final : public ScrollbarsController {
+class ScrollbarsControllerMac final : public ScrollbarsController, public CanMakeCheckedPtr<ScrollbarsControllerMac> {
     WTF_MAKE_TZONE_ALLOCATED(ScrollbarsControllerMac);
     WTF_MAKE_NONCOPYABLE(ScrollbarsControllerMac);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScrollbarsControllerMac);
 public:
     explicit ScrollbarsControllerMac(ScrollableArea&);
     ~ScrollbarsControllerMac();

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -30,6 +30,7 @@
 #include "LayerAncestorClippingStack.h"
 #include "RenderLayer.h"
 #include <pal/HysteresisActivity.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/OptionSet.h>
 #include <wtf/TZoneMalloc.h>
@@ -161,8 +162,9 @@ private:
 // 
 // There is one RenderLayerCompositor per RenderView.
 
-class RenderLayerCompositor final : public GraphicsLayerClient {
+class RenderLayerCompositor final : public GraphicsLayerClient, public CanMakeCheckedPtr<RenderLayerCompositor> {
     WTF_MAKE_TZONE_ALLOCATED(RenderLayerCompositor);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderLayerCompositor);
     friend class LegacyWebKitScrollingLayerCoordinator;
 public:
     explicit RenderLayerCompositor(RenderView&);

--- a/Source/WebCore/rendering/RenderMarquee.h
+++ b/Source/WebCore/rendering/RenderMarquee.h
@@ -46,25 +46,18 @@
 #include "Length.h"
 #include "RenderStyleConstants.h"
 #include "Timer.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMalloc.h>
-
-namespace WebCore {
-class RenderMarquee;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::RenderMarquee> : std::true_type { };
-}
 
 namespace WebCore {
 
 class RenderLayer;
 
 // This class handles the auto-scrolling for <marquee>
-class RenderMarquee final {
+class RenderMarquee final : public CanMakeCheckedPtr<RenderMarquee> {
     WTF_MAKE_TZONE_ALLOCATED(RenderMarquee);
     WTF_MAKE_NONCOPYABLE(RenderMarquee);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMarquee);
 public:
     explicit RenderMarquee(RenderLayer*);
     ~RenderMarquee();


### PR DESCRIPTION
#### fd551468dc9c548394b2929a5668a753104233dc
<pre>
Further reduce use of IsDeprecatedTimerSmartPointerException in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=283126">https://bugs.webkit.org/show_bug.cgi?id=283126</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::scanSelectionForTelephoneNumbers):
* Source/WebCore/editing/SelectionGeometryGatherer.cpp:
(WebCore::SelectionGeometryGatherer::Notifier::~Notifier):
* Source/WebCore/html/parser/HTMLParserScheduler.h:
(WebCore::HTMLParserScheduler::shouldYieldBeforeToken): Deleted.
(WebCore::HTMLParserScheduler::isScheduledForResume const): Deleted.
(WebCore::HTMLParserScheduler::didBeginYieldingParser): Deleted.
(WebCore::HTMLParserScheduler::didEndYieldingParser): Deleted.
(WebCore::HTMLParserScheduler::checkForYield): Deleted.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::scrollLatchingController):
(WebCore::Page::protectedServicesOverlayController):
* Source/WebCore/page/Page.h:
(WebCore::Page::servicesOverlayController):
* Source/WebCore/page/mac/ServicesOverlayController.h:
* Source/WebCore/page/mac/ServicesOverlayController.mm:
(WebCore::ServicesOverlayController::ref const):
(WebCore::ServicesOverlayController::deref const):
* Source/WebCore/page/mac/TextIndicatorWindow.h:
* Source/WebCore/page/scrolling/ScrollLatchingController.cpp:
(WebCore::ScrollLatchingController::ScrollLatchingController):
(WebCore::ScrollLatchingController::ref const):
(WebCore::ScrollLatchingController::deref const):
* Source/WebCore/page/scrolling/ScrollLatchingController.h:
* Source/WebCore/platform/CaretAnimator.h:

Canonical link: <a href="https://commits.webkit.org/286645@main">https://commits.webkit.org/286645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47782f9365b712d2d52c5e0d0759b667b2e78963

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76624 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81155 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27900 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78741 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3952 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60074 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18172 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79691 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65793 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40399 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47391 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23287 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26224 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68513 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23617 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82600 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2641 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68352 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65765 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67600 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11571 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9658 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11849 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3947 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6756 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3970 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7400 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5728 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->