### PR TITLE
[WebIDL] Callbacks should leave the choice to report or rethrow exceptions to the invoker (part 1, rename rethrowing handler)

### DIFF
--- a/Source/WebCore/Modules/web-locks/WebLockGrantedCallback.h
+++ b/Source/WebCore/Modules/web-locks/WebLockGrantedCallback.h
@@ -39,7 +39,7 @@ class WebLockGrantedCallback : public RefCounted<WebLockGrantedCallback>, public
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<RefPtr<DOMPromise>> handleEvent(WebLock*) = 0;
+    virtual CallbackResult<RefPtr<DOMPromise>> handleEventRethrowingException(WebLock*) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/web-locks/WebLockManager.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.cpp
@@ -261,7 +261,7 @@ void WebLockManager::didCompleteLockRequest(WebLockIdentifier lockIdentifier, bo
             }
 
             auto lock = WebLock::create(*request.lockIdentifier, request.name, request.mode);
-            auto result = request.grantedCallback->handleEvent(lock.ptr());
+            auto result = request.grantedCallback->handleEventRethrowingException(lock.ptr());
             RefPtr<DOMPromise> waitingPromise = result.type() == CallbackResultType::Success ? result.releaseReturnValue() : nullptr;
             if (!waitingPromise || waitingPromise->isSuspended()) {
                 m_mainThreadBridge->releaseLock(*request.lockIdentifier, request.name);
@@ -276,7 +276,7 @@ void WebLockManager::didCompleteLockRequest(WebLockIdentifier lockIdentifier, bo
                 settleReleasePromise(lockIdentifier, static_cast<JSC::JSValue>(waitingPromise->promise()));
             });
         } else {
-            auto result = request.grantedCallback->handleEvent(nullptr);
+            auto result = request.grantedCallback->handleEventRethrowingException(nullptr);
             RefPtr<DOMPromise> waitingPromise = result.type() == CallbackResultType::Success ? result.releaseReturnValue() : nullptr;
             if (!waitingPromise || waitingPromise->isSuspended()) {
                 settleReleasePromise(*request.lockIdentifier, Exception { ExceptionCode::ExistingExceptionError });

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -6771,6 +6771,7 @@ sub GenerateCallbackHeaderContent
             
             # FIXME: Change the default name (used for callback functions) to something other than handleEvent. It makes little sense.
             my $functionName = $operation->extendedAttributes->{ImplementedAs} || $operation->name || "handleEvent";
+            $functionName .= "RethrowingException" if $operation->extendedAttributes->{RethrowException};
 
             push(@$contentRef, "    ${nativeReturnType} ${functionName}(" . join(", ", @arguments) . ") override;\n");
         }
@@ -6896,7 +6897,9 @@ sub GenerateCallbackImplementationContent
             
             # FIXME: Change the default name (used for callback functions) to something other than handleEvent. It makes little sense.
             my $functionName = $operation->name || "handleEvent";
+
             my $functionImplementationName = $operation->extendedAttributes->{ImplementedAs} || $functionName;
+            $functionImplementationName .= "RethrowingException" if $operation->extendedAttributes->{RethrowException};
 
             my @arguments = ();
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.cpp
@@ -55,7 +55,7 @@ JSTestCallbackFunctionRethrow::~JSTestCallbackFunctionRethrow()
 #endif
 }
 
-CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunctionRethrow::handleEvent(typename IDLSequence<IDLLong>::ParameterType argument)
+CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunctionRethrow::handleEventRethrowingException(typename IDLSequence<IDLLong>::ParameterType argument)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.h
@@ -40,7 +40,7 @@ public:
     JSCallbackData* callbackData() { return m_data; }
 
     // Functions
-    CallbackResult<typename IDLDOMString::CallbackReturnType> handleEvent(typename IDLSequence<IDLLong>::ParameterType argument) override;
+    CallbackResult<typename IDLDOMString::CallbackReturnType> handleEventRethrowingException(typename IDLSequence<IDLLong>::ParameterType argument) override;
 
 private:
     JSTestCallbackFunctionRethrow(JSC::JSObject*, JSDOMGlobalObject*);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -391,7 +391,7 @@ CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackInterfac
     return { returnValue.releaseReturnValue() };
 }
 
-CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackInterface::callbackThatRethrowsExceptions(typename IDLEnumeration<TestCallbackInterface::Enum>::ParameterType enumParam)
+CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackInterface::callbackThatRethrowsExceptionsRethrowingException(typename IDLEnumeration<TestCallbackInterface::Enum>::ParameterType enumParam)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
@@ -53,7 +53,7 @@ public:
     CallbackResult<typename IDLUndefined::CallbackReturnType> callbackWithBoolean(typename IDLBoolean::ParameterType boolParam) override;
     CallbackResult<typename IDLUndefined::CallbackReturnType> callbackRequiresThisToPass(typename IDLLong::ParameterType longParam, typename IDLInterface<TestNode>::ParameterType testNodeParam) override;
     CallbackResult<typename IDLDOMString::CallbackReturnType> callbackWithAReturnValue() override;
-    CallbackResult<typename IDLDOMString::CallbackReturnType> callbackThatRethrowsExceptions(typename IDLEnumeration<TestCallbackInterface::Enum>::ParameterType enumParam) override;
+    CallbackResult<typename IDLDOMString::CallbackReturnType> callbackThatRethrowsExceptionsRethrowingException(typename IDLEnumeration<TestCallbackInterface::Enum>::ParameterType enumParam) override;
     CallbackResult<typename IDLPromise<IDLUndefined>::CallbackReturnType> callbackThatTreatsExceptionAsRejectedPromise(typename IDLEnumeration<TestCallbackInterface::Enum>::ParameterType enumParam) override;
     CallbackResult<typename IDLDOMString::CallbackReturnType> callbackWithThisObject(typename IDLInterface<TestNode>::ParameterType thisObject, typename IDLInterface<TestObj>::ParameterType testObjParam) override;
 

--- a/Source/WebCore/dom/CreateHTMLCallback.h
+++ b/Source/WebCore/dom/CreateHTMLCallback.h
@@ -38,7 +38,7 @@ public:
 
     virtual bool hasCallback() const = 0;
 
