### PR TITLE
Add JS API to attach metadata to an element during autofill

### DIFF
--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -60,6 +60,9 @@ public:
     void setAllowAutofill() { m_allowAutofill = true; }
     bool allowAutofill() const { return m_allowAutofill; }
 
+    void setAllowElementUserInfo() { m_allowElementUserInfo = true; }
+    bool allowElementUserInfo() const { return m_allowElementUserInfo; }
+
     void setShadowRootIsAlwaysOpen() { m_shadowRootIsAlwaysOpen = true; }
     bool shadowRootIsAlwaysOpen() const { return m_shadowRootIsAlwaysOpen; }
 
@@ -88,6 +91,7 @@ private:
     Type m_type { Type::Internal };
 
     bool m_allowAutofill { false };
+    bool m_allowElementUserInfo { false };
     bool m_shadowRootIsAlwaysOpen { false };
     bool m_shouldDisableLegacyOverrideBuiltInsBehavior { false };
 };

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -159,6 +159,7 @@
 #include "XMLNSNames.h"
 #include "XMLNames.h"
 #include "markup.h"
+#include <JavaScriptCore/JSONObject.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -2182,6 +2183,24 @@ bool Element::isElementsArrayReflectionAttribute(const QualifiedName& name)
         break;
     }
     return false;
+}
+
+void Element::setUserInfo(JSC::JSGlobalObject& globalObject, JSC::JSValue userInfo)
+{
+    auto throwScope = DECLARE_THROW_SCOPE(globalObject.vm());
+
+    auto serializedData = JSONStringify(&globalObject, userInfo, 0);
+    if (throwScope.exception())
+        return;
+
+    ensureElementRareData().setUserInfo(WTFMove(serializedData));
+}
+
+String Element::userInfo() const
+{
+    if (!hasRareData())
+        return { };
+    return elementRareData()->userInfo();
 }
 
 void Element::notifyAttributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason reason)

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -42,6 +42,7 @@
 
 namespace JSC {
 class JSGlobalObject;
+class JSValue;
 }
 
 namespace WebCore {
@@ -185,6 +186,9 @@ public:
     WEBCORE_EXPORT void setElementsArrayAttribute(const QualifiedName& attributeName, std::optional<Vector<Ref<Element>>>&& value);
     static bool isElementReflectionAttribute(const Settings&, const QualifiedName&);
     static bool isElementsArrayReflectionAttribute(const QualifiedName&);
+
+    WEBCORE_EXPORT void setUserInfo(JSC::JSGlobalObject&, JSC::JSValue);
+    WEBCORE_EXPORT String userInfo() const;
 
     // Call this to get the value of an attribute that is known not to be the style
     // attribute or one of the SVG animatable attributes.

--- a/Source/WebCore/dom/Element.idl
+++ b/Source/WebCore/dom/Element.idl
@@ -96,6 +96,9 @@
 
     // Non-standard: https://developer.apple.com/reference/webkitjs/element/1629580-onwebkitplaybacktargetavailabili.
     [NotEnumerable, Conditional=WIRELESS_PLAYBACK_TARGET] attribute EventHandler onwebkitplaybacktargetavailabilitychanged;
+
+    // WebKit extension for DOM wrapper worlds.
+    [EnabledForWorld=allowElementUserInfo, CallWith=CurrentGlobalObject] undefined setUserInfo(any userInfo);
 };
 
 Element includes AccessibilityRole;

--- a/Source/WebCore/dom/ElementRareData.cpp
+++ b/Source/WebCore/dom/ElementRareData.cpp
@@ -40,7 +40,7 @@ struct SameSizeAsElementRareData : NodeRareData {
     IntPoint savedLayerScrollPosition;
     HashMap<std::optional<Style::PseudoElementIdentifier>, std::unique_ptr<ElementAnimationRareData>> animationRareData;
     HashMap<std::optional<Style::PseudoElementIdentifier>, AtomString> viewTransitionCapture;
-    void* pointers[17];
+    void* pointers[18];
     void* intersectionObserverData;
     void* typedOMData[2];
     void* resizeObserverData;

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -95,6 +95,9 @@ public:
     NamedNodeMap* attributeMap() const { return m_attributeMap.get(); }
     void setAttributeMap(std::unique_ptr<NamedNodeMap>&& attributeMap) { m_attributeMap = WTFMove(attributeMap); }
 
+    String userInfo() const { return m_userInfo; }
+    void setUserInfo(String&& userInfo) { m_userInfo = WTFMove(userInfo); }
+
     RenderStyle* computedStyle() const { return m_computedStyle.get(); }
     void setComputedStyle(std::unique_ptr<RenderStyle>&& computedStyle) { m_computedStyle = WTFMove(computedStyle); }
 
@@ -215,6 +218,8 @@ public:
             result.add(UseType::ChildIndex);
         if (!m_customStateSet.isEmpty())
             result.add(UseType::CustomStateSet);
+        if (m_userInfo)
+            result.add(UseType::UserInfo);
         return result;
     }
 #endif
