### PR TITLE
[css-images] imported/w3c/web-platform-tests/css/css-images/animation/image-slice-interpolation-math-functions-tentative.html needs to be rebaselined

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/animation/image-slice-interpolation-math-functions-tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/animation/image-slice-interpolation-math-functions-tentative-expected.txt
@@ -47,28 +47,28 @@ PASS Web Animations: property <border-image-slice> from [100%] to [calc(sign(20r
 PASS Web Animations: property <border-image-slice> from [100%] to [calc(sign(20rem - 20px) * 180%)] at (0.875) should be [170%]
 PASS Web Animations: property <border-image-slice> from [100%] to [calc(sign(20rem - 20px) * 180%)] at (1) should be [180%]
 PASS Web Animations: property <border-image-slice> from [100%] to [calc(sign(20rem - 20px) * 180%)] at (2) should be [260%]
-FAIL CSS Transitions: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (-1) should be [20%] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0) should be [100%] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0.125) should be [110%] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0.875) should be [170%] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (1) should be [180%] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (2) should be [260%] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (-1) should be [20%] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0) should be [100%] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0.125) should be [110%] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0.875) should be [170%] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (1) should be [180%] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (2) should be [260%] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (-1) should be [20%] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0) should be [100%] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0.125) should be [110%] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0.875) should be [170%] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (1) should be [180%] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (2) should be [260%] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (-1) should be [20%] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0) should be [100%] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0.125) should be [110%] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0.875) should be [170%] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (1) should be [180%] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (2) should be [260%] assert_true: 'to' value should be supported expected true got false
+PASS CSS Transitions: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (-1) should be [20%]
+PASS CSS Transitions: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0) should be [100%]
+PASS CSS Transitions: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0.125) should be [110%]
+PASS CSS Transitions: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0.875) should be [170%]
+PASS CSS Transitions: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (1) should be [180%]
+PASS CSS Transitions: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (2) should be [260%]
+PASS CSS Transitions with transition: all: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (-1) should be [20%]
+PASS CSS Transitions with transition: all: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0) should be [100%]
+PASS CSS Transitions with transition: all: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0.125) should be [110%]
+PASS CSS Transitions with transition: all: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0.875) should be [170%]
+PASS CSS Transitions with transition: all: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (1) should be [180%]
+PASS CSS Transitions with transition: all: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (2) should be [260%]
+PASS CSS Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (-1) should be [20%]
+PASS CSS Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0) should be [100%]
+PASS CSS Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0.125) should be [110%]
+PASS CSS Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0.875) should be [170%]
+PASS CSS Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (1) should be [180%]
+PASS CSS Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (2) should be [260%]
+PASS Web Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (-1) should be [20%]
+PASS Web Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0) should be [100%]
+PASS Web Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0.125) should be [110%]
+PASS Web Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (0.875) should be [170%]
+PASS Web Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (1) should be [180%]
+PASS Web Animations: property <border-image-slice> from [calc(sign(20rem - 20px) * 100%)] to [calc(progress(10rem from 20px to 100px) * 180%)] at (2) should be [260%]
 


### PR DESCRIPTION
#### edf8369500a61548622b18f47da4ab0bd6a79f1b
<pre>
[css-images] imported/w3c/web-platform-tests/css/css-images/animation/image-slice-interpolation-math-functions-tentative.html needs to be rebaselined
<a href="https://bugs.webkit.org/show_bug.cgi?id=283175">https://bugs.webkit.org/show_bug.cgi?id=283175</a>
<a href="https://rdar.apple.com/139969725">rdar://139969725</a>

Unreviewed test gardening.

* LayoutTests/imported/w3c/web-platform-tests/css/css-images/animation/image-slice-interpolation-math-functions-tentative-expected.txt:

Canonical link: <a href="https://commits.webkit.org/286643@main">https://commits.webkit.org/286643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98733d9f904b941b0aae15354ff7596006fbb171

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76623 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81154 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27899 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/3951 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60073 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18175 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79690 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65789 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40398 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47390 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23283 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26223 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23613 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82599 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/3999 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2640 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68350 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67598 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11568 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9654 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11848 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/3946 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/3969 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7399 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5727 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->