### PR TITLE
[iOS] Invoking date picker controls with large values may cause crash

### DIFF
--- a/LayoutTests/fast/forms/ios/date-picker-value-crash-expected.txt
+++ b/LayoutTests/fast/forms/ios/date-picker-value-crash-expected.txt
@@ -1,0 +1,21 @@
+This test verifies that invoking a date picker for an input with a value outside or at the limit of the user-selectable range does not cause a crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Date picker invocation did not crash for value 0001-01-01
+PASS Date picker invocation did not crash for value 10000-12-31
+PASS Date picker invocation did not crash for value 20000-12-31
+PASS Date picker invocation did not crash for value 0001-01
+PASS Date picker invocation did not crash for value 10000-12
+PASS Date picker invocation did not crash for value 20000-12
+PASS Date picker invocation did not crash for value 0001-01-01T00:00
+PASS Date picker invocation did not crash for value 10000-12-31T23:59
+PASS Date picker invocation did not crash for value 20000-12-31T00:00
+PASS Date picker invocation did not crash for value 0001-W01
+PASS Date picker invocation did not crash for value 10000-W52
+PASS Date picker invocation did not crash for value 20000-W52
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/date-picker-value-crash.html
+++ b/LayoutTests/fast/forms/ios/date-picker-value-crash.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<input type="date"></input>
+<input id="month" type="month"></input>
+<input type="datetime-local"></input>
+<input type="week"></input>
+<script>
+jsTestIsAsync = true;
+
+let dateValues = ["0001-01-01", "10000-12-31", "20000-12-31"];
+let monthValues = ["0001-01", "10000-12", "20000-12"];
+let datetime_localValues = ["0001-01-01T00:00", "10000-12-31T23:59", "20000-12-31T00:00"];
+let weekValues = ["0001-W01", "10000-W52", "20000-W52"];
+
+let inputs = document.querySelectorAll("input");
+let values = [dateValues, monthValues, datetime_localValues, weekValues];
+
+addEventListener("load", async () => {
+    description("This test verifies that invoking a date picker for an input with a value outside or at the limit of the user-selectable range does not cause a crash.");
+    for (var i = 0; i < inputs.length; i++) {
+        for (var j = 0; j < values[i].length; j++){
+            inputs[i].value = values[i][j];
+            await UIHelper.activateElement(inputs[i]);
+            await UIHelper.waitForContextMenuToShow();
+            await UIHelper.deactivateFormControl(inputs[i]);
+            await UIHelper.waitForContextMenuToHide();
+            testPassed("Date picker invocation did not crash for value " + values[i][j]);
+        }
+    }
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios-17/TestExpectations
+++ b/LayoutTests/platform/ios-17/TestExpectations
@@ -13,6 +13,9 @@ fast/forms/switch/pointer-tracking-there-and-back-again-rtl.html [ Timeout Image
 fast/forms/switch/pointer-tracking-there-and-back-again.html [ Timeout ImageOnlyFailure ]
 fast/forms/switch/pointer-tracking.html [ Pass Timeout ] # appears to be timing out only in stress mode
 
+# Week input control is only available starting in iOS 18
+fast/forms/ios/date-picker-value-crash.html [ Skip ]
+
 # -- The below regressed on iOS 18 but are passing on iOS 17 --
 
 # rdar://130594018 (REGRESSION (278344@main?): [ iOS 18 Release ] 2 http/tests/xmlhttprequest/* layout tests are constantly failing.)

--- a/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
@@ -53,6 +53,7 @@
     WKContentView *_view;
     CGPoint _interactionPoint;
     RetainPtr<UIDatePicker> _datePicker;
+    RetainPtr<NSDateInterval> _dateInterval;
 #if HAVE(UI_CALENDAR_SELECTION_WEEK_OF_YEAR)
     RetainPtr<UICalendarView> _calendarView;
     RetainPtr<UICalendarSelectionWeekOfYear> _selectionWeekOfYear;
@@ -85,6 +86,11 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
     if (!(self = [super init]))
         return nil;
 
+    RetainPtr maximumDateFormatter = adoptNS([[NSDateFormatter alloc] init]);
+    [maximumDateFormatter setDateFormat:kDateTimeFormatString];
+    RetainPtr maximumDate = [maximumDateFormatter dateFromString:@"10000-12-31T23:59"]; // UIDatePicker cannot have more than 10,000 selectable years
+    _dateInterval = adoptNS([[NSDateInterval alloc] initWithStartDate:[NSDate distantPast] endDate:maximumDate.get()]);
+
     _view = view;
     _interactionPoint = [_view lastInteractionLocation];
 
@@ -114,6 +120,7 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
         _calendarView = adoptNS([[UICalendarView alloc] init]);
         [_calendarView setCalendar:[NSCalendar calendarWithIdentifier:NSCalendarIdentifierISO8601]];
         [_calendarView setSelectionBehavior:_selectionWeekOfYear.get()];
+        [_calendarView setAvailableDateRange:_dateInterval.get()];
         return self;
 #endif
     default:
@@ -122,6 +129,8 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
     }
 
     _datePicker = adoptNS([[UIDatePicker alloc] init]);
+    [_datePicker setMinimumDate:[_dateInterval startDate]];
+    [_datePicker setMaximumDate:[_dateInterval endDate]];
     [_datePicker addTarget:self action:@selector(_dateChanged) forControlEvents:UIControlEventValueChanged];
 
     if ([self shouldForceGregorianCalendar])
@@ -281,11 +290,13 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
 
     RetainPtr parsedDate = [[self iso8601DateFormatterForCalendarView] dateFromString:[self _sanitizeInputValueForFormatter:_initialValue.get()]];
 
-    if (!parsedDate || ![[_calendarView availableDateRange] containsDate:parsedDate.get()])
-        parsedDate = [NSDate date];
+    bool dateParsedAndSelectable = parsedDate && [[_calendarView availableDateRange] containsDate:parsedDate.get()];
 
-    RetainPtr<NSDateComponents> dateComponents = [[NSCalendar calendarWithIdentifier:NSCalendarIdentifierISO8601] components:unitFlags fromDate:parsedDate.get()];
+    RetainPtr dateComponents = [[NSCalendar calendarWithIdentifier:NSCalendarIdentifierISO8601] components:unitFlags fromDate:dateParsedAndSelectable ? parsedDate.get() : [NSDate date]];
     [_selectionWeekOfYear setSelectedWeekOfYear:dateComponents.get() animated:YES];
+
+    if (!dateParsedAndSelectable)
+        [self _dateChanged];
 }
 
 #endif
@@ -303,8 +314,14 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
         return;
     }
 
