### PR TITLE
Add CanvasRenderingContext2DSettings.pixelFormat to support higher bit depths

### DIFF
--- a/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-disabled-expected.txt
+++ b/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-disabled-expected.txt
@@ -1,0 +1,13 @@
+Test that the pixelFormat member of CanvasRenderingContext2DSettings is unsupported when CanvasPixelFormatEnabled=false.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS testSettings.pixelFormat is undefined.
+PASS testSettings.pixelFormat is undefined.
+PASS testSettings.pixelFormat is undefined.
+PASS testSettings.pixelFormat is undefined.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-disabled.html
+++ b/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-disabled.html
@@ -1,0 +1,24 @@
+<!-- webkit-test-runner [ CanvasPixelFormatEnabled=false ] -->
+<html>
+    <script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+    description("Test that the pixelFormat member of CanvasRenderingContext2DSettings is unsupported when CanvasPixelFormatEnabled=false.");
+
+    function testPixelFormatUnsupported(settings) {
+        let canvas = document.createElement("canvas");
+        let context = canvas.getContext("2d", settings);
+        window.testSettings = context.getContextAttributes();
+        shouldBeUndefined("testSettings.pixelFormat");
+    }
+
+    testPixelFormatUnsupported(undefined);
+    testPixelFormatUnsupported({ pixelFormat: "uint8" });
+    testPixelFormatUnsupported({ pixelFormat: "float16" });
+    testPixelFormatUnsupported({ pixelFormat: "foo" });
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-enabled-expected.txt
+++ b/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-enabled-expected.txt
@@ -1,0 +1,13 @@
+Test that the pixelFormat member of CanvasRenderingContext2DSettings is supported when CanvasPixelFormatEnabled=true.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS testSettings.pixelFormat is "uint8"
+PASS testSettings.pixelFormat is "uint8"
+PASS testSettings.pixelFormat is "float16"
+PASS document.createElement("canvas").getContext("2d", { pixelFormat: "foo" }) threw exception TypeError: Type error.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-enabled.html
+++ b/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-enabled.html
@@ -1,0 +1,29 @@
+<!-- webkit-test-runner [ CanvasPixelFormatEnabled=true ] -->
+<html>
+    <script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+    description("Test that the pixelFormat member of CanvasRenderingContext2DSettings is supported when CanvasPixelFormatEnabled=true.");
+
+    function testpixelFormat(settings, expectedpixelFormat) {
+        let canvas = document.createElement("canvas");
+        let context = canvas.getContext("2d", settings);
+        window.testSettings = context.getContextAttributes();
+        shouldBeEqualToString("testSettings.pixelFormat", expectedpixelFormat);
+    }
+
+    // Test default value of pixelFormat is "uint8".
+    testpixelFormat(undefined, "uint8");
+
+    // Test setting pixelFormat to a valid value works.
+    testpixelFormat({ pixelFormat: "uint8" }, "uint8");
+    testpixelFormat({ pixelFormat: "float16" }, "float16");
+
+    // Test setting pixelFormat to an unsupported value.
+    shouldThrowErrorName(`document.createElement("canvas").getContext("2d", { pixelFormat: "foo" })`, "TypeError")
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1792,6 +1792,22 @@ CanvasLayersEnabled:
     WebCore:
       default: false
 
+CanvasPixelFormatEnabled:
+  type: bool
+  status: unstable
+  category: dom
+  humanReadableName: "CanvasRenderingContext2DSettings.pixelFormat"
+  humanReadableDescription: "Allow different pixel formats in 2D canvas"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+  disableInLockdownMode: true
+  sharedPreferenceForWebProcess: true
+
 CanvasUsesAcceleratedDrawing:
   type: bool
   status: embedder

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.h
@@ -35,6 +35,11 @@ struct CanvasRenderingContext2DSettings {
     bool desynchronized { false };
     bool willReadFrequently { false };
     PredefinedColorSpace colorSpace { PredefinedColorSpace::SRGB };
+    enum class PixelFormat : bool {
+        Uint8,
+        Float16,
+    };
+    PixelFormat pixelFormat { PixelFormat::Uint8 };
     enum class RenderingMode {
         Unaccelerated,
         Accelerated

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.idl
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.idl
@@ -23,6 +23,12 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://github.com/w3c/ColorWeb-CG/blob/main/canvas_float.md with Chromium renaming (subject to change)
+enum CanvasPixelFormat {
+    "uint8",
+    "float16",
+};
+
 enum RenderingMode {
     "Unaccelerated",
     "Accelerated",
@@ -38,5 +44,6 @@ enum RenderingMode {
     boolean desynchronized = false;
     boolean willReadFrequently = false;
     [EnabledBySetting=CanvasColorSpaceEnabled] PredefinedColorSpace colorSpace = "srgb";
+    [EnabledBySetting=CanvasPixelFormatEnabled] CanvasPixelFormat pixelFormat = "uint8";
     [EnabledBySetting=DOMTestingAPIsEnabled] RenderingMode? renderingModeForTesting;
 };


### PR DESCRIPTION
#### e9af57b86e4d575626553d667fa60595ffbd688c
<pre>
Add CanvasRenderingContext2DSettings.pixelFormat to support higher bit depths
<a href="https://bugs.webkit.org/show_bug.cgi?id=283281">https://bugs.webkit.org/show_bug.cgi?id=283281</a>
<a href="https://rdar.apple.com/problem/140105324">rdar://problem/140105324</a>

Reviewed by Simon Fraser.

Start supporting different pixel formats in 2D canvas, as per
<a href="https://github.com/w3c/ColorWeb-CG/blob/main/canvas_float.md">https://github.com/w3c/ColorWeb-CG/blob/main/canvas_float.md</a> ,
with naming based on Chromium implementation.
This is needed to eventually support HDR.

This adds:
- An unstable preference &quot;CanvasPixelFormatEnabled&quot;.
- CanvasRenderingContext2DSettings.pixelFormat of type CanvasPixelFormat,
  which can be &quot;uint8&quot; (default) or &quot;float16&quot; for now.
  (The property has no effects yet, but can be set and queried.)

* LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-disabled-expected.txt: Added.
* LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-disabled.html: Added.
* LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-enabled-expected.txt: Added.
* LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-pixelFormat-enabled.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.idl:

Canonical link: <a href="https://commits.webkit.org/286934@main">https://commits.webkit.org/286934@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bda44123a67d132fdd265b6056ea1a2d04920a85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82090 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28788 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79623 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60729 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18728 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66527 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41007 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48105 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24023 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27116 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/70694 "Found 5 new JSC stress test failures: stress/get-by-val-hoist-above-structure-2.js.ftl-eager-no-cjit-b3o1, stress/get-by-val-hoist-above-structure-2.js.ftl-no-cjit-small-pool, stress/get-by-val-hoist-above-structure.js.ftl-eager-no-cjit-b3o1, stress/get-by-val-hoist-above-structure.js.ftl-no-cjit-no-put-stack-validate, wasm.yaml/wasm/modules/wasm-imports-js-exports.js.wasm-no-cjit (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69215 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83495 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76785 "Found 3 new JSC stress test failures: stress/attribute-custom-accessor.js.ftl-eager, stress/get-by-val-hoist-above-structure.js.ftl-eager-no-cjit-b3o1, wasm.yaml/wasm/stress/referenced-function.js.wasm-collect-continuously (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4886 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3327 "Found 3 new test failures: imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-invalid-behavior.tentative.html ipc/create-connection-and-send-async.html webrtc/vp9-profile2.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68966 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66494 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68231 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17063 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12248 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10346 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/99037 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4833 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7648 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21650 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4852 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8287 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6611 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->