### PR TITLE
High CPU usage (GPU:100%) when using VideoMediaSampleRenderer's WebCoreDecompressionQueue

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -452,6 +452,15 @@ void VideoMediaSampleRenderer::requestMediaDataWhenReady(Function<void()>&& func
 void VideoMediaSampleRenderer::resetReadyForMoreSample()
 {
     assertIsMainThread();
+
+    if (m_decompressionSession) {
+        callOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->maybeBecomeReadyForMoreMediaData();
+        });
+        return;
+    }
+
     ThreadSafeWeakPtr weakThis { *this };
     [renderer() requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:^{
         if (RefPtr protectedThis = weakThis.get())


### PR DESCRIPTION
#### c938454bf09c26e84a193a5b00527b634296da0a
<pre>
High CPU usage (GPU:100%) when using VideoMediaSampleRenderer&apos;s WebCoreDecompressionQueue
<a href="https://bugs.webkit.org/show_bug.cgi?id=283353">https://bugs.webkit.org/show_bug.cgi?id=283353</a>
<a href="https://rdar.apple.com/140188853">rdar://140188853</a>

Reviewed by Youenn Fablet.

When using a decompression session, we add to the AVSampleBufferDisplayLayer an image only when it&apos;s time to be displayed.
As such, AVSampleBufferDisplayLayer.readyForMoreMediaData is always true.
We use to set AVSBDL.requestMediaDataWhenReadyOnQueue unconditionally. Once we had decoded sufficient video frames (minimum of 30)
we would exit early.
The AVSBDL callback requesting more data would not be resolved and would immediately run again.

When we have a WebCoreDecompressionSession, we don&apos;t need the AVSBDL callback as displaying data is driven by the AVSampleBufferRenderSynchronizer&apos;s timeBase and the decoding queue and will independently notify the player to feed more data.

This change drops the GPU&apos;s CPU usage from 120-140% to under 5%.

* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::resetReadyForMoreSample):

Canonical link: <a href="https://commits.webkit.org/286831@main">https://commits.webkit.org/286831@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c34969cf2f7b5caad91eda589e1db638737423a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30047 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81690 "Hash c34969cf for PR 36847 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28414 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79249 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4463 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/81690 "Hash c34969cf for PR 36847 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18504 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50399 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66212 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/81690 "Hash c34969cf for PR 36847 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47801 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23710 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26737 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68916 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24040 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83117 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4512 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3041 "Found 1 new test failure: webrtc/vp8-then-h264.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68721 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66185 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/67975 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16985 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/11960 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10049 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4458 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7274 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4478 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/7913 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6237 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->