### PR TITLE
[CSS] Implement the target-within Pseudo

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/target-within-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/target-within-expected.txt
@@ -1,0 +1,15 @@
+Article element should have yellow background color
+
+Table of Contents
+
+First paragraph!
+Second paragraph!
+My Article
+
+First paragraph!
+
+Second paragraph!
+
+
+PASS Test target-within
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/target-within.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/target-within.html
@@ -1,0 +1,48 @@
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Test target-within</title>
+<link rel="author" href="mailto:alexbdamac@gmail.com"  title="Alexsander Borges Damaceno">
+<link rel="help" href="https://drafts.csswg.org/selectors/#target-within-pseudo">
+<script src="../../resources/testharness.js""></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+    article:target-within {
+        background-color: yellow;
+    }
+</style>
+</head>
+<body onload="onload_test()">
+<p>Article element should have yellow background color</p>
+<h3>Table of Contents</h3>
+<ol>
+    <li><a id="anchor_P1" href="#p1">First paragraph!</a></li>
+    <li><a href="#p2">Second paragraph!</a></li>
+</ol>
+<article id="article1">
+    <h3>My Article</h3>
+    <p id="p1">
+        First paragraph!
+    </p>
+    <p id="p2">
+        Second paragraph!
+    </p>
+</article>
+<div id="console"></div>
+<script>
+setup({single_test: true});
+function verifyElementBackgroundColor() {
+    const element = document.getElementById('article1');
+    backgroundColor = getComputedStyle(element).backgroundColor; 
+    assert_equals(backgroundColor, 'rgb(255, 255, 0)');
+    done();
+}
+
+function onload_test() { 
+    const elem = document.getElementById("anchor_P1");
+    elem.click();
+    verifyElementBackgroundColor();       
+} 
+</script>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7522,6 +7522,20 @@ TargetTextPseudoElementEnabled:
     WebCore:
       default: true
 
+TargetWithinPseudoElementEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "::target-within pseudo-element"
+  humanReadableDescription: "Enable the ::target-within CSS pseudo-element"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 TelephoneNumberParsingEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -227,6 +227,9 @@
             "status": "non-standard"
         },
         "target": {},
+        "target-within": {
+            "settings-flag": "targetWithinPseudoElementEnabled"
+        },
         "user-invalid": {},
         "user-valid": {},
         "valid": {},

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1026,6 +1026,11 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
             if (&element == element.document().cssTarget() || InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClass::Target))
                 return true;
             break;
+        case CSSSelector::PseudoClass::TargetWithin: {
+            if (InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClass::TargetWithin))
+                return true;
+            return element.isUserActionElement() && element.document().userActionElements().hasTargetWithin(element);
+        }
         case CSSSelector::PseudoClass::Autofill:
             return isAutofilled(element);
         case CSSSelector::PseudoClass::WebKitAutofillAndObscured:

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -116,6 +116,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , lightDarkColorEnabled { document.settings().cssLightDarkEnabled() }
     , contrastColorEnabled { document.settings().cssContrastColorEnabled() }
     , targetTextPseudoElementEnabled { document.settings().targetTextPseudoElementEnabled() }
+    , targetWithinPseudoElementEnabled { document.settings().targetWithinPseudoElementEnabled() }
     , viewTransitionTypesEnabled { document.settings().viewTransitionsEnabled() && document.settings().viewTransitionTypesEnabled() }
     , cssProgressFunctionEnabled { document.settings().cssProgressFunctionEnabled() }
     , cssMediaProgressFunctionEnabled { document.settings().cssMediaProgressFunctionEnabled() }
@@ -160,7 +161,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.cssMediaProgressFunctionEnabled           << 25
         | context.cssContainerProgressFunctionEnabled       << 26
         | context.cssRandomFunctionEnabled                  << 27
