### PR TITLE
[JSC] Add parsing for deferred import proposal

### DIFF
--- a/JSTests/stress/modules-syntax-error.js
+++ b/JSTests/stress/modules-syntax-error.js
@@ -180,6 +180,10 @@ checkModuleSyntaxError(String.raw`
 import { hello, binding as
 `, `SyntaxError: Unexpected end of script:3`);
 
+checkModuleSyntaxError(String.raw`
+import defer * as ns from "mod"
+`, `SyntaxError: Unexpected token '*'. Expected 'from' before imported module name.:2`);
+
 // --------------- export -------------------
 
 checkModuleSyntaxError(String.raw`

--- a/JSTests/stress/modules-syntax-import-defer-error.js
+++ b/JSTests/stress/modules-syntax-import-defer-error.js
@@ -1,0 +1,47 @@
+//@ requireOptions("--useImportDefer=1")
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (errorMessage) {
+        if (String(error) !== errorMessage)
+            throw new Error(`bad error: ${String(error)}`);
+    }
+}
+
+function checkModuleSyntaxError(source, errorMessage) {
+    shouldThrow(() => checkModuleSyntax(source), errorMessage);
+}
+
+checkModuleSyntaxError(`import defer "mod"`);
+checkModuleSyntaxError(`import defer v from "mod"`);
+checkModuleSyntaxError(`import defer, v from "mod"`);
+checkModuleSyntaxError(`import defer, from "mod"`);
+checkModuleSyntaxError(`import defer, as ns from "mod"`);
+checkModuleSyntaxError(`import defer, defer from "mod"`);
+checkModuleSyntaxError(`import defer, { e1, e2 }, * as ns from "mod"`);
+checkModuleSyntaxError(`import defer, * as ns1, * as ns2 from "mod"`);
+checkModuleSyntaxError(`import defer {} from "mod"`);
+checkModuleSyntaxError(`import defer {x} from "mod"`);
+checkModuleSyntaxError(`import defer {x,} from "mod"`);
+checkModuleSyntaxError(`import defer {x, y} from "mod"`);
+checkModuleSyntaxError(`import defer {x as v} from "mod"`);
+checkModuleSyntaxError(`import defer {x}, y from "mod"`);
+checkModuleSyntaxError(`import defer *`);
+checkModuleSyntaxError(`import defer * as`);
+checkModuleSyntaxError(`import defer * as {}`);
+checkModuleSyntaxError(`import defer * as {} from "mod"`);
+checkModuleSyntaxError(`import defer * as ns from`);
+checkModuleSyntaxError(`import defer * ns from "mod"`);
+checkModuleSyntaxError(`import defer * from "mod"`);
+checkModuleSyntaxError(`import defer()`);
+checkModuleSyntaxError(`export defer`);
+checkModuleSyntaxError(`export defer * as ns from "mod"`);

--- a/JSTests/stress/modules-syntax-import-defer.js
+++ b/JSTests/stress/modules-syntax-import-defer.js
@@ -1,0 +1,8 @@
+//@ requireOptions("--useImportDefer=1")
+
+checkModuleSyntax(`import defer * as ns from "mod"`);
+checkModuleSyntax(`import defer from "mod"`);
+checkModuleSyntax(`import defer, * as ns from "mod"`);
+checkModuleSyntax(`import defer, { e1, e2 } from "mod"`);
+checkModuleSyntax(`import {defer} from "mod"`);
+checkModuleSyntax(`import defer * as defer from "mod"`);

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -91,6 +91,7 @@ namespace JSC {
     macro(set) \
     macro(clear) \
     macro(context) \
+    macro(defer) \
     macro(delete) \
     macro(size) \
     macro(shift) \

--- a/Source/JavaScriptCore/parser/ASTBuilder.h
+++ b/Source/JavaScriptCore/parser/ASTBuilder.h
@@ -832,9 +832,9 @@ public:
         attributesList->append(key, value);
     }
 
-    StatementNode* createImportDeclaration(const JSTokenLocation& location, ImportSpecifierListNode* importSpecifierList, ModuleNameNode* moduleName, ImportAttributesListNode* importAttributesList)
+    StatementNode* createImportDeclaration(const JSTokenLocation& location, ImportDeclarationNode::ImportType type, ImportSpecifierListNode* importSpecifierList, ModuleNameNode* moduleName, ImportAttributesListNode* importAttributesList)
     {
-        return new (m_parserArena) ImportDeclarationNode(location, importSpecifierList, moduleName, importAttributesList);
+        return new (m_parserArena) ImportDeclarationNode(location, type, importSpecifierList, moduleName, importAttributesList);
     }
 
     StatementNode* createExportAllDeclaration(const JSTokenLocation& location, ModuleNameNode* moduleName, ImportAttributesListNode* importAttributesList)

--- a/Source/JavaScriptCore/parser/NodeConstructors.h
+++ b/Source/JavaScriptCore/parser/NodeConstructors.h
@@ -879,11 +879,12 @@ namespace JSC {
     {
     }
 
-    inline ImportDeclarationNode::ImportDeclarationNode(const JSTokenLocation& location, ImportSpecifierListNode* importSpecifierList, ModuleNameNode* moduleName, ImportAttributesListNode* importAttributesList)
+    inline ImportDeclarationNode::ImportDeclarationNode(const JSTokenLocation& location, ImportType type, ImportSpecifierListNode* importSpecifierList, ModuleNameNode* moduleName, ImportAttributesListNode* importAttributesList)
         : ModuleDeclarationNode(location)
         , m_specifierList(importSpecifierList)
         , m_moduleName(moduleName)
         , m_attributesList(importAttributesList)
+        , m_type(type)
     {
     }
 

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -2128,7 +2128,11 @@ namespace JSC {
 
     class ImportDeclarationNode final : public ModuleDeclarationNode {
     public:
-        ImportDeclarationNode(const JSTokenLocation&, ImportSpecifierListNode*, ModuleNameNode*, ImportAttributesListNode*);
+        enum class ImportType : uint8_t {
+            Normal,
+            Deferred
+        };
+        ImportDeclarationNode(const JSTokenLocation&, ImportType, ImportSpecifierListNode*, ModuleNameNode*, ImportAttributesListNode*);
 
         ImportSpecifierListNode* specifierList() const { return m_specifierList; }
         ModuleNameNode* moduleName() const { return m_moduleName; }
@@ -2141,6 +2145,7 @@ namespace JSC {
         ImportSpecifierListNode* m_specifierList;
         ModuleNameNode* m_moduleName;
         ImportAttributesListNode* m_attributesList;
+        ImportType m_type;
     };
 
     class ExportAllDeclarationNode final : public ModuleDeclarationNode {

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -322,6 +322,7 @@
     macro(continue) \
     macro(debugger) \
     macro(default) \
+    macro(defer) \
     macro(delete) \
     macro(do) \
     macro(else) \

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -594,6 +594,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useAtomicsPause, true, Normal, "Expose Atomics.pause."_s) \
     v(Bool, useErrorIsError, false, Normal, "Expose Error.isError feature."_s) \
     v(Bool, useFloat16Array, true, Normal, "Expose Float16Array."_s) \
+    v(Bool, useImportDefer, false, Normal, "Enable deferred module import."_s) \
     v(Bool, useIteratorChunking, false, Normal, "Expose the Iterator.prototype.chunks and Iterator.prototype.windows methods."_s) \
     v(Bool, useIteratorHelpers, true, Normal, "Expose the Iterator Helpers."_s) \
     v(Bool, useIteratorSequencing, false, Normal, "Expose the Iterator.concat method."_s) \


### PR DESCRIPTION
#### 4e8dd496fc1158acdbcd5f20dbe67e9b13475386
<pre>
[JSC] Add parsing for deferred import proposal

<a href="https://bugs.webkit.org/show_bug.cgi?id=283133">https://bugs.webkit.org/show_bug.cgi?id=283133</a>

Reviewed by Yusuke Suzuki.

This patch adds initial parsing support for deferred
imports:
  * Adds feature flag for deferred imports
  * Adds syntax for `import defer` (no `import.defer` yet)
  * Adds parsing tests
  * Adds part of data representation for deferred
    imports relevant to the parser
  * `import defer` acts identical to plain `import` for now

The spec for the proposal is at:
  <a href="https://github.com/tc39/proposal-defer-import-eval/">https://github.com/tc39/proposal-defer-import-eval/</a>

* JSTests/stress/modules-syntax-error.js:
* JSTests/stress/modules-syntax-import-defer-error.js: Added.
(shouldThrow):
* JSTests/stress/modules-syntax-import-defer.js: Added.
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/parser/ASTBuilder.h:
(JSC::ASTBuilder::createImportDeclaration):
* Source/JavaScriptCore/parser/NodeConstructors.h:
(JSC::ImportDeclarationNode::ImportDeclarationNode):
* Source/JavaScriptCore/parser/Nodes.h:
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseImportDeclaration):
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/287419@main">https://commits.webkit.org/287419@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9b34c918e4b9b08fa6b62cec2b9e12d1c5639bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83985 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30511 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62088 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19968 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52145 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72320 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42397 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49505 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26507 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28915 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/72461 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70730 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85389 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/78564 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4633 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70341 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68197 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69698 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17387 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13630 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12497 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/100906 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6603 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24661 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-eager (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6662 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9991 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->