### PR TITLE
Further reduce use of IsDeprecatedTimerSmartPointerException in WebCore/

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -103,7 +103,6 @@ platform/graphics/ComplexTextController.h
 platform/graphics/DrawGlyphsRecorder.h
 platform/graphics/GraphicsLayer.h
 platform/graphics/ImageBuffer.h
-platform/graphics/ImageFrameAnimator.h
 platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
 platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.h
 platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1587,7 +1587,6 @@ platform/graphics/ImageAdapter.cpp
 platform/graphics/ImageBackingStore.h
 platform/graphics/ImageBufferContextSwitcher.cpp
 platform/graphics/ImageFrame.cpp
-platform/graphics/ImageFrameAnimator.cpp
 platform/graphics/ImageFrameWorkQueue.cpp
 platform/graphics/MediaPlayer.cpp
 platform/graphics/Path.cpp

--- a/Source/WebCore/platform/generic/ScrollbarsControllerGeneric.h
+++ b/Source/WebCore/platform/generic/ScrollbarsControllerGeneric.h
@@ -32,19 +32,13 @@
 
 #include "ScrollbarsController.h"
 #include "Timer.h"
-
-namespace WebCore {
-class ScrollbarsControllerGeneric;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::ScrollbarsControllerGeneric> : std::true_type { };
-}
+#include <wtf/CheckedPtr.h>
 
 namespace WebCore {
 
-class ScrollbarsControllerGeneric final : public ScrollbarsController {
+class ScrollbarsControllerGeneric final : public ScrollbarsController, public CanMakeCheckedPtr<ScrollbarsControllerGeneric> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScrollbarsControllerGeneric);
 public:
     explicit ScrollbarsControllerGeneric(ScrollableArea&);
     virtual ~ScrollbarsControllerGeneric();

--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -87,7 +87,7 @@ ImageFrameAnimator* BitmapImageSource::frameAnimator() const
     if (!isAnimated())
         return nullptr;
 
-    m_frameAnimator = ImageFrameAnimator::create(const_cast<BitmapImageSource&>(*this));
+    m_frameAnimator = makeUniqueWithoutRefCountedCheck<ImageFrameAnimator>(const_cast<BitmapImageSource&>(*this));
     return m_frameAnimator.get();
 }
 
@@ -267,7 +267,7 @@ void BitmapImageSource::startAnimation()
 
 bool BitmapImageSource::startAnimation(SubsamplingLevel subsamplingLevel, const DecodingOptions& options)
 {
-    auto frameAnimator = this->frameAnimator();
+    RefPtr frameAnimator = this->frameAnimator();
     if (!frameAnimator)
         return false;
 
@@ -363,7 +363,7 @@ void BitmapImageSource::decode(Function<void(DecodingStatus)>&& decodeCallback)
     }
 
     bool isCompatibleNativeImage = isCompatibleWithOptionsAtIndex(index, SubsamplingLevel::Default, DecodingMode::Asynchronous);
