### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF::StringBuilder

### DIFF
--- a/Source/WTF/wtf/text/StringBuilder.cpp
+++ b/Source/WTF/wtf/text/StringBuilder.cpp
@@ -30,8 +30,6 @@
 #include <wtf/dtoa.h>
 #include <wtf/text/StringBuilderInternals.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 static constexpr unsigned maxCapacity = String::MaxLength;
@@ -95,9 +93,9 @@ void StringBuilder::shrink(unsigned newLength)
         }
         // Allocate a fresh buffer, with a copy of the characters we are keeping.
         if (m_buffer->is8Bit())
-            allocateBuffer<LChar>(m_buffer->span8().data(), newLength);
+            allocateBuffer<LChar>(m_buffer->span8(), newLength);
         else
-            allocateBuffer<UChar>(m_buffer->span16().data(), newLength);
+            allocateBuffer<UChar>(m_buffer->span16(), newLength);
         return;
     }
 
@@ -124,11 +122,11 @@ void StringBuilder::reserveCapacity(unsigned newCapacity)
     } else {
         if (newCapacity > m_length) {
             if (!m_length)
-                allocateBuffer<LChar>(static_cast<LChar*>(nullptr), newCapacity);
+                allocateBuffer<LChar>(std::span<const LChar> { }, newCapacity);
             else if (m_string.is8Bit())
-                allocateBuffer<LChar>(m_string.span8().data(), newCapacity);
+                allocateBuffer<LChar>(m_string.span8(), newCapacity);
             else
-                allocateBuffer<UChar>(m_string.span16().data(), newCapacity);
+                allocateBuffer<UChar>(m_string.span16(), newCapacity);
         }
     }
     ASSERT(hasOverflowed() || !newCapacity || m_buffer->length() >= newCapacity);
@@ -143,7 +141,7 @@ std::span<LChar> StringBuilder::extendBufferForAppendingLChar(unsigned requiredL
 std::span<UChar> StringBuilder::extendBufferForAppendingWithUpconvert(unsigned requiredLength)
 {
     if (is8Bit()) {
-        allocateBuffer<UChar>(characters<LChar>(), expandedCapacity(capacity(), requiredLength));
+        allocateBuffer<UChar>(span8(), expandedCapacity(capacity(), requiredLength));
         if (UNLIKELY(hasOverflowed()))
             return { };
         return spanConstCast<UChar>(m_buffer->span16().subspan(std::exchange(m_length, requiredLength)));
@@ -199,5 +197,3 @@ bool StringBuilder::containsOnlyASCII() const
 }
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/text/StringBuilderInternals.h
+++ b/Source/WTF/wtf/text/StringBuilderInternals.h
@@ -33,7 +33,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 namespace WTF {
 
 // Allocate a new buffer, copying in currentCharacters (these may come from either m_string or m_buffer.
-template<typename AllocationCharacterType, typename CurrentCharacterType> void StringBuilder::allocateBuffer(const CurrentCharacterType* currentCharacters, unsigned requiredCapacity)
+template<typename AllocationCharacterType, typename CurrentCharacterType> void StringBuilder::allocateBuffer(std::span<const CurrentCharacterType> currentCharacters, unsigned requiredCapacity)
 {
     std::span<AllocationCharacterType> bufferCharacters;
     auto buffer = StringImpl::tryCreateUninitialized(requiredCapacity, bufferCharacters);
@@ -43,7 +43,7 @@ template<typename AllocationCharacterType, typename CurrentCharacterType> void S
     }
 
     ASSERT(!hasOverflowed());
-    StringImpl::copyCharacters(bufferCharacters.data(), { currentCharacters, m_length });
+    StringImpl::copyCharacters(bufferCharacters.data(), currentCharacters);
 
     m_buffer = WTFMove(buffer);
     m_string = { };
@@ -66,7 +66,7 @@ template<typename CharacterType> void StringBuilder::reallocateBuffer(unsigned r
         }
     }
 
-    allocateBuffer<CharacterType>(characters<CharacterType>(), requiredCapacity);
+    allocateBuffer<CharacterType>(span<CharacterType>(), requiredCapacity);
 }
 
 // Make 'additionalLength' additional capacity be available in m_buffer, update m_string & m_length to use,

--- a/Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp
@@ -397,7 +397,7 @@ TEST(StringBuilderTest, Equal)
     StringBuilder builder1;
     StringBuilder builder2;
     EXPECT_TRUE(builder1 == builder2);
-    EXPECT_TRUE(equal(builder1, static_cast<LChar*>(0), 0));
+    EXPECT_TRUE(equal(builder1, std::span<const LChar>()));
     EXPECT_TRUE(builder1 == String());
     EXPECT_TRUE(String() == builder1);
     EXPECT_TRUE(builder1 != String("abc"_s));


### PR DESCRIPTION
#### f4ca7c87e0ecbba8df2a92541089c0820f758227
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF::StringBuilder
<a href="https://bugs.webkit.org/show_bug.cgi?id=283347">https://bugs.webkit.org/show_bug.cgi?id=283347</a>

Reviewed by Geoffrey Garen.

* Source/WTF/wtf/text/StringBuilder.cpp:
* Source/WTF/wtf/text/StringBuilder.h:
(WTF::StringBuilder::span8 const):
(WTF::StringBuilder::span16 const):
(WTF::StringBuilder::span const):
(WTF::StringBuilder::operator[] const):
(WTF::equal):

Canonical link: <a href="https://commits.webkit.org/286813@main">https://commits.webkit.org/286813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba7ea0987cf96b3d9aa18841c12d20b1e319b4ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81732 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28422 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79257 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4471 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18507 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50404 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66216 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/40763 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47806 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23714 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26745 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/70325 "Found 16 jsc stress test failures: stress/attribute-custom-accessor.js.dfg-eager, stress/get-by-val-hoist-above-structure-2.js.eager-jettison-no-cjit, stress/get-by-val-hoist-above-structure-2.js.ftl-no-cjit-b3o0, stress/get-by-val-hoist-above-structure-2.js.ftl-no-cjit-no-put-stack-validate, stress/get-by-val-hoist-above-structure-2.js.ftl-no-cjit-small-pool ...") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68921 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24049 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83125 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76418 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4520 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3045 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68733 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4676 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66189 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67978 "Found 1 new API test failure: /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/test-page-list (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11964 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10053 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98671 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11948 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4466 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21588 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4486 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7921 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6245 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->