### PR TITLE
[GStreamer][PipeWire] getDisplayMedia() broken

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -97,6 +97,11 @@
 #define IS_GST_FULL_1_18 0
 #endif
 
+#if USE(GBM)
+#include "DRMDeviceManager.h"
+#include <drm_fourcc.h>
+#endif
+
 GST_DEBUG_CATEGORY(webkit_gst_common_debug);
 #define GST_CAT_DEFAULT webkit_gst_common_debug
 
@@ -1714,6 +1719,104 @@ void gstStructureFilterAndMapInPlace(GstStructure* structure, Function<bool(GstI
     }, &callback);
 #endif
 }
+
+#if !GST_CHECK_VERSION(1, 24, 0)
+static GstVideoFormat drmFourccToGstVideoFormat(uint32_t fourcc)
+{
+    switch (fourcc) {
+    case DRM_FORMAT_XRGB8888:
+        return GST_VIDEO_FORMAT_BGRx;
+    case DRM_FORMAT_XBGR8888:
+        return GST_VIDEO_FORMAT_RGBx;
+    case DRM_FORMAT_ARGB8888:
+        return GST_VIDEO_FORMAT_BGRA;
+    case DRM_FORMAT_ABGR8888:
+        return GST_VIDEO_FORMAT_RGBA;
+    case DRM_FORMAT_YUV420:
+        return GST_VIDEO_FORMAT_I420;
+    case DRM_FORMAT_YVU420:
+        return GST_VIDEO_FORMAT_YV12;
+    case DRM_FORMAT_NV12:
+        return GST_VIDEO_FORMAT_NV12;
+    case DRM_FORMAT_NV21:
+        return GST_VIDEO_FORMAT_NV21;
+    case DRM_FORMAT_YUV444:
+        return GST_VIDEO_FORMAT_Y444;
+    case DRM_FORMAT_YUV411:
+        return GST_VIDEO_FORMAT_Y41B;
+    case DRM_FORMAT_YUV422:
+        return GST_VIDEO_FORMAT_Y42B;
+    case DRM_FORMAT_P010:
+        return GST_VIDEO_FORMAT_P010_10LE;
+    default:
+        break;
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+    return GST_VIDEO_FORMAT_UNKNOWN;
+}
+#endif // !GST_CHECK_VERSION(1, 24, 0)
+
+#if USE(GBM)
+GRefPtr<GstCaps> buildDMABufCaps()
+{
+    GRefPtr<GstCaps> caps = adoptGRef(gst_caps_from_string("video/x-raw(memory:DMABuf), width = " GST_VIDEO_SIZE_RANGE ", height = " GST_VIDEO_SIZE_RANGE ", framerate = " GST_VIDEO_FPS_RANGE));
+#if GST_CHECK_VERSION(1, 24, 0)
+    gst_caps_set_simple(caps.get(), "format", G_TYPE_STRING, "DMA_DRM", nullptr);
+
+    static const char* formats = g_getenv("WEBKIT_GST_DMABUF_FORMATS");
+    if (formats && *formats) {
+        auto formatsString = StringView::fromLatin1(formats);
+        GValue drmSupportedFormats = G_VALUE_INIT;
+        g_value_init(&drmSupportedFormats, GST_TYPE_LIST);
+        for (auto token : formatsString.split(',')) {
+            GValue value = G_VALUE_INIT;
+            g_value_init(&value, G_TYPE_STRING);
+            g_value_set_string(&value, token.toStringWithoutCopying().ascii().data());
+            gst_value_list_append_and_take_value(&drmSupportedFormats, &value);
+        }
+        gst_caps_set_value(caps.get(), "drm-format", &drmSupportedFormats);
+        g_value_unset(&drmSupportedFormats);
+        return caps;
+    }
+#endif
+
+    GValue supportedFormats = G_VALUE_INIT;
+    g_value_init(&supportedFormats, GST_TYPE_LIST);
+    const auto& dmabufFormats = PlatformDisplay::sharedDisplay().dmabufFormatsForVideo();
+    for (const auto& format : dmabufFormats) {
+#if GST_CHECK_VERSION(1, 24, 0)
+        if (format.modifiers.isEmpty() || format.modifiers[0] == DRM_FORMAT_MOD_INVALID) {
+            GValue value = G_VALUE_INIT;
+            g_value_init(&value, G_TYPE_STRING);
+            g_value_take_string(&value, gst_video_dma_drm_fourcc_to_string(format.fourcc, DRM_FORMAT_MOD_LINEAR));
+            gst_value_list_append_and_take_value(&supportedFormats, &value);
+        } else {
+            for (auto modifier : format.modifiers) {
+                GValue value = G_VALUE_INIT;
+                g_value_init(&value, G_TYPE_STRING);
+                g_value_take_string(&value, gst_video_dma_drm_fourcc_to_string(format.fourcc, modifier));
+                gst_value_list_append_and_take_value(&supportedFormats, &value);
+            }
+        }
+#else
+        GValue value = G_VALUE_INIT;
+        g_value_init(&value, G_TYPE_STRING);
+        g_value_set_string(&value, gst_video_format_to_string(drmFourccToGstVideoFormat(format.fourcc)));
+        gst_value_list_append_and_take_value(&supportedFormats, &value);
+#endif
+    }
+
+#if GST_CHECK_VERSION(1, 24, 0)
+    gst_caps_set_value(caps.get(), "drm-format", &supportedFormats);
+#else
+    gst_caps_set_value(caps.get(), "format", &supportedFormats);
+#endif
+    g_value_unset(&supportedFormats);
+
+    return caps;
+}
+#endif // USE(GBM)
 
 #undef GST_CAT_DEFAULT
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -348,6 +348,10 @@ bool gstStructureMapInPlace(GstStructure*, Function<bool(GstId, GValue*)>&&);
 StringView gstIdToString(GstId);
 void gstStructureFilterAndMapInPlace(GstStructure*, Function<bool(GstId, GValue*)>&&);
 
+#if USE(GBM)
+WARN_UNUSED_RETURN GRefPtr<GstCaps> buildDMABufCaps();
+#endif
+
 } // namespace WebCore
 
 #ifndef GST_BUFFER_DTS_OR_PTS

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -84,7 +84,9 @@ GstElement* GStreamerVideoCapturer::createSource()
 GstElement* GStreamerVideoCapturer::createConverter()
 {
     if (isCapturingDisplay()) {
-        gst_caps_set_features(m_caps.get(), 0, gst_caps_features_new("memory:DMABuf", nullptr));
+#if USE(GBM)
+        m_caps = buildDMABufCaps();
+#endif
         return makeGStreamerElement("identity", nullptr);
     }
 


### PR DESCRIPTION
#### 34beac2e36062cf3deab0683312ecf76458e0648
<pre>
[GStreamer][PipeWire] getDisplayMedia() broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=283298">https://bugs.webkit.org/show_bug.cgi?id=283298</a>

Reviewed by Xabier Rodriguez-Calvar.

Move the DMABuf caps builder utility function to GStreamerCommon and use it from the VideoCapturer,
fixing caps negotiation issues with PipeWire.

* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(initializeDMABufAvailability):
(drmFourccToGstVideoFormat): Deleted.
(buildDMABufCaps): Deleted.
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::drmFourccToGstVideoFormat):
(WebCore::buildDMABufCaps):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::GStreamerVideoCapturer::createConverter):

Canonical link: <a href="https://commits.webkit.org/286790@main">https://commits.webkit.org/286790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b680f2039dfd2167c304817832b5e9c063435ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/55986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81497 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28227 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79068 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4279 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60309 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18383 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40625 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47650 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23552 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26554 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68768 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23883 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82931 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2894 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68583 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4481 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67838 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16946 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11819 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9899 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4274 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7087 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4297 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7728 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6055 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->