-    auto frameAnimator = this->frameAnimator();
+    RefPtr frameAnimator = this->frameAnimator();
 
     if (frameAnimator && (frameAnimator->hasEverAnimated() || isCompatibleNativeImage)) {
         // startAnimation() always decodes the nextFrame which is currentFrameIndex + 1.

--- a/Source/WebCore/platform/graphics/FontCache.h
+++ b/Source/WebCore/platform/graphics/FontCache.h
@@ -39,6 +39,7 @@
 #include "Timer.h"
 #include <array>
 #include <limits.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/Forward.h>
 #include <wtf/HashFunctions.h>
@@ -83,15 +84,6 @@ struct IDWriteFactory;
 #endif
 
 namespace WebCore {
-class FontCache;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::FontCache> : std::true_type { };
-}
-
-namespace WebCore {
 
 class Font;
 class FontCascade;
@@ -122,9 +114,10 @@ enum class FontLookupOptions : uint8_t {
     DisallowObliqueSynthesis = 1 << 2,
 };
 
-class FontCache {
+class FontCache : public CanMakeCheckedPtr<FontCache> {
     WTF_MAKE_TZONE_ALLOCATED(FontCache);
     WTF_MAKE_NONCOPYABLE(FontCache);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FontCache);
 public:
     WEBCORE_EXPORT static FontCache& forCurrentThread();
     static FontCache* forCurrentThreadIfExists();

--- a/Source/WebCore/platform/graphics/ImageFrameAnimator.cpp
+++ b/Source/WebCore/platform/graphics/ImageFrameAnimator.cpp
@@ -34,11 +34,6 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageFrameAnimator);
 
-std::unique_ptr<ImageFrameAnimator> ImageFrameAnimator::create(BitmapImageSource& source)
-{
-    return makeUnique<ImageFrameAnimator>(source);
-}
-
 ImageFrameAnimator::ImageFrameAnimator(BitmapImageSource& source)
     : m_source(source)
     , m_frameCount(source.frameCount())
@@ -48,6 +43,16 @@ ImageFrameAnimator::ImageFrameAnimator(BitmapImageSource& source)
     ASSERT(m_frameCount > 0);
     ASSERT(m_repetitionCount != RepetitionCountNone);
     ASSERT(m_currentFrameIndex < m_frameCount);
+}
+
+void ImageFrameAnimator::ref() const
+{
+    m_source.get()->ref();
+}
+
+void ImageFrameAnimator::deref() const
+{
+    m_source.get()->deref();
 }
 
 ImageFrameAnimator::~ImageFrameAnimator()
@@ -61,10 +66,11 @@ void ImageFrameAnimator::destroyDecodedData(bool destroyAll)
     // only hang on to one frame at a time.
     static constexpr unsigned LargeAnimationCutoff = 30 * 1024 * 1024;
 
-    if (m_source.decodedSize() < LargeAnimationCutoff)
+    RefPtr source = m_source.get();
+    if (source->decodedSize() < LargeAnimationCutoff)
         return;
 
-    m_source.destroyDecodedData(destroyAll);
+    source->destroyDecodedData(destroyAll);
 }
 
 void ImageFrameAnimator::startTimer(Seconds delay)
@@ -83,12 +89,14 @@ void ImageFrameAnimator::timerFired()
 {
     clearTimer();
 
+    RefPtr source = m_source.get();
+
     // Don't advance to nextFrame if the next frame is being decoded.
-    if (m_source.isPendingDecodingAtIndex(nextFrameIndex(), m_nextFrameSubsamplingLevel, m_nextFrameOptions))
+    if (source->isPendingDecodingAtIndex(nextFrameIndex(), m_nextFrameSubsamplingLevel, m_nextFrameOptions))
         return;
 
     advanceAnimation();
-    m_source.imageFrameAtIndexAvailable(m_currentFrameIndex, ImageAnimatingState::Yes, m_source.frameDecodingStatusAtIndex(m_currentFrameIndex));
+    source->imageFrameAtIndexAvailable(m_currentFrameIndex, ImageAnimatingState::Yes, source->frameDecodingStatusAtIndex(m_currentFrameIndex));
 }
 
 bool ImageFrameAnimator::imageFrameDecodeAtIndexHasFinished(unsigned index, ImageAnimatingState animatingState, DecodingStatus decodingStatus)
@@ -107,7 +115,7 @@ bool ImageFrameAnimator::imageFrameDecodeAtIndexHasFinished(unsigned index, Imag
         return true;
 
     advanceAnimation();
-    m_source.imageFrameAtIndexAvailable(m_currentFrameIndex, animatingState, decodingStatus);
+    m_source.get()->imageFrameAtIndexAvailable(m_currentFrameIndex, animatingState, decodingStatus);
     return true;
 }
 
