### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/

### DIFF
--- a/Source/WebCore/loader/FormSubmission.cpp
+++ b/Source/WebCore/loader/FormSubmission.cpp
@@ -53,8 +53,6 @@
 #include <wtf/WallTime.h>
 #include <wtf/text/MakeString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 using namespace HTMLNames;
@@ -77,7 +75,7 @@ static void appendMailtoPostFormDataToURL(URL& url, const FormData& data, const 
         body = PAL::decodeURLEscapeSequences(makeStringByReplacingAll(makeStringByReplacingAll(body, '&', "\r\n"_s), '+', ' '));
     }
 
-    Vector<uint8_t> bodyData(std::span<const char>("body=", static_cast<size_t>(5)));
+    Vector<uint8_t> bodyData("body="_s.span8());
     FormDataBuilder::encodeStringAsFormData(bodyData, body.utf8());
     body = makeStringByReplacingAll(bodyData.span(), '+', "%20"_s);
 
@@ -284,5 +282,3 @@ void FormSubmission::populateFrameLoadRequest(FrameLoadRequest& frameRequest)
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -60,8 +60,6 @@
 #include "MultiRepresentationHEICMetrics.h"
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 CachedImage::CachedImage(CachedResourceRequest&& request, PAL::SessionID sessionID, const CookieJar* cookieJar)
@@ -542,7 +540,7 @@ void CachedImage::updateBufferInternal(const FragmentedSharedBuffer& data)
 
 bool CachedImage::shouldDeferUpdateImageData() const
 {
-    static const double updateImageDataBackoffIntervals[] = { 0, 1, 3, 6, 15 };
+    static constexpr std::array<double, 5> updateImageDataBackoffIntervals { 0, 1, 3, 6, 15 };
     unsigned interval = m_updateImageDataCount;
 
     // The first time through, the chunk time will be 0 and the image will get an update.
@@ -793,5 +791,3 @@ bool CachedImage::isVisibleInViewport(const Document& document) const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/page/PerformanceObserver.cpp
+++ b/Source/WebCore/page/PerformanceObserver.cpp
@@ -33,8 +33,6 @@
 #include "PerformanceObserverEntryList.h"
 #include "WorkerGlobalScope.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 PerformanceObserver::PerformanceObserver(ScriptExecutionContext& scriptExecutionContext, Ref<PerformanceObserverCallback>&& callback)
@@ -93,9 +91,10 @@ ExceptionOr<void> PerformanceObserver::observe(Init&& init)
             isBuffered = true;
             auto oldSize = m_entriesToDeliver.size();
             protectedPerformance()->appendBufferedEntriesByType(*init.type, m_entriesToDeliver, *this);
-            auto begin = m_entriesToDeliver.begin();
-            auto oldEnd = begin + oldSize;
-            auto end = m_entriesToDeliver.end();
+            auto entriesToDeliver = m_entriesToDeliver.mutableSpan();
+            auto begin = entriesToDeliver.begin();
+            auto oldEnd = entriesToDeliver.subspan(oldSize).begin();
+            auto end = entriesToDeliver.end();
             std::stable_sort(oldEnd, end, PerformanceEntry::startTimeCompareLessThan);
             std::inplace_merge(begin, oldEnd, end, PerformanceEntry::startTimeCompareLessThan);
         }
@@ -166,5 +165,3 @@ Vector<String> PerformanceObserver::supportedEntryTypes(ScriptExecutionContext& 
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -37,8 +37,6 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringParsingBuffer.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ContentSecurityPolicyDirectiveList);
@@ -518,42 +516,42 @@ template<typename CharacterType> auto ContentSecurityPolicyDirectiveList::parseD
     if (buffer.atEnd())
         return std::nullopt;
 
-    auto nameBegin = buffer.position();
+    auto nameBegin = buffer.span();
     skipWhile<isDirectiveNameCharacter>(buffer);
 
     // The directive-name must be non-empty.
