### PR TITLE
[web-animations] progress-based animations in the idle state should be relevant

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7360,10 +7360,16 @@ imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-not-fired-o
 imported/w3c/web-platform-tests/dom/events/scrolling/input-text-scroll-event-when-using-arrow-keys.html [ Skip ]
 
 # webkit.org/b/263870 [scroll-animations] some WPT tests are timing out
+imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-with-scroll-timeline-in-auto-subtree.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/css/deferred-timeline-composited.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-range-animation.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animation.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-root-scroller.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/constructor-no-document.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/updating-the-finished-state.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-subject.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-001.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-002.html [ Skip ]
 
 # webkit.org/b/263871 [scroll-animations] some WPT tests are failures or flaky failures
 imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none.html [ Pass Failure ]
@@ -7381,7 +7387,6 @@ imported/w3c/web-platform-tests/scroll-animations/css/printing/scroll-timeline-d
 imported/w3c/web-platform-tests/scroll-animations/css/printing/scroll-timeline-default-print.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-default-writing-mode-rl.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-transform.html [ Pass ImageOnlyFailure ]
-imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/custom-property.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/layout-changes-on-percentage-based-timeline.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/progress-based-effect-delay.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline-cancel-one.html [ Pass ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-with-scroll-timeline-in-auto-subtree-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-with-scroll-timeline-in-auto-subtree-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL Animation with scroll-timeline should be affected c-v promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'animation.ready')"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Animation with scroll-timeline should be affected c-v Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-with-scroll-timeline-in-hidden-subtree-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-with-scroll-timeline-in-hidden-subtree-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Animation with scroll-timeline should be affected c-v promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'animation.ready')"
+PASS Animation with scroll-timeline should be affected c-v
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Animation API call rangeStart overrides animation-range-start promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
-FAIL Animation API call rangeEnd overrides animation-range-end promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
+FAIL Animation API call rangeStart overrides animation-range-start assert_approx_equals: values do not match for "timeline's current time before style change" expected 16.666666666666668 +/- 0.125 but got 230
+FAIL Animation API call rangeEnd overrides animation-range-end assert_approx_equals: values do not match for "timeline's current time after first set of range updates" expected 16.666666666666668 +/- 0.125 but got 230
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-normal-matches-cover-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-normal-matches-cover-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Changing the animation range updates the play state assert_equals: Expecting 2 animations expected 2 but got 0
+FAIL Changing the animation range updates the play state assert_equals: expected (string) "normal" but got (object) object "[object Object]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred-expected.txt
@@ -1,5 +1,5 @@
 
 FAIL Animation.timeline returns attached timeline promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'animations[0].timeline')"
-FAIL Animation.timeline returns null for inactive deferred timeline promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'animating.getAnimations()[0].timeline')"
-FAIL Animation.timeline returns null for inactive (overattached) deferred timeline promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'animating.getAnimations()[0].timeline')"
+FAIL Animation.timeline returns null for inactive deferred timeline assert_equals: expected null but got object "[object ScrollTimeline]"
+FAIL Animation.timeline returns null for inactive (overattached) deferred timeline assert_equals: expected null but got object "[object ScrollTimeline]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
@@ -4,8 +4,8 @@ FAIL scroll-timeline-name is referenceable in animation-timeline on that element
 FAIL scroll-timeline-name is not referenceable in animation-timeline on that element's siblings assert_equals: Animation with unknown timeline name holds current time at zero expected "50px" but got "none"
 PASS scroll-timeline-name on an element which is not a scroll-container
 FAIL Change in scroll-timeline-name to match animation timeline updates animation. assert_equals: expected null but got object "[object DocumentTimeline]"
