### PR TITLE
Stop using WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/style

### DIFF
--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -57,8 +57,6 @@
 #include "UserAgentStyle.h"
 #include <wtf/SetForScope.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 namespace Style {
 
@@ -564,9 +562,7 @@ void ElementRuleCollector::collectMatchingRulesForList(const RuleSet::RuleDataVe
     if (!rules)
         return;
 
-    for (unsigned i = 0, size = rules->size(); i < size; ++i) {
-        const auto& ruleData = rules->data()[i];
-
+    for (auto& ruleData : *rules) {
         if (UNLIKELY(!ruleData.isEnabled()))
             continue;
 
@@ -906,5 +902,3 @@ void ElementRuleCollector::addAuthorKeyframeRules(const StyleRuleKeyframe& keyfr
 
 }
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -37,8 +37,6 @@
 #include "StylePropertyShorthand.h"
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 namespace Style {
 
@@ -385,15 +383,15 @@ void PropertyCascade::addImportantMatches(CascadeLevel cascadeLevel)
 
 void PropertyCascade::sortLogicalGroupPropertyIDs()
 {
-    auto begin = m_logicalGroupPropertyIDs.begin();
-    auto end = begin;
+    size_t endIndex = 0;
     for (uint16_t id = m_lowestSeenLogicalGroupProperty; id <= m_highestSeenLogicalGroupProperty; ++id) {
         auto propertyID = static_cast<CSSPropertyID>(id);
         if (hasLogicalGroupProperty(propertyID))
-            *end++ = propertyID;
+            m_logicalGroupPropertyIDs[endIndex++] = propertyID;
     }
-    m_seenLogicalGroupPropertyCount = end - begin;
-    std::sort(begin, end, [&](auto id1, auto id2) {
+    m_seenLogicalGroupPropertyCount = endIndex;
+    auto logicalGroupPropertyIDs = std::span { m_logicalGroupPropertyIDs }.first(endIndex);
+    std::sort(logicalGroupPropertyIDs.begin(), logicalGroupPropertyIDs.end(), [&](auto id1, auto id2) {
         return logicalGroupPropertyIndex(id1) < logicalGroupPropertyIndex(id2);
     });
 }
@@ -407,5 +405,3 @@ const HashSet<AnimatableCSSProperty> PropertyCascade::overriddenAnimatedProperti
 
 }
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -50,8 +50,6 @@
 #include "StyleSheetContents.h"
 #include "UserAgentParts.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 namespace Style {
 
@@ -149,7 +147,8 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
         if (identifier) {
             auto oldSize = container.size();
             container.grow(m_ruleCount);
-            std::fill(container.begin() + oldSize, container.end(), 0);
+            auto newlyAllocated = container.mutableSpan().subspan(oldSize);
+            std::fill(newlyAllocated.begin(), newlyAllocated.end(), 0);
             container.last() = identifier;
         }
     };
@@ -573,5 +572,3 @@ Vector<Ref<const StyleRuleScope>> RuleSet::scopeRulesFor(const RuleData& ruleDat
 
 } // namespace Style
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -65,8 +65,6 @@
 #include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 using namespace HTMLNames;
@@ -640,7 +638,7 @@ void Scope::updateResolver(Vector<RefPtr<CSSStyleSheet>>& activeStyleSheets, Res
 
     unsigned firstNewIndex = m_activeStyleSheets.size();
     Vector<RefPtr<CSSStyleSheet>> newStyleSheets;
-    newStyleSheets.appendRange(activeStyleSheets.begin() + firstNewIndex, activeStyleSheets.end());
+    newStyleSheets.append(activeStyleSheets.subspan(firstNewIndex));
     m_resolver->appendAuthorStyleSheets(newStyleSheets);
 }
 
@@ -1049,5 +1047,3 @@ void Scope::clearAnchorPositioningState()
 
 }
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### fd6072bac1fc004c68c974449b6f94415f96b4d4
<pre>
Stop using WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/style
<a href="https://bugs.webkit.org/show_bug.cgi?id=283195">https://bugs.webkit.org/show_bug.cgi?id=283195</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingRulesForList):
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::sortLogicalGroupPropertyIDs):
* Source/WebCore/style/RuleSet.cpp:
* Source/WebCore/style/StyleFontSizeFunctions.cpp:
(WebCore::Style::findNearestLegacyFontSize):
(WebCore::Style::legacyFontSizeForPixelSize):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::updateResolver):

Canonical link: <a href="https://commits.webkit.org/286690@main">https://commits.webkit.org/286690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53057d97a85a385f0bc5aa4d017db7c90aaf59fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76715 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27991 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78832 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64892 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60121 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18213 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65868 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40443 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47469 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23362 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26315 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82692 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4091 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2700 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68403 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4244 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67655 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11639 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9714 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11880 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4038 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6847 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4061 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7491 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5819 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->