### PR TITLE
[WPE] Add environment variables initial documentation

### DIFF
--- a/Source/WebKit/wpe/environment-variables.md
+++ b/Source/WebKit/wpe/environment-variables.md
@@ -1,0 +1,23 @@
+Title: Environment variables
+Slug: environment-variables
+
+# List of environment varibles
+
+WebKit uses several environment variables, most of which are designed for developers or debugging purposes. These variables should be used carefully, as they can impact the behavior of the software. These environment variables and their behavior are not guaranteed to remain stable across versions of WPE WebKit. Always ensure that your WPE WebKit version corresponds to the documentation you are referencing to avoid compatibility issues.
+
+- `WPE_DRM_DEVICE`
+Specifies the primary device that WebKit will use for gpu buffer allocation when it needs access to the main device. It is interesting for DRM backend. You need to specify a file path.
+Example: `dev/dri/card0`
+
+- `WPE_DRM_RENDER_NODE`:
+Specifies the render device that WebKit will use for buffer allocation, this is the one used for allocating general gpu buffers. You need to specify a file path.
+Example: `/dev/dri/renderD128`
+
+- `WPE_DMABUF_BUFFER_FORMAT`:
+You can ask WebKit to try to use a format instead the one that is recommended by the underlying system (wayland, drm, etc.), when you define this variable then no other data is going to be used from wayland so it is recommended to also define the drm devices. The value must follow the following format: `pixel_format:memory_layout:usage`:
+    - Pixel format, specifies the pixel format as a fourcc code, example: `AR24`
+    - Memory layout, defines the memory layout of the buffer, 0 for linear layout
+    - Usage, indicates how the buffers is going to be used: `rendering`, `mapping` and `scanout`
+Example: `AR24:0:scanout`
+
+

--- a/Source/WebKit/wpe/wpewebkit.toml.in
+++ b/Source/WebKit/wpe/wpewebkit.toml.in
@@ -34,3 +34,6 @@ base_url = "https://github.com/WebKit/WebKit/tree/main/"
 
 [extra]
 urlmap_file = "wpe@WPE_API_MAJOR_VERSION@-urlmap.js"
+content_files = [
+    "environment-variables.md"
+]


### PR DESCRIPTION
#### beca1cad03a2bf37a11503a3b3784fd32fc1cc0f
<pre>
[WPE] Add environment variables initial documentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=283164">https://bugs.webkit.org/show_bug.cgi?id=283164</a>

Reviewed by Adrian Perez de Castro.

We are going to start creating environment variables documentation,
adding some initial examples Hopefully at some point we can integrate
them with the proposal in bug #280610 but for the moment we are going
to start adding some:

* Source/WebKit/wpe/environment-variables.md: Added.
* Source/WebKit/wpe/wpewebkit.toml.in:

Canonical link: <a href="https://commits.webkit.org/286638@main">https://commits.webkit.org/286638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2299e0baa5b0014003e219b5345e5b45b65d470

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81140 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27886 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3938 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60059 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18159 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49977 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40384 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47377 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26210 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82586 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3986 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2628 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68336 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4139 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65748 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67585 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11556 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9641 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11846 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3933 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6742 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3956 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7386 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->