-FAIL Change in scroll-timeline-name to no longer match animation timeline updates animation. assert_true: Failed to create animation expected true got false
-FAIL Timeline lookup updates candidate when closer match available. promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.timeline')"
+FAIL Change in scroll-timeline-name to no longer match animation timeline updates animation. assert_equals: expected "75px" but got "none"
+FAIL Timeline lookup updates candidate when closer match available. assert_equals: expected "A" but got "target"
 FAIL Timeline lookup updates candidate when match becomes available. assert_equals: expected "50px" but got "none"
 FAIL scroll-timeline-axis is block assert_equals: expected "50" but got "auto"
 FAIL scroll-timeline-axis is inline assert_equals: expected "50" but got "auto"

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-scroll-functional-notation.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-scroll-functional-notation.tentative-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL animation-timeline: scroll(nearest) assert_equals: expected "50px" but got "none"
-FAIL animation-timeline: scroll(root) assert_equals: expected "50px" but got "none"
-FAIL animation-timeline: scroll(self) assert_equals: expected "100px" but got "none"
+PASS animation-timeline: scroll(nearest)
+PASS animation-timeline: scroll(root)
+PASS animation-timeline: scroll(self)
 PASS animation-timeline: scroll(self), on non-scroller
-FAIL animation-timeline: scroll(inline) assert_equals: expected "100px" but got "none"
-FAIL animation-timeline: scroll(x) assert_equals: expected "100px" but got "none"
+PASS animation-timeline: scroll(inline)
+PASS animation-timeline: scroll(x)
 FAIL animation-timeline: scroll(y) assert_equals: expected "100px" but got "none"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative-expected.txt
@@ -1,13 +1,13 @@
 
