### PR TITLE
[WTF][GTK] SHA1 fails to build with Clang 18 and -Wunsafe-buffer-usage

### DIFF
--- a/Source/WTF/wtf/SHA1.cpp
+++ b/Source/WTF/wtf/SHA1.cpp
@@ -159,7 +159,7 @@ void SHA1::processBlock()
 {
     ASSERT(m_cursor == 64);
 
-    uint32_t w[80] = { 0 };
+    std::array <uint32_t, 80> w { };
     for (int t = 0; t < 16; ++t)
         w[t] = (m_buffer[t * 4] << 24) | (m_buffer[t * 4 + 1] << 16) | (m_buffer[t * 4 + 2] << 8) | m_buffer[t * 4 + 3];
     for (int t = 16; t < 80; ++t)
@@ -200,7 +200,7 @@ void SHA1::reset()
     m_hash[4] = 0xc3d2e1f0;
 
     // Clear the buffer after use in case it's sensitive.
-    memset(m_buffer, 0, sizeof(m_buffer));
+    m_buffer.fill(0);
 }
 
 #endif

--- a/Source/WTF/wtf/SHA1.h
+++ b/Source/WTF/wtf/SHA1.h
@@ -86,10 +86,10 @@ public:
     typedef std::array<uint8_t, hashSize> Digest;
 
     WTF_EXPORT_PRIVATE void computeHash(Digest&);
-    
+
     // Get a hex hash from the digest.
     WTF_EXPORT_PRIVATE static CString hexDigest(const Digest&);
-    
+
     // Compute the hex digest directly.
     WTF_EXPORT_PRIVATE CString computeHexDigest();
 
@@ -101,10 +101,10 @@ private:
     void processBlock();
     void reset();
 
-    uint8_t m_buffer[64];
+    std::array<uint8_t, 64> m_buffer;
     size_t m_cursor; // Number of bytes filled in m_buffer (0-64).
     uint64_t m_totalBytes; // Number of bytes added so far.
-    uint32_t m_hash[5];
+    std::array<uint32_t, 5> m_hash;
 #endif
 };
 


### PR DESCRIPTION
#### 3a08f985baf74a6a165fcc94bdf8e6f0a5ec0bc1
<pre>
[WTF][GTK] SHA1 fails to build with Clang 18 and -Wunsafe-buffer-usage
<a href="https://bugs.webkit.org/show_bug.cgi?id=283356">https://bugs.webkit.org/show_bug.cgi?id=283356</a>

Reviewed by Adrian Perez de Castro and Chris Dumez.

Replace usage of C arrays with std::array in SHA1.

* Source/WTF/wtf/SHA1.cpp:
(WTF::SHA1::processBlock):
(WTF::SHA1::reset):
* Source/WTF/wtf/SHA1.h:

Canonical link: <a href="https://commits.webkit.org/286802@main">https://commits.webkit.org/286802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/002147a7c81d5708f2e1b9ce08cad26d75a97a76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56145 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81668 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28389 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4441 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60426 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18487 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50383 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66193 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40733 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47785 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23691 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26715 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/70295 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68900 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83095 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76388 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4490 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3023 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68708 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4646 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66166 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67962 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11943 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10030 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98641 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11938 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4436 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21583 "Found 2 new JSC stress test failures: stress/json-stringify-inspector-check.js.no-llint, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4456 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7891 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->