### PR TITLE
Update Safer CPP expectations after updating clang

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -1,6 +1,5 @@
 Modules/webaudio/AudioWorkletThread.h
 Modules/websockets/WorkerThreadableWebSocketChannel.h
-html/parser/HTMLParserScheduler.h
 html/parser/HTMLTreeBuilder.h
 loader/WorkerThreadableLoader.h
 page/LocalFrameViewLayoutContext.cpp

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -1,4 +1,3 @@
-ByteLengthQueuingStrategyBuiltins.h
 CommandLineAPIModuleSourceBuiltins.h
 Modules/WebGPU/GPUPresentationContextDescriptor.h
 Modules/encryptedmedia/MediaKeyStatusMap.h
@@ -45,7 +44,6 @@ css/StyleSheetList.h
 css/color/CSSUnresolvedStyleColorResolutionState.h
 css/parser/SizesCalcParser.h
 dom/CollectionIndexCache.h
-dom/ContainerNodeAlgorithms.h
 dom/ElementAncestorIterator.h
 dom/Node.cpp
 dom/Node.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -4,7 +4,6 @@ CompressionStreamBuiltins.h
 CountQueuingStrategyBuiltins.h
 DecompressionStreamBuiltins.h
 EventNames.h
-HTMLNames.cpp
 InternalSettingsGenerated.cpp
 JSAbortController.cpp
 JSAbortSignal.cpp
@@ -92,6 +91,7 @@ JSDOMMimeTypeArray.cpp
 JSDOMPlugin.cpp
 JSDOMPluginArray.cpp
 JSDOMQuad.cpp
+JSDOMRectList.cpp
 JSDOMSelection.cpp
 JSDOMStringList.cpp
 JSDOMStringMap.cpp
@@ -103,6 +103,7 @@ JSDataTransferItemList.cpp
 JSDedicatedWorkerGlobalScope.cpp
 JSDelayNode.cpp
 JSDeprecatedCSSOMRGBColor.cpp
+JSDeprecatedCSSOMValueList.cpp
 JSDocument.cpp
 JSDocumentFragment.cpp
 JSDocumentType.cpp
@@ -418,7 +419,6 @@ JSXMLSerializer.cpp
 JSXPathEvaluator.cpp
 JSXPathExpression.cpp
 JSXSLTProcessor.cpp
-MathMLNames.cpp
 Modules/ShapeDetection/BarcodeDetector.cpp
 Modules/ShapeDetection/FaceDetector.cpp
 Modules/ShapeDetection/TextDetector.cpp
@@ -470,6 +470,7 @@ Modules/encryptedmedia/MediaKeyStatusMap.cpp
 Modules/encryptedmedia/MediaKeySystemAccess.cpp
 Modules/encryptedmedia/MediaKeySystemRequest.cpp
 Modules/encryptedmedia/MediaKeys.cpp
+Modules/encryptedmedia/legacy/LegacyCDMSessionClearKey.cpp
 Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
 Modules/encryptedmedia/legacy/WebKitMediaKeys.cpp
 Modules/entriesapi/DOMFileSystem.cpp
@@ -504,8 +505,6 @@ Modules/identity/CredentialRequestCoordinator.cpp
 Modules/indexeddb/IDBActiveDOMObject.h
 Modules/indexeddb/IDBCursor.cpp
 Modules/indexeddb/IDBDatabase.cpp
-Modules/indexeddb/IDBDatabaseNameAndVersionRequest.cpp
-Modules/indexeddb/IDBDatabaseNameAndVersionRequest.h
 Modules/indexeddb/IDBFactory.cpp
 Modules/indexeddb/IDBIndex.cpp
 Modules/indexeddb/IDBKey.cpp
@@ -630,6 +629,7 @@ Modules/webaudio/BaseAudioContext.cpp
 Modules/webaudio/BiquadDSPKernel.cpp
 Modules/webaudio/BiquadFilterNode.cpp
 Modules/webaudio/BiquadProcessor.cpp
+Modules/webaudio/ChannelMergerNode.cpp
 Modules/webaudio/ConstantSourceNode.cpp
 Modules/webaudio/ConvolverNode.cpp
 Modules/webaudio/DefaultAudioDestinationNode.cpp
@@ -680,20 +680,15 @@ ReadableStreamBYOBRequestBuiltins.h
 ReadableStreamDefaultControllerBuiltins.h
 ReadableStreamDefaultReaderBuiltins.h
 ReadableStreamInternalsBuiltins.h
