### PR TITLE
Switching light/dark modes doesn't update the base background color if the root has `color` set explicitly

### DIFF
--- a/Source/WebCore/css/color/StyleColor.cpp
+++ b/Source/WebCore/css/color/StyleColor.cpp
@@ -419,7 +419,7 @@ void serializationForCSS(StringBuilder& builder, const StyleColor& color)
 
 // MARK: - TextStream.
 
-WTF::TextStream& operator<<(WTF::TextStream& out, const StyleColor& color)
+TextStream& operator<<(TextStream& out, const StyleColor& color)
 {
     out << "StyleColor[";
 
@@ -430,6 +430,17 @@ WTF::TextStream& operator<<(WTF::TextStream& out, const StyleColor& color)
     );
 
     out << "]";
+    return out;
+}
+
+TextStream& operator<<(TextStream& out, StyleColorOptions colorOptions)
+{
+    switch (colorOptions) {
+    case StyleColorOptions::ForVisitedLink: out << "ForVisitedLink"; break;
+    case StyleColorOptions::UseSystemAppearance: out << "UseSystemAppearance"; break;
+    case StyleColorOptions::UseDarkAppearance: out << "UseDarkAppearance"; break;
+    case StyleColorOptions::UseElevatedUserInterfaceLevel: out << "UseElevatedUserInterfaceLevel"; break;
+    }
     return out;
 }
 

--- a/Source/WebCore/css/color/StyleColor.h
+++ b/Source/WebCore/css/color/StyleColor.h
@@ -178,5 +178,6 @@ void serializationForCSS(StringBuilder&, const StyleColor&);
 WEBCORE_EXPORT String serializationForCSS(const StyleColor&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, const StyleColor&);
+WTF::TextStream& operator<<(WTF::TextStream&, StyleColorOptions);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2629,6 +2629,10 @@ void Document::resolveStyle(ResolveStyleType type)
     // check if they need to be resumed after layout.
     if (updatedCompositingLayers && !frameView->needsLayout())
         frameView->viewportContentsChanged();
+
+#if ENABLE(DARK_MODE_CSS)
+    frameView->updateBaseBackgroundColorIfNecessary();
+#endif
 }
 
 void Document::updateTextRenderer(Text& text, unsigned offsetOfReplacedText, unsigned lengthOfReplacedText)
@@ -4866,10 +4870,6 @@ void Document::processColorScheme(const String& colorSchemeString)
         colorScheme.add(ColorScheme::Light);
 
     m_colorScheme = colorScheme;
-    m_allowsColorSchemeTransformations = allowsTransformations;
-
-    if (RefPtr frameView = view())
-        frameView->recalculateBaseBackgroundColor();
 
     if (RefPtr page = this->page())
         page->updateStyleAfterChangeInEnvironment();

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2556,7 +2556,6 @@ private:
 
 #if ENABLE(DARK_MODE_CSS)
     OptionSet<ColorScheme> m_colorScheme;
-    bool m_allowsColorSchemeTransformations { true };
 #endif
 
     bool m_activeParserWasAborted { false };

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -563,10 +563,8 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
                 maskedCorners.add(InteractionRegion::CornerMask::MinXMaxYCorner);
             if (borderRadii.bottomRight().minDimension() == maxRadius)
                 maskedCorners.add(InteractionRegion::CornerMask::MaxXMaxYCorner);
-        } else {
+        } else
             clipPath = borderShape.pathForOuterShape(renderBox->document().deviceScaleFactor());
-            WTF_ALWAYS_LOG("interactionRegionForRenderedRegion - rounded rect" << borderShape.deprecatedRoundedRect() << " device scale " << renderBox->document().deviceScaleFactor() << " " << clipPath);
-        }
     }
 
     bool canTweakShape = !isPhoto

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -205,13 +205,15 @@ public:
     void prepareForDetach();
     void detachCustomScrollbars();
     WEBCORE_EXPORT void recalculateScrollbarOverlayStyle();
+
 #if ENABLE(DARK_MODE_CSS)
-    void recalculateBaseBackgroundColor();
+    void updateBaseBackgroundColorIfNecessary();
 #endif
 
     void clear();
     void resetLayoutMilestones();
 
