### PR TITLE
LAYER_POSITIONS_ASSERT(m_repaintContainer == repaintContainer) on bbc.com

### DIFF
--- a/LayoutTests/compositing/shared-backing/make-sharing-layer-composited-expected.txt
+++ b/LayoutTests/compositing/shared-backing/make-sharing-layer-composited-expected.txt
@@ -1,0 +1,1 @@
+This test should not crash.

--- a/LayoutTests/compositing/shared-backing/make-sharing-layer-composited.html
+++ b/LayoutTests/compositing/shared-backing/make-sharing-layer-composited.html
@@ -1,0 +1,53 @@
+<!DOCTYPE HTML>
+<html class="reftest-wait">
+<head>
+<style>
+div {
+  position: relative;
+  width: 200px;
+  height: 200px;
+}
+
+.composited {
+  transform: translateZ(0px);
+}
+</style>
+</head>
+<body>
+
+<div class="composited" style="position: absolute"></div>
+
+<!-- div composited due to overlap, with two backing sharing descendants -->
+<div>
+  <div id="sharing">
+    <div></div>
+  </div>
+</div>
+
+<div id="mutation"></div>
+
+<p>This test should not crash.</p>
+<script>
+if (window.testRunner)
+  testRunner.dumpAsText();
+
+async function test() {
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+ 
+    // Make the first sharing layer composited (synchronously) 
+    document.getElementById("sharing").classList.add("composited");
+    
+    // Wait for a rendering update so that the second sharing layer gets updated to no longer share
+    await new Promise(requestAnimationFrame);
+  
+    // Trigger an unrelated style change to update layer positions and verify that it was left in
+    // a valid state after the previous rendering update.
+    document.getElementById("mutation").style.backgroundColor = "blue";
+    document.documentElement.classList.remove("reftest-wait");
+}
+window.addEventListener('load', test, false);
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -318,6 +318,9 @@ static void clearBackingSharingLayerProviders(SingleThreadWeakListHashSet<Render
 void RenderLayerBacking::setBackingSharingLayers(SingleThreadWeakListHashSet<RenderLayer>&& sharingLayers)
 {
     bool sharingLayersChanged = m_backingSharingLayers.computeSize() != sharingLayers.computeSize();
+
+    clearBackingSharingLayerProviders(m_backingSharingLayers, m_owningLayer);
+
     // For layers that used to share and no longer do, and are not composited, recompute repaint rects.
     for (auto& oldSharingLayer : m_backingSharingLayers) {
         // Layers that go from shared to composited have their repaint rects recomputed in RenderLayerCompositor::updateBacking().
@@ -327,8 +330,6 @@ void RenderLayerBacking::setBackingSharingLayers(SingleThreadWeakListHashSet<Ren
                 oldSharingLayer.compositingStatusChanged(LayoutUpToDate::Yes);
         }
     }
-
-    clearBackingSharingLayerProviders(m_backingSharingLayers, m_owningLayer);
 
     if (sharingLayersChanged) {
         if (!sharingLayers.isEmptyIgnoringNullReferences())


### PR DESCRIPTION
#### 9a66248c727caddb8d851630a22f0fa9e56442bc
<pre>
LAYER_POSITIONS_ASSERT(m_repaintContainer == repaintContainer) on bbc.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=282944">https://bugs.webkit.org/show_bug.cgi?id=282944</a>
&lt;<a href="https://rdar.apple.com/139930342">rdar://139930342</a>&gt;

Reviewed by Dan Glastonbury.

RenderLayerBacking::setBackingSharingLayers calls `compositingStatusChanged` on
layers that no longer share to recompute their repaint rects, but we haven&apos;t yet
called `clearBackingSharingLayerProviders` to disconnect them.

This results in the repaint rects being computed with the sharing layer as the
repaint container still, and are invalid.

Next time recursiveUpdateLayerPositions runs in debug (without those invalid
layers being marked as dirty) it asserts on the invalid state.

This would also cause incorrect repaints being issued, if those happened while
in this invalid state.

* LayoutTests/compositing/shared-backing/make-sharing-layer-composited-expected.txt: Added.
* LayoutTests/compositing/shared-backing/make-sharing-layer-composited.html: Added.
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::setBackingSharingLayers):

Canonical link: <a href="https://commits.webkit.org/286633@main">https://commits.webkit.org/286633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca29ebba6e2b419d0ed3680ad61c1b63522de598

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81106 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27855 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60028 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18131 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49950 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65750 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40353 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47350 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23243 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26179 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68472 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23574 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82555 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2601 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68309 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4108 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65722 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67557 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16855 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11529 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9616 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3902 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6711 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3925 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5683 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->