-SVGNames.cpp
 StreamInternalsBuiltins.h
 StyleBuilderGenerated.cpp
 TextDecoderStreamBuiltins.h
 TextEncoderStreamBuiltins.h
 TransformStreamDefaultControllerBuiltins.h
 TransformStreamInternalsBuiltins.h
-WebKitFontFamilyNames.cpp
 WritableStreamDefaultControllerBuiltins.h
 WritableStreamDefaultWriterBuiltins.h
 WritableStreamInternalsBuiltins.h
-XLinkNames.cpp
-XMLNSNames.cpp
-XMLNames.cpp
 accessibility/AXCoreObject.cpp
 accessibility/AXImage.cpp
 accessibility/AXLogger.cpp
@@ -775,7 +770,6 @@ bindings/js/JSDOMConvertDate.cpp
 bindings/js/JSDOMConvertEnumeration.h
 bindings/js/JSDOMConvertEventListener.h
 bindings/js/JSDOMConvertInterface.h
-bindings/js/JSDOMConvertResult.h
 bindings/js/JSDOMConvertScheduledAction.h
 bindings/js/JSDOMConvertStrings.h
 bindings/js/JSDOMConvertWebGL.cpp
@@ -879,6 +873,7 @@ contentextensions/ContentExtension.cpp
 contentextensions/ContentExtensionStyleSheet.cpp
 contentextensions/ContentExtensionsBackend.cpp
 crypto/SubtleCrypto.cpp
+crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h
 css/CSSComputedStyleDeclaration.cpp
 css/CSSCounterStyle.cpp
 css/CSSCounterStyleDescriptors.cpp
@@ -937,7 +932,6 @@ css/CSSStyleRule.cpp
 css/CSSStyleSheet.cpp
 css/CSSStyleSheetObservableArray.cpp
 css/CSSTimingFunctionValue.cpp
-css/CSSTimingFunctionValue.h
 css/CSSToStyleMap.cpp
 css/CSSValueList.cpp
 css/CSSValuePair.cpp
@@ -1036,7 +1030,6 @@ dom/ElementInlines.h
 dom/ElementInternals.cpp
 dom/ElementIteratorInlines.h
 dom/EmptyScriptExecutionContext.h
-dom/EventContext.cpp
 dom/EventDispatcher.cpp
 dom/EventLoop.cpp
 dom/EventLoop.h
@@ -1081,7 +1074,6 @@ dom/QualifiedName.cpp
 dom/Range.cpp
 dom/RangeBoundaryPoint.h
 dom/RejectedPromiseTracker.cpp
-dom/ScriptDisallowedScope.h
 dom/ScriptElement.cpp
 dom/ScriptExecutionContext.cpp
 dom/ScriptExecutionContext.h
@@ -1101,10 +1093,8 @@ dom/Subscriber.cpp
 dom/TextDecoderStreamDecoder.h
 dom/Traversal.cpp
 dom/TreeScope.cpp
-dom/TreeScopeOrderedMap.cpp
 dom/TreeWalker.cpp
 dom/TrustedType.cpp
-dom/UserGestureIndicator.cpp
 dom/ViewTransition.cpp
 dom/ViewTransitionTypeSet.cpp
 dom/VisitedLinkState.cpp
@@ -1120,6 +1110,7 @@ editing/ChangeListTypeCommand.cpp
 editing/CompositeEditCommand.cpp
 editing/CustomUndoStep.cpp
 editing/DeleteSelectionCommand.cpp
+editing/EditCommand.cpp
 editing/Editing.cpp
 editing/EditingStyle.cpp
 editing/Editor.cpp
@@ -1131,7 +1122,6 @@ editing/InsertIntoTextNodeCommand.cpp
 editing/InsertLineBreakCommand.cpp
 editing/InsertListCommand.cpp
 editing/InsertNestedListCommand.cpp
-editing/InsertNodeBeforeCommand.cpp
 editing/InsertParagraphSeparatorCommand.cpp
 editing/InsertTextCommand.cpp
 editing/ModifySelectionListLevel.cpp
@@ -1179,7 +1169,6 @@ html/CanvasBase.cpp
 html/CheckboxInputType.cpp
 html/ColorInputType.cpp
 html/CustomPaintCanvas.cpp
-html/CustomPaintImage.cpp
 html/DOMFormData.cpp
 html/DOMTokenList.cpp
 html/DOMURL.cpp
@@ -1189,7 +1178,6 @@ html/FTPDirectoryDocument.cpp
 html/FileInputType.cpp
 html/FormAssociatedCustomElement.cpp
 html/FormAssociatedElement.cpp
