### PR TITLE
Do more span adoption in JSString

### DIFF
--- a/Source/JavaScriptCore/runtime/JSString.cpp
+++ b/Source/JavaScriptCore/runtime/JSString.cpp
@@ -142,9 +142,9 @@ void JSString::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 DEFINE_VISIT_CHILDREN(JSString);
 
 template<typename CharacterType>
-void JSRopeString::resolveRopeInternalNoSubstring(CharacterType* buffer, uint8_t* stackLimit) const
+void JSRopeString::resolveRopeInternalNoSubstring(std::span<CharacterType> buffer, uint8_t* stackLimit) const
 {
-    resolveToBuffer(fiber0(), fiber1(), fiber2(), buffer, length(), stackLimit);
+    resolveToBuffer(fiber0(), fiber1(), fiber2(), buffer, stackLimit);
 }
 
 AtomString JSRopeString::resolveRopeToAtomString(JSGlobalObject* globalObject) const
@@ -169,13 +169,13 @@ AtomString JSRopeString::resolveRopeToAtomString(JSGlobalObject* globalObject) c
     uint8_t* stackLimit = std::bit_cast<uint8_t*>(vm.softStackLimit());
     if (!isSubstring()) {
         if (is8Bit()) {
-            LChar buffer[maxLengthForOnStackResolve];
-            resolveRopeInternalNoSubstring(buffer, stackLimit);
-            atomString = std::span<const LChar> { buffer, length() };
+            std::array<LChar, maxLengthForOnStackResolve> buffer;
+            resolveRopeInternalNoSubstring(std::span { buffer }.first(length()), stackLimit);
+            atomString = std::span<const LChar> { buffer }.first(length());
         } else {
-            UChar buffer[maxLengthForOnStackResolve];
-            resolveRopeInternalNoSubstring(buffer, stackLimit);
-            atomString = std::span<const UChar> { buffer, length() };
+            std::array<UChar, maxLengthForOnStackResolve> buffer;
+            resolveRopeInternalNoSubstring(std::span { buffer }.first(length()), stackLimit);
+            atomString = std::span<const UChar> { buffer }.first(length());
         }
     } else
         atomString = StringView { substringBase()->valueInternal() }.substring(substringOffset(), length()).toAtomString();
