### PR TITLE
[css-anchor-position-1] Implement `anchor-center` alignment value

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7976,7 +7976,6 @@ webkit.org/b/282024 fast/text/text-box-edge-with-margin-padding-border-simple.ht
 # -- Anchor Positioning -- #
 
 # general failures
-imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-003.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-htb-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-htb-htb-expected.txt
@@ -1,32 +1,12 @@
 
 PASS .target 1
-FAIL .target 2 assert_equals:
-<div class="container">
-  <div class="anchor"></div>
-  <div class="target" style="max-width: 60px;" data-expected-width="60" data-offset-x="35"></div>
-</div>
-offsetLeft expected 35 but got 0
+PASS .target 2
 PASS .target 3
-FAIL .target 4 assert_equals:
-<div class="container">
-  <div class="anchor"></div>
-  <div class="target" style="right: 20px;" data-expected-width="80" data-offset-x="20"></div>
-</div>
-offsetLeft expected 20 but got 0
+PASS .target 4
 PASS .target 5
-FAIL .target 6 assert_equals:
-<div class="container">
-  <div class="anchor"></div>
-  <div class="target" style="max-width: 100px; right: -20px;" data-expected-width="100" data-offset-x="15"></div>
-</div>
-offsetLeft expected 15 but got 20
+PASS .target 6
 PASS .target 7
-FAIL .target 8 assert_equals:
-<div class="container">
-  <div class="anchor"></div>
-  <div class="target" style="left: 10px; right: 20px;" data-expected-width="70" data-offset-x="30"></div>
-</div>
-offsetLeft expected 30 but got 10
+PASS .target 8
 PASS .target 9
 PASS .target 10
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-htb-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-htb-vrl-expected.txt
@@ -1,37 +1,12 @@
 
-FAIL .target 1 assert_equals:
-<div class="container">
-  <div class="anchor"></div>
-  <div class="target" data-expected-height="100" data-offset-y="0"></div>
-</div>
-height expected 100 but got 50
-FAIL .target 2 assert_equals:
-<div class="container">
-  <div class="anchor"></div>
-  <div class="target" style="max-height: 60px;" data-expected-height="60" data-offset-y="35"></div>
-</div>
-height expected 60 but got 50
+PASS .target 1
+PASS .target 2
 PASS .target 3
-FAIL .target 4 assert_equals:
-<div class="container">
-  <div class="anchor"></div>
-  <div class="target" style="bottom: 20px;" data-expected-height="80" data-offset-y="20"></div>
-</div>
-offsetTop expected 20 but got 0
+PASS .target 4
 PASS .target 5
-FAIL .target 6 assert_equals:
-<div class="container">
-  <div class="anchor"></div>
-  <div class="target" style="max-height: 100px; bottom: -20px;" data-expected-height="100" data-offset-y="15"></div>
-</div>
-offsetTop expected 15 but got 20
+PASS .target 6
 PASS .target 7
-FAIL .target 8 assert_equals:
-<div class="container">
-  <div class="anchor"></div>
-  <div class="target" style="top: 10px; bottom: 20px;" data-expected-height="70" data-offset-y="30"></div>
-</div>
-offsetTop expected 30 but got 10
+PASS .target 8
 PASS .target 9
 PASS .target 10
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-vrl-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-vrl-htb-expected.txt
@@ -1,37 +1,12 @@
 
-FAIL .target 1 assert_equals:
-<div class="container">
-  <div class="anchor"></div>
-  <div class="target" data-expected-width="100" data-offset-x="0"></div>
-</div>
-width expected 100 but got 50
-FAIL .target 2 assert_equals:
-<div class="container">
-  <div class="anchor"></div>
-  <div class="target" style="max-width: 60px;" data-expected-width="60" data-offset-x="35"></div>
-</div>
-width expected 60 but got 50
+PASS .target 1
+PASS .target 2
 PASS .target 3
-FAIL .target 4 assert_equals:
-<div class="container">
-  <div class="anchor"></div>
-  <div class="target" style="right: 20px;" data-expected-width="80" data-offset-x="20"></div>
-</div>
-offsetLeft expected 20 but got 0
+PASS .target 4
 PASS .target 5