-    if (nameBegin == buffer.position()) {
+    if (nameBegin.data() == buffer.position()) {
         skipWhile<isNotASCIISpace>(buffer);
-        m_policy.reportUnsupportedDirective(String({ nameBegin, buffer.position() }));
+        m_policy.reportUnsupportedDirective(nameBegin.first(buffer.position() - nameBegin.data()));
         return std::nullopt;
     }
 
-    auto name = String({ nameBegin, buffer.position() });
+    String name { nameBegin.first(buffer.position() - nameBegin.data()) };
 
     if (buffer.atEnd())
         return ParsedDirective { WTFMove(name), { } };
 
     if (!skipExactly<isUnicodeCompatibleASCIIWhitespace>(buffer)) {
         skipWhile<isNotASCIISpace>(buffer);
-        m_policy.reportUnsupportedDirective(String({ nameBegin, buffer.position() }));
+        m_policy.reportUnsupportedDirective(nameBegin.first(buffer.position() - nameBegin.data()));
         return std::nullopt;
     }
 
     skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
 
-    auto valueBegin = buffer.position();
+    auto valueBegin = buffer.span();
     skipWhile<isDirectiveValueCharacter>(buffer);
 
     if (!buffer.atEnd()) {
-        m_policy.reportInvalidDirectiveValueCharacter(name, String({ valueBegin, buffer.end() }));
+        m_policy.reportInvalidDirectiveValueCharacter(name, valueBegin);
         return std::nullopt;
     }
 
     // The directive-value may be empty.
-    if (valueBegin == buffer.position())
+    if (valueBegin.data() == buffer.position())
         return ParsedDirective { WTFMove(name), { } };
 
-    auto value = String({ valueBegin, buffer.position() });
+    String value { valueBegin.first(buffer.position() - valueBegin.data()) };
     return ParsedDirective { WTFMove(name), WTFMove(value) };
 }
 
@@ -618,7 +616,7 @@ void ContentSecurityPolicyDirectiveList::parseRequireTrustedTypesFor(ParsedDirec
             if (skipExactlyIgnoringASCIICase(buffer, "'script'"_s))
                 m_requireTrustedTypesForScript = true;
             else {
-                policy().reportInvalidTrustedTypesSinkGroup(String({ begin, buffer.position() }));
+                policy().reportInvalidTrustedTypesSinkGroup(std::span { begin, buffer.position() });
                 return;
             }
 
@@ -779,5 +777,3 @@ bool ContentSecurityPolicyDirectiveList::shouldReportSample(const String& violat
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### d3c05474b8c2feaf1a3aa51934a70a13769bf622
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/
<a href="https://bugs.webkit.org/show_bug.cgi?id=283201">https://bugs.webkit.org/show_bug.cgi?id=283201</a>

Reviewed by Darin Adler.

* Source/WebCore/loader/FormSubmission.cpp:
(WebCore::appendMailtoPostFormDataToURL):
* Source/WebCore/loader/ResourceCryptographicDigest.cpp:
(WebCore::parseCryptographicDigestImpl):
(WebCore::parseEncodedCryptographicDigestImpl):
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::shouldDeferUpdateImageData const):
* Source/WebCore/page/PerformanceObserver.cpp:
(WebCore::PerformanceObserver::observe):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::ContentSecurityPolicyDirectiveList::parseDirective):
* Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp:
(WebCore::ContentSecurityPolicySourceList::parse):
(WebCore::ContentSecurityPolicySourceList::parseSource):
(WebCore::ContentSecurityPolicySourceList::parseScheme):
(WebCore::ContentSecurityPolicySourceList::parseHost):
(WebCore::ContentSecurityPolicySourceList::parsePath):
(WebCore::ContentSecurityPolicySourceList::parsePort):
(WebCore::ContentSecurityPolicySourceList::parseNonceSource):

Canonical link: <a href="https://commits.webkit.org/286696@main">https://commits.webkit.org/286696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c346e74c94cc080a55720fd6c4aaceb5a4ee543

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81332 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28075 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4127 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60180 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18270 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79866 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65933 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40499 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47531 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23427 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26399 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68648 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23757 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82776 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4175 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2767 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68465 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67718 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16883 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11694 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9775 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4122 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/6933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4145 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7575 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5903 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->