+    // This represents externally-imposed transparency. iframes are transparent by default, but that's handled in RenderView::shouldPaintBaseBackground().
     WEBCORE_EXPORT bool isTransparent() const;
     WEBCORE_EXPORT void setTransparent(bool isTransparent);
     

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -384,10 +384,6 @@ void RenderBox::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle
     bool isBodyRenderer = isBody();
 
     if (isDocElementRenderer || isBodyRenderer) {
-#if ENABLE(DARK_MODE_CSS)
-        view().frameView().recalculateBaseBackgroundColor();
-#endif
-
         view().frameView().recalculateScrollbarOverlayStyle();
         
         if (diff != StyleDifference::Equal)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2226,10 +2226,8 @@ ExceptionOr<void> Internals::setViewIsTransparent(bool transparent)
     Document* document = contextDocument();
     if (!document || !document->view())
         return Exception { ExceptionCode::InvalidAccessError };
-    std::optional<Color> backgroundColor;
-    if (transparent)
-        backgroundColor = Color(Color::transparentBlack);
-    document->view()->updateBackgroundRecursively(backgroundColor);
+
+    document->view()->setTransparent(transparent);
     return { };
 }
 
@@ -2238,6 +2236,9 @@ ExceptionOr<String> Internals::viewBaseBackgroundColor()
     Document* document = contextDocument();
     if (!document || !document->view())
         return Exception { ExceptionCode::InvalidAccessError };
+
+    document->updateLayout(LayoutOptions::IgnorePendingStylesheets);
+
     return serializationForCSS(document->view()->baseBackgroundColor());
 }
 


### PR DESCRIPTION
#### 060793dcd5868ea0c16ad35818ba4ed8f2551d28
<pre>
Switching light/dark modes doesn&apos;t update the base background color if the root has `color` set explicitly
<a href="https://bugs.webkit.org/show_bug.cgi?id=283140">https://bugs.webkit.org/show_bug.cgi?id=283140</a>
<a href="https://rdar.apple.com/139917332">rdar://139917332</a>

Reviewed by Aditya Keerthi.

The base background color is hardcoded to use a system color,
CSSValueAppleSystemControlBackground, in LocalFrameView. &quot;Dark mode&quot;, &quot;elevated user
interface&quot; and color scheme state feed into the computation of the color returned for
CSSValueAppleSystemControlBackground. However, when those states change, there&apos;s no
renderer that sees a change to the background-color style, so no clear code path that
results in `LocalFrameView::updateBaseBackgroundColor()` being called.

`RenderBox::styleDidChange()` does call `frameView().recalculateBaseBackgroundColor()`
when it sees a style change for the document element or body renderers, but on light/dark
mode switches, that is triggered by chance because the `color` property (which is
inherited) changes, and we get a RepaintForText diff. If the content sets an explicit
color on the root, as the test case does, then the bug occurs (or at least it will once
fixing bug 267252 means that we don&apos;t get spurious render style diffs.)

Fix by calling `updateBaseBackgroundColorIfNecessary()` in `Document::resolveStyle().`
This needs to happen after style update, and before layout, because the color feeds
into scrollbar colors and compositing, both of which are consulted during/after layout.
I also tried to make this a &quot;once per rendering update&quot; thing, but that would require
extra dirty state tracking, and `updateBaseBackgroundColorIfNecessary()` is almost
always cheap, so it didn&apos;t seem necessary.

I also tried putting the base background color into the Document&apos;s RenderStyle, but
then it can inherit onto the document element, which is web-exposed.

* Source/WebCore/css/color/StyleColor.cpp:
(WebCore::operator&lt;&lt;): Make StyleColorOptions dumpable.
* Source/WebCore/css/color/StyleColor.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resolveStyle):
(WebCore::Document::processColorScheme): No need to call `recalculateBaseBackgroundColor()` here, since
it will be called on the next style update.
* Source/WebCore/dom/Document.h: Drive-by: m_allowsColorSchemeTransformations was unused; remove it.
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion): Remove a log from an earlier commit.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::updateBaseBackgroundColorIfNecessary):
(WebCore::LocalFrameView::updateBackgroundRecursively):
(WebCore::LocalFrameView::recalculateBaseBackgroundColor): Deleted.
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::styleDidChange): No need to call `recalculateBaseBackgroundColor()` here.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setViewIsTransparent): call `setTransparent()`.
(WebCore::Internals::viewBaseBackgroundColor): Force a layout before getting the color.

Canonical link: <a href="https://commits.webkit.org/286833@main">https://commits.webkit.org/286833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8638a9b851b07fc91ebe7ff5a35ab1fd9626e641

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81685 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28409 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79244 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4458 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60436 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18501 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50398 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66207 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40743 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47800 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23705 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26732 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68915 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83112 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4507 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3039 "Found 1 new test failure: webrtc/vp8-then-h264.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68716 "Found 32 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-001.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-005.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-006.html imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-local/attachment-local-positioning-5.html imported/w3c/web-platform-tests/css/css-backgrounds/background-color-body-propagation-006.html imported/w3c/web-platform-tests/css/css-backgrounds/background-color-root-propagation-002.html imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-descendant-text-mutated-001.html imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-under-left-001.xht imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-under-right-001.xht imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-character.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4663 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67970 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16987 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11958 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10044 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4453 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7269 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4473 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7908 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6232 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->