### PR TITLE
VideoMediaSampleRenderer will produce out of order, corrupted frame when used with b-frames.

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -28,6 +28,7 @@
 #include "ProcessIdentity.h"
 #include "SampleMap.h"
 #include <wtf/Function.h>
+#include <wtf/Lock.h>
 #include <wtf/Ref.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/ThreadSafeWeakPtr.h>
@@ -58,7 +59,7 @@ public:
     void setPrefersDecompressionSession(bool);
 
     void setTimebase(RetainPtr<CMTimebaseRef>&&);
-    RetainPtr<CMTimebaseRef> timebase() const { return m_timebase; }
+    RetainPtr<CMTimebaseRef> timebase() const;
 
     bool isReadyForMoreMediaData() const;
     void requestMediaDataWhenReady(Function<void()>&&);
@@ -90,13 +91,13 @@ public:
 private:
     VideoMediaSampleRenderer(WebSampleBufferVideoRendering *);
 
-    void setPrefersDecompressionSessionInternal(bool);
-    void setTimebaseInternal(RetainPtr<CMTimebaseRef>&&);
+    void clearTimebase();
 
     void resetReadyForMoreSample();
     void initializeDecompressionSession();
     void decodeNextSample();
     void decodedFrameAvailable(RetainPtr<CMSampleBufferRef>&&);
+    void maybeQueueFrameForDisplay(CMSampleBufferRef);
     void flushCompressedSampleQueue();
     void flushDecodedSampleQueue();
     void purgeDecodedSampleQueue();
@@ -104,15 +105,21 @@ private:
     void assignResourceOwner(CMSampleBufferRef);
     void maybeBecomeReadyForMoreMediaData();
 
+    void cancelTimer();
+
     const Ref<WTF::WorkQueue> m_workQueue;
     RetainPtr<AVSampleBufferDisplayLayer> m_displayLayer;
     RetainPtr<AVSampleBufferVideoRenderer> m_renderer;
-    RetainPtr<CMTimebaseRef> m_timebase;
-    RetainPtr<CMBufferQueueRef> m_compressedSampleQueue; // created on the main thread, always set if m_decompressionSession and on workQueue.
-    RetainPtr<CMBufferQueueRef> m_decodedSampleQueue;
-    OSObjectPtr<dispatch_source_t> m_timerSource;
+    mutable Lock m_lock;
+    RetainPtr<CMTimebaseRef> m_timebase WTF_GUARDED_BY_LOCK(m_lock);
+    OSObjectPtr<dispatch_source_t> m_timerSource WTF_GUARDED_BY_LOCK(m_lock);
+    std::atomic<ssize_t> m_framesBeingDecoded { 0 };
+    std::atomic<int> m_flushId { 0 };
+    Deque<std::pair<RetainPtr<CMSampleBufferRef>, int>> m_compressedSampleQueue WTF_GUARDED_BY_CAPABILITY(m_workQueue.get());
+    RetainPtr<CMBufferQueueRef> m_decodedSampleQueue WTF_GUARDED_BY_CAPABILITY(m_workQueue.get());
     RefPtr<WebCoreDecompressionSession> m_decompressionSession;
-    bool m_isDecodingSample { false };
+    bool m_isDecodingSample WTF_GUARDED_BY_CAPABILITY(m_workQueue.get()) { false };
+    bool m_isDisplayingSample WTF_GUARDED_BY_CAPABILITY(m_workQueue.get()) { false };
     Function<void()> m_readyForMoreSampleFunction;
     bool m_prefersDecompressionSession { false };
     std::optional<uint32_t> m_currentCodec;


### PR DESCRIPTION
#### ad4c63c079db6dd47dd2487858aae1a850e64bbf
<pre>
VideoMediaSampleRenderer will produce out of order, corrupted frame when used with b-frames.
<a href="https://bugs.webkit.org/show_bug.cgi?id=283235">https://bugs.webkit.org/show_bug.cgi?id=283235</a>
<a href="https://rdar.apple.com/140046888">rdar://140046888</a>

Reviewed by Youenn Fablet.