-FAIL .target 6 assert_equals:
-<div class="container">
-  <div class="anchor"></div>
-  <div class="target" style="max-width: 100px; right: -20px;" data-expected-width="100" data-offset-x="15"></div>
-</div>
-offsetLeft expected 15 but got 20
+PASS .target 6
 PASS .target 7
-FAIL .target 8 assert_equals:
-<div class="container">
-  <div class="anchor"></div>
-  <div class="target" style="left: 10px; right: 20px;" data-expected-width="70" data-offset-x="30"></div>
-</div>
-offsetLeft expected 30 but got 10
+PASS .target 8
 PASS .target 9
 PASS .target 10
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-vrl-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-vrl-vrl-expected.txt
@@ -1,32 +1,12 @@
 
 PASS .target 1
-FAIL .target 2 assert_equals:
-<div class="container">
-  <div class="anchor"></div>
-  <div class="target" style="max-height: 60px;" data-expected-height="60" data-offset-y="35"></div>
-</div>
-offsetTop expected 35 but got 0
+PASS .target 2
 PASS .target 3
-FAIL .target 4 assert_equals:
-<div class="container">
-  <div class="anchor"></div>
-  <div class="target" style="bottom: 20px;" data-expected-height="80" data-offset-y="20"></div>
-</div>
-offsetTop expected 20 but got 0
+PASS .target 4
 PASS .target 5
-FAIL .target 6 assert_equals:
-<div class="container">
-  <div class="anchor"></div>
-  <div class="target" style="max-height: 100px; bottom: -20px;" data-expected-height="100" data-offset-y="15"></div>
-</div>
-offsetTop expected 15 but got 20
+PASS .target 6
 PASS .target 7
-FAIL .target 8 assert_equals:
-<div class="container">
-  <div class="anchor"></div>
-  <div class="target" style="top: 10px; bottom: 20px;" data-expected-height="70" data-offset-y="30"></div>
-</div>
-offsetTop expected 30 but got 10
+PASS .target 8
 PASS .target 9
 PASS .target 10
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7284,11 +7284,7 @@
                 "start",
                 "end",
                 "self-start",
-                "self-end",
-                {
-                    "value": "anchor-center",
-                    "settings-flag": "cssAnchorPositioningEnabled"
-                }
+                "self-end"
             ],
             "codegen-properties": {
                 "aliases": [
@@ -7297,7 +7293,7 @@
                 "initial": "initialDefaultAlignment",
                 "converter": "SelfOrDefaultAlignmentData",
                 "parser-function": "consumeAlignItems",
-                "parser-grammar-unused": "normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ] | anchor-center",
+                "parser-grammar-unused": "normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ]",
                 "parser-grammar-unused-reason": "Needs support for ordered groups, '&&' groups and optionals.",
                 "comment": "Alternate definition in css-flexbox - flex-start | flex-end | center | baseline | stretch"
             },
@@ -7323,11 +7319,7 @@
                 "start",
                 "end",
                 "self-start",
-                "self-end",
-                {
-                    "value": "anchor-center",
-                    "settings-flag": "cssAnchorPositioningEnabled"
-                }
+                "self-end"
             ],
             "codegen-properties": {
                 "aliases": [
@@ -7336,7 +7328,7 @@
                 "initial": "initialSelfAlignment",
                 "converter": "SelfOrDefaultAlignmentData",
                 "parser-function": "consumeAlignSelf",
-                "parser-grammar-unused": "auto | normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ] | anchor-center",
+                "parser-grammar-unused": "auto | normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ]",
                 "parser-grammar-unused-reason": "Needs support for ordered groups, '&&' groups and optionals.",
                 "comment": "Alternate definition in css-flexbox - auto | flex-start | flex-end | center | baseline | stretch"
             },
@@ -7528,7 +7520,7 @@
                 "initial": "initialSelfAlignment",
                 "converter": "SelfOrDefaultAlignmentData",
                 "parser-function": "consumeJustifySelf",
-                "parser-grammar-unused": "auto | normal | stretch | <baseline-position> | [ <overflow-position>? [ <self-position> | left | right ] ] | anchor-center",
+                "parser-grammar-unused": "auto | normal | stretch | <baseline-position> | [ <overflow-position>? [ <self-position> | left | right ] ]",
                 "parser-grammar-unused-reason": "Needs support for ordered groups, '&&' groups and optionals."
             },
             "specification": {
@@ -7543,7 +7535,7 @@
                 ],
                 "converter": "SelfOrDefaultAlignmentData",
                 "parser-function": "consumeJustifyItems",
