### PR TITLE
[GTK] Provide an overview page for WebKitGTK

### DIFF
--- a/Source/WebKit/gtk/gtk4-webkitgtk.toml.in
+++ b/Source/WebKit/gtk/gtk4-webkitgtk.toml.in
@@ -39,6 +39,7 @@ base_url = "https://github.com/WebKit/WebKit/tree/main/"
 
 [extra]
 content_files = [
+    "overview.md",
     "migrating-to-webkitgtk-6.0.md"
 ]
 

--- a/Source/WebKit/gtk/overview.md
+++ b/Source/WebKit/gtk/overview.md
@@ -1,0 +1,28 @@
+Title: Overview
+Slug: overview
+
+WebKitGTK is a GObject-based library that provides a GTK widget
+to interact with the WebKit engine. It can be used to write a
+variety of apps, from web browers to news readers to rich text
+editors.
+
+WebkitGTK is distributed under the [BSD][bsd] and [LGPL-2.1][lgpl-2.1]
+licenses.
+
+Besides offering a C API for app developers, WebKitGTK also
+provides bindings to many other programming languages using
+GObject Introspection, including Python, Rust, JavaScript, and
+more.
+
+The main widget is [class@WebKit.WebView], which can be added
+to any GTK container or window like a regular widget.
+[class@WebKit.WebView] will then render the web page in the
+area allocated to it.
+
+Most other objects offered by WebKitGTK provide extra controls
+to [class@WebKit.WebView]. For example, the [class@WebKit.Settings]
+object can be used to enable or disable features of the web view.
+
+
+[bsd]: https://github.com/WebKit/WebKit/blob/main/Source/WebCore/LICENSE-APPLE
+[lgpl-2.1]: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html


### PR DESCRIPTION
#### 1cb2076dd84c65ea1e3dc03867f3bc3e5665d78f
<pre>
[GTK] Provide an overview page for WebKitGTK
<a href="https://bugs.webkit.org/show_bug.cgi?id=283166">https://bugs.webkit.org/show_bug.cgi?id=283166</a>

Reviewed by Adrian Perez de Castro.

Provide an overview page for the WebKitGTK documentation. This is
turned into a web page by gi-docgen.

* Source/WebKit/gtk/gtk4-webkitgtk.toml.in:
* Source/WebKit/gtk/overview.md: Added.

Canonical link: <a href="https://commits.webkit.org/286658@main">https://commits.webkit.org/286658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46c0642a34dfa385da9a5744a95eec2caf4a955d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81141 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27887 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3939 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60060 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18161 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65780 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40385 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47380 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26211 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68502 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82587 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2630 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68339 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4140 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65752 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67586 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11560 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9645 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11857 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3934 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6743 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3957 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7387 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5715 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->