1- The queue used to feed the decoder was a CMBufferQueue which re-order samples in presentation order.
So we ended up feeding the decoder the frames in presentation order rather than decode order, leading to decoding artifacts
2- The way the WebCoreDecompression was used by the VideoMediaSampleRenderer, was to immediately queue the decoded frame to the AVSampleBufferDisplayLayer,
without letting the CMBufferQueue re-sort the frames by presentation order. So frames were displayed in decode order instead.

To solve 1-, we remove the use of a sorted CMBufferQueue and instead use a plain Dequeue. The Dequeue store the compressed
image along the flushing session id. Whenever we process the compressed frame, if the Ids don&apos;t match, the frame is dropped.
For 2- we only add the decoded frame at the time it is ready for display, using the AV synchroniser&apos;s CMTimeBase timer.
By only ever dequeuing the video frame at the time we should be displaying it, we guarantee that the frames have been fully
sorted in presentation order, without the downside of added latency (as we would otherwise have to wait until we&apos;ve reached the
minimum required number of frames in the queue: the &quot;H264 sliding window&quot;).
If we were to display a frame out of order, those future incoming earlier frames would have been dropped anyway by the time they are received
being now too late.

Fly-by: setTimeBase if called multiple times, could potentially cause access to the m_timebase member to be access concurrently.
We limit the use so that it can be either set once or cleared and protect the variable member with a lock.

Manually tested. The VideoMediaSampleRenderer isn&apos;t currently used with players supporting B-Frames.

* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
(WebCore::VideoMediaSampleRenderer::timebase const): Deleted.
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::~VideoMediaSampleRenderer): Cancel (flush) any pending decoding tasks.
(WebCore::VideoMediaSampleRenderer::isReadyForMoreMediaData const):
(WebCore::VideoMediaSampleRenderer::maybeBecomeReadyForMoreMediaData):
(WebCore::VideoMediaSampleRenderer::setTimebase): Whenever the CMTimeSource calls, maybe enqueue for display the earliest decoded frame.
(WebCore::VideoMediaSampleRenderer::clearTimebase):
(WebCore::VideoMediaSampleRenderer::timebase const):
(WebCore::VideoMediaSampleRenderer::enqueueSample):
(WebCore::VideoMediaSampleRenderer::decodeNextSample):
(WebCore::VideoMediaSampleRenderer::initializeDecompressionSession): Fly-by: the current code can&apos;t deal with m_decodedSampleQueue changing mid-flight
as accessed to this member would become racy. As such, we make it an error to clear m_decodedSampleQueue.
There&apos;s also no need to set the timebase and ResourceOwner to the WebCoreDecompression as we aren&apos;t using its internal samples queueing.
(WebCore::VideoMediaSampleRenderer::decodedFrameAvailable):
(WebCore::VideoMediaSampleRenderer::maybeQueueFrameForDisplay):
(WebCore::VideoMediaSampleRenderer::flushCompressedSampleQueue):
(WebCore::VideoMediaSampleRenderer::flushDecodedSampleQueue):
(WebCore::VideoMediaSampleRenderer::cancelTimer):
(WebCore::VideoMediaSampleRenderer::purgeDecodedSampleQueue):
(WebCore::VideoMediaSampleRenderer::flush):
(WebCore::VideoMediaSampleRenderer::expectMinimumUpcomingSampleBufferPresentationTime): Fly-by: When using a decompression session
frames queued for display are always earlier than the value set in expectMinimumUpcomingSampleBufferPresentationTime as
the time given if of the compressed frame about to be enqueued leading to very AVFoundation verbose warnings.
(WebCore::VideoMediaSampleRenderer::copyDisplayedPixelBuffer): Fly-By, if we don&apos;t have an active WebCoreDecompressionSession and [AVSBDL copyDisplayedPixelBuffer]
didn&apos;t return an image, exit early as there&apos;s nothing to retrieve in the decoded queue.
(WebCore::VideoMediaSampleRenderer::copyDisplayedPixelBuffer): add workQueue assertion.

Canonical link: <a href="https://commits.webkit.org/286719@main">https://commits.webkit.org/286719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8adaf8988f9c4f3201ea0d3ce37bd83ec46b4358

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81469 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28201 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4253 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60278 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18361 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79992 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50228 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66037 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40593 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47630 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23532 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26527 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68748 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23863 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82905 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4301 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2873 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68553 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67811 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16893 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11798 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9879 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4248 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7061 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4271 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7702 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6029 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->