### PR TITLE
[GTK][Debug] Crash in AudioWorkletMessagingProxy destructor

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2136,25 +2136,6 @@ webkit.org/b/218010 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-a
 
 webkit.org/b/264729 imported/w3c/web-platform-tests/fetch/metadata/generated/audioworklet.https.sub.html [ Pass Crash DumpJSConsoleLogInStdErr ]
 
-webkit.org/b/282331 [ Debug ] http/wpt/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-message-port.https.html [ Crash ]
-webkit.org/b/282331 [ Debug ] imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/worklet-paint-import-data.https.html [ Crash ]
-webkit.org/b/282331 [ Debug ] imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/worklet-paint-import-data.https.html [ Crash ]
-webkit.org/b/282331 [ Debug ] imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-none/worklet-paint-import-data.https.html [ Crash ]
-webkit.org/b/282331 [ Debug ] imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/worklet-audio-import-data.https.html [ Crash ]
-webkit.org/b/282331 [ Debug ] imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/worklet-layout-import-data.https.html [ Crash ]
-webkit.org/b/282331 [ Debug ] imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/worklet-paint-import-data.https.html [ Crash ]
-webkit.org/b/282331 [ Debug ] imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/worklet-layout.https.html [ Crash ]
-webkit.org/b/282331 [ Debug ] imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/worklet-audio.https.html [ Crash ]
-webkit.org/b/282331 [ Debug ] imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-none/worklet-layout-import-data.https.html [ Crash ]
-webkit.org/b/282331 [ Debug ] imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-self/worklet-audio.https.html [ Crash ]
-webkit.org/b/282331 [ Debug ] imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/worklet-audio.https.html [ Crash ]
-webkit.org/b/282331 [ Debug ] imported/w3c/web-platform-tests/mixed-content/gen/top.http-rp/opt-in/worklet-layout-import-data.https.html [ Crash ]
-webkit.org/b/282331 [ Debug ] imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/worklet-paint-import-data.https.html [ Crash ]
-webkit.org/b/282331 [ Debug ] imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/worklet-layout-import-data.https.html [ Crash ]
-webkit.org/b/282331 [ Debug ] imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/unset/worklet-audio.https.html [ Crash ]
-webkit.org/b/282331 [ Debug ] imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/upgrade/worklet-audio.https.html [ Crash ]
-webkit.org/b/282331 [ Debug ] imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/unset/worklet-audio.https.html [ Crash ]
-
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of WebAudio-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h
@@ -38,7 +38,7 @@ class AudioWorklet;
 class AudioWorkletThread;
 class Document;
 
-class AudioWorkletMessagingProxy : public WorkletGlobalScopeProxy, public WorkerLoaderProxy, public CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy> {
+class AudioWorkletMessagingProxy final : public WorkletGlobalScopeProxy, public WorkerLoaderProxy, public CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AudioWorkletMessagingProxy);
 public:
@@ -57,10 +57,10 @@ public:
     void postTaskToAudioWorklet(Function<void(AudioWorklet&)>&&);
     ScriptExecutionContextIdentifier loaderContextIdentifier() const final;
 
-    uint32_t checkedPtrCount() const { return CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::checkedPtrCount(); }
-    uint32_t checkedPtrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::checkedPtrCountWithoutThreadCheck(); }
-    void incrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::incrementCheckedPtrCount(); }
-    void decrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::decrementCheckedPtrCount(); }
+    uint32_t checkedPtrCount() const final { return CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::decrementCheckedPtrCount(); }
 
 private:
     explicit AudioWorkletMessagingProxy(AudioWorklet&);


### PR DESCRIPTION
#### de32c4a55821aee88b7bed8e605cedb360191bc1
<pre>
[GTK][Debug] Crash in AudioWorkletMessagingProxy destructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=282331">https://bugs.webkit.org/show_bug.cgi?id=282331</a>

Reviewed by Chris Dumez.

Declare the AudioWorkletMessagingProxy as final, without this, GCC builds hit an ASSERT in the
destructor.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h:
(WebCore::AudioWorkletMessagingProxy::create): Deleted.
(WebCore::AudioWorkletMessagingProxy::workletThread): Deleted.
(WebCore::AudioWorkletMessagingProxy::checkedPtrCount const): Deleted.
(WebCore::AudioWorkletMessagingProxy::checkedPtrCountWithoutThreadCheck const): Deleted.
(WebCore::AudioWorkletMessagingProxy::incrementCheckedPtrCount const): Deleted.
(WebCore::AudioWorkletMessagingProxy::decrementCheckedPtrCount const): Deleted.

Canonical link: <a href="https://commits.webkit.org/286725@main">https://commits.webkit.org/286725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e09bd46726c204b049104dc6f515b8637b71013

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81474 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28206 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79047 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60286 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18362 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/79997 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40600 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47633 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23536 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26532 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68751 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82910 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4306 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2879 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68559 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/backdrop-filter-captured.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4460 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67814 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16894 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11803 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9883 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4253 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7066 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4276 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7707 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6034 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->