### PR TITLE
[WTF] Add differenceWith and formDifference to WTF::HashSet

### DIFF
--- a/Source/WTF/wtf/HashSet.h
+++ b/Source/WTF/wtf/HashSet.h
@@ -150,6 +150,13 @@ public:
     template<typename OtherCollection>
     HashSet intersectionWith(const OtherCollection&) const;
 
+    // Returns a new set with the elements of this set that are not in
+    // the given collection (a.k.a. A - B).
+    //
+    // NOTE: OtherCollection is required to implement `bool contains(Value)`.
+    template<typename OtherCollection>
+    HashSet differenceWith(const OtherCollection&) const;
+
     // Returns a new set with the elements that are either in this set or
     // in the given collection, but not in both. (a.k.a. XOR).
     template<typename OtherCollection>
@@ -158,6 +165,12 @@ public:
     // Adds the elements of the given collection to the set (a.k.a. OR).
     template<typename OtherCollection>
     void formUnion(const OtherCollection&);
+
+    // Removes the elements of this set that are in the given collection (a.k.a. A - B).
+    //
+    // NOTE: OtherCollection is required to implement `bool contains(Value)`.
+    template<typename OtherCollection>
+    void formDifference(const OtherCollection&);
 
     // Removes the elements of this set that aren't also in the given
     // collection (a.k.a. AND).
@@ -433,6 +446,18 @@ inline auto HashSet<T, U, V, W>::intersectionWith(const OtherCollection& other) 
 
 template<typename T, typename U, typename V, typename W>
 template<typename OtherCollection>
+inline auto HashSet<T, U, V, W>::differenceWith(const OtherCollection& other) const -> HashSet<T, U, V, W>
+{
+    HashSet result;
+    for (const auto& value : *this) {
+        if (!other.contains(value))
+            result.add(value);
+    }
+    return result;
+}
+
+template<typename T, typename U, typename V, typename W>
+template<typename OtherCollection>
 inline auto HashSet<T, U, V, W>::symmetricDifferenceWith(const OtherCollection& other) const -> HashSet<T, U, V, W>
 {
     auto copy = *this;
@@ -452,6 +477,13 @@ template<typename OtherCollection>
 inline void HashSet<T, U, V, W>::formIntersection(const OtherCollection& other)
 {
     *this = intersectionWith(other);
+}
+
+template<typename T, typename U, typename V, typename W>
+template<typename OtherCollection>
+inline void HashSet<T, U, V, W>::formDifference(const OtherCollection& other)
+{
+    *this = differenceWith(other);
 }
 
 template<typename T, typename U, typename V, typename W>

--- a/Tools/TestWebKitAPI/Tests/WTF/HashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/HashSet.cpp
@@ -755,6 +755,99 @@ TEST(WTF_HashSet, FormIntersection)
     }
 }
 
+TEST(WTF_HashSet, DifferenceWith)
+{
+    HashSet<int> emptySet;
+    HashSet<int> set1 { 1, 2, 3 };
+    HashSet<int> set2 { 2, 3, 4 };
+    Vector<int> sequence { 2, 3, 4 };
+
+    {
+        auto result = emptySet.differenceWith(set1);
+        EXPECT_EQ(result, emptySet);
+    }
+
+    {
+        auto result = set1.differenceWith(emptySet);
+        EXPECT_EQ(result, set1);
+    }
+
+    {
+        auto result = emptySet.differenceWith(emptySet);
+        EXPECT_EQ(result, emptySet);
+    }
+
+    {
+        auto result = set1.differenceWith(set1);
+        EXPECT_EQ(result, emptySet);
+    }
+
+    {
+        auto result = set1.differenceWith(set2);
+        EXPECT_EQ(result, HashSet<int> { 1 });
+    }
+
+    {
+        auto result = set2.differenceWith(set1);
+        EXPECT_EQ(result, HashSet<int> { 4 });
+    }
+
+    {
+        auto result = set1.differenceWith(sequence);
+        EXPECT_EQ(result, HashSet<int> { 1 });
+    }
+}
+
+TEST(WTF_HashSet, FormDifference)
+{
+    HashSet<int> emptySet;
+    HashSet<int> set1 { 1, 2, 3 };
+    HashSet<int> set2 { 2, 3, 4 };
+    Vector<int> sequence { 2, 3, 4 };
+
+    {
+        auto result = emptySet;
+        result.formDifference(set1);
+        EXPECT_EQ(result, emptySet);
+    }
+
+    {
+        auto result = set1;
+        result.formDifference(emptySet);
+        EXPECT_EQ(result, set1);
+    }
+
+    {
+        auto result = emptySet;
+        result.formDifference(emptySet);
+        EXPECT_EQ(result, emptySet);
+    }
+
+    {
+        auto result = set1;
+        result.formDifference(set1);
+        EXPECT_EQ(result, emptySet);
+    }
+
+    {
+        auto result = set1;
+        result.formDifference(set2);
+        EXPECT_EQ(result, HashSet<int> { 1 });
+    }
+
+    {
+        auto result = set2;
+        result.formDifference(set1);
+        EXPECT_EQ(result, HashSet<int> { 4 });
+    }
+
+    {
+        auto result = set1;
+        result.formDifference(sequence);
+        EXPECT_EQ(result, HashSet<int> { 1 });
+    }
+}
+
 TEST(WTF_HashSet, SymmetricDifferenceWith)
 {
     HashSet<int> emptySet;


### PR DESCRIPTION
#### 958f9ea25b9da16154b6edf22cb0ee1246eb90a7
<pre>
[WTF] Add differenceWith and formDifference to WTF::HashSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=283206">https://bugs.webkit.org/show_bug.cgi?id=283206</a>
<a href="https://rdar.apple.com/140004975">rdar://140004975</a>

Reviewed by Yusuke Suzuki and Sam Weinig.

Add differenceWith and formDifference that compute a collection
with the elements of this set that are not in the given collection (a.k.a. A - B).

* Source/WTF/wtf/HashSet.h:
(WTF::W&gt;::differenceWith const):
(WTF::W&gt;::formDifference):

Canonical link: <a href="https://commits.webkit.org/286708@main">https://commits.webkit.org/286708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3af56cae1212ab7a23b00bd6e9b8dde9328945bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76877 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81419 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28153 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4205 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/18319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79944 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/50187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/65995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/40555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/47589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/23490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26478 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/70060 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/68706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/23819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82857 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76154 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4253 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/2827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4407 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/65968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/67771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/11755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98409 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11896 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4200 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/21530 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7654 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->