### PR TITLE
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF/

### DIFF
--- a/Source/WTF/wtf/SHA1.cpp
+++ b/Source/WTF/wtf/SHA1.cpp
@@ -38,8 +38,6 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 #if PLATFORM(COCOA)
@@ -222,7 +220,7 @@ void SHA1::addUTF8Bytes(StringView string)
 void SHA1::addUTF8Bytes(CFStringRef string)
 {
     if (auto* characters = CFStringGetCStringPtr(string, kCFStringEncodingASCII)) {
-        addBytes(std::span { byteCast<uint8_t>(characters), static_cast<size_t>(CFStringGetLength(string)) });
+        addBytes(unsafeMakeSpan(byteCast<uint8_t>(characters), CFStringGetLength(string)));
         return;
     }
 
@@ -254,5 +252,3 @@ CString SHA1::computeHexDigest()
 }
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/SixCharacterHash.cpp
+++ b/Source/WTF/wtf/SixCharacterHash.cpp
@@ -28,8 +28,6 @@
 
 #include <wtf/ASCIICType.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 unsigned sixCharacterHashStringToInteger(std::span<const char, 6> string)
@@ -56,7 +54,11 @@ unsigned sixCharacterHashStringToInteger(std::span<const char, 6> string)
 
 std::array<char, 6> integerToSixCharacterHashString(unsigned hash)
 {
-    static const char table[63] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    static constexpr std::array<char, 62> table {
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'
+    };
     std::array<char, 6> buffer;
     unsigned accumulator = hash;
     for (unsigned i = 6; i--;) {
@@ -67,5 +69,3 @@ std::array<char, 6> integerToSixCharacterHashString(unsigned hash)
 }
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/StackBounds.cpp
+++ b/Source/WTF/wtf/StackBounds.cpp
@@ -48,8 +48,6 @@
 
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 #if OS(DARWIN)
@@ -58,7 +56,9 @@ StackBounds StackBounds::newThreadStackBounds(PlatformThreadHandle thread)
 {
     void* origin = pthread_get_stackaddr_np(thread);
     rlim_t size = pthread_get_stacksize_np(thread);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     void* bound = static_cast<char*>(origin) - size;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return StackBounds { origin, bound };
 }
 
@@ -73,7 +73,9 @@ StackBounds StackBounds::currentThreadStackBoundsInternal()
         rlim_t size = limit.rlim_cur;
         if (size == RLIM_INFINITY)
             size = 8 * MB;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         void* bound = static_cast<char*>(origin) - size;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         return StackBounds { origin, bound };
     }
     return newThreadStackBounds(pthread_self());
@@ -88,7 +90,9 @@ StackBounds StackBounds::newThreadStackBounds(PlatformThreadHandle thread)
     stack_t stack;
     pthread_stackseg_np(thread, &stack);
     void* origin = stack.ss_sp;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     void* bound = static_cast<char*>(origin) - stack.ss_size;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return StackBounds { origin, bound };
 }
 
@@ -98,7 +102,9 @@ StackBounds StackBounds::newThreadStackBounds(PlatformThreadHandle thread)
 {
     struct _thread_local_storage* tls = __tls();
     void* bound = tls->__stackaddr;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     void* origin = static_cast<char*>(bound) + tls->__stacksize;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return StackBounds { origin, bound };
 }
 
@@ -122,7 +128,9 @@ StackBounds StackBounds::newThreadStackBounds(PlatformThreadHandle thread)
     UNUSED_PARAM(rc);
     ASSERT(bound);
     pthread_attr_destroy(&sattr);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     void* origin = static_cast<char*>(bound) + stackSize;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     // pthread_attr_getstack's bound is the lowest accessible pointer of the stack.
     return StackBounds { origin, bound };
 }
@@ -147,7 +155,9 @@ StackBounds StackBounds::currentThreadStackBoundsInternal()
             size = 8 * MB;
         // account for a guard page
         size -= static_cast<rlim_t>(sysconf(_SC_PAGESIZE));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         void* bound = static_cast<char*>(origin) - size;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         return StackBounds { origin, bound };
     }
 #endif
@@ -210,5 +220,3 @@ StackBounds StackBounds::currentThreadStackBoundsInternal()
 #endif
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/StringPrintStream.cpp
+++ b/Source/WTF/wtf/StringPrintStream.cpp
@@ -28,113 +28,107 @@
 
 #include <stdarg.h>
 #include <stdio.h>