-    virtual CallbackResult<String> handleEvent(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
+    virtual CallbackResult<String> handleEventRethrowingException(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/CreateScriptCallback.h
+++ b/Source/WebCore/dom/CreateScriptCallback.h
@@ -38,7 +38,7 @@ public:
 
     virtual bool hasCallback() const = 0;
 
-    virtual CallbackResult<String> handleEvent(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
+    virtual CallbackResult<String> handleEventRethrowingException(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/CreateScriptURLCallback.h
+++ b/Source/WebCore/dom/CreateScriptURLCallback.h
@@ -38,7 +38,7 @@ public:
 
     virtual bool hasCallback() const = 0;
 
-    virtual CallbackResult<String> handleEvent(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
+    virtual CallbackResult<String> handleEventRethrowingException(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverDrop.cpp
+++ b/Source/WebCore/dom/InternalObserverDrop.cpp
@@ -52,7 +52,7 @@ public:
             return adoptRef(*new InternalObserverDrop::SubscriberCallbackDrop(context, source, amount));
         }
 
-        CallbackResult<void> handleEvent(Subscriber& subscriber) final
+        CallbackResult<void> handleEventRethrowingException(Subscriber& subscriber) final
         {
             RefPtr context = scriptExecutionContext();
 

--- a/Source/WebCore/dom/InternalObserverEvery.cpp
+++ b/Source/WebCore/dom/InternalObserverEvery.cpp
@@ -68,7 +68,7 @@ private:
             // rejection handlers and abort handlers.
             auto scope = DECLARE_CATCH_SCOPE(vm);
 
-            auto result = protectedCallback()->handleEvent(value, m_idx++);
+            auto result = protectedCallback()->handleEventRethrowingException(value, m_idx++);
 
             JSC::Exception* exception = scope.exception();
             if (UNLIKELY(exception)) {

--- a/Source/WebCore/dom/InternalObserverFilter.cpp
+++ b/Source/WebCore/dom/InternalObserverFilter.cpp
@@ -53,7 +53,7 @@ public:
             return adoptRef(*new InternalObserverFilter::SubscriberCallbackFilter(context, source, predicate));
         }
 
-        CallbackResult<void> handleEvent(Subscriber& subscriber) final
+        CallbackResult<void> handleEventRethrowingException(Subscriber& subscriber) final
         {
             RefPtr context = scriptExecutionContext();
 
@@ -101,7 +101,7 @@ private:
         JSC::Exception* previousException = nullptr;
         {
             auto catchScope = DECLARE_CATCH_SCOPE(vm);
-            auto result = m_predicate->handleEvent(value, m_idx);
+            auto result = m_predicate->handleEventRethrowingException(value, m_idx);
             previousException = catchScope.exception();
             if (previousException) {
                 catchScope.clearException();

--- a/Source/WebCore/dom/InternalObserverFind.cpp
+++ b/Source/WebCore/dom/InternalObserverFind.cpp
@@ -69,7 +69,7 @@ private:
             // rejection handlers and abort handlers.
             auto scope = DECLARE_CATCH_SCOPE(vm);
 
-            auto result = protectedCallback()->handleEvent(value, m_idx++);
+            auto result = protectedCallback()->handleEventRethrowingException(value, m_idx++);
 
             JSC::Exception* exception = scope.exception();
             if (UNLIKELY(exception)) {

--- a/Source/WebCore/dom/InternalObserverForEach.cpp
+++ b/Source/WebCore/dom/InternalObserverForEach.cpp
@@ -66,7 +66,7 @@ private:
             // rejection handlers and abort handlers.
             auto scope = DECLARE_CATCH_SCOPE(vm);
 
-            protectedCallback()->handleEvent(value, m_idx++);
+            protectedCallback()->handleEventRethrowingException(value, m_idx++);
 
             JSC::Exception* exception = scope.exception();
             if (UNLIKELY(exception)) {

--- a/Source/WebCore/dom/InternalObserverMap.cpp
+++ b/Source/WebCore/dom/InternalObserverMap.cpp
@@ -53,7 +53,7 @@ public:
             return adoptRef(*new InternalObserverMap::SubscriberCallbackMap(context, source, mapper));
         }
 
-        CallbackResult<void> handleEvent(Subscriber& subscriber) final
+        CallbackResult<void> handleEventRethrowingException(Subscriber& subscriber) final
         {
             RefPtr context = scriptExecutionContext();
 
@@ -99,7 +99,7 @@ private:
         JSC::Exception* previousException = nullptr;
         {
             auto catchScope = DECLARE_CATCH_SCOPE(vm);
-            auto result = m_mapper->handleEvent(value, m_idx);
+            auto result = m_mapper->handleEventRethrowingException(value, m_idx);
             previousException = catchScope.exception();
             if (previousException) {
                 catchScope.clearException();

--- a/Source/WebCore/dom/InternalObserverSome.cpp
+++ b/Source/WebCore/dom/InternalObserverSome.cpp
@@ -69,7 +69,7 @@ private:
             // rejection handlers and abort handlers.
             auto scope = DECLARE_CATCH_SCOPE(vm);
 
-            auto result = protectedCallback()->handleEvent(value, m_idx++);
+            auto result = protectedCallback()->handleEventRethrowingException(value, m_idx++);
 
             JSC::Exception* exception = scope.exception();
             if (UNLIKELY(exception)) {

--- a/Source/WebCore/dom/InternalObserverTake.cpp
+++ b/Source/WebCore/dom/InternalObserverTake.cpp
@@ -52,7 +52,7 @@ public:
             return adoptRef(*new InternalObserverTake::SubscriberCallbackTake(context, source, amount));
         }
 
-        CallbackResult<void> handleEvent(Subscriber& subscriber) final
+        CallbackResult<void> handleEventRethrowingException(Subscriber& subscriber) final
         {
             RefPtr context = scriptExecutionContext();
 

--- a/Source/WebCore/dom/MapperCallback.h
+++ b/Source/WebCore/dom/MapperCallback.h
@@ -35,7 +35,7 @@ class MapperCallback : public RefCounted<MapperCallback>, public ActiveDOMCallba
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<JSC::JSValue> handleEvent(JSC::JSValue, uint64_t) = 0;
+    virtual CallbackResult<JSC::JSValue> handleEventRethrowingException(JSC::JSValue, uint64_t) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/dom/NativeNodeFilter.cpp
+++ b/Source/WebCore/dom/NativeNodeFilter.cpp
@@ -39,7 +39,7 @@ bool NativeNodeFilter::hasCallback() const
     return true;
 }
 
-CallbackResult<unsigned short> NativeNodeFilter::acceptNode(Node& node)
+CallbackResult<unsigned short> NativeNodeFilter::acceptNodeRethrowingException(Node& node)
 {
     return Ref { m_condition }->acceptNode(node);
 }

--- a/Source/WebCore/dom/NativeNodeFilter.h
+++ b/Source/WebCore/dom/NativeNodeFilter.h
@@ -38,7 +38,7 @@ public:
         return adoptRef(*new NativeNodeFilter(context, WTFMove(condition)));
     }
 
-    CallbackResult<unsigned short> acceptNode(Node&) override;
+    CallbackResult<unsigned short> acceptNodeRethrowingException(Node&) override;
 
 private:
     WEBCORE_EXPORT explicit NativeNodeFilter(ScriptExecutionContext*, Ref<NodeFilterCondition>&&);

--- a/Source/WebCore/dom/NodeFilter.h
+++ b/Source/WebCore/dom/NodeFilter.h
@@ -37,7 +37,7 @@ class NodeFilter : public RefCounted<NodeFilter>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<unsigned short> acceptNode(Node&) = 0;
+    virtual CallbackResult<unsigned short> acceptNodeRethrowingException(Node&) = 0;
 
     virtual bool hasCallback() const = 0;
 

--- a/Source/WebCore/dom/Observable.cpp
+++ b/Source/WebCore/dom/Observable.cpp
@@ -95,7 +95,7 @@ void Observable::subscribeInternal(ScriptExecutionContext& context, Ref<Internal
     JSC::Exception* previousException = nullptr;
     {
         auto catchScope = DECLARE_CATCH_SCOPE(vm);
-        m_subscriberCallback->handleEvent(subscriber);
+        m_subscriberCallback->handleEventRethrowingException(subscriber);
         previousException = catchScope.exception();
         if (previousException) {
             catchScope.clearException();

--- a/Source/WebCore/dom/PredicateCallback.h
+++ b/Source/WebCore/dom/PredicateCallback.h
@@ -35,7 +35,7 @@ class PredicateCallback : public RefCounted<PredicateCallback>, public ActiveDOM
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<bool> handleEvent(JSC::JSValue, uint64_t) = 0;
+    virtual CallbackResult<bool> handleEventRethrowingException(JSC::JSValue, uint64_t) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/dom/SubscriberCallback.h
+++ b/Source/WebCore/dom/SubscriberCallback.h
@@ -37,7 +37,7 @@ class SubscriberCallback : public RefCounted<SubscriberCallback>, public ActiveD
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(Subscriber&) = 0;
+    virtual CallbackResult<void> handleEventRethrowingException(Subscriber&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/dom/Traversal.cpp
+++ b/Source/WebCore/dom/Traversal.cpp
@@ -50,7 +50,7 @@ ExceptionOr<unsigned short> NodeIteratorBase::acceptNodeSlowCase(Node& node)
         return NodeFilter::FILTER_SKIP;
 
     SetForScope isActive(m_isActive, true);
-    auto callbackResult = m_filter->acceptNode(node);
+    auto callbackResult = m_filter->acceptNodeRethrowingException(node);
     if (callbackResult.type() == CallbackResultType::ExceptionThrown)
         return Exception { ExceptionCode::ExistingExceptionError };
     return callbackResult.releaseReturnValue();

--- a/Source/WebCore/dom/TrustedTypePolicy.cpp
+++ b/Source/WebCore/dom/TrustedTypePolicy.cpp
@@ -90,7 +90,7 @@ ExceptionOr<String> TrustedTypePolicy::getPolicyValue(TrustedType trustedTypeNam
             protectedCreateHTML = m_options.createHTML;
         }
         if (protectedCreateHTML && protectedCreateHTML->hasCallback())
-            policyValue = protectedCreateHTML->handleEvent(input, WTFMove(arguments));
+            policyValue = protectedCreateHTML->handleEventRethrowingException(input, WTFMove(arguments));
     } else if (trustedTypeName == TrustedType::TrustedScript) {
         RefPtr<CreateScriptCallback> protectedCreateScript;
         {
@@ -98,7 +98,7 @@ ExceptionOr<String> TrustedTypePolicy::getPolicyValue(TrustedType trustedTypeNam
             protectedCreateScript = m_options.createScript;
         }
         if (protectedCreateScript && protectedCreateScript->hasCallback())
-            policyValue = protectedCreateScript->handleEvent(input, WTFMove(arguments));
+            policyValue = protectedCreateScript->handleEventRethrowingException(input, WTFMove(arguments));
     } else if (trustedTypeName == TrustedType::TrustedScriptURL) {
         RefPtr<CreateScriptURLCallback> protectedCreateScriptURL;
         {
@@ -106,7 +106,7 @@ ExceptionOr<String> TrustedTypePolicy::getPolicyValue(TrustedType trustedTypeNam
             protectedCreateScriptURL = m_options.createScriptURL;
         }
         if (protectedCreateScriptURL && protectedCreateScriptURL->hasCallback())
-            policyValue = protectedCreateScriptURL->handleEvent(input, WTFMove(arguments));
+            policyValue = protectedCreateScriptURL->handleEventRethrowingException(input, WTFMove(arguments));
     } else {
         ASSERT_NOT_REACHED();
         return Exception { ExceptionCode::TypeError };

--- a/Source/WebCore/dom/VisitorCallback.h
+++ b/Source/WebCore/dom/VisitorCallback.h
@@ -35,7 +35,7 @@ class VisitorCallback : public RefCounted<VisitorCallback>, public ActiveDOMCall
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent(JSC::JSValue, uint64_t) = 0;
+    virtual CallbackResult<void> handleEventRethrowingException(JSC::JSValue, uint64_t) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebKitLegacy/mac/DOM/DOM.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOM.mm
@@ -802,7 +802,7 @@ WebCore::NodeFilter* core(DOMNodeFilter *wrapper)
     if (!node)
         raiseTypeErrorException();
     
-    auto result = core(self)->acceptNode(*core(node));
+    auto result = core(self)->acceptNodeRethrowingException(*core(node));
     return result.type() == CallbackResultType::Success ? result.releaseReturnValue() : NodeFilter::FILTER_REJECT;
 }
 


### PR DESCRIPTION
#### 169dfb0cbc4012bfad05ba1a467d207def698d33
<pre>
[WebIDL] Callbacks should leave the choice to report or rethrow exceptions to the invoker (part 1, rename rethrowing handler)
<a href="https://bugs.webkit.org/show_bug.cgi?id=283177">https://bugs.webkit.org/show_bug.cgi?id=283177</a>

Reviewed by Chris Dumez.

Part 1 of a series to move the decision choice of a WebIDL callback to report exceptions
or rethrow them to the caller instead of it being baked into the type.

This initial change keeps the extended attribute, [RethrowException], but has it update
the name of the callback method from &lt;name&gt;(...) to &lt;name&gt;RethrowingException(...).

* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateCallbackHeaderContent):
(GenerateCallbackImplementationContent):
- Update handler name to have the `RethrowingException` suffix if [RethrowException] is present.

* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h:
    - Update test bindings test generation results for new name.

* Source/WebCore/Modules/web-locks/WebLockGrantedCallback.h:
* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
* Source/WebCore/dom/CreateHTMLCallback.h:
* Source/WebCore/dom/CreateScriptCallback.h:
* Source/WebCore/dom/CreateScriptURLCallback.h:
* Source/WebCore/dom/InternalObserverDrop.cpp:
* Source/WebCore/dom/InternalObserverEvery.cpp:
* Source/WebCore/dom/InternalObserverFilter.cpp:
* Source/WebCore/dom/InternalObserverFind.cpp:
* Source/WebCore/dom/InternalObserverForEach.cpp:
* Source/WebCore/dom/InternalObserverMap.cpp:
* Source/WebCore/dom/InternalObserverSome.cpp:
* Source/WebCore/dom/InternalObserverTake.cpp:
* Source/WebCore/dom/MapperCallback.h:
* Source/WebCore/dom/NativeNodeFilter.cpp:
* Source/WebCore/dom/NativeNodeFilter.h:
* Source/WebCore/dom/NodeFilter.h:
* Source/WebCore/dom/Observable.cpp:
* Source/WebCore/dom/PredicateCallback.h:
* Source/WebCore/dom/SubscriberCallback.h:
* Source/WebCore/dom/Traversal.cpp:
* Source/WebCore/dom/TrustedTypePolicy.cpp:
* Source/WebCore/dom/VisitorCallback.h:
* Source/WebKitLegacy/mac/DOM/DOM.mm:
Update implementations and callers to new names.

Canonical link: <a href="https://commits.webkit.org/286706@main">https://commits.webkit.org/286706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/655562c5674a94df7e421d7688b8d730cdb98793

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81310 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28053 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4105 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60162 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18252 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65915 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40481 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47510 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23409 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26377 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82754 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4153 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2745 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68446 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4306 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67698 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16887 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11674 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9757 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4100 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6910 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4123 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7553 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5881 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->