### PR TITLE
[WebGPU] An invalid TextureView may be considered valid if its parent is destroyed

### DIFF
--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -3273,6 +3273,9 @@ WGPUExtent3D Texture::physicalMiplevelSpecificTextureExtent(uint32_t mipLevel)
 
 WGPUExtent3D Texture::physicalTextureExtent(WGPUTextureDimension dimension, WGPUTextureFormat format, WGPUExtent3D logicalExtent)
 {
+    ASSERT(texelBlockWidth(format));
+    ASSERT(texelBlockHeight(format));
+
     switch (dimension) {
     case WGPUTextureDimension_1D:
         return {

--- a/Source/WebGPU/WebGPU/TextureView.mm
+++ b/Source/WebGPU/WebGPU/TextureView.mm
@@ -165,7 +165,7 @@ bool TextureView::isDestroyed() const
 
 bool TextureView::isValid() const
 {
-    return m_texture || isDestroyed();
+    return m_texture;
 }
 
 void TextureView::destroy()


### PR DESCRIPTION
#### 9de8ad6aad769be26a81306385b97d0b7a48bcb4
<pre>
[WebGPU] An invalid TextureView may be considered valid if its parent is destroyed
<a href="https://bugs.webkit.org/show_bug.cgi?id=283334">https://bugs.webkit.org/show_bug.cgi?id=283334</a>
<a href="https://rdar.apple.com/140161514">rdar://140161514</a>

Reviewed by Cameron McCormack.

An invalid TextureView created from a valid Texture
should remain invalid throughout its lifetime and not
become valid if the parent Texture instance is destroyed.

We can simply remove the check for &quot; || isDestroyed()&quot; in
TextureView::isValid() because m_texture is set to a placeholder,
not nil, when the TextureView is destroyed.

Test: fuzz-275229.html continues to pass in debug.

* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::physicalTextureExtent):
Add debug assertion since it is never expected to reach this
function with a texture format of &apos;Undefined&apos; or &apos;Force32&apos;

* Source/WebGPU/WebGPU/TextureView.mm:
(WebGPU::TextureView::isValid const):

Canonical link: <a href="https://commits.webkit.org/286781@main">https://commits.webkit.org/286781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b70d0f48bcf692de4d81c76f8ee54645807c84f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81600 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28328 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4380 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60378 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18446 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66138 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40684 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47730 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26654 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68846 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83033 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4429 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2973 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68660 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4584 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67913 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16943 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11883 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/9975 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4375 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4395 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7830 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6154 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->