-html/FormController.cpp
 html/FormListedElement.cpp
 html/HTMLAllCollection.cpp
 html/HTMLAnchorElement.cpp
@@ -1251,6 +1239,7 @@ html/HTMLVideoElement.cpp
 html/HTMLVideoElement.h
 html/HiddenInputType.cpp
 html/ImageBitmap.cpp
+html/ImageData.cpp
 html/ImageDocument.cpp
 html/ImageInputType.cpp
 html/InputType.cpp
@@ -1314,7 +1303,6 @@ html/parser/HTMLConstructionSite.h
 html/parser/HTMLDocumentParser.cpp
 html/parser/HTMLDocumentParserFastPath.cpp
 html/parser/HTMLElementStack.cpp
-html/parser/HTMLFormattingElementList.cpp
 html/parser/HTMLParserScheduler.cpp
 html/parser/HTMLScriptRunner.cpp
 html/parser/HTMLTreeBuilder.cpp
@@ -1385,14 +1373,9 @@ inspector/agents/page/PageDOMDebuggerAgent.cpp
 inspector/agents/page/PageNetworkAgent.cpp
 inspector/agents/page/PageRuntimeAgent.cpp
 inspector/agents/worker/ServiceWorkerAgent.cpp
-inspector/agents/worker/WorkerAuditAgent.cpp
-inspector/agents/worker/WorkerCanvasAgent.cpp
-inspector/agents/worker/WorkerConsoleAgent.cpp
 inspector/agents/worker/WorkerDebuggerAgent.cpp
 inspector/agents/worker/WorkerNetworkAgent.cpp
 inspector/agents/worker/WorkerRuntimeAgent.cpp
-inspector/agents/worker/WorkerWorkerAgent.cpp
-layout/Verification.cpp
 layout/formattingContexts/inline/InlineItemsBuilder.cpp
 layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
 layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -1478,7 +1461,6 @@ page/NavigationDestination.h
 page/NavigationHistoryEntry.cpp
 page/NavigationTransition.cpp
 page/Navigator.cpp
-page/NavigatorBase.cpp
 page/NavigatorLoginStatus.cpp
 page/OpportunisticTaskScheduler.cpp
 page/Page.cpp
@@ -1558,7 +1540,9 @@ platform/animation/Animation.cpp
 platform/animation/AnimationList.cpp
 platform/audio/AudioResampler.cpp
 platform/audio/HRTFDatabaseLoader.cpp
+platform/audio/MultiChannelResampler.cpp
 platform/audio/PlatformMediaSessionManager.cpp
+platform/audio/PushPullFIFO.cpp
 platform/audio/Reverb.cpp
 platform/audio/ReverbConvolver.cpp
 platform/audio/cocoa/AudioDestinationCocoa.cpp
@@ -1580,6 +1564,7 @@ platform/graphics/BitmapImage.cpp
 platform/graphics/BitmapImage.h
 platform/graphics/BitmapImageDescriptor.cpp
 platform/graphics/BitmapImageSource.cpp
+platform/graphics/ByteArrayPixelBuffer.cpp
 platform/graphics/Color.cpp
 platform/graphics/Color.h
 platform/graphics/ComplexTextController.cpp
@@ -1695,7 +1680,6 @@ platform/mac/ScrollbarsControllerMac.mm
 platform/mac/VideoPresentationInterfaceMac.mm
 platform/mediarecorder/MediaRecorderPrivate.h
 platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
-platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
 platform/mediarecorder/MediaRecorderPrivateMock.cpp
 platform/mediarecorder/cocoa/AudioSampleBufferCompressor.mm
 platform/mediastream/AudioTrackPrivateMediaStream.cpp
@@ -1713,7 +1697,6 @@ platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
 platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp
 platform/mediastream/mac/AVCaptureDeviceManager.mm
 platform/mediastream/mac/AVVideoCaptureSource.mm
-platform/mediastream/mac/BaseAudioSharedUnit.cpp
 platform/mediastream/mac/CoreAudioSharedUnit.cpp
 platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.cpp
 platform/mediastream/mac/MockAudioSharedUnit.mm
@@ -2047,6 +2030,7 @@ svg/properties/SVGValuePropertyAnimator.h
 svg/properties/SVGValuePropertyListAnimatorImpl.h
 testing/InternalSettings.cpp
 testing/Internals.cpp
