### PR TITLE
[WebGPU] Fix webGpuSwift build

### DIFF
--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -477,13 +477,13 @@ void Buffer::indirectBufferInvalidated()
 #if ENABLE(WEBGPU_SWIFT)
 void Buffer::copy(const std::span<const uint8_t> data, const size_t offset)
 {
+    RELEASE_ASSERT(m_buffer.contents);
     auto buffer = getBufferContents();
-    RELEASE_ASSERT(buffer);
     auto endOffset = checkedSum<size_t>(offset, data.size());
     RELEASE_ASSERT(!(endOffset.hasOverflowed() || endOffset.value() > currentSize()));
     auto checkSize = checkedSum<size_t>(currentSize());
     RELEASE_ASSERT(!checkSize.hasOverflowed());
-    auto destination = std::span<uint8_t> { buffer + offset, static_cast<size_t>(currentSize()) - offset };
+    auto destination = buffer.subspan(offset);
     WebGPU::copySpan(destination, data);
 }
 #endif


### PR DESCRIPTION
#### 3d3c00b0af030c2cb74bd70618627dfa1d377659
<pre>
[WebGPU] Fix webGpuSwift build
<a href="https://bugs.webkit.org/show_bug.cgi?id=283322">https://bugs.webkit.org/show_bug.cgi?id=283322</a>
<a href="https://rdar.apple.com/140149757">rdar://140149757</a>

Reviewed by Mike Wyrzykowski.

Update the Swift implementation of `Buffer::copy` after `getBufferContents` was
changed to return a span.

* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::copy):

Canonical link: <a href="https://commits.webkit.org/286808@main">https://commits.webkit.org/286808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5b921f69e5899f2178aaa86842b6f27e3543fda

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81561 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28291 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60354 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18427 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66106 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40665 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47705 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26617 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/82996 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4392 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2949 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68627 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66079 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67878 "Found 1 new API test failure: /TestWebKit:WebKit.AboutBlankLoad (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16956 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11863 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9945 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4338 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4358 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7793 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6117 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->