### PR TITLE
[TZone] Add missing TZone annotations for subclasses before turning on TZones

### DIFF
--- a/Source/WebCore/page/ImageAnalysisQueue.h
+++ b/Source/WebCore/page/ImageAnalysisQueue.h
@@ -48,7 +48,7 @@ class Timer;
 class WeakPtrImplWithEventTargetData;
 
 class ImageAnalysisQueue final : public RefCounted<ImageAnalysisQueue> {
-    WTF_MAKE_TZONE_ALLOCATED(ImageAnalysisQueue);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ImageAnalysisQueue, WEBCORE_EXPORT);
 public:
     static Ref<ImageAnalysisQueue> create(Page&);
     WEBCORE_EXPORT ~ImageAnalysisQueue();

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
@@ -33,8 +33,11 @@
 #include "ScrollingTree.h"
 #include "ScrollingTreeFrameScrollingNode.h"
 #include "ScrollingTreeScrollingNode.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ThreadedScrollingTreeScrollingNodeDelegate);
 
 ThreadedScrollingTreeScrollingNodeDelegate::ThreadedScrollingTreeScrollingNodeDelegate(ScrollingTreeScrollingNode& scrollingNode)
     : ScrollingTreeScrollingNodeDelegate(scrollingNode)

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.h
@@ -30,6 +30,7 @@
 #if ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)
 
 #include "ScrollingEffectsController.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -41,6 +42,7 @@ class ScrollingTreeScrollingNode;
 class ScrollingTree;
 
 class ThreadedScrollingTreeScrollingNodeDelegate : public ScrollingTreeScrollingNodeDelegate, private ScrollingEffectsControllerClient {
+    WTF_MAKE_TZONE_ALLOCATED(ThreadedScrollingTreeScrollingNodeDelegate);
 public:
     void updateSnapScrollState();
 

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
@@ -31,6 +31,7 @@
 #include "ScrollingEffectsController.h"
 #include "ThreadedScrollingTreeScrollingNodeDelegate.h"
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS NSScrollerImp;
 
@@ -44,6 +45,7 @@ class ScrollingTreeScrollingNode;
 class ScrollingTree;
 
 class ScrollingTreeScrollingNodeDelegateMac final : public ThreadedScrollingTreeScrollingNodeDelegate {
+    WTF_MAKE_TZONE_ALLOCATED(ScrollingTreeScrollingNodeDelegateMac);
 public:
     explicit ScrollingTreeScrollingNodeDelegateMac(ScrollingTreeScrollingNode&);
     virtual ~ScrollingTreeScrollingNodeDelegateMac();

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -37,8 +37,11 @@
 #import <QuartzCore/QuartzCore.h>
 #import <pal/spi/mac/NSScrollerImpSPI.h>
 #import <wtf/BlockObjCExceptions.h>
+#import <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingTreeScrollingNodeDelegateMac);
 
 ScrollingTreeScrollingNodeDelegateMac::ScrollingTreeScrollingNodeDelegateMac(ScrollingTreeScrollingNode& scrollingNode)
     : ThreadedScrollingTreeScrollingNodeDelegate(scrollingNode)

--- a/Source/WebCore/platform/ScrollAnimationKeyboard.cpp
+++ b/Source/WebCore/platform/ScrollAnimationKeyboard.cpp
@@ -31,9 +31,12 @@
 #include "ScrollExtents.h"
 #include "ScrollableArea.h"
 #include "TimingFunction.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollAnimationKeyboard);
 
 static FloatSize perpendicularAbsoluteUnitVector(ScrollDirection direction)
 {

--- a/Source/WebCore/platform/ScrollAnimationKeyboard.h
+++ b/Source/WebCore/platform/ScrollAnimationKeyboard.h
@@ -28,6 +28,7 @@
 #include "KeyboardScroll.h"
 #include "RectEdges.h"
 #include "ScrollAnimation.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -35,6 +36,7 @@ class FloatPoint;
 class TimingFunction;
 
 class ScrollAnimationKeyboard final: public ScrollAnimation {
+    WTF_MAKE_TZONE_ALLOCATED(ScrollAnimationKeyboard);
 public:
     ScrollAnimationKeyboard(ScrollAnimationClient&);
     virtual ~ScrollAnimationKeyboard();

--- a/Source/WebCore/platform/ScrollAnimationKinetic.cpp
+++ b/Source/WebCore/platform/ScrollAnimationKinetic.cpp
@@ -29,6 +29,7 @@
 
 #include "PlatformWheelEvent.h"
 #include "ScrollExtents.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 /*
@@ -71,6 +72,8 @@ static constexpr double velocityAccumulationMax = 6.0;
 static constexpr Seconds scrollCaptureThreshold { 150_ms };
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollAnimationKinetic);
 
 ScrollAnimationKinetic::PerAxisData::PerAxisData(double lower, double upper, double initialOffset, double initialVelocity)
     : m_lower(lower)

--- a/Source/WebCore/platform/ScrollAnimationKinetic.h
+++ b/Source/WebCore/platform/ScrollAnimationKinetic.h
@@ -28,12 +28,14 @@
 
 #include "FloatPoint.h"
 #include "ScrollAnimation.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class PlatformWheelEvent;
 
 class ScrollAnimationKinetic final : public ScrollAnimation {
+    WTF_MAKE_TZONE_ALLOCATED(ScrollAnimationKinetic);
 private:
     class PerAxisData {
     public:

--- a/Source/WebCore/platform/ScrollAnimationMomentum.cpp
+++ b/Source/WebCore/platform/ScrollAnimationMomentum.cpp
@@ -27,9 +27,12 @@
 
 #include "Logging.h"
 #include "ScrollingMomentumCalculator.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollAnimationMomentum);
 
 ScrollAnimationMomentum::ScrollAnimationMomentum(ScrollAnimationClient& client)
     : ScrollAnimation(Type::Momentum, client)

--- a/Source/WebCore/platform/ScrollAnimationMomentum.h
+++ b/Source/WebCore/platform/ScrollAnimationMomentum.h
@@ -25,12 +25,14 @@
 #pragma once
 
 #include "ScrollAnimation.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class ScrollingMomentumCalculator;
 
 class ScrollAnimationMomentum final : public ScrollAnimation {
+    WTF_MAKE_TZONE_ALLOCATED(ScrollAnimationMomentum);
 public:
     ScrollAnimationMomentum(ScrollAnimationClient&);
     virtual ~ScrollAnimationMomentum();

--- a/Source/WebCore/platform/ScrollAnimationSmooth.cpp
+++ b/Source/WebCore/platform/ScrollAnimationSmooth.cpp
@@ -33,9 +33,12 @@
 #include "ScrollExtents.h"
 #include "ScrollableArea.h"
 #include "TimingFunction.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollAnimationSmooth);
 
 static const float animationSpeed { 1000.0f };
 static const Seconds maxAnimationDuration { 200_ms };

--- a/Source/WebCore/platform/ScrollAnimationSmooth.h
+++ b/Source/WebCore/platform/ScrollAnimationSmooth.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "ScrollAnimation.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
@@ -34,6 +35,7 @@ class FloatPoint;
 class TimingFunction;
 
 class ScrollAnimationSmooth final: public ScrollAnimation {
+    WTF_MAKE_TZONE_ALLOCATED(ScrollAnimationSmooth);
 public:
     ScrollAnimationSmooth(ScrollAnimationClient&);
     virtual ~ScrollAnimationSmooth();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/OutOfBandTextTrackPrivateAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/OutOfBandTextTrackPrivateAVF.h
@@ -29,12 +29,14 @@
 #if ENABLE(VIDEO) && (USE(AVFOUNDATION) || PLATFORM(IOS_FAMILY))
 
 #include "InbandTextTrackPrivateAVF.h"
+#include <wtf/TZoneMallocInlines.h>
 
 OBJC_CLASS AVMediaSelectionOption;
 
 namespace WebCore {
     
 class OutOfBandTextTrackPrivateAVF : public InbandTextTrackPrivateAVF {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(OutOfBandTextTrackPrivateAVF);
 public:
     static Ref<OutOfBandTextTrackPrivateAVF> create(AVFInbandTrackParent* player,  AVMediaSelectionOption* selection, TrackID trackID)
     {

--- a/Source/WebCore/platform/mac/ScrollAnimationRubberBand.h
+++ b/Source/WebCore/platform/mac/ScrollAnimationRubberBand.h
@@ -25,12 +25,14 @@
 #pragma once
 
 #include "ScrollAnimation.h"
+#include <wtf/TZoneMalloc.h>
 
 #if HAVE(RUBBER_BANDING)
 
 namespace WebCore {
 
 class ScrollAnimationRubberBand final: public ScrollAnimation {
+    WTF_MAKE_TZONE_ALLOCATED(ScrollAnimationRubberBand);
 public:
     ScrollAnimationRubberBand(ScrollAnimationClient&);
     virtual ~ScrollAnimationRubberBand();

--- a/Source/WebCore/platform/mac/ScrollAnimationRubberBand.mm
+++ b/Source/WebCore/platform/mac/ScrollAnimationRubberBand.mm
@@ -30,6 +30,7 @@
 #import "FloatPoint.h"
 #import "GeometryUtilities.h"
 #import <pal/spi/mac/NSScrollViewSPI.h>
+#import <wtf/TZoneMallocInlines.h>
 
 static float elasticDeltaForTimeDelta(float initialPosition, float initialVelocity, Seconds elapsedTime)
 {
@@ -37,6 +38,8 @@ static float elasticDeltaForTimeDelta(float initialPosition, float initialVeloci
 }
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollAnimationRubberBand);
 
 static inline float roundTowardZero(float num)
 {

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -59,6 +59,8 @@ public:
     using WriteOperationIdentifier = ObjectIdentifier<WriteOperationIdentifierType>;
 
     struct Record {
+        WTF_MAKE_STRUCT_TZONE_ALLOCATED(Record);
+
         Record() = default;
         Record(const Key& key, WallTime timeStamp, const Data& header, const Data& body, std::optional<SHA1::Digest> bodyHash)
             : key(key)
@@ -80,6 +82,8 @@ public:
     };
 
     struct Timings {
+        WTF_MAKE_STRUCT_TZONE_ALLOCATED(Timings);
+
         MonotonicTime startTime;
         MonotonicTime dispatchTime;
         MonotonicTime recordIOStartTime;
@@ -92,8 +96,6 @@ public:
         bool synchronizationInProgressAtDispatch { false };
         bool shrinkInProgressAtDispatch { false };
         bool wasCanceled { false };
-
-        WTF_MAKE_TZONE_ALLOCATED(Timings);
     };
 
     // This may call completion handler synchronously on failure.

--- a/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp
+++ b/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp
@@ -30,8 +30,13 @@
 
 #include "Logging.h"
 #include <WebCore/CARingBuffer.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SharedCARingBufferBase);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ConsumerSharedCARingBuffer);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ProducerSharedCARingBuffer);
 
 SharedCARingBufferBase::SharedCARingBufferBase(size_t bytesPerFrame, size_t frameCount, uint32_t numChannelStream, Ref<WebCore::SharedMemory> storage)
     : CARingBuffer(bytesPerFrame, frameCount, numChannelStream)

--- a/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h
+++ b/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h
@@ -33,10 +33,12 @@
 #include <wtf/Atomics.h>
 #include <wtf/Function.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class SharedCARingBufferBase : public WebCore::CARingBuffer {
+    WTF_MAKE_TZONE_ALLOCATED(SharedCARingBufferBase);
 protected:
     SharedCARingBufferBase(size_t bytesPerFrame, size_t frameCount, uint32_t numChannelStream, Ref<WebCore::SharedMemory>);
     void* data() final { return byteCast<Byte>(m_storage->mutableSpan().subspan(sizeof(TimeBoundsBuffer)).data()); }
@@ -53,6 +55,7 @@ struct ConsumerSharedCARingBufferHandle {
 };
 
 class ConsumerSharedCARingBuffer final : public SharedCARingBufferBase {
+    WTF_MAKE_TZONE_ALLOCATED(ConsumerSharedCARingBuffer);
 public:
     using Handle = ConsumerSharedCARingBufferHandle;
 
@@ -67,6 +70,7 @@ protected:
 };
 
 class ProducerSharedCARingBuffer final : public SharedCARingBufferBase {
+    WTF_MAKE_TZONE_ALLOCATED(ProducerSharedCARingBuffer);
 public:
     struct Pair {
         std::unique_ptr<ProducerSharedCARingBuffer> producer;

--- a/Source/WebKit/UIProcess/API/C/WKContext.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContext.cpp
@@ -49,6 +49,7 @@
 #include "WebProcessPool.h"
 #include <WebCore/GamepadProvider.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 // Supplements
@@ -104,6 +105,7 @@ void WKContextSetInjectedBundleClient(WKContextRef contextRef, const WKContextIn
 void WKContextSetHistoryClient(WKContextRef contextRef, const WKContextHistoryClientBase* wkClient)
 {
     class HistoryClient final : public API::Client<WKContextHistoryClientBase>, public API::LegacyContextHistoryClient {
+        WTF_MAKE_TZONE_ALLOCATED_INLINE(HistoryClient);
     public:
         explicit HistoryClient(const WKContextHistoryClientBase* client)
         {

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -986,6 +986,7 @@ void WKPageSetPageContextMenuClient(WKPageRef pageRef, const WKPageContextMenuCl
     CRASH_IF_SUSPENDED;
 #if ENABLE(CONTEXT_MENUS)
     class ContextMenuClient final : public API::Client<WKPageContextMenuClientBase>, public API::ContextMenuClient {
+        WTF_MAKE_TZONE_ALLOCATED_INLINE(ContextMenuClient);
     public:
         explicit ContextMenuClient(const WKPageContextMenuClientBase* client)
         {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKDataTask.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDataTask.mm
@@ -37,9 +37,11 @@
 #import <WebCore/ResourceRequest.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/SpanCocoa.h>
 
 class WKDataTaskClient final : public API::DataTaskClient {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WKDataTaskClient);
 public:
     static Ref<WKDataTaskClient> create(id <_WKDataTaskDelegate> delegate) { return adoptRef(*new WKDataTaskClient(delegate)); }
 private:

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
@@ -40,6 +40,7 @@
 #import <WebCore/FrameIdentifier.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMallocInlines.h>
 #import <wtf/text/WTFString.h>
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
@@ -50,6 +51,7 @@
 #endif
 
 class InspectorClient final : public API::InspectorClient {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(InspectorClient);
 public:
     explicit InspectorClient(id <_WKInspectorDelegate> delegate)
         : m_delegate(delegate)

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -73,6 +73,7 @@ public:
 private:
 #if ENABLE(CONTEXT_MENUS)
     class ContextMenuClient : public API::ContextMenuClient {
+        WTF_MAKE_TZONE_ALLOCATED(ContextMenuClient);
     public:
         explicit ContextMenuClient(UIDelegate&);
         ~ContextMenuClient();

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -87,6 +87,9 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(UIDelegate);
 WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(UIDelegateUIClient, UIDelegate::UIClient);
+#if ENABLE(CONTEXT_MENUS)
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(UIDelegateContextMenuClient, UIDelegate::ContextMenuClient);
+#endif
 
 UIDelegate::UIDelegate(WKWebView *webView)
     : m_webView(webView)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -53,6 +53,7 @@ namespace WebKit {
 using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteImageBufferProxy);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteSerializedImageBufferProxy);
 
 RemoteImageBufferProxy::RemoteImageBufferProxy(Parameters parameters, const ImageBufferBackend::Info& info, RemoteRenderingBackendProxy& remoteRenderingBackendProxy, std::unique_ptr<ImageBufferBackend>&& backend, RenderingResourceIdentifier identifier)
     : ImageBuffer(parameters, info, { }, WTFMove(backend), identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -109,6 +109,7 @@ private:
 };
 
 class RemoteSerializedImageBufferProxy : public WebCore::SerializedImageBuffer {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteSerializedImageBufferProxy);
     friend class RemoteRenderingBackendProxy;
 public:
     ~RemoteSerializedImageBufferProxy();


### PR DESCRIPTION
#### a035d4ab316afbc6325a251e0fc843f5cd2e8760
<pre>
[TZone] Add missing TZone annotations for subclasses before turning on TZones
<a href="https://bugs.webkit.org/show_bug.cgi?id=283323">https://bugs.webkit.org/show_bug.cgi?id=283323</a>
<a href="https://rdar.apple.com/140150103">rdar://140150103</a>

Reviewed by Yusuke Suzuki.

During bench testing with TZones end TZone logging enabled, found several derived classes that weren&apos;t annotated.
Also changed the class ImageAnalysisQueue to the EXPORT annotation version and changed the nested struct
Storage::Timing to use the WTF_MAKE_STRUCT_TZONE_ALLOCATED annotation.

* Source/WebCore/page/ImageAnalysisQueue.h:
* Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp:
* Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
* Source/WebCore/platform/ScrollAnimationKeyboard.cpp:
* Source/WebCore/platform/ScrollAnimationKeyboard.h:
* Source/WebCore/platform/ScrollAnimationKinetic.cpp:
* Source/WebCore/platform/ScrollAnimationKinetic.h:
* Source/WebCore/platform/ScrollAnimationMomentum.cpp:
* Source/WebCore/platform/ScrollAnimationMomentum.h:
* Source/WebCore/platform/ScrollAnimationSmooth.cpp:
* Source/WebCore/platform/ScrollAnimationSmooth.h:
* Source/WebCore/platform/graphics/avfoundation/objc/OutOfBandTextTrackPrivateAVF.h:
* Source/WebCore/platform/mac/ScrollAnimationRubberBand.h:
* Source/WebCore/platform/mac/ScrollAnimationRubberBand.mm:
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp:
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h:
* Source/WebKit/UIProcess/API/C/WKContext.cpp:
(WKContextSetHistoryClient):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetPageContextMenuClient):
* Source/WebKit/UIProcess/API/Cocoa/_WKDataTask.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:

Canonical link: <a href="https://commits.webkit.org/286772@main">https://commits.webkit.org/286772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19b4d58564c06516e78881c45ce4c54843f67a86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81565 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28295 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79133 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4347 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60355 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18426 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40666 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47703 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23609 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26621 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68821 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83000 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2948 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68628 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4551 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67879 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16937 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11864 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9949 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4342 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7158 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4362 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7797 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6121 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->