### PR TITLE
Allow taking a ref of IncomingAudioMediaStreamTrackRendererUnit

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2339,6 +2339,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/mediastream/WebAudioSourceProvider.h
     platform/mediastream/WebRTCProvider.h
 
+    platform/mediastream/libwebrtc/LibWebRTCAudioModule.h
     platform/mediastream/libwebrtc/LibWebRTCMacros.h
     platform/mediastream/libwebrtc/LibWebRTCProvider.h
     platform/mediastream/libwebrtc/LibWebRTCSocketIdentifier.h

--- a/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h
@@ -29,6 +29,7 @@
 
 #include "BaseAudioMediaStreamTrackRendererUnit.h"
 #include "CAAudioStreamDescription.h"
+#include "LibWebRTCAudioModule.h"
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
 #include <wtf/LoggerHelper.h>
@@ -45,7 +46,6 @@ class AudioMediaStreamTrackRendererInternalUnit;
 class AudioSampleDataSource;
 class AudioSampleBufferList;
 class CAAudioStreamDescription;
-class LibWebRTCAudioModule;
 class WebAudioBufferList;
 
 class IncomingAudioMediaStreamTrackRendererUnit : public BaseAudioMediaStreamTrackRendererUnit
@@ -59,6 +59,9 @@ public:
     ~IncomingAudioMediaStreamTrackRendererUnit();
 
     void newAudioChunkPushed(uint64_t);
+
+    void ref() { m_audioModule.get()->ref(); };
+    void deref() { m_audioModule.get()->deref(); };
 
 private:
     void start();
@@ -80,9 +83,10 @@ private:
     uint64_t logIdentifier() const final;
 #endif
 
+    const ThreadSafeWeakPtr<LibWebRTCAudioModule> m_audioModule;
+    const Ref<WTF::WorkQueue> m_queue;
+
     // Main thread variables.
-    LibWebRTCAudioModule& m_audioModule;
-    Ref<WTF::WorkQueue> m_queue;
     HashSet<Ref<AudioSampleDataSource>> m_sources;
     RefPtr<AudioSampleDataSource> m_registeredMixedSource;
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp
@@ -30,15 +30,12 @@
 
 #include "LibWebRTCAudioFormat.h"
 #include "Logging.h"
-#include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA)
 #include "IncomingAudioMediaStreamTrackRendererUnit.h"
 #endif
 
 namespace WebCore {
-
-WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCAudioModule);
 
 LibWebRTCAudioModule::LibWebRTCAudioModule()
     : m_queue(WorkQueue::create("WebKitWebRTCAudioModule"_s, WorkQueue::QOS::UserInteractive))
@@ -164,7 +161,7 @@ void LibWebRTCAudioModule::pollFromSource()
 BaseAudioMediaStreamTrackRendererUnit& LibWebRTCAudioModule::incomingAudioMediaStreamTrackRendererUnit()
 {
     if (!m_incomingAudioMediaStreamTrackRendererUnit)
-        m_incomingAudioMediaStreamTrackRendererUnit = makeUnique<IncomingAudioMediaStreamTrackRendererUnit>(*this);
+        m_incomingAudioMediaStreamTrackRendererUnit = makeUniqueWithoutRefCountedCheck<IncomingAudioMediaStreamTrackRendererUnit>(*this);
     return *m_incomingAudioMediaStreamTrackRendererUnit;
 }
 #endif


### PR DESCRIPTION
#### 441e431f0380b2a400fa1237156a8b1f202f0a9b
<pre>
Allow taking a ref of IncomingAudioMediaStreamTrackRendererUnit
<a href="https://rdar.apple.com/140113682">rdar://140113682</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=283293">https://bugs.webkit.org/show_bug.cgi?id=283293</a>

Reviewed by Jean-Yves Avenard.

Instead of taking a ref of LibWebRTCAudioModule to keep its IncomingAudioMediaStreamTrackRendererUnit alive, we implement ref/deref in IncomingAudioMediaStreamTrackRendererUnit.
We can then create a Ref of IncomingAudioMediaStreamTrackRendererUnit when posting a task and keeping it alive.

We update LibWebRTCAudioModule to make it ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr and use a ThreadSafeWeakPtr in IncomingAudioMediaStreamTrackRendererUnit.
This ThreadSafeWeakPtr is expected to always be valid given LibWebRTCAudioModule owns IncomingAudioMediaStreamTrackRendererUnit.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp:
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::~IncomingAudioMediaStreamTrackRendererUnit):
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::addSource):
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::removeSource):
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::start):
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::stop):
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::postTask):
* Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h:
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::ref):
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::deref):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp:
(WebCore::LibWebRTCAudioModule::incomingAudioMediaStreamTrackRendererUnit):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.h:
(WebCore::LibWebRTCAudioModule::create):
(WebCore::LibWebRTCAudioModule::stop):
(WebCore::LibWebRTCAudioModule::ref): Deleted.
(WebCore::LibWebRTCAudioModule::deref): Deleted.
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp:
(WebCore::LibWebRTCProvider::~LibWebRTCProvider):
(WebCore::LibWebRTCProvider::createPeerConnectionFactory):

Canonical link: <a href="https://commits.webkit.org/286852@main">https://commits.webkit.org/286852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/144f52198494a9a18c2647820c90525e3581f868

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81841 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28554 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4603 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60535 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18577 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50509 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66320 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40835 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47911 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23819 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26877 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/69022 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83260 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4652 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3144 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68807 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4808 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66292 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68064 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17001 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12054 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10153 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4599 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7414 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4618 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8053 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6377 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->