### PR TITLE
REGRESSION(265569@main): Fix division by zero in calculating the boundingRect of a QuadraticCurve

### DIFF
--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -61,7 +61,7 @@ public:
 
     WEBCORE_EXPORT void addLineTo(const FloatPoint&);
     WEBCORE_EXPORT void addQuadCurveTo(const FloatPoint& controlPoint, const FloatPoint& endPoint);
-    void addBezierCurveTo(const FloatPoint& controlPoint1, const FloatPoint& controlPoint2, const FloatPoint& endPoint);
+    WEBCORE_EXPORT void addBezierCurveTo(const FloatPoint& controlPoint1, const FloatPoint& controlPoint2, const FloatPoint& endPoint);
     void addArcTo(const FloatPoint& point1, const FloatPoint& point2, float radius);
 
     void addArc(const FloatPoint&, float radius, float startAngle, float endAngle, RotationDirection);
@@ -113,7 +113,7 @@ public:
     bool strokeContains(const FloatPoint&, const Function<void(GraphicsContext&)>& strokeStyleApplier) const;
 
     WEBCORE_EXPORT FloatRect fastBoundingRect() const;
-    FloatRect boundingRect() const;
+    WEBCORE_EXPORT FloatRect boundingRect() const;
     FloatRect strokeBoundingRect(const Function<void(GraphicsContext&)>& strokeStyleApplier = { }) const;
 
     WEBCORE_EXPORT void ensureImplForTesting();

--- a/Source/WebCore/platform/graphics/PathSegmentData.cpp
+++ b/Source/WebCore/platform/graphics/PathSegmentData.cpp
@@ -141,12 +141,32 @@ static float calculateQuadraticExtremity(float p0, float p1, float p2)
     // B'(t) = 2(1 - t) (P1 - P0) + 2t (P2 - P1)
     //       = 2 (P1 - P0) + 2t (P0 - 2P1 + P2)
     //
+    // Let i = P1 - P0
+    //     j = P2 - P1
+    //
+    // B'(t) = 2i - 2t (i - j)
+    //
+    // Let k = i - j
+    //
+    // B'(t) = 2i - 2kt
+    //
     // Solve for B'(t) = 0
     //
-    //     t = (P0 - P1) / (P0 - 2P1 + P2)
+    //     t = i / k
     //
-    float t = (p0 - p1) / (p0 - 2 * p1 + p2);
+    float i = p1 - p0;
+    float j = p2 - p1;
 
+    float k = i - j;
+
+    static constexpr float epsilon = 0.1;
+
+    if (abs(k) < epsilon) {
+        float t = 0.5;
+        return calculateQuadratic(t, p0, p1, p2);
+    }
+
+    float t = i / k;
     return calculateQuadratic(t, p0, p1, p2);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/PathTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PathTests.cpp
@@ -101,4 +101,38 @@ TEST(Path, DefinitelyNotEqual)
     ASSERT_FALSE(path2.definitelyEqual(path1));
 }
 
+TEST(Path, CurveBoundingRect)
+{
+    auto currentPoint = FloatPoint { 100, 0 };
+    auto endPoint = FloatPoint { 300, 0 };
+    auto controlPoint = FloatPoint { 200, 328 };
+
+    Path path1;
+    path1.moveTo(currentPoint);
+    path1.addQuadCurveTo(controlPoint, endPoint);
+
+    auto fastboundingRect1 = path1.fastBoundingRect();
+    auto boundingRect1 = path1.boundingRect();
+
+    ASSERT_TRUE(fastboundingRect1 != boundingRect1);
+    ASSERT_TRUE(fastboundingRect1.contains(boundingRect1));
+
+    // Build an equivalent cubic BezierCurve for the above QuadraticCurve.
+    auto controlPoint1 = currentPoint + controlPoint.scaled(2);
+    auto controlPoint2 = endPoint + controlPoint.scaled(2);
+
+    static const float gOneOverThree = 1 / 3.f;
+
+    controlPoint1.scale(gOneOverThree);
+    controlPoint2.scale(gOneOverThree);
+
+    Path path2;
+    path2.moveTo(currentPoint);
+    path2.addBezierCurveTo(controlPoint1, controlPoint2, endPoint);
+
+    auto boundingRect2 = path2.boundingRect();
+
+    ASSERT_TRUE(areEssentiallyEqual(boundingRect1, boundingRect2));
+}
+
 }


### PR DESCRIPTION
#### dae159bae23196b46c00aedcf723635de8443d01
<pre>
REGRESSION(265569@main): Fix division by zero in calculating the boundingRect of a QuadraticCurve
<a href="https://bugs.webkit.org/show_bug.cgi?id=283127">https://bugs.webkit.org/show_bug.cgi?id=283127</a>
<a href="https://rdar.apple.com/139904014">rdar://139904014</a>

Reviewed by Simon Fraser.

Avoid dividing by zero if the controlPoint is the mid-point of the currentPoint
and the endPoint.

* Source/WebCore/platform/graphics/Path.h:
* Source/WebCore/platform/graphics/PathSegmentData.cpp:
(WebCore::calculateQuadraticExtremity):
* Tools/TestWebKitAPI/Tests/WebCore/PathTests.cpp:
(TestWebKitAPI::TEST(Path, CurveBoundingRect)):

Canonical link: <a href="https://commits.webkit.org/286618@main">https://commits.webkit.org/286618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb040d94e603b306d33c4051ff9963c8c8d889bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76546 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/55581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/29452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/81073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/27822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78663 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/64723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/3874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/81073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/27822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49914 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/65718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/81073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47309 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/23210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/26146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/68435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/23541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/82522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/75823 "Build is in progress. Recent messages:") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/3922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/2574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/4075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/65689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/67533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16843 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/11498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/3869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/6678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/3892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/7322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/5650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->