@@ -225,6 +230,8 @@ private:
 
     std::optional<OptionSet<ContentRelevancy>> m_contentRelevancy;
     ScrollPosition m_savedLayerScrollPosition;
+
+    String m_userInfo;
 
     std::unique_ptr<RenderStyle> m_computedStyle;
     std::unique_ptr<RenderStyle> m_displayContentsOrNoneStyle;

--- a/Source/WebCore/dom/Event.cpp
+++ b/Source/WebCore/dom/Event.cpp
@@ -55,6 +55,7 @@ ALWAYS_INLINE Event::Event(MonotonicTime createTime, enum EventInterfaceType eve
     , m_isTrusted { isTrusted == IsTrusted::Yes }
     , m_isExecutingPassiveEventListener { false }
     , m_currentTargetIsInShadowTree { false }
+    , m_isAutofillEvent { false }
     , m_eventPhase { NONE }
     , m_eventInterface(enumToUnderlyingType(eventInterface))
     , m_type { type }

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -155,6 +155,9 @@ public:
 
     virtual String debugDescription() const;
 
+    bool isAutofillEvent() { return m_isAutofillEvent; }
+    void setIsAutofillEvent() { m_isAutofillEvent = true; }
+
 protected:
     explicit Event(enum EventInterfaceType, IsTrusted = IsTrusted::No);
     Event(enum EventInterfaceType, const AtomString& type, CanBubble, IsCancelable, IsComposed = IsComposed::No);
@@ -183,6 +186,7 @@ private:
     unsigned m_isTrusted : 1;
     unsigned m_isExecutingPassiveEventListener : 1;
     unsigned m_currentTargetIsInShadowTree : 1;
+    unsigned m_isAutofillEvent : 1;
 
     unsigned m_eventPhase : 2;
 
@@ -192,7 +196,7 @@ private:
 
     unsigned m_eventInterface : 7 { 0 };
 
-    // 10-bits left.
+    // 9-bits left.
 
     AtomString m_type;
 

--- a/Source/WebCore/dom/EventNames.json
+++ b/Source/WebCore/dom/EventNames.json
@@ -295,6 +295,7 @@
     "webkitAnimationStart": { "categories": ["CSSAnimation"] },
     "webkitBeforeTextInserted": { "defaultEventHandler": true },
     "webkitTransitionEnd": { "categories": ["CSSTransition"] },
+    "webkitautofillrequest": { },
     "webkitbeginfullscreen": { },
     "webkitcurrentplaybacktargetiswirelesschanged": { },
     "webkitendfullscreen": { },

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -354,6 +354,11 @@ void EventTarget::innerInvokeEventListeners(Event& event, EventListenerVector li
         JSC::EnsureStillAliveScope wrapperProtector(callback->wrapper());
         JSC::EnsureStillAliveScope jsFunctionProtector(callback->jsFunction());
 
+        if (UNLIKELY(event.isAutofillEvent())) {
+            if (!worldForDOMObject(*callback->jsFunction()).allowAutofill())
+                continue; // webkitrequestautofill only fires in a world with autofill capability.
+        }
+
         // Do this before invocation to avoid reentrancy issues.
         if (registeredListener->isOnce())
             removeEventListener(event.type(), callback, registeredListener->useCapture());

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -194,6 +194,8 @@ static ASCIILiteral stringForRareDataUseType(NodeRareData::UseType useType)
         return "ExplicitlySetAttrElementsMap"_s;
     case NodeRareData::UseType::Popover:
         return "Popover"_s;
+    case NodeRareData::UseType::UserInfo:
+        return "UserInfo"_s;
     }
     return { };
 }

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -258,6 +258,7 @@ public:
         Popover = 1 << 25,
         DisplayContentsOrNoneStyle = 1 << 26,
         CustomStateSet = 1 << 27,
