### PR TITLE
[WPE][Stable][2.46] Many layout tests crash on 32-bits due to an overflow issue at FrameLoader::updateNavigationAPIEntries

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4837,7 +4837,7 @@ void FrameLoader::updateNavigationAPIEntries(std::optional<NavigationNavigationT
     if (startingIndex != notFound) {
         Ref startingOrigin = SecurityOrigin::create(rawEntries[startingIndex]->url());
 
-        for (int64_t i = startingIndex - 1; i >= 0; i--) {
+        for (int64_t i = static_cast<int64_t>(startingIndex) - 1; i >= 0; i--) {
             Ref item = rawEntries[i];
 
             if (!SecurityOrigin::create(item->url())->isSameOriginAs(startingOrigin))


### PR DESCRIPTION
#### edcd1a11dfe3c5983963635e7083b38795344c1e
<pre>
[WPE][Stable][2.46] Many layout tests crash on 32-bits due to an overflow issue at FrameLoader::updateNavigationAPIEntries
<a href="https://bugs.webkit.org/show_bug.cgi?id=283136">https://bugs.webkit.org/show_bug.cgi?id=283136</a>

Reviewed by Michael Catanzaro.

* This was noticed when running layout tests on ARMv7, lot of layout
tests crash. Easily reproduced for example with the layout test
imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-replace.html

* The crash happens when startingIndex is 0 because startingIndex is
declared as size_t (unsigned), and due to the C++ unsigned arithmetic behavior
0 - 1 is actually 4294967295 on a 32-bit platform (size_t).
However this issue is avoided on 64-bits by pure luck, because on 64-bits
this computation underflows to 18446744073709551615 which exceeds the maximum
value of int64_t (2^63 - 1 = 9223372036854775807) and this results in signed
integer overflow, causing the value to wrap into the negative range.
Specifically, the value will be interpreted as -1 because of how large unsigned
values map to signed integers when exceeding the signed type&apos;s capacity.

* Fix this issue by casting startingIndex to a signed int64_t before
substracting 1.

* This patch is not needed on main as this code is not longer there,
because it was rewrote as part of <a href="https://commits.webkit.org/283604@main">https://commits.webkit.org/283604@main</a>

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::updateNavigationAPIEntries):

Canonical link: <a href="https://commits.webkit.org/282416.283@fix_overflow_32bits">https://commits.webkit.org/282416.283@fix_overflow_32bits</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d935a06e6c72787805cefbfa78e4322c29d7bcd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76536 "18044 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29442 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81063 "Failed to compile WebKit") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/27812 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64713 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3864 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/81063 "Failed to compile WebKit") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/27812 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49923 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65722 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/81063 "Failed to compile WebKit") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47320 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23215 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26136 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68445 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82512 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3912 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/3864 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68299 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4065 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65694 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67607 "Found 1 new API test failure: /WebKitGTK/TestWebKitNetworkSession:/webkit/WebKitNetworkSession/proxy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16886 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9593 "Passed tests") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3859 "Failed to compile WebKit") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6668 "") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3882 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7312 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5640 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->