### PR TITLE
Make the pre-push template be valid Python syntactically

### DIFF
--- a/Tools/Scripts/hooks/pre-push
+++ b/Tools/Scripts/hooks/pre-push
@@ -47,10 +47,8 @@ QUIET = -1
 VERBOSE = 1
 VERBOSITY = int(os.environ.get('VERBOSITY', '0'))
 
-SECURITY_LEVELS = { {% for key, value in security_levels.items() %}
-    '{{ key }}': {{ value }},{% endfor %}
-}
-MAX_LEVEL = max(list(SECURITY_LEVELS.values()) + [0])
+SECURITY_LEVELS = {{ security_levels }}
+MAX_LEVEL = max(SECURITY_LEVELS.values(), default=0)
 
 
 def print_error(why):


### PR DESCRIPTION
#### 6dae686bbeaf583d2b986705ef4c0343259fd201
<pre>
Make the pre-push template be valid Python syntactically
<a href="https://bugs.webkit.org/show_bug.cgi?id=283141">https://bugs.webkit.org/show_bug.cgi?id=283141</a>

Reviewed by Jonathan Bedard.

This moves SECURITY_LEVELS to being generated prior to being passed to
the template, being styled with pprint.pformat. This isn&apos;t ideal
stylistically (as pprint isn&apos;t very flexible with its output), but it
doesn&apos;t seem worthwhile over-investing in the built formatting.

While we&apos;re at it, move SECURITY_LEVELS to always being output in a
deterministic order, allowing us to use the same ordering in both our
tests and in production.

* Tools/Scripts/hooks/pre-push:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py:
(InstallHooks.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/install_hooks_unittest.py:
(TestInstallHooks.write_hook):
(TestInstallHooks.test_security_levels):

Canonical link: <a href="https://commits.webkit.org/287311@main">https://commits.webkit.org/287311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d271e7e05ef1a19ebf2310a28e4673895fa38e94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12219 "Built successfully and passed tests") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-11-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-11-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->