### PR TITLE
[macOS] Mitigate sync IPC hangs underneath -[WKWebView shouldDelayWindowOrderingForEvent:]

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1004,6 +1004,7 @@ public:
 
 #if PLATFORM(COCOA)
     void scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID);
+    WebCore::FloatRect selectionBoundingRectInRootViewCoordinates() const;
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -1116,7 +1117,6 @@ public:
     bool isScrollingOrZooming() const { return m_isScrollingOrZooming; }
     void requestEvasionRectsAboveSelection(CompletionHandler<void(const Vector<WebCore::FloatRect>&)>&&);
     void updateSelectionWithDelta(int64_t locationDelta, int64_t lengthDelta, CompletionHandler<void()>&&);
-    WebCore::FloatRect selectionBoundingRectInRootViewCoordinates() const;
     void requestDocumentEditingContext(DocumentEditingContextRequest&&, CompletionHandler<void(DocumentEditingContext&&)>&&);
     void generateSyntheticEditingCommand(SyntheticEditingCommandType);
     void showDataDetectorsUIForPositionInformation(const InteractionInformationAtPosition&);
@@ -1983,7 +1983,7 @@ public:
     WebCore::UserInterfaceLayoutDirection userInterfaceLayoutDirection();
     void setUserInterfaceLayoutDirection(WebCore::UserInterfaceLayoutDirection);
 
-    bool hasHadSelectionChangesFromUserInteraction() const { return m_hasHadSelectionChangesFromUserInteraction; }
+    bool hasFocusedElementWithUserInteraction() const { return m_hasFocusedElementWithUserInteraction; }
 
 #if HAVE(TOUCH_BAR)
     bool isTouchBarUpdateSuppressedForHiddenContentEditable() const { return m_isTouchBarUpdateSuppressedForHiddenContentEditable; }
@@ -2606,6 +2606,10 @@ public:
     void isPotentialTapInProgress(CompletionHandler<void(bool)>&&);
 #endif
 
