### PR TITLE
Add Metal debug test options to WebKitTestRunner

### DIFF
--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
@@ -72,6 +72,10 @@ struct GPUProcessCreationParameters {
     String renderDeviceFile;
 #endif
     Vector<String> overrideLanguages;
+#if PLATFORM(COCOA)
+    bool enableMetalDebugDeviceForTesting { false };
+    bool enableMetalShaderValidationForTesting { false };
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.serialization.in
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.serialization.in
@@ -63,6 +63,10 @@
 #endif
 
     Vector<String> overrideLanguages;
+#if PLATFORM(COCOA)
+    bool enableMetalDebugDeviceForTesting;
+    bool enableMetalShaderValidationForTesting;
+#endif
 };
 
 #endif

--- a/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
@@ -118,6 +118,19 @@ void GPUProcess::platformInitializeGPUProcess(GPUProcessCreationParameters& para
     if (launchServicesExtension)
         launchServicesExtension->revoke();
 #endif // PLATFORM(MAC)
+
+    if (parameters.enableMetalDebugDeviceForTesting) {
+        RELEASE_LOG(Process, "%p - GPUProcess::platformInitializeGPUProcess: enabling Metal debug device", this);
+        setenv("MTL_DEBUG_LAYER", "1", 1);
+    }
+
+    if (parameters.enableMetalShaderValidationForTesting) {
+        RELEASE_LOG(Process, "%p - GPUProcess::platformInitializeGPUProcess: enabling Metal shader validation", this);
+        setenv("MTL_SHADER_VALIDATION", "1", 1);
+        setenv("MTL_SHADER_VALIDATION_ABORT_ON_FAULT", "1", 1);
+        setenv("MTL_SHADER_VALIDATION_REPORT_TO_STDERR", "1", 1);
+    }
+
 #if USE(SANDBOX_EXTENSIONS_FOR_CACHE_AND_TEMP_DIRECTORY_ACCESS) && USE(EXTENSIONKIT)
     MTLSetShaderCachePath(parameters.containerCachesDirectory);
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -529,6 +529,30 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     WebKit::setLockdownModeEnabledGloballyForTesting(std::nullopt);
 }
 
