### PR TITLE
Drop IsDeprecatedTimerSmartPointerException from InspectorOverlay

### DIFF
--- a/Source/WTF/wtf/UniqueRef.h
+++ b/Source/WTF/wtf/UniqueRef.h
@@ -77,20 +77,13 @@ public:
         ASSERT(m_ref);
     }
 
-    T* ptr() RETURNS_NONNULL { ASSERT(m_ref); return m_ref.get(); }
     T* ptr() const RETURNS_NONNULL { ASSERT(m_ref); return m_ref.get(); }
+    T& get() const { ASSERT(m_ref); return *m_ref; }
 
-    T& get() { ASSERT(m_ref); return *m_ref; }
-    const T& get() const { ASSERT(m_ref); return *m_ref; }
-
-    T* operator&() { ASSERT(m_ref); return m_ref.get(); }
-    const T* operator&() const { ASSERT(m_ref); return m_ref.get(); }
-
+    T* operator&() const { ASSERT(m_ref); return m_ref.get(); }
     T* operator->() const { ASSERT(m_ref); return m_ref.get(); }
 
-    operator T&() { ASSERT(m_ref); return *m_ref; }
-    operator const T&() const { ASSERT(m_ref); return *m_ref; }
-
+    operator T&() const { ASSERT(m_ref); return *m_ref; }
     T& operator*() const { ASSERT(m_ref); return *m_ref.get(); }
 
     std::unique_ptr<T> moveToUniquePtr() { return WTFMove(m_ref); }

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -61,7 +61,6 @@ inspector/DOMPatchSupport.cpp
 inspector/DOMPatchSupport.h
 inspector/InspectorFrontendHost.cpp
 inspector/InspectorFrontendHost.h
-inspector/InspectorOverlay.h
 inspector/InspectorShaderProgram.h
 inspector/InspectorStyleSheet.cpp
 inspector/InspectorStyleSheet.h

--- a/Source/WebCore/inspector/InspectorController.h
+++ b/Source/WebCore/inspector/InspectorController.h
@@ -37,6 +37,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -63,13 +64,15 @@ class PageDebugger;
 class WebInjectedScriptManager;
 struct PageAgentContext;
 
