### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in wtf/HexNumber.h

### DIFF
--- a/Source/WTF/wtf/HexNumber.cpp
+++ b/Source/WTF/wtf/HexNumber.cpp
@@ -31,26 +31,21 @@ namespace WTF {
 
 namespace Internal {
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
-std::pair<LChar*, unsigned> appendHex(LChar* buffer, unsigned bufferSize, std::uintmax_t number, unsigned minimumDigits, HexConversionMode mode)
+std::span<LChar> appendHex(std::span<LChar> buffer, std::uintmax_t number, unsigned minimumDigits, HexConversionMode mode)
 {
-    auto end = buffer + bufferSize;
-    auto start = end;
-    auto hexDigits = hexDigitsForMode(mode);
+    size_t startIndex = buffer.size();
+    auto& hexDigits = hexDigitsForMode(mode);
     do {
-        *--start = hexDigits[number & 0xF];
+        buffer[--startIndex] = hexDigits[number & 0xF];
         number >>= 4;
     } while (number);
-    auto startWithLeadingZeros = end - std::min(minimumDigits, bufferSize);
-    if (start > startWithLeadingZeros) {
-        std::memset(startWithLeadingZeros, '0', start - startWithLeadingZeros);
-        start = startWithLeadingZeros;
+    auto startIndexWithLeadingZeros = buffer.size() - std::min<size_t>(minimumDigits, buffer.size());
+    if (startIndex > startIndexWithLeadingZeros) {
+        memsetSpan(buffer.subspan(startIndexWithLeadingZeros, startIndex - startIndexWithLeadingZeros), '0');
+        startIndex = startIndexWithLeadingZeros;
     }
-    return { start, end - start };
+    return buffer.subspan(startIndex);
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 }
 

--- a/Source/WTF/wtf/HexNumber.h
+++ b/Source/WTF/wtf/HexNumber.h
@@ -23,27 +23,25 @@
 #include <array>
 #include <wtf/text/StringImpl.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 enum HexConversionMode { Lowercase, Uppercase };
 
 namespace Internal {
 
-inline const LChar* hexDigitsForMode(HexConversionMode mode)
+inline const std::array<LChar, 16>& hexDigitsForMode(HexConversionMode mode)
 {
-    static const LChar lowercaseHexDigits[17] = "0123456789abcdef";
-    static const LChar uppercaseHexDigits[17] = "0123456789ABCDEF";
+    static constexpr std::array<LChar, 16> lowercaseHexDigits { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+    static constexpr std::array<LChar, 16> uppercaseHexDigits { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
     return mode == Lowercase ? lowercaseHexDigits : uppercaseHexDigits;
 }
 
-WTF_EXPORT_PRIVATE std::pair<LChar*, unsigned> appendHex(LChar* buffer, unsigned bufferSize, std::uintmax_t number, unsigned minimumDigits, HexConversionMode);
+WTF_EXPORT_PRIVATE std::span<LChar> appendHex(std::span<LChar> buffer, std::uintmax_t number, unsigned minimumDigits, HexConversionMode);
 
 template<size_t arraySize, typename NumberType>
-inline std::pair<LChar*, unsigned> appendHex(std::array<LChar, arraySize>& buffer, NumberType number, unsigned minimumDigits, HexConversionMode mode)
+inline std::span<LChar> appendHex(std::array<LChar, arraySize>& buffer, NumberType number, unsigned minimumDigits, HexConversionMode mode)
 {
-    return appendHex(&buffer.front(), buffer.size(), static_cast<typename std::make_unsigned<NumberType>::type>(number), minimumDigits, mode);
+    return appendHex(std::span<LChar> { buffer }, static_cast<typename std::make_unsigned<NumberType>::type>(number), minimumDigits, mode);
 }
 
 } // namespace Internal
@@ -63,7 +61,7 @@ template<typename NumberType> HexNumberBuffer hex(NumberType number, unsigned mi
     HexNumberBuffer buffer;
     static_assert(sizeof(buffer.buffer) >= sizeof(NumberType) * 2, "number too large for hexNumber");
     auto result = Internal::appendHex(buffer.buffer, number, minimumDigits, mode);
-    buffer.length = result.second;
+    buffer.length = result.size();
     return buffer;
 }
 
@@ -99,5 +97,3 @@ using WTF::hex;
 using WTF::toHexCString;
 using WTF::toHexString;
 using WTF::Lowercase;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### cb1bea10533fe2e34e7b5596613b1ad76e8e1642
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in wtf/HexNumber.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=283245">https://bugs.webkit.org/show_bug.cgi?id=283245</a>

Reviewed by Geoffrey Garen.

* Source/WTF/wtf/HexNumber.cpp:
(WTF::Internal::appendHex):
* Source/WTF/wtf/HexNumber.h:
(WTF::Internal::hexDigitsForMode):
(WTF::Internal::appendHex):
(WTF::hex):

Canonical link: <a href="https://commits.webkit.org/286699@main">https://commits.webkit.org/286699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2834a5c9ff105a5fe3b98349eac739e338f2e134

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81352 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28091 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/64992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4143 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60193 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18282 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50142 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40512 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47544 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23441 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26415 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/69998 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68661 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23771 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82793 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76092 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2780 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68483 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65920 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67737 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11707 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9789 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98346 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11889 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4138 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21513 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4161 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7592 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5919 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->