-FAIL animation-timeline: view() without timeline range name assert_equals: At 0% expected "0" but got "1"
-FAIL animation-timeline: view(50px) without timeline range name assert_equals: At 0% expected "0" but got "1"
-FAIL animation-timeline: view(auto 50px) without timeline range name assert_equals: At 0% expected "0" but got "1"
-FAIL animation-timeline: view(inline) without timeline range name assert_approx_equals: At 66.7% expected 0.33333 +/- 0.00001 but got 1
-FAIL animation-timeline: view(x) without timeline range name assert_approx_equals: At 66.7% expected 0.33333 +/- 0.00001 but got 1
-FAIL animation-timeline: view(y) without timeline range name assert_approx_equals: At 66.7% expected 0.33333 +/- 0.00001 but got 1
-FAIL animation-timeline: view(x 50px) without timeline range name assert_equals: At 75% expected "0.25" but got "1"
-FAIL animation-timeline: view(50px), view(inline 50px) without timeline range name assert_equals: At 75% inline expected "25px" but got "16px"
-FAIL animation-timeline: view(inline) changes to view(inline 50px), withouttimeline range name assert_approx_equals: At 66.7% expected 0.33333 +/- 0.00001 but got 1
+FAIL animation-timeline: view() without timeline range name assert_equals: At 0% expected "0" but got "0.833333"
+FAIL animation-timeline: view(50px) without timeline range name assert_equals: At 20% expected "0.5" but got "0"
+FAIL animation-timeline: view(auto 50px) without timeline range name assert_equals: At 20% expected "0.5" but got "0"
+FAIL animation-timeline: view(inline) without timeline range name assert_equals: At 80% expected "0.2" but got "0.066667"
+FAIL animation-timeline: view(x) without timeline range name assert_equals: At 80% expected "0.2" but got "0.066667"
+FAIL animation-timeline: view(y) without timeline range name assert_approx_equals: At 66.7% expected 0.33333 +/- 0.00001 but got 0.350877
+FAIL animation-timeline: view(x 50px) without timeline range name assert_equals: At 80% expected "0.2" but got "0.15"
+FAIL animation-timeline: view(50px), view(inline 50px) without timeline range name assert_equals: At 80% inline expected "26px" but got "27px"
+FAIL animation-timeline: view(inline) changes to view(inline 50px), withouttimeline range name assert_equals: At 80% expected "0.2" but got "0.066667"
 FAIL animation-timeline: view() assert_equals: At entry 0% expected "0" but got "1"
 FAIL animation-timeline: view(50px) assert_equals: At entry 0% expected "0" but got "1"
 FAIL animation-timeline: view(auto 50px) assert_equals: At entry 0% expected "0" but got "1"

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/get-animations-inactive-timeline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/get-animations-inactive-timeline-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL getAnimations includes inactive scroll-linked animations that have not been canceled assert_equals: Single running animation expected 1 but got 0
+FAIL getAnimations includes inactive scroll-linked animations that have not been canceled assert_equals: Inactive timeline when timeline's source element cannot be scrolled expected null but got object "0%"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/merge-timeline-offset-keyframes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/merge-timeline-offset-keyframes-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Keyframes with same easing and timeline offset are merged. promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
-FAIL Keyframes with same timeline offset but different easing function are not merged. promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
+FAIL Keyframes with same easing and timeline offset are merged. assert_equals: number of frames:  expected 4 but got 0
+FAIL Keyframes with same timeline offset but different easing function are not merged. assert_equals: number of frames:  expected 5 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/progress-based-animation-animation-longhand-properties.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/progress-based-animation-animation-longhand-properties.tentative-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL animation-duration assert_equals: expected "25px" but got "none"
-FAIL animation-duration: 0s assert_equals: expected "100px" but got "none"
-FAIL animation-iteration-count assert_equals: expected "25px" but got "none"
-FAIL animation-iteration-count: 0 assert_equals: expected "0px" but got "none"
-FAIL animation-iteration-count: infinite assert_equals: expected "100px" but got "none"
-FAIL animation-direction: normal assert_equals: expected "25px" but got "none"
-FAIL animation-direction: reverse assert_equals: expected "75px" but got "none"
-FAIL animation-direction: alternate assert_equals: expected "20px" but got "none"
-FAIL animation-direction: alternate-reverse assert_equals: expected "80px" but got "none"
-FAIL animation-delay with a positive value assert_equals: expected "25px" but got "none"
-FAIL animation-delay with a negative value assert_equals: expected "60px" but got "none"
-FAIL animation-fill-mode assert_equals: expected "0px" but got "none"
+PASS animation-duration
+FAIL animation-duration: 0s assert_equals: expected "100px" but got "25px"
+PASS animation-iteration-count
+PASS animation-iteration-count: 0
+PASS animation-iteration-count: infinite
+PASS animation-direction: normal
+PASS animation-direction: reverse
+FAIL animation-direction: alternate assert_equals: expected "80px" but got "79.999992px"
+FAIL animation-direction: alternate-reverse assert_equals: expected "20px" but got "20.000008px"
+FAIL animation-delay with a positive value assert_equals: expected "0px" but got "50px"
+FAIL animation-delay with a negative value assert_equals: expected "60px" but got "20px"
+FAIL animation-fill-mode assert_equals: expected "none" but got "25px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-name-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-name-shadow-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Outer animation can see scroll timeline defined by :host assert_equals: expected 1 but got 0
-FAIL Outer animation can see scroll timeline defined by ::slotted assert_equals: expected 1 but got 0
-FAIL Inner animation can see scroll timeline defined by ::part assert_equals: expected 1 but got 0
-FAIL Slotted element can see scroll timeline within the shadow assert_equals: expected 1 but got 0
+FAIL Outer animation can see scroll timeline defined by :host assert_equals: expected "y" but got "x"
+FAIL Outer animation can see scroll timeline defined by ::slotted assert_equals: expected "y" but got "x"
+PASS Inner animation can see scroll timeline defined by ::part
+FAIL Slotted element can see scroll timeline within the shadow assert_equals: expected "y" but got "x"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-paused-animations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-paused-animations-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Test that the scroll animation is paused
-FAIL Test that the scroll animation is paused by updating animation-play-state promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
+FAIL Test that the scroll animation is paused by updating animation-play-state assert_equals: Current time preserved when pause-pending. expected "200px" but got "50px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-range-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-range-animation-expected.txt
@@ -1,10 +1,12 @@
 
+Harness Error (TIMEOUT), message = null
+
 PASS Animation with ranges [initial, initial]