@@ -116,8 +124,10 @@ bool ImageFrameAnimator::startAnimation(SubsamplingLevel subsamplingLevel, const
     if (m_frameTimer)
         return true;
 
+    RefPtr source = m_source.get();
+
     // ImageObserver may disallow animation.
-    if (!m_source.isAnimationAllowed())
+    if (!source->isAnimationAllowed())
         return false;
 
     m_nextFrameSubsamplingLevel = subsamplingLevel;
@@ -127,7 +137,7 @@ bool ImageFrameAnimator::startAnimation(SubsamplingLevel subsamplingLevel, const
 
     if (options.decodingMode() == DecodingMode::Asynchronous) {
         LOG(Images, "ImageFrameAnimator::%s - %p - url: %s. Decoding for frame at index = %d will be requested.", __FUNCTION__, this, sourceUTF8(), nextFrameIndex());
-        m_source.requestNativeImageAtIndexIfNeeded(nextFrameIndex(), subsamplingLevel, ImageAnimatingState::Yes, options);
+        source->requestNativeImageAtIndexIfNeeded(nextFrameIndex(), subsamplingLevel, ImageAnimatingState::Yes, options);
     }
 
     auto time = MonotonicTime::now();
@@ -136,7 +146,7 @@ bool ImageFrameAnimator::startAnimation(SubsamplingLevel subsamplingLevel, const
     if (!m_desiredFrameStartTime)
         m_desiredFrameStartTime = time;
 
-    auto duration = m_source.frameDurationAtIndex(m_currentFrameIndex);
+    auto duration = source->frameDurationAtIndex(m_currentFrameIndex);
 
     // Setting 'm_desiredFrameStartTime' to 'time' means we are late; otherwise we are early.
     m_desiredFrameStartTime = std::max(time, m_desiredFrameStartTime + duration);
@@ -167,7 +177,7 @@ void ImageFrameAnimator::resetAnimation()
 {
     stopAnimation();
 
-    m_currentFrameIndex = m_source.primaryFrameIndex();
+    m_currentFrameIndex = m_source.get()->primaryFrameIndex();
     m_repetitionsComplete = RepetitionCountNone;
     m_desiredFrameStartTime = { };
 
@@ -182,7 +192,7 @@ bool ImageFrameAnimator::isAnimationAllowed() const
 
 const char* ImageFrameAnimator::sourceUTF8() const
 {
-    return m_source.sourceUTF8();
+    return m_source.get()->sourceUTF8();
 }
 
 void ImageFrameAnimator::dump(TextStream& ts) const

--- a/Source/WebCore/platform/graphics/ImageFrameAnimator.h
+++ b/Source/WebCore/platform/graphics/ImageFrameAnimator.h
@@ -29,15 +29,7 @@
 #include "ImageTypes.h"
 #include "Timer.h"
 #include <wtf/TZoneMalloc.h>
-
-namespace WebCore {
-class ImageFrameAnimator;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::ImageFrameAnimator> : std::true_type { };
-}
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 
@@ -47,9 +39,11 @@ class ImageFrame;
 class ImageFrameAnimator {
     WTF_MAKE_TZONE_ALLOCATED(ImageFrameAnimator);
 public:
-    static std::unique_ptr<ImageFrameAnimator> create(BitmapImageSource&);
+    explicit ImageFrameAnimator(BitmapImageSource&);
 
-    ImageFrameAnimator(BitmapImageSource&);
+    void ref() const;
+    void deref() const;
+
     ~ImageFrameAnimator();
 
     bool imageFrameDecodeAtIndexHasFinished(unsigned index, ImageAnimatingState, DecodingStatus);
@@ -77,7 +71,7 @@ private:
 
     const char* sourceUTF8() const;
 
-    BitmapImageSource& m_source;
+    ThreadSafeWeakPtr<BitmapImageSource> m_source; // Cannot be null.
     unsigned m_frameCount { 0 };
     RepetitionCount m_repetitionCount { RepetitionCountNone };
 

--- a/Source/WebCore/platform/graphics/MediaPlaybackTargetPicker.h
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTargetPicker.h
@@ -29,24 +29,18 @@
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 
 #include "PlatformView.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Ref.h>
 #include <wtf/RunLoop.h>
-
-namespace WebCore {
-class MediaPlaybackTargetPicker;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::MediaPlaybackTargetPicker> : std::true_type { };
-}
 
 namespace WebCore {
 
 class FloatRect;
 class MediaPlaybackTarget;
 
-class MediaPlaybackTargetPicker {
+class MediaPlaybackTargetPicker : public CanMakeCheckedPtr<MediaPlaybackTargetPicker> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaPlaybackTargetPicker);
 public:
     class Client {
     protected:

--- a/Source/WebCore/platform/graphics/ShadowBlur.cpp
+++ b/Source/WebCore/platform/graphics/ShadowBlur.cpp
@@ -36,6 +36,7 @@
 #include "ImageBuffer.h"
 #include "PixelBuffer.h"
 #include "Timer.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Lock.h>
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
@@ -45,15 +46,6 @@
 #include <wtf/TZoneMallocInlines.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
-namespace WebCore {
-class ScratchBuffer;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::ScratchBuffer> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -71,8 +63,9 @@ static inline int roundUpToMultipleOf32(int d)
 // ShadowBlur needs a scratch image as the buffer for the blur filter.
 // Instead of creating and destroying the buffer for every operation,
 // we create a buffer which will be automatically purged via a timer.
-class ScratchBuffer {
+class ScratchBuffer final : public CanMakeThreadSafeCheckedPtr<ScratchBuffer> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(ScratchBuffer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScratchBuffer);
 public:
     ScratchBuffer()
         : m_purgeTimer(RunLoop::main(), this, &ScratchBuffer::purgeTimerFired)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlaybackTargetPickerMac.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlaybackTargetPickerMac.h
@@ -38,6 +38,7 @@ namespace WebCore {
 class MediaPlaybackTargetPickerMac final : public MediaPlaybackTargetPicker, public AVPlaybackTargetPickerClient {
     WTF_MAKE_TZONE_ALLOCATED(MediaPlaybackTargetPickerMac);
     WTF_MAKE_NONCOPYABLE(MediaPlaybackTargetPickerMac);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaPlaybackTargetPickerMac);
 public:
     explicit MediaPlaybackTargetPickerMac(MediaPlaybackTargetPicker::Client&);
     virtual ~MediaPlaybackTargetPickerMac();

--- a/Source/WebCore/platform/graphics/ca/TileCoverageMap.h
+++ b/Source/WebCore/platform/graphics/ca/TileCoverageMap.h
@@ -31,18 +31,10 @@
 #include "PlatformCALayer.h"
 #include "PlatformCALayerClient.h"
 #include "Timer.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
-
-namespace WebCore {
-class TileCoverageMap;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::TileCoverageMap> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -51,9 +43,10 @@ class IntPoint;
 class IntRect;
 class TileController;
 
-class TileCoverageMap : public PlatformCALayerClient {
+class TileCoverageMap final : public PlatformCALayerClient, public CanMakeCheckedPtr<TileCoverageMap> {
     WTF_MAKE_TZONE_ALLOCATED(TileCoverageMap);
     WTF_MAKE_NONCOPYABLE(TileCoverageMap);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TileCoverageMap);
 public:
     TileCoverageMap(const TileController&);
     ~TileCoverageMap();

--- a/Source/WebCore/platform/mock/DeviceOrientationClientMock.h
+++ b/Source/WebCore/platform/mock/DeviceOrientationClientMock.h
@@ -29,18 +29,9 @@
 #include "DeviceOrientationClient.h"
 #include "DeviceOrientationData.h"
 #include "Timer.h"
-
+#include <wtf/CheckedPtr.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
-
-namespace WebCore {
-class DeviceOrientationClientMock;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::DeviceOrientationClientMock> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -49,15 +40,16 @@ class DeviceOrientationController;
 // A mock implementation of DeviceOrientationClient used to test the feature in
 // DumpRenderTree. Embedders should should configure the Page object to use this
 // client when running DumpRenderTree.
-class DeviceOrientationClientMock : public DeviceOrientationClient {
+class DeviceOrientationClientMock final : public DeviceOrientationClient, public CanMakeCheckedPtr<DeviceOrientationClientMock> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(DeviceOrientationClientMock, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceOrientationClientMock);
 public:
     WEBCORE_EXPORT DeviceOrientationClientMock();
 
     // DeviceOrientationClient
-    void setController(DeviceOrientationController*) override;
-    void startUpdating() override;
-    void stopUpdating() override;
+    WEBCORE_EXPORT void setController(DeviceOrientationController*) override;
+    WEBCORE_EXPORT void startUpdating() override;
+    WEBCORE_EXPORT void stopUpdating() override;
     DeviceOrientationData* lastOrientation() const override { return m_orientation.get(); }
     void deviceOrientationControllerDestroyed() override { }
 

--- a/Source/WebCore/platform/mock/MediaPlaybackTargetPickerMock.h
+++ b/Source/WebCore/platform/mock/MediaPlaybackTargetPickerMock.h
@@ -47,6 +47,7 @@ namespace WebCore {
 class MediaPlaybackTargetPickerMock final : public MediaPlaybackTargetPicker, public CanMakeWeakPtr<MediaPlaybackTargetPickerMock> {
     WTF_MAKE_TZONE_ALLOCATED(MediaPlaybackTargetPickerMock);
     WTF_MAKE_NONCOPYABLE(MediaPlaybackTargetPickerMock);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaPlaybackTargetPickerMock);
 public:
     explicit MediaPlaybackTargetPickerMock(MediaPlaybackTargetPicker::Client&);
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -37,15 +37,6 @@
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
-class RenderLayerCompositor;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedTimerSmartPointerException;
-template<> struct IsDeprecatedTimerSmartPointerException<WebCore::RenderLayerCompositor> : std::true_type { };
-}
-
-namespace WebCore {
 
 class DisplayRefreshMonitorFactory;
 class FixedPositionViewportConstraints;


### PR DESCRIPTION
#### 7cdbf035958eb63352db6691b800702c12d71c3c
<pre>
Further reduce use of IsDeprecatedTimerSmartPointerException in WebCore/
<a href="https://bugs.webkit.org/show_bug.cgi?id=283238">https://bugs.webkit.org/show_bug.cgi?id=283238</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/generic/ScrollbarsControllerGeneric.h:
* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::frameAnimator const):
* Source/WebCore/platform/graphics/FontCache.h:
* Source/WebCore/platform/graphics/ImageFrameAnimator.cpp:
(WebCore::ImageFrameAnimator::ref const):
(WebCore::ImageFrameAnimator::deref const):
(WebCore::ImageFrameAnimator::destroyDecodedData):
(WebCore::ImageFrameAnimator::timerFired):
(WebCore::ImageFrameAnimator::imageFrameDecodeAtIndexHasFinished):
(WebCore::ImageFrameAnimator::startAnimation):
(WebCore::ImageFrameAnimator::resetAnimation):
(WebCore::ImageFrameAnimator::sourceUTF8 const):
(WebCore::ImageFrameAnimator::create): Deleted.
* Source/WebCore/platform/graphics/ImageFrameAnimator.h:
* Source/WebCore/platform/graphics/MediaPlaybackTargetPicker.h:
* Source/WebCore/platform/graphics/ShadowBlur.cpp:
(WebCore::ScratchBuffer::ScratchBuffer): Deleted.
(WebCore::ScratchBuffer::WTF_REQUIRES_LOCK): Deleted.
(WebCore::ScratchBuffer::WTF_RETURNS_LOCK): Deleted.
(WebCore::ScratchBuffer::scheduleScratchBufferPurge): Deleted.
(WebCore::ScratchBuffer::purgeTimerFired): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlaybackTargetPickerMac.h:
* Source/WebCore/platform/graphics/ca/TileCoverageMap.h:
(WebCore::TileCoverageMap::setPosition): Deleted.
(WebCore::TileCoverageMap::layer): Deleted.
* Source/WebCore/platform/mock/DeviceOrientationClientMock.h:
* Source/WebCore/platform/mock/MediaPlaybackTargetPickerMock.h:
* Source/WebCore/rendering/RenderLayerCompositor.h:

Canonical link: <a href="https://commits.webkit.org/286709@main">https://commits.webkit.org/286709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e62f0bfb6df9702761842c4dfc4d2907123bdac2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81413 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28148 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78989 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4200 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60233 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18314 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65991 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40550 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47584 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23486 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26473 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68701 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82852 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4248 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2823 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68512 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4402 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65964 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67767 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11751 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9834 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11897 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4195 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7008 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4218 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7649 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5976 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->