### PR TITLE
REGRESSION(286771@main): ASSERTION FAILED: &object == m_impl->template get<T>() in WTF::WeakPtr<WebCore::WebAnimation, WebCore::WeakPtrImplWithEventTargetData>::WeakPtr(const T &, EnableWeakPtrThreadingAssertions) under AnimationTimelinesController::setTi

### DIFF
--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -158,7 +158,7 @@ void AnimationTimelinesController::updateAnimationsAndSendEvents(ReducedResoluti
             // schedule invalidation if required for this animation.
             animation->tick();
 
-            if (!animation->isRelevant() && !animation->needsTick())
+            if (!animation->isRelevant() && !animation->needsTick() && !isPendingTimelineAttachment(animation))
                 animationsToRemove.append(animation);
 
             if (auto* transition = dynamicDowncast<CSSTransition>(animation.get())) {
@@ -566,6 +566,13 @@ void AnimationTimelinesController::updateNamedTimelineMapForTimelineScope(const 
         break;
     }
     attachPendingOperations();
+}
+
+bool AnimationTimelinesController::isPendingTimelineAttachment(const WebAnimation& animation) const
+{
+    return m_pendingAttachOperations.containsIf([&] (auto& entry) {
+        return entry.animation.ptr() == &animation;
+    });
 }
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -56,7 +56,7 @@ struct ViewTimelineInsets;
 struct TimelineMapAttachOperation {
     WeakPtr<Element, WeakPtrImplWithEventTargetData> element;
     AtomString name;
-    WeakPtr<WebAnimation, WeakPtrImplWithEventTargetData> animation;
+    Ref<WebAnimation> animation;
 };
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AnimationTimelinesController);
@@ -101,6 +101,7 @@ private:
     Vector<Ref<ScrollTimeline>>& timelinesForName(const AtomString&);
     Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>> relatedTimelineScopeElements(const AtomString&);
     void attachPendingOperations();
+    bool isPendingTimelineAttachment(const WebAnimation&) const;
 
     Vector<TimelineMapAttachOperation> m_pendingAttachOperations;
     Vector<std::pair<TimelineScope, WeakPtr<Element, WeakPtrImplWithEventTargetData>>> m_timelineScopeEntries;


### PR DESCRIPTION
#### b364108c2896962f5f87a506e6c45b7af1e3a99d
<pre>
REGRESSION(286771@main): ASSERTION FAILED: &amp;object == m_impl-&gt;template get&lt;T&gt;() in WTF::WeakPtr&lt;WebCore::WebAnimation, WebCore::WeakPtrImplWithEventTargetData&gt;::WeakPtr(const T &amp;, EnableWeakPtrThreadingAssertions) under AnimationTimelinesController::setTi
<a href="https://bugs.webkit.org/show_bug.cgi?id=283346">https://bugs.webkit.org/show_bug.cgi?id=283346</a>
<a href="https://rdar.apple.com/140180425">rdar://140180425</a>

Reviewed by Antoine Quint.

We need to keep around a strong reference to the WebAnimation awaiting attachment to prevent
it from being destroyed.

* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::updateAnimationsAndSendEvents):
(WebCore::AnimationTimelinesController::setTimelineForName):
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::WebAnimation):
(WebCore::WebAnimation::~WebAnimation):
* Source/WebCore/animation/WebAnimation.h:
(WebCore::WebAnimation::setIsPendingTimelineAttachment):
(WebCore::WebAnimation::isPendingTimelineAttachment):

Canonical link: <a href="https://commits.webkit.org/286920@main">https://commits.webkit.org/286920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b58b7da212812fa55ddbb81bab4a91945632d86b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82087 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28785 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60732 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18725 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80570 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66521 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41003 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/48107 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24017 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27108 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69217 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24355 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83492 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3324 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68965 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5039 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68230 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12242 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/10340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12001 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4830 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7645 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4849 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8284 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6608 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->