-FAIL Animation with ranges [0%, 100%] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [10%, 100%] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [0%, 50%] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [10%, 50%] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [150px, 75em] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [calc(1% + 135px), calc(70em + 50px)] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [calc(1% + 135px), calc(70em + 50px)] (scoped) assert_equals: expected "0" but got "-1"
+TIMEOUT Animation with ranges [0%, 100%] Test timed out
+NOTRUN Animation with ranges [10%, 100%]
+NOTRUN Animation with ranges [0%, 50%]
+NOTRUN Animation with ranges [10%, 50%]
+NOTRUN Animation with ranges [150px, 75em]
+NOTRUN Animation with ranges [calc(1% + 135px), calc(70em + 50px)]
+NOTRUN Animation with ranges [calc(1% + 135px), calc(70em + 50px)] (scoped)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-responsiveness-from-endpoint-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-responsiveness-from-endpoint-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test that the scroll animation is still responsive after moving from 100% promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
+PASS Test that the scroll animation is still responsive after moving from 100%
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Outer animation can see view timeline defined by :host assert_equals: expected 1 but got 0
-FAIL Outer animation can see view timeline defined by ::slotted assert_equals: expected 1 but got 0
-FAIL Inner animation can see view timeline defined by ::part assert_equals: expected 1 but got 0
-FAIL Slotted element can see view timeline within the shadow assert_equals: expected 1 but got 0
+FAIL Outer animation can see view timeline defined by :host assert_equals: expected "y" but got "x"
+FAIL Outer animation can see view timeline defined by ::slotted assert_equals: expected "y" but got "x"
+PASS Inner animation can see view timeline defined by ::part
+FAIL Slotted element can see view timeline within the shadow assert_equals: expected "y" but got "x"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animation-expected.txt
@@ -1,18 +1,20 @@
 
+Harness Error (TIMEOUT), message = null
+
 FAIL Animation with ranges [initial, initial] assert_equals: expected "0" but got "100"
-FAIL Animation with ranges [cover 0%, cover 100%] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [contain 0%, contain 100%] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [entry 0%, entry 100%] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [exit 0%, exit 100%] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [contain -50%, entry 200%] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [entry 0%, exit 100%] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [cover 20px, cover 100px] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [contain 20px, contain 100px] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [entry 20px, entry 100px] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [entry-crossing 20px, entry-crossing 100px] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [exit 20px, exit 80px] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [exit-crossing 20px, exit-crossing 80px] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [contain 20px, contain calc(100px - 10%)] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [exit 2em, exit 8em] assert_equals: expected "0" but got "-1"
-FAIL Animation with ranges [exit 2em, exit 8em] (scoped) assert_equals: expected "0" but got "-1"
+TIMEOUT Animation with ranges [cover 0%, cover 100%] Test timed out
+NOTRUN Animation with ranges [contain 0%, contain 100%]
+NOTRUN Animation with ranges [entry 0%, entry 100%]
+NOTRUN Animation with ranges [exit 0%, exit 100%]
+NOTRUN Animation with ranges [contain -50%, entry 200%]
+NOTRUN Animation with ranges [entry 0%, exit 100%]
+NOTRUN Animation with ranges [cover 20px, cover 100px]
+NOTRUN Animation with ranges [contain 20px, contain 100px]
+NOTRUN Animation with ranges [entry 20px, entry 100px]
+NOTRUN Animation with ranges [entry-crossing 20px, entry-crossing 100px]
+NOTRUN Animation with ranges [exit 20px, exit 80px]
+NOTRUN Animation with ranges [exit-crossing 20px, exit-crossing 80px]
+NOTRUN Animation with ranges [contain 20px, contain calc(100px - 10%)]
+NOTRUN Animation with ranges [exit 2em, exit 8em]
+NOTRUN Animation with ranges [exit 2em, exit 8em] (scoped)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-with-delay-and-range.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-with-delay-and-range.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL ViewTimeline with animation delays and range promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
+FAIL ViewTimeline with animation delays and range promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-inactive-timeline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-inactive-timeline-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Play pending task doesn't run when the timeline is inactive.
 PASS Animation start and current times are correct if scroll timeline is activated after animation.play call.
-FAIL Animation start and current times are correct if scroll timeline is activated after setting start time. assert_equals: Animation has an effect when the timeline is active. expected 0 but got 1
+PASS Animation start and current times are correct if scroll timeline is activated after setting start time.
 PASS Animation current time is correct when the timeline becomes newly inactive and then active again.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/change-animation-range-updates-play-state-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/change-animation-range-updates-play-state-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Changing the animation range updates the play state promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
