### PR TITLE
[run-benchmark] Motionmark 1.3 and 1.3.1 plans are not setting the canvas size when running individual subtests with the webserver driver

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/MotionMark1.3.1.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/MotionMark1.3.1.patch
@@ -40,11 +40,11 @@ index d27fa04fe3af698b079f39c4e753a1448e4ebeb9..78d2f300d0e61c60f07290273ae5a513
      updateLocalStorageFromJSON: function(results)
      {
          for (var suiteName in results[Strings.json.results.tests]) {
-@@ -679,17 +710,12 @@ Utilities.extendObject(window.benchmarkController, {
+@@ -679,16 +710,12 @@ Utilities.extendObject(window.benchmarkController, {
  
      startBenchmarkImmediatelyIfEncoded: function()
      {
--        benchmarkController.determineCanvasSize();
+         benchmarkController.determineCanvasSize();
 -        benchmarkController.options = Utilities.convertQueryStringToObject(location.search);
 -        if (!benchmarkController.options)
 -            return false;

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/MotionMark1.3.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/MotionMark1.3.patch
@@ -40,10 +40,11 @@ index 8f7a3c10e907cfeead784f3b768633322fd9e603..78d2f300d0e61c60f07290273ae5a513
      updateLocalStorageFromJSON: function(results)
      {
          for (var suiteName in results[Strings.json.results.tests]) {
-@@ -679,16 +710,12 @@ Utilities.extendObject(window.benchmarkController, {
+@@ -679,16 +710,13 @@ Utilities.extendObject(window.benchmarkController, {
  
      startBenchmarkImmediatelyIfEncoded: function()
      {
++        benchmarkController.determineCanvasSize();
 -        benchmarkController.options = Utilities.convertQueryStringToObject(location.search);
 -        if (!benchmarkController.options)
 -            return false;


### PR DESCRIPTION
#### f25b506a1242551633758b3f9b7542fc03bf89c1
<pre>
[run-benchmark] Motionmark 1.3 and 1.3.1 plans are not setting the canvas size when running individual subtests with the webserver driver
<a href="https://bugs.webkit.org/show_bug.cgi?id=283319">https://bugs.webkit.org/show_bug.cgi?id=283319</a>

Reviewed by Simon Fraser.

When running individual subtests from MotionMark 1.3 via the subtests feature,
the test elements that appear on the screen are very small and do not match
what one gets by manually selecting the options on developer.html

This was reported at MotionMark at <a href="https://github.com/WebKit/MotionMark/issues/43">https://github.com/WebKit/MotionMark/issues/43</a>
and got fixed on MotionMark 1.3.1

However, the patch that we are carrying for the webserver test automation
removed this fix.

So this brings the fix back to the MotionMark 1.3.1 webserver patch and also
backports it to the 1.3 one.

This is reproducible with the following command:
    Tools/Scripts/run-benchmark --plan motionmark1.3.1 \
        --driver webserver --subtests CanvasSuite/CanvasPutGetImageData

* Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/MotionMark1.3.1.patch:
* Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/MotionMark1.3.patch:

Canonical link: <a href="https://commits.webkit.org/286837@main">https://commits.webkit.org/286837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c55df0f15f77c63ff17adbdc528335793ab925c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56043 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81557 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28287 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60349 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18423 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80075 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66102 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40660 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/76514 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47696 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23599 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26613 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68814 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23928 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82992 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2945 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68622 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-includes-scrollbar-gutter.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4543 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67874 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11860 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9941 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11960 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4334 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4354 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7789 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6113 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->