-#include <wtf/FastMalloc.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#include <wtf/MallocSpan.h>
+#include <wtf/StdLibExtras.h>
 
 namespace WTF {
 
 StringPrintStream::StringPrintStream()
-    : m_buffer(m_inlineBuffer)
-    , m_next(0)
-    , m_size(sizeof(m_inlineBuffer))
 {
+    m_buffer = std::span { m_inlineBuffer };
     m_buffer[0] = 0; // Make sure that we always have a null terminator.
 }
 
 StringPrintStream::~StringPrintStream()
 {
-    if (m_buffer == m_inlineBuffer)
-        return;
-    fastFree(m_buffer);
+    if (m_buffer.data() != m_inlineBuffer.data())
+        fastFree(m_buffer.data());
 }
 
 void StringPrintStream::vprintf(const char* format, va_list argList)
 {
-    ASSERT_WITH_SECURITY_IMPLICATION(m_next < m_size);
-    ASSERT(!m_buffer[m_next]);
+    ASSERT_WITH_SECURITY_IMPLICATION(m_length < m_buffer.size());
+    ASSERT(!m_buffer[m_length]);
 
     va_list firstPassArgList;
     va_copy(firstPassArgList, argList);
 
     int numberOfBytesNotIncludingTerminatorThatWouldHaveBeenWritten =
-        vsnprintf(m_buffer + m_next, m_size - m_next, format, firstPassArgList);
+        vsnprintf(m_buffer.subspan(m_length).data(), m_buffer.size() - m_length, format, firstPassArgList);
 
     va_end(firstPassArgList);
 
     int numberOfBytesThatWouldHaveBeenWritten =
         numberOfBytesNotIncludingTerminatorThatWouldHaveBeenWritten + 1;
 
-    if (m_next + numberOfBytesThatWouldHaveBeenWritten <= m_size) {
-        m_next += numberOfBytesNotIncludingTerminatorThatWouldHaveBeenWritten;
+    if (m_length + numberOfBytesThatWouldHaveBeenWritten <= m_buffer.size()) {
+        m_length += numberOfBytesNotIncludingTerminatorThatWouldHaveBeenWritten;
         return; // This means that vsnprintf() succeeded.
     }
 
-    increaseSize(m_next + numberOfBytesThatWouldHaveBeenWritten);
+    increaseSize(m_length + numberOfBytesThatWouldHaveBeenWritten);
 
     int numberOfBytesNotIncludingTerminatorThatWereWritten =
-        vsnprintf(m_buffer + m_next, m_size - m_next, format, argList);
+        vsnprintf(m_buffer.subspan(m_length).data(), m_buffer.size() - m_length, format, argList);
 
     int numberOfBytesThatWereWritten = numberOfBytesNotIncludingTerminatorThatWereWritten + 1;
 
-    ASSERT_UNUSED(numberOfBytesThatWereWritten, m_next + numberOfBytesThatWereWritten <= m_size);
+    ASSERT_UNUSED(numberOfBytesThatWereWritten, m_length + numberOfBytesThatWereWritten <= m_buffer.size());
 
-    m_next += numberOfBytesNotIncludingTerminatorThatWereWritten;
+    m_length += numberOfBytesNotIncludingTerminatorThatWereWritten;
 
-    ASSERT_WITH_SECURITY_IMPLICATION(m_next < m_size);
-    ASSERT(!m_buffer[m_next]);
+    ASSERT_WITH_SECURITY_IMPLICATION(m_length < m_buffer.size());
+    ASSERT(!m_buffer[m_length]);
 }
 
-CString StringPrintStream::toCString()
+CString StringPrintStream::toCString() const
 {
-    ASSERT(m_next == strlen(m_buffer));
-    return CString({ m_buffer, m_next });
+    ASSERT(m_length == strlen(m_buffer.data()));
+    return CString(m_buffer.first(m_length));
 }
 
 void StringPrintStream::reset()
 {
-    m_next = 0;
+    m_length = 0;
     m_buffer[0] = 0;
 }
 
-Expected<String, UTF8ConversionError> StringPrintStream::tryToString()
+Expected<String, UTF8ConversionError> StringPrintStream::tryToString() const
 {
-    ASSERT(m_next == strlen(m_buffer));
-    if (m_next > String::MaxLength)
+    ASSERT(m_length == strlen(m_buffer.data()));
+    if (m_length > String::MaxLength)
         return makeUnexpected(UTF8ConversionError::OutOfMemory);
-    return String::fromUTF8({ m_buffer, m_next });
+    return String::fromUTF8(m_buffer.first(m_length));
 }
 
-String StringPrintStream::toString()
+String StringPrintStream::toString() const
 {
-    ASSERT(m_next == strlen(m_buffer));
-    return String::fromUTF8({ m_buffer, m_next });
+    ASSERT(m_length == strlen(m_buffer.data()));
+    return String::fromUTF8(m_buffer.first(m_length));
 }
 
-String StringPrintStream::toStringWithLatin1Fallback()
+String StringPrintStream::toStringWithLatin1Fallback() const
 {
-    ASSERT(m_next == strlen(m_buffer));
-    return String::fromUTF8WithLatin1Fallback({ m_buffer, m_next });
+    ASSERT(m_length == strlen(m_buffer.data()));
+    return String::fromUTF8WithLatin1Fallback(m_buffer.first(m_length));
 }
 
 void StringPrintStream::increaseSize(size_t newSize)
 {
-    ASSERT_WITH_SECURITY_IMPLICATION(newSize > m_size);
-    ASSERT(newSize > sizeof(m_inlineBuffer));
+    ASSERT_WITH_SECURITY_IMPLICATION(newSize > m_buffer.size());
+    ASSERT(newSize > m_inlineBuffer.size());
 
     // Use exponential resizing to reduce thrashing.
-    m_size = newSize << 1;
+    newSize = newSize << 1;
 
     // Use fastMalloc instead of fastRealloc because we know that for the sizes we're using,
     // fastRealloc will just do malloc+free anyway. Also, this simplifies the code since
     // we can't realloc the inline buffer.
-    char* newBuffer = static_cast<char*>(fastMalloc(m_size));
-    memcpy(newBuffer, m_buffer, m_next + 1);
-    if (m_buffer != m_inlineBuffer)
-        fastFree(m_buffer);
-    m_buffer = newBuffer;
+    auto newBuffer = MallocSpan<char>::malloc(newSize);
+    memcpySpan(newBuffer.mutableSpan(), m_buffer.first(m_length + 1));
+    if (m_buffer.data() != m_inlineBuffer.data())
+        fastFree(m_buffer.data());
+    m_buffer = newBuffer.leakSpan();
 }
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/StringPrintStream.h
+++ b/Source/WTF/wtf/StringPrintStream.h
@@ -38,21 +38,20 @@ public:
     
     WTF_EXPORT_PRIVATE void vprintf(const char* format, va_list) final WTF_ATTRIBUTE_PRINTF(2, 0);
 
-    size_t length() const { return m_next; }
+    size_t length() const { return m_length; }
     
-    WTF_EXPORT_PRIVATE CString toCString();
-    WTF_EXPORT_PRIVATE Expected<String, UTF8ConversionError> tryToString();
-    WTF_EXPORT_PRIVATE String toString();
-    WTF_EXPORT_PRIVATE String toStringWithLatin1Fallback();
+    WTF_EXPORT_PRIVATE CString toCString() const;
+    WTF_EXPORT_PRIVATE Expected<String, UTF8ConversionError> tryToString() const;
+    WTF_EXPORT_PRIVATE String toString() const;
+    WTF_EXPORT_PRIVATE String toStringWithLatin1Fallback() const;
     WTF_EXPORT_PRIVATE void reset();
     
 private:
     void increaseSize(size_t);
     
-    char* m_buffer;
-    size_t m_next;
-    size_t m_size;
-    char m_inlineBuffer[128];
+    std::array<char, 128> m_inlineBuffer;
+    std::span<char> m_buffer;
+    size_t m_length { 0 };
 };
 
 // Stringify any type T that has a WTF::printInternal(PrintStream&, const T&)

--- a/Source/WTF/wtf/dtoa/double-conversion.cc
+++ b/Source/WTF/wtf/dtoa/double-conversion.cc
@@ -451,14 +451,14 @@ static double SignedZero(bool sign) {
 }
 
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 // Returns true, when the iterator is equal to end.
 template<class Iterator>
 static inline bool Advance(Iterator* it, Iterator& end) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
   ++(*it);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
   return *it == end;
 }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 template <typename FloatingPointType>
 inline FloatingPointType StringToFloatingPointType(BufferReference<const char> buffer, int exponent);