+#if PLATFORM(COCOA) && ENABLE(ASYNC_SCROLLING)
+    WebCore::FloatPoint mainFrameScrollPosition() const;
+#endif
+
 private:
     void getWebCryptoMasterKey(CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
@@ -2821,7 +2825,7 @@ private:
     void closeOverlayedViews();
 
     void compositionWasCanceled();
-    void setHasHadSelectionChangesFromUserInteraction(bool);
+    void setHasFocusedElementWithUserInteraction(bool);
 
 #if HAVE(TOUCH_BAR)
     void setIsTouchBarUpdateSuppressedForHiddenContentEditable(bool);
@@ -3597,7 +3601,7 @@ private:
 
     WebCore::IntDegrees m_orientationForMediaCapture { 0 };
 
-    bool m_hasHadSelectionChangesFromUserInteraction { false };
+    bool m_hasFocusedElementWithUserInteraction { false };
 
 #if HAVE(TOUCH_BAR)
     bool m_isTouchBarUpdateSuppressedForHiddenContentEditable { false };

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -231,7 +231,7 @@ messages -> WebPageProxy {
     # Editor notifications
     EditorStateChanged(struct WebKit::EditorState editorState)
     CompositionWasCanceled()
-    SetHasHadSelectionChangesFromUserInteraction(bool hasHadUserSelectionChanges)
+    SetHasFocusedElementWithUserInteraction(bool hasFocusedElement)
 
 #if ENABLE(IMAGE_ANALYSIS)
     RequestTextRecognition(URL imageURL, WebCore::ShareableBitmapHandle imageData, String source, String target) -> (struct WebCore::TextRecognitionResult result)

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -437,6 +437,10 @@ public:
     RunLoop::Timer activityStateChangeTimer;
 #endif
 
+#if PLATFORM(MAC)
+    WebCore::FloatPoint scrollPositionDuringLastEditorStateUpdate;
+#endif
+
     bool allowsLayoutViewportHeightExpansion { true };
 
     explicit Internals(WebPageProxy&);

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -932,6 +932,19 @@ void WebPageProxy::handleContextMenuWritingTools(WebCore::WritingTools::Requeste
 
 #endif
 
+WebCore::FloatRect WebPageProxy::selectionBoundingRectInRootViewCoordinates() const
+{
+    if (editorState().selectionIsNone)
+        return { };
+
+    if (!editorState().hasPostLayoutData())
+        return { };
+
+    auto bounds = WebCore::FloatRect { editorState().postLayoutData->selectionBoundingRect };
+    bounds.move(internals().scrollPositionDuringLastEditorStateUpdate - mainFrameScrollPosition());
+    return bounds;
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2667,8 +2667,12 @@ private:
     bool m_userIsInteracting { false };
     bool m_hasEverDisplayedContextMenu { false };
 
+    enum class UserInteractionFlag : uint8_t {
+        FocusedElement      = 1 << 0,
+        SelectedRange       = 1 << 1,
+    };
+    OptionSet<UserInteractionFlag> m_userInteractionsSincePageTransition;
 #if HAVE(TOUCH_BAR)
-    bool m_hasEverFocusedElementDueToUserInteractionSincePageTransition { false };
     bool m_requiresUserActionForEditingControlsManager { false };
     bool m_isTouchBarUpdateSuppressedForHiddenContentEditable { false };
     bool m_isNeverRichlyEditableForTouchBar { false };

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -1086,7 +1086,7 @@ bool WebPage::shouldAvoidComputingPostLayoutDataForEditorState() const
         return false;
     }
 
-    if (!m_requiresUserActionForEditingControlsManager || m_hasEverFocusedElementDueToUserInteractionSincePageTransition) {
+    if (!m_requiresUserActionForEditingControlsManager || !m_userInteractionsSincePageTransition.isEmpty()) {
         // Text editing controls on the touch bar depend on having post-layout editor state data.
         return false;
     }

--- a/Tools/TestWebKitAPI/Tests/mac/MouseEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/MouseEventTests.mm
@@ -237,6 +237,30 @@ TEST(MouseEventTests, MouseEnterDoesNotDispatchMultipleMouseMoveEvents)
     EXPECT_EQ([mouseEvents count], 1U);
 }
 
+TEST(MouseEventTests, ShouldDelayWindowOrderingForEvent)
+{
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    [processPoolConfiguration setIgnoreSynchronousMessagingTimeoutsForTesting:YES];
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() processPoolConfiguration:processPoolConfiguration.get()]);
+    [[webView window] resignKeyWindow];
+    [webView synchronouslyLoadTestPageNamed:@"lots-of-text"];
+    [webView objectByEvaluatingJavaScript:@"const t = document.body.childNodes[0]; getSelection().setBaseAndExtent(t, 0, t, 400);"];
+    [webView waitForNextPresentationUpdate];
+
+    auto makeMouseEventAt = [webView](float x, float y) {
+        auto windowHeight = NSHeight([[webView window] frame]);
+        return [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown location:NSMakePoint(x, windowHeight - y) modifierFlags:0 timestamp:0 windowNumber:[webView window].windowNumber context:[NSGraphicsContext currentContext] eventNumber:1 clickCount:1 pressure:NO];
+    };
+
+    EXPECT_TRUE([webView shouldDelayWindowOrderingForEvent:makeMouseEventAt(16, 16)]);
+
+    [webView evaluateJavaScript:@"while (1);" completionHandler:nil];
+
+    EXPECT_FALSE([webView shouldDelayWindowOrderingForEvent:makeMouseEventAt(16, 500)]);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### aa1f6fdb951f6911cfd79a363ddce8c4340edc71
<pre>
[macOS] Mitigate sync IPC hangs underneath -[WKWebView shouldDelayWindowOrderingForEvent:]
<a href="https://bugs.webkit.org/show_bug.cgi?id=283212">https://bugs.webkit.org/show_bug.cgi?id=283212</a>
<a href="https://rdar.apple.com/138094916">rdar://138094916</a>

Reviewed by Abrar Rahman Protyasha.

Further mitigate sync IPC hangs underneath `-shouldDelayWindowOrderingForEvent:`

1.  If the web content process is not currently responsive, avoid sync IPC.
2.  If the mouse location is not over the selection bounding rect (in `WKWebView` coordinates),
    avoid sync IPC.

See below for more details.

Test: MouseEventTests.ShouldDelayWindowOrderingForEvent

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setHasFocusedElementWithUserInteraction):
(WebKit::WebPageProxy::updateEditorState):
(WebKit::WebPageProxy::resetStateAfterProcessExited):
(WebKit::WebPageProxy::mainFrameScrollPosition const):

Add a helper method to return the current main frame scroll position, by consulting the async
scrolling coordinator.

(WebKit::WebPageProxy::setHasHadSelectionChangesFromUserInteraction): Deleted.

Rename this to `setHasFocusedElementWithUserInteraction` (along with the associated member variable)
to better reflect the intent of this code.

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:

Add `scrollPositionDuringLastEditorStateUpdate`, so that we can adjust the last selection bounding
rect to account for any main frame scrolling since the selection was made. Note that on iOS, this
isn&apos;t necessary since the &quot;root view coordinate space&quot; refers to `WKContentView` which is already in
content coordinates; however, on macOS, the root view is the web view itself.

* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::selectionBoundingRectInRootViewCoordinates const):

