### PR TITLE
Web Inspector: disallow out of bounds `nameIndex` when parsing source map

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/SourceMap.js
+++ b/Source/WebInspectorUI/UserInterface/Models/SourceMap.js
@@ -319,7 +319,7 @@ WI.SourceMap = class SourceMap
             let relativeNameIndex = this._decodeVLQ(stringCharIterator);
             if (relativeNameIndex !== WI.SourceMap.VLQ_AT_SEPARATOR) {
                 nameIndex += relativeNameIndex;
-                if (nameIndex < 0 || nameIndex > map.names.length)
+                if (nameIndex < 0 || nameIndex >= map.names.length)
                     throw this._invalidPropertyError(WI.unlocalizedString("mappings"));
                 // Currently `names` is unused, but check it anyways for conformance.
             }


### PR DESCRIPTION
#### 0fa2a9fb892d567bcf9afa2d6e106a34ddb6e2f2
<pre>
Web Inspector: disallow out of bounds `nameIndex` when parsing source map
<a href="https://bugs.webkit.org/show_bug.cgi?id=283266">https://bugs.webkit.org/show_bug.cgi?id=283266</a>

Reviewed by Ryan Reno.

Previously `nameIndex` was only invalid if it &quot;is negative or greater than names’s size&quot;.

This was problematic because if `nameIndex` is equal to `names` size then that would be out of bounds.

Now the spec states &quot;is negative or greater than or equal to names’s size&quot;.  &lt;<a href="https://github.com/tc39/source-map/pull/150">https://github.com/tc39/source-map/pull/150</a>&gt;

* Source/WebInspectorUI/UserInterface/Models/SourceMap.js:
(WI.SourceMap.prototype._parseMap):

Canonical link: <a href="https://commits.webkit.org/286745@main">https://commits.webkit.org/286745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b62986fdeedd851e3bb6591eb47b72eb888bba9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81410 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28145 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4197 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60231 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18313 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79936 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50181 "Found 1 new test failure: compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/65987 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40548 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47583 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23482 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26470 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68700 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82849 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4245 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2818 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68510 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4399 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67765 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16912 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11746 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9830 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4192 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4215 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7646 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5973 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->