--- a/Source/WTF/wtf/text/EscapedFormsForJSON.h
+++ b/Source/WTF/wtf/text/EscapedFormsForJSON.h
@@ -11,10 +11,12 @@
 
 #pragma once
 
+#include <array>
+
 namespace WTF {
 
 // This table for escaping was originally taken from SpiderMonkey.
-constexpr char escapedFormsForJSON[0x100] = {
+constexpr std::array<char, 0x100> escapedFormsForJSON {
     'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u',
     'b', 't', 'n', 'u', 'f', 'r', 'u', 'u',
     'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u',

--- a/Source/WTF/wtf/text/StringSearch.h
+++ b/Source/WTF/wtf/text/StringSearch.h
@@ -29,8 +29,6 @@
 #include <wtf/text/StringCommon.h>
 #include <wtf/text/StringView.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 template<typename OffsetType>
@@ -83,7 +81,7 @@ private:
             for (auto& element : m_table)
                 element = length;
             for (unsigned i = 0; i < (pattern.size() - 1); ++i) {
-                unsigned index = pattern.data()[i] & 0xff;
+                unsigned index = pattern[i] & 0xff;
                 m_table[index] = length - 1 - i;
             }
         }
@@ -92,21 +90,19 @@ private:
     template <typename SearchCharacterType, typename MatchCharacterType>
     ALWAYS_INLINE size_t findInner(std::span<const SearchCharacterType> characters, std::span<const MatchCharacterType> matchCharacters) const
     {
-        auto* cursor = characters.data();
-        auto* last = characters.data() + characters.size() - matchCharacters.size();
+        size_t cursor = 0;
+        size_t last = characters.size() - matchCharacters.size();
         while (cursor <= last) {
-            if (equal(cursor, matchCharacters))
-                return cursor - characters.data();
-            cursor += m_table[static_cast<uint8_t>(cursor[matchCharacters.size() - 1])];
+            if (equal(characters.subspan(cursor).data(), matchCharacters))
+                return cursor;
+            cursor += m_table[static_cast<uint8_t>(characters[cursor + matchCharacters.size() - 1])];
         }
         return notFound;
     }
 
-    OffsetType m_table[size];
+    std::array<OffsetType, size> m_table;
 };
 
 }
 
 using WTF::BoyerMooreHorspoolTable;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 83a834b1ac4f39bd80bb986051d2ad80af7d23ea
