### PR TITLE
[GTK][WPE][Skia] Add GPU synchronization primitives to NativeImage/ImageBuffer for Skia

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -415,6 +415,20 @@ RefPtr<cairo_surface_t> ImageBuffer::createCairoSurface()
 }
 #endif
 
+#if USE(SKIA)
+void ImageBuffer::finishAcceleratedRenderingAndCreateFence()
+{
+    if (auto* backend = ensureBackend())
+        backend->finishAcceleratedRenderingAndCreateFence();
+}
+
+void ImageBuffer::waitForAcceleratedRenderingFenceCompletion()
+{
+    if (auto* backend = ensureBackend())
+        backend->waitForAcceleratedRenderingFenceCompletion();
+}
+#endif
+
 RefPtr<GraphicsLayerContentsDisplayDelegate> ImageBuffer::layerContentsDisplayDelegate()
 {
     if (auto* backend = ensureBackend())

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -185,6 +185,13 @@ public:
     WEBCORE_EXPORT RefPtr<cairo_surface_t> createCairoSurface();
 #endif
 
+#if USE(SKIA)
+    // During DisplayList recording a fence is created, so that we can wait until the SkSurface finished rendering
+    // before we attempt to access the GPU resource from a secondary thread during replay (in threaded GPU painting mode).
+    void finishAcceleratedRenderingAndCreateFence();
+    void waitForAcceleratedRenderingFenceCompletion();
+#endif
+
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     WEBCORE_EXPORT virtual std::optional<DynamicContentScalingDisplayList> dynamicContentScalingDisplayList();
 #endif

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -133,6 +133,11 @@ public:
     virtual RefPtr<cairo_surface_t> createCairoSurface() { return nullptr; }
 #endif
 
+#if USE(SKIA)
+    virtual void finishAcceleratedRenderingAndCreateFence() { }
+    virtual void waitForAcceleratedRenderingFenceCompletion() { }
+#endif
+
     virtual bool isInUse() const { return false; }
     virtual void releaseGraphicsContext() { ASSERT_NOT_REACHED(); }
 

--- a/Source/WebCore/platform/graphics/NativeImage.cpp
+++ b/Source/WebCore/platform/graphics/NativeImage.cpp
@@ -25,6 +25,11 @@
 
 #include "config.h"
 #include "NativeImage.h"
+
+#if USE(SKIA)
+#include "GLFence.h"
+#endif
+
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -37,8 +37,11 @@
 
 namespace WebCore {
 
-class GraphicsContext;
+#if USE(SKIA)
+class GLFence;
+#endif
 
+class GraphicsContext;
 class NativeImageBackend;
 
 class NativeImage final : public RenderingResource {
@@ -82,6 +85,11 @@ public:
     virtual DestinationColorSpace colorSpace() const = 0;
     virtual Headroom headroom() const = 0;
     WEBCORE_EXPORT virtual bool isRemoteNativeImageBackendProxy() const;
+
+#if USE(SKIA)
+    virtual void finishAcceleratedRenderingAndCreateFence() { }
+    virtual void waitForAcceleratedRenderingFenceCompletion() { }
+#endif
 };
 
 class PlatformImageNativeImageBackend final : public NativeImageBackend {
@@ -93,8 +101,16 @@ public:
     WEBCORE_EXPORT bool hasAlpha() const final;
     WEBCORE_EXPORT DestinationColorSpace colorSpace() const final;
     WEBCORE_EXPORT Headroom headroom() const final;
+
+#if USE(SKIA)
+    void finishAcceleratedRenderingAndCreateFence() final;
+    void waitForAcceleratedRenderingFenceCompletion() final;
+#endif
 private:
     PlatformImagePtr m_platformImage;
+#if USE(SKIA)
+    std::unique_ptr<GLFence> m_fence;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-class BitmapTexture;
+class GLFence;
 
 class ImageBufferSkiaAcceleratedBackend final : public ImageBufferSkiaSurfaceBackend
 {
@@ -54,11 +54,16 @@ private:
     void getPixelBuffer(const IntRect&, PixelBuffer&) final;
     void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat) final;
 
+    void finishAcceleratedRenderingAndCreateFence() final;
+    void waitForAcceleratedRenderingFenceCompletion() final;
+
 #if USE(COORDINATED_GRAPHICS)
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() const final;
 
     RefPtr<GraphicsLayerContentsDisplayDelegate> m_layerContentsDisplayDelegate;
 #endif
+
+    std::unique_ptr<GLFence> m_fence;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
@@ -27,10 +27,9 @@
 #include "NativeImage.h"
 
 #if USE(SKIA)
-
 #include "GLContext.h"
+#include "GLFence.h"
 #include "GraphicsContextSkia.h"
-#include "NotImplemented.h"
 #include "PlatformDisplay.h"
 #include <skia/core/SkData.h>
 #include <skia/core/SkImage.h>
@@ -40,6 +39,35 @@ IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
 IGNORE_CLANG_WARNINGS_END
 
 namespace WebCore {
+
+void PlatformImageNativeImageBackend::finishAcceleratedRenderingAndCreateFence()
+{
+    auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
+    if (!glContext || !glContext->makeContextCurrent())
+        return;
+
+    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+    RELEASE_ASSERT(grContext);
+
+    grContext->flush(m_platformImage);
+
+    if (GLFence::isSupported()) {
+        grContext->submit(GrSyncCpu::kNo);
+        m_fence = GLFence::create();
+    }
+
+    if (!m_fence)
+        grContext->submit(GrSyncCpu::kYes);
+}
+
+void PlatformImageNativeImageBackend::waitForAcceleratedRenderingFenceCompletion()
+{
+    if (!m_fence)
+        return;
+
+    m_fence->serverWait();
+    m_fence = nullptr;
+}
 
 IntSize PlatformImageNativeImageBackend::size() const
 {


### PR DESCRIPTION
#### 774fd3dddd84bda499316f2f8ab5d28b42147e23
<pre>
[GTK][WPE][Skia] Add GPU synchronization primitives to NativeImage/ImageBuffer for Skia
<a href="https://bugs.webkit.org/show_bug.cgi?id=283286">https://bugs.webkit.org/show_bug.cgi?id=283286</a>

Reviewed by Said Abou-Hallawa.

Prepare for threaded GPU rendering: add Skia specific functions
to ImageBuffer(Backend)/NativeImageBackend:

 - finishAcceleratedRenderingAndCreateFence()

   Used to notify the underlying SkSurface, that it should flush
   all pending rendering operations and submit the work to the GPU.
   Afterwards inject a fence into the GL command stream, so that we
   we can wait upon completion at a later point, before attempting
   to use the ImageBuffer/NativeImage.

 - waitForAcceleratedRenderingFenceCompletion()

   Performs a &apos;serverWait()&apos; operation on the GLFence, previously
   created by finishAcceleratedRenderingAndCreateFence(). This
   instructs to GPU to await completion of the previous rendering.

finishAcceleratedRenderingAndCreateFence() will be used during
DisplayList recording, whenever an ImageBuffer/NativeImage resource
is used, upon entering the DisplayList::ResourceHeap cache.

waitForAcceleratedRenderingFenceCompletion() will be used during
DisplayList replaying, whenever an ImageBuffer/NativeImage resource
is extracted from the DisplayList::ResourceHeap cache.

This PR only contains the Skia specific ImageBuffer/NativeImage related
changes -- the hooks in the DisplayList code that make use of these
methods will be added in a separated PR.

No change in functionality for existing tests.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::finishAcceleratedRenderingAndCreateFence):
(WebCore::ImageBuffer::waitForAcceleratedRenderingFenceCompletion):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::finishAcceleratedRenderingAndCreateFence):
(WebCore::ImageBufferBackend::waitForAcceleratedRenderingFenceCompletion):
* Source/WebCore/platform/graphics/NativeImage.cpp:
* Source/WebCore/platform/graphics/NativeImage.h:
(WebCore::NativeImageBackend::finishAcceleratedRenderingAndCreateFence):
(WebCore::NativeImageBackend::waitForAcceleratedRenderingFenceCompletion):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::finishAcceleratedRenderingAndCreateFence):
(WebCore::ImageBufferSkiaAcceleratedBackend::waitForAcceleratedRenderingFenceCompletion):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h:
* Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp:
(WebCore::PlatformImageNativeImageBackend::finishAcceleratedRenderingAndCreateFence):
(WebCore::PlatformImageNativeImageBackend::waitForAcceleratedRenderingFenceCompletion):

Canonical link: <a href="https://commits.webkit.org/286767@main">https://commits.webkit.org/286767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba48b443522371408b036d56b18c7fd0bc8d43c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81470 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28202 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4254 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60283 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18360 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40597 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23533 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26528 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68749 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82906 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2874 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68556 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67810 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16931 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11799 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9880 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4249 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7062 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4272 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7703 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6030 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->