-        | (uint32_t)context.mode                            << 28; // This is multiple bits, so keep it last.
+        | context.targetWithinPseudoElementEnabled          << 28
+        | (uint32_t)context.mode                            << 29; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -100,6 +100,7 @@ struct CSSParserContext {
     bool lightDarkColorEnabled : 1 { false };
     bool contrastColorEnabled : 1 { false };
     bool targetTextPseudoElementEnabled : 1 { false };
+    bool targetWithinPseudoElementEnabled : 1 { false };
     bool viewTransitionTypesEnabled : 1 { false };
     bool cssProgressFunctionEnabled : 1 { false };
     bool cssMediaProgressFunctionEnabled : 1 { false };

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -486,6 +486,7 @@ static bool isUserActionPseudoClass(CSSSelector::PseudoClass pseudo)
     case CSSSelector::PseudoClass::Active:
     case CSSSelector::PseudoClass::FocusVisible:
     case CSSSelector::PseudoClass::FocusWithin:
+    case CSSSelector::PseudoClass::TargetWithin:
         return true;
     default:
         return false;

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
@@ -40,6 +40,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& conte
 #endif
     , popoverAttributeEnabled(context.popoverAttributeEnabled)
     , targetTextPseudoElementEnabled(context.targetTextPseudoElementEnabled)
+    , targetWithinPseudoElementEnabled(context.targetWithinPseudoElementEnabled)
     , thumbAndTrackPseudoElementsEnabled(context.thumbAndTrackPseudoElementsEnabled)
     , viewTransitionsEnabled(context.propertySettings.viewTransitionsEnabled)
     , viewTransitionClassesEnabled(viewTransitionsEnabled && context.propertySettings.viewTransitionClassesEnabled)
@@ -55,6 +56,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
 #endif
     , popoverAttributeEnabled(document.settings().popoverAttributeEnabled())
     , targetTextPseudoElementEnabled(document.settings().targetTextPseudoElementEnabled())
+    , targetWithinPseudoElementEnabled(document.settings().targetWithinPseudoElementEnabled())
     , thumbAndTrackPseudoElementsEnabled(document.settings().thumbAndTrackPseudoElementsEnabled())
     , viewTransitionsEnabled(document.settings().viewTransitionsEnabled())
     , viewTransitionClassesEnabled(viewTransitionsEnabled && document.settings().viewTransitionClassesEnabled())
@@ -72,6 +74,7 @@ void add(Hasher& hasher, const CSSSelectorParserContext& context)
 #endif
         context.popoverAttributeEnabled,
         context.targetTextPseudoElementEnabled,
+        context.targetWithinPseudoElementEnabled,
         context.thumbAndTrackPseudoElementsEnabled,
         context.viewTransitionsEnabled,
         context.viewTransitionClassesEnabled,

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.h
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.h
@@ -41,6 +41,7 @@ struct CSSSelectorParserContext {
 #endif
     bool popoverAttributeEnabled : 1 { false };
     bool targetTextPseudoElementEnabled : 1 { false };
+    bool targetWithinPseudoElementEnabled : 1 { false };
     bool thumbAndTrackPseudoElementsEnabled : 1 { false };
     bool viewTransitionsEnabled : 1 { false };
     bool viewTransitionClassesEnabled : 1 { false };

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1262,6 +1262,9 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
         if (selectorContext == SelectorContext::QuerySelector)
             return FunctionType::SimpleSelectorChecker;
         return FunctionType::SelectorCheckerWithCheckingContext;
+    case CSSSelector::PseudoClass::TargetWithin:
+        return FunctionType::CannotCompile;
+
 
     case CSSSelector::PseudoClass::NthChild:
         return addNthChildType(selector, selectorContext, positionInRootFragments, CSSSelector::PseudoClass::FirstChild, visitedMatchEnabled, fragment.nthChildFilters, fragment.nthChildOfFilters, fragment.pseudoClasses);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6292,12 +6292,26 @@ void Document::setCSSTarget(Element* newTarget)
         return;
 
     std::optional<Style::PseudoClassChangeInvalidation> oldInvalidation;
-    if (m_cssTarget)
+    if (m_cssTarget) {
         emplace(oldInvalidation, *m_cssTarget, { { CSSSelector::PseudoClass::Target, false } });
+        for (auto* element = m_cssTarget->parentElement(); element; element = element->parentElement()) {
+            if (element) {
+                Style::PseudoClassChangeInvalidation styleInvalidation(*element, CSSSelector::PseudoClass::TargetWithin, false);
+                element->document().userActionElements().setHasTargetWithin(*element, false);
+            }
+        }
+    }
 
     std::optional<Style::PseudoClassChangeInvalidation> newInvalidation;
-    if (newTarget)
+    if (newTarget) {
         emplace(newInvalidation, *newTarget, { { CSSSelector::PseudoClass::Target, true } });
+        for (auto* element = newTarget->parentElement(); element; element = element->parentElement()) {
+            if (element) {
+                Style::PseudoClassChangeInvalidation styleInvalidation(*element, CSSSelector::PseudoClass::TargetWithin, true);
+                element->document().userActionElements().setHasTargetWithin(*element, true);
+            }
+        }
+    }
     m_cssTarget = newTarget;
 }
 

--- a/Source/WebCore/dom/UserActionElementSet.h
+++ b/Source/WebCore/dom/UserActionElementSet.h
@@ -46,6 +46,7 @@ public:
     bool isBeingDragged(const Element& element) { return hasFlag(element, Flag::IsBeingDragged); }
     bool hasFocusVisible(const Element& element) { return hasFlag(element, Flag::HasFocusVisible); }
     bool hasFocusWithin(const Element& element) { return hasFlag(element, Flag::HasFocusWithin); }
+    bool hasTargetWithin(const Element& element) { return hasFlag(element, Flag::HasTargetWithin); }
 
     void setActive(Element& element, bool enable) { setFlags(element, enable, Flag::IsActive); }
     void setFocused(Element& element, bool enable) { setFlags(element, enable, Flag::IsFocused); }
@@ -54,6 +55,7 @@ public:
     void setBeingDragged(Element& element, bool enable) { setFlags(element, enable, Flag::IsBeingDragged); }
     void setHasFocusVisible(Element& element, bool enable) { setFlags(element, enable, Flag::HasFocusVisible); }
     void setHasFocusWithin(Element& element, bool enable) { setFlags(element, enable, Flag::HasFocusWithin); }
+    void setHasTargetWithin(Element& element, bool enable) { setFlags(element, enable, Flag::HasTargetWithin); }
 
     void clearActiveAndHovered(Element& element) { clearFlags(element, { Flag::IsActive, Flag::InActiveChain, Flag::IsHovered }); }
     void clearAllForElement(Element& element) { clearFlags(element, { Flag::IsActive, Flag::InActiveChain, Flag::IsHovered, Flag::IsFocused, Flag::IsBeingDragged, Flag::HasFocusVisible, Flag::HasFocusWithin }); }
@@ -69,6 +71,7 @@ private:
         IsBeingDragged  = 1 << 4,
         HasFocusVisible = 1 << 5,
         HasFocusWithin  = 1 << 6,
+        HasTargetWithin = 1 << 7,
     };
 
     void setFlags(Element& element, bool enable, OptionSet<Flag> flags) { enable ? setFlags(element, flags) : clearFlags(element, flags); }


### PR DESCRIPTION
#### 788a7a03becdabd58eb3940c5acb7996127ad1f1
<pre>
[CSS] Implement the target-within Pseudo
<a href="https://bugs.webkit.org/show_bug.cgi?id=283248">https://bugs.webkit.org/show_bug.cgi?id=283248</a>

Reviewed by NOBODY (OOPS!).

Implement the target-within Pseudo

* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::isUserActionPseudoClass):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addPseudoClassType):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setCSSTarget):
* Source/WebCore/dom/UserActionElementSet.h:
(WebCore::UserActionElementSet::hasTargetWithin):
(WebCore::UserActionElementSet::setHasTargetWithin):
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml: Added.
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSSelectorParserContext.cpp:
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSSelectorParserContext.h:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/target-within-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/target-within.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/788a7a03becdabd58eb3940c5acb7996127ad1f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15672 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101121 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46567 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73235 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30453 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86777 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53572 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11708 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4531 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45902 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88731 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81854 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4632 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103148 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94679 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82283 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23376 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81655 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26249 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3691 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16481 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23088 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28243 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/118156 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22747 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26227 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24488 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->