-                "parser-grammar-unused": "[ normal | stretch | anchor-center | <baseline-position> | [ <overflow-position>? [ <self-position> | left | right ] ] | legacy | legacy ] && [ left | right | center | anchor-center ]",
+                "parser-grammar-unused": "[ normal | stretch | <baseline-position> | [ <overflow-position>? [ <self-position> | left | right ] ] | legacy | legacy ] && [ left | right | center ]",
                 "parser-grammar-unused-reason": "Needs support for ordered groups, '&&' groups and optionals."
             },
             "specification": {
@@ -11016,7 +11008,7 @@
             }
         },
         "<self-position>": {
-            "grammar": "center | start | end | self-start | self-end | flex-start | flex-end",
+            "grammar": "center | start | end | self-start | self-end | flex-start | flex-end | anchor-center",
             "specification": {
                 "category": "css-align",
                 "url": "https://www.w3.org/TR/css-align-3/#typedef-self-position"

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "RenderBox.h"
 
+#include "AnchorPositionEvaluator.h"
 #include "BackgroundPainter.h"
 #include "BorderPainter.h"
 #include "BorderShape.h"
@@ -4035,6 +4036,21 @@ void RenderBox::computePositionedLogicalWidth(LogicalExtentComputedValues& compu
     Length logicalLeftLength = style().logicalLeft();
     Length logicalRightLength = style().logicalRight();
 
+    // https://drafts.csswg.org/css-anchor-position-1/#anchor-center
+    auto defaultAnchorBoxForAnchorCenter = [&]() -> CheckedPtr<const RenderBoxModelObject> {
+        if ((container()->isHorizontalWritingMode() != isHorizontalWritingMode() && style().alignSelf().position() == ItemPosition::AnchorCenter)
+            || (container()->isHorizontalWritingMode() == isHorizontalWritingMode() && style().justifySelf().position() == ItemPosition::AnchorCenter))
+            return dynamicDowncast<const RenderBoxModelObject>(defaultAnchorRenderer());
+        return nullptr;
+    }();
+    // Any auto inset properties resolve to 0 if the box is absolutely positioned and does have a default anchor box.
+    if (defaultAnchorBoxForAnchorCenter) {
+        if (logicalLeftLength.isAuto())
+            logicalLeftLength = Length(0, LengthType::Fixed);
+        if (logicalRightLength.isAuto())
+            logicalRightLength = Length(0, LengthType::Fixed);
+    }
+
     /*---------------------------------------------------------------------------*\
      * For the purposes of this section and the next, the term "static position"
      * (of an element) refers, roughly, to the position an element would have had
@@ -4117,6 +4133,9 @@ void RenderBox::computePositionedLogicalWidth(LogicalExtentComputedValues& compu
         computedValues.m_margins.m_start = minValues.m_margins.m_start;
         computedValues.m_margins.m_end = minValues.m_margins.m_end;
     }
+
+    if (defaultAnchorBoxForAnchorCenter)
+        computeAnchorCenteredPosition(computedValues, defaultAnchorBoxForAnchorCenter, logicalLeftLength, logicalRightLength, containerLogicalWidth, true);
 
     computedValues.m_extent += bordersPlusPadding;
     if (auto* containingBox = dynamicDowncast<RenderBox>(containerBlock)) {
@@ -4458,6 +4477,21 @@ void RenderBox::computePositionedLogicalHeight(LogicalExtentComputedValues& comp
     Length logicalTopLength = styleToUse.logicalTop();
     Length logicalBottomLength = styleToUse.logicalBottom();
 
+    // https://drafts.csswg.org/css-anchor-position-1/#anchor-center
+    auto defaultAnchorBoxForAnchorCenter = [&]() -> CheckedPtr<const RenderBoxModelObject> {
+        if ((container()->isHorizontalWritingMode() != isHorizontalWritingMode() && style().justifySelf().position() == ItemPosition::AnchorCenter)
+            || (container()->isHorizontalWritingMode() == isHorizontalWritingMode() && style().alignSelf().position() == ItemPosition::AnchorCenter))
+            return dynamicDowncast<const RenderBoxModelObject>(defaultAnchorRenderer());
+        return nullptr;
+    }();
+    // Any auto inset properties resolve to 0 if the box is absolutely positioned and does have a default anchor box.
+    if (defaultAnchorBoxForAnchorCenter) {
+        if (logicalTopLength.isAuto())
+            logicalTopLength = Length(0, LengthType::Fixed);
+        if (logicalBottomLength.isAuto())
+            logicalBottomLength = Length(0, LengthType::Fixed);
+    }
+
     /*---------------------------------------------------------------------------*\
      * For the purposes of this section and the next, the term "static position"
      * (of an element) refers, roughly, to the position an element would have had
@@ -4520,6 +4554,9 @@ void RenderBox::computePositionedLogicalHeight(LogicalExtentComputedValues& comp
             computedValues.m_margins.m_after = minValues.m_margins.m_after;
         }
     }
+
+    if (defaultAnchorBoxForAnchorCenter)
+        computeAnchorCenteredPosition(computedValues, defaultAnchorBoxForAnchorCenter, logicalTopLength, logicalBottomLength, containerLogicalHeight, false);
 
     // Set final height value.
     computedValues.m_extent += bordersPlusPadding;
@@ -5944,6 +5981,81 @@ void RenderBox::removeShapeOutsideInfo()
 
     setRenderBoxHasShapeOutsideInfo(false);
     shapeOutsideInfoMap().remove(*this);
+}
+
+// FIXME: Consider extracting to RenderElement as the same is used in LocalFrameViewLayoutContext.cpp.
+static bool isObjectAncestorContainerOf(const RenderElement& ancestor, const RenderElement& descendant)
+{
+    for (auto* renderer = &descendant; renderer; renderer = renderer->container()) {
+        if (renderer == &ancestor)
+            return true;
+    }
+    return false;
+}
+
+static CheckedPtr<const RenderBlock> findClosestCommonContainer(const RenderElement& elementA, const RenderElement& elementB)
+{
+    CheckedPtr closestCommonContainer = dynamicDowncast<RenderBlock>(&elementA);
+    while (closestCommonContainer && !isObjectAncestorContainerOf(*closestCommonContainer, elementB))
+        closestCommonContainer = dynamicDowncast<RenderBlock>(closestCommonContainer->container());
+    return closestCommonContainer;
+}
+
+// https://drafts.csswg.org/css-anchor-position-1/#anchor-center
+void RenderBox::computeAnchorCenteredPosition(LogicalExtentComputedValues& computedValues, CheckedPtr<const RenderBoxModelObject> defaultAnchorBox, Length logicalLeftLength, Length logicalRightLength, LayoutUnit containerLogicalWidth, bool computeHorizontally) const
+{
+    // Calculate desired anchor-centered position.
+    CheckedPtr closestCommonContainer = findClosestCommonContainer(*this, *defaultAnchorBox);
+    LayoutRect relativeAnchorRect = Style::AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock(*defaultAnchorBox, *closestCommonContainer);
+    LayoutUnit desiredPosition = computeHorizontally == isHorizontalWritingMode()
+        ? relativeAnchorRect.x() + (relativeAnchorRect.width() - computedValues.m_extent) / 2
+        : relativeAnchorRect.y() + (relativeAnchorRect.height() - computedValues.m_extent) / 2;
+    LayoutUnit desiredEnd = desiredPosition + computedValues.m_extent;
+
+    LayoutUnit actualLeft = valueForLength(logicalLeftLength, containerLogicalWidth);
+    LayoutUnit actualRight = valueForLength(logicalRightLength, containerLogicalWidth);
+    auto* parentContainer = downcast<RenderBox>(container());
+
+    // Switch from rl to lr as all the calculations are done in lr.
+    if (!container()->isHorizontalWritingMode() && isHorizontalWritingMode()) {
+        auto borderAndPaddingLeft = computeHorizontally ? (parentContainer->borderLeft() + parentContainer->paddingLeft()) : (parentContainer->borderTop() + parentContainer->paddingTop());
+        computedValues.m_position = borderAndPaddingLeft + actualLeft;
+    }
+
+    // https://drafts.csswg.org/css-align-3/#auto-safety-position
+
+    LayoutUnit insetModifiedContainingBlockPosition = computedValues.m_position;
+    LayoutUnit insetModifiedContainingBlockEnd = computedValues.m_position - actualLeft + containerLogicalWidth - actualRight;
+    LayoutUnit containingBlockPosition = insetModifiedContainingBlockPosition - actualLeft;
+    LayoutUnit containingBlockEnd = containingBlockPosition + containerLogicalWidth;
+
+    // 4.4.1.2.1.
+    LayoutUnit defaultOverflowRectPosition = std::min(containingBlockPosition, insetModifiedContainingBlockPosition);
+    LayoutUnit defaultOverflowRectEnd = std::max(containingBlockEnd, insetModifiedContainingBlockEnd);
+    LayoutUnit defaultOverflowRectSize = defaultOverflowRectEnd - defaultOverflowRectPosition;
+
+    const bool overflowsInsetModifiedContainingBlock = desiredPosition < insetModifiedContainingBlockPosition || desiredEnd > insetModifiedContainingBlockEnd;
+    const bool overflowsDefaultOverflowRect = desiredPosition < defaultOverflowRectPosition || desiredEnd > defaultOverflowRectEnd;
+
+    // 4.4.1.2.2.
+    if (overflowsInsetModifiedContainingBlock && !overflowsDefaultOverflowRect)
+        computedValues.m_position = desiredPosition;
+    // 4.4.1.2.3.
+    else if (defaultOverflowRectSize >= computedValues.m_extent && overflowsDefaultOverflowRect) {
+        if (desiredPosition < defaultOverflowRectPosition)
+            computedValues.m_position = desiredPosition + (defaultOverflowRectPosition - desiredPosition);
+        else
+            computedValues.m_position = desiredPosition - (desiredEnd - defaultOverflowRectEnd);
+    } else if (defaultOverflowRectSize < computedValues.m_extent) // 4.4.1.2.4.
+        computedValues.m_position = insetModifiedContainingBlockPosition;
+    else
+        computedValues.m_position = desiredPosition;
+
+    // Switch back from lr to rl if necessary.
+    if (!container()->isHorizontalWritingMode() && isHorizontalWritingMode()) {
+        auto parentContainerLogicalWidth = computeHorizontally == isHorizontalWritingMode() ? parentContainer->width() : parentContainer->height();
+        computedValues.m_position = parentContainerLogicalWidth - (computedValues.m_position + computedValues.m_extent);
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -770,6 +770,8 @@ private:
     ShapeOutsideInfo& ensureShapeOutsideInfo();
     void removeShapeOutsideInfo();
 
+    void computeAnchorCenteredPosition(LogicalExtentComputedValues&, CheckedPtr<const RenderBoxModelObject> defaultAnchorBox, Length logicalLeftLength, Length logicalRightLength, LayoutUnit containerLogicalWidth, bool computeHorizontally) const;
+
 private:
     // The width/height of the contents + borders + padding.  The x/y location is relative to our container (which is not always our parent).
     LayoutRect m_frameRect;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -95,6 +95,7 @@
 #include "ShadowRoot.h"
 #include "StylePendingResources.h"
 #include "StyleResolver.h"
+#include "StyleScope.h"
 #include "Styleable.h"
 #include "TextAutoSizing.h"
 #include "ViewTransition.h"
@@ -1616,6 +1617,31 @@ bool RenderElement::isVisibleInViewport() const
     Ref frameView = view().frameView();
     auto visibleRect = frameView->windowToContents(frameView->windowClipRect());
     return isVisibleInDocumentRect(visibleRect);
+}
+
+const Element* RenderElement::defaultAnchor() const
+{
+    if (!element())
+        return nullptr;
+    auto& anchorPositionedStates = document().styleScope().anchorPositionedStates();
+    auto anchoringStateLookupResult = anchorPositionedStates.find(*element());
+    if (anchoringStateLookupResult == anchorPositionedStates.end() || !anchoringStateLookupResult->value)
+        return nullptr;
+    const auto& anchoringState = *anchoringStateLookupResult->value;
+    const auto& anchorName = style().positionAnchor();
+    if (!anchorName)
+        return nullptr;
+    auto defaultAnchorLookupResult = anchoringState.anchorElements.find(anchorName->name);
+    if (defaultAnchorLookupResult == anchoringState.anchorElements.end())
+        return nullptr;
+    return &defaultAnchorLookupResult->value.get();
+}
+
+const RenderElement* RenderElement::defaultAnchorRenderer() const
+{
+    if (auto* defaultAnchor = this->defaultAnchor())
+        return defaultAnchor->renderer();
+    return nullptr;
 }
 
 VisibleInViewportState RenderElement::imageFrameAvailable(CachedImage& image, ImageAnimatingState animatingState, const IntRect* changeRect)

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -350,6 +350,9 @@ protected:
     bool shouldApplyLayoutOrPaintContainment(bool) const;
     inline bool shouldApplySizeOrStyleContainment(bool) const;
 
+    const Element* defaultAnchor() const;
+    const RenderElement* defaultAnchorRenderer() const;
+
 private:
     RenderElement(Type, ContainerNode&, RenderStyle&&, OptionSet<TypeFlag>, TypeSpecificFlags);
     void node() const = delete;

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1886,12 +1886,11 @@ static LayoutUnit alignmentOffset(LayoutUnit availableFreeSpace, ItemPosition po
     case ItemPosition::FlexEnd:
         return availableFreeSpace;
     case ItemPosition::Center:
+    case ItemPosition::AnchorCenter:
         return availableFreeSpace / 2;
     case ItemPosition::Baseline:
     case ItemPosition::LastBaseline: 
         return maxAscent.value_or(0_lu) - ascent.value_or(0_lu);
-    case ItemPosition::AnchorCenter:
-        return 0; // TODO: Implement - see https://bugs.webkit.org/show_bug.cgi?id=275451.
     }
     return 0;
 }

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -1998,6 +1998,7 @@ GridAxisPosition RenderGrid::columnAxisPositionForGridItem(const RenderBox& grid
         // The alignment axis (column axis) is always orthogonal to the inline axis, hence this value behaves as 'start'.
         return GridAxisPosition::GridAxisStart;
     case ItemPosition::Center:
+    case ItemPosition::AnchorCenter:
         return GridAxisPosition::GridAxisCenter;
     case ItemPosition::FlexStart: // Only used in flex layout, otherwise equivalent to 'start'.
         // Aligns the alignment subject to be flush with the alignment container's 'start' edge (block-start) in the column axis.
@@ -2024,8 +2025,6 @@ GridAxisPosition RenderGrid::columnAxisPositionForGridItem(const RenderBox& grid
     case ItemPosition::Auto:
     case ItemPosition::Normal:
         break;
-    case ItemPosition::AnchorCenter:
-        return GridAxisPosition::GridAxisStart; // TODO: Implement - see https://bugs.webkit.org/show_bug.cgi?id=275451.
     }
 
     ASSERT_NOT_REACHED();
@@ -2057,6 +2056,7 @@ GridAxisPosition RenderGrid::rowAxisPositionForGridItem(const RenderBox& gridIte
         // We want the physical 'right' side, so we have to take account, container's inline-flow direction.
         return writingMode().isBidiLTR() ? GridAxisPosition::GridAxisEnd : GridAxisPosition::GridAxisStart;
     case ItemPosition::Center:
+    case ItemPosition::AnchorCenter:
         return GridAxisPosition::GridAxisCenter;
     case ItemPosition::FlexStart: // Only used in flex layout, otherwise equivalent to 'start'.
         // Aligns the alignment subject to be flush with the alignment container's 'start' edge (inline-start) in the row axis.
@@ -2076,8 +2076,6 @@ GridAxisPosition RenderGrid::rowAxisPositionForGridItem(const RenderBox& gridIte
     case ItemPosition::Auto:
     case ItemPosition::Normal:
         break;
-    case ItemPosition::AnchorCenter:
-        return GridAxisPosition::GridAxisStart; // TODO: Implement - see https://bugs.webkit.org/show_bug.cgi?id=275451.
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -273,7 +273,7 @@ static LayoutSize scrollOffsetFromAncestorContainer(const RenderElement& descend
 
 // This computes the top left location, physical width, and physical height of the specified
 // anchor element. The location is computed relative to the specified containing block.
-static LayoutRect computeAnchorRectRelativeToContainingBlock(CheckedRef<const RenderBoxModelObject> anchorBox, const RenderBlock& containingBlock)
+LayoutRect AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock(CheckedRef<const RenderBoxModelObject> anchorBox, const RenderBlock& containingBlock)
 {
     // Fragmented flows are a little tricky to deal with. One example of a fragmented
     // flow is a block anchor element that is "fragmented" or split across multiple columns
@@ -326,7 +326,7 @@ static LayoutUnit computeInsetValue(CSSPropertyID insetPropertyID, CheckedRef<co
 
     auto insetPropertySide = mapInsetPropertyToPhysicalSide(insetPropertyID, anchorPositionedRenderer->writingMode());
     auto anchorSideID = std::holds_alternative<CSSValueID>(anchorSide) ? std::get<CSSValueID>(anchorSide) : CSSValueInvalid;
-    auto anchorRect = computeAnchorRectRelativeToContainingBlock(anchorBox, *containingBlock);
+    auto anchorRect = AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock(anchorBox, *containingBlock);
 
     // Explicitly deal with the center/percentage value here.
     // "Refers to a position a corresponding percentage between the start and end sides, with

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -38,6 +38,8 @@ namespace WebCore {
 
 class Document;
 class Element;
+class LayoutRect;
+class RenderBlock;
 class RenderBoxModelObject;
 
 namespace Style {
@@ -99,6 +101,8 @@ public:
     static void updateAnchorPositioningStatesAfterInterleavedLayout(const Document&);
     static void cleanupAnchorPositionedState(Element&);
     static void updateSnapshottedScrollOffsets(Document&);
+
+    static LayoutRect computeAnchorRectRelativeToContainingBlock(CheckedRef<const RenderBoxModelObject> anchorBox, const RenderBlock& containingBlock);
 
 private:
     static AnchorElements findAnchorsForAnchorPositionedElement(const Element&, const HashSet<AtomString>& anchorNames, const AnchorsForAnchorName&);


### PR DESCRIPTION
#### a84350ee19f346b0c7515b2c84464b055ac4c954
<pre>
[css-anchor-position-1] Implement `anchor-center` alignment value
<a href="https://bugs.webkit.org/show_bug.cgi?id=275451">https://bugs.webkit.org/show_bug.cgi?id=275451</a>

Reviewed by Antti Koivisto.

This change implements `anchor-center` CSS value as specified in:
<a href="https://drafts.csswg.org/css-anchor-position-1/#anchor-center">https://drafts.csswg.org/css-anchor-position-1/#anchor-center</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-htb-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-htb-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-vrl-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-vrl-vrl-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computePositionedLogicalWidth const):
(WebCore::RenderBox::computePositionedLogicalHeight const):
(WebCore::isObjectAncestorContainerOf):
(WebCore::findClosestCommonContainer):
(WebCore::RenderBox::computeAnchorCenteredPosition const):
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::defaultAnchor const):
(WebCore::RenderElement::defaultAnchorRenderer const):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::alignmentOffset):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::columnAxisPositionForGridItem const):
(WebCore::RenderGrid::rowAxisPositionForGridItem const):
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock):
(WebCore::Style::computeInsetValue):
(WebCore::Style::computeAnchorRectRelativeToContainingBlock): Deleted.
* Source/WebCore/style/AnchorPositionEvaluator.h:

Canonical link: <a href="https://commits.webkit.org/287144@main">https://commits.webkit.org/287144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01ac09f52e622085ef97fe65033fa856ebe3d054

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78460 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83121 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29725 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5786 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61447 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19365 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69285 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41760 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48806 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25299 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28062 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69903 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84487 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3968 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69718 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5986 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67451 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68928 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17188 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12950 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11328 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5772 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/9118 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5761 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9194 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7547 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->