+FAIL Changing the animation range updates the play state assert_equals: expected "running" but got "finished"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/fieldset-source-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/fieldset-source-expected.txt
@@ -1,3 +1,8 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input1 expected -74 +/- 0.1 but got -56.40625
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input2 expected -48 +/- 0.1 but got -56.40625
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input3 expected -22 +/- 0.1 but got -56.40625
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input4 expected 4 +/- 0.1 but got -56.40625
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input5 expected 30 +/- 0.1 but got -56.40625
 Reservation Details
 Name:
 
@@ -10,5 +15,5 @@ Number of guests:
 Contact info:
 
 
-FAIL Fieldset is a valid source for a view timeline assert_equals: expected 5 but got 0
+PASS Fieldset is a valid source for a view timeline
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-subject-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-subject-expected.txt
@@ -1,5 +1,7 @@
 Hello world
 
 
-FAIL View timeline attached to SVG graphics element promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline attached to SVG graphics element Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-001-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL View timeline attached to SVG graphics element promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline attached to SVG graphics element Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-002-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL View timeline attached to SVG graphics element promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT View timeline attached to SVG graphics element Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/zero-intrinsic-iteration-duration.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/zero-intrinsic-iteration-duration.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Intrinsic iteration duration is non-negative promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'anim.ready')"
+FAIL Intrinsic iteration duration is non-negative assert_equals: 'actual' unit type must be 'percent' for "Default duration is 100%" expected (string) "percent" but got (undefined) undefined
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2115,6 +2115,9 @@ webkit.org/b/281211 [ Debug ] http/wpt/mediastream/transfer-videotrackgenerator-
 webkit.org/b/281211 [ Debug ] imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-in-auto-subtree.html [ Crash ]
 webkit.org/b/281211 [ Debug ] imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-entry.html [ Crash ]
 
