### PR TITLE
[TZones] Enable TZones and turn on OS Logging by default

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssembler.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.cpp
@@ -37,6 +37,7 @@
 
 namespace JSC {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MacroAssembler);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MacroAssemblerBase);
 
 const double MacroAssembler::twoToThe32 = (double)0x100000000ull;

--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -32,7 +32,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #if ENABLE(ASSEMBLER)
 
 #include "JSCJSValue.h"
-#include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #define DEFINE_SIMD_FUNC(name, func, lane) \
     template <typename ...Args> \
@@ -124,7 +124,7 @@ typedef Vector<PrintRecord> PrintRecordList;
 using MacroAssemblerBase = TARGET_MACROASSEMBLER;
 
 class MacroAssembler : public MacroAssemblerBase {
-    WTF_MAKE_TZONE_ALLOCATED(MacroAssemblerBase);
+    WTF_MAKE_TZONE_ALLOCATED(MacroAssembler);
 public:
     using Base = MacroAssemblerBase;
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp
@@ -63,8 +63,6 @@ static unsigned long getauxval(unsigned long type)
 
 namespace JSC {
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(MacroAssemblerARM64);
-
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(ctiMasmProbeTrampoline, void, ());
 JSC_ANNOTATE_JIT_OPERATION_PROBE(ctiMasmProbeTrampoline);
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(ctiMasmProbeTrampolineSIMD, void, ());

--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -307,8 +307,7 @@
 
 #if !defined(USE_TZONE_MALLOC)
 #if (CPU(ARM64) || CPU(X86_64)) && OS(DARWIN) && (__SIZEOF_POINTER__ == 8)
-// Building with TZONE_MALLOC currently disabled for all platforms.
-#define USE_TZONE_MALLOC 0
+#define USE_TZONE_MALLOC 1
 #else
 #define USE_TZONE_MALLOC 0
 #endif

--- a/Source/bmalloc/bmalloc/TZoneLog.cpp
+++ b/Source/bmalloc/bmalloc/TZoneLog.cpp
@@ -41,6 +41,12 @@ void TZoneLog::init()
 {
     auto logEnv = getenv("TZONE_LOGGING");
 
+#if BUSE(OS_LOG)
+    // Enable OS Logging by default
+    if (!logEnv)
+        logEnv = const_cast<char*>("oslog");
+#endif
+
     if (logEnv) {
         if (!strcasecmp(logEnv, "stderr"))
             m_logDest = LogDestination::Stderr;


### PR DESCRIPTION
#### e61197d5c88d5fb14dec8e85e923398ccd8b58fb
<pre>
[TZones] Enable TZones and turn on OS Logging by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=283326">https://bugs.webkit.org/show_bug.cgi?id=283326</a>
<a href="https://rdar.apple.com/140151461">rdar://140151461</a>

Reviewed by Yusuke Suzuki and Mark Lam.

Turned on TZone for configured platform in PlatformUse.h.
Set TZone Debug logging to go to OS Logs for Darwin platforms.  Note that the log message are Debug category
so they do not persist on a system.  This can be turned off later.
Added a fix when building with arm64 (non-E).  MacroAssembler.h has an annotation for its declaration and
MacroAssembler.cpp has annotations for the definition of itself and the selected MacroAssemblerBase.

* Source/WTF/wtf/PlatformUse.h:
* Source/bmalloc/bmalloc/TZoneLog.cpp:
* Source/JavaScriptCore/assembler/MacroAssembler.cpp:
* Source/JavaScriptCore/assembler/MacroAssembler.h:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp:
(bmalloc::api::TZoneLog::init):

Canonical link: <a href="https://commits.webkit.org/286801@main">https://commits.webkit.org/286801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b6fb35f06f6a39f05b79983452819edd101cb40

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29982 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81620 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28346 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4398 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60388 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18458 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80134 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66153 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40697 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47747 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23651 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26672 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/70252 "Found 17 new JSC stress test failures: stress/get-by-val-hoist-above-structure-2.js.eager-jettison-no-cjit, stress/get-by-val-hoist-above-structure-2.js.ftl-eager-no-cjit-b3o1, stress/get-by-val-hoist-above-structure-2.js.ftl-no-cjit-b3o0, stress/get-by-val-hoist-above-structure-2.js.ftl-no-cjit-no-put-stack-validate, stress/get-by-val-hoist-above-structure-2.js.ftl-no-cjit-small-pool, stress/get-by-val-hoist-above-structure-2.js.ftl-no-cjit-validate-sampling-profiler, stress/get-by-val-hoist-above-structure-2.js.no-cjit-validate-phases, stress/get-by-val-hoist-above-structure.js.eager-jettison-no-cjit, stress/get-by-val-hoist-above-structure.js.ftl-eager-no-cjit-b3o1, stress/get-by-val-hoist-above-structure.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68863 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83052 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76345 "Found 5 new JSC stress test failures: stress/get-by-val-hoist-above-structure-2.js.eager-jettison-no-cjit, stress/get-by-val-hoist-above-structure-2.js.ftl-eager-no-cjit-b3o1, stress/get-by-val-hoist-above-structure.js.eager-jettison-no-cjit, wasm.yaml/wasm/modules/wasm-imports-js-exports.js.wasm-no-cjit, wasm.yaml/wasm/stress/referenced-function.js.wasm-collect-continuously (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4447 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2986 "Found 2 new test failures: fast/css/view-transitions-hide-under-page-background-color.html webrtc/vp8-then-h264.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68670 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4602 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66126 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67925 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/16953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11904 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9990 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98598 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11937 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4393 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21575 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4413 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7848 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6172 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->