### PR TITLE
[scroll-animations] view timelines should support inline and SVG subjects

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7374,9 +7374,6 @@ imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animat
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-root-scroller.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/constructor-no-document.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/updating-the-finished-state.html [ Skip ]
-imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-subject.html [ Skip ]
-imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-001.html [ Skip ]
-imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-002.html [ Skip ]
 
 # webkit.org/b/263871 [scroll-animations] some WPT tests are failures or flaky failures
 imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none.html [ Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-subject-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-subject-expected.txt
@@ -1,7 +1,5 @@
 Hello world
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT View timeline attached to SVG graphics element Test timed out
+PASS View timeline attached to SVG graphics element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-001-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT View timeline attached to SVG graphics element Test timed out
+PASS View timeline attached to SVG graphics element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-002-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT View timeline attached to SVG graphics element Test timed out
+PASS View timeline attached to SVG graphics element
 


### PR DESCRIPTION
#### 7d3cb9238db77f66577af7605a78d2a19213b3cf
<pre>
[scroll-animations] view timelines should support inline and SVG subjects
<a href="https://bugs.webkit.org/show_bug.cgi?id=283291">https://bugs.webkit.org/show_bug.cgi?id=283291</a>
<a href="https://rdar.apple.com/140111170">rdar://140111170</a>

Reviewed by Antti Koivisto.

We only supported elements with a `RenderBox` renderer as subjects for view timelines,
thus excluding inlines and SVG elements. This made a few tests time out because their
`ready` promise never `resolved` as their timeline never reports a resolved current time.

We now add support for `RenderInline`, `RenderSVGModelObject` and `LegacyRenderSVGModelObject`
renderers which makes the affected tests pass.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-subject-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-002-expected.txt:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::computeTimelineData const):

Canonical link: <a href="https://commits.webkit.org/286724@main">https://commits.webkit.org/286724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63d36df113422e0710bd936fc88a6f17ebf1b5ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81468 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28200 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79041 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4252 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60279 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18357 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50226 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66032 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40594 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47628 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23527 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26526 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68746 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82904 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4300 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2872 "Build is in progress. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 30 flakes 2 failures; Uploaded test results; 25 flakes 1 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68552 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67806 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11795 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9874 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11903 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4247 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7060 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4270 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7701 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6028 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->