### PR TITLE
[Writing Tools] Can no longer type in compose view after using Writing Tools proofreading in Mail

### DIFF
--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.swift
@@ -239,6 +239,9 @@ import WebKitSwift
             return
         }
 
+        let oldEffect = self.activePonderingEffect
+        self.activePonderingEffect = effect
+
         if let effect {
             self.setupViewIfNeeded()
             await self.effectView?.addEffect(effect)
@@ -250,14 +253,12 @@ import WebKitSwift
             //
             // Therefore, the delegate method itself must avoid any work so that it can be synchronous, which is what the platform
             // interfaces expect.
-            await self.updateTextChunkVisibility(self.activePonderingEffect!.chunk, visible: true, force: true)
+            await self.updateTextChunkVisibility(oldEffect!.chunk, visible: true, force: true)
 
-            await self.effectView?.removeEffect(self.activePonderingEffect!.id)
+            await self.effectView?.removeEffect(oldEffect!.id)
 
             self.destroyViewIfNeeded()
         }
-
-        self.activePonderingEffect = effect
     }
 
     @nonobjc final private func setActiveReplacementEffect(_ effect: PlatformIntelligenceReplacementTextEffect<Chunk>?) async {
@@ -266,15 +267,16 @@ import WebKitSwift
             return
         }
 
+        let oldEffect = self.activeReplacementEffect
+        self.activeReplacementEffect = effect
+
         if let effect {
             self.setupViewIfNeeded()
             await self.effectView?.addEffect(effect)
         } else {
-            await self.effectView?.removeEffect(self.activeReplacementEffect!.id)
+            await self.effectView?.removeEffect(oldEffect!.id)
             self.destroyViewIfNeeded()
         }
-
-        self.activeReplacementEffect = effect
     }
 
     @nonobjc final private func reset() {


### PR DESCRIPTION
#### dc67c7bd3684b12516732e4a45a2298fb9429181
<pre>
[Writing Tools] Can no longer type in compose view after using Writing Tools proofreading in Mail
<a href="https://bugs.webkit.org/show_bug.cgi?id=283329">https://bugs.webkit.org/show_bug.cgi?id=283329</a>
<a href="https://rdar.apple.com/140133728">rdar://140133728</a>

Reviewed by Abrar Rahman Protyasha.

This is essentially the same bug as <a href="https://commits.webkit.org/283274@main.">https://commits.webkit.org/283274@main.</a> This time, even though there
was supposed to be logic to ensure that the view got removed when there were no longer any active effects,
the logic was flawed due to the wrong order of operations; the call to remove the view happened prior to
the effects actually being set to `nil`.

Fix by ensuring that the order of operations of when the effects are set to `nil` and when the view is
requested to be removed is correct.

* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.swift:
(setActivePonderingEffect(_:)):
(setActiveReplacementEffect(_:)):

Canonical link: <a href="https://commits.webkit.org/286776@main">https://commits.webkit.org/286776@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d10f345d9aa649782f448e95f171df7c54857df0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29959 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81594 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28323 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79161 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4375 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60369 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18439 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80111 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66132 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40680 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47726 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23630 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26649 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68842 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23958 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83028 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4424 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68647 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4579 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67899 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16939 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11882 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9969 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4370 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7186 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4390 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6149 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->