### PR TITLE
Google search page renders 16% slower when enabling requestIdleCallback

### DIFF
--- a/Source/WebCore/dom/IdleCallbackController.h
+++ b/Source/WebCore/dom/IdleCallbackController.h
@@ -59,9 +59,8 @@ public:
     bool isEmpty() const { return m_idleRequestCallbacks.isEmpty() && m_runnableIdleCallbacks.isEmpty(); }
 
 private:
-    void queueTaskToStartIdlePeriod();
     void queueTaskToInvokeIdleCallbacks();
-    void invokeIdleCallbacks();
+    bool invokeIdleCallbacks();
     void invokeIdleCallbackTimeout(unsigned identifier);
 
     unsigned m_idleCallbackIdentifier { 0 };
@@ -69,6 +68,7 @@ private:
     struct IdleRequest {
         unsigned identifier { 0 };
         Ref<IdleRequestCallback> callback;
+        std::optional<MonotonicTime> timeout;
     };
 
     Deque<IdleRequest> m_idleRequestCallbacks;


### PR DESCRIPTION
#### 4565e660a939035ba49bffe5fa4770ec0dffc076
<pre>
Google search page renders 16% slower when enabling requestIdleCallback
<a href="https://bugs.webkit.org/show_bug.cgi?id=283145">https://bugs.webkit.org/show_bug.cgi?id=283145</a>

Reviewed by Chris Dumez.

requestIdleCallback specification&apos;s steps to start an idle period specifies that
we must queue a task to invoke the idle callbacks algorithm:
<a href="https://w3c.github.io/requestidlecallback/#start-an-idle-period-algorithm">https://w3c.github.io/requestidlecallback/#start-an-idle-period-algorithm</a>

In practice, this has an effect of delaying the idle callbacks to be processed by
one event loop cycle. Because the steps to invoke idle callbacks algorithm exits
early when there are a higher priority tasks and queues a new task before invoking
the next idle callback in the list of runnable idle callbacks, this has an effect
of significantly reducing the chance of idle callbacks being invoked. On google.com
search results, this has an effect of delaying the first meaningful paint time by 16%.

This PR improves this situation by having IdleCallbackController::startIdlePeriod
directly invoke idle callbacks until we run out of time. This dramatically increases
the chance of idle callbacks running between other tasks &amp; timers and fixes the page
load time regression on google.com.

* Source/WebCore/dom/IdleCallbackController.cpp:
(WebCore::IdleCallbackController::queueIdleCallback):
(WebCore::IdleCallbackController::startIdlePeriod):
(WebCore::IdleCallbackController::queueTaskToInvokeIdleCallbacks):
(WebCore::IdleCallbackController::invokeIdleCallbacks):
(WebCore::IdleCallbackController::queueTaskToStartIdlePeriod): Deleted.
* Source/WebCore/dom/IdleCallbackController.h:

Canonical link: <a href="https://commits.webkit.org/286631@main">https://commits.webkit.org/286631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/def6b393a998f4bc2c0c89e520d582d5e61cc999

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81118 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27864 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78705 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3916 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60040 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18141 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79655 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65757 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40365 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23250 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26188 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68479 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23581 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82564 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3964 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/2609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68318 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4117 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65729 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67567 "Found 1 new API test failure: /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11537 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11843 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3911 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6720 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3934 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7364 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5692 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->