### PR TITLE
serialization/deserialization during read/write operation of Clipboard APIs is different from other browsers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-html-script-removal.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-html-script-removal.https-expected.txt
@@ -1,4 +1,4 @@
 Body needed for test_driver.click()
 
-FAIL Verify write and read clipboard with scripts removed given text/html: <title>Title of the document</title> <script>const a = 5;</script> <p>Hello World</p> promise_test: Unhandled rejection with value: object "Error: Unsupported permission name "clipboard-read"."
+FAIL Verify write and read clipboard with scripts removed given text/html. The string "<script>const a = 5;</script>" has been removed. promise_test: Unhandled rejection with value: object "Error: Unsupported permission name "clipboard-read"."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-html-script-removal.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-html-script-removal.https.html
@@ -31,9 +31,9 @@ function reformatHtml(html) {
 const html_with_script =
   '<title>Title of the document</title> <script>const a = 5;</scr'
   + 'ipt> <p>Hello World</p>';
-const html_without_script =
-  '<title>Title of the document</title> <p>Hello World</p>';
-promise_test(async t => {
+const html_script = '<script>const a = 5;</scr'
+  + 'ipt>';
+  promise_test(async t => {
   await test_driver.set_permission({name: 'clipboard-read'}, 'granted');
   await test_driver.set_permission({name: 'clipboard-write'}, 'granted');
   const blobInput = new Blob([html_with_script], {type: 'text/html'});
@@ -53,8 +53,7 @@ promise_test(async t => {
   const blobText = await (new Response(blobOutput)).text();
 
   const outputHtml = reformatHtml(blobText);
-  const inputHtml = reformatHtml(html_without_script);
-  assert_equals(outputHtml, inputHtml);
-}, 'Verify write and read clipboard with scripts removed given text/html: '
-    + html_with_script);
+  const html_script_no_spaces = reformatHtml(html_script);
+  assert_true(!outputHtml.includes(html_script_no_spaces));
+}, 'Verify write and read clipboard with scripts removed given text/html. The string "' + html_script + '" has been removed.');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-navigator-clipboard-read-resource-load.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-navigator-clipboard-read-resource-load.https.html
@@ -34,7 +34,7 @@ promise_test(async test => {
   const htmlBlob = await items[0].getType("text/html");
   const html = await htmlBlob.text();
 
-  assert_equals(html, '<img src="https://example.com/oops">');
+  assert_true(html.includes('<img src="https://example.com/oops">'));
 
   // Allow resource loading to start asynchronously
   await new Promise(resolve => test.step_timeout(resolve, 100));


### PR DESCRIPTION
#### f3759551803835f54479eac0cd10b0d173a25ff3
<pre>
serialization/deserialization during read/write operation of Clipboard APIs is different from other browsers
<a href="https://bugs.webkit.org/show_bug.cgi?id=280749">https://bugs.webkit.org/show_bug.cgi?id=280749</a>
<a href="https://rdar.apple.com/137577746">rdar://137577746</a>

Reviewed by Wenson Hsieh.

WebKit sends back style attributes with the clipboard results.
The current tests are checking requirements on markup which
are not exactly the purpose of the test.

The first test is checking that the script element has been removed
  which WebKit does correctly.
The second test is checking that the img src is in the html code,
  which again WebKit does correctly

These two tests seems to fail on WPT for the wrong reasons. This is
an attempt to make the tests more robust.

* LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-html-script-removal.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-html-script-removal.https.html:
* LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-navigator-clipboard-read-resource-load.https.html:

Canonical link: <a href="https://commits.webkit.org/286766@main">https://commits.webkit.org/286766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64bb88aba78a4026f8e13d0eaa3158b90e47af6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81456 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28189 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4241 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60266 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18349 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66019 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40581 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47616 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23514 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26515 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68734 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23845 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82893 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2860 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68543 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/65992 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67797 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16932 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11782 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9863 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4236 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4259 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7690 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6017 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->