### PR TITLE
Added ZippedRange, and ported some improvements from it to IndexedRange

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		143DDE9620C8BC37007F76FA /* Entitlements.mm in Sources */ = {isa = PBXBuildFile; fileRef = 143DDE9520C8BC37007F76FA /* Entitlements.mm */; };
 		143F611F1565F0F900DB514A /* RAMSize.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 143F611D1565F0F900DB514A /* RAMSize.cpp */; };
 		144EB7462CBC94B100926E1B /* AbstractRefCounted.h in Headers */ = {isa = PBXBuildFile; fileRef = 144EB7452CBC94B100926E1B /* AbstractRefCounted.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		145DE2882CE95CE700F9F1D2 /* ZippedRange.h in Headers */ = {isa = PBXBuildFile; fileRef = 145DE2872CE95CE700F9F1D2 /* ZippedRange.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1469419D16EAB10A0024E146 /* AutodrainedPool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1469419B16EAB10A0024E146 /* AutodrainedPool.cpp */; };
 		1470EAF32BD6F6D900E26254 /* WeakPtrImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 1470EAF22BD6F6D900E26254 /* WeakPtrImpl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1470EAF52BD6F8AF00E26254 /* WeakPtrFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 1470EAF42BD6F8AF00E26254 /* WeakPtrFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1135,6 +1136,7 @@
 		1447AEC518FCE57700B3D7FF /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		1447AECA18FCE5B900B3D7FF /* libicucore.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libicucore.dylib; path = /usr/lib/libicucore.dylib; sourceTree = "<absolute>"; };
 		144EB7452CBC94B100926E1B /* AbstractRefCounted.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AbstractRefCounted.h; path = wtf/AbstractRefCounted.h; sourceTree = "<group>"; };
+		145DE2872CE95CE700F9F1D2 /* ZippedRange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZippedRange.h; sourceTree = "<group>"; };
 		1469419416EAAFF80024E146 /* SchedulePair.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SchedulePair.h; sourceTree = "<group>"; };
 		1469419A16EAB10A0024E146 /* AutodrainedPool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AutodrainedPool.h; sourceTree = "<group>"; };
 		1469419B16EAB10A0024E146 /* AutodrainedPool.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AutodrainedPool.cpp; sourceTree = "<group>"; };
@@ -2606,6 +2608,7 @@
 				E36BA9DC29E275DB00300057 /* WTFProcess.cpp */,
 				E36BA9DD29E275DB00300057 /* WTFProcess.h */,
 				A36E16F7216FF828008DD87E /* WTFSemaphore.h */,
+				145DE2872CE95CE700F9F1D2 /* ZippedRange.h */,
 			);
 			path = wtf;
 			sourceTree = "<group>";
@@ -3715,6 +3718,7 @@
 				FFE39CB02B1D7472004972B0 /* wuint.h in Headers */,
 				FF41AC672A79C9BA00AC0FA5 /* WYHash.h in Headers */,
 				DDF306EA27C08654006A526F /* XPCSPI.h in Headers */,
