### PR TITLE
[Swift in WebKit] Downlevel build failure "error: -enable-upcoming-feature IsolatedDefaultValues"

### DIFF
--- a/Source/WebKit/Configurations/Base.xcconfig
+++ b/Source/WebKit/Configurations/Base.xcconfig
@@ -117,7 +117,7 @@ SUPPORTS_MACCATALYST = YES;
 // Can't enable objcxx mode until rdar://135979809 is resolved.
 SWIFT_OBJC_INTEROP_MODE = objc;
 SWIFT_VERSION = 5.0;
-OTHER_SWIFT_FLAGS = $(inherited) $(OTHER_SWIFT_FLAGS$(WK_MACOS_1400)) -no-warnings-as-errors -Xfrontend -experimental-spi-only-imports -Xfrontend -enable-experimental-concurrency -enable-upcoming-feature IsolatedDefaultValues $(OTHER_SWIFT_FLAGS_AVAILABILITY_$(USE_INTERNAL_SDK));
+OTHER_SWIFT_FLAGS = $(inherited) $(OTHER_SWIFT_FLAGS$(WK_MACOS_1400)) -no-warnings-as-errors -Xfrontend -experimental-spi-only-imports -Xfrontend -enable-experimental-concurrency -Xfrontend -enable-upcoming-feature -Xfrontend IsolatedDefaultValues $(OTHER_SWIFT_FLAGS_AVAILABILITY_$(USE_INTERNAL_SDK));
 OTHER_SWIFT_FLAGS_AVAILABILITY_YES = @$(WK_WEBKITADDITIONS_HEADERS_FOLDER_PATH)/Scripts/availability-definitions.txt;
 
 OTHER_CPLUSPLUSFLAGS = $(inherited) -isystem $(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders;


### PR DESCRIPTION
#### 26754398e658acc6e3dfd1ed9122f87be6452fa9
<pre>
[Swift in WebKit] Downlevel build failure &quot;error: -enable-upcoming-feature IsolatedDefaultValues&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=283219">https://bugs.webkit.org/show_bug.cgi?id=283219</a>
<a href="https://rdar.apple.com/140004811">rdar://140004811</a>

Unreviewed build fix.

Old versions of swift are complaining about not recognizing these
compiler flags, despite AFAICT the language officially supporting the
&quot;enable-upcoming-feature&quot; directive.

    SwiftDriver WebKit normal x86_64 com.apple.xcode.tools.swift.compiler (in target &apos;WebKit&apos; from project &apos;WebKit&apos;)
    ...
    warning: Save unknown driver flag -enable-upcoming-feature as additional swift-frontend flag (in target &apos;WebKit&apos; from project &apos;WebKit&apos;)
    error: Unexpected input file: OpenSource/Source/WebKit/IsolatedDefaultValues (in target &apos;WebKit&apos; from project &apos;WebKit&apos;)

This isn&apos;t affecting open source builds, so maybe it&apos;s due to a slight
difference between compilers. I see that other options like this one are
passed directly to the frontend with -Xfrontend. Do that as a
speculative fix.

* Source/WebKit/Configurations/Base.xcconfig:

Canonical link: <a href="https://commits.webkit.org/286682@main">https://commits.webkit.org/286682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f79c5d59f18df9ed00699eb7d8f21217f39ef79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81284 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28027 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4079 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60135 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/18230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79818 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50085 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/65897 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40457 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47487 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26351 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82728 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4127 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/2725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4280 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65869 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67673 "Found 1 new API test failure: /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16878 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11655 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4074 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/6883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4097 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7527 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5855 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->