### PR TITLE
[iOS] [Mail Compose] Unable to tap to put text cursor at end of line if last word was autocorrected

### DIFF
--- a/LayoutTests/editing/caret/ios/place-caret-after-autocorrected-word-expected.txt
+++ b/LayoutTests/editing/caret/ios/place-caret-after-autocorrected-word-expected.txt
@@ -1,0 +1,15 @@
+Testing
+Verifies that the text cursor can be placed after the end of an autocorrected word. This test requires WebKitTestRunner
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS Typed 'Testign'
+PASS Applied autocorrection
+PASS getSelection().type is "Range"
+PASS Selected autocorrection
+PASS Moved selection to end
+PASS getSelection().type is "Caret"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/caret/ios/place-caret-after-autocorrected-word.html
+++ b/LayoutTests/editing/caret/ios/place-caret-after-autocorrected-word.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<head>
+<style>
+body {
+    font-family: monospace;
+    font-size: 24px;
+}
+</style>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that the text cursor can be placed after the end of an autocorrected word. This test requires WebKitTestRunner");
+
+    if (!window.testRunner)
+        return;
+
+    const editor = document.querySelector("div[contenteditable]");
+    let rect = document.getElementById("target1").getBoundingClientRect();
+    const afterEndOfWord = { x : 250, y : rect.top + rect.height / 2 };
+
+    await UIHelper.activateAndWaitForInputSessionAt(afterEndOfWord.x, afterEndOfWord.y);
+
+    for (let character of [..."Testign"]) {
+        await UIHelper.callFunctionAndWaitForEvent(async () => {
+            await UIHelper.typeCharacter(character);
+            await UIHelper.ensurePresentationUpdate();
+        }, editor, "input");
+    }
+    testPassed("Typed 'Testign'");
+
+    await UIHelper.applyAutocorrection("Testing", "Testign", true);
+    testPassed("Applied autocorrection");
+
+    await UIHelper.callFunctionAndWaitForEvent(async () => {
+        await UIHelper.selectWordForReplacement();
+        await UIHelper.ensurePresentationUpdate();
+    }, document, "selectionchange");
+    shouldBeEqualToString("getSelection().type", "Range");
+    testPassed("Selected autocorrection");
+
+    await UIHelper.callFunctionAndWaitForEvent(async () => {
+        await UIHelper.activateAt(afterEndOfWord.x, afterEndOfWord.y);
+        await UIHelper.ensurePresentationUpdate();
+    }, document, "selectionchange");
+    testPassed("Moved selection to end");
+
+    await UIHelper.selectWordForReplacement();
+    await UIHelper.ensurePresentationUpdate();
+    shouldBeEqualToString("getSelection().type", "Caret");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div contenteditable>
+        <div><br id="target1"></div>
+    </div>
+    <pre id="description"></pre>
+    <pre id="console"></pre>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1334,13 +1334,21 @@ window.UIHelper = class UIHelper {
         return new Promise(resolve => testRunner.runUIScript(uiScript, resolve));
     }
 