++ (void)_setEnableMetalDebugDeviceInNewGPUProcessesForTesting:(BOOL)enable
+{
+    WebKit::GPUProcessProxy::setEnableMetalDebugDeviceInNewGPUProcessesForTesting(enable);
+}
+
++ (void)_setEnableMetalShaderValidationInNewGPUProcessesForTesting:(BOOL)enable
+{
+    WebKit::GPUProcessProxy::setEnableMetalShaderValidationInNewGPUProcessesForTesting(enable);
+}
+
++ (BOOL)_isMetalDebugDeviceEnabledInGPUProcessForTesting
+{
+    if (auto gpuProcess = WebKit::GPUProcessProxy::singletonIfCreated())
+        return gpuProcess->isMetalDebugDeviceEnabledForTesting();
+    return WebKit::GPUProcessProxy::isMetalDebugDeviceEnabledInNewGPUProcessesForTesting();
+}
+
++ (BOOL)_isMetalShaderValidationEnabledInGPUProcessForTesting
+{
+    if (auto gpuProcess = WebKit::GPUProcessProxy::singletonIfCreated())
+        return gpuProcess->isMetalShaderValidationEnabledForTesting();
+    return WebKit::GPUProcessProxy::isMetalShaderValidationEnabledInNewGPUProcessesForTesting();
+}
+
 - (BOOL)_isCookieStoragePartitioningEnabled
 {
     return _processPool->cookieStoragePartitioningEnabled();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
@@ -165,6 +165,12 @@ WK_CLASS_AVAILABLE(macos(14.5), ios(17.5), visionos(1.2))
 + (void)_clearCaptivePortalModeEnabledGloballyForTesting WK_API_AVAILABLE(macos(13.0), ios(16.0));
 + (BOOL)_lockdownModeEnabledGloballyForTesting WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
+// Test only. Should be called before a GPU process has been launched.
++ (void)_setEnableMetalDebugDeviceInNewGPUProcessesForTesting:(BOOL)enable WK_API_AVAILABLE(macos(15.5), ios(18.5), visionos(2.5));
++ (void)_setEnableMetalShaderValidationInNewGPUProcessesForTesting:(BOOL)enable WK_API_AVAILABLE(macos(15.5), ios(18.5), visionos(2.5));
++ (BOOL)_isMetalDebugDeviceEnabledInGPUProcessForTesting WK_API_AVAILABLE(macos(15.5), ios(18.5), visionos(2.5));
++ (BOOL)_isMetalShaderValidationEnabledInGPUProcessForTesting WK_API_AVAILABLE(macos(15.5), ios(18.5), visionos(2.5));
+
 - (void)_preconnectToServer:(NSURL *)serverURL WK_API_DEPRECATED_WITH_REPLACEMENT("WKWebView._preconnectToServer", macos(10.13.4, 10.15.4), ios(11.3, 13.4));
 
 // Test only.

--- a/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
@@ -44,6 +44,9 @@ WTF_WEAK_LINK_FORCE_IMPORT(PLQueryRegistered);
 
 namespace WebKit {
 
+bool GPUProcessProxy::s_enableMetalDebugDeviceInNewGPUProcessesForTesting { false };
+bool GPUProcessProxy::s_enableMetalShaderValidationInNewGPUProcessesForTesting { false };
+
 void GPUProcessProxy::platformInitializeGPUProcessParameters(GPUProcessCreationParameters& parameters)
 {
     parameters.mobileGestaltExtensionHandle = createMobileGestaltSandboxExtensionIfNeeded();
@@ -53,6 +56,8 @@ void GPUProcessProxy::platformInitializeGPUProcessParameters(GPUProcessCreationP
     if (auto launchServicesExtensionHandle = SandboxExtension::createHandleForMachLookup("com.apple.coreservices.launchservicesd"_s, std::nullopt))
         parameters.launchServicesExtensionHandle = WTFMove(*launchServicesExtensionHandle);
 #endif
+    parameters.enableMetalDebugDeviceForTesting = m_isMetalDebugDeviceEnabledForTesting;
+    parameters.enableMetalShaderValidationForTesting = m_isMetalShaderValidationEnabledForTesting;
 }
 
 #if HAVE(POWERLOG_TASK_MODE_QUERY)

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -206,6 +206,11 @@ GPUProcessProxy::GPUProcessProxy()
     parameters.renderDeviceFile = drmRenderNodeDevice();
 #endif
 
+#if PLATFORM(COCOA)
+    m_isMetalDebugDeviceEnabledForTesting = s_enableMetalDebugDeviceInNewGPUProcessesForTesting;
+    m_isMetalShaderValidationEnabledForTesting = s_enableMetalShaderValidationInNewGPUProcessesForTesting;
+#endif
+
     platformInitializeGPUProcessParameters(parameters);
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -60,6 +60,11 @@ enum class VideoFrameRotation : uint16_t;
 
 namespace WebKit {
 
+#if PLATFORM(COCOA)
+void enableMetalDebugDeviceInNextGPUProcessForTesting();
+void enableMetalShaderValidationInNextGPUProcessForTesting();
+#endif
+
 enum class ProcessTerminationReason : uint8_t;
 
 class SandboxExtensionHandle;
@@ -136,6 +141,15 @@ public:
 
     void terminateForTesting();
     void webProcessConnectionCountForTesting(CompletionHandler<void(uint64_t)>&&);
+
+#if PLATFORM(COCOA)
+    static void setEnableMetalDebugDeviceInNewGPUProcessesForTesting(bool enable) { s_enableMetalDebugDeviceInNewGPUProcessesForTesting = enable; }
+    static void setEnableMetalShaderValidationInNewGPUProcessesForTesting(bool enable) { s_enableMetalShaderValidationInNewGPUProcessesForTesting = enable; }
+    static bool isMetalDebugDeviceEnabledInNewGPUProcessesForTesting() { return s_enableMetalDebugDeviceInNewGPUProcessesForTesting; }
+    static bool isMetalShaderValidationEnabledInNewGPUProcessesForTesting() { return s_enableMetalShaderValidationInNewGPUProcessesForTesting; }
+    bool isMetalDebugDeviceEnabledForTesting() const { return m_isMetalDebugDeviceEnabledForTesting; }
+    bool isMetalShaderValidationEnabledForTesting() const { return m_isMetalShaderValidationEnabledForTesting; }
+#endif
 
 #if ENABLE(VIDEO)
     void requestBitmapImageForCurrentTime(WebCore::ProcessIdentifier, WebCore::MediaPlayerIdentifier, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&);
@@ -225,6 +239,8 @@ private:
     bool m_hasSentMicrophoneSandboxExtension { false };
     bool m_hasSentDisplayCaptureSandboxExtension { false };
     bool m_hasSentGPUToolsSandboxExtensions { false };
+    bool m_isMetalDebugDeviceEnabledForTesting { false };
+    bool m_isMetalShaderValidationEnabledForTesting { false };
 #endif
 
 #if HAVE(SCREEN_CAPTURE_KIT)
@@ -235,6 +251,10 @@ private:
 #endif
 #if ENABLE(AV1)
     static std::optional<bool> s_hasAV1HardwareDecoder;
+#endif
+#if PLATFORM(COCOA)
+    static bool s_enableMetalDebugDeviceInNewGPUProcessesForTesting;
+    static bool s_enableMetalShaderValidationInNewGPUProcessesForTesting;
 #endif
 
     HashSet<PAL::SessionID> m_sessionIDs;

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1071,6 +1071,7 @@ void TestController::ensureViewSupportsOptionsForTest(const TestInvocation& test
         m_createdOtherPage = false;
     }
 
+    platformEnsureGPUProcessConfiguredForOptions(options);
     createWebViewWithOptions(options);
 
     if (!resetStateToConsistentValues(options, ResetStage::BeforeTest))
@@ -4274,6 +4275,10 @@ bool TestController::keyExistsInKeychain(const String&, const String&)
 }
 
 void TestController::setAllowedMenuActions(const Vector<String>&)
+{
+}
+
+void TestController::platformEnsureGPUProcessConfiguredForOptions(const TestOptions&)
 {
 }
 #endif

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -462,6 +462,7 @@ private:
     void platformDestroy();
     WKContextRef platformAdjustContext(WKContextRef, WKContextConfigurationRef);
     void platformInitializeContext();
+    void platformEnsureGPUProcessConfiguredForOptions(const TestOptions&);
     void platformCreateWebView(WKPageConfigurationRef, const TestOptions&);
     static UniqueRef<PlatformWebView> platformCreateOtherPage(PlatformWebView* parentView, WKPageConfigurationRef, const TestOptions&);
 

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -207,6 +207,8 @@ const TestFeatures& TestOptions::defaults()
             { "enhancedWindowingEnabled", false },
             { "textExtractionEnabled", false },
             { "useHardwareKeyboardMode", false },
+            { "enableMetalDebugDevice", false },
+            { "enableMetalShaderValidation", false },
         };
         features.doubleTestRunnerFeatures = {
             { "contentInset.top", 0 },
@@ -280,6 +282,9 @@ const std::unordered_map<std::string, TestHeaderKeyType>& TestOptions::keyTypeMa
         { "enhancedWindowingEnabled", TestHeaderKeyType::BoolTestRunner },
         { "textExtractionEnabled", TestHeaderKeyType::BoolTestRunner },
         { "useHardwareKeyboardMode", TestHeaderKeyType::BoolTestRunner },
+        { "enableMetalDebugDevice", TestHeaderKeyType::BoolTestRunner },
+        { "enableMetalShaderValidation", TestHeaderKeyType::BoolTestRunner },
+
         { "contentInset.top", TestHeaderKeyType::DoubleTestRunner },
         { "obscuredInset.top", TestHeaderKeyType::DoubleTestRunner },
         { "horizontalSystemMinimumLayoutMargin", TestHeaderKeyType::DoubleTestRunner },

--- a/Tools/WebKitTestRunner/TestOptions.h
+++ b/Tools/WebKitTestRunner/TestOptions.h
@@ -86,6 +86,9 @@ public:
     bool enhancedWindowingEnabled() const { return boolTestRunnerFeatureValue("enhancedWindowingEnabled"); }
     bool textExtractionEnabled() const { return boolTestRunnerFeatureValue("textExtractionEnabled"); }
     bool useHardwareKeyboardMode() const { return boolTestRunnerFeatureValue("useHardwareKeyboardMode"); }
+    bool shouldIgnoreWebProcessTermination() const { return boolTestRunnerFeatureValue("ignoreWebProcessTermination"); }
+    bool enableMetalDebugDevice() const { return boolTestRunnerFeatureValue("enableMetalDebugDevice"); }
+    bool enableMetalShaderValidation() const { return boolTestRunnerFeatureValue("enableMetalShaderValidation"); }
     double contentInsetTop() const { return doubleTestRunnerFeatureValue("contentInset.top"); }
     double obscuredInsetTop() const { return doubleTestRunnerFeatureValue("obscuredInset.top"); }
     double horizontalSystemMinimumLayoutMargin() const { return doubleTestRunnerFeatureValue("horizontalSystemMinimumLayoutMargin"); }
@@ -105,7 +108,6 @@ public:
     std::string captionDisplayMode() const { return stringTestRunnerFeatureValue("captionDisplayMode"); }
     std::string standaloneWebApplicationURL() const { return stringTestRunnerFeatureValue("standaloneWebApplicationURL"); }
     std::vector<std::string> overrideLanguages() const { return stringVectorTestRunnerFeatureValue("language"); }
-    bool shouldIgnoreWebProcessTermination() const { return boolTestRunnerFeatureValue("ignoreWebProcessTermination"); }
 
     bool shouldEnableProcessSwapOnNavigation() const
     {

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -292,6 +292,26 @@ void TestController::platformInitializeDataStore(WKPageConfigurationRef, const T
         m_websiteDataStore = (__bridge WKWebsiteDataStoreRef)[globalWebViewConfiguration() websiteDataStore];
 }
 
+static bool currentGPUProcessConfigurationCompatibleWithOptions(const TestOptions& options)
+{
+    if ([WKProcessPool _isMetalDebugDeviceEnabledInGPUProcessForTesting] != options.enableMetalDebugDevice())
+        return false;
+
+    if ([WKProcessPool _isMetalShaderValidationEnabledInGPUProcessForTesting] != options.enableMetalShaderValidation())
+        return false;
+
+    return true;
+}
+
+void TestController::platformEnsureGPUProcessConfiguredForOptions(const TestOptions& options)
+{
+    [WKProcessPool _setEnableMetalDebugDeviceInNewGPUProcessesForTesting:options.enableMetalDebugDevice()];
+    [WKProcessPool _setEnableMetalShaderValidationInNewGPUProcessesForTesting:options.enableMetalShaderValidation()];
+
+    if (!currentGPUProcessConfigurationCompatibleWithOptions(options))
+        terminateGPUProcess();
+}
+
 void TestController::platformCreateWebView(WKPageConfigurationRef, const TestOptions& options)
 {
     auto copiedConfiguration = adoptNS([globalWebViewConfiguration() copy]);


### PR DESCRIPTION
#### 61fb3600ad265b55fa0f2aaa81611a8c254b32cc
<pre>
Add Metal debug test options to WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=283270">https://bugs.webkit.org/show_bug.cgi?id=283270</a>
<a href="https://rdar.apple.com/problem/140088138">rdar://problem/140088138</a>

Reviewed by Mike Wyrzykowski.

This adds two new WebKitTestRunner test options, enableMetalDebugDevice
and enableMetalShaderValidation, which enable different Metal framework
validation layers that will cause GPU process crashes if they fail.
These test options will be used for some WebGPU crash tests.

Because the only way to enable these validation layers is to set some
environment variables in the Metal-using process early on (before the
first use of Metal), it means that any time these test options change
between tests, we must restart the GPU process.

These test options only have an effect on Cocoa ports.

* Source/WebKit/GPUProcess/GPUProcessCreationParameters.h:
* Source/WebKit/GPUProcess/GPUProcessCreationParameters.serialization.in:
* Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm:
(WebKit::GPUProcess::platformInitializeGPUProcess):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(+[WKProcessPool _setEnableMetalDebugDeviceInNewGPUProcessesForTesting:]):
(+[WKProcessPool _setEnableMetalShaderValidationInNewGPUProcessesForTesting:]):
(+[WKProcessPool _isMetalDebugDeviceEnabledInGPUProcessForTesting]):
(+[WKProcessPool _isMetalShaderValidationEnabledInGPUProcessForTesting]):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h:
* Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm:
(WebKit::GPUProcessProxy::platformInitializeGPUProcessParameters):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::GPUProcessProxy):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::ensureViewSupportsOptionsForTest):
(WTR::TestController::platformEnsureGPUProcessConfiguredForOptions):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
(WTR::TestOptions::keyTypeMapping):
* Tools/WebKitTestRunner/TestOptions.h:
(WTR::TestOptions::shouldIgnoreWebProcessTermination const):
(WTR::TestOptions::enableMetalDebugDevice const):
(WTR::TestOptions::enableMetalShaderValidation const):
(WTR::TestOptions::overrideLanguages const):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::currentGPUProcessConfigurationCompatibleWithOptions):
(WTR::TestController::platformEnsureGPUProcessConfiguredForOptions):

Canonical link: <a href="https://commits.webkit.org/286761@main">https://commits.webkit.org/286761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd8f1440cc4a9c8648a1b75a9086f7baf30b5968

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55923 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81430 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28164 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79005 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4216 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60247 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-images/object-fit-cover-svg-005p.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18327 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79955 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66004 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40562 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23499 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26490 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68715 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23829 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82868 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4264 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68526 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4418 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65977 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67778 "Found 1 new API test failure: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/open-window-default-size (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16926 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11764 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9848 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4211 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7024 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4234 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7665 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/5992 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->