### PR TITLE
TextIterator & StyledMarkupAccumulator should consider skipped content as invisible

### DIFF
--- a/LayoutTests/editing/pasteboard/data-transfer-get-data-on-paste-skipped-content-expected.txt
+++ b/LayoutTests/editing/pasteboard/data-transfer-get-data-on-paste-skipped-content-expected.txt
@@ -1,0 +1,16 @@
+Tests that skipped content is successfully removed from pasted content. To manually test, press "Copy" below and paste (Command+V on macOS and Control+V elsewhere).
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS JSON.stringify(event.clipboardData.types) is "[\"text/html\",\"text/plain\"]"
+PASS event.clipboardData.getData("text/plain") is "hello, world\nWebKit"
+PASS event.clipboardData.getData("text/html").length is > 0
+PASS event.clipboardData.getData("text/html").includes("sensitive") is false
+PASS event.clipboardData.items.length is 2
+PASS item = event.clipboardData.items[0]; item.kind is "string"
+PASS item.type is "text/html"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/pasteboard/data-transfer-get-data-on-paste-skipped-content.html
+++ b/LayoutTests/editing/pasteboard/data-transfer-get-data-on-paste-skipped-content.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<div id="container">
+<button onclick="runTest()">Copy</button>
+<div id="source" contenteditable="true">hello, <b>world</b><br>WebKit<span style="content-visibility: hidden;">super sensitive content</span></div>
+<div id="destination" onpaste="check(event)" contenteditable="true" style="width: 500px; height: 100px; border: solid red 1px"></div>
+</div>
+</body>
+<script>
+description('Tests that skipped content is successfully removed from pasted content. To manually test, press "Copy" below and paste (Command+V on macOS and Control+V elsewhere).');
+jsTestIsAsync = true;
+
+function runTest()
+{
+    if (window.internals)
+        internals.settings.setCustomPasteboardDataEnabled(true);
+
+    document.getElementById("source").focus();
+    document.execCommand("SelectAll");
+    document.execCommand("Copy");
+
+    document.getElementById("destination").focus();
+    if (window.testRunner)
+        document.execCommand("Paste");
+}
+
+function check(event)
+{
+    shouldBeEqualToString('JSON.stringify(event.clipboardData.types)', '["text/html","text/plain"]');
+    shouldBeEqualToString('event.clipboardData.getData("text/plain")', 'hello, world\nWebKit');
+    shouldBeGreaterThan('event.clipboardData.getData("text/html").length', '0');
+    shouldBeFalse('event.clipboardData.getData("text/html").includes("sensitive")');
+    shouldBe('event.clipboardData.items.length', '2');
+    shouldBeEqualToString('item = event.clipboardData.items[0]; item.kind', 'string');
+    shouldBeEqualToString('item.type', 'text/html');
+
+    document.getElementById('container').remove();
+
+    finishJSTest();
+}
+
+if (window.testRunner)
+    runTest();
+
+</script>
+</html>

--- a/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying-expected.txt
+++ b/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS typesInSameDocument.includes("text/html") is true
-PASS htmlInSameDocument is "<meta content=\"secret\"><b onmouseover=\"dangerousCode()\">hello</b><!-- secret-->, world<script>dangerousCode()</script>"
+PASS htmlInSameDocument is "<meta content=\"secret\"><u style=\"content-visibility: hidden\">secret</u><b onmouseover=\"dangerousCode()\">hello</b><!-- secret-->, world<script>dangerousCode()</script>"
 PASS JSON.stringify(itemsInSameDocument[0]) is "{\"kind\":\"string\",\"type\":\"text/html\"}"
 PASS htmlInAnotherDocument.includes("secret") is false
 PASS htmlInAnotherDocument.includes("dangerousCode") is false

--- a/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying-in-null-origin-expected.txt
+++ b/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying-in-null-origin-expected.txt
@@ -9,7 +9,7 @@ PASS htmlInNullOrigin.includes("dangerousCode") is false
 PASS b = (new DOMParser).parseFromString(htmlInNullOrigin, "text/html").querySelector("b"); b.textContent is "hello"
 PASS b.parentNode.textContent is "hello, world"
 PASS JSON.stringify(itemsInNullOrigin[0]) is "{\"kind\":\"string\",\"type\":\"text/html\"}"
-PASS event.clipboardData.getData("text/html") is "<meta content=\"secret\"><b onmouseover=\"dangerousCode()\">hello</b><!-- secret-->, world<script>dangerousCode()</script>"
+PASS event.clipboardData.getData("text/html") is "<meta content=\"secret\"><u style=\"content-visibility: hidden\">secret</u><b onmouseover=\"dangerousCode()\">hello</b><!-- secret-->, world<script>dangerousCode()</script>"
 PASS event.clipboardData.types.includes("text/html") is true
 PASS JSON.stringify(pastedItems[0]) is "{\"kind\":\"string\",\"type\":\"text/html\"}"
 PASS successfullyParsed is true