@@ -209,13 +209,13 @@ RefPtr<AtomStringImpl> JSRopeString::resolveRopeToExistingAtomString(JSGlobalObj
     if (!isSubstring()) {
         uint8_t* stackLimit = std::bit_cast<uint8_t*>(vm.softStackLimit());
         if (is8Bit()) {
-            LChar buffer[maxLengthForOnStackResolve];
-            resolveRopeInternalNoSubstring(buffer, stackLimit);
-            existingAtomString = AtomStringImpl::lookUp(std::span { buffer, length() });
+            std::array<LChar, maxLengthForOnStackResolve> buffer;
+            resolveRopeInternalNoSubstring(std::span { buffer }.first(length()), stackLimit);
+            existingAtomString = AtomStringImpl::lookUp(std::span { buffer }.first(length()));
         } else {
-            UChar buffer[maxLengthForOnStackResolve];
-            resolveRopeInternalNoSubstring(buffer, stackLimit);
-            existingAtomString = AtomStringImpl::lookUp(std::span { buffer, length() });
+            std::array<UChar, maxLengthForOnStackResolve> buffer;
+            resolveRopeInternalNoSubstring(std::span { buffer }.first(length()), stackLimit);
+            existingAtomString = AtomStringImpl::lookUp(std::span { buffer }.first(length()));
         }
     } else
         existingAtomString = StringView { substringBase()->valueInternal() }.substring(substringOffset(), length()).toExistingAtomString().releaseImpl();
@@ -248,7 +248,7 @@ const String& JSRopeString::resolveRopeWithFunction(JSGlobalObject* nullOrGlobal
 
         size_t sizeToReport = newImpl->cost();
         uint8_t* stackLimit = std::bit_cast<uint8_t*>(vm.softStackLimit());
-        resolveRopeInternalNoSubstring(buffer.data(), stackLimit);
+        resolveRopeInternalNoSubstring(buffer, stackLimit);
         convertToNonRope(function(newImpl.releaseNonNull()));
         if constexpr (reportAllocation)
             vm.heap.reportExtraMemoryAllocated(this, sizeToReport);
@@ -264,7 +264,7 @@ const String& JSRopeString::resolveRopeWithFunction(JSGlobalObject* nullOrGlobal
     
     size_t sizeToReport = newImpl->cost();
     uint8_t* stackLimit = std::bit_cast<uint8_t*>(vm.softStackLimit());
-    resolveRopeInternalNoSubstring(buffer.data(), stackLimit);
+    resolveRopeInternalNoSubstring(buffer, stackLimit);
     convertToNonRope(function(newImpl.releaseNonNull()));
     if constexpr (reportAllocation)
         vm.heap.reportExtraMemoryAllocated(this, sizeToReport);

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -612,11 +612,11 @@ public:
     JS_EXPORT_PRIVATE const String& resolveRopeWithoutGC() const;
 
     template<typename CharacterType>
-    static void resolveToBuffer(JSString*, JSString*, JSString*, CharacterType* buffer, unsigned length, uint8_t* stackLimit);
+    static void resolveToBuffer(JSString*, JSString*, JSString*, std::span<CharacterType> buffer, uint8_t* stackLimit);
 
 private:
     template<typename CharacterType>
-    static void resolveToBufferSlow(JSString*, JSString*, JSString*, CharacterType* buffer, unsigned length, uint8_t* stackLimit);
+    static void resolveToBufferSlow(JSString*, JSString*, JSString*, std::span<CharacterType> buffer, uint8_t* stackLimit);
 
     static JSRopeString* create(VM& vm, JSString* s1, JSString* s2)
     {
@@ -653,7 +653,7 @@ private:
     template<bool reportAllocation, typename Function> const String& resolveRopeWithFunction(JSGlobalObject* nullOrGlobalObjectForOOM, Function&&) const;
     JS_EXPORT_PRIVATE AtomString resolveRopeToAtomString(JSGlobalObject*) const;
     JS_EXPORT_PRIVATE RefPtr<AtomStringImpl> resolveRopeToExistingAtomString(JSGlobalObject*) const;
-    template<typename CharacterType> void resolveRopeInternalNoSubstring(CharacterType*, uint8_t* stackLimit) const;
+    template<typename CharacterType> void resolveRopeInternalNoSubstring(std::span<CharacterType>, uint8_t* stackLimit) const;
     Identifier toIdentifier(JSGlobalObject*) const;
     void outOfMemory(JSGlobalObject* nullOrGlobalObjectForOOM) const;
     GCOwnedDataScope<StringView> view(JSGlobalObject*) const;


### PR DESCRIPTION
#### 70e970418e813addb06c4cd256202a73f8588b43
<pre>
Do more span adoption in JSString
<a href="https://bugs.webkit.org/show_bug.cgi?id=283341">https://bugs.webkit.org/show_bug.cgi?id=283341</a>

Reviewed by Yusuke Suzuki.

* Source/JavaScriptCore/runtime/JSString.cpp:
(JSC::JSRopeString::resolveRopeInternalNoSubstring const):
(JSC::JSRopeString::resolveRopeToAtomString const):
(JSC::JSRopeString::resolveRopeToExistingAtomString const):
(JSC::JSRopeString::resolveRopeWithFunction const):
* Source/JavaScriptCore/runtime/JSString.h:
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::JSRopeString::resolveToBufferSlow):
(JSC::JSRopeString::resolveToBuffer):
(JSC::jsAtomString):

Canonical link: <a href="https://commits.webkit.org/286892@main">https://commits.webkit.org/286892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3d321941536e0806425e4fff11b6b55e0254eb5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82015 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28717 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4767 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18685 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66461 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/40967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48047 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23958 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27040 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/70623 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69156 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24296 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83424 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76714 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4815 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68926 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4971 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68190 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17025 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12187 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10283 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98966 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4762 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21633 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4781 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8216 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6540 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->