### PR TITLE
[Media] Avoid play() call during seek flow before the finishSeek()

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3758,6 +3758,10 @@ void HTMLMediaElement::seekWithTolerance(const SeekTarget& target, bool fromDOM)
     refreshCachedTime();
     MediaTime now = currentMediaTime();
 
+    // Needed to detect a special case in updatePlayState().
+    if (now >= durationMediaTime())
+        m_seekAfterPlaybackEnded = true;
+
     // 3 - If the element's seeking IDL attribute is true, then another instance of this algorithm is
     // already running. Abort that other instance of the algorithm without waiting for the step that
     // it is running to complete.
@@ -3945,6 +3949,8 @@ void HTMLMediaElement::finishSeek()
 #endif
     if (wasPlayingBeforeSeeking)
         playInternal();
+
+    m_seekAfterPlaybackEnded = false;
 }
 
 HTMLMediaElement::ReadyState HTMLMediaElement::readyState() const
@@ -4390,8 +4396,10 @@ void HTMLMediaElement::playInternal()
     if (!m_player || m_networkState == NETWORK_EMPTY)
         selectMediaResource();
 
-    if (endedPlayback())
+    if (endedPlayback()) {
+        m_seekAfterPlaybackEnded = true;
         seekInternal(MediaTime::zeroTime());
+    }
 
     if (RefPtr mediaController = m_mediaController)
         mediaController->bringElementUpToSpeed(*this);
@@ -6416,7 +6424,17 @@ void HTMLMediaElement::updatePlayState()
     if (shouldBePlaying) {
         invalidateCachedTime();
 
-        if (playerPaused) {
+        // Play is always allowed, except when seeking (to avoid unpausing the video by mistake until the
+        // target time is reached). However, there are some exceptional situations when we allow playback
+        // during seek. This is because GStreamer-based implementation have a design limitation that doesn't
+        // allow initial seeks (seeking before going to playing state), and these exceptions make things
+        // work for those platforms.
+        bool isLooping = loop() && m_lastSeekTime == MediaTime::zeroTime();
+        bool playExceptionsWhenSeeking = m_seeking && (m_firstTimePlaying
+            || isLooping || m_isResumingPlayback || m_seekAfterPlaybackEnded);
+        bool allowPlay = !m_seeking || playExceptionsWhenSeeking;
+
+        if (playerPaused && allowPlay) {
             mediaSession().clientWillBeginPlayback();
 
             // Set rate, muted and volume before calling play in case they were set before the media engine was set up.
@@ -8978,8 +8996,11 @@ void HTMLMediaElement::resumeAutoplaying()
 void HTMLMediaElement::mayResumePlayback(bool shouldResume)
 {
     ALWAYS_LOG(LOGIDENTIFIER, "paused = ", paused());
-    if (!ended() && paused() && shouldResume)
+    if (!ended() && paused() && shouldResume) {
+        m_isResumingPlayback = true;
         play();
+        m_isResumingPlayback = false;
+    }
 }
 
 String HTMLMediaElement::mediaSessionTitle() const

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1295,6 +1295,8 @@ private:
     bool m_volumeLocked : 1;
     bool m_cachedIsInVisibilityAdjustmentSubtree : 1 { false };
     bool m_requiresTextTrackRepresentation : 1 { false };
+    bool m_isResumingPlayback : 1 { false };
+    bool m_seekAfterPlaybackEnded : 1 { false };
 
     IntRect m_textTrackRepresentationBounds;
 


### PR DESCRIPTION
#### 71a7e0a09291cc45f28866d3cc93adb0da61050c
<pre>
[Media] Avoid play() call during seek flow before the finishSeek()
<a href="https://bugs.webkit.org/show_bug.cgi?id=283172">https://bugs.webkit.org/show_bug.cgi?id=283172</a>

Reviewed by Xabier Rodriguez-Calvar.

During the video playback states should ideally flow as play -&gt; pause -&gt;
seek_start -&gt; seek_done -&gt; play, but randomly it is observed that the
play event is being sent before finishing the seek (seek_done) i.e, play
-&gt; pause -&gt; seek_start -&gt; play -&gt; seek_done. Ideally play call might be
triggered continuously by the webapp when we are playing a video, so in
our scenario between seek_start and seek_done we should avoid the play
call.

This commit adds a new condition to skip the playPlayer() call during
updatePlayState() when the seek is ongoing. This would avoid the play
event to happen.

There&apos;s also some special cases to not skip playPlayer() on first play,
because initial seeks aren&apos;t fully supported on WebKitGTK/WPE and that
play call might be required for them to work:

- First time playing
- Looping
- Resuming playback
- Seek after playback ended (either as part of a loop or a manual seek)

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1423">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1423</a>
Co-authored with: gowthami &lt;gchikkadasarahallilo.ext@libertyglobal.com&gt;

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::seekWithTolerance): Set seek after playback ended flag when the current position is equal to duration.
(WebCore::HTMLMediaElement::finishSeek): Reset the seek after playback ended flag.
(WebCore::HTMLMediaElement::playInternal): Set seek after playback ended flag when needed.
(WebCore::HTMLMediaElement::updatePlayState): Add the new conditions and exceptions to disallow playback when seeking.
(WebCore::HTMLMediaElement::mayResumePlayback): Set the isResumingPlayback condition and reset it after the call to play().
* Source/WebCore/html/HTMLMediaElement.h: Added m_isResumingPlayback and m_seekAfterPlaybackEnded flags.

Canonical link: <a href="https://commits.webkit.org/287274@main">https://commits.webkit.org/287274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92c4716ec7152d15bb685c3be2ce8855dd99ebbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78441 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83102 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29706 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80574 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61430 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19351 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41743 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25183 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28043 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69884 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84468 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3953 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69655 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5967 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67437 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68910 "Found 4 new API test failures: /TestWebKit:WebKit.PageLoadBasic, /TestWebKit:WebKit.FrameMIMETypePNG, /TestWebKit:WebKit.LoadAlternateHTMLStringWithNonDirectoryURL, /TestWebKit:WebKit2UserMessageRoundTripTest.WKURLRequestRef (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17277 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12934 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11302 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5753 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8823 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5742 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9175 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7528 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->