+testing/LegacyMockCDM.cpp
 testing/MockContentFilter.cpp
 testing/MockContentFilterManager.cpp
 testing/MockMediaSessionCoordinator.cpp
@@ -2056,7 +2040,6 @@ testing/MockPaymentCoordinator.cpp
 testing/ServiceWorkerInternals.cpp
 testing/js/WebCoreTestSupport.cpp
 workers/DedicatedWorkerGlobalScope.cpp
-workers/ScriptBuffer.cpp
 workers/Worker.cpp
 workers/WorkerAnimationController.cpp
 workers/WorkerConsoleClient.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -427,6 +427,7 @@ Modules/webaudio/PannerNode.cpp
 Modules/webaudio/ScriptProcessorNode.cpp
 Modules/webaudio/StereoPannerNode.cpp
 Modules/webaudio/WaveShaperDSPKernel.cpp
+Modules/webaudio/WaveShaperNode.cpp
 Modules/webauthn/AuthenticatorCoordinator.cpp
 Modules/webauthn/PublicKeyCredential.cpp
 Modules/webcodecs/WebCodecsAudioData.cpp
@@ -632,7 +633,6 @@ css/CSSKeyframeRule.cpp
 css/CSSLayerBlockRule.cpp
 css/CSSPageRule.cpp
 css/CSSPrimitiveValue.cpp
-css/CSSPrimitiveValueMappings.h
 css/CSSRule.cpp
 css/CSSStyleRule.cpp
 css/CSSStyleSheet.cpp
@@ -769,6 +769,7 @@ fileapi/ThreadableBlobRegistry.cpp
 history/BackForwardCache.cpp
 history/CachedFrame.cpp
 history/CachedPage.cpp
+history/HistoryItem.cpp
 html/Autofill.cpp
 html/BaseCheckableInputType.cpp
 html/BaseDateAndTimeInputType.cpp
@@ -865,9 +866,11 @@ html/track/InbandGenericTextTrack.cpp
 html/track/TextTrack.cpp
 html/track/TextTrackCue.cpp
 html/track/TextTrackCueGeneric.cpp
+html/track/TextTrackList.cpp
 html/track/TrackBase.cpp
 html/track/VTTCue.cpp
 html/track/VTTRegion.cpp
+html/track/VideoTrackList.cpp
 inspector/CommandLineAPIHost.cpp
 inspector/DOMPatchSupport.cpp
 inspector/InspectorAuditAccessibilityObject.cpp
@@ -1008,7 +1011,6 @@ page/mac/ServicesOverlayController.mm
 page/scrolling/AsyncScrollingCoordinator.cpp
 page/scrolling/ScrollAnchoringController.cpp
 page/scrolling/ScrollingCoordinator.cpp
-page/scrolling/ScrollingStateStickyNode.cpp
 page/scrolling/ScrollingTree.cpp
 page/scrolling/ScrollingTreeFixedNode.cpp
 page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp
@@ -1026,7 +1028,6 @@ platform/ScrollableArea.cpp
 platform/ScrollbarsController.cpp
 platform/ThreadGlobalData.cpp
 platform/ThreadGlobalData.h
-platform/Timer.cpp
 platform/animation/AcceleratedEffect.cpp
 platform/animation/AcceleratedEffectValues.cpp
 platform/audio/AudioBus.cpp
@@ -1041,6 +1042,7 @@ platform/graphics/FontCache.cpp
 platform/graphics/FontCascade.h
 platform/graphics/FontCascadeFonts.cpp
 platform/graphics/FontRanges.cpp
+platform/graphics/GlyphBuffer.h
 platform/graphics/GraphicsLayer.cpp
 platform/graphics/Image.cpp
 platform/graphics/Path.cpp
@@ -1117,7 +1119,6 @@ plugins/PluginInfoProvider.cpp
 rendering/AccessibilityRegionContext.cpp
 rendering/BackgroundPainter.cpp
 rendering/BorderPainter.cpp
-rendering/CounterNode.cpp
 rendering/GlyphDisplayListCache.cpp
 rendering/HitTestResult.cpp
 rendering/ImageQualityController.cpp

--- a/Source/WebKit/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -1,4 +1,3 @@
 AutomationFrontendDispatchers.h
 UIProcess/Inspector/WebPageInspectorAgentBase.h
-UIProcess/PageLoadState.h
 WebProcess/ApplePay/WebPaymentCoordinator.h

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1,14 +1,6 @@
 AutomationBackendDispatchers.cpp
 AutomationFrontendDispatchers.cpp
 AutomationProtocolObjects.h