<pre>
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF/
<a href="https://bugs.webkit.org/show_bug.cgi?id=283252">https://bugs.webkit.org/show_bug.cgi?id=283252</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/SHA1.cpp:
(WTF::SHA1::addUTF8Bytes):
* Source/WTF/wtf/SixCharacterHash.cpp:
(WTF::integerToSixCharacterHashString):
* Source/WTF/wtf/StackBounds.cpp:
(WTF::StackBounds::newThreadStackBounds):
(WTF::StackBounds::currentThreadStackBoundsInternal):
* Source/WTF/wtf/StringPrintStream.cpp:
(WTF::StringPrintStream::StringPrintStream):
(WTF::StringPrintStream::~StringPrintStream):
(WTF::StringPrintStream::vprintf):
(WTF::StringPrintStream::toCString const):
(WTF::StringPrintStream::reset):
(WTF::StringPrintStream::tryToString const):
(WTF::StringPrintStream::toString const):
(WTF::StringPrintStream::toStringWithLatin1Fallback const):
(WTF::StringPrintStream::increaseSize):
(WTF::StringPrintStream::toCString): Deleted.
(WTF::StringPrintStream::tryToString): Deleted.
(WTF::StringPrintStream::toString): Deleted.
(WTF::StringPrintStream::toStringWithLatin1Fallback): Deleted.
* Source/WTF/wtf/StringPrintStream.h:
* Source/WTF/wtf/dtoa/double-conversion.cc:
* Source/WTF/wtf/text/EscapedFormsForJSON.h:
* Source/WTF/wtf/text/StringBuilderJSON.cpp:
(WTF::StringBuilder::appendQuotedJSONString):
* Source/WTF/wtf/text/StringBuilderJSON.h:
(WTF::appendEscapedJSONStringContent):
* Source/WTF/wtf/text/StringSearch.h:
(WTF::BoyerMooreHorspoolTable::initializeTable):
(WTF::BoyerMooreHorspoolTable::findInner const):

Canonical link: <a href="https://commits.webkit.org/286712@main">https://commits.webkit.org/286712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9057a5d2117df3e7805acee3edb25441e62796f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76880 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29786 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81422 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28156 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4208 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60240 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18322 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50190 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40557 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47592 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23492 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26481 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/70063 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68709 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82860 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76157 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4256 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2830 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68518 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65970 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67773 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11758 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9841 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98412 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11899 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4203 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21532 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4226 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7657 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5984 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->