+webkit.org/b/263870 imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored.html [ Skip ]
+webkit.org/b/263870 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range.html [ Skip ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of WebAnimations-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored-expected.txt
@@ -1,0 +1,6 @@
+
+Harness Error (TIMEOUT), message = null
+
+FAIL Animation API call rangeStart overrides animation-range-start assert_approx_equals: values do not match for "timeline's current time before style change" expected 16.666666666666668 +/- 0.125 but got 230
+TIMEOUT Animation API call rangeEnd overrides animation-range-end Test timed out
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range-expected.txt
@@ -1,10 +1,12 @@
 
+Harness Error (TIMEOUT), message = null
+
 PASS Scroll timeline with percentage range [JavaScript API]
 PASS Scroll timeline with px range [JavaScript API]
 FAIL Scroll timeline with calculated range [JavaScript API] assert_approx_equals: expected a number but got a "object"
 FAIL Scroll timeline with EM range [JavaScript API] assert_approx_equals: expected a number but got a "object"
-PASS Scroll timeline with percentage range [CSS]
-PASS Scroll timeline with px range [CSS]
-PASS Scroll timeline with calculated range [CSS]
-PASS Scroll timeline with EM range [CSS]
+TIMEOUT Scroll timeline with percentage range [CSS] Test timed out
+NOTRUN Scroll timeline with px range [CSS]
+NOTRUN Scroll timeline with calculated range [CSS]
+NOTRUN Scroll timeline with EM range [CSS]
 

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -1034,6 +1034,8 @@ imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/layout-change
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-animatable-interface.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-display-none.html [ ImageOnlyFailure ]
 
+webkit.org/b/263870 imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored.html [ Skip ]
+webkit.org/b/263870 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range.html [ Skip ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////
 # Compositing

--- a/LayoutTests/platform/win/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored-expected.txt
+++ b/LayoutTests/platform/win/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored-expected.txt
@@ -1,0 +1,6 @@
+
+Harness Error (TIMEOUT), message = null
+
+FAIL Animation API call rangeStart overrides animation-range-start assert_approx_equals: values do not match for "timeline's current time before style change" expected 16.666666666666668 +/- 0.125 but got 230
+TIMEOUT Animation API call rangeEnd overrides animation-range-end Test timed out
+

--- a/LayoutTests/platform/win/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range-expected.txt
+++ b/LayoutTests/platform/win/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range-expected.txt
@@ -1,10 +1,12 @@
 
+Harness Error (TIMEOUT), message = null
+
 PASS Scroll timeline with percentage range [JavaScript API]
 PASS Scroll timeline with px range [JavaScript API]
 FAIL Scroll timeline with calculated range [JavaScript API] assert_approx_equals: expected a number but got a "object"
 FAIL Scroll timeline with EM range [JavaScript API] assert_approx_equals: expected a number but got a "object"
-PASS Scroll timeline with percentage range [CSS]
-PASS Scroll timeline with px range [CSS]
-PASS Scroll timeline with calculated range [CSS]
-PASS Scroll timeline with EM range [CSS]
+TIMEOUT Scroll timeline with percentage range [CSS] Test timed out
+NOTRUN Scroll timeline with px range [CSS]
+NOTRUN Scroll timeline with calculated range [CSS]
+NOTRUN Scroll timeline with EM range [CSS]
 

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1584,6 +1584,10 @@ void WebAnimation::updateRelevance()
 
 bool WebAnimation::computeRelevance()
 {
+    // https://drafts.csswg.org/web-animations-1/#relevant-animations-section
+    // https://drafts.csswg.org/web-animations-1/#current
+    // https://drafts.csswg.org/web-animations-1/#in-effect
+
     // An animation is relevant if:
     // - its associated effect is current or in effect, and
     if (!m_effect)
@@ -1609,6 +1613,11 @@ bool WebAnimation::computeRelevance()
 
     // - the animation effect is associated with an animation with a playback rate < 0 and the animation effect is in the after phase.
     if (m_playbackRate < 0 && timing.phase == AnimationEffectPhase::After)
+        return true;
+
+    // - the animation effect is associated with an animation not in the idle play state with a non-null
+    // associated timeline that is not monotonically increasing.
+    if (m_timeline && !m_timeline->isMonotonic() && playState() != PlayState::Idle)
         return true;
 
     // An animation effect is in effect if its active time, as calculated according to the procedure in


### PR DESCRIPTION
#### 7b0e9d741fedbbf9e9cd5bfe14df98d9214e22a6
<pre>
[web-animations] progress-based animations in the idle state should be relevant
<a href="https://bugs.webkit.org/show_bug.cgi?id=283199">https://bugs.webkit.org/show_bug.cgi?id=283199</a>
<a href="https://rdar.apple.com/140001534">rdar://140001534</a>

Reviewed by Tim Nguyen.

The Web Animations specification has an update provision that states that an &quot;animation
not in the idle play state with a non-null associated timeline that is not monotonically
increasing&quot; is &quot;current&quot; (<a href="https://drafts.csswg.org/web-animations-1/#current)">https://drafts.csswg.org/web-animations-1/#current)</a> and thus
should be considered relevant.

This allows a number of tests to progress, but also a few tests which were complete failures
are now timeouts, so we mark those as such.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-with-scroll-timeline-in-auto-subtree-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-with-scroll-timeline-in-hidden-subtree-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-normal-matches-cover-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-scroll-functional-notation.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/get-animations-inactive-timeline-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/merge-timeline-offset-keyframes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/progress-based-animation-animation-longhand-properties.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-name-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-paused-animations-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-range-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-responsiveness-from-endpoint-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-with-delay-and-range.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-inactive-timeline-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/change-animation-range-updates-play-state-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/fieldset-source-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-subject-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/zero-intrinsic-iteration-duration.tentative-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range-expected.txt: Added.
* LayoutTests/platform/win/TestExpectations:
* LayoutTests/platform/win/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored-expected.txt: Added.
* LayoutTests/platform/win/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range-expected.txt: Added.
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::computeRelevance):

Canonical link: <a href="https://commits.webkit.org/286687@main">https://commits.webkit.org/286687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1680b377687cbf6e4d6adf484323a3046ae14d04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81300 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28043 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78884 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60155 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18243 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65909 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40474 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47503 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-animations/view-timelines/fieldset-source.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23403 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26367 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68620 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82744 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4143 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2738 "Found 1 new test failure: fast/css/view-transitions-hide-under-page-background-color.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68438 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67690 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11668 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9751 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11878 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4090 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6900 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4113 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7543 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5871 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->