+				145DE2882CE95CE700F9F1D2 /* ZippedRange.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -371,6 +371,7 @@ set(WTF_PUBLIC_HEADERS
     WordLock.h
     WorkQueue.h
     WorkerPool.h
+    ZippedRange.h
     dtoa.h
 
     dragonbox/dragonbox.h

--- a/Source/WTF/wtf/HexNumber.cpp
+++ b/Source/WTF/wtf/HexNumber.cpp
@@ -61,7 +61,7 @@ void printInternal(PrintStream& out, HexNumberBuffer buffer)
 
 static void toHexInternal(std::span<const uint8_t> values, std::span<LChar> hexadecimalOutput)
 {
-    for (auto [i, digestValue] : IndexedRange(values)) {
+    for (auto [i, digestValue] : indexedRange(values)) {
         hexadecimalOutput[i * 2] = upperNibbleToASCIIHexDigit(digestValue);
         hexadecimalOutput[i * 2 + 1] = lowerNibbleToASCIIHexDigit(digestValue);
     }

--- a/Source/WTF/wtf/JSONValues.cpp
+++ b/Source/WTF/wtf/JSONValues.cpp
@@ -35,7 +35,7 @@
 
 #include <functional>
 #include <wtf/CommaPrinter.h>
-#include <wtf/IndexedRange.h>
+#include <wtf/ZippedRange.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -71,8 +71,8 @@ bool parseConstToken(std::span<const CodeUnit> data, std::span<const CodeUnit>& 
     if (data.size() < token.length())
         return false;
 
-    for (auto [i, tokenCharacter] : IndexedRange(token.span8())) {
-        if (tokenCharacter != data[i])
+    for (auto [character, tokenCharacter] : zippedRange(data, token.span8())) {
+        if (character != tokenCharacter)
             return false;
     }
 

--- a/Source/WTF/wtf/ZippedRange.h
+++ b/Source/WTF/wtf/ZippedRange.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/IndexedRange.h>
+
+namespace WTF {
+
+template<typename IteratorA, typename IteratorB> class ZippedRangeIterator {
+public:
+    ZippedRangeIterator(IteratorA&& iteratorA, IteratorB&& iteratorB)
+        : m_iteratorA(WTFMove(iteratorA))
+        , m_iteratorB(WTFMove(iteratorB))
+    {
+    }
+
+    ZippedRangeIterator& operator++()
+    {
+        ++m_iteratorA;
+        ++m_iteratorB;
+        return *this;
+    }
+
+    auto operator*()
+    {
+        return std::pair<decltype(*m_iteratorA), decltype(*m_iteratorB)> { *m_iteratorA, *m_iteratorB };
+    }
+
+    bool operator==(const ZippedRangeIterator& other) const
+    {
+        // To ensure that we compare equal to end() even when we iterate two
+        // collections of different sizes, we need to compare both A and B.
+        // (Otherwise comparing either A or B would be sufficient, since they
+        // increment in lockstep.)
+        return m_iteratorA == other.m_iteratorA || m_iteratorB == other.m_iteratorB;
+    }
+
+private:
+    IteratorA m_iteratorA;
+    IteratorB m_iteratorB;
+};
+
+template<typename Iterator>
+class ZippedRange {
+public:
+    template<typename CollectionA, typename CollectionB>
+    ZippedRange(CollectionA&& collectionA, CollectionB&& collectionB)
+        : m_begin(boundsCheckedBegin(std::forward<CollectionA>(collectionA)), boundsCheckedBegin(std::forward<CollectionB>(collectionB)))
+        , m_end(boundsCheckedEnd(std::forward<CollectionA>(collectionA)), boundsCheckedEnd(std::forward<CollectionB>(collectionB)))
+    {
+        // Prevent use after destruction of a returned temporary.
+        static_assert(std::ranges::borrowed_range<CollectionA>);
+        static_assert(std::ranges::borrowed_range<CollectionB>);
+    }
+
+    auto begin() { return m_begin; }
+    auto end() { return m_end; }
+
+private:
+    Iterator m_begin;
+    Iterator m_end;
+};
+
+// Usage: for (auto [ valueA, valueB ] : zippedRange(collectionA, collectionB)) { ... }
+template<typename CollectionA, typename CollectionB> auto zippedRange(CollectionA&& collectionA, CollectionB&& collectionB)
+{
+    using Iterator = ZippedRangeIterator<decltype(boundsCheckedBegin(std::forward<CollectionA>(collectionA))), decltype(boundsCheckedBegin(std::forward<CollectionB>(collectionB)))>;
+    return ZippedRange<Iterator>(std::forward<CollectionA>(collectionA), std::forward<CollectionB>(collectionB));
+}
+
+} // namespace WTF
+
+using WTF::zippedRange;

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -502,7 +502,7 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
     uint32_t textureWidth = 0, textureHeight = 0, sampleCount = 0;
     using SliceSet = HashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
     HashMap<void*, SliceSet> depthSlices;
-    for (auto [ i, attachment ] : IndexedRange(descriptor.colorAttachmentsSpan())) {
+    for (auto [ i, attachment ] : indexedRange(descriptor.colorAttachmentsSpan())) {
         if (!attachment.view)
             continue;
 

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -172,7 +172,7 @@ Ref<RenderBundleEncoder> Device::createRenderBundleEncoder(const WGPURenderBundl
         generateAValidationError(error);
         return RenderBundleEncoder::createInvalid(*this, error);
     }
-    for (auto [ i, textureFormat ] : IndexedRange(descriptor.colorFormatsSpan())) {
+    for (auto [ i, textureFormat ] : indexedRange(descriptor.colorFormatsSpan())) {
         if (textureFormat == WGPUTextureFormat_Undefined)
             continue;
         if (!Texture::isColorRenderableFormat(textureFormat, *this)) {

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -96,7 +96,7 @@ RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEn
     parentEncoder->lock(true);
 
     m_attachmentsToClear = [NSMutableDictionary dictionary];
-    for (auto [ i, attachment ] : IndexedRange(colorAttachments)) {
+    for (auto [ i, attachment ] : indexedRange(colorAttachments)) {
         if (!attachment.view)
             continue;
 

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -564,7 +564,7 @@ static MTLVertexDescriptor *createVertexDescriptor(WGPUVertexState vertexState, 
     }
 
     ShaderModule::VertexStageIn shaderLocations;
-    for (auto [ bufferIndex, buffer ] : IndexedRange(vertexState.buffersSpan())) {
+    for (auto [ bufferIndex, buffer ] : indexedRange(vertexState.buffersSpan())) {
         if (buffer.arrayStride == WGPU_COPY_STRIDE_UNDEFINED)
             continue;
 
@@ -1418,7 +1418,7 @@ std::pair<Ref<RenderPipeline>, NSString*> Device::createRenderPipeline(const WGP
         fragmentInputs = fragmentModule->fragmentInputsForEntryPoint(fragmentEntryPoint);
         fragmentReturnTypes = fragmentModule->fragmentReturnTypeForEntryPoint(fragmentEntryPoint);
         colorAttachmentCount = fragmentDescriptor.targetCount;
-        for (auto [ i, targetDescriptor ] : IndexedRange(fragmentDescriptor.targetsSpan())) {
+        for (auto [ i, targetDescriptor ] : indexedRange(fragmentDescriptor.targetsSpan())) {
             if (targetDescriptor.format == WGPUTextureFormat_Undefined)
                 continue;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTouchEventGenerator.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTouchEventGenerator.mm
@@ -115,7 +115,7 @@ static void delayBetweenMove(int eventIndex, double elapsed)
     if (!self)
         return nil;
 
-    for (auto [i, fingerIdentifier] : IndexedRange(fingerIdentifiers))
+    for (auto [i, fingerIdentifier] : indexedRange(fingerIdentifiers))
         _activePoints[i].identifier = fingerIdentifier;
 
     _eventCallbacks = [[NSMutableDictionary alloc] init];
@@ -259,7 +259,7 @@ static void delayBetweenMove(int eventIndex, double elapsed)
     _activePointCount = points.size();
 
     // Update point locations.
-    for (auto [i, point] : IndexedRange(points))
+    for (auto [i, point] : indexedRange(points))
         _activePoints[i].point = point;
 
     RetainPtr<IOHIDEventRef> eventRef = adoptCF([self _createIOHIDEventType:handEventType]);
@@ -273,7 +273,7 @@ static void delayBetweenMove(int eventIndex, double elapsed)
 
     _activePointCount = touchCount;
 
-    for (auto [i, location] : IndexedRange(locations))
+    for (auto [i, location] : indexedRange(locations))
         _activePoints[i].point = location;
 
     RetainPtr<IOHIDEventRef> eventRef = adoptCF([self _createIOHIDEventType:HandEventTouched]);
@@ -294,7 +294,7 @@ static void delayBetweenMove(int eventIndex, double elapsed)
 
     NSUInteger newPointCount = _activePointCount - touchCount;
 
-    for (auto [i, location] : IndexedRange(locations))
+    for (auto [i, location] : indexedRange(locations))
         _activePoints[newPointCount + i].point = location;
 
     RetainPtr<IOHIDEventRef> eventRef = adoptCF([self _createIOHIDEventType:HandEventLifted]);


### PR DESCRIPTION
#### 15e2f508ca1a41912a0d13c510a4c5704883f2b9
<pre>
Added ZippedRange, and ported some improvements from it to IndexedRange
<a href="https://bugs.webkit.org/show_bug.cgi?id=283249">https://bugs.webkit.org/show_bug.cgi?id=283249</a>
<a href="https://rdar.apple.com/140054429">rdar://140054429</a>

Reviewed by Chris Dumez.

We use these types to assist bounds-safe iteration.

* Source/WTF/WTF.xcodeproj/project.pbxproj: New header.

* Source/WTF/wtf/CMakeLists.txt: New header.

* Source/WTF/wtf/IndexedRange.h:
(WTF::BoundsCheckedIterator::begin):
(WTF::BoundsCheckedIterator::end): Use a universal reference argument type and
std::forward so that we can handle const / non-const and other variations.
Previously we only supported const&amp;, but sometimes you want to assign while
you iterate.

(WTF::BoundsCheckedIterator::operator* const): Support non-copyable types and
avoid expensive copies by returning the universal reference type.

&apos;auto&apos; return values decay &quot;T&amp;&quot; to &quot;T&quot;, which often creates a copy. &apos;auto&amp;&amp;&apos;
does not decay, and returns &quot;T&amp;&quot; for &quot;T&amp;&quot;.

If you are as confused as I am, these sources may help you:

<a href="https://skebanga.github.io/structured-bindings/">https://skebanga.github.io/structured-bindings/</a>
<a href="https://devblogs.microsoft.com/oldnewthing/20201015-00/?p=104369">https://devblogs.microsoft.com/oldnewthing/20201015-00/?p=104369</a>
<a href="https://devblogs.microsoft.com/oldnewthing/20201014-00/?p=104367">https://devblogs.microsoft.com/oldnewthing/20201014-00/?p=104367</a>

(WTF::BoundsCheckedIterator::BoundsCheckedIterator):
(WTF::boundsCheckedBegin):
(WTF::boundsCheckedEnd): No need to have Collection as a part of our type;
it&apos;s only needed in our constructor.

(WTF::IndexedRangeIterator::operator*): Just use pair. Tuple is more fancy
than we need to be.

(WTF::IndexedRange::IndexedRange): Use the universal reference type.

(WTF::indexedRange): We need to use a helper function instead of instantiating
IndexedRange directly in order to trigger template argument deduction.

* Source/WTF/wtf/JSONValues.cpp: Initial use of ZippedRange.

* Source/WTF/wtf/ZippedRange.h: Added. Same as IndexedRange, except we keep
two iterators instead of an index and an iterator. There are fancier ways to
do this, but this seems to fit our needs.

Here&apos;s one fancier option:
<a href="https://github.com/alemuntoni/zip-views">https://github.com/alemuntoni/zip-views</a>

(WTF::ZippedRangeIterator::ZippedRangeIterator):
(WTF::ZippedRangeIterator::operator++):
(WTF::ZippedRangeIterator::operator*):
(WTF::ZippedRangeIterator::operator== const):
(WTF::ZippedRange::ZippedRange):
(WTF::ZippedRange::begin):
(WTF::ZippedRange::end):
(WTF::zippedRange):

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::beginRenderPass):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::Device::createRenderBundleEncoder):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::m_maxDrawCount):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::createVertexDescriptor):
* Source/WebKit/UIProcess/API/Cocoa/_WKTouchEventGenerator.mm:
(-[_WKTouchEventGenerator init]):
(-[_WKTouchEventGenerator _updateTouchPoints:window:]):
(-[_WKTouchEventGenerator touchDownAtPoints:touchCount:window:]):
(-[_WKTouchEventGenerator liftUpAtPoints:touchCount:window:]): Updated to use
indexedRange() instead of IndexedRange(), since indexedRange() is now required
for template argument deduction.

Canonical link: <a href="https://commits.webkit.org/286698@main">https://commits.webkit.org/286698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1afc9c141787df4d01a78bc6b61e7bfaf75c7596

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81366 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28104 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4156 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60195 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18285 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50148 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40514 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47550 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23446 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26428 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/70011 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68667 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23776 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82807 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76105 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4204 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2785 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68477 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4357 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65925 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67731 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11713 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9794 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98359 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11888 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4151 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/6963 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21515 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4174 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7605 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5932 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->