### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/svg/

### DIFF
--- a/Source/WebCore/platform/graphics/PathElement.h
+++ b/Source/WebCore/platform/graphics/PathElement.h
@@ -39,7 +39,7 @@ struct PathElement {
         CloseSubpath
     };
     Type type;
-    FloatPoint points[3];
+    std::array<FloatPoint, 3> points;
 };
 
 using PathElementApplier = Function<void(const PathElement&)>;

--- a/Source/WebCore/platform/graphics/PathTraversalState.cpp
+++ b/Source/WebCore/platform/graphics/PathTraversalState.cpp
@@ -228,7 +228,7 @@ bool PathTraversalState::finalizeAppendPathElement()
     return m_success;
 }
 
-bool PathTraversalState::appendPathElement(PathElement::Type type, const FloatPoint* points)
+bool PathTraversalState::appendPathElement(PathElement::Type type, std::span<const FloatPoint> points)
 {
     switch (type) {
     case PathElement::Type::MoveToPoint:
@@ -251,7 +251,7 @@ bool PathTraversalState::appendPathElement(PathElement::Type type, const FloatPo
     return finalizeAppendPathElement();
 }
 
-bool PathTraversalState::processPathElement(PathElement::Type type, const FloatPoint* points)
+bool PathTraversalState::processPathElement(PathElement::Type type, std::span<const FloatPoint> points)
 {
     if (m_success)
         return true;

--- a/Source/WebCore/platform/graphics/PathTraversalState.h
+++ b/Source/WebCore/platform/graphics/PathTraversalState.h
@@ -42,7 +42,7 @@ public:
     PathTraversalState(Action, float desiredLength = 0);
 
 public:
-    bool processPathElement(PathElement::Type, const FloatPoint*);
+    bool processPathElement(PathElement::Type, std::span<const FloatPoint>);
     bool processPathElement(const PathElement& element) { return processPathElement(element.type, element.points); }
 
     Action action() const { return m_action; }
@@ -64,7 +64,7 @@ private:
     void cubicBezierTo(const FloatPoint&, const FloatPoint&, const FloatPoint&);
 
     bool finalizeAppendPathElement();
-    bool appendPathElement(PathElement::Type, const FloatPoint*);
+    bool appendPathElement(PathElement::Type, std::span<const FloatPoint>);
 
 private:
     Action m_action;

--- a/Source/WebCore/platform/graphics/skia/PathSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PathSkia.cpp
@@ -205,8 +205,8 @@ void PathSkia::addPath(const PathSkia& path, const AffineTransform& transform)
 
 bool PathSkia::applyElements(const PathElementApplier& applier) const
 {
-    auto convertPoints = [](FloatPoint dst[], const SkPoint src[], int count) {
-        for (int i = 0; i < count; i++) {
+    auto convertPoints = [](std::span<FloatPoint, 3> dst, const SkPoint src[], int count) {
+        for (int i = 0; i < count; ++i) {
             dst[i].setX(SkScalarToFloat(src[i].fX));
             dst[i].setY(SkScalarToFloat(src[i].fY));
         }

--- a/Source/WebCore/svg/SVGPathByteStreamSource.h
+++ b/Source/WebCore/svg/SVGPathByteStreamSource.h
@@ -23,8 +23,6 @@
 #include "SVGPathByteStream.h"
 #include "SVGPathSource.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 class SVGPathByteStreamSource final : public SVGPathSource {
@@ -56,9 +54,11 @@ private:
         DataType data;
         size_t dataSize = sizeof(DataType);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         ASSERT_WITH_SECURITY_IMPLICATION(m_streamCurrent + dataSize <= m_streamEnd);
         memcpy(&data, m_streamCurrent, dataSize);
         m_streamCurrent += dataSize;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         return data;
     }
 
@@ -88,5 +88,3 @@ private:
 };
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/svg/SVGPathTraversalStateBuilder.cpp
+++ b/Source/WebCore/svg/SVGPathTraversalStateBuilder.cpp
@@ -25,6 +25,7 @@
 #include "SVGPathTraversalStateBuilder.h"
 
 #include "PathTraversalState.h"
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 
@@ -36,24 +37,24 @@ SVGPathTraversalStateBuilder::SVGPathTraversalStateBuilder(PathTraversalState& s
 
 void SVGPathTraversalStateBuilder::moveTo(const FloatPoint& targetPoint, bool, PathCoordinateMode)
 {
-    m_traversalState.processPathElement(PathElement::Type::MoveToPoint, &targetPoint);
+    m_traversalState.processPathElement(PathElement::Type::MoveToPoint, singleElementSpan(targetPoint));
 }
 
 void SVGPathTraversalStateBuilder::lineTo(const FloatPoint& targetPoint, PathCoordinateMode)
 {
-    m_traversalState.processPathElement(PathElement::Type::AddLineToPoint, &targetPoint);
+    m_traversalState.processPathElement(PathElement::Type::AddLineToPoint, singleElementSpan(targetPoint));
 }
 
 void SVGPathTraversalStateBuilder::curveToCubic(const FloatPoint& point1, const FloatPoint& point2, const FloatPoint& targetPoint, PathCoordinateMode)
 {
-    FloatPoint points[] = { point1, point2, targetPoint };
+    std::array points { point1, point2, targetPoint };
 
-    m_traversalState.processPathElement(PathElement::Type::AddCurveToPoint, points);
+    m_traversalState.processPathElement(PathElement::Type::AddCurveToPoint, std::span<FloatPoint> { points });
 }
 
 void SVGPathTraversalStateBuilder::closePath()
 {
-    m_traversalState.processPathElement(PathElement::Type::CloseSubpath, nullptr);
+    m_traversalState.processPathElement(PathElement::Type::CloseSubpath, { });
 }
 
 bool SVGPathTraversalStateBuilder::continueConsuming()

--- a/Source/WebCore/svg/SVGPathUtilities.cpp
+++ b/Source/WebCore/svg/SVGPathUtilities.cpp
@@ -38,8 +38,6 @@
 #include "SVGPathStringViewSource.h"
 #include "SVGPathTraversalStateBuilder.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 Path buildPathFromString(StringView d)
@@ -235,5 +233,3 @@ std::optional<SVGPathByteStream> convertSVGPathByteStreamToAbsoluteCoordinates(c
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/svg/SVGToOTFFontConversion.cpp
+++ b/Source/WebCore/svg/SVGToOTFFontConversion.cpp
@@ -43,8 +43,6 @@
 #include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/StringView.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 class SVGToOTFFontConverter;
 }
@@ -166,7 +164,7 @@ private:
         WebCore::append32(m_result, value);
     }
 
-    void append32BitCode(const char code[4])
+    void append32BitCode(ASCIILiteral code)
     {
         m_result.append(code[0]);
         m_result.append(code[1]);
@@ -209,7 +207,7 @@ private:
     void processGlyphElement(const SVGElement& glyphOrMissingGlyphElement, const SVGGlyphElement*, float defaultHorizontalAdvance, float defaultVerticalAdvance, const String& codepoints, std::optional<FloatRect>& boundingBox);
 
     typedef void (SVGToOTFFontConverter::*FontAppendingFunction)();
-    void appendTable(const char identifier[4], FontAppendingFunction);
+    void appendTable(ASCIILiteral identifier, FontAppendingFunction);
     void appendFormat12CMAPTable(const Vector<std::pair<char32_t, Glyph>>& codepointToGlyphMappings);
     void appendFormat4CMAPTable(const Vector<std::pair<char32_t, Glyph>>& codepointToGlyphMappings);
     void appendCMAPTable();
@@ -527,7 +525,7 @@ void SVGToOTFFontConverter::appendOS2Table()
 
     unsigned numPanoseBytes = 0;
     constexpr unsigned panoseSize = 10;
-    char panoseBytes[panoseSize];
+    std::array<char, panoseSize> panoseBytes;
     if (m_fontFaceElement) {
         auto segments = StringView(m_fontFaceElement->attributeWithoutSynchronization(SVGNames::panose_1Attr)).split(' ');
         for (auto segment : segments) {
@@ -540,8 +538,8 @@ void SVGToOTFFontConverter::appendOS2Table()
         }
     }
     if (numPanoseBytes != panoseSize)
-        memset(panoseBytes, 0, panoseSize);
-    m_result.append(std::span { panoseBytes });
+        memset(panoseBytes.data(), 0, panoseSize);
+    m_result.append(std::span<char> { panoseBytes });
 
     for (int i = 0; i < 4; ++i)
         append32(0); // "Bit assignments are pending. Set to 0"
@@ -874,9 +872,9 @@ void SVGToOTFFontConverter::appendGSUBTable()
     // ScriptList
     auto scriptListLocation = m_result.size();
     append16(2); // Number of ScriptRecords
-    append32BitCode("DFLT");
+    append32BitCode("DFLT"_s);
     append16(0); // Placeholder for offset of Script table, relative to beginning of ScriptList
-    append32BitCode("arab");
+    append32BitCode("arab"_s);
     append16(0); // Placeholder for offset of Script table, relative to beginning of ScriptList
 
     overwrite16(scriptListLocation + 6, m_result.size() - scriptListLocation);
@@ -892,15 +890,15 @@ void SVGToOTFFontConverter::appendGSUBTable()
     size_t featureListSize = 2 + 6 * featureCount;
     size_t featureTableSize = 6;
     append16(featureCount); // FeatureCount
-    append32BitCode("liga");
+    append32BitCode("liga"_s);
     append16(featureListSize + featureTableSize * 0); // Offset of feature table, relative to beginning of FeatureList table
-    append32BitCode("fina");
+    append32BitCode("fina"_s);
     append16(featureListSize + featureTableSize * 1); // Offset of feature table, relative to beginning of FeatureList table
-    append32BitCode("medi");
+    append32BitCode("medi"_s);
     append16(featureListSize + featureTableSize * 2); // Offset of feature table, relative to beginning of FeatureList table
-    append32BitCode("init");
+    append32BitCode("init"_s);
     append16(featureListSize + featureTableSize * 3); // Offset of feature table, relative to beginning of FeatureList table
-    append32BitCode("rlig");
+    append32BitCode("rlig"_s);
     append16(featureListSize + featureTableSize * 4); // Offset of feature table, relative to beginning of FeatureList table
     ASSERT_UNUSED(featureListLocation, featureListLocation + featureListSize == m_result.size());
 
@@ -918,7 +916,7 @@ void SVGToOTFFontConverter::appendGSUBTable()
     append16(featureCount); // LookupCount
     for (unsigned i = 0; i < featureCount; ++i)
         append16(0); // Placeholder for offset to feature table, relative to beginning of LookupList
-    size_t subtableRecordLocations[featureCount];
+    std::array<size_t, featureCount> subtableRecordLocations;
     for (unsigned i = 0; i < featureCount; ++i) {
         subtableRecordLocations[i] = m_result.size();
         overwrite16(lookupListLocation + 2 + 2 * i, m_result.size() - lookupListLocation);
@@ -1008,11 +1006,11 @@ void SVGToOTFFontConverter::appendVMTXTable()
 
 static String codepointToString(char32_t codepoint)
 {
-    UChar buffer[2];
+    std::array<UChar, 2> buffer;
     uint8_t length = 0;
     UBool error = false;
     U16_APPEND(buffer, length, 2, codepoint, error);
-    return error ? String() : String({ buffer, length });
+    return error ? String() : String(std::span<UChar> { buffer }.first(length));
 }
 
 Vector<Glyph, 1> SVGToOTFFontConverter::glyphsForCodepoint(char32_t codepoint) const
@@ -1497,7 +1495,7 @@ uint32_t SVGToOTFFontConverter::calculateChecksum(size_t startingOffset, size_t 
     return sum;
 }
 
-void SVGToOTFFontConverter::appendTable(const char identifier[4], FontAppendingFunction appendingFunction)
+void SVGToOTFFontConverter::appendTable(ASCIILiteral identifier, FontAppendingFunction appendingFunction)
 {
     size_t offset = m_result.size();
     ASSERT(isFourByteAligned(offset));
@@ -1541,21 +1539,21 @@ bool SVGToOTFFontConverter::convertSVGToOTFFont()
     for (size_t i = 0; i < directoryEntrySize * numTables; ++i)
         m_result.append(0);
 
-    appendTable("CFF ", &SVGToOTFFontConverter::appendCFFTable);
-    appendTable("GSUB", &SVGToOTFFontConverter::appendGSUBTable);
-    appendTable("OS/2", &SVGToOTFFontConverter::appendOS2Table);
-    appendTable("VORG", &SVGToOTFFontConverter::appendVORGTable);
-    appendTable("cmap", &SVGToOTFFontConverter::appendCMAPTable);
+    appendTable("CFF "_s, &SVGToOTFFontConverter::appendCFFTable);
+    appendTable("GSUB"_s, &SVGToOTFFontConverter::appendGSUBTable);
+    appendTable("OS/2"_s, &SVGToOTFFontConverter::appendOS2Table);
+    appendTable("VORG"_s, &SVGToOTFFontConverter::appendVORGTable);
+    appendTable("cmap"_s, &SVGToOTFFontConverter::appendCMAPTable);
     auto headTableOffset = m_result.size();
-    appendTable("head", &SVGToOTFFontConverter::appendHEADTable);
-    appendTable("hhea", &SVGToOTFFontConverter::appendHHEATable);
-    appendTable("hmtx", &SVGToOTFFontConverter::appendHMTXTable);
-    appendTable("kern", &SVGToOTFFontConverter::appendKERNTable);
-    appendTable("maxp", &SVGToOTFFontConverter::appendMAXPTable);
-    appendTable("name", &SVGToOTFFontConverter::appendNAMETable);
-    appendTable("post", &SVGToOTFFontConverter::appendPOSTTable);
-    appendTable("vhea", &SVGToOTFFontConverter::appendVHEATable);
-    appendTable("vmtx", &SVGToOTFFontConverter::appendVMTXTable);
+    appendTable("head"_s, &SVGToOTFFontConverter::appendHEADTable);
+    appendTable("hhea"_s, &SVGToOTFFontConverter::appendHHEATable);
+    appendTable("hmtx"_s, &SVGToOTFFontConverter::appendHMTXTable);
+    appendTable("kern"_s, &SVGToOTFFontConverter::appendKERNTable);
+    appendTable("maxp"_s, &SVGToOTFFontConverter::appendMAXPTable);
+    appendTable("name"_s, &SVGToOTFFontConverter::appendNAMETable);
+    appendTable("post"_s, &SVGToOTFFontConverter::appendPOSTTable);
+    appendTable("vhea"_s, &SVGToOTFFontConverter::appendVHEATable);
+    appendTable("vmtx"_s, &SVGToOTFFontConverter::appendVMTXTable);
 
     ASSERT(numTables == m_tablesAppendedCount);
 
@@ -1576,5 +1574,3 @@ std::optional<Vector<uint8_t>> convertSVGToOTFFont(const SVGFontElement& element
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/svg/SVGTransformable.cpp
+++ b/Source/WebCore/svg/SVGTransformable.cpp
@@ -30,13 +30,11 @@
 #include <wtf/text/StringParsingBuffer.h>
 #include <wtf/text/StringView.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 SVGTransformable::~SVGTransformable() = default;
 
-template<typename CharacterType> static int parseTransformParamList(StringParsingBuffer<CharacterType>& buffer, float* values, int required, int optional)
+template<typename CharacterType> static int parseTransformParamList(StringParsingBuffer<CharacterType>& buffer, std::span<float, 6> values, int required, int optional)
 {
     int optionalParams = 0, requiredParams = 0;
     
@@ -98,8 +96,8 @@ template<typename CharacterType> static int parseTransformParamList(StringParsin
 }
 
 // These should be kept in sync with enum SVGTransformType
-static constexpr int requiredValuesForType[] =  { 0, 6, 1, 1, 1, 1, 1 };
-static constexpr int optionalValuesForType[] =  { 0, 0, 1, 1, 2, 0, 0 };
+static constexpr std::array requiredValuesForType { 0, 6, 1, 1, 1, 1, 1 };
+static constexpr std::array optionalValuesForType { 0, 0, 1, 1, 2, 0, 0 };
 
 template<typename CharacterType> static std::optional<SVGTransformValue> parseTransformValueGeneric(SVGTransformValue::SVGTransformType type, StringParsingBuffer<CharacterType>& buffer)
 {
@@ -107,7 +105,7 @@ template<typename CharacterType> static std::optional<SVGTransformValue> parseTr
         return std::nullopt;
 
     int valueCount = 0;
-    float values[] = { 0, 0, 0, 0, 0, 0 };
+    std::array<float, 6> values { 0, 0, 0, 0, 0, 0 };
     if ((valueCount = parseTransformParamList(buffer, values, requiredValuesForType[type], optionalValuesForType[type])) < 0)
         return std::nullopt;
 
@@ -214,5 +212,3 @@ std::optional<SVGTransformValue::SVGTransformType> SVGTransformable::parseTransf
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### a08c0907686839170bf652d6c8abedfda61eb60d
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/svg/
<a href="https://bugs.webkit.org/show_bug.cgi?id=283268">https://bugs.webkit.org/show_bug.cgi?id=283268</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/platform/graphics/PathElement.h:
* Source/WebCore/svg/SVGParserUtilities.cpp:
* Source/WebCore/svg/SVGPathByteStreamSource.h:
* Source/WebCore/svg/SVGPathUtilities.cpp:
* Source/WebCore/svg/SVGToOTFFontConversion.cpp:
(WebCore::SVGToOTFFontConverter::append32BitCode):
(WebCore::SVGToOTFFontConverter::appendOS2Table):
(WebCore::SVGToOTFFontConverter::appendGSUBTable):
(WebCore::codepointToString):
(WebCore::SVGToOTFFontConverter::appendTable):
(WebCore::SVGToOTFFontConverter::convertSVGToOTFFont):
* Source/WebCore/svg/SVGTransformable.cpp:
(WebCore::parseTransformParamList):
(WebCore::parseTransformValueGeneric):

Canonical link: <a href="https://commits.webkit.org/286713@main">https://commits.webkit.org/286713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/060416332f26a65fc244887d2e174b8cfd7908d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76883 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81425 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28159 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4211 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60242 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18324 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66000 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40559 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47595 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23495 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26484 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68712 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23824 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82863 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4259 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2833 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68522 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4413 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65973 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67776 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11761 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9844 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11900 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4206 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7019 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4229 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7660 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5987 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->