### PR TITLE
[JSC] Implement `Array.prototype.fill` in C++

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-fill-contiguous.js
+++ b/JSTests/microbenchmarks/array-prototype-fill-contiguous.js
@@ -1,0 +1,11 @@
+const array = new Array(1024);
+array.fill({});
+
+function test(value, start, end) {
+    array.fill(value, start, end);
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+    test({}, 4, 824);
+}

--- a/JSTests/microbenchmarks/array-prototype-fill-double.js
+++ b/JSTests/microbenchmarks/array-prototype-fill-double.js
@@ -1,0 +1,11 @@
+const array = new Array(1024);
+array.fill(999.99);
+
+function test(value, start, end) {
+    array.fill(value, start, end);
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+    test(20.12, 4, 824);
+}

--- a/JSTests/microbenchmarks/array-prototype-fill-int32.js
+++ b/JSTests/microbenchmarks/array-prototype-fill-int32.js
@@ -1,0 +1,11 @@
+const array = new Array(1024);
+array.fill(999);
+
+function test(value, start, end) {
+    array.fill(value, start, end);
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+    test(20, 4, 824);
+}

--- a/JSTests/microbenchmarks/array-prototype-fill-undecided.js
+++ b/JSTests/microbenchmarks/array-prototype-fill-undecided.js
@@ -1,0 +1,10 @@
+const array = new Array(1024);
+
+function test(value, start, end) {
+    array.fill(value, start, end);
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+    test({}, 4, 824);
+}

--- a/JSTests/stress/array-prototype-fill-fast.js
+++ b/JSTests/stress/array-prototype-fill-fast.js
@@ -1,0 +1,100 @@
+function sameArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected ${b.length} but got ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`${i}: Expected ${b[i]} but got ${a[i]}`);
+    }
+}
+
+{
+    // ArrayWithInt32 * Int32
+    const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+    arr.fill(12, 2, 7);
+    sameArray(arr, [1, 2, 12, 12, 12, 12, 12, 8, 9]);
+}
+
+{
+    // ArrayWithInt32 * Double
+    const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+    arr.fill(1.2, 2, 7);
+    sameArray(arr, [1, 2, 1.2, 1.2, 1.2, 1.2, 1.2, 8, 9]);
+}
+
+{
+    // ArrayWithInt32 * Other
+    const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const obj = {};
+    arr.fill(obj, 2, 7);
+    sameArray(arr, [1, 2, obj, obj, obj, obj, obj, 8, 9]);
+}
+
+{
+    // ArrayWithDouble * Int32
+    const arr = [1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9];
+    arr.fill(12, 2, 7);
+    sameArray(arr, [1.1, 1.2, 12, 12, 12, 12, 12, 1.8, 1.9]);
+}
+
+{
+    // ArrayWithDouble * Double
+    const arr = [1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9];
+    arr.fill(12.1, 2, 7);
+    sameArray(arr, [1.1, 1.2, 12.1, 12.1, 12.1, 12.1, 12.1, 1.8, 1.9]);
+
+}
+
+{
+    // ArrayWithDouble * Other
+    const arr = [1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9];
+    const obj = {};
+    arr.fill(obj, 2, 7);
+    sameArray(arr, [1.1, 1.2, obj, obj, obj, obj, obj, 1.8, 1.9]);
+}
+
+{
+    // ArrayWithContiguous * Int32
+    const obj = {};
+    const arr = [obj, obj, obj, obj, obj, obj, obj, obj, obj];
+    arr.fill(12, 2, 7);
+    sameArray(arr, [obj, obj, 12, 12, 12, 12, 12, obj, obj]);
+}
+
+{
+    // ArrayWithContiguous * Double
+    const obj = {};
+    const arr = [obj, obj, obj, obj, obj, obj, obj, obj, obj];
+    arr.fill(12.1, 2, 7);
+    sameArray(arr, [obj, obj, 12.1, 12.1, 12.1, 12.1, 12.1, obj, obj]);
+}
+
+{
+    // ArrayWithContiguous * Double
+    const obj = {};
+    const arr = [obj, obj, obj, obj, obj, obj, obj, obj, obj];
+    const obj2 = {};
+    arr.fill(obj2, 2, 7);
+    sameArray(arr, [obj, obj, obj2, obj2, obj2, obj2, obj2, obj, obj]);
+}
+
+{
+    // ArrayWithUndecided * Int32
+    const arr = new Array(9);
+    arr.fill(12, 2, 7);
+    sameArray(arr, [undefined, undefined, 12, 12, 12, 12, 12, undefined, undefined]);
+}
+
+{
+    // ArrayWithUndecided * Double
+    const arr = new Array(9);
+    arr.fill(12.1, 2, 7);
+    sameArray(arr, [undefined, undefined, 12.1, 12.1, 12.1, 12.1, 12.1, undefined, undefined]);
+}
+
+{
+    // ArrayWithUndecided * Double
+    const arr = new Array(9);
+    const obj = {};
+    arr.fill(obj, 2, 7);
+    sameArray(arr, [undefined, undefined, obj, obj, obj, obj, obj, undefined, undefined]);
+}