+        UserInfo = 1 << 28,
     };
 #endif
 

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -815,12 +815,17 @@ bool TextFieldInputType::shouldDrawAutoFillButton() const
 
 void TextFieldInputType::autoFillButtonElementWasClicked()
 {
-    ASSERT(element());
-    Page* page = element()->document().page();
+    RefPtr element = this->element();
+    ASSERT(element);
+    Page* page = element->document().page();
     if (!page)
         return;
 
-    page->chrome().client().handleAutoFillButtonClick(*element());
+    auto event = Event::create(eventNames().webkitautofillrequestEvent, Event::CanBubble::No, Event::IsCancelable::No);
+    event->setIsAutofillEvent();
+    element->dispatchEvent(WTFMove(event));
+
+    page->chrome().client().handleAutoFillButtonClick(*element);
 }
 
 void TextFieldInputType::createContainer(PreserveSelectionRange preserveSelection)

--- a/Source/WebKit/Shared/ContentWorldData.serialization.in
+++ b/Source/WebKit/Shared/ContentWorldData.serialization.in
@@ -23,8 +23,9 @@
 header: "ContentWorldData.h"
 
 [OptionSet] enum class WebKit::ContentWorldOption : uint8_t {
-    AllowAutofill,
     AllowAccessToClosedShadowRoots,
+    AllowAutofill,
+    AllowElementUserInfo,
     DisableLegacyBuiltinOverrides,
 };
 

