### PR TITLE
CFNetwork URLRequest::initialize(CFDictionaryRef webKitSecureCodingDictionary) crashes when HTTP headers come in String -> String form

### DIFF
--- a/LayoutTests/ipc/cfnetwork-crashes-with-string-to-string-http-headers-expected.txt
+++ b/LayoutTests/ipc/cfnetwork-crashes-with-string-to-string-http-headers-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit did not crash.

--- a/LayoutTests/ipc/cfnetwork-crashes-with-string-to-string-http-headers.html
+++ b/LayoutTests/ipc/cfnetwork-crashes-with-string-to-string-http-headers.html
@@ -1,0 +1,122 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<script>
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+    import('./coreipc.js').then(({
+        CoreIPC
+    }) => {
+        CoreIPC.GPU.RemoteMediaResourceManager.RedirectReceived(0, {
+            identifier: 262147,
+            request: {
+                getRequestDataToSerialize: {
+                    variantType: 'WebCore::ResourceRequestPlatformData',
+                    variant: {
+                        m_urlRequest: {
+                            optionalValue: {
+                                wrapper: {
+                                    m_data: {
+                                        protocolProperties: {},
+                                        isMutable: false,
+                                        url: {
+                                            m_url: {
+                                                string: ''
+                                            }
+                                        },
+                                        timeout: 48,
+                                        cachePolicy: 2,
+                                        mainDocumentURL: {
+                                            optionalValue: {
+                                                m_url: {
+                                                    string: location.href
+                                                }
+                                            }
+                                        },
+                                        shouldHandleHTTPCookies: true,
+                                        explicitFlags: 4096,
+                                        allowCellular: true,
+                                        preventsIdleSystemSleep: false,
+                                        timeWindowDelay: 118,
+                                        timeWindowDuration: 15,
+                                        networkServiceType: 0,
+                                        requestPriority: 89,
+                                        isHTTP: {
+                                            optionalValue: true
+                                        },
+                                        httpMethod: {},
+                                        // This crashes CFNetwork
+                                        headerFields: {
+                                            optionalValue: [{
+                                                alias: ['A', {
+                                                    variantType: 'String',
+                                                    variant: location.href
+                                                }]
+                                            }]
+                                        },
+                                        body: {
+                                            optionalValue: {
+                                                dataReference: {}
+                                            }
+                                        },
+                                        bodyParts: {},
+                                        startTimeoutTime: 58,
+                                        requiresShortConnectionTimeout: true,
+                                        payloadTransmissionTimeout: 63,
+                                        allowedProtocolTypes: 60,
+                                        boundInterfaceIdentifier: {},
+                                        allowsExpensiveNetworkAccess: {
+                                            optionalValue: false
+                                        },
+                                        allowsConstrainedNetworkAccess: {
+                                            optionalValue: false
+                                        },
+                                        allowsUCA: {},
+                                        assumesHTTP3Capable: false,
+                                        attribution: 0,
+                                        knownTracker: false,
+                                        trackerContext: {},
+                                        privacyProxyFailClosed: true,
+                                        privacyProxyFailClosedForUnreachableNonMainHosts: true,
+                                        privacyProxyFailClosedForUnreachableHosts: false,
+                                        requiresDNSSECValidation: {
+                                            optionalValue: false
+                                        },
+                                        allowsPersistentDNS: true,
+                                        prohibitPrivacyProxy: true,
+                                        allowPrivateAccessTokensForThirdParty: false,
+                                        useEnhancedPrivacyMode: false,
+                                        blockTrackers: false,
+                                        failInsecureLoadWithHTTPSDNSRecord: false,
+                                        isWebSearchContent: false,
+                                        contentDispositionEncodingFallbackArray: {}
+                                    }
+                                }
+                            }
+                        },
+                        m_isAppInitiated: {
+                            optionalValue: true
+                        },
+                        m_requester: {
+                            optionalValue: 6
+                        },
+                        m_privacyProxyFailClosedForUnreachableNonMainHosts: false,
+                        m_useAdvancedPrivacyProtections: true,
+                        m_didFilterLinkDecoration: false,
+                        m_isPrivateTokenUsageByThirdPartyAllowed: true,
+                        m_wasSchemeOptimisticallyUpgraded: true
+                    }
+                },
+                cachePartition: '',
+                hiddenFromInspector: false
+            },
+            response: {
+                getResponseData: {}
+            }
+        });
+    });
+    function callDone() {
+        window.testRunner?.notifyDone();
+    }
+</script>
+<body onload="callDone()">
+    <p>This test passes if WebKit did not crash.</p>
+</body>

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
@@ -258,8 +258,11 @@ RetainPtr<id> CoreIPCNSURLRequest::toID() const
         for (auto& headerPair : *m_data.headerFields) {
             WTF::switchOn(headerPair.second,
                 [&] (const String& s) {
-                    if (!s.isNull() && !headerPair.first.isNull())
-                        [headerFields setObject:(NSString *)s forKey:(NSString *)headerPair.first];
+                    auto array = adoptNS([[NSMutableArray alloc] initWithCapacity:1]);
+                    if (!s.isNull() && !headerPair.first.isNull()) {
+                        [array addObject: s];
+                        [headerFields setObject:array.get() forKey:(NSString *)headerPair.first];
+                    }
                 },
                 [&] (const Vector<String>& vector) {
                     auto array = adoptNS([[NSMutableArray alloc] initWithCapacity:vector.size()]);


### PR DESCRIPTION
#### 1ad5fb31623179dafbb14cfe6dbe3a00c13c18df
<pre>
CFNetwork URLRequest::initialize(CFDictionaryRef webKitSecureCodingDictionary) crashes when HTTP headers come in String -&gt; String form
<a href="https://bugs.webkit.org/show_bug.cgi?id=283307">https://bugs.webkit.org/show_bug.cgi?id=283307</a>
<a href="https://rdar.apple.com/139800100">rdar://139800100</a>

Reviewed by Ryosuke Niwa.

Only send String -&gt; Array HTTP headers to CFNetwork URLRequest webkit dictionary initializer, String -&gt; String ones will crash when CFNetwork tried to for iterate a String

* LayoutTests/ipc/cfnetwork-crashes-with-string-to-string-http-headers-expected.txt: Added.
* LayoutTests/ipc/cfnetwork-crashes-with-string-to-string-http-headers.html: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm:
(WebKit::CoreIPCNSURLRequest::toID const):

Canonical link: <a href="https://commits.webkit.org/286883@main">https://commits.webkit.org/286883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61a810e84e05a39207fcd07765426a73efa247c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81898 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28608 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4658 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60582 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18616 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40881 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47964 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23879 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26931 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69075 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83315 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4706 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3199 "Exiting early after 10 failures. 18 tests run. 1 flakes") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68852 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4862 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66351 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68107 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12102 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10212 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11983 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4653 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7468 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4672 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8107 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->