Make this (previously-iOS-specific) helper method available for all Cocoa, and add an implementation
on macOS that uses the editor state&apos;s post-layout data (adjusting for any main frame scrolling since
the editor state update).

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::shouldDelayWindowOrderingForEvent):

See comments above.

(WebKit::WebViewImpl::showWritingTools):

Drive-by fix: deploy `selectionBoundingRectInRootViewCoordinates()` here as well, to fix an issue
where selecting text in Mail compose, scrolling, and then showing the writing tools popup through
Mail&apos;s toolbar would cause the popup to show up docked to a stale rect.

(WebKit::WebViewImpl::updateTouchBar):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didStartPageTransition):
(WebKit::WebPage::didChangeSelection):

Set `UserInteractionFlag::SelectedRange` if we&apos;re both handling user interaction, and the selection
is a range.

(WebKit::WebPage::didChangeSelectionOrOverflowScrollPosition):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Refactor `m_hasEverFocusedElementDueToUserInteractionSincePageTransition` so that it&apos;s now an
`OptionSet`, `m_userInteractionsSincePageTransition`. The intent here is to propagate editor state
updates to the UI process in the case where the user has either manually selected text, or focused
an editable element. This is needed in order to ensure that we have the requisite post-layout data
cached in the UI process, to return early from `-shouldDelayWindowOrderingForEvent:` without
consulting the web process in the case where the mouse location isn&apos;t in the selection.

* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::shouldAvoidComputingPostLayoutDataForEditorState const):
* Tools/TestWebKitAPI/Tests/mac/MouseEventTests.mm:
(TestWebKitAPI::TEST(MouseEventTests, ShouldDelayWindowOrderingForEvent)):

Write a simple API test to verify that (1) window ordering is correctly delayed when clicking over a
text selection in an inactive window, and (2) window ordering is not only not delayed when clicking
over the unselected content. We also verify that we can make this determination even if the web
content process is permanently hanging and IPC timeouts are disabled.

Canonical link: <a href="https://commits.webkit.org/286746@main">https://commits.webkit.org/286746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55c23daecfb82ddc0d3fbf11261efb39015b05d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81278 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28022 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60133 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18225 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40455 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47486 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23385 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26346 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68603 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82723 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4122 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2721 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68420 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4275 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65863 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67672 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16913 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11653 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9734 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4069 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6878 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4092 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7522 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5850 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->