-    static applyAutocorrection(newText, oldText)
+    static selectWordForReplacement()
+    {
+        if (!this.isWebKit2())
+            return;
+
+        return new Promise(resolve => testRunner.runUIScript("uiController.selectWordForReplacement()", resolve));
+    }
+
+    static applyAutocorrection(newText, oldText, underline)
     {
         if (!this.isWebKit2())
             return;
 
         const [escapedNewText, escapedOldText] = [newText.replace(/`/g, "\\`"), oldText.replace(/`/g, "\\`")];
-        const uiScript = `uiController.applyAutocorrection(\`${escapedNewText}\`, \`${escapedOldText}\`, () => uiController.uiScriptComplete())`;
+        const uiScript = `uiController.applyAutocorrection(\`${escapedNewText}\`, \`${escapedOldText}\`, () => uiController.uiScriptComplete(), ${underline})`;
         return new Promise(resolve => testRunner.runUIScript(uiScript, resolve));
     }
 

--- a/Source/WebCore/dom/SimpleRange.h
+++ b/Source/WebCore/dom/SimpleRange.h
@@ -33,9 +33,9 @@ struct WeakSimpleRange {
     WeakBoundaryPoint start;
     WeakBoundaryPoint end;
 
-    WeakSimpleRange(const WeakBoundaryPoint&, const WeakBoundaryPoint&);
-    WeakSimpleRange(WeakBoundaryPoint&&, WeakBoundaryPoint&&);
-    WeakSimpleRange(const BoundaryPoint&&, const BoundaryPoint&&);
+    WEBCORE_EXPORT WeakSimpleRange(const WeakBoundaryPoint&, const WeakBoundaryPoint&);
+    WEBCORE_EXPORT WeakSimpleRange(WeakBoundaryPoint&&, WeakBoundaryPoint&&);
+    WEBCORE_EXPORT WeakSimpleRange(const BoundaryPoint&&, const BoundaryPoint&&);
 };
 
 struct SimpleRange {
@@ -62,11 +62,14 @@ SimpleRange makeSimpleRangeHelper(BoundaryPoint&&, BoundaryPoint&&);
 std::optional<SimpleRange> makeSimpleRangeHelper(std::optional<BoundaryPoint>&&, std::optional<BoundaryPoint>&&);
 SimpleRange makeSimpleRangeHelper(BoundaryPoint&&);
 std::optional<SimpleRange> makeSimpleRangeHelper(std::optional<BoundaryPoint>&&);
+std::optional<SimpleRange> makeSimpleRangeHelper(const WeakBoundaryPoint&, const WeakBoundaryPoint&);
+std::optional<SimpleRange> makeSimpleRange(const WeakSimpleRange&);
 
 inline BoundaryPoint makeBoundaryPointHelper(const BoundaryPoint& point) { return point; }
 inline BoundaryPoint makeBoundaryPointHelper(BoundaryPoint&& point) { return WTFMove(point); }
 inline std::optional<BoundaryPoint> makeBoundaryPointHelper(const std::optional<BoundaryPoint>& point) { return point; }
 inline std::optional<BoundaryPoint> makeBoundaryPointHelper(std::optional<BoundaryPoint>&& point) { return WTFMove(point); }
+std::optional<BoundaryPoint> makeBoundaryPointHelper(const WeakBoundaryPoint&);
 template<typename T> auto makeBoundaryPointHelper(T&& argument) -> decltype(makeBoundaryPoint(std::forward<T>(argument))) { return makeBoundaryPoint(std::forward<T>(argument)); }
 
 template<typename ...T> auto makeSimpleRange(T&& ...arguments) -> decltype(makeSimpleRangeHelper(makeBoundaryPointHelper(std::forward<T>(arguments))...)) { return makeSimpleRangeHelper(makeBoundaryPointHelper(std::forward<T>(arguments))...); }
@@ -217,6 +220,23 @@ inline std::optional<SimpleRange> makeSimpleRangeHelper(std::optional<BoundaryPo
     if (!point)
         return std::nullopt;
     return makeSimpleRangeHelper(WTFMove(*point));
+}
+
+inline std::optional<BoundaryPoint> makeBoundaryPointHelper(const WeakBoundaryPoint& point)
+{
+    if (!point.container)
+        return { };
+    return BoundaryPoint { *point.container, point.offset };
+}
+
+inline std::optional<SimpleRange> makeSimpleRangeHelper(const WeakBoundaryPoint& start, const WeakBoundaryPoint& end)
+{
+    return makeSimpleRangeHelper(makeBoundaryPointHelper(start), makeBoundaryPointHelper(end));
+}
+
+inline std::optional<SimpleRange> makeSimpleRange(const WeakSimpleRange& range)
+{
+    return makeSimpleRangeHelper(range.start, range.end);
 }
 
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7168,6 +7168,8 @@ void WebPage::didChangeSelection(LocalFrame& frame)
 #endif
 
 #if PLATFORM(IOS_FAMILY)
+    resetLastSelectedReplacementRangeIfNeeded();
+
     if (!std::exchange(m_sendAutocorrectionContextAfterFocusingElement, false))
         return;
 
@@ -7697,6 +7699,7 @@ void WebPage::didCommitLoad(WebFrame* frame)
     m_estimatedLatency = Seconds(1.0 / 60);
     m_shouldRevealCurrentSelectionAfterInsertion = true;
     m_lastLayerTreeTransactionIdAndPageScaleBeforeScalingPage = std::nullopt;
+    m_lastSelectedReplacementRange = { };
 
     invokePendingSyntheticClickCallback(SyntheticClickResult::PageInvalid);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1901,6 +1901,7 @@ private:
     void setSelectedRangeDispatchingSyntheticMouseEventsIfNeeded(const WebCore::SimpleRange&, WebCore::Affinity);
     void dispatchSyntheticMouseEventsForSelectionGesture(SelectionTouch, const WebCore::IntPoint&);
     void invokePendingSyntheticClickCallback(WebCore::SyntheticClickResult);
+    void resetLastSelectedReplacementRangeIfNeeded();
 
     void sendPositionInformation(InteractionInformationAtPosition&&);
     RefPtr<WebCore::ShareableBitmap> shareableBitmapSnapshotForNode(WebCore::Element&);
@@ -2739,6 +2740,7 @@ private:
     WebCore::FloatSize m_overrideAvailableScreenSize;
 
     std::optional<WebCore::SimpleRange> m_initialSelection;
+    std::optional<WebCore::WeakSimpleRange> m_lastSelectedReplacementRange;
     WebCore::VisibleSelection m_storedSelectionForAccessibility { WebCore::VisibleSelection() };
     WebCore::IntDegrees m_deviceOrientation { 0 };
     bool m_keyboardIsAttached { false };

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -253,7 +253,8 @@ interface UIScriptController {
     undefined keyboardAccessoryBarNext();
     undefined keyboardAccessoryBarPrevious();
 
-    undefined applyAutocorrection(DOMString newString, DOMString oldString, object callback);
+    undefined selectWordForReplacement();
+    undefined applyAutocorrection(DOMString newString, DOMString oldString, object callback, boolean underline);
 
     // Returned object is a dictionary with the passed in string as a key for returned object
     object contentsOfUserInterfaceItem(DOMString interfaceItem);

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -238,7 +238,8 @@ public:
     virtual void keyboardAccessoryBarNext() { notImplemented(); }
     virtual void keyboardAccessoryBarPrevious() { notImplemented(); }
 
-    virtual void applyAutocorrection(JSStringRef, JSStringRef, JSValueRef) { notImplemented(); }
+    virtual void selectWordForReplacement() { notImplemented(); }
+    virtual void applyAutocorrection(JSStringRef, JSStringRef, JSValueRef, bool) { notImplemented(); }
 
     virtual bool isShowingKeyboard() const { notImplemented(); return false; }
     virtual bool hasInputSession() const { notImplemented(); return false; }

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -111,7 +111,8 @@ private:
     void keyboardAccessoryBarPrevious() override;
     bool isShowingKeyboard() const override;
     bool hasInputSession() const override;
-    void applyAutocorrection(JSStringRef newString, JSStringRef oldString, JSValueRef) override;
+    void selectWordForReplacement() override;
+    void applyAutocorrection(JSStringRef newString, JSStringRef oldString, JSValueRef, bool) override;
     double minimumZoomScale() const override;
     double maximumZoomScale() const override;
     std::optional<bool> stableStateOverride() const override;


### PR DESCRIPTION
#### abdb8d25bff5d073b594a550095cee3b82f08b82
<pre>
[iOS] [Mail Compose] Unable to tap to put text cursor at end of line if last word was autocorrected
<a href="https://bugs.webkit.org/show_bug.cgi?id=283304">https://bugs.webkit.org/show_bug.cgi?id=283304</a>
<a href="https://rdar.apple.com/129961069">rdar://129961069</a>

Reviewed by Abrar Rahman Protyasha and Richard Robinson.

Currently, it&apos;s possible to get stuck in a state where you can&apos;t move the text cursor to the end of
a line by tapping after the end of the word, if the last word on the line was autocorrected. This is
because UIKit&apos;s text interaction tap gesture tells us to `-selectWordForReplacement` when tapping
after the end of the autocorrected word, which we (currently) always honor.

To mitigate this, we prevent the same autocorrected word range from being selected multiple times in
a row, as long as the selection is still inside of the word range. This allows the user to toggle
between selecting the autocorrected word and setting the selection to the end of the line, which
matches platform behavior in Notes.

* LayoutTests/editing/caret/ios/place-caret-after-autocorrected-word-expected.txt: Added.
* LayoutTests/editing/caret/ios/place-caret-after-autocorrected-word.html: Added.

Add a new layout test to exercise this change, by calling into `-selectWordForReplacement` from a
new testing hook. I couldn&apos;t reliably get UIKit&apos;s text interactions to exhibit this same behavior in
a testing environment purely by tapping to set the selection, but we can still simulate UIKit
behavior at the API boundary using this approach.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.selectWordForReplacement):
(window.UIHelper.applyAutocorrection):

Add an `underline` argument to this testing helper, to determine whether or not we should add blue
autocorrection underlines.

* Source/WebCore/dom/SimpleRange.h:
(WebCore::makeBoundaryPointHelper):
(WebCore::makeSimpleRangeHelper):
(WebCore::makeSimpleRange):

Add a helper method to convert from `WeakSimpleRange` to `std::optional&lt;SimpleRange&gt;`. This returns
`nullopt` if either of the boundary points are invalidated.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didChangeSelection):
(WebKit::WebPage::didCommitLoad):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::extendSelectionForReplacement):

See above for more details.

(WebKit::WebPage::resetLastSelectedReplacementRangeIfNeeded):

Clear out `m_lastSelectedReplacementRange` when the selection moves outside of the range.

* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::selectWordForReplacement):
(WTR::UIScriptController::applyAutocorrection):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::selectWordForReplacement):
(WTR::UIScriptControllerIOS::applyAutocorrection):

Canonical link: <a href="https://commits.webkit.org/286757@main">https://commits.webkit.org/286757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee39c4481c972175ef5458ea77ee2c61cf55b651

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29902 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81534 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28266 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4318 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60338 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18408 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80054 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40650 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47681 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23581 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26592 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68802 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82970 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4367 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2929 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68614 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4522 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67870 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16923 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11846 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9929 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4313 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7128 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4333 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7768 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6092 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->