--- a/JSTests/stress/array-prototype-fill-side-effects.js
+++ b/JSTests/stress/array-prototype-fill-side-effects.js
@@ -1,0 +1,20 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = [1, 2, 3, 4, 5, 6];
+let get2Count = 0;
+Object.defineProperty(array, 2, {
+    set(value) {
+        get2Count++;
+    }
+});
+array.fill(12, 1, 4);
+shouldBe(get2Count, 1);
+shouldBe(array[0], 1);
+shouldBe(array[1], 12);
+shouldBe(array[2], undefined);
+shouldBe(array[3], 12);
+shouldBe(array[4], 5);
+shouldBe(array[5], 6);

--- a/Source/JavaScriptCore/builtins/ArrayPrototype.js
+++ b/Source/JavaScriptCore/builtins/ArrayPrototype.js
@@ -199,43 +199,6 @@ function some(callback /*, thisArg */)
     return false;
 }
 
-function fill(value /* [, start [, end]] */)
-{
-    "use strict";
-
-    var array = @toObject(this, "Array.prototype.fill requires that |this| not be null or undefined");
-    var length = @toLength(array.length);
-
-    var relativeStart = @toIntegerOrInfinity(@argument(1));
-    var k = 0;
-    if (relativeStart < 0) {
-        k = length + relativeStart;
-        if (k < 0)
-            k = 0;
-    } else {
-        k = relativeStart;
-        if (k > length)
-            k = length;
-    }
-    var relativeEnd = length;
-    var end = @argument(2);
-    if (end !== @undefined)
-        relativeEnd = @toIntegerOrInfinity(end);
-    var final = 0;
-    if (relativeEnd < 0) {
-        final = length + relativeEnd;
-        if (final < 0)
-            final = 0;
-    } else {
-        final = relativeEnd;
-        if (final > length)
-            final = length;
-    }
-    for (; k < final; k++)
-        array[k] = value;
-    return array;
-}
-
 function find(callback /*, thisArg */)
 {
     "use strict";

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -64,6 +64,7 @@ static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncUnShift);
 static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncIndexOf);
 static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncLastIndexOf);
 static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncConcat);
+static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncFill);
 
 // ------------------------------ ArrayPrototype ----------------------------
 
@@ -93,7 +94,7 @@ void ArrayPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
 
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->toLocaleString, arrayProtoFuncToLocaleString, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().concatPublicName(), arrayProtoFuncConcat, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
-    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().fillPublicName(), arrayPrototypeFillCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->fill, arrayProtoFuncFill, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->join, arrayProtoFuncJoin, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("pop"_s, arrayProtoFuncPop, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public, ArrayPopIntrinsic);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().pushPublicName(), arrayProtoFuncPush, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, ArrayPushIntrinsic);
@@ -143,7 +144,7 @@ void ArrayPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
         &vm.propertyNames->builtinNames().atPublicName(),
         &vm.propertyNames->builtinNames().copyWithinPublicName(),
         &vm.propertyNames->builtinNames().entriesPublicName(),
-        &vm.propertyNames->builtinNames().fillPublicName(),
+        &vm.propertyNames->fill,
         &vm.propertyNames->builtinNames().findPublicName(),
         &vm.propertyNames->builtinNames().findIndexPublicName(),
         &vm.propertyNames->builtinNames().findLastPublicName(),
