### PR TITLE
[WebM] video freeze after about 2s.

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -100,9 +100,11 @@ private:
     void maybeQueueFrameForDisplay(CMSampleBufferRef);
     void flushCompressedSampleQueue();
     void flushDecodedSampleQueue();
-    void purgeDecodedSampleQueue();
-    CMBufferQueueRef ensureDecodedSampleQueue();
+    bool purgeDecodedSampleQueue();
+    size_t decodedSamplesCount() const;
     void assignResourceOwner(CMSampleBufferRef);
+    bool areSamplesQueuesReadyForMoreMediaData(size_t waterMark) const;
+    void queueMaybeBecomeReadyForMoreMediaData() const;
     void maybeBecomeReadyForMoreMediaData();
 
     void cancelTimer();
@@ -116,7 +118,7 @@ private:
     std::atomic<ssize_t> m_framesBeingDecoded { 0 };
     std::atomic<int> m_flushId { 0 };
     Deque<std::pair<RetainPtr<CMSampleBufferRef>, int>> m_compressedSampleQueue WTF_GUARDED_BY_CAPABILITY(m_workQueue.get());
-    RetainPtr<CMBufferQueueRef> m_decodedSampleQueue WTF_GUARDED_BY_CAPABILITY(m_workQueue.get());
+    RetainPtr<CMBufferQueueRef> m_decodedSampleQueue; // created on the main thread, immutable after creation.
     RefPtr<WebCoreDecompressionSession> m_decompressionSession;
     bool m_isDecodingSample WTF_GUARDED_BY_CAPABILITY(m_workQueue.get()) { false };
     bool m_isDisplayingSample WTF_GUARDED_BY_CAPABILITY(m_workQueue.get()) { false };


### PR DESCRIPTION
#### 9928bbc3693acd073a77d5843aca83a25f75c3c2
<pre>
[WebM] video freeze after about 2s.
<a href="https://bugs.webkit.org/show_bug.cgi?id=283360">https://bugs.webkit.org/show_bug.cgi?id=283360</a>
<a href="https://rdar.apple.com/140197940">rdar://140197940</a>

Reviewed by Eric Carlson.

The CMSampleBufferQueue used to store the decoded frames and re-order them by presentation time
has a maximum capacity of 120 frames.
When playing a 60fps video, it would take just 2s before decoded frames were dropped.

We limit the total number of compressed+decoded frames to determine if we should stop accepting more data.

Fly-By: the time at which we would schedule a frame to be displayed was always the
end of the frame. If there was a gap between the frame, the frame following the gap wouldn&apos;t be displayed.
So instead, we set the next timer to be either the start of the frame if there&apos;s a gap, or its end.

Manually tested. Writing a test is problematic. Issue would have occurred on machine fast enough to decode
data before we had the time finishing processing the compressed queue and for the video to be long enough to
fully fill the decoding queue.

* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::decodedSamplesCount const):
(WebCore::VideoMediaSampleRenderer::isReadyForMoreMediaData const):
(WebCore::VideoMediaSampleRenderer::areSamplesQueuesReadyForMoreMediaData const):
(WebCore::VideoMediaSampleRenderer::queueMaybeBecomeReadyForMoreMediaData const): Add convenience method to call maybeBecomeReadyForMoreMediaData on the main thread.
(WebCore::VideoMediaSampleRenderer::maybeBecomeReadyForMoreMediaData): If the renderer isn&apos;t ready for data and a decompression session is used set a request callback to call maybeBecomeReadyForMoreMediaData once it is available.
(WebCore::VideoMediaSampleRenderer::setTimebase):
(WebCore::VideoMediaSampleRenderer::decodeNextSample):
(WebCore::VideoMediaSampleRenderer::initializeDecompressionSession):
(WebCore::VideoMediaSampleRenderer::decodedFrameAvailable):
(WebCore::VideoMediaSampleRenderer::purgeDecodedSampleQueue):
(WebCore::VideoMediaSampleRenderer::flush):
(WebCore::VideoMediaSampleRenderer::resetReadyForMoreSample):
(WebCore::VideoMediaSampleRenderer::copyDisplayedPixelBuffer):
(WebCore::VideoMediaSampleRenderer::ensureDecodedSampleQueue): Deleted.

Canonical link: <a href="https://commits.webkit.org/286844@main">https://commits.webkit.org/286844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7bdb5e58b6df0f11e67588f70c0744eb10ec01c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81823 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28536 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79371 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4585 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60521 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18561 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66305 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40821 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47890 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23803 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26859 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69001 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24137 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83242 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3129 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68793 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4790 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68049 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16995 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12038 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10139 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4581 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7396 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4600 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8035 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6359 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->