### PR TITLE
ASSERTION FAILED: m_start != m_end in WTF::Deque<WTF::String>::last() under WebCore::FragmentDirectiveParser::parseFragmentDirective

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-expected.txt
@@ -1,6 +1,8 @@
 
 PASS Test navigation with fragment: Empty hash should scroll to top.
 PASS Test navigation with fragment: Text directive with invalid syntax (context terms without "-") should not parse as a text directive.
+PASS Test navigation with fragment: Text directive with invalid syntax (only prefix, no start text) should not parse as a text directive.
+PASS Test navigation with fragment: Text directive with invalid syntax (only suffix, no start text) should not parse as a text directive.
 PASS Test navigation with fragment: Generic fragment directive with existing element fragment should scroll to element.
 PASS Test navigation with fragment: Uppercase TEXT directive should not parse as a text directive.
 PASS Test navigation with fragment: Exact text with no context should match text.

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment.html
@@ -31,6 +31,16 @@ let test_cases = [
     description: 'Text directive with invalid syntax (context terms without "-") should not parse as a text directive'
   },
   {
+    fragment: '#:~:text=foo-',
+    expect_position: 'top',
+    description: 'Text directive with invalid syntax (only prefix, no start text) should not parse as a text directive'
+  },
+  {
+    fragment: '#:~:text=-foo',
+    expect_position: 'top',
+    description: 'Text directive with invalid syntax (only suffix, no start text) should not parse as a text directive'
+  },
+  {
     fragment: '#element:~:directive',
     expect_position: 'element',
     description: 'Generic fragment directive with existing element fragment should scroll to element'

--- a/Source/WebCore/dom/FragmentDirectiveParser.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveParser.cpp
@@ -90,6 +90,11 @@ void FragmentDirectiveParser::parseFragmentDirective(StringView fragmentDirectiv
                 LOG_WITH_STREAM(TextFragment, stream << " could not decode prefix ");
         }
         
+        if (tokens.isEmpty()) {
+            LOG_WITH_STREAM(TextFragment, stream << " not enough tokens ");
+            continue;
+        }
+
         if (tokens.last().startsWith('-') && tokens.last().length() > 1) {
             tokens.last() = tokens.last().substring(1);
             


### PR DESCRIPTION
#### 31115c9484ff27791069366e86d8bee510089bcf
<pre>
ASSERTION FAILED: m_start != m_end in WTF::Deque&lt;WTF::String&gt;::last() under WebCore::FragmentDirectiveParser::parseFragmentDirective
<a href="https://bugs.webkit.org/show_bug.cgi?id=282814">https://bugs.webkit.org/show_bug.cgi?id=282814</a>

Reviewed by Tim Horton.

If a text directive consists of only the prefix but no start text, for
example &lt;<a href="https://webkit.org/#">https://webkit.org/#</a>:~:text=prefix-&gt;, a release assertion
failed.

* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment.html:
* Source/WebCore/dom/FragmentDirectiveParser.cpp:
(WebCore::FragmentDirectiveParser::parseFragmentDirective):

Canonical link: <a href="https://commits.webkit.org/286654@main">https://commits.webkit.org/286654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24b674876879f8a71cf18592a58c6058a73a5817

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81124 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27870 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78711 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60047 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18148 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65764 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40372 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47364 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23257 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26194 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68486 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23588 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82570 "Hash 24b67487 for PR 36684 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3970 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2614 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/82570 "Hash 24b67487 for PR 36684 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65736 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/82570 "Hash 24b67487 for PR 36684 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11544 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9629 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11854 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3917 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6726 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3940 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7370 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5698 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->