@@ -1898,6 +1899,47 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncConcat, (JSGlobalObject* globalObject, Ca
     scope.release();
     setLength(globalObject, vm, result, resultIndex);
     return JSValue::encode(result);
+}
+
+JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncFill, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto thisValue = callFrame->thisValue().toThis(globalObject, ECMAMode::strict());
+    RETURN_IF_EXCEPTION(scope, { });
+    if (UNLIKELY(thisValue.isUndefinedOrNull()))
+        return throwVMTypeError(globalObject, scope, "Array.prototype.fill requires that |this| not be null or undefined"_s);
+    auto* thisObject = thisValue.toObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    uint64_t length = toLength(globalObject, thisObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    JSValue argStart = callFrame->argument(1);
+    uint64_t k = argumentClampedIndexFromStartOrEnd(globalObject, argStart, length, 0);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    JSValue argEnd = callFrame->argument(2);
+    uint64_t finalIndex = argumentClampedIndexFromStartOrEnd(globalObject, argEnd, length, length);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (k > finalIndex)
+        return JSValue::encode(thisObject);
+
+    JSValue value = callFrame->argument(0);
+    if (isJSArray(thisValue)) {
+        auto* array = jsCast<JSArray*>(thisValue);
+        if (array->fastFill(vm, k, finalIndex, value))
+            return JSValue::encode(array);
+    }
+
+    for (; k < finalIndex; k++) {
+        thisObject->putByIndexInline(globalObject, k, value, true);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    return JSValue::encode(thisObject);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -128,6 +128,7 @@
     macro(exitKind) \
     macro(exports) \
     macro(fallback) \
+    macro(fill) \
     macro(flags) \
     macro(firstDayOfWeek) \
     macro(forEach) \

--- a/Source/JavaScriptCore/runtime/JSArray.h
+++ b/Source/JavaScriptCore/runtime/JSArray.h
@@ -118,6 +118,8 @@ public:
     bool appendMemcpy(JSGlobalObject*, VM&, unsigned startIndex, JSArray* otherArray);
     bool appendMemcpy(JSGlobalObject*, VM&, unsigned startIndex, IndexingType, std::span<const EncodedJSValue>);
 
+    bool fastFill(VM&, unsigned startIndex, unsigned endIndex, JSValue);
+
     ALWAYS_INLINE bool definitelyNegativeOneMiss() const;
 
     enum ShiftCountMode {

--- a/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp
@@ -485,7 +485,7 @@ void JSTypedArrayViewPrototype::finishCreation(VM& vm, JSGlobalObject* globalObj
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("filter"_s, typedArrayPrototypeFilterCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().entriesPublicName(), typedArrayProtoViewFuncEntries, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public, TypedArrayEntriesIntrinsic);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("includes"_s, typedArrayViewProtoFuncIncludes, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
-    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().fillPublicName(), typedArrayViewProtoFuncFill, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->fill, typedArrayViewProtoFuncFill, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("find"_s, typedArrayPrototypeFindCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().findLastPublicName(), typedArrayPrototypeFindLastCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("findIndex"_s, typedArrayPrototypeFindIndexCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));


### PR DESCRIPTION
#### 619232f3b3be51ce68b813947cdaf3e414a4d3e6
<pre>
[JSC] Implement `Array.prototype.fill` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=283255">https://bugs.webkit.org/show_bug.cgi?id=283255</a>

Reviewed by Yusuke Suzuki and Keith Miller.

The current implementation of Array#fill is written in simple JavaScript. This patch implements it
in C++.

                                         TipOfTree                  Patched

array-prototype-fill-undecided         5.3186+-0.0609     ^      1.1502+-0.0220        ^ definitely 4.6240x faster
array-prototype-fill-int32             4.0577+-0.4950     ^      1.1149+-0.0158        ^ definitely 3.6395x faster
array-prototype-fill-contiguous        5.6943+-0.3723     ^      1.1534+-0.0211        ^ definitely 4.9368x faster
array-prototype-fill-double            3.6932+-0.1337     ^      1.1045+-0.0155        ^ definitely 3.3438x faster

* JSTests/microbenchmarks/array-prototype-fill-contiguous.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-fill-double.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-fill-int32.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-fill-undecided.js: Added.
(test):
* JSTests/stress/array-prototype-fill-fast.js: Added.
(sameArray):
(throw.new.Error):
* JSTests/stress/array-prototype-fill-side-effects.js: Added.
(shouldBe):
(set value):
* Source/JavaScriptCore/builtins/ArrayPrototype.js:
(fill):
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ArrayPrototype.h:
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fillMemcpy):
* Source/JavaScriptCore/runtime/JSArray.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):

Canonical link: <a href="https://commits.webkit.org/287215@main">https://commits.webkit.org/287215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf953f1571d0b7ff1580a741d5c03d1bc5e64a1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83262 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29866 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61567 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19490 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81668 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51581 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/70103 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41877 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48927 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25465 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28204 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71747 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70029 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84630 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77838 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5966 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4101 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69793 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6127 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69047 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17223 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13071 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11556 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/100146 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5913 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21874 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5900 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7688 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->