-GPUProcess/graphics/RemoteGraphicsContextGL.cpp
-GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
-GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
-GPUProcess/graphics/RemoteImageBuffer.cpp
-GPUProcess/graphics/RemoteImageBufferSet.cpp
-GPUProcess/graphics/RemoteRenderingBackend.cpp
-GPUProcess/graphics/WebGPU/RemoteGPU.cpp
-GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
 JSWebExtensionAPIAction.mm
 JSWebExtensionAPIAlarms.mm
 JSWebExtensionAPICommands.mm
@@ -86,9 +78,7 @@ NetworkProcess/storage/OriginStorageManager.cpp
 NetworkProcess/storage/SQLiteStorageArea.cpp
 NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
 Platform/IPC/ArgumentCoders.h
-Platform/IPC/Connection.cpp
 Platform/IPC/SharedBufferReference.cpp
-Platform/IPC/StreamClientConnection.h
 Platform/cocoa/WKPaymentAuthorizationDelegate.mm
 Platform/cocoa/WebPrivacyHelpers.mm
 Shared/API/APIArray.h
@@ -133,7 +123,6 @@ Shared/Cocoa/WKNSURL.mm
 Shared/Cocoa/WebKit2InitializeCocoa.mm
 Shared/ContextMenuContextData.cpp
 Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
-Shared/IPCTester.cpp
 Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
 Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
 Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
@@ -150,7 +139,6 @@ UIProcess/API/APIDataTask.cpp
 UIProcess/API/APIDownloadClient.h
 UIProcess/API/APIHTTPCookieStore.cpp
 UIProcess/API/APIInspectorExtension.cpp
-UIProcess/API/APINavigation.cpp
 UIProcess/API/APINavigationClient.h
 UIProcess/API/APIPageConfiguration.cpp
 UIProcess/API/APIWebAuthenticationAssertionResponse.cpp
@@ -276,7 +264,6 @@ UIProcess/Cocoa/WebInspectorPreferenceObserver.mm
 UIProcess/DeviceIdHashSaltStorage.cpp
 UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
 UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
-UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
 UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
 UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
 UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
@@ -418,7 +405,6 @@ WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
 WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
 WebProcess/GPU/media/RemoteRemoteCommandListener.cpp
 WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
-WebProcess/GPU/media/RemoteVideoFrameProxy.cpp
 WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
 WebProcess/GPU/media/SourceBufferPrivateRemote.h
 WebProcess/GPU/media/TextTrackPrivateRemote.cpp
@@ -532,7 +518,6 @@ WebProcess/WebPage/Cocoa/WebPageCocoa.mm
 WebProcess/WebPage/DrawingArea.cpp
 WebProcess/WebPage/EventDispatcher.cpp
 WebProcess/WebPage/FindController.cpp
-WebProcess/WebPage/IPCTestingAPI.cpp
 WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
 WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
 WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -9,8 +9,6 @@ NetworkProcess/cocoa/NetworkProcessCocoa.mm
 NetworkProcess/cocoa/NetworkSessionCocoa.mm
 NetworkProcess/storage/NetworkStorageManager.cpp
 NetworkProcess/storage/OriginStorageManager.cpp
-Platform/IPC/JSIPCBinding.cpp
-Platform/IPC/JSIPCBinding.h
 Platform/IPC/MessageSenderInlines.h
 Platform/cocoa/WKPaymentAuthorizationDelegate.mm
 Shared/API/APIArray.cpp
@@ -132,7 +130,6 @@ WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
 WebProcess/WebPage/Cocoa/WebPageCocoa.mm
 WebProcess/WebPage/EventDispatcher.cpp
 WebProcess/WebPage/FindController.cpp
-WebProcess/WebPage/IPCTestingAPI.cpp
 WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
 WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
 WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm


### PR DESCRIPTION
#### e577dc8aa26ef91a90f48eef77101b7f01d4c370
<pre>
Update Safer CPP expectations after updating clang

Reviewed by Ryosuke Niwa.

We updated clang to 9a8740e1, which uncovered new failures and cleaned up some
false positives.

* Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/286742@main">https://commits.webkit.org/286742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5918aa97d2b12fe85212d91fe62f05dfc3e2fa7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/76997 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/56032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29912 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/81545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/28276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4328 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/81545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/28276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80064 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/50283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/66089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/81545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/47685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/23586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26602 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/68805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/23915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82980 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/4377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/2935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/4532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/66062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67864 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/9930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11911 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/4323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/4343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/7778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/6102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->