### PR TITLE
[GStreamer][LibWebRTC] No H.264 decoder found when using broadcom and westeros quirks and no FFmpeg installed

### DIFF
--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
@@ -24,6 +24,7 @@
 #include "GStreamerVideoDecoderFactory.h"
 
 #include "GStreamerQuirks.h"
+#include "GStreamerRegistryScanner.h"
 #include "GStreamerVideoCommon.h"
 #include "GStreamerVideoFrameLibWebRTC.h"
 #include "webrtc/modules/video_coding/codecs/h264/include/h264.h"
@@ -277,19 +278,7 @@ public:
 
     static GRefPtr<GstElementFactory> GstDecoderFactory(const char* capsStr)
     {
-        auto allDecoders = gst_element_factory_list_get_elements(GST_ELEMENT_FACTORY_TYPE_DECODER,
-            GST_RANK_MARGINAL);
-        auto caps = adoptGRef(gst_caps_from_string(capsStr));
-        auto decoders = gst_element_factory_list_filter(allDecoders,
-            caps.get(), GST_PAD_SINK, FALSE);
-
-        gst_plugin_feature_list_free(allDecoders);
-        GRefPtr<GstElementFactory> res;
-        if (decoders)
-            res = GST_ELEMENT_FACTORY(decoders->data);
-        gst_plugin_feature_list_free(decoders);
-
-        return res;
+        return GStreamerRegistryScanner::singleton().isCodecSupported(GStreamerRegistryScanner::Configuration::Decoding, String::fromUTF8(capsStr), false).factory;
     }
 
     bool HasGstDecoder()


### PR DESCRIPTION
#### 20f5df0feb7da718bfd61e59b1decfbcdaf02bbf
<pre>
[GStreamer][LibWebRTC] No H.264 decoder found when using broadcom and westeros quirks and no FFmpeg installed
<a href="https://bugs.webkit.org/show_bug.cgi?id=283359">https://bugs.webkit.org/show_bug.cgi?id=283359</a>

Reviewed by Philippe Normand.

Use GStreamerRegistryScanner::isCodecSupport() instead of the
hand-written implementation of GstDecoderFactory(), because this is more
robust to detect decoders in hardware-accelerated scenarios with custom
elements and GStreamer quirks.

This is cherry-pick of <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/d7a7509280358127a6ac75d9ba2242aa9b88150e">https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/d7a7509280358127a6ac75d9ba2242aa9b88150e</a>
Original author: Vivek.A &lt;Vivek_Arumugam@comcast.com&gt;

* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp:
(WebCore::GStreamerWebRTCVideoDecoder::GstDecoderFactory):

Canonical link: <a href="https://commits.webkit.org/286848@main">https://commits.webkit.org/286848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9e56d67d6b859fcb5bac5ba48b89e655a182134

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81820 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28533 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4582 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60519 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18560 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80318 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50488 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66301 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40819 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47891 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23799 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26856 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69002 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83239 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4631 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3125 "Found 2 new test failures: fast/css/view-transitions-nested-transparency-layers.html webrtc/vp8-then-h264.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68791 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4787 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66273 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68047 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16998 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12037 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10135 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4578 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7393 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4597 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8032 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6356 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->