### PR TITLE
[BuildStream SDK] Forward port GStreamer sticky events race fix

### DIFF
--- a/Tools/buildstream/elements/freedesktop-sdk.bst
+++ b/Tools/buildstream/elements/freedesktop-sdk.bst
@@ -22,6 +22,8 @@ sources:
   path: patches/fdo-0010-GStreamer-Vendor-WebRTC-related-patches-scheduled-to.patch
 - kind: patch
   path: patches/fdo-0011-GStreamer-Vendor-rtpfunnel-patch-scheduled-to-ship-i.patch
+- kind: patch
+  path: patches/fdo-0012-GStreamer-Vendor-GstPad-patch-scheduled-to-ship-in-1.patch
 config:
   options:
     target_arch: '%{arch}'

--- a/Tools/buildstream/patches/fdo-0012-GStreamer-Vendor-GstPad-patch-scheduled-to-ship-in-1.patch
+++ b/Tools/buildstream/patches/fdo-0012-GStreamer-Vendor-GstPad-patch-scheduled-to-ship-in-1.patch
@@ -1,0 +1,100 @@
+From 863fc27bd104f7c470ff7c88c7ae4959c13ca6a0 Mon Sep 17 00:00:00 2001
+From: Philippe Normand <philn@igalia.com>
+Date: Mon, 18 Nov 2024 10:02:09 +0000
+Subject: [PATCH] GStreamer: Vendor GstPad patch scheduled to ship in 1.26
+
+---
+ ...ticky-events-in-response-to-a-FLUSH_.patch | 81 +++++++++++++++++++
+ 1 file changed, 81 insertions(+)
+ create mode 100644 patches/gstreamer/0001-pad-Never-push-sticky-events-in-response-to-a-FLUSH_.patch
+
+diff --git a/patches/gstreamer/0001-pad-Never-push-sticky-events-in-response-to-a-FLUSH_.patch b/patches/gstreamer/0001-pad-Never-push-sticky-events-in-response-to-a-FLUSH_.patch
+new file mode 100644
+index 0000000..8987aa1
+--- /dev/null
++++ b/patches/gstreamer/0001-pad-Never-push-sticky-events-in-response-to-a-FLUSH_.patch
+@@ -0,0 +1,81 @@
++From 59b714edc36c6d5887d54741cd628f38efe9e30c Mon Sep 17 00:00:00 2001
++From: =?UTF-8?q?Alicia=20Boya=20Garc=C3=ADa?= <aboya@igalia.com>
++Date: Wed, 9 Oct 2024 13:35:33 -0400
++Subject: [PATCH] pad: Never push sticky events in response to a FLUSH_STOP
++
++FLUSH_STOP is meant to clear the flushing state of pads and elements
++downstream, not to process data. Hence, a FLUSH_STOP should not
++propagate sticky events. This is also consistent with how flushes are a
++special case for probes.
++
++Currently this is almost always the case, since a FLUSH_STOP is
++__usually__ preceded by a FLUSH_START, and events (sticky or not) are
++discarded while a pad has the FLUSHING flag active (set by FLUSH_START).
++
++However, it is currently assumed that a FLUSH_STOP not preceded by a
++FLUSH_START is correct behavior, and this will occur while autoplugging
++pipelines are constructed. This leaves us with an unhandled edge case!
++
++This patch explicitly disables sending sticky events when pushing a
++FLUSH_STOP, instead of relying on the flushing flag of the pad, which
++will break in the edge case of a FLUSH_STOP not preceded by a
++FLUSH_START.
++
++If sticky events are propagated in response to a FLUSH_STOP, the
++flushing thread can end up deadlocked in blocking code of a downstream
++pad, such as a blocking probe. Instead, those events should be
++propagated from the streaming thread of the pad when handling a
++non-flushing synchronized event or buffer.
++
++This fixes a deadlock found in WebKit with playbin3 when seeks occur
++before preroll, where the seeking thread ended up stuck in the blocking
++probe of playsink:
++https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1367
++
++Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/7632>
++---
++ subprojects/gstreamer/gst/gstpad.c | 17 ++++++++++++++---
++ 1 file changed, 14 insertions(+), 3 deletions(-)
++
++diff --git a/subprojects/gstreamer/gst/gstpad.c b/subprojects/gstreamer/gst/gstpad.c
++index d8bda692b2..7c159d2816 100644
++--- a/subprojects/gstreamer/gst/gstpad.c
+++++ b/subprojects/gstreamer/gst/gstpad.c
++@@ -5580,8 +5580,12 @@ gst_pad_push_event_unchecked (GstPad * pad, GstEvent * event,
++   PROBE_PUSH (pad, type | GST_PAD_PROBE_TYPE_PUSH, event, probe_stopped);
++ 
++   /* recheck sticky events because the probe might have cause a relink */
+++  /* Note: FLUSH_STOP is a serialized event, but must not propagate sticky
+++   * events. FLUSH_STOP is only targeted at removing the flushing state from
+++   * pads and elements, and not actually pushing data/events. */
++   if (GST_PAD_HAS_PENDING_EVENTS (pad) && GST_PAD_IS_SRC (pad)
++-      && (GST_EVENT_IS_SERIALIZED (event))) {
+++      && (GST_EVENT_IS_SERIALIZED (event))
+++      && GST_EVENT_TYPE (event) != GST_EVENT_FLUSH_STOP) {
++     PushStickyData data = { GST_FLOW_OK, FALSE, event };
++     GST_OBJECT_FLAG_UNSET (pad, GST_PAD_FLAG_PENDING_EVENTS);
++ 
++@@ -5740,11 +5744,18 @@ gst_pad_push_event (GstPad * pad, GstEvent * event)
++         break;
++     }
++   }
++-  if (GST_PAD_IS_SRC (pad) && serialized) {
+++  if (GST_PAD_IS_SRC (pad) && serialized
+++      && GST_EVENT_TYPE (event) != GST_EVENT_FLUSH_STOP) {
++     /* All serialized events on the srcpad trigger push of sticky events.
++      *
++      * Note that we do not do this for non-serialized sticky events since it
++-     * could potentially block. */
+++     * could potentially block.
+++     *
+++     * We must NOT propagate sticky events in response to FLUSH_STOP either, as
+++     * FLUSH_STOP is only targeted at removing the flushing state from pads and
+++     * elements, and not actually pushing data/events. This also makes it
+++     * consistent with the way flush events are handled in "blocking" pad
+++     * probes. */
++     res = (check_sticky (pad, event) == GST_FLOW_OK);
++   }
++   if (!serialized || !sticky) {
++-- 
++2.47.0
++
+-- 
+2.47.0
+


### PR DESCRIPTION
#### dbbd4a7159343e9a734f3168dda35d1b8b7738ea
<pre>
[BuildStream SDK] Forward port GStreamer sticky events race fix
<a href="https://bugs.webkit.org/show_bug.cgi?id=283121">https://bugs.webkit.org/show_bug.cgi?id=283121</a>

Reviewed by Xabier Rodriguez-Calvar.

This patch is currently scheduled to ship in GStreamer 1.26.

* Tools/buildstream/elements/freedesktop-sdk.bst:
* Tools/buildstream/patches/fdo-0012-GStreamer-Vendor-GstPad-patch-scheduled-to-ship-in-1.patch: Added.

Canonical link: <a href="https://commits.webkit.org/286788@main">https://commits.webkit.org/286788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4938954673b9b3156790b06020bac940ee0ee065

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81463 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28196 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79037 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4248 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60280 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18352 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50220 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40588 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47622 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23525 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26522 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68740 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23856 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82900 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4296 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2867 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68548 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4450 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67802 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11794 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9872 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11930 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4243 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4266 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7697 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6024 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->