### PR TITLE
[macOS] espn.com: Fullscreen video progress bar marker follows the cursor

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -773,8 +773,10 @@ private:
     bool isRichlyEditableForTouchBar() const;
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
-    void installImageAnalysisOverlayView(VKCImageAnalysis *);
+    void installImageAnalysisOverlayView(RetainPtr<VKCImageAnalysis>&&);
     void uninstallImageAnalysisOverlayView();
+    void performOrDeferImageAnalysisOverlayViewHierarchyTask(std::function<void()>&&);
+    void fulfillDeferredImageAnalysisOverlayViewHierarchyTask();
 #endif
 
     bool hasContentRelativeChildViews() const;
@@ -857,7 +859,7 @@ private:
 
 #if ENABLE(IMAGE_ANALYSIS)
     CocoaImageAnalyzer *ensureImageAnalyzer();
-    int32_t processImageAnalyzerRequest(CocoaImageAnalyzerRequest *, CompletionHandler<void(CocoaImageAnalysis *, NSError *)>&&);
+    int32_t processImageAnalyzerRequest(CocoaImageAnalyzerRequest *, CompletionHandler<void(RetainPtr<CocoaImageAnalysis>&&, NSError *)>&&);
 #endif
 
     std::optional<EditorState::PostLayoutData> postLayoutDataForContentEditable();
@@ -1019,6 +1021,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     RetainPtr<WKImageAnalysisOverlayViewDelegate> m_imageAnalysisOverlayViewDelegate;
     uint32_t m_currentImageAnalysisRequestID { 0 };
     WebCore::FloatRect m_imageAnalysisInteractionBounds;
+    std::function<void()> m_imageAnalysisOverlayViewHierarchyDeferredTask;
 #endif
 
 #if HAVE(TRANSLATION_UI_SERVICES) && ENABLE(CONTEXT_MENUS)


### PR DESCRIPTION
#### 931bf0326ed7683d24a33afe2590e39c6f843790
<pre>
[macOS] espn.com: Fullscreen video progress bar marker follows the cursor
<a href="https://bugs.webkit.org/show_bug.cgi?id=283184">https://bugs.webkit.org/show_bug.cgi?id=283184</a>
<a href="https://rdar.apple.com/133321873">rdar://133321873</a>

Reviewed by Wenson Hsieh.

The video element on espn.com uses a mouseUp event listener on the
progress bar to deactivate its &quot;scrubbing&quot; mode. This works as expected
when the video element is inline, but breaks down when the video element
is fullscreened, and manifests itself as the cursor following the
progress bar marker.

When the video element is both in fullscreen and paused/seeked,
WebFullScreenManager thinks it is safe to begin text recognition, and
thus installs an image analysis overlay on the web view. When a user
then clicks on the progress bar (or starts dragging it), AppKit
performs hit testing during mouseDown event handling and remembers that
the overlay view is the view to route future mouse events (drag/up) to.
This is fine because the VKC views know how to re-route mouse events
to the web view when necessary. However, while this is happening,
espn.com marks their fullscreen video element as seeking, so
WebFullScreenManager ends text recognition and schedules an overlay
uninstallation. This overlay uninstallation causes the associated VKC
view to detach from the view hierarchy, and the hit tested view that
AppKit remembered to route events to no longer exists. Thus, when the
user finally releases their mouse, the resultant mouseUp event gets
routed to a null view, and the mouseUp event listener for the video
element does not fire.

We fix this issue by enforcing the invariant that any kind of view
hierarchy maintenance associated with the image analysis overlay cannot
happen while a mouse press is active. Deferring these tasks means that we
don&apos;t unexpectedly alter the view hierarchy under AppKit&apos;s event routing
path. This is safe to do because the VKC views appropriately re-route
events to the web view, unless their is an active text recognition
selection.

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::mouseUp):
(WebKit::WebViewImpl::ensureImageAnalyzer):
(WebKit::WebViewImpl::requestTextRecognition):
(WebKit::WebViewImpl::beginTextRecognitionForVideoInElementFullscreen):
(WebKit::WebViewImpl::cancelTextRecognitionForVideoInElementFullscreen):
(WebKit::WebViewImpl::installImageAnalysisOverlayView):
(WebKit::WebViewImpl::uninstallImageAnalysisOverlayView):
(WebKit::WebViewImpl::performOrDeferImageAnalysisOverlayViewHierarchyTask):

Canonical link: <a href="https://commits.webkit.org/286840@main">https://commits.webkit.org/286840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e28bca1a0481b12aaf96c16dfd555a482b27d35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77214 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30129 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81778 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28496 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4545 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60497 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18542 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80281 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66272 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40797 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47862 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26819 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68972 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83202 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3098 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68771 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66245 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68028 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16993 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12015 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10107 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4541 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7356 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4560 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7995 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6319 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->