### PR TITLE
Make RemoteAudioDestinationManager ref-counted

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -272,6 +272,7 @@ private:
 
 #if ENABLE(WEB_AUDIO)
     RemoteAudioDestinationManager& remoteAudioDestinationManager();
+    Ref<RemoteAudioDestinationManager> protectedRemoteAudioDestinationManager();
 #endif
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     Ref<RemoteSampleBufferDisplayLayerManager> protectedSampleBufferDisplayLayerManager() const;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
@@ -193,6 +193,16 @@ RemoteAudioDestinationManager::RemoteAudioDestinationManager(GPUConnectionToWebP
 
 RemoteAudioDestinationManager::~RemoteAudioDestinationManager() = default;
 
+void RemoteAudioDestinationManager::ref() const
+{
+    m_gpuConnectionToWebProcess.get()->ref();
+}
+
+void RemoteAudioDestinationManager::deref() const
+{
+    m_gpuConnectionToWebProcess.get()->deref();
+}
+
 void RemoteAudioDestinationManager::createAudioDestination(RemoteAudioDestinationIdentifier identifier, const String& inputDeviceId, uint32_t numberOfInputChannels, uint32_t numberOfOutputChannels, float sampleRate, float hardwareSampleRate, IPC::Semaphore&& renderSemaphore, WebCore::SharedMemory::Handle&& handle)
 {
     auto connection = m_gpuConnectionToWebProcess.get();

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
@@ -42,14 +42,12 @@
 #include "SharedCARingBuffer.h"
 #endif
 
-
 namespace WebCore {
 #if PLATFORM(COCOA)
 class CAAudioStreamDescription;
 #endif
 class SharedMemoryHandle;
 }
-
 
 namespace WebKit {
 
@@ -63,6 +61,9 @@ class RemoteAudioDestinationManager : private IPC::MessageReceiver {
 public:
     RemoteAudioDestinationManager(GPUConnectionToWebProcess&);
     ~RemoteAudioDestinationManager();
+
+    void ref() const;
+    void deref() const;
 
     void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
 


### PR DESCRIPTION
#### 33e9ede75da51a58bc155519ee8e7560f9c050b8
<pre>
Make RemoteAudioDestinationManager ref-counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=283221">https://bugs.webkit.org/show_bug.cgi?id=283221</a>
<a href="https://rdar.apple.com/140016649">rdar://140016649</a>

Reviewed by Chris Dumez.

As part of our effort to eventually make IPC::MessageReceiver
ref-counted, we&apos;re making each of its subclasses ref-counted.
RemoteAudioDestinationManager is one of them.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::allowsExitUnderMemoryPressure const):
(WebKit::GPUConnectionToWebProcess::remoteAudioDestinationManager):
(WebKit::GPUConnectionToWebProcess::protectedRemoteAudioDestinationManager):
(WebKit::GPUConnectionToWebProcess::dispatchMessage):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp:
(WebKit::RemoteAudioDestinationManager::ref const):
(WebKit::RemoteAudioDestinationManager::deref const):
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h:

Canonical link: <a href="https://commits.webkit.org/286703@main">https://commits.webkit.org/286703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcd7129a91c663612ba7664c0988343a2fbab754

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81287 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28030 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4082 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60139 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18232 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79821 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65898 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40460 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47491 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26354 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68608 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82731 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4130 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2726 "Found 1 new test failure: fast/css/view-transitions-hide-under-page-background-color.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68426 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4283 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67678 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11656 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9740 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11892 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4077 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6886 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4100 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7530 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5858 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->