### PR TITLE
AX: AccessibilityRegionContext::takeBounds(const RenderText&, FloatRect paintRect) unnecessarily rotates for vertical writing mode

### DIFF
--- a/Source/WebCore/rendering/AccessibilityRegionContext.cpp
+++ b/Source/WebCore/rendering/AccessibilityRegionContext.cpp
@@ -94,13 +94,6 @@ void AccessibilityRegionContext::takeBoundsInternal(const RenderBoxModelObject& 
 void AccessibilityRegionContext::takeBounds(const RenderText& renderText, FloatRect paintRect)
 {
     auto mappedPaintRect = enclosingIntRect(mapRect(WTFMove(paintRect)));
-    if (renderText.writingMode().isVertical()) {
-        // This is a hack we shouldn't need to do, but have to for some reason because the paintRect isn't flipped.
-        // For vertical text, swap the width and height, and move `y` by the line width.
-        mappedPaintRect.setSize({ mappedPaintRect.height(), mappedPaintRect.width() });
-        mappedPaintRect.setY(mappedPaintRect.y() + mappedPaintRect.width());
-    }
-
     if (auto* view = renderText.document().view())
         mappedPaintRect = view->contentsToRootView(mappedPaintRect);
 

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -107,14 +107,19 @@ void TextBoxPainter::paint()
         return;
     }
 
-    if (m_paintInfo.phase == PaintPhase::Accessibility) {
-        m_paintInfo.accessibilityRegionContext()->takeBounds(m_renderer, m_paintRect);
-        return;
-    }
-
     bool shouldRotate = !textBox().isHorizontal() && !m_isCombinedText;
     if (shouldRotate)
         m_paintInfo.context().concatCTM(rotation(m_paintRect, RotationDirection::Clockwise));
+
+    if (m_paintInfo.phase == PaintPhase::Accessibility) {
+        if (shouldRotate) {
+            auto transform = rotation(m_paintRect, RotationDirection::Clockwise);
+            m_paintInfo.accessibilityRegionContext()->takeBounds(m_renderer, transform.mapRect(m_paintRect));
+        } else
+            m_paintInfo.accessibilityRegionContext()->takeBounds(m_renderer, m_paintRect);
+
+        return;
+    }
 
     if (m_paintInfo.phase == PaintPhase::Foreground) {
         if (!m_isPrinting)


### PR DESCRIPTION
#### 3ad7a1a795504f3fe7e4dc20c671b2ad422e1743
<pre>
AX: AccessibilityRegionContext::takeBounds(const RenderText&amp;, FloatRect paintRect) unnecessarily rotates for vertical writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=283155">https://bugs.webkit.org/show_bug.cgi?id=283155</a>
<a href="https://rdar.apple.com/139938931">rdar://139938931</a>

Reviewed by Chris Fleizach.

AccessibilityRegionContext::takeBounds(const RenderText&amp;, FloatRect paintRect) manually rotated the given paint rect
to account for vertical writing modes, but TextBoxPainter already did that and we just weren&apos;t using it. This commit
re-uses the same logic that non-accessibility paints use.

* Source/WebCore/rendering/AccessibilityRegionContext.cpp:
(WebCore::AccessibilityRegionContext::takeBounds):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter::paint):

Canonical link: <a href="https://commits.webkit.org/286748@main">https://commits.webkit.org/286748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d71e890ac82b439f85f2dab063e98a2d235e81b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81116 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27862 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78703 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3914 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60038 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18138 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 1 flakes") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65756 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40363 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47356 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23249 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26186 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68478 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82562 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2607 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68317 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65728 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67565 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16916 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11535 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9622 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3909 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6718 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3932 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7362 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5690 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->