### PR TITLE
[GTK][WPE][Skia] Use GPU synchronization primitives for ImageBuffer/NativeImage during DisplayList recording/replaying

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayList.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayList.h
@@ -43,7 +43,10 @@ class DisplayList {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(DisplayList, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(DisplayList);
 public:
-    DisplayList() = default;
+    DisplayList(OptionSet<ReplayOption> options = { })
+        : m_options(options)
+    {
+    }
 
     WEBCORE_EXPORT void append(Item&&);
     void shrinkToFit();
@@ -65,9 +68,12 @@ public:
     WEBCORE_EXPORT String asText(OptionSet<AsTextFlag>) const;
     void dump(WTF::TextStream&) const;
 
+    const OptionSet<ReplayOption>& replayOptions() const { return m_options; }
+
 private:
     Vector<Item> m_items;
     ResourceHeap m_resourceHeap;
+    OptionSet<ReplayOption> m_options;
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const DisplayList&);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
@@ -51,10 +51,10 @@ bool isValid(const Item& item)
 }
 
 template<class T>
-inline static std::optional<RenderingResourceIdentifier> applyFilteredImageBufferItem(GraphicsContext& context, const ResourceHeap& resourceHeap, const T& item)
+inline static std::optional<RenderingResourceIdentifier> applyFilteredImageBufferItem(GraphicsContext& context, const ResourceHeap& resourceHeap, const T& item, OptionSet<ReplayOption> options)
 {
     auto resourceIdentifier = item.sourceImageIdentifier();
-    auto sourceImage = resourceIdentifier ? resourceHeap.getImageBuffer(*resourceIdentifier) : nullptr;
+    auto sourceImage = resourceIdentifier ? resourceHeap.getImageBuffer(*resourceIdentifier, options) : nullptr;
     if (UNLIKELY(!sourceImage && resourceIdentifier))
         return resourceIdentifier;
 
@@ -64,10 +64,10 @@ inline static std::optional<RenderingResourceIdentifier> applyFilteredImageBuffe
 }
 
 template<class T>
