### PR TITLE
Specify underlying type for enum classes in CryptoKey

### DIFF
--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -626,7 +626,7 @@ static String agentClusterIDFromGlobalObject(JSGlobalObject& globalObject)
 
 const uint32_t currentKeyFormatVersion = 1;
 
-enum class CryptoKeyClassSubtag {
+enum class CryptoKeyClassSubtag : uint8_t {
     HMAC = 0,
     AES = 1,
     RSA = 2,
@@ -636,13 +636,13 @@ enum class CryptoKeyClassSubtag {
 };
 const uint8_t cryptoKeyClassSubtagMaximumValue = 5;
 
-enum class CryptoKeyAsymmetricTypeSubtag {
+enum class CryptoKeyAsymmetricTypeSubtag : bool {
     Public = 0,
     Private = 1
 };
 const uint8_t cryptoKeyAsymmetricTypeSubtagMaximumValue = 1;
 
-enum class CryptoKeyUsageTag {
+enum class CryptoKeyUsageTag : uint8_t {
     Encrypt = 0,
     Decrypt = 1,
     Sign = 2,
@@ -691,7 +691,7 @@ static unsigned countUsages(CryptoKeyUsageBitmap usages)
     return count;
 }
 
-enum class CryptoKeyOKPOpNameTag {
+enum class CryptoKeyOKPOpNameTag : bool {
     X25519 = 0,
     ED25519 = 1,
 };

--- a/Source/WebCore/crypto/CryptoKey.h
+++ b/Source/WebCore/crypto/CryptoKey.h
@@ -45,7 +45,7 @@ namespace WebCore {
 
 class WebCoreOpaqueRoot;
 
-enum class CryptoKeyClass {
+enum class CryptoKeyClass : uint8_t {
     AES,
     EC,
     HMAC,

--- a/Source/WebCore/crypto/CryptoKeyUsage.h
+++ b/Source/WebCore/crypto/CryptoKeyUsage.h
@@ -41,7 +41,7 @@ enum {
 typedef int CryptoKeyUsageBitmap;
 
 // Only for binding purpose.
-enum class CryptoKeyUsage {
+enum class CryptoKeyUsage : uint8_t {
     Encrypt,
     Decrypt,
     Sign,

--- a/Source/WebCore/crypto/SubtleCrypto.h
+++ b/Source/WebCore/crypto/SubtleCrypto.h
@@ -49,7 +49,7 @@ class CryptoKey;
 class DeferredPromise;
 
 enum class CryptoAlgorithmIdentifier : uint8_t;
-enum class CryptoKeyUsage;
+enum class CryptoKeyUsage : uint8_t;
 
 class SubtleCrypto : public ContextDestructionObserver, public RefCounted<SubtleCrypto>, public CanMakeWeakPtr<SubtleCrypto> {
 public:

--- a/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
@@ -40,14 +40,14 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
-bool CryptoKeyOKP::isPlatformSupportedCurve(NamedCurve namedCurve)
+bool CryptoKeyOKP::supportsNamedCurve()
 {
-    return namedCurve == NamedCurve::Ed25519 || namedCurve == NamedCurve::X25519;
+    return true;
 }
 
 std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, bool extractable, CryptoKeyUsageBitmap usages)
 {
-    if (!isPlatformSupportedCurve(namedCurve))
+    if (!supportsNamedCurve())
         return { };
 #if !HAVE(SWIFT_CPP_INTEROP)
     ccec25519pubkey ccPublicKey;
@@ -129,9 +129,9 @@ std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmI
 #endif
 }
 
-bool CryptoKeyOKP::platformCheckPairedKeys(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, const Vector<uint8_t>& privateKey, const Vector<uint8_t>& publicKey)
+bool CryptoKeyOKP::platformCheckPairedKeys(CryptoAlgorithmIdentifier identifier, NamedCurve, const Vector<uint8_t>& privateKey, const Vector<uint8_t>& publicKey)
 {
-    if (!isPlatformSupportedCurve(namedCurve))
+    if (!supportsNamedCurve())
         return false;
 
     if (privateKey.size() != 32 || publicKey.size() != 32)
@@ -185,7 +185,7 @@ bool CryptoKeyOKP::platformCheckPairedKeys(CryptoAlgorithmIdentifier identifier,
 // For all of the OIDs, the parameters MUST be absent.
 RefPtr<CryptoKeyOKP> CryptoKeyOKP::importSpki(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
-    if (!isPlatformSupportedCurve(namedCurve))
+    if (!supportsNamedCurve())
         return nullptr;
 
     // FIXME: We should use the underlying crypto library to import PKCS8 OKP keys.
@@ -313,7 +313,7 @@ ExceptionOr<Vector<uint8_t>> CryptoKeyOKP::exportSpki() const
 // For all of the OIDs, the parameters MUST be absent.
 RefPtr<CryptoKeyOKP> CryptoKeyOKP::importPkcs8(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
-    if (!isPlatformSupportedCurve(namedCurve))
+    if (!supportsNamedCurve())
         return nullptr;
 
     // FIXME: We should use the underlying crypto library to import PKCS8 OKP keys.

--- a/Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp
@@ -31,9 +31,9 @@
 
 namespace WebCore {
 
-bool CryptoKeyOKP::isPlatformSupportedCurve(NamedCurve namedCurve)
+bool CryptoKeyOKP::supportsNamedCurve()
 {
-    return namedCurve == NamedCurve::Ed25519 || namedCurve == NamedCurve::X25519;
+    return true;
 }
 
 namespace CryptoKeyOKPImpl {
@@ -113,7 +113,7 @@ static std::optional<std::pair<Vector<uint8_t>, Vector<uint8_t>>> gcryptGenerate
 
 std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, bool extractable, CryptoKeyUsageBitmap usages)
 {
-    if (!isPlatformSupportedCurve(namedCurve))
+    if (!supportsNamedCurve())
         return std::nullopt;
 
     std::optional<std::pair<Vector<uint8_t>, Vector<uint8_t>>> keyPair;
@@ -147,7 +147,7 @@ std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmI
 
 bool CryptoKeyOKP::platformCheckPairedKeys(CryptoAlgorithmIdentifier, NamedCurve namedCurve, const Vector<uint8_t>& privateKey, const Vector<uint8_t>& publicKey)
 {
-    if (!isPlatformSupportedCurve(namedCurve))
+    if (!supportsNamedCurve())
         return false;
 
     switch (namedCurve) {
@@ -175,7 +175,7 @@ bool CryptoKeyOKP::platformCheckPairedKeys(CryptoAlgorithmIdentifier, NamedCurve
 // For all of the OIDs, the parameters MUST be absent.
 RefPtr<CryptoKeyOKP> CryptoKeyOKP::importSpki(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
-    if (!isPlatformSupportedCurve(curve))
+    if (!supportsNamedCurve())
         return nullptr;
 
     // Decode the `SubjectPublicKeyInfo` structure using the provided key data.
@@ -296,7 +296,7 @@ ExceptionOr<Vector<uint8_t>> CryptoKeyOKP::exportSpki() const
 // For all of the OIDs, the parameters MUST be absent.
 RefPtr<CryptoKeyOKP> CryptoKeyOKP::importPkcs8(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
-    if (!isPlatformSupportedCurve(curve))
+    if (!supportsNamedCurve())
         return nullptr;
 
     // Decode the `PrivateKeyInfo` structure using the provided key data.

--- a/Source/WebCore/crypto/keys/CryptoKeyEC.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyEC.h
@@ -69,7 +69,7 @@ struct JsonWebKey;
 
 class CryptoKeyEC final : public CryptoKey {
 public:
-    enum class NamedCurve {
+    enum class NamedCurve : uint8_t {
         P256,
         P384,
         P521,

--- a/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
@@ -61,7 +61,7 @@ CryptoKeyOKP::CryptoKeyOKP(CryptoAlgorithmIdentifier identifier, NamedCurve curv
 
 ExceptionOr<CryptoKeyPair> CryptoKeyOKP::generatePair(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, bool extractable, CryptoKeyUsageBitmap usages)
 {
-    if (!isPlatformSupportedCurve(namedCurve))
+    if (!supportsNamedCurve())
         return Exception { ExceptionCode::NotSupportedError };
 
     auto result = platformGeneratePair(identifier, namedCurve, extractable, usages);
@@ -73,7 +73,7 @@ ExceptionOr<CryptoKeyPair> CryptoKeyOKP::generatePair(CryptoAlgorithmIdentifier 
 
 RefPtr<CryptoKeyOKP> CryptoKeyOKP::importRaw(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
-    if (!isPlatformSupportedCurve(namedCurve))
+    if (!supportsNamedCurve())
         return nullptr;
 
     // FIXME: The Ed25519 spec states that import in raw format must be used only for Verify.
@@ -82,7 +82,7 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importRaw(CryptoAlgorithmIdentifier identifie
 
 RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwk(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, JsonWebKey&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
-    if (!isPlatformSupportedCurve(namedCurve))
+    if (!supportsNamedCurve())
         return nullptr;
 
     switch (namedCurve) {
@@ -201,7 +201,7 @@ auto CryptoKeyOKP::algorithm() const -> KeyAlgorithm
 
 #if !PLATFORM(COCOA) && !USE(GCRYPT)
 
-bool CryptoKeyOKP::isPlatformSupportedCurve(NamedCurve)
+bool CryptoKeyOKP::supportsNamedCurve()
 {
     return false;
 }

--- a/Source/WebCore/crypto/keys/CryptoKeyOKP.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyOKP.h
@@ -37,7 +37,7 @@ class CryptoKeyOKP final : public CryptoKey {
 public:
     using KeyMaterial = Vector<uint8_t>;
 
-    enum class NamedCurve {
+    enum class NamedCurve : bool {
         X25519,
         Ed25519,
     };
@@ -73,7 +73,7 @@ private:
     String generateJwkD() const;
     String generateJwkX() const;
 
-    static bool isPlatformSupportedCurve(NamedCurve);
+    static bool supportsNamedCurve();
     static std::optional<CryptoKeyPair> platformGeneratePair(CryptoAlgorithmIdentifier, NamedCurve, bool extractable, CryptoKeyUsageBitmap);
     static bool platformCheckPairedKeys(CryptoAlgorithmIdentifier, NamedCurve, const Vector<uint8_t>&, const Vector<uint8_t>&);
     Vector<uint8_t> platformExportRaw() const;


### PR DESCRIPTION
#### bf1655dee5e2866f57e28ef03d04cbc736abfabc
<pre>
Specify underlying type for enum classes in CryptoKey
<a href="https://bugs.webkit.org/show_bug.cgi?id=283381">https://bugs.webkit.org/show_bug.cgi?id=283381</a>
<a href="https://rdar.apple.com/140231507">rdar://140231507</a>

Reviewed by Per Arne Vollan.

Also, remove paramter in isPlatformSupportedCurve() and rename it since the return value does not rely on the NamedCurve
value.

* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
* Source/WebCore/crypto/CryptoKey.h:
* Source/WebCore/crypto/CryptoKeyUsage.h:
* Source/WebCore/crypto/SubtleCrypto.h:
* Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp:
(WebCore::CryptoKeyOKP::supportsNamedCurve):
(WebCore::CryptoKeyOKP::platformGeneratePair):
(WebCore::CryptoKeyOKP::platformCheckPairedKeys):
(WebCore::CryptoKeyOKP::importSpki):
(WebCore::CryptoKeyOKP::importPkcs8):
(WebCore::CryptoKeyOKP::isPlatformSupportedCurve): Deleted.
* Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp:
(WebCore::CryptoKeyOKP::supportsNamedCurve):
(WebCore::CryptoKeyOKP::platformGeneratePair):
(WebCore::CryptoKeyOKP::platformCheckPairedKeys):
(WebCore::CryptoKeyOKP::importSpki):
(WebCore::CryptoKeyOKP::importPkcs8):
(WebCore::CryptoKeyOKP::isPlatformSupportedCurve): Deleted.
* Source/WebCore/crypto/keys/CryptoKeyEC.h:
* Source/WebCore/crypto/keys/CryptoKeyOKP.cpp:
(WebCore::CryptoKeyOKP::generatePair):
(WebCore::CryptoKeyOKP::importRaw):
(WebCore::CryptoKeyOKP::importJwk):
(WebCore::CryptoKeyOKP::supportsNamedCurve):
(WebCore::CryptoKeyOKP::isPlatformSupportedCurve): Deleted.
* Source/WebCore/crypto/keys/CryptoKeyOKP.h:

Canonical link: <a href="https://commits.webkit.org/286864@main">https://commits.webkit.org/286864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/665bd6783b5cdd7a25a48d2fb21dc05dd2d1daa6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81819 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28528 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79363 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60518 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18557 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50484 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66299 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40818 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47887 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23797 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26851 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83234 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4626 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3121 "Found 1 new test failure: webrtc/vp8-then-h264.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68786 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4782 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66271 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68042 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17008 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12033 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10133 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4573 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7388 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4592 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8027 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6351 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->