### PR TITLE
[WebGPU] pathological integer wrap in createVertexDescriptor

### DIFF
--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -555,7 +555,7 @@ static bool matchesFormat(const ShaderModule::VertexStageIn& stageIn, uint32_t s
 static MTLVertexDescriptor *createVertexDescriptor(WGPUVertexState vertexState, const WGPULimits& limits, const ShaderModule::VertexStageIn& stageIn, RenderPipeline::RequiredBufferIndicesContainer& requiredBufferIndices, NSString** error)
 {
     MTLVertexDescriptor *vertexDescriptor = [MTLVertexDescriptor new];
-    uint32_t totalAttributeCount = 0;
+    Checked<uint32_t> totalAttributeCount = 0;
     ASSERT(error);
 
     if (vertexState.bufferCount > limits.maxVertexBuffers) {
@@ -576,7 +576,12 @@ static MTLVertexDescriptor *createVertexDescriptor(WGPUVertexState vertexState, 
         if (!buffer.attributeCount)
             continue;
 
-        totalAttributeCount += buffer.attributeCount;
+        totalAttributeCount = checkedSum<uint32_t>(totalAttributeCount, buffer.attributeCount);
+        if (totalAttributeCount.hasOverflowed()) {
+            *error = @"Over 2^32 - 1 attributes in the vertex descriptor, failing due to out-of-memory.";
+            return nil;
+        }
+
         auto stride = std::max<NSUInteger>(sizeof(int), buffer.arrayStride);
         RELEASE_ASSERT(!requiredBufferIndices.contains(bufferIndex));
         ASSERT(bufferIndex <= std::numeric_limits<uint32_t>::max() && stride <= std::numeric_limits<uint32_t>::max());
@@ -642,7 +647,7 @@ static MTLVertexDescriptor *createVertexDescriptor(WGPUVertexState vertexState, 
         }
     }
 
-    if (totalAttributeCount > limits.maxVertexAttributes) {
+    if (totalAttributeCount.value() > limits.maxVertexAttributes) {
         *error = @"totalAttributeCount > limits.maxVertexAttributes";
         return nil;
     }


### PR DESCRIPTION
#### 1cc2d18fb3defe593385f5f10e1555ccdc9ab894
<pre>
[WebGPU] pathological integer wrap in createVertexDescriptor
<a href="https://bugs.webkit.org/show_bug.cgi?id=283200">https://bugs.webkit.org/show_bug.cgi?id=283200</a>
<a href="https://rdar.apple.com/136576990">rdar://136576990</a>

Reviewed by Tadeu Zagallo.

Migrate += to using checked math in a case which should not overflow.

Test: existing tests pass. No new test because overflow test would
require vector with &gt; 2^32 - 1 elements and we would run out of memory
first given the elements are each 16 bytes so ~64GB of memory from that
allocation alone.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::createVertexDescriptor):

Canonical link: <a href="https://commits.webkit.org/286758@main">https://commits.webkit.org/286758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/567f94bb6d439e330e5e9059e8ff2e59b66f8006

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81242 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/27986 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4038 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60138 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18209 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40439 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47459 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26310 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68580 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23687 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82687 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4086 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2703 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68400 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65835 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67652 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16920 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11624 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9710 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4033 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4056 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7486 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5814 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->