-inline static std::optional<RenderingResourceIdentifier> applyImageBufferItem(GraphicsContext& context, const ResourceHeap& resourceHeap, const T& item)
+inline static std::optional<RenderingResourceIdentifier> applyImageBufferItem(GraphicsContext& context, const ResourceHeap& resourceHeap, const T& item, OptionSet<ReplayOption> options)
 {
     auto resourceIdentifier = item.imageBufferIdentifier();
-    if (auto* imageBuffer = resourceHeap.getImageBuffer(resourceIdentifier)) {
+    if (auto* imageBuffer = resourceHeap.getImageBuffer(resourceIdentifier, options)) {
         item.apply(context, *imageBuffer);
         return std::nullopt;
     }
@@ -75,10 +75,10 @@ inline static std::optional<RenderingResourceIdentifier> applyImageBufferItem(Gr
 }
 
 template<class T>
-inline static std::optional<RenderingResourceIdentifier> applyNativeImageItem(GraphicsContext& context, const ResourceHeap& resourceHeap, const T& item)
+inline static std::optional<RenderingResourceIdentifier> applyNativeImageItem(GraphicsContext& context, const ResourceHeap& resourceHeap, const T& item, OptionSet<ReplayOption> options)
 {
     auto resourceIdentifier = item.imageIdentifier();
-    if (auto* image = resourceHeap.getNativeImage(resourceIdentifier)) {
+    if (auto* image = resourceHeap.getNativeImage(resourceIdentifier, options)) {
         item.apply(context, *image);
         return std::nullopt;
     }
@@ -86,24 +86,24 @@ inline static std::optional<RenderingResourceIdentifier> applyNativeImageItem(Gr
 }
 
 template<class T>
-inline static std::optional<RenderingResourceIdentifier> applySourceImageItem(GraphicsContext& context, const ResourceHeap& resourceHeap, const T& item)
+inline static std::optional<RenderingResourceIdentifier> applySourceImageItem(GraphicsContext& context, const ResourceHeap& resourceHeap, const T& item, OptionSet<ReplayOption> options)
 {
     auto resourceIdentifier = item.imageIdentifier();
-    if (auto sourceImage = resourceHeap.getSourceImage(resourceIdentifier)) {
+    if (auto sourceImage = resourceHeap.getSourceImage(resourceIdentifier, options)) {
         item.apply(context, *sourceImage);
         return std::nullopt;
     }
     return resourceIdentifier;
 }
 
-inline static std::optional<RenderingResourceIdentifier> applySetStateItem(GraphicsContext& context, const ResourceHeap& resourceHeap, const SetState& item)
+inline static std::optional<RenderingResourceIdentifier> applySetStateItem(GraphicsContext& context, const ResourceHeap& resourceHeap, const SetState& item, OptionSet<ReplayOption> options)
 {
     auto fixPatternTileImage = [&](Pattern* pattern) -> std::optional<RenderingResourceIdentifier> {
         if (!pattern)
             return std::nullopt;
 
         auto imageIdentifier = pattern->tileImage().imageIdentifier();
-        auto sourceImage = resourceHeap.getSourceImage(imageIdentifier);
+        auto sourceImage = resourceHeap.getSourceImage(imageIdentifier, options);
         if (!sourceImage)
             return imageIdentifier;
 
@@ -147,14 +147,14 @@ inline static std::optional<RenderingResourceIdentifier> applyDrawDecomposedGlyp
     return std::nullopt;
 }
 
-ApplyItemResult applyItem(GraphicsContext& context, const ResourceHeap& resourceHeap, ControlFactory& controlFactory, const Item& item)
+ApplyItemResult applyItem(GraphicsContext& context, const ResourceHeap& resourceHeap, ControlFactory& controlFactory, const Item& item, OptionSet<ReplayOption> options)
 {
     if (!isValid(item))
         return { StopReplayReason::InvalidItemOrExtent, std::nullopt };
 
     return WTF::switchOn(item,
         [&](const ClipToImageBuffer& item) -> ApplyItemResult {
-            if (auto missingCachedResourceIdentifier = applyImageBufferItem(context, resourceHeap, item))
+            if (auto missingCachedResourceIdentifier = applyImageBufferItem(context, resourceHeap, item, options))
                 return { StopReplayReason::MissingCachedResource, WTFMove(missingCachedResourceIdentifier) };
             return { };
         }, [&](const DrawControlPart& item) -> ApplyItemResult {
@@ -172,23 +172,23 @@ ApplyItemResult applyItem(GraphicsContext& context, const ResourceHeap& resource
             item.apply(context, resourceHeap, controlFactory);
             return { };
         }, [&](const DrawFilteredImageBuffer& item) -> ApplyItemResult {
-            if (auto missingCachedResourceIdentifier = applyFilteredImageBufferItem(context, resourceHeap, item))
+            if (auto missingCachedResourceIdentifier = applyFilteredImageBufferItem(context, resourceHeap, item, options))
                 return { StopReplayReason::MissingCachedResource, WTFMove(missingCachedResourceIdentifier) };
             return { };
         }, [&](const DrawImageBuffer& item) -> ApplyItemResult {
-            if (auto missingCachedResourceIdentifier = applyImageBufferItem(context, resourceHeap, item))
+            if (auto missingCachedResourceIdentifier = applyImageBufferItem(context, resourceHeap, item, options))
                 return { StopReplayReason::MissingCachedResource, WTFMove(missingCachedResourceIdentifier) };
             return { };
         }, [&](const DrawNativeImage& item) -> ApplyItemResult {
-            if (auto missingCachedResourceIdentifier = applyNativeImageItem<DrawNativeImage>(context, resourceHeap, item))
+            if (auto missingCachedResourceIdentifier = applyNativeImageItem<DrawNativeImage>(context, resourceHeap, item, options))
                 return { StopReplayReason::MissingCachedResource, WTFMove(missingCachedResourceIdentifier) };
             return { };
         }, [&](const DrawPattern& item) -> ApplyItemResult {
-            if (auto missingCachedResourceIdentifier = applySourceImageItem<DrawPattern>(context, resourceHeap, item))
+            if (auto missingCachedResourceIdentifier = applySourceImageItem<DrawPattern>(context, resourceHeap, item, options))
                 return { StopReplayReason::MissingCachedResource, WTFMove(missingCachedResourceIdentifier) };
             return { };
         }, [&](const SetState& item) -> ApplyItemResult {
-            if (auto missingCachedResourceIdentifier = applySetStateItem(context, resourceHeap, item))
+            if (auto missingCachedResourceIdentifier = applySetStateItem(context, resourceHeap, item, options))
                 return { StopReplayReason::MissingCachedResource, WTFMove(missingCachedResourceIdentifier) };
             return { };
         }, [&](const auto& item) -> ApplyItemResult {

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
@@ -208,6 +208,10 @@ struct ApplyItemResult {
     std::optional<RenderingResourceIdentifier> resourceIdentifier;
 };
 
+enum class ReplayOption : uint8_t {
+    FlushImagesAndWaitForCompletion = 1 << 0,
+};
+
 enum class AsTextFlag : uint8_t {
     IncludePlatformOperations      = 1 << 0,
     IncludeResourceIdentifiers     = 1 << 1,
@@ -215,7 +219,7 @@ enum class AsTextFlag : uint8_t {
 
 bool isValid(const Item&);
 
-ApplyItemResult applyItem(GraphicsContext&, const ResourceHeap&, ControlFactory&, const Item&);
+ApplyItemResult applyItem(GraphicsContext&, const ResourceHeap&, ControlFactory&, const Item&, OptionSet<ReplayOption>);
 
 bool shouldDumpItem(const Item&, OptionSet<AsTextFlag>);
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -489,12 +489,22 @@ void RecorderImpl::applyDeviceScaleFactor(float scaleFactor)
 
 bool RecorderImpl::recordResourceUse(NativeImage& nativeImage)
 {
+#if USE(SKIA)
+    if (m_displayList.replayOptions().contains(ReplayOption::FlushImagesAndWaitForCompletion))
+        nativeImage.backend().finishAcceleratedRenderingAndCreateFence();
+#endif
+
     m_displayList.cacheNativeImage(nativeImage);
     return true;
 }
 
 bool RecorderImpl::recordResourceUse(ImageBuffer& imageBuffer)
 {
+#if USE(SKIA)
+    if (m_displayList.replayOptions().contains(ReplayOption::FlushImagesAndWaitForCompletion))
+        imageBuffer.finishAcceleratedRenderingAndCreateFence();
+#endif
+
     m_displayList.cacheImageBuffer(imageBuffer);
     return true;
 }

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.cpp
@@ -35,15 +35,16 @@ namespace WebCore {
 namespace DisplayList {
 
 Replayer::Replayer(GraphicsContext& context, const DisplayList& displayList)
-    : Replayer(context, displayList.items(), displayList.resourceHeap(), ControlFactory::shared())
+    : Replayer(context, displayList.items(), displayList.resourceHeap(), ControlFactory::shared(), displayList.replayOptions())
 {
 }
 
-Replayer::Replayer(GraphicsContext& context, const Vector<Item>& items, const ResourceHeap& resourceHeap, ControlFactory& controlFactory)
+Replayer::Replayer(GraphicsContext& context, const Vector<Item>& items, const ResourceHeap& resourceHeap, ControlFactory& controlFactory, OptionSet<ReplayOption> options)
     : m_context(context)
     , m_items(items)
     , m_resourceHeap(resourceHeap)
     , m_controlFactory(controlFactory)
+    , m_options(options)
 {
 }
 
@@ -63,7 +64,7 @@ ReplayResult Replayer::replay(const FloatRect& initialClip, bool trackReplayList
     for (auto& item : m_items) {
         LOG_WITH_STREAM(DisplayLists, stream << "applying " << i++ << " " << item);
 
-        auto applyResult = applyItem(m_context, m_resourceHeap, m_controlFactory, item);
+        auto applyResult = applyItem(m_context, m_resourceHeap, m_controlFactory, item, m_options);
         if (applyResult.stopReason) {
             result.reasonForStopping = *applyResult.stopReason;
             result.missingCachedResourceIdentifier = WTFMove(applyResult.resourceIdentifier);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.h
@@ -50,7 +50,7 @@ class Replayer {
     WTF_MAKE_NONCOPYABLE(Replayer);
 public:
     WEBCORE_EXPORT Replayer(GraphicsContext&, const DisplayList&);
-    WEBCORE_EXPORT Replayer(GraphicsContext&, const Vector<Item>&, const ResourceHeap&, ControlFactory&);
+    WEBCORE_EXPORT Replayer(GraphicsContext&, const Vector<Item>&, const ResourceHeap&, ControlFactory&, OptionSet<ReplayOption> = { });
     ~Replayer() = default;
 
     WEBCORE_EXPORT ReplayResult replay(const FloatRect& initialClip = { }, bool trackReplayList = false);
@@ -60,6 +60,7 @@ private:
     const Vector<Item>& m_items;
     const ResourceHeap& m_resourceHeap;
     Ref<ControlFactory> m_controlFactory;
+    OptionSet<ReplayOption> m_options;
 };
 
 } // namespace DisplayList

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "DecomposedGlyphs.h"
+#include "DisplayListItem.h"
 #include "Filter.h"
 #include "Font.h"
 #include "FontCustomPlatformData.h"
@@ -92,23 +93,41 @@ public:
         add<FontCustomPlatformData>(renderingResourceIdentifier, WTFMove(customPlatformData), m_customPlatformDataCount);
     }
 
-    ImageBuffer* getImageBuffer(RenderingResourceIdentifier renderingResourceIdentifier) const
+    ImageBuffer* getImageBuffer(RenderingResourceIdentifier renderingResourceIdentifier, OptionSet<ReplayOption> options = { }) const
     {
-        return get<ImageBuffer>(renderingResourceIdentifier);
+        auto* imageBuffer = get<ImageBuffer>(renderingResourceIdentifier);
+
+#if USE(SKIA)
+        if (imageBuffer && options.contains(ReplayOption::FlushImagesAndWaitForCompletion))
+            imageBuffer->waitForAcceleratedRenderingFenceCompletion();
+#else
+        UNUSED_PARAM(options);
+#endif
+
+        return imageBuffer;
     }
 
-    NativeImage* getNativeImage(RenderingResourceIdentifier renderingResourceIdentifier) const
+    NativeImage* getNativeImage(RenderingResourceIdentifier renderingResourceIdentifier, OptionSet<ReplayOption> options = { }) const
     {
         auto* renderingResource = get<RenderingResource>(renderingResourceIdentifier);
-        return dynamicDowncast<NativeImage>(renderingResource);
+        auto* nativeImage = dynamicDowncast<NativeImage>(renderingResource);
+
+#if USE(SKIA)
+        if (nativeImage && options.contains(ReplayOption::FlushImagesAndWaitForCompletion))
+            nativeImage->backend().waitForAcceleratedRenderingFenceCompletion();
+#else
+        UNUSED_PARAM(options);
+#endif
+
+        return nativeImage;
     }
 
-    std::optional<SourceImage> getSourceImage(RenderingResourceIdentifier renderingResourceIdentifier) const
+    std::optional<SourceImage> getSourceImage(RenderingResourceIdentifier renderingResourceIdentifier, OptionSet<ReplayOption> options = { }) const
     {
-        if (auto nativeImage = getNativeImage(renderingResourceIdentifier))
+        if (auto nativeImage = getNativeImage(renderingResourceIdentifier, options))
             return { { *nativeImage } };
 
-        if (auto imageBuffer = getImageBuffer(renderingResourceIdentifier))
+        if (auto imageBuffer = getImageBuffer(renderingResourceIdentifier, options))
             return { { *imageBuffer } };
 
         return std::nullopt;

--- a/Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.cpp
@@ -54,7 +54,7 @@ std::unique_ptr<SkiaThreadedPaintingPool> SkiaThreadedPaintingPool::create()
 
 std::unique_ptr<DisplayList::DisplayList> SkiaThreadedPaintingPool::recordDisplayList(const CoordinatedGraphicsLayer& layer, const IntRect& dirtyRect) const
 {
-    auto displayList = makeUnique<DisplayList::DisplayList>();
+    auto displayList = makeUnique<DisplayList::DisplayList>(DisplayList::ReplayOption::FlushImagesAndWaitForCompletion);
     DisplayList::RecorderImpl recordingContext(*displayList, GraphicsContextState(), FloatRect({ }, dirtyRect.size()), AffineTransform());
     layer.paintIntoGraphicsContext(recordingContext, dirtyRect);
     return displayList;


### PR DESCRIPTION
#### 10435abe82ca31859fc6d3290c43857925f2df92
<pre>
[GTK][WPE][Skia] Use GPU synchronization primitives for ImageBuffer/NativeImage during DisplayList recording/replaying
<a href="https://bugs.webkit.org/show_bug.cgi?id=283292">https://bugs.webkit.org/show_bug.cgi?id=283292</a>

Reviewed by Said Abou-Hallawa.

Prepare for threaded GPU painting: Use new GPU synchronization
primitives in ImageBuffer/NativeImage during DisplayList
recording/replaying.

During recording, when a NativeImage/ImageBuffer is used call
finishAcceleratedRenderingAndCreateFence(), to make sure the
rendering commands are flushed to the GPU, and a fence is
injected in the GL command stream, so that we can wait during
replaying (in a worker thread!) that the GPU finished
processing, before we attempt to use the NativeImage or
ImageBuffer (in the accelerated case only!).

Covered by existing tests.

* Source/WebCore/platform/graphics/displaylists/DisplayList.h:
(WebCore::DisplayList::DisplayList::DisplayList):
(WebCore::DisplayList::DisplayList::replayOptions const):
* Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp:
(WebCore::DisplayList::applyFilteredImageBufferItem):
(WebCore::DisplayList::applyImageBufferItem):
(WebCore::DisplayList::applyNativeImageItem):
(WebCore::DisplayList::applySourceImageItem):
(WebCore::DisplayList::applySetStateItem):
(WebCore::DisplayList::applyItem):
* Source/WebCore/platform/graphics/displaylists/DisplayListItem.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::recordResourceUse):
* Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.cpp:
(WebCore::DisplayList::Replayer::Replayer):
(WebCore::DisplayList::Replayer::replay):
* Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.h:
(WebCore::DisplayList::Replayer::Replayer):
* Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h:
(WebCore::DisplayList::ResourceHeap::getImageBuffer):
(WebCore::DisplayList::ResourceHeap::getNativeImage):
(WebCore::DisplayList::ResourceHeap::getSourceImage):
(WebCore::DisplayList::ResourceHeap::getImageBuffer const): Deleted.
(WebCore::DisplayList::ResourceHeap::getNativeImage const): Deleted.
(WebCore::DisplayList::ResourceHeap::getSourceImage const): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaThreadedPaintingPool.cpp:
(WebCore::SkiaThreadedPaintingPool::recordDisplayList const):

Canonical link: <a href="https://commits.webkit.org/286787@main">https://commits.webkit.org/286787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3ad558d09f7f24a0957336995ae3a00ae5fca9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81649 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28372 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4424 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18469 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66174 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/40711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47767 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/23672 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26698 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68882 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83078 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4473 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3005 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68684 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4628 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66147 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/67938 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16945 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11921 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10011 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4419 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4439 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7874 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6198 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->