### PR TITLE
Fix LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace* tests

### DIFF
--- a/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace-disabled-expected.txt
+++ b/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace-disabled-expected.txt
@@ -6,6 +6,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS testSettings.colorSpace is undefined.
 PASS testSettings.colorSpace is undefined.
 PASS testSettings.colorSpace is undefined.
+PASS testSettings.colorSpace is undefined.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace-disabled.html
+++ b/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace-disabled.html
@@ -6,7 +6,7 @@
 <script>
     description("Test that the colorSpace member of CanvasRenderingContext2DSettings is unsupported when CanvasColorSpaceEnabled=false.");
 
-    function testColorSpaceUnsupported(settings, expectedColorSpace) {
+    function testColorSpaceUnsupported(settings) {
         let canvas = document.createElement("canvas");
         let context = canvas.getContext("2d", settings);
         window.testSettings = context.getContextAttributes();
@@ -15,6 +15,7 @@
 
     testColorSpaceUnsupported(undefined);
     testColorSpaceUnsupported({ colorSpace: "srgb" });
+    testColorSpaceUnsupported({ colorSpace: "display-p3" });
     testColorSpaceUnsupported({ colorSpace: "foo" });
 </script>
     

--- a/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace-enabled-expected.txt
+++ b/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace-enabled-expected.txt
@@ -5,6 +5,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS testSettings.colorSpace is "srgb"
 PASS testSettings.colorSpace is "srgb"
+PASS correct handling of "display-p3"
 PASS document.createElement("canvas").getContext("2d", { colorSpace: "foo" }) threw exception TypeError: Type error.
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace-enabled.html
+++ b/LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace-enabled.html
@@ -5,11 +5,15 @@
 <script>
     description("Test that the colorSpace member of CanvasRenderingContext2DSettings is supported.");
 
-    function testColorSpace(settings, expectedColorSpace) {
+    function tryColorSpace(settings) {
         let canvas = document.createElement("canvas");
         let context = canvas.getContext("2d", settings);
-        window.testSettings = context.getContextAttributes();
-        shouldBeEqualToString("testSettings.colorSpace", "srgb");
+        return context.getContextAttributes();
+    }
+
+    function testColorSpace(settings, expectedColorSpace) {
+        window.testSettings = tryColorSpace(settings);
+        shouldBeEqualToString("testSettings.colorSpace", expectedColorSpace);
     }
 
     // Test default value of colorSpace is "srgb".
@@ -17,6 +21,35 @@
 
     // Test setting colorSpace to "srgb" works.
     testColorSpace({ colorSpace: "srgb" }, "srgb");
+
+    // Test "display-p3", support may vary per platform.
+    function testDisplayP3Error() {
+        const settings = { colorSpace: "display-p3" };
+        if (window.internals && internals.displayP3Available()) {
+            let contextAttributes = tryColorSpace(settings);
+            if (contextAttributes.colorSpace == "display-p3") {
+                return "";
+            }
+            return 'colorSpace:"display-p3" returned "' + JSON.stringify(contextAttributes) + '"';
+        }
+        let contextAttributes;
+        try {
+            contextAttributes = tryColorSpace(settings);
+        } catch (e) {
+            if (e.name == "TypeError") {
+                return "";
+            }
+            return 'expected "TypeError" for colorSpace:"display-p3"';
+        }
+        return 'colorSpace:"display-p3" did not throw but returned "' + JSON.stringify(contextAttributes) + '"';
+    }
+    const error = testDisplayP3Error();
+    if (!error) {
+        // Note: The "pass" message must be the same on all platforms, to match the unified expected results.
+        testPassed('correct handling of "display-p3"');
+    } else {
+        testFailed(error);
+    }
 
     // Test setting colorSpace to an unsupported value.
     shouldThrowErrorName(`document.createElement("canvas").getContext("2d", { colorSpace: "foo" })`, "TypeError")

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -381,6 +381,15 @@ public:
 
     ExceptionOr<String> documentBackgroundColor();
 
+    ExceptionOr<bool> displayP3Available()
+    {
+#if ENABLE(PREDEFINED_COLOR_SPACE_DISPLAY_P3)
+        return true;
+#else
+        return false;
+#endif
+    }
+
     ExceptionOr<void> setPagination(const String& mode, int gap, int pageLength);
     ExceptionOr<uint64_t> lineIndexAfterPageBreak(Element&);
     ExceptionOr<String> configurationForViewport(float devicePixelRatio, int deviceWidth, int deviceHeight, int availableWidth, int availableHeight);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -594,6 +594,8 @@ enum RenderingMode {
 
     DOMString documentBackgroundColor();
 
+    boolean displayP3Available();
+
     undefined setPagination(DOMString mode, long gap, optional long pageLength = 0);
     unsigned long long lineIndexAfterPageBreak(Element element);
 


### PR DESCRIPTION
#### 203a7bc84353b7666360283e418164b26183e209
<pre>
Fix LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace* tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=283285">https://bugs.webkit.org/show_bug.cgi?id=283285</a>
<a href="https://rdar.apple.com/problem/140109547">rdar://problem/140109547</a>

Reviewed by Said Abou-Hallawa.

Fix some programming issues (unused parameters).
These did not make the tests fail, but it&apos;s best to clean them
to avoid future surprises.

* LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace-disabled-expected.txt:
* LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace-disabled.html:
* LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace-enabled-expected.txt:
* LayoutTests/fast/canvas/CanvasRenderingContext2DSettings-colorSpace-enabled.html:
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/286819@main">https://commits.webkit.org/286819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02bf840714ecee5b5a950f50cefe47215b227590

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77037 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29952 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81587 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28316 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4368 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60365 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18437 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50316 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40676 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47718 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23624 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26642 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23952 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83021 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2964 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68646 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-animations/translation-animation-subpixel-offset.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-separate.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4572 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67898 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16970 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11877 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4363 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7179 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4383 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7818 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6142 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->