### PR TITLE
SWServerToContextConnection::terminateWhenPossible should ask UIProcess to disable service workers on the corresponding WebProcess

### DIFF
--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -917,7 +917,11 @@ void SWServer::terminateContextConnectionWhenPossible(const RegistrableDomain& r
     if (!contextConnection || contextConnection->webProcessIdentifier() != processIdentifier)
         return;
 
-    contextConnection->terminateWhenPossible();
+    if (!contextConnection->terminateWhenPossible())
+        return;
+
+    removeContextConnection(*contextConnection);
+    contextConnection->connectionIsNoLongerNeeded();
 }
 
 OptionSet<AdvancedPrivacyProtections> SWServer::advancedPrivacyProtectionsFromClient(const ClientOrigin& origin) const

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.cpp
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.cpp
@@ -137,7 +137,7 @@ void SWServerToContextConnection::setAsInspected(ServiceWorkerIdentifier identif
         worker->setAsInspected(isInspected);
 }
 
-void SWServerToContextConnection::terminateWhenPossible()
+bool SWServerToContextConnection::terminateWhenPossible()
 {
     m_shouldTerminateWhenPossible = true;
 
@@ -152,8 +152,7 @@ void SWServerToContextConnection::terminateWhenPossible()
 
     // FIXME: If there is a service worker with pending events and we don't close the connection right away, we'd ideally keep
     // track of this and close the connection once it becomes idle.
-    if (!hasServiceWorkerWithPendingEvents)
-        close();
+    return !hasServiceWorkerWithPendingEvents;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.h
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.h
@@ -64,7 +64,7 @@ public:
 
     // This flag gets set when the service worker process is no longer clean (because it has loaded several eTLD+1s).
     bool shouldTerminateWhenPossible() const { return m_shouldTerminateWhenPossible; }
-    void terminateWhenPossible();
+    bool terminateWhenPossible();
 
     // Messages to the SW host process
     virtual void installServiceWorkerContext(const ServiceWorkerContextData&, const ServiceWorkerData&, const String& userAgent, WorkerThreadMode, OptionSet<AdvancedPrivacyProtections>) = 0;
@@ -108,8 +108,6 @@ public:
 
 protected:
     WEBCORE_EXPORT SWServerToContextConnection(SWServer&, Site&&, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier);
-
-    virtual void close() = 0;
 
 private:
     WeakPtr<WebCore::SWServer> m_server;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -162,11 +162,6 @@ void WebSWServerToContextConnection::skipWaiting(ServiceWorkerIdentifier service
     callback();
 }
 
-void WebSWServerToContextConnection::close()
-{
-    send(Messages::WebSWContextManagerConnection::Close { });
-}
-
 void WebSWServerToContextConnection::installServiceWorkerContext(const ServiceWorkerContextData& contextData, const ServiceWorkerData& workerData, const String& userAgent, WorkerThreadMode workerThreadMode, OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections)
 {
     serviceWorkerNeedsRunning();

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -125,7 +125,6 @@ private:
     void fireNotificationEvent(WebCore::ServiceWorkerIdentifier, const WebCore::NotificationData&, WebCore::NotificationEventType, CompletionHandler<void(bool)>&&) final;
     void fireBackgroundFetchEvent(WebCore::ServiceWorkerIdentifier, const WebCore::BackgroundFetchInformation&, CompletionHandler<void(bool)>&&) final;
     void fireBackgroundFetchClickEvent(WebCore::ServiceWorkerIdentifier, const WebCore::BackgroundFetchInformation&, CompletionHandler<void(bool)>&&) final;
-    void close() final;
     void focus(WebCore::ScriptExecutionContextIdentifier, CompletionHandler<void(std::optional<WebCore::ServiceWorkerClientData>&&)>&&);
     void navigate(WebCore::ScriptExecutionContextIdentifier, WebCore::ServiceWorkerIdentifier, const URL&, CompletionHandler<void(Expected<std::optional<WebCore::ServiceWorkerClientData>, WebCore::ExceptionData>&&)>&&);
 


### PR DESCRIPTION
#### 7b303b1c7b274341cc5757fd1ede764f100559d3
<pre>
SWServerToContextConnection::terminateWhenPossible should ask UIProcess to disable service workers on the corresponding WebProcess
<a href="https://rdar.apple.com/139968744">rdar://139968744</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=283173">https://bugs.webkit.org/show_bug.cgi?id=283173</a>

Reviewed by Chris Dumez.

UIProcess may sometimes ask network process to stop using a web process for service workers.
This ends up calling SWServerToContextConnection::terminateWhenPossible.
When feasible, network process will then ask the web process to close its service workers and will think it no longer has a web process for running service workers.
But network process forgets to tell UIProcess about it so UIProcess does not call disableRemoteWorkers on the corresponding WebProcessProxy.

When network process needs a process for running service workers, it will ask UIProcess for a web process and UIProcess may reuse that process.
Normally it should not reuse it since UIProcess asked network process to stop using this web process for service workers as it was dirtied.
But this may be happening and UIProcess may terminate service workers for other reasons as well.

For that reason, instead of letting network process stops service workers directly, we make it go through UIProcess using the usual connectionIsNoLongerNeeded code path.
It is then UIProcess that will tell the web process to stop the service workers.

* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::terminateContextConnectionWhenPossible):
* Source/WebCore/workers/service/server/SWServerToContextConnection.cpp:
(WebCore::SWServerToContextConnection::terminateWhenPossible):
* Source/WebCore/workers/service/server/SWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::close): Deleted.
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:

Canonical link: <a href="https://commits.webkit.org/286849@main">https://commits.webkit.org/286849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69fe9b5b036b687ab8421151dacab666ca0a602a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81735 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28456 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79291 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4505 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60461 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18522 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50430 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66238 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40764 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47832 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23736 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26779 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68947 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24071 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83161 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4554 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3066 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68750 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4710 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66211 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68006 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16999 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11984 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10074 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4501 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7316 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4520 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7955 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6279 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->