--- a/Source/WebKit/Shared/ContentWorldShared.h
+++ b/Source/WebKit/Shared/ContentWorldShared.h
@@ -40,9 +40,10 @@ inline ContentWorldIdentifier pageContentWorldIdentifier()
 }
 
 enum class ContentWorldOption : uint8_t {
-    AllowAutofill = 1 << 0,
-    AllowAccessToClosedShadowRoots = 1 << 1,
-    DisableLegacyBuiltinOverrides = 1 << 2,
+    AllowAccessToClosedShadowRoots = 1 << 0,
+    AllowAutofill = 1 << 1,
+    AllowElementUserInfo = 1 << 2,
+    DisableLegacyBuiltinOverrides = 1 << 3,
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/APIContentWorld.h
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.h
@@ -50,11 +50,14 @@ public:
     const WTF::String& name() const { return m_name; }
     WebKit::ContentWorldData worldData() const { return { m_identifier, m_name, m_options }; }
 
+    bool allowAccessToClosedShadowRoots() const { return m_options.contains(WebKit::ContentWorldOption::AllowAccessToClosedShadowRoots); }
+    void setAllowAccessToClosedShadowRoots(bool value) { m_options.add(WebKit::ContentWorldOption::AllowAccessToClosedShadowRoots); }
+
     bool allowAutofill() const { return m_options.contains(WebKit::ContentWorldOption::AllowAutofill); }
     void setAllowAutofill(bool value) { m_options.add(WebKit::ContentWorldOption::AllowAutofill); }
 
-    bool allowAccessToClosedShadowRoots() const { return m_options.contains(WebKit::ContentWorldOption::AllowAccessToClosedShadowRoots); }
-    void setAllowAccessToClosedShadowRoots(bool value) { m_options.add(WebKit::ContentWorldOption::AllowAccessToClosedShadowRoots); }
+    bool allowElementUserInfo() const { return m_options.contains(WebKit::ContentWorldOption::AllowElementUserInfo); }
+    void setAllowElementUserInfo(bool value) { m_options.add(WebKit::ContentWorldOption::AllowElementUserInfo); }
 
     bool disableLegacyBuiltinOverrides() const { return m_options.contains(WebKit::ContentWorldOption::DisableLegacyBuiltinOverrides); }
     void setDisableLegacyBuiltinOverrides(bool value) { m_options.add(WebKit::ContentWorldOption::DisableLegacyBuiltinOverrides); }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm
@@ -31,10 +31,12 @@
 
 static void checkContentWorldOptions(API::ContentWorld& world, _WKContentWorldConfiguration *configuration)
 {
-    if (world.allowAutofill() != (configuration && configuration.allowAutofill))
-        [NSException raise:NSInternalInconsistencyException format:@"The value of allowAutofill does not match the existing world"];
     if (world.allowAccessToClosedShadowRoots() != (configuration && configuration.allowAccessToClosedShadowRoots))
         [NSException raise:NSInternalInconsistencyException format:@"The value of allowAccessToClosedShadowRoots does not match the existing world"];
+    if (world.allowAutofill() != (configuration && configuration.allowAutofill))
+        [NSException raise:NSInternalInconsistencyException format:@"The value of allowAutofill does not match the existing world"];
+    if (world.allowElementUserInfo() != (configuration && configuration.allowElementUserInfo))
+        [NSException raise:NSInternalInconsistencyException format:@"The value of allowElementUserInfo does not match the existing world"];
     if (world.disableLegacyBuiltinOverrides() != (configuration && configuration.disableLegacyBuiltinOverrides))
         [NSException raise:NSInternalInconsistencyException format:@"The value of disableLegacyBuiltinOverrides does not match the existing world"];
 }
@@ -99,10 +101,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 + (WKContentWorld *)_worldWithConfiguration:(_WKContentWorldConfiguration *)configuration
 {
     OptionSet<WebKit::ContentWorldOption> optionSet;
-    if (configuration.allowAutofill)
-        optionSet.add(WebKit::ContentWorldOption::AllowAutofill);
     if (configuration.allowAccessToClosedShadowRoots)
         optionSet.add(WebKit::ContentWorldOption::AllowAccessToClosedShadowRoots);
+    if (configuration.allowAutofill)
+        optionSet.add(WebKit::ContentWorldOption::AllowAutofill);
+    if (configuration.allowElementUserInfo)
+        optionSet.add(WebKit::ContentWorldOption::AllowElementUserInfo);
     if (configuration.disableLegacyBuiltinOverrides)
         optionSet.add(WebKit::ContentWorldOption::DisableLegacyBuiltinOverrides);
     Ref world = API::ContentWorld::sharedWorldWithName(configuration.name, optionSet);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
@@ -49,8 +49,9 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     _WKContentWorldConfiguration *clone = [(_WKContentWorldConfiguration *)[[self class] allocWithZone:zone] init];
 
     clone.name = self.name;
-    clone.allowAutofill = self.allowAutofill;
     clone.allowAccessToClosedShadowRoots = self.allowAccessToClosedShadowRoots;
+    clone.allowAutofill = self.allowAutofill;
+    clone.allowElementUserInfo = self.allowElementUserInfo;
     clone.disableLegacyBuiltinOverrides = self.disableLegacyBuiltinOverrides;
 
     return clone;
@@ -66,8 +67,9 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 - (void)encodeWithCoder:(NSCoder *)coder
 {
     [coder encodeObject:self.name forKey:@"name"];
-    [coder encodeBool:self.allowAutofill forKey:@"allowAutofill"];
     [coder encodeBool:self.allowAccessToClosedShadowRoots forKey:@"allowAccessToClosedShadowRoots"];
+    [coder encodeBool:self.allowAutofill forKey:@"allowAutofill"];
+    [coder encodeBool:self.allowElementUserInfo forKey:@"allowElementUserInfo"];
     [coder encodeBool:self.disableLegacyBuiltinOverrides forKey:@"disableLegacyBuiltinOverrides"];
 }
 
@@ -77,8 +79,9 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
         return nil;
 
     self.name = [coder decodeObjectOfClass:[NSString class] forKey:@"name"];
-    self.allowAutofill = [coder decodeBoolForKey:@"allowAutofill"];
     self.allowAccessToClosedShadowRoots = [coder decodeBoolForKey:@"allowAccessToClosedShadowRoots"];
+    self.allowAutofill = [coder decodeBoolForKey:@"allowAutofill"];
+    self.allowElementUserInfo = [coder decodeBoolForKey:@"allowElementUserInfo"];
     self.disableLegacyBuiltinOverrides = [coder decodeBoolForKey:@"disableLegacyBuiltinOverrides"];
 
     return self;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h
@@ -38,11 +38,14 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 
 @property (nonatomic, copy) NSString *name;
 
+/*! @abstract A boolean value indicating whether every shadow root should be treated as open mode shadow root or not. */
+@property (nonatomic) BOOL allowAccessToClosedShadowRoots;
+
 /*! @abstract A boolean value indicating whether the capability to trigger autofill is exposed to scripts or not. */
 @property (nonatomic) BOOL allowAutofill;
 
-/*! @abstract A boolean value indicating whether every shadow root should be treated as open mode shadow root or not. */
-@property (nonatomic) BOOL allowAccessToClosedShadowRoots;
+/*! @abstract A boolean value indicating whether the ability to attach user info on an element is exposed to scripts or not. */
+@property (nonatomic) BOOL allowElementUserInfo;
 
 /*! @abstract A boolean value indicating whether the behavior that elements with a name attribute overrides builtin methods on document object should be disabled or not. */
 @property (nonatomic) BOOL disableLegacyBuiltinOverrides;

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
@@ -121,6 +121,11 @@ void InjectedBundleScriptWorld::setAllowAutofill()
     m_world->setAllowAutofill();
 }
 
+void InjectedBundleScriptWorld::setAllowElementUserInfo()
+{
+    m_world->setAllowElementUserInfo();
+}
+
 void InjectedBundleScriptWorld::makeAllShadowRootsOpen()
 {
     m_world->setShadowRootIsAlwaysOpen();

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
@@ -54,6 +54,7 @@ public:
 
     void clearWrappers();
     void setAllowAutofill();
+    void setAllowElementUserInfo();
     void makeAllShadowRootsOpen();
     void disableOverrideBuiltinsBehavior();
 

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -122,10 +122,12 @@ InjectedBundleScriptWorld* WebUserContentController::addContentWorld(const Conte
 
     if (addResult.isNewEntry) {
         Ref scriptWorld = addResult.iterator->value.first;
-        if (world.options.contains(ContentWorldOption::AllowAutofill))
-            scriptWorld->setAllowAutofill();
         if (world.options.contains(ContentWorldOption::AllowAccessToClosedShadowRoots))
             scriptWorld->makeAllShadowRootsOpen();
+        if (world.options.contains(ContentWorldOption::AllowAutofill))
+            scriptWorld->setAllowAutofill();
+        if (world.options.contains(ContentWorldOption::AllowElementUserInfo))
+            scriptWorld->setAllowElementUserInfo();
         if (world.options.contains(ContentWorldOption::DisableLegacyBuiltinOverrides))
             scriptWorld->disableOverrideBuiltinsBehavior();
         return scriptWorld.ptr();


### PR DESCRIPTION
#### 4a788cf43c3144d67fdfc2b7c2cae28ec74463a2
<pre>
Add JS API to attach metadata to an element during autofill
<a href="https://bugs.webkit.org/show_bug.cgi?id=283247">https://bugs.webkit.org/show_bug.cgi?id=283247</a>

Reviewed by Wenson Hsieh.

This PR adds a new content world configuration to expose JS API on Element to attach user info,
and pass this information to WKUIDelegatePrivate&apos;s _webView:didClickAutoFillButtonWithUserInfo
during autofill.

It also introduces &quot;webkitautofillrequest&quot; event when the user activates an autofill button in
an input element. The event only fires in a content world where autofill capability is enabled.

* Source/WebCore/bindings/js/DOMWrapperWorld.h:
(WebCore::DOMWrapperWorld::setAllowElementUserInfo):
(WebCore::DOMWrapperWorld::allowElementUserInfo const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setUserInfo):
(WebCore::Element::userInfo const):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Element.idl:
* Source/WebCore/dom/ElementRareData.cpp:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::userInfo const):
(WebCore::ElementRareData::setUserInfo):
(WebCore::ElementRareData::useTypes const):
* Source/WebCore/dom/Event.cpp:
(WebCore::Event::Event):
* Source/WebCore/dom/Event.h:
(WebCore::Event::isAutofillEvent):
(WebCore::Event::setIsAutofillEvent):
* Source/WebCore/dom/EventNames.json:
* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::innerInvokeEventListeners):
* Source/WebCore/dom/Node.cpp:
(WebCore::stringForRareDataUseType):
* Source/WebCore/dom/NodeRareData.h:
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::autoFillButtonElementWasClicked):
* Source/WebKit/Shared/ContentWorldData.serialization.in:
* Source/WebKit/Shared/ContentWorldShared.h:
* Source/WebKit/UIProcess/API/APIContentWorld.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm:
(checkContentWorldOptions):
(+[WKContentWorld _worldWithConfiguration:]):
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm:
(-[_WKContentWorldConfiguration copyWithZone:]):
(-[_WKContentWorldConfiguration encodeWithCoder:]):
(-[_WKContentWorldConfiguration initWithCoder:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp:
(WebKit::InjectedBundleScriptWorld::setAllowElementUserInfo):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::WebUserContentController::addContentWorld):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::userDataFromJSONData):
(WebKit::WebChromeClient::handleAutoFillButtonClick):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm:
(-[AutoFillDelegateForElementUserInfo _webView:didClickAutoFillButtonWithUserInfo:]):
(TEST(WKUserContentController, AllowElementUserInfo)):

Canonical link: <a href="https://commits.webkit.org/286826@main">https://commits.webkit.org/286826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4853bac406f4980295024255bc675973b6454b76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81750 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28470 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79305 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4519 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60481 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18530 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80255 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66252 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40783 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47841 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23750 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26793 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24085 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83175 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4568 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3080 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68755 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/marker-animate-002.html imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-pseudo-class-match.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4724 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66225 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68011 "Found 1 new API test failure: /TestWebKit:WebKit.Find (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11996 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10088 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11954 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4515 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7330 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4534 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7969 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6293 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->