### PR TITLE
Non-unified build fixes, mid-November 2024 edition

### DIFF
--- a/Source/WTF/wtf/glib/GRefPtr.h
+++ b/Source/WTF/wtf/glib/GRefPtr.h
@@ -31,10 +31,20 @@
 extern "C" {
     typedef struct _GDBusConnection GDBusConnection;
     typedef struct _GDBusNodeInfo GDBusNodeInfo;
+
     GDBusNodeInfo* g_dbus_node_info_ref(GDBusNodeInfo*);
     void g_dbus_node_info_unref(GDBusNodeInfo*);
+
+    // Since GLib 2.56 a g_object_ref_sink() macro may be defined which propagates
+    // the type of the parameter to the returned value, but it conflicts with the
+    // declaration below, causing an error when glib-object.h is included before
+    // this file. Thus, add the forward declarations only when the macro is not
+    // present.
+#ifndef g_object_ref_sink
+    void g_object_unref(gpointer);
+    gpointer g_object_ref_sink(gpointer);
+#endif
 };
-extern "C" void g_object_unref(gpointer);
 
 namespace WTF {
 

--- a/Source/WTF/wtf/glib/Sandbox.cpp
+++ b/Source/WTF/wtf/glib/Sandbox.cpp
@@ -27,7 +27,6 @@
 #include <wtf/glib/Sandbox.h>
 
 #include <gio/gio.h>
-#include <glib.h>
 #include <wtf/FileSystem.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/glib/GRefPtr.h>

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
@@ -32,6 +32,7 @@
 #include "HTMLCanvasElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLVideoElement.h"
+#include "ImageBitmap.h"
 #include "JSWebCodecsVideoFrame.h"
 #include "Logging.h"
 #include "OffscreenCanvas.h"

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNodeNicosia.cpp
@@ -32,6 +32,7 @@
 #include "Logging.h"
 #include "ScrollingStateOverflowScrollProxyNode.h"
 #include "ScrollingStateTree.h"
+#include "ScrollingTree.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.cpp
@@ -33,6 +33,7 @@
 
 #include "Logging.h"
 #include "ScrollingStatePositionedNode.h"
+#include "ScrollingTree.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/LowPowerModeNotifier.h
+++ b/Source/WebCore/platform/LowPowerModeNotifier.h
@@ -36,7 +36,9 @@ OBJC_CLASS WebLowPowerModeObserver;
 
 #if USE(GLIB)
 #include <wtf/glib/GRefPtr.h>
+extern "C" {
 typedef struct _GPowerProfileMonitor GPowerProfileMonitor;
+};
 #endif
 
 namespace WebCore {

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -34,6 +34,7 @@
 
 namespace WebCore {
 
+class CSSToLengthConversionData;
 class RenderStyle;
 struct BlendingContext;
 

--- a/Source/WebCore/style/values/color-adjust/StyleColorScheme.cpp
+++ b/Source/WebCore/style/values/color-adjust/StyleColorScheme.cpp
@@ -27,6 +27,7 @@
 
 #if ENABLE(DARK_MODE_CSS)
 
+#include "CSSToLengthConversionData.h"
 #include "CSSValueKeywords.h"
 #include <wtf/text/TextStream.h>
 

--- a/Source/WebKit/NetworkProcess/soup/NetworkProcessMainSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkProcessMainSoup.cpp
@@ -29,6 +29,7 @@
 
 #include "AuxiliaryProcessMain.h"
 #include "NetworkProcess.h"
+#include "NetworkSession.h"
 #include <WebCore/NetworkStorageSession.h>
 
 #if USE(GCRYPT)


### PR DESCRIPTION
#### d85604cdce9afa4ca56b9c10047152f995790878
<pre>
Non-unified build fixes, mid-November 2024 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=283241">https://bugs.webkit.org/show_bug.cgi?id=283241</a>

Unreviewed non-unified build fixes.

* Source/WTF/wtf/glib/GRefPtr.h: Avoid forward declarations for
  g_object_unref() and g_object_ref_sink() if they are already defined
  due to an earlier inclusion of glib-object.h.
* Source/WTF/wtf/glib/Sandbox.cpp: Remove unneeded inclusion of glib.h.
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp: Add
  missing ImageBitmap.h inclusion.
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNodeNicosia.cpp:
  Add missing ScrollingTree.h inclusion.
* Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.cpp:
  Ditto.
* Source/WebCore/platform/LowPowerModeNotifier.h: Mark forward declaration
  of GPowerProfileMonitor be extern &quot;C&quot;.
* Source/WebCore/style/values/StyleValueTypes.h: Add forward declaration
  for CSSToLengthConversionData.
* Source/WebCore/style/values/color-adjust/StyleColorScheme.cpp: Add
  missing CSSToLengthConversionData.h inclusion.
* Source/WebKit/NetworkProcess/soup/NetworkProcessMainSoup.cpp: Add
  missing NetworkSession.h inclusion.

Canonical link: <a href="https://commits.webkit.org/286701@main">https://commits.webkit.org/286701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d876bebe163dac56c89f96e7f1c84abf1ca23806

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81336 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28079 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60182 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18272 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65938 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40501 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47532 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23432 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26403 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69986 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68649 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23762 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82780 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76080 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2770 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68468 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4332 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65911 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67721 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11698 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9780 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98334 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11891 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4126 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6937 "Build is in progress. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0; Checked out pull request; Found 47176 issues") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21508 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4149 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7579 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5907 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->