### PR TITLE
[GTK][WPE][Skia] WebKitTestRunners asserts under SKIA_DEBUG builds

### DIFF
--- a/Tools/WebKitTestRunner/skia/TestInvocationSkia.cpp
+++ b/Tools/WebKitTestRunner/skia/TestInvocationSkia.cpp
@@ -44,12 +44,12 @@ namespace WTR {
 static std::string computeSHA1HashStringForPixmap(const SkPixmap& pixmap)
 {
     size_t pixelsWidth = pixmap.width();
-    size_t pixelsHight = pixmap.height();
+    size_t pixelsHeight = pixmap.height();
     size_t bytesPerRow = pixmap.info().minRowBytes();
 
     SHA1 sha1;
-    const auto* bitmapData = pixmap.addr8();
-    for (size_t row = 0; row < pixelsHight; ++row) {
+    const auto* bitmapData = reinterpret_cast<const uint8_t*>(pixmap.addr32());
+    for (size_t row = 0; row < pixelsHeight; ++row) {
         sha1.addBytes(std::span { bitmapData, 4 * pixelsWidth });
         bitmapData += bytesPerRow;
     }


### PR DESCRIPTION
#### 88d4dbb4efd092d7f1c4930a88b6bccf2786591f
<pre>
[GTK][WPE][Skia] WebKitTestRunners asserts under SKIA_DEBUG builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=283284">https://bugs.webkit.org/show_bug.cgi?id=283284</a>

Reviewed by Carlos Garcia Campos.

WebKitTestRunner fires an assertion under SKIA_DEBUG builds.
Don&apos;t attempt to access SkPixmap::addr8(), use addr32() as
we deal with RGBA8 buffers, that span 32 bits, not 8 bits.

Covered by existing tests.

* Tools/WebKitTestRunner/skia/TestInvocationSkia.cpp:
(WTR::computeSHA1HashStringForPixmap):

Canonical link: <a href="https://commits.webkit.org/286716@main">https://commits.webkit.org/286716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4f66d3371a0b27cbaca73aa055ec6fe9c55c91c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76910 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29816 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81453 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28186 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4238 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60263 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18345 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40578 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47613 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23519 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26512 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68731 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82890 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4286 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2855 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68540 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4440 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67794 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16890 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11784 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9868 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4233 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4256 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7687 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6014 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->