### PR TITLE
[block-step-sizing] Support block-step-size for some simple content.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/content-based-height-rounds-up-to-step-unit-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/content-based-height-rounds-up-to-step-unit-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/content-based-height-rounds-up-to-step-unit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/content-based-height-rounds-up-to-step-unit.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="">
+<link rel="match" href="">
+<meta name="assert" content="Content based block size is rounded up to step unit.">
+<style>
+.container {
+  display: flow-root;
+  width: 100px;
+  background-color: green;
+}
+.block-step {
+  width: min-content;
+  block-step-size: 100px;
+  color: green;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <div class="block-step">
+    x x x
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/definite-height-rounds-up-to-next-multiple-of-step-unit-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/definite-height-rounds-up-to-next-multiple-of-step-unit-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/definite-height-rounds-up-to-next-multiple-of-step-unit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/definite-height-rounds-up-to-next-multiple-of-step-unit.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Definite height should be rounded up to next multiple of specified step unit.">
+<style>
+.container {
+  display: flow-root;
+  width: 100px;
+  background-color: green;
+}
+.block-step {
+  block-step-size: 50px;
+  height: 51px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <div class="block-step"></div>
+</div>
+</body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/definite-height-rounds-up-to-step-unit-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/definite-height-rounds-up-to-step-unit-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/definite-height-rounds-up-to-step-unit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/definite-height-rounds-up-to-step-unit.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Definite height smaller than step size should be rounded up to step size.">
+<style>
+.container {
+  display: flow-root;
+  width: 100px;
+  background-color: green;
+}
+.block-step {
+  block-step-size: 100px;
+  height: 33px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <div class="block-step"></div>
+</div>
+</body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/definite-height-same-as-step-unit-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/definite-height-same-as-step-unit-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/definite-height-same-as-step-unit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/definite-height-same-as-step-unit.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#block-step-size">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Block size that is the same as the step unit should be unchanged.">
+<style>
+.container {
+  display: flow-root;
+  width: 100px;
+  background-color: green;
+}
+.block-step {
+  height: 100px;
+  block-step-size: 100px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <div class="block-step"></div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -238,6 +238,7 @@ public:
     };
 
     bool shouldTrimChildMargin(MarginTrimType, const RenderBox&) const;
+    void distributeExtraBlockStepSizingSpaceToChild(RenderBox& child, LayoutUnit extraSpace) const;
 
     void layoutBlockChild(RenderBox& child, MarginInfo&, LayoutUnit& previousFloatLogicalBottom, LayoutUnit& maxFloatLogicalBottom);
     void adjustPositionedBlock(RenderBox& child, const MarginInfo&);


### PR DESCRIPTION
#### 140fa4b7c9c1fa567212f19d743a211b0622f417
<pre>
[block-step-sizing] Support block-step-size for some simple content.
<a href="https://bugs.webkit.org/show_bug.cgi?id=283378">https://bugs.webkit.org/show_bug.cgi?id=283378</a>
<a href="https://rdar.apple.com/140229901">rdar://140229901</a>

Reviewed by Alan Baradlay.

This patch serves as a first step towards the implementation of block step sizing.
Specifically, this patch adds support for the block-step-size property on some very
simple pieces of content. These pieces of content are described in more detail below
as a description for the tests added, but for a brief description: The tests focus on
rounding up the outer sizes of boxes with both a definite and content-based height.

This sizing is performed during block layout after we perform child on the block level
box. We check to see if the box has block-step-size specified and do the following if it
does:
1.) Compute the extra space that should be distributed as part of this sizing. This is
done by taking the outer size of the box and computing the next multiple of the step unit
that is larger than or equal to the outer size. We then return the difference between
the two as the extra space to distribute. If the outer size of the box is already a multiple
of the step unit, then there is no space to distribute.

2.) Distribute the computed extra space by distributing it in half among the block margins
of the box.

This patch should allow us to perform block step sizing correctly with the test cases
attached, but there will need to be further testing needed for different types of content.
Some of this should happen naturally as we continue to implement the spec, but other
tests will likely come as we experiment with the feature in different contexts.

* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/content-based-height-rounds-up-to-step-unit-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/content-based-height-rounds-up-to-step-unit.html: Added.
Simple test where some content of a block level box drives its block size. This content
driven size is smaller than the specified step unit so it should just get rounded up to
that value.

* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/definite-height-rounds-up-to-next-multiple-of-step-unit-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/definite-height-rounds-up-to-next-multiple-of-step-unit.html: Added.
The definite height that is specified on this box is larger than the step unit so it
should just get rounded up to the next multiple of the step unit.

* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/definite-height-rounds-up-to-step-unit-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/definite-height-rounds-up-to-step-unit.html: Added.
The definite height of the box is smaller than the step unit so it should just get rounded
up to the step unit.

* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/definite-height-same-as-step-unit-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/definite-height-same-as-step-unit.html: Added.
This definite height is the same as the step unit so there should be no extra space
computed and the size of the box should not change.

* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::computeExtraSpaceForBlockStepSizing):
(WebCore::RenderBlockFlow::distributeExtraBlockStepSizingSpaceToChild const):
(WebCore::RenderBlockFlow::layoutBlockChild):
* Source/WebCore/rendering/RenderBlockFlow.h:

Canonical link: <a href="https://commits.webkit.org/286969@main">https://commits.webkit.org/286969@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23ede0a6308f61e5a0535dc1deb9d7d7b9cc84f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81808 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28522 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60509 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18551 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40809 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47880 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23789 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26845 "Hash 23ede0a6 for PR 36865 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68990 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24124 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83228 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4620 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68781 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4776 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68038 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17084 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12029 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10126 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4567 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7382 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4586 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8021 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6345 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->