### PR TITLE
Update WTF::writeIntegerToBuffer() to take in a std::span

### DIFF
--- a/Source/WTF/wtf/ObjectIdentifier.h
+++ b/Source/WTF/wtf/ObjectIdentifier.h
@@ -260,7 +260,7 @@ class ObjectIdentifierGenericBaseStringTypeAdapter<uint64_t> {
 public:
     unsigned length() const { return lengthOfIntegerAsString(m_identifier); }
     bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { writeIntegerToBuffer(m_identifier, destination.data()); }
+    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { writeIntegerToBuffer(m_identifier, destination); }
 protected:
     explicit ObjectIdentifierGenericBaseStringTypeAdapter(uint64_t identifier)
         : m_identifier(identifier) { }

--- a/Source/WTF/wtf/text/IntegerToStringConversion.h
+++ b/Source/WTF/wtf/text/IntegerToStringConversion.h
@@ -69,11 +69,11 @@ inline typename IntegerToStringConversionTrait<T>::ReturnType numberToStringUnsi
 }
 
 template<typename CharacterType, typename UnsignedIntegerType, PositiveOrNegativeNumber NumberType>
-static void writeIntegerToBufferImpl(UnsignedIntegerType number, CharacterType* destination)
+static void writeIntegerToBufferImpl(UnsignedIntegerType number, std::span<CharacterType> destination)
 {
     static_assert(!std::is_same_v<bool, std::remove_cv_t<UnsignedIntegerType>>, "'bool' not supported");
-    LChar buf[sizeof(UnsignedIntegerType) * 3 + 1];
-    LChar* end = std::end(buf);
+    std::array<LChar, sizeof(UnsignedIntegerType) * 3 + 1> buf;
+    LChar* end = std::to_address(buf.end());
     LChar* p = end;
 
     do {
@@ -84,12 +84,12 @@ static void writeIntegerToBufferImpl(UnsignedIntegerType number, CharacterType* 
     if (NumberType == NegativeNumber)
         *--p = '-';
     
-    while (p < end)
-        *destination++ = static_cast<CharacterType>(*p++);
+    for (size_t i = 0; i < static_cast<size_t>(end - p); ++i)
+        destination[i] = static_cast<CharacterType>(p[i]);
 }
 
 template<typename CharacterType, typename IntegerType>
-inline void writeIntegerToBuffer(IntegerType integer, CharacterType* destination)
+inline void writeIntegerToBuffer(IntegerType integer, std::span<CharacterType> destination)
 {
     static_assert(std::is_integral_v<IntegerType>);
     if constexpr (std::is_same_v<IntegerType, bool>)

--- a/Source/WTF/wtf/text/StringConcatenateNumbers.h
+++ b/Source/WTF/wtf/text/StringConcatenateNumbers.h
@@ -44,7 +44,7 @@ public:
     unsigned length() const { return lengthOfIntegerAsString(m_number); }
     bool is8Bit() const { return true; }
     template<typename CharacterType>
-    void writeTo(std::span<CharacterType> destination) const { writeIntegerToBuffer(m_number, destination.data()); }
+    void writeTo(std::span<CharacterType> destination) const { writeIntegerToBuffer(m_number, destination); }
 
 private:
     Integer m_number;
@@ -62,7 +62,7 @@ public:
     unsigned length() const { return lengthOfIntegerAsString(static_cast<UnderlyingType>(m_enum)); }
     bool is8Bit() const { return true; }
     template<typename CharacterType>
-    void writeTo(std::span<CharacterType> destination) const { writeIntegerToBuffer(static_cast<UnderlyingType>(m_enum), destination.data()); }
+    void writeTo(std::span<CharacterType> destination) const { writeIntegerToBuffer(static_cast<UnderlyingType>(m_enum), destination); }
 
 private:
     Enum m_enum;

--- a/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
@@ -1091,9 +1091,9 @@ constexpr size_t maxUChar32Digits = 10;
 
 static void appendDecimal(char32_t c, Vector<uint8_t>& result)
 {
-    uint8_t buffer[lengthOfIntegerAsString(std::numeric_limits<decltype(c)>::max())];
-    writeIntegerToBuffer(c, buffer);
-    result.append(std::span { buffer, lengthOfIntegerAsString(c) });
+    std::array<uint8_t, lengthOfIntegerAsString(std::numeric_limits<decltype(c)>::max())> buffer;
+    writeIntegerToBuffer(c, std::span<uint8_t> { buffer });
+    result.append(std::span { buffer }.first(lengthOfIntegerAsString(c)));
 }
 
 static void urlEncodedEntityUnencodableHandler(char32_t c, Vector<uint8_t>& result)

--- a/Source/WebCore/platform/ProcessQualified.h
+++ b/Source/WebCore/platform/ProcessQualified.h
@@ -168,9 +168,9 @@ public:
     template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const
     {
         auto processIdentifierLength = lengthOfIntegerAsString(m_processIdentifier);
-        writeIntegerToBuffer(m_processIdentifier, destination.data());
+        writeIntegerToBuffer(m_processIdentifier, destination);
         destination[processIdentifierLength] = '-';
-        writeIntegerToBuffer(m_objectIdentifier, destination.subspan(processIdentifierLength + 1).data());
+        writeIntegerToBuffer(m_objectIdentifier, destination.subspan(processIdentifierLength + 1));
     }
 protected:
     explicit ProcessQualifiedStringTypeAdapter(uint64_t processIdentifier, uint64_t objectIdentifier)

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -731,7 +731,7 @@ void TileGrid::drawTileMapContents(CGContextRef context, CGRect layerBounds) con
 
         auto repaintCount = m_tileRepaintCounts.count(tileLayer);
         std::array<char8_t, lengthOfIntegerAsString(std::numeric_limits<decltype(repaintCount)>::max())> repaintCountCharacters;
-        writeIntegerToBuffer(repaintCount, repaintCountCharacters.data());
+        writeIntegerToBuffer(repaintCount, std::span<char8_t> { repaintCountCharacters });
         tileLayer->drawTextAtPoint(context, frame.origin.x + 64, frame.origin.y + 192, CGSizeMake(3, -3), 58, repaintCountCharacters);
 
         CGContextRestoreGState(context);


### PR DESCRIPTION
#### 04734c4544d9eb9f28e684326e055afd99780564
<pre>
Update WTF::writeIntegerToBuffer() to take in a std::span
<a href="https://bugs.webkit.org/show_bug.cgi?id=283243">https://bugs.webkit.org/show_bug.cgi?id=283243</a>

Reviewed by Geoffrey Garen.

* Source/WTF/wtf/ObjectIdentifier.h:
(WTF::ObjectIdentifierGenericBaseStringTypeAdapter&lt;uint64_t&gt;::writeTo const):
* Source/WTF/wtf/text/IntegerToStringConversion.h:
(WTF::writeIntegerToBufferImpl):
(WTF::writeIntegerToBuffer):
* Source/WTF/wtf/text/StringConcatenateNumbers.h:
* Source/WebCore/PAL/pal/text/TextCodecCJK.cpp:
(PAL::appendDecimal):
* Source/WebCore/platform/ProcessQualified.h:
(WTF::ProcessQualifiedStringTypeAdapter::writeTo const):
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::drawTileMapContents const):

Canonical link: <a href="https://commits.webkit.org/286700@main">https://commits.webkit.org/286700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d749fd60c779008459ebba22fdbbe2bfe4f93f1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81346 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28088 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/78929 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60188 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18279 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50140 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65946 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40507 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47542 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23440 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26412 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69995 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68659 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23770 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82789 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76089 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4188 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2777 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68473 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67728 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11705 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9788 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98343 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11890 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4135 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6947 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21512 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4158 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7589 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5916 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->