--- a/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying-in-null-origin.html
+++ b/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying-in-null-origin.html
@@ -24,7 +24,7 @@ function runTest() {
 
 let container = document.getElementById('container');
 
-var originalHTML = '<meta content="secret"><b onmouseover="dangerousCode()">hello</b><!-- secret-->, world<script>dangerousCode()</scr' + 'ipt>';
+var originalHTML = '<meta content="secret"><u style="content-visibility: hidden">secret</u><b onmouseover="dangerousCode()">hello</b><!-- secret-->, world<script>dangerousCode()</scr' + 'ipt>';
 function doCopy(event) {
     event.clipboardData.setData('text/html', originalHTML);
     event.preventDefault();

--- a/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying.html
+++ b/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying.html
@@ -22,7 +22,7 @@ iframe.src = `data:text/html;charset=utf-8,<!DOCTYPE html>
 <div id="destination" onpaste="doPaste(event)" contenteditable>2. Paste here</div>
 <script>
 
-const originalHTML = '<meta content="secret"><b onmouseover="dangerousCode()">hello</b><!-- secret-->, world<script>dangerousCode()</scr' + 'ipt>';
+const originalHTML = '<meta content="secret"><u style="content-visibility: hidden">secret</u><b onmouseover="dangerousCode()">hello</b><!-- secret-->, world<script>dangerousCode()</scr' + 'ipt>';
 
 function runTest() {
     document.getElementById('source').focus();

--- a/LayoutTests/editing/selection/selection-toString-skipped-content-expected.txt
+++ b/LayoutTests/editing/selection/selection-toString-skipped-content-expected.txt
@@ -1,0 +1,5 @@
+PASS getSelection().toString() is "hello"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+hello

--- a/LayoutTests/editing/selection/selection-toString-skipped-content.html
+++ b/LayoutTests/editing/selection/selection-toString-skipped-content.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<div id="content">hello<div style="content-visibility: hidden;">secret content</div></div>
+<script>
+
+let range = document.createRange();
+range.selectNode(content);
+window.getSelection().addRange(range);
+shouldBeEqualToString('getSelection().toString()', 'hello');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-035-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-035-expected.txt
@@ -1,4 +1,3 @@
 
-
 PASS Testing focus and force layout on element with hidden flat-tree ancestor
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-044-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-044-expected.txt
@@ -1,4 +1,3 @@
 
-
 PASS Content Visibility: slot moved after container is hidden
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-relevancy-updates-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-relevancy-updates-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Relevancy updated after changing proximity to the viewport. assert_false: far from viewport expected false got true
-FAIL Relevancy updated after being focused/unfocused. assert_false: initial relevancy expected false got true
-FAIL Relevancy updated after being selected/unselected. assert_false: initial relevancy expected false got true
+PASS Relevancy updated after changing proximity to the viewport.
+PASS Relevancy updated after being focused/unfocused.
+PASS Relevancy updated after being selected/unselected.
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-053-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-053-expected.txt
@@ -1,3 +1,4 @@
 
+
 PASS Targetting a slotted auto-hidden element with focus makes it the active element
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-053-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-053-expected.txt
@@ -1,3 +1,4 @@
 
+
 PASS Targetting a slotted auto-hidden element with focus makes it the active element
 

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -437,7 +437,7 @@ static inline bool hasDisplayContents(Node& node)
 
 static bool isRendererVisible(const RenderObject* renderer, TextIteratorBehaviors behaviors)
 {
-    return renderer && !(renderer->style().usedUserSelect() == UserSelect::None && behaviors.contains(TextIteratorBehavior::IgnoresUserSelectNone));
+    return renderer && !renderer->isSkippedContent() && !(renderer->style().usedUserSelect() == UserSelect::None && behaviors.contains(TextIteratorBehavior::IgnoresUserSelectNone));
 }
 
 void TextIterator::advance()

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -774,6 +774,9 @@ RefPtr<Node> StyledMarkupAccumulator::traverseNodesForSerialization(Node& startN
         if (!node.renderer() && !isDisplayContents && !enclosingElementWithTag(firstPositionInOrBeforeNode(&node), selectTag))
             return false;
 
+        if (node.renderer() && node.renderer()->isSkippedContent())
+            return false;
+
         if (m_ignoresUserSelectNone && userSelectNoneStateCache.nodeOnlyContainsUserSelectNone(node))
             return false;
 


### PR DESCRIPTION
#### 8d60cd8712f39a96e7bd61fd006af22fd76a5c2a
<pre>
TextIterator &amp; StyledMarkupAccumulator should consider skipped content as invisible
<a href="https://bugs.webkit.org/show_bug.cgi?id=283344">https://bugs.webkit.org/show_bug.cgi?id=283344</a>
<a href="https://rdar.apple.com/140172890">rdar://140172890</a>

Reviewed by Ryosuke Niwa.

When content is skipped as a result of content-visibility: hidden/auto, it is not visible to the user.

Make sure we properly skip the content from selection or copy &amp; paste to avoid privacy leaks.

innerText should also avoid skipped content as per spec: <a href="https://drafts.csswg.org/css-contain/#cv-notes">https://drafts.csswg.org/css-contain/#cv-notes</a>

* LayoutTests/editing/pasteboard/data-transfer-get-data-on-paste-skipped-content-expected.txt: Added.
* LayoutTests/editing/pasteboard/data-transfer-get-data-on-paste-skipped-content.html: Added.
* LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying-expected.txt:
* LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying-in-null-origin-expected.txt:
* LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying-in-null-origin.html:
* LayoutTests/editing/pasteboard/data-transfer-set-data-sanitizes-html-when-copying.html:
* LayoutTests/editing/selection/selection-toString-skipped-content-expected.txt: Added.
* LayoutTests/editing/selection/selection-toString-skipped-content.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-035-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-044-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-053-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-relevancy-updates-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-053-expected.txt: Added.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-053-expected.txt: Added.
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::isRendererVisible):
* Source/WebCore/editing/markup.cpp:
(WebCore::StyledMarkupAccumulator::traverseNodesForSerialization):

Canonical link: <a href="https://commits.webkit.org/286799@main">https://commits.webkit.org/286799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f472633207529c006f916a80f8f23313d7136fbe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30034 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/81677 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28401 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79236 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4450 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/81677 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/18493 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80186 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/50390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/66198 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/81677 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/47792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/23696 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26724 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/68907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/24024 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/83104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4499 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/83104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4655 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/66171 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/83104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/11948 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/10035 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11935 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4445 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7261 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4465 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7900 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->