### PR TITLE
AX: AccessibilityObject::visibleCharacterRange() returns the wrong result for vertical writing mode text that is only partially visible

### DIFF
--- a/LayoutTests/accessibility/visible-character-range-vertical-rl-expected.txt
+++ b/LayoutTests/accessibility/visible-character-range-vertical-rl-expected.txt
@@ -1,0 +1,10 @@
+This test ensures we compute the right visible character range for writing-mode: vertical-rl text.
+
+Testing window width 623px, height 1240px, scrollTop 506px
+Testing window width 305px, height 1477px, scrollTop 632px
+Testing window width 625px, height 48px, scrollTop 29px
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/visible-character-range-vertical-rl.html
+++ b/LayoutTests/accessibility/visible-character-range-vertical-rl.html
@@ -1,0 +1,108 @@
+
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<style>
+/* All of these styles are critical in reproducing the bug. */
+body { writing-mode: vertical-rl; }
+
+#content-wrapper {
+    overflow-wrap: break-word;
+    -webkit-line-break: after-white-space;
+}
+p {
+    line-height: 1.7999999999999998;
+    margin-top: 21pt;
+    margin-bottom: 21pt;
+}
+.text-style {
+    font-size: 20pt;
+    white-space: pre;
+}
+</style>
+</head>
+<body id="body" contenteditable="true" role="application" style="margin: 0 !important;">
+
+<div id="content-wrapper">
+<!-- This markup is of a similar style to that of a Google Docs document. -->
+<p>
+    <span class="text-style">Line one line one</span><span contenteditable="false"> <br role="presentation"/></span>
+    <span class="text-style">Line two line two</span><span contenteditable="false"></span>
+</p>
+<p>
+    <span class="text-style">Line three line three</span><span contenteditable="false"> <br role="presentation"/></span>
+    <span class="text-style">Line four line four </span><span contenteditable="false"></span>
+</p>
+<p>
+    <span class="text-style">Line five line five</span><span contenteditable="false"> <br role="presentation"/></span>
+    <span class="text-style">Line six line six</span><span contenteditable="false"></span>
+</p>
+<p>
+    <span class="text-style">Line seven line seven</span><span contenteditable="false"> <br role="presentation"/></span>
+    <span class="text-style">Line eight line eight </span><span contenteditable="false"></span>
+</p>
+<p>
+    <span class="text-style">Line nine line nine</span><span contenteditable="false"> <br role="presentation"/></span>
+    <span class="text-style">Line ten line ten</span><span contenteditable="false"></span>
+</p>
+<p>
+    <span class="text-style">Line eleven line eleven</span><span contenteditable="false"> <br role="presentation"/></span>
+    <span class="text-style">Line twelve line twelve</span><span contenteditable="false"></span>
+</p>
+<p>
+    <span class="text-style">Line thirteen line thirteen</span><span contenteditable="false"> <br role="presentation"/></span>
+    <span class="text-style">Line fourteen line fourteen</span><span contenteditable="false"></span>
+</p>
+<p>
+    <span class="text-style">Line fifteen line fifteen</span><span contenteditable="false"> <br role="presentation"/></span>
+    <span class="text-style">Line sixteen line sixteen</span><span contenteditable="false"></span>
+</p>
+<p>
+    <span class="text-style">Line seventeen line seventeen</span><span contenteditable="false"> <br role="presentation"/></span>
+    <span class="text-style">Line eighteen line eighteen</span><span contenteditable="false"></span>
+</p>
+<p>
+    <span class="text-style">Line nineteen line nineteen</span><span contenteditable="false"> <br role="presentation"/></span>
+    <span class="text-style">Line twenty line twenty </span><span contenteditable="false"></span>
+</p>
+<p>
+    <span class="text-style">Line twentyone line twentyone</span><span contenteditable="false"> <br role="presentation"/></span>
+    <span class="text-style">Line twentytwo line twentytwo</span><span contenteditable="false"></span>
+</p>
+</div>
+
+<script>
+var output = "This test ensures we compute the right visible character range for writing-mode: vertical-rl text.\n\n";
+
+var axBody;
+async function verifyRange(windowWidth, windowHeight, scrollBy, expectedRangeString) {
+    testRunner.setViewSize(windowWidth, windowHeight);
+    document.body.scrollTop = scrollBy;
+    output += `Testing window width ${windowWidth}px, height ${windowHeight}px, scrollTop ${scrollBy}px\n`;
+    await waitFor(() => axBody.stringDescriptionOfAttributeValue("AXVisibleCharacterRange").includes(expectedRangeString));
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        axBody = accessibilityController.accessibleElementById("body");
+
+        // These values are chosen because they exercise shrinking line-by-line from the end of the text to find the visible character range.
+        await verifyRange(/* width */ 623, /* height */ 1240, /* scrollTop */ 506, "{0, 240}");
+
+        // These values exercise shrinking line-by-line from the start of the text.
+        await verifyRange(/* width */ 305, /* height */ 1477, /* scrollTop */ 632, accessibilityController.platformName === "ios" ? "{0, 124}" : "{0, 106}");
+        await verifyRange(/* width */ 625, /* height */ 48, /* scrollTop */ 29, "{537, 500}");
+
+        debug(output);
+        document.getElementById("content-wrapper").style.display = "none";
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -681,6 +681,7 @@ accessibility/editable-webpage-focused-ui-element.html [ Skip ]
 accessibility/visible-character-range-basic.html [ Skip ]
 accessibility/visible-character-range-height-changes.html [ Skip ]
 accessibility/visible-character-range-scrolling.html [ Skip ]
+accessibility/visible-character-range-vertical-rl.html [ Skip ]
 accessibility/visible-character-range-width-changes.html [ Skip ]
 
 accessibility/display-contents/tree-and-treeitems.html [ Skip ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2353,6 +2353,7 @@ accessibility/url-test.html [ Pass ]
 accessibility/video-element-url-attribute.html [ Pass ]
 accessibility/visible-character-range-basic.html [ Pass ]
 accessibility/visible-character-range-height-changes.html [ Pass ]
+accessibility/visible-character-range-vertical-rl.html [ Pass ]
 accessibility/visible-character-range-width-changes.html [ Pass ]
 accessibility/ancestor-computation.html [ Pass ]
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1763,6 +1763,7 @@ accessibility/mixed-contenteditable-double-br-visible-character-range-hang.html 
 accessibility/visible-character-range-basic.html [ Skip ]
 accessibility/visible-character-range-height-changes.html [ Skip ]
 accessibility/visible-character-range-scrolling.html [ Skip ]
+accessibility/visible-character-range-vertical-rl.html [ Skip ]
 accessibility/visible-character-range-width-changes.html [ Skip ]
 accessibility/aria-description.html [ Skip ]
 

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -895,12 +895,12 @@ private:
     std::optional<SimpleRange> rangeOfStringClosestToRangeInDirection(const SimpleRange&, AccessibilitySearchDirection, const Vector<String>&) const;
     std::optional<SimpleRange> selectionRange() const;
     std::optional<SimpleRange> findTextRange(const Vector<String>& searchStrings, const SimpleRange& start, AccessibilitySearchTextDirection) const;
-    std::optional<SimpleRange> visibleCharacterRangeInternal(const std::optional<SimpleRange>&, const FloatRect&, const IntRect&) const;
+    std::optional<SimpleRange> visibleCharacterRangeInternal(SimpleRange&, const FloatRect&, const IntRect&) const;
     Vector<BoundaryPoint> previousLineStartBoundaryPoints(const VisiblePosition&, const SimpleRange&, unsigned) const;
     std::optional<VisiblePosition> previousLineStartPositionInternal(const VisiblePosition&) const;
-    bool boundaryPointsContainedInRect(const BoundaryPoint&, const BoundaryPoint&, const FloatRect&) const;
-    std::optional<BoundaryPoint> lastBoundaryPointContainedInRect(const Vector<BoundaryPoint>&, const BoundaryPoint&, const FloatRect&, int, int) const;
-    std::optional<BoundaryPoint> lastBoundaryPointContainedInRect(const Vector<BoundaryPoint>& boundaryPoints, const BoundaryPoint& startBoundaryPoint, const FloatRect& targetRect) const;
+    bool boundaryPointsContainedInRect(const BoundaryPoint&, const BoundaryPoint&, const FloatRect&, bool isFlippedWritingMode) const;
+    std::optional<BoundaryPoint> lastBoundaryPointContainedInRect(const Vector<BoundaryPoint>&, const BoundaryPoint&, const FloatRect&, int, int, bool isFlippedWritingMode) const;
+    std::optional<BoundaryPoint> lastBoundaryPointContainedInRect(const Vector<BoundaryPoint>& boundaryPoints, const BoundaryPoint& startBoundaryPoint, const FloatRect& targetRect, bool isFlippedWritingMode) const;
 
     // Note that "withoutCache" refers to the lack of referencing AXComputedObjectAttributeCache in the function, not the AXObjectCache parameter we pass in here.
     bool isIgnoredWithoutCache(AXObjectCache*) const;
@@ -920,10 +920,6 @@ protected: // FIXME: Make the data members private.
 private:
     OptionSet<AXAncestorFlag> m_ancestorFlags;
     AccessibilityObjectInclusion m_lastKnownIsIgnoredValue { AccessibilityObjectInclusion::DefaultBehavior };
-    // std::nullopt is a valid cached value if this object has no visible characters.
-    mutable std::optional<SimpleRange> m_cachedVisibleCharacterRange;
-    // This is std::nullopt if we haven't cached any input yet.
-    mutable std::optional<std::tuple<std::optional<SimpleRange>, FloatRect, IntRect>> m_cachedVisibleCharacterRangeInputs;
 #if PLATFORM(IOS_FAMILY)
     InlineTextPrediction m_lastPresentedTextPrediction;
     InlineTextPrediction m_lastPresentedTextPredictionComplete;
@@ -947,9 +943,9 @@ inline void AccessibilityObject::recomputeIsIgnored()
     isIgnoredWithoutCache(axObjectCache());
 }
 
-inline std::optional<BoundaryPoint> AccessibilityObject::lastBoundaryPointContainedInRect(const Vector<BoundaryPoint>& boundaryPoints, const BoundaryPoint& startBoundaryPoint, const FloatRect& targetRect) const
+inline std::optional<BoundaryPoint> AccessibilityObject::lastBoundaryPointContainedInRect(const Vector<BoundaryPoint>& boundaryPoints, const BoundaryPoint& startBoundaryPoint, const FloatRect& targetRect, bool isFlippedWritingMode) const
 {
-    return lastBoundaryPointContainedInRect(boundaryPoints, startBoundaryPoint, targetRect, 0, boundaryPoints.size() - 1);
+    return lastBoundaryPointContainedInRect(boundaryPoints, startBoundaryPoint, targetRect, 0, boundaryPoints.size() - 1, isFlippedWritingMode);
 }
 
 inline VisiblePosition AccessibilityObject::previousLineStartPosition(const VisiblePosition& position) const


### PR DESCRIPTION
#### 9ac2c0188b7d0974774a40da80a628b1bd82b89e
<pre>
AX: AccessibilityObject::visibleCharacterRange() returns the wrong result for vertical writing mode text that is only partially visible
<a href="https://bugs.webkit.org/show_bug.cgi?id=283330">https://bugs.webkit.org/show_bug.cgi?id=283330</a>
<a href="https://rdar.apple.com/140158374">rdar://140158374</a>

Reviewed by Chris Fleizach.

AccessibilityObject::visibleCharacterRange() is implemented by shrinking the start and end of the element&apos;s rect
line-by-line until it fits within the viewport. The problem was that the logic for determining whether to start or
continue shrinking lines was based on checking rect.location() for shrinking the start of the text, or rect.location() + rect.size()
for the shrinking the end. This is wrong for &quot;flipped&quot; writing-modes (e.g. vertical-rl), whose `x` represents the end
of the text, not the start. This meant we would shrink the end lines when we actually should&apos;ve been shrinking the start,
and vice versa (hence this problem being specific to &quot;flipped&quot; writing modes).

With this commit, this logic now properly checks for and handles flipped writing modes. A test is added to prove we
behave correctly.

This commit also critically removes AccessibilityObject::m_cachedVisibleCharacterRange and AccessibilityObject::m_cachedVisibleCharacterRangeInputs.
These caches were added to make repeated calls for the same visibleCharacterRange fast, as Books seemed to be doing this
in the past. However, it doesn&apos;t seem to be doing this anymore. This cache was not a great idea in the first place (I added it).
It adds 120 bytes of size to every single AccessibilityObject, even if nothing has or will request visibleCharacterRange on it.

Removing it saves a substantial amount of memory — 68.1mb on <a href="http://html.spec.whatwg.org">http://html.spec.whatwg.org</a> (567769 objects times 120 bytes).

* LayoutTests/accessibility/visible-character-range-vertical-rl-expected.txt: Added.
* LayoutTests/accessibility/visible-character-range-vertical-rl.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::lastBoundaryPointContainedInRect const):
(WebCore::textStartPoint):
(WebCore::textEndPoint):
(WebCore::AccessibilityObject::boundaryPointsContainedInRect const):
(WebCore::AccessibilityObject::visibleCharacterRange const):
(WebCore::AccessibilityObject::visibleCharacterRangeInternal const):
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::lastBoundaryPointContainedInRect const):

Canonical link: <a href="https://commits.webkit.org/286780@main">https://commits.webkit.org/286780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae170613fb4855acb7a00d1d5570a6f30d23597f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77041 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81591 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28320 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79158 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4372 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60367 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18441 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80108 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50321 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40678 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47723 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23628 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26646 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68839 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23956 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83025 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68650 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4576 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66103 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67903 "Found 1 new API test failure: /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16942 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11880 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9967 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4367 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7183 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4387 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7822 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6146 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->