-    NSDate *parsedDate = [[self dateFormatterForPicker] dateFromString:[self _sanitizeInputValueForFormatter:_initialValue.get()]];
-    [_datePicker setDate:parsedDate ? parsedDate : [NSDate date]];
+    RetainPtr parsedDate = [[self dateFormatterForPicker] dateFromString:[self _sanitizeInputValueForFormatter:_initialValue.get()]];
+
+    if (!parsedDate || ![_dateInterval containsDate:parsedDate.get()]) {
+        parsedDate = [NSDate date];
+        [self _dateChanged];
+    }
+
+    [_datePicker setDate:parsedDate.get()];
 }
 
 - (UIView *)controlView


### PR DESCRIPTION
#### 7ec0f38dfd7736be65b933384a700fecb9e73987
<pre>
[iOS] Invoking date picker controls with large values may cause crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=283317">https://bugs.webkit.org/show_bug.cgi?id=283317</a>
<a href="https://rdar.apple.com/135733092">rdar://135733092</a>

Reviewed by Wenson Hsieh.

An explicit date interval is now applied to the UIDatePicker
or UICalendarView used for date-related input types. If the value
of the input is outside of this interval, invoking the control
will set the value of the input to current day.

* LayoutTests/fast/forms/ios/date-picker-value-crash-expected.txt: Added.
* LayoutTests/fast/forms/ios/date-picker-value-crash.html: Added.
* Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm:
(-[WKDateTimePicker initWithView:inputType:]):
(-[WKDateTimePicker setWeekPickerToInitialValue]):
(-[WKDateTimePicker setDateTimePickerToInitialValue]):

Canonical link: <a href="https://commits.webkit.org/286777@main">https://commits.webkit.org/286777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1faeedd3bc92ebe16aa8ba7fa9aeaa6f1fefae31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81575 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28305 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60363 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18434 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50313 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66117 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40674 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47715 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23615 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26631 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68833 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23943 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83010 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2957 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68636 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67887 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16940 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11872 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9956 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4352 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7168 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4372 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7807 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6131 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->