### PR TITLE
Refactor WPT text-autospace-dynamic-001 test for no implicit initial value

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3063,7 +3063,6 @@ imported/w3c/web-platform-tests/css/css-text/tab-size/tab-size-block-ancestor.ht
 imported/w3c/web-platform-tests/css/css-text/tab-size/tab-size-integer-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/tab-size/tab-size-spacing-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/tab-size/tab-size-spacing-003.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-dynamic-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/text-group-align/text-group-align-center-vlr.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/text-group-align/text-group-align-center.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/text-group-align/text-group-align-end-vlr.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-dynamic-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-dynamic-001-expected.html
@@ -1,4 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<style>
+div { text-autospace: no-autospace; }
+.manual-spacing {
+    margin: 0px 0.125em;
+}
+</style>
+<div><span>国国</span><span class="manual-spacing">AA</span><span>国国</span><span class="manual-spacing">AA</span><span>国国</span></div>
 <div>国国AA国国AA国国</div>
-<div>国国&ZeroWidthSpace;AA&ZeroWidthSpace;国国&ZeroWidthSpace;AA&ZeroWidthSpace;国国</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-dynamic-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-dynamic-001.html
@@ -4,6 +4,7 @@
 <link rel="match" href="text-autospace-no-001-ref.html">
 <link rel="mismatch" href="text-autospace-no-001-mismatch-ref.html">
 <style>
+.test { text-autospace: normal; }
 .no-as { text-autospace: no-autospace; }
 </style>
 <div class="test no-as">国国AA国国AA国国</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-no-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-no-001-ref.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <style>
-.no-as { text-autospace: no-autospace; }
+div { text-autospace: no-autospace; }
 .manual-spacing {
     margin: 0px 0.125em;
 }
 </style>
-<div class="no-as"><span>国国</span><span class="manual-spacing">AA</span><span>国国</span><span class="manual-spacing">AA</span><span>国国</span></div>
-<div>国国&ZeroWidthSpace;AA&ZeroWidthSpace;国国&ZeroWidthSpace;AA&ZeroWidthSpace;国国</div>
+<div><span>国国</span><span class="manual-spacing">AA</span><span>国国</span><span class="manual-spacing">AA</span><span>国国</span></div>
+<div>国国AA国国AA国国</div>


### PR DESCRIPTION
#### 306ebd761a5ed57eb5de76de2b947c653b03d7bc
<pre>
Refactor WPT text-autospace-dynamic-001 test for no implicit initial value
<a href="https://bugs.webkit.org/show_bug.cgi?id=283182">https://bugs.webkit.org/show_bug.cgi?id=283182</a>
<a href="https://rdar.apple.com/139978867">rdar://139978867</a>

Reviewed by NOBODY (OOPS!).

This test verifies the dynamic  behavior of text-autospace.
For building the test, we assume that the initial value
for the property is `normal`, which is what spec currently
expects but not what WebKit is willing to implement initially.

We are refactoring the test to explicitly set text-autospace
to normal, which won&apos;t change the test behavior for other
implementations for other implementation.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-dynamic-001-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-dynamic-001.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/306ebd761a5ed57eb5de76de2b947c653b03d7bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28447 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4496 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60455 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18517 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80232 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50425 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40758 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47827 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23723 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26770 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68942 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83152 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4545 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3061 "Found 1 new test failure: webrtc/vp8-then-h264.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68736 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4701 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66198 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67991 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11979 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10061 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4492 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4511 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7946 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->