### PR TITLE
[Bugzilla] Use monospaced font

### DIFF
--- a/Websites/bugs.webkit.org/skins/custom/global.css
+++ b/Websites/bugs.webkit.org/skins/custom/global.css
@@ -2256,7 +2256,7 @@ table.attachment_entry {
 }
 
 .bz_comment_text {
-   font-family: initial;
+   font-family: monospace;
    white-space: pre-wrap;
 }
 


### PR DESCRIPTION
#### 21b2fb9329fa9ed22b965a8b08a1411e9f6f48ed
<pre>
[Bugzilla] Use monospaced font
<a href="https://bugs.webkit.org/show_bug.cgi?id=283303">https://bugs.webkit.org/show_bug.cgi?id=283303</a>

Reviewed by NOBODY (OOPS!).

It&apos;s not uncommon for comments in bug reports to include pieces of code
or other text-based content. An example of this is this is the file
format dump in <a href="https://bugs.webkit.org/show_bug.cgi?id=254222.">https://bugs.webkit.org/show_bug.cgi?id=254222.</a> For this
kind of content, it makes more sense to use monospaced font in comment
text boxes, which was a feature available in the previous Bugzilla
version.

This patch changes the right style to use monospace font.

* Websites/bugs.webkit.org/skins/custom/global.css:
(.bz_comment_text): Use monospace font.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21b2fb9329fa9ed22b965a8b08a1411e9f6f48ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81524 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28256 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60329 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18407 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80043 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40641 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47673 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26582 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68794 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82960 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4357 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68602 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4511 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66048 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67853 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11836 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9919 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4303 "Built successfully") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4323 "Failed to checkout and rebase branch from PR 36806") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7758 "Failed to checkout and rebase branch from PR 36806") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6082 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->