### PR TITLE
Add <wtf/TZoneMalloc.m> to WebCore, WebKit, WebKitLegacy, and JavaScriptCore precompiled header files

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCorePrefix.h
+++ b/Source/JavaScriptCore/JavaScriptCorePrefix.h
@@ -66,6 +66,7 @@
 #include <mutex>
 #include <string>
 #include <typeinfo>
+#include <wtf/TZoneMalloc.h>
 #endif
 
 #ifdef __cplusplus

--- a/Source/WebCore/WebCorePrefix.h
+++ b/Source/WebCore/WebCorePrefix.h
@@ -161,12 +161,12 @@
 #ifdef __cplusplus
 
 #if !PLATFORM(WIN)
-#import <wtf/FastMalloc.h>
-#import <wtf/HashMap.h>
-#import <wtf/StdLibExtras.h>
-#import <wtf/TZoneMallocInlines.h>
-#import <wtf/text/AtomString.h>
-#import <wtf/text/WTFString.h>
+#include <wtf/FastMalloc.h>
+#include <wtf/HashMap.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/text/AtomString.h>
+#include <wtf/text/WTFString.h>
 #endif
 
 #define new ("if you use new/delete make sure to include config.h at the top of the file"()) 

--- a/Source/WebKit/WebKit2Prefix.h
+++ b/Source/WebKit/WebKit2Prefix.h
@@ -64,6 +64,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <wtf/TZoneMalloc.h>
 #endif
 
 #ifdef __OBJC__

--- a/Source/WebKitLegacy/mac/WebKitPrefix.h
+++ b/Source/WebKitLegacy/mac/WebKitPrefix.h
@@ -94,6 +94,7 @@ typedef float CGFloat;
 
 #ifdef __cplusplus
 #include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 #endif
 
 #include <wtf/DisallowCType.h>


### PR DESCRIPTION
#### 1e7b7ad77352a38f600ec54b0ce3c31aa6238629
<pre>
Add &lt;wtf/TZoneMalloc.m&gt; to WebCore, WebKit, WebKitLegacy, and JavaScriptCore precompiled header files
<a href="https://bugs.webkit.org/show_bug.cgi?id=283343">https://bugs.webkit.org/show_bug.cgi?id=283343</a>
&lt;<a href="https://rdar.apple.com/problem/140172578">rdar://problem/140172578</a>&gt;

Reviewed by Michael Saboff.

As more clases adopt WTF_MAKE_TZONE_ALLOCATED(), the cost to include &lt;wtf/TZoneMalloc.h&gt; has exploded.
Adding it to the precompiled header files reduces build times by approximately 5%.

* Source/JavaScriptCore/JavaScriptCorePrefix.h:
* Source/WebCore/WebCorePrefix.h:
* Source/WebKit/WebKit2Prefix.h:
* Source/WebKitLegacy/mac/WebKitPrefix.h:

Canonical link: <a href="https://commits.webkit.org/286806@main">https://commits.webkit.org/286806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3f9d12befae390a4dd584c47dcb1040fafa332a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/29992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81631 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28356 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79194 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4408 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60395 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18463 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66163 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40703 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47755 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23661 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26682 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/70262 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68871 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/23989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83062 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76355 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4457 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/2994 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68677 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4612 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67931 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16954 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11914 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10000 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98608 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4403 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7219 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21577 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4423 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7858 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6182 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->