-class InspectorController final : public Inspector::InspectorEnvironment, public CanMakeCheckedPtr<InspectorController> {
+class InspectorController final : public Inspector::InspectorEnvironment, public CanMakeWeakPtr<InspectorController> {
     WTF_MAKE_NONCOPYABLE(InspectorController);
     WTF_MAKE_TZONE_ALLOCATED(InspectorController);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorController);
 public:
     InspectorController(Page&, std::unique_ptr<InspectorClient>&&);
     ~InspectorController() override;
+
+    WEBCORE_EXPORT void ref() const;
+    WEBCORE_EXPORT void deref() const;
 
     void inspectedPageDestroyed();
 
@@ -104,7 +107,7 @@ public:
     WEBCORE_EXPORT void didComposite(LocalFrame&);
 
     // Testing support.
-    WEBCORE_EXPORT bool isUnderTest() const;
+    bool isUnderTest() const { return m_isUnderTest; }
     void setIsUnderTest(bool isUnderTest) { m_isUnderTest = isUnderTest; }
     WEBCORE_EXPORT void evaluateForTestInFrontend(const String& script);
     WEBCORE_EXPORT unsigned gridOverlayCount() const;
@@ -134,16 +137,16 @@ private:
     PageAgentContext pageAgentContext();
     void createLazyAgents();
 
+    WeakRef<Page> m_page;
     Ref<InstrumentingAgents> m_instrumentingAgents;
     std::unique_ptr<WebInjectedScriptManager> m_injectedScriptManager;
     Ref<Inspector::FrontendRouter> m_frontendRouter;
     Ref<Inspector::BackendDispatcher> m_backendDispatcher;
-    std::unique_ptr<InspectorOverlay> m_overlay;
+    const UniqueRef<InspectorOverlay> m_overlay;
     Ref<WTF::Stopwatch> m_executionStopwatch;
     std::unique_ptr<PageDebugger> m_debugger;
     Inspector::AgentRegistry m_agents;
 
-    Page& m_page;
     std::unique_ptr<InspectorClient> m_inspectorClient;
     InspectorFrontendClient* m_inspectorFrontendClient { nullptr };
 

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.h
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.h
@@ -145,7 +145,9 @@ private:
     friend class FrontendMenuProvider;
     std::optional<bool> evaluationResultToBoolean(InspectorFrontendAPIDispatcher::EvaluationResult);
 
-    InspectorController* m_inspectedPageController { nullptr };
+    RefPtr<InspectorController> protectedInspectedPageController() const;
+
+    WeakPtr<InspectorController> m_inspectedPageController;
     WeakPtr<Page> m_frontendPage;
     // TODO(yurys): this ref shouldn't be needed.
     RefPtr<InspectorFrontendHost> m_frontendHost;

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -392,8 +392,8 @@ static void drawShapeHighlight(GraphicsContext& context, Node& node, InspectorOv
     context.fillPath(shapePath);
 }
 
-InspectorOverlay::InspectorOverlay(Page& page, InspectorClient* client)
-    : m_page(page)
+InspectorOverlay::InspectorOverlay(InspectorController& controller, InspectorClient* client)
+    : m_controller(controller)
     , m_client(client)
     , m_paintRectUpdateTimer(*this, &InspectorOverlay::updatePaintRectsTimerFired)
 {
@@ -401,12 +401,27 @@ InspectorOverlay::InspectorOverlay(Page& page, InspectorClient* client)
 
 InspectorOverlay::~InspectorOverlay() = default;
 
+void InspectorOverlay::ref() const
+{
+    m_controller->ref();
+}
+
+void InspectorOverlay::deref() const
+{
+    m_controller->deref();
+}
+
+Page& InspectorOverlay::page() const
+{
+    return m_controller->inspectedPage();
+}
+
 void InspectorOverlay::paint(GraphicsContext& context)
 {
     if (!shouldShowOverlay())
         return;
 
-    auto viewportSize = m_page.mainFrame().virtualView()->sizeForVisibleContent();
+    auto viewportSize = page().mainFrame().virtualView()->sizeForVisibleContent();
 
     context.clearRect({ FloatPoint::zero(), viewportSize });
 
@@ -604,7 +619,7 @@ void InspectorOverlay::highlightNode(Node* node, const InspectorOverlay::Highlig
 void InspectorOverlay::highlightQuad(std::unique_ptr<FloatQuad> quad, const InspectorOverlay::Highlight::Config& highlightConfig)
 {
     if (highlightConfig.usePageCoordinates)
-        *quad -= toIntSize(m_page.mainFrame().virtualView()->scrollPosition());
+        *quad -= toIntSize(page().mainFrame().virtualView()->scrollPosition());
 
     m_quadHighlightConfig = highlightConfig;
     m_highlightQuad = WTFMove(quad);
@@ -650,7 +665,7 @@ void InspectorOverlay::update()
         return;
     }
 
-    if (!m_page.mainFrame().virtualView())
+    if (!page().mainFrame().virtualView())
         return;
 
     m_client->highlight();
@@ -674,7 +689,7 @@ void InspectorOverlay::showPaintRect(const FloatRect& rect)
     if (!m_showPaintRects)
         return;
 
-    auto rootRect = m_page.mainFrame().virtualView()->contentsToRootView(enclosingIntRect(rect));
+    auto rootRect = page().mainFrame().virtualView()->contentsToRootView(enclosingIntRect(rect));
 
     const auto removeDelay = 250_ms;
 
@@ -846,7 +861,7 @@ void InspectorOverlay::drawPaintRects(GraphicsContext& context, const Deque<Time
 
 void InspectorOverlay::drawBounds(GraphicsContext& context, const InspectorOverlay::Highlight::Bounds& bounds)
 {
-    Ref mainFrame = m_page.mainFrame();
+    Ref mainFrame = page().mainFrame();
     RefPtr pageView = mainFrame->virtualView();
     FloatSize viewportSize = pageView->sizeForVisibleContent();
     FloatSize contentInset(0, pageView->topContentInset(ScrollView::TopContentInsetType::WebCoreOrPlatformContentInset));
@@ -902,7 +917,7 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
     constexpr auto darkRulerColor = Color::black.colorWithAlphaByte(128);
 
     IntPoint scrollOffset;
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    auto* localMainFrame = dynamicDowncast<LocalFrame>(page().mainFrame());
     if (!localMainFrame)
         return;
 
@@ -912,7 +927,7 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
 
     FloatSize viewportSize = pageView->sizeForVisibleContent();
     FloatSize contentInset(0, pageView->topContentInset(ScrollView::TopContentInsetType::WebCoreOrPlatformContentInset));
-    float pageScaleFactor = m_page.pageScaleFactor();
+    float pageScaleFactor = page().pageScaleFactor();
     float pageZoomFactor = localMainFrame->pageZoomFactor();
 
     float pageFactor = pageZoomFactor * pageScaleFactor;
@@ -977,7 +992,7 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
     // Draw lines.
     {
         FontCascadeDescription fontDescription;
-        fontDescription.setOneFamily(AtomString { m_page.settings().sansSerifFontFamily() });
+        fontDescription.setOneFamily(AtomString { page().settings().sansSerifFontFamily() });
         fontDescription.setComputedSize(10);
 
         FontCascade font(WTFMove(fontDescription));
@@ -1067,7 +1082,7 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
     // Draw viewport size.
     {
         FontCascadeDescription fontDescription;
-        fontDescription.setOneFamily(AtomString { m_page.settings().sansSerifFontFamily() });
+        fontDescription.setOneFamily(AtomString { page().settings().sansSerifFontFamily() });
         fontDescription.setComputedSize(12);
 
         FontCascade font(WTFMove(fontDescription));
@@ -1245,7 +1260,7 @@ Path InspectorOverlay::drawElementTitle(GraphicsContext& context, Node& node, co
         }
     }
 
-    Ref mainFrame = m_page.mainFrame();
+    Ref mainFrame = page().mainFrame();
     RefPtr pageView = mainFrame->virtualView();
     FloatSize viewportSize = pageView->sizeForVisibleContent();
     FloatSize contentInset(0, pageView->topContentInset(ScrollView::TopContentInsetType::WebCoreOrPlatformContentInset));
@@ -1511,7 +1526,7 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
 
     constexpr auto translucentLabelBackgroundColor = Color::white.colorWithAlphaByte(230);
 
-    RefPtr pageView = m_page.mainFrame().virtualView();
+    RefPtr pageView = page().mainFrame().virtualView();
     if (!pageView)
         return { };
     FloatRect viewportBounds = { { 0, 0 }, pageView->sizeForVisibleContent() };
@@ -1904,7 +1919,7 @@ std::optional<InspectorOverlay::Highlight::FlexHighlightOverlay> InspectorOverla
 
     auto& renderFlex = *downcast<RenderFlexibleBox>(renderer);
 
-    auto itemsAtStartOfLine = m_page.inspectorController().ensureDOMAgent().flexibleBoxRendererCachedItemsAtStartOfLine(renderFlex);
+    auto itemsAtStartOfLine = m_controller->ensureDOMAgent().flexibleBoxRendererCachedItemsAtStartOfLine(renderFlex);
 
     auto* containingFrame = node->document().frame();
     if (!containingFrame)

--- a/Source/WebCore/inspector/InspectorOverlay.h
+++ b/Source/WebCore/inspector/InspectorOverlay.h
@@ -36,6 +36,7 @@
 #include "InspectorOverlayLabel.h"
 #include "Path.h"
 #include "Timer.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Deque.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/RefPtr.h>
@@ -53,21 +54,13 @@ using ErrorStringOr = Expected<T, ErrorString>;
 }
 
 namespace WebCore {
-class InspectorOverlay;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::InspectorOverlay> : std::true_type { };
-}
-
-namespace WebCore {
 
 class WeakPtrImplWithEventTargetData;
 class FontCascade;
 class FloatPoint;
 class GraphicsContext;
 class InspectorClient;
+class InspectorController;
 class Node;
 class NodeList;
 class Page;
@@ -147,11 +140,14 @@ struct InspectorOverlayHighlight {
     using Bounds = FloatRect;
 };
 
-class InspectorOverlay {
+class InspectorOverlay : public CanMakeWeakPtr<InspectorOverlay> {
     WTF_MAKE_TZONE_ALLOCATED(InspectorOverlay);
 public:
-    InspectorOverlay(Page&, InspectorClient*);
+    InspectorOverlay(InspectorController&, InspectorClient*);
     ~InspectorOverlay();
+
+    void ref() const;
+    void deref() const;
 
     using Highlight = InspectorOverlayHighlight;
 
@@ -254,7 +250,9 @@ private:
     bool removeGridOverlayForNode(Node&);
     bool removeFlexOverlayForNode(Node&);
 
-    Page& m_page;
+    Page& page() const;
+
+    const WeakRef<InspectorController> m_controller;
     InspectorClient* m_client;
 
     RefPtr<Node> m_highlightNode;

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -310,7 +310,7 @@ String InspectorDOMAgent::toErrorString(Exception&& exception)
     return DOMException::name(exception.code());
 }
 
-InspectorDOMAgent::InspectorDOMAgent(PageAgentContext& context, InspectorOverlay* overlay)
+InspectorDOMAgent::InspectorDOMAgent(PageAgentContext& context, InspectorOverlay& overlay)
     : InspectorAgentBase("DOM"_s, context)
     , m_injectedScriptManager(context.injectedScriptManager)
     , m_frontendDispatcher(makeUnique<Inspector::DOMFrontendDispatcher>(context.frontendRouter))
@@ -325,6 +325,11 @@ InspectorDOMAgent::InspectorDOMAgent(PageAgentContext& context, InspectorOverlay
 }
 
 InspectorDOMAgent::~InspectorDOMAgent() = default;
+
+Ref<InspectorOverlay> InspectorDOMAgent::protectedOverlay() const
+{
+    return m_overlay.get();
+}
 
 void InspectorDOMAgent::didCreateFrontendAndBackend(Inspector::FrontendRouter*, Inspector::BackendDispatcher*)
 {
@@ -361,8 +366,9 @@ void InspectorDOMAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReaso
     setSearchingForNode(ignored, false, nullptr, nullptr, nullptr, false);
     hideHighlight();
 
-    m_overlay->clearAllGridOverlays();
-    m_overlay->clearAllFlexOverlays();
+    Ref overlay = m_overlay.get();
+    overlay->clearAllGridOverlays();
+    overlay->clearAllFlexOverlays();
 
     m_instrumentingAgents.setPersistentDOMAgent(nullptr);
     m_documentRequested = false;
@@ -1215,8 +1221,8 @@ bool InspectorDOMAgent::handleMousePress()
     if (!m_searchingForNode)
         return false;
 
-    if (Node* node = m_overlay->highlightedNode()) {
-        inspect(node);
+    if (RefPtr node = protectedOverlay()->highlightedNode()) {
+        inspect(node.get());
         return true;
     }
     return false;
@@ -1228,7 +1234,7 @@ bool InspectorDOMAgent::handleTouchEvent(Node& node)
         return false;
 
     if (m_inspectModeHighlightConfig) {
-        m_overlay->highlightNode(&node, *m_inspectModeHighlightConfig, m_inspectModeGridOverlayConfig, m_inspectModeFlexOverlayConfig, m_inspectModeShowRulers);
+        protectedOverlay()->highlightNode(&node, *m_inspectModeHighlightConfig, m_inspectModeGridOverlayConfig, m_inspectModeFlexOverlayConfig, m_inspectModeShowRulers);
         inspect(&node);
         return true;
     }
@@ -1291,7 +1297,7 @@ void InspectorDOMAgent::highlightMousedOverNode()
         return;
 
     if (m_inspectModeHighlightConfig)
-        m_overlay->highlightNode(node, *m_inspectModeHighlightConfig, m_inspectModeGridOverlayConfig, m_inspectModeFlexOverlayConfig, m_inspectModeShowRulers);
+        protectedOverlay()->highlightNode(node, *m_inspectModeHighlightConfig, m_inspectModeGridOverlayConfig, m_inspectModeFlexOverlayConfig, m_inspectModeShowRulers);
 }
 
 void InspectorDOMAgent::setSearchingForNode(Inspector::Protocol::ErrorString& errorString, bool enabled, RefPtr<JSON::Object>&& highlightInspectorObject, RefPtr<JSON::Object>&& gridOverlayInspectorObject, RefPtr<JSON::Object>&& flexOverlayInspectorObject, bool showRulers)
@@ -1322,7 +1328,7 @@ void InspectorDOMAgent::setSearchingForNode(Inspector::Protocol::ErrorString& er
     } else
         hideHighlight();
 
-    m_overlay->didSetSearchingForNode(m_searchingForNode);
+    protectedOverlay()->didSetSearchingForNode(m_searchingForNode);
 
     if (InspectorClient* client = m_inspectedPage.inspectorController().inspectorClient())
         client->elementSelectionChanged(m_searchingForNode);
@@ -1433,7 +1439,7 @@ void InspectorDOMAgent::innerHighlightQuad(std::unique_ptr<FloatQuad> quad, RefP
     highlightConfig->content = parseColor(WTFMove(color)).value_or(Color::transparentBlack);
     highlightConfig->contentOutline = parseColor(WTFMove(outlineColor)).value_or(Color::transparentBlack);
     highlightConfig->usePageCoordinates = usePageCoordinates ? *usePageCoordinates : false;
-    m_overlay->highlightQuad(WTFMove(quad), *highlightConfig);
+    protectedOverlay()->highlightQuad(WTFMove(quad), *highlightConfig);
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -1538,7 +1544,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(co
         }
     }
 
-    m_overlay->highlightNodeList(StaticNodeList::create(WTFMove(nodeList)), *highlightConfig, WTFMove(gridOverlayConfig), WTFMove(flexOverlayConfig), showRulers && *showRulers);
+    protectedOverlay()->highlightNodeList(StaticNodeList::create(WTFMove(nodeList)), *highlightConfig, WTFMove(gridOverlayConfig), WTFMove(flexOverlayConfig), showRulers && *showRulers);
 
     return { };
 }
@@ -1582,7 +1588,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightNode(std::o
     if (providedFlexOverlayConfig && !flexOverlayConfig)
         return makeUnexpected(errorString);
 
-    m_overlay->highlightNode(node, *highlightConfig, WTFMove(gridOverlayConfig), WTFMove(flexOverlayConfig), showRulers && *showRulers);
+    protectedOverlay()->highlightNode(node, *highlightConfig, WTFMove(gridOverlayConfig), WTFMove(flexOverlayConfig), showRulers && *showRulers);
 
     return { };
 }
@@ -1632,7 +1638,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightNodeList(Re
     if (providedFlexOverlayConfig && !flexOverlayConfig)
         return makeUnexpected(errorString);
 
-    m_overlay->highlightNodeList(StaticNodeList::create(WTFMove(nodes)), *highlightConfig, WTFMove(gridOverlayConfig), WTFMove(flexOverlayConfig), showRulers && *showRulers);
+    protectedOverlay()->highlightNodeList(StaticNodeList::create(WTFMove(nodes)), *highlightConfig, WTFMove(gridOverlayConfig), WTFMove(flexOverlayConfig), showRulers && *showRulers);
 
     return { };
 }
@@ -1654,7 +1660,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightFrame(const
         highlightConfig->showInfo = true; // Always show tooltips for frames.
         highlightConfig->content = parseColor(WTFMove(color)).value_or(Color::transparentBlack);
         highlightConfig->contentOutline = parseColor(WTFMove(outlineColor)).value_or(Color::transparentBlack);
-        m_overlay->highlightNode(frame->ownerElement(), *highlightConfig);
+        protectedOverlay()->highlightNode(frame->ownerElement(), *highlightConfig);
     }
 
     return { };
@@ -1662,7 +1668,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightFrame(const
 
 Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::hideHighlight()
 {
-    m_overlay->hideHighlight();
+    protectedOverlay()->hideHighlight();
 
     return { };
 }
@@ -1678,7 +1684,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::showGridOverlay(Insp
     if (!config)
         return makeUnexpected(errorString);
 
-    m_overlay->setGridOverlayForNode(*node, *config);
+    protectedOverlay()->setGridOverlayForNode(*node, *config);
 
     return { };
 }
@@ -1691,10 +1697,10 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::hideGridOverlay(std:
         if (!node)
             return makeUnexpected(errorString);
 
-        return m_overlay->clearGridOverlayForNode(*node);
+        return protectedOverlay()->clearGridOverlayForNode(*node);
 }
 
-    m_overlay->clearAllGridOverlays();
+    protectedOverlay()->clearAllGridOverlays();
 
     return { };
 }
@@ -1710,7 +1716,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::showFlexOverlay(Insp
     if (!config)
         return makeUnexpected(errorString);
 
-    m_overlay->setFlexOverlayForNode(*node, *config);
+    protectedOverlay()->setFlexOverlayForNode(*node, *config);
 
     return { };
 }
@@ -1723,10 +1729,10 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::hideFlexOverlay(std:
         if (!node)
             return makeUnexpected(errorString);
 
-        return m_overlay->clearFlexOverlayForNode(*node);
+        return protectedOverlay()->clearFlexOverlayForNode(*node);
     }
 
-    m_overlay->clearAllFlexOverlays();
+    protectedOverlay()->clearAllFlexOverlays();
 
     return { };
 }

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -94,7 +94,7 @@ class InspectorDOMAgent final : public InspectorAgentBase, public Inspector::DOM
     WTF_MAKE_NONCOPYABLE(InspectorDOMAgent);
     WTF_MAKE_TZONE_ALLOCATED(InspectorDOMAgent);
 public:
-    InspectorDOMAgent(PageAgentContext&, InspectorOverlay*);
+    InspectorDOMAgent(PageAgentContext&, InspectorOverlay&);
     ~InspectorDOMAgent();
 
     static String toErrorString(ExceptionCode);
@@ -279,11 +279,13 @@ private:
 
     void relayoutDocument();
 
+    Ref<InspectorOverlay> protectedOverlay() const;
+
     Inspector::InjectedScriptManager& m_injectedScriptManager;
     std::unique_ptr<Inspector::DOMFrontendDispatcher> m_frontendDispatcher;
     RefPtr<Inspector::DOMBackendDispatcher> m_backendDispatcher;
     Page& m_inspectedPage;
-    InspectorOverlay* m_overlay { nullptr };
+    WeakRef<InspectorOverlay> m_overlay;
     WeakHashMap<Node, Inspector::Protocol::DOM::NodeId, WeakPtrImplWithEventTargetData> m_nodeToId;
     HashMap<Inspector::Protocol::DOM::NodeId, WeakPtr<Node, WeakPtrImplWithEventTargetData>> m_idToNode;
     HashSet<Inspector::Protocol::DOM::NodeId> m_childrenRequested;

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -40,6 +40,7 @@
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -58,7 +59,7 @@ class InspectorPageAgent final : public InspectorAgentBase, public Inspector::Pa
     WTF_MAKE_NONCOPYABLE(InspectorPageAgent);
     WTF_MAKE_TZONE_ALLOCATED(InspectorPageAgent);
 public:
-    InspectorPageAgent(PageAgentContext&, InspectorClient*, InspectorOverlay*);
+    InspectorPageAgent(PageAgentContext&, InspectorClient*, InspectorOverlay&);
     ~InspectorPageAgent();
 
     enum ResourceType {
@@ -156,6 +157,8 @@ public:
 private:
     double timestamp();
 
+    Ref<InspectorOverlay> protectedOverlay() const;
+
     static bool mainResourceContent(LocalFrame*, bool withBase64Encode, String* result);
     static bool dataContent(std::span<const uint8_t> data, const String& textEncodingName, bool withBase64Encode, String* result);
 
@@ -171,7 +174,7 @@ private:
 
     Page& m_inspectedPage;
     InspectorClient* m_client { nullptr };
-    InspectorOverlay* m_overlay { nullptr };
+    WeakRef<InspectorOverlay> m_overlay;
 
     WeakHashMap<Frame, String> m_frameToIdentifier;
     MemoryCompactRobinHoodHashMap<String, WeakPtr<Frame>> m_identifierToFrame;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -344,7 +344,7 @@ Page::Page(PageConfiguration&& pageConfiguration)
 #if ENABLE(CONTEXT_MENUS)
     , m_contextMenuController(makeUniqueRef<ContextMenuController>(*this, WTFMove(pageConfiguration.contextMenuClient)))
 #endif
-    , m_inspectorController(makeUniqueRef<InspectorController>(*this, WTFMove(pageConfiguration.inspectorClient)))
+    , m_inspectorController(makeUniqueRefWithoutRefCountedCheck<InspectorController>(*this, WTFMove(pageConfiguration.inspectorClient)))
     , m_pointerCaptureController(makeUniqueRef<PointerCaptureController>(*this))
 #if ENABLE(POINTER_LOCK)
     , m_pointerLockController(makeUniqueRef<PointerLockController>(*this))
@@ -5329,6 +5329,11 @@ void Page::applyWindowFeatures(const WindowFeatures& features)
 bool Page::isAlwaysOnLoggingAllowed() const
 {
     return m_sessionID.isAlwaysOnLoggingAllowed() || protectedSettings()->allowPrivacySensitiveOperationsInNonPersistentDataStores();
+}
+
+Ref<InspectorController> Page::protectedInspectorController()
+{
+    return m_inspectorController.get();
 }
 
 #if PLATFORM(MAC) && (ENABLE(SERVICE_CONTROLS) || ENABLE(TELEPHONE_NUMBER_DETECTION))

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -437,6 +437,7 @@ public:
     const ContextMenuController& contextMenuController() const { return m_contextMenuController.get(); }
 #endif
     InspectorController& inspectorController() { return m_inspectorController.get(); }
+    WEBCORE_EXPORT Ref<InspectorController> protectedInspectorController();
     PointerCaptureController& pointerCaptureController() { return m_pointerCaptureController.get(); }
 #if ENABLE(POINTER_LOCK)
     PointerLockController& pointerLockController() { return m_pointerLockController.get(); }
@@ -1324,7 +1325,7 @@ private:
 #if ENABLE(CONTEXT_MENUS)
     UniqueRef<ContextMenuController> m_contextMenuController;
 #endif
-    UniqueRef<InspectorController> m_inspectorController;
+    const UniqueRef<InspectorController> m_inspectorController;
     UniqueRef<PointerCaptureController> m_pointerCaptureController;
 #if ENABLE(POINTER_LOCK)
     UniqueRef<PointerLockController> m_pointerLockController;

--- a/Source/WebCore/page/PageDebuggable.cpp
+++ b/Source/WebCore/page/PageDebuggable.cpp
@@ -97,9 +97,10 @@ String PageDebuggable::url() const
 
 bool PageDebuggable::hasLocalDebugger() const
 {
-    bool hasLocalDebugger;
+    bool hasLocalDebugger = false;
     callOnMainThreadAndWait([this, protectedThis = Ref { *this }, &hasLocalDebugger] {
-        hasLocalDebugger = m_page && m_page->inspectorController().hasLocalFrontend();
+        if (RefPtr page = m_page.get())
+            hasLocalDebugger = page->protectedInspectorController()->hasLocalFrontend();
     });
     return hasLocalDebugger;
 }
@@ -108,7 +109,7 @@ void PageDebuggable::connect(FrontendChannel& channel, bool isAutomaticConnectio
 {
     callOnMainThreadAndWait([this, protectedThis = Ref { *this }, &channel, isAutomaticConnection, immediatelyPause] {
         if (RefPtr page = m_page.get())
-            page->inspectorController().connectFrontend(channel, isAutomaticConnection, immediatelyPause);
+            page->protectedInspectorController()->connectFrontend(channel, isAutomaticConnection, immediatelyPause);
     });
 }
 
@@ -116,7 +117,7 @@ void PageDebuggable::disconnect(FrontendChannel& channel)
 {
     callOnMainThreadAndWait([this, protectedThis = Ref { *this }, &channel] {
         if (RefPtr page = m_page.get())
-            page->inspectorController().disconnectFrontend(channel);
+            page->protectedInspectorController()->disconnectFrontend(channel);
     });
 }
 
@@ -124,7 +125,7 @@ void PageDebuggable::dispatchMessageFromRemote(String&& message)
 {
     callOnMainThreadAndWait([this, protectedThis = Ref { *this }, message = WTFMove(message).isolatedCopy()]() mutable {
         if (RefPtr page = m_page.get())
-            page->inspectorController().dispatchMessageFromFrontend(WTFMove(message));
+            page->protectedInspectorController()->dispatchMessageFromFrontend(WTFMove(message));
     });
 }
 
@@ -132,7 +133,7 @@ void PageDebuggable::setIndicating(bool indicating)
 {
     callOnMainThreadAndWait([this, protectedThis = Ref { *this }, indicating] {
         if (RefPtr page = m_page.get())
-            page->inspectorController().setIndicating(indicating);
+            page->protectedInspectorController()->setIndicating(indicating);
     });
 }
 

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
@@ -76,8 +76,8 @@ void WebInspectorUI::establishConnection(WebPageProxyIdentifier inspectedPageIde
 #endif
 
     m_frontendAPIDispatcher->reset();
-    m_frontendController = &m_page->corePage()->inspectorController();
-    m_frontendController->setInspectorFrontendClient(this);
+    m_frontendController = m_page->corePage()->inspectorController();
+    Ref { *m_frontendController }->setInspectorFrontendClient(this);
 
     updateConnection();
 
@@ -150,10 +150,8 @@ void WebInspectorUI::closeWindow()
         m_backendConnection = nullptr;
     }
 
-    if (m_frontendController) {
-        m_frontendController->setInspectorFrontendClient(nullptr);
-        m_frontendController = nullptr;
-    }
+    if (RefPtr frontendController = std::exchange(m_frontendController, nullptr).get())
+        frontendController->setInspectorFrontendClient(nullptr);
 
     if (m_frontendHost)
         m_frontendHost->disconnectClient();

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
@@ -188,7 +188,7 @@ private:
 
     // Keep a pointer to the frontend's inspector controller rather than going through
     // corePage(), since we may need it after the frontend's page has started destruction.
-    CheckedPtr<WebCore::InspectorController> m_frontendController;
+    WeakPtr<WebCore::InspectorController> m_frontendController;
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     RefPtr<WebInspectorUIExtensionController> m_extensionController;

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTarget.cpp
@@ -58,7 +58,7 @@ void WebPageInspectorTarget::connect(Inspector::FrontendChannel::ConnectionType 
     Ref page = m_page.get();
     m_channel = makeUnique<WebPageInspectorTargetFrontendChannel>(page, identifier(), connectionType);
     if (RefPtr corePage = page->corePage())
-        corePage->inspectorController().connectFrontend(*m_channel);
+        corePage->protectedInspectorController()->connectFrontend(*m_channel);
 }
 
 void WebPageInspectorTarget::disconnect()
@@ -66,14 +66,14 @@ void WebPageInspectorTarget::disconnect()
     if (!m_channel)
         return;
     if (RefPtr corePage = m_page->corePage())
-        corePage->inspectorController().disconnectFrontend(*m_channel);
+        corePage->protectedInspectorController()->disconnectFrontend(*m_channel);
     m_channel.reset();
 }
 
 void WebPageInspectorTarget::sendMessageToTargetBackend(const String& message)
 {
     if (RefPtr corePage = m_page->corePage())
-        corePage->inspectorController().dispatchMessageFromFrontend(message);
+        corePage->protectedInspectorController()->dispatchMessageFromFrontend(message);
 }
 
 String WebPageInspectorTarget::toTargetID(WebCore::PageIdentifier pageID)


### PR DESCRIPTION
#### a1fc09b8809df9379e9574683767eae01758b5da
<pre>
Drop IsDeprecatedTimerSmartPointerException from InspectorOverlay
<a href="https://bugs.webkit.org/show_bug.cgi?id=283191">https://bugs.webkit.org/show_bug.cgi?id=283191</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/UniqueRef.h:
Update UniqueRef const method to return non-const references / pointers. This
matches the behavior of unique_ptr / Ref / RefPtr and makes switching between
smart pointer types easier.

* Source/WebCore/inspector/InspectorController.cpp:
(WebCore::InspectorController::InspectorController):
(WebCore::InspectorController::ref const):
(WebCore::InspectorController::deref const):
(WebCore::InspectorController::connectFrontend):
(WebCore::InspectorController::disconnectFrontend):
(WebCore::InspectorController::disconnectAllFrontends):
(WebCore::InspectorController::developerExtrasEnabled const):
(WebCore::InspectorController::frontendInitialized):
* Source/WebCore/inspector/InspectorController.h:
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::InspectorOverlay::InspectorOverlay):
(WebCore::InspectorOverlay::ref const):
(WebCore::InspectorOverlay::deref const):
(WebCore::InspectorOverlay::page const):
(WebCore::InspectorOverlay::paint):
(WebCore::InspectorOverlay::highlightQuad):
(WebCore::InspectorOverlay::update):
(WebCore::InspectorOverlay::showPaintRect):
(WebCore::InspectorOverlay::drawBounds):
(WebCore::InspectorOverlay::drawRulers):
(WebCore::InspectorOverlay::drawElementTitle):
(WebCore::InspectorOverlay::buildGridOverlay):
(WebCore::InspectorOverlay::buildFlexOverlay):
* Source/WebCore/inspector/InspectorOverlay.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::Page):
* Source/WebCore/page/Page.h:

Canonical link: <a href="https://commits.webkit.org/286683@main">https://commits.webkit.org/286683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f01731a6b380932fffd4c9f544d760eb3f4b4322

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81264 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28008 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4060 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60142 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18227 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65882 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40463 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47476 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23376 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26332 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69915 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68593 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82709 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76009 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4108 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2713 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68417 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65854 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67669 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11642 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9726 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98263 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11876 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4055 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6864 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21492 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4078 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7508 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5836 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->