### PR TITLE
Add more descriptive error details to better diagnose URLPattern test failures

### DIFF
--- a/LayoutTests/fast/urlpattern/urlpattern-component-expected.txt
+++ b/LayoutTests/fast/urlpattern/urlpattern-component-expected.txt
@@ -4,6 +4,7 @@ Tests URLPattern: URLPattern constructor
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+Testing: {"pattern":[{"pathname":"/foo/bar"}],"inputs":[{"pathname":"/foo/bar"}],"expected_match":{"pathname":{"input":"/foo/bar","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -22,6 +23,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar"}],"inputs":[{"pathname":"/foo/ba"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -40,6 +42,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar"}],"inputs":[{"pathname":"/foo/bar/"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -58,6 +61,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar"}],"inputs":[{"pathname":"/foo/bar/baz"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -76,6 +80,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar"}],"inputs":["https://example.com/foo/bar"],"expected_match":{"hostname":{"input":"example.com","groups":{"0":"example.com"}},"pathname":{"input":"/foo/bar","groups":{}},"protocol":{"input":"https","groups":{"0":"https"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -94,6 +99,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar"}],"inputs":["https://example.com/foo/bar/baz"],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -112,6 +118,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar"}],"inputs":[{"hostname":"example.com","pathname":"/foo/bar"}],"expected_match":{"hostname":{"input":"example.com","groups":{"0":"example.com"}},"pathname":{"input":"/foo/bar","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -130,6 +137,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar"}],"inputs":[{"hostname":"example.com","pathname":"/foo/bar/baz"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -148,6 +156,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar"}],"inputs":[{"pathname":"/foo/bar","baseURL":"https://example.com"}],"expected_match":{"hostname":{"input":"example.com","groups":{"0":"example.com"}},"pathname":{"input":"/foo/bar","groups":{}},"protocol":{"input":"https","groups":{"0":"https"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -166,6 +175,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar"}],"inputs":[{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -184,24 +194,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
-Component: protocol
-PASS urlPatternComponent is "https"
-Component: username
-PASS urlPatternComponent is "*"
-Component: password
-PASS urlPatternComponent is "*"
-Component: hostname
-PASS urlPatternComponent is "example.com"
-Component: port
-PASS urlPatternComponent is ""
-Component: password
-PASS urlPatternComponent is "*"
-Component: pathname
-PASS urlPatternComponent is "/foo/bar"
-Component: search
-PASS urlPatternComponent is "*"
-Component: hash
-PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}],"inputs":[{"pathname":"/foo/bar"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -220,6 +213,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}],"inputs":[{"hostname":"example.com","pathname":"/foo/bar"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -238,6 +232,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}],"inputs":[{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}],"exactly_empty_components":["port"],"expected_match":{"hostname":{"input":"example.com","groups":{}},"pathname":{"input":"/foo/bar","groups":{}},"protocol":{"input":"https","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -256,6 +251,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar","baseURL":"https://example.com"}],"inputs":[{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}],"exactly_empty_components":["port"],"expected_match":{"hostname":{"input":"example.com","groups":{}},"pathname":{"input":"/foo/bar","groups":{}},"protocol":{"input":"https","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -274,6 +270,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar","baseURL":"https://example.com"}],"inputs":[{"protocol":"https","hostname":"example.com","pathname":"/foo/bar/baz"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -292,6 +289,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}],"inputs":[{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}],"exactly_empty_components":["port"],"expected_match":{"hash":{"input":"otherhash","groups":{"0":"otherhash"}},"hostname":{"input":"example.com","groups":{}},"pathname":{"input":"/foo/bar","groups":{}},"protocol":{"input":"https","groups":{}},"search":{"input":"otherquery","groups":{"0":"otherquery"}}}}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -310,6 +308,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar","baseURL":"https://example.com"}],"inputs":[{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}],"exactly_empty_components":["port"],"expected_match":{"hash":{"input":"otherhash","groups":{"0":"otherhash"}},"hostname":{"input":"example.com","groups":{}},"pathname":{"input":"/foo/bar","groups":{}},"protocol":{"input":"https","groups":{}},"search":{"input":"otherquery","groups":{"0":"otherquery"}}}}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -328,6 +327,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}],"inputs":[{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}],"exactly_empty_components":["port"],"expected_match":{"hash":{"input":"otherhash","groups":{"0":"otherhash"}},"hostname":{"input":"example.com","groups":{}},"pathname":{"input":"/foo/bar","groups":{}},"protocol":{"input":"https","groups":{}},"search":{"input":"otherquery","groups":{"0":"otherquery"}}}}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -346,6 +346,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}],"inputs":["https://example.com/foo/bar"],"exactly_empty_components":["port"],"expected_match":{"hostname":{"input":"example.com","groups":{}},"pathname":{"input":"/foo/bar","groups":{}},"protocol":{"input":"https","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -364,6 +365,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}],"inputs":["https://example.com/foo/bar?otherquery#otherhash"],"exactly_empty_components":["port"],"expected_match":{"hash":{"input":"otherhash","groups":{"0":"otherhash"}},"hostname":{"input":"example.com","groups":{}},"pathname":{"input":"/foo/bar","groups":{}},"protocol":{"input":"https","groups":{}},"search":{"input":"otherquery","groups":{"0":"otherquery"}}}}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -382,6 +384,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}],"inputs":["https://example.com/foo/bar?query#hash"],"exactly_empty_components":["port"],"expected_match":{"hash":{"input":"hash","groups":{"0":"hash"}},"hostname":{"input":"example.com","groups":{}},"pathname":{"input":"/foo/bar","groups":{}},"protocol":{"input":"https","groups":{}},"search":{"input":"query","groups":{"0":"query"}}}}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -400,6 +403,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}],"inputs":["https://example.com/foo/bar/baz"],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -418,6 +422,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}],"inputs":["https://other.com/foo/bar"],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -436,6 +441,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}],"inputs":["http://other.com/foo/bar"],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -454,6 +460,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}],"inputs":[{"pathname":"/foo/bar","baseURL":"https://example.com"}],"exactly_empty_components":["port"],"expected_match":{"hostname":{"input":"example.com","groups":{}},"pathname":{"input":"/foo/bar","groups":{}},"protocol":{"input":"https","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -472,6 +479,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}],"inputs":[{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}],"exactly_empty_components":["port"],"expected_match":{"hostname":{"input":"example.com","groups":{}},"pathname":{"input":"/foo/bar","groups":{}},"protocol":{"input":"https","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -490,6 +498,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}],"inputs":[{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -508,6 +517,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}],"inputs":[{"pathname":"/foo/bar","baseURL":"https://other.com"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -526,6 +536,26 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}],"inputs":[{"pathname":"/foo/bar","baseURL":"http://example.com"}],"expected_match":null}
+Component: protocol
+PASS urlPatternComponent is "https"
+Component: username
+PASS urlPatternComponent is "*"
+Component: password
+PASS urlPatternComponent is "*"
+Component: hostname
+PASS urlPatternComponent is "example.com"
+Component: port
+PASS urlPatternComponent is ""
+Component: password
+PASS urlPatternComponent is "*"
+Component: pathname
+PASS urlPatternComponent is "/foo/bar"
+Component: search
+PASS urlPatternComponent is "*"
+Component: hash
+PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar"}],"inputs":[{"pathname":"/foo/bar"}],"expected_match":{"pathname":{"input":"/foo/bar","groups":{"bar":"bar"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -544,6 +574,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/([^\\/]+?)"}],"inputs":[{"pathname":"/foo/bar"}],"expected_match":{"pathname":{"input":"/foo/bar","groups":{"0":"bar"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -562,6 +593,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar"}],"inputs":[{"pathname":"/foo/index.html"}],"expected_match":{"pathname":{"input":"/foo/index.html","groups":{"bar":"index.html"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -580,6 +612,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar"}],"inputs":[{"pathname":"/foo/bar/"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -598,6 +631,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar"}],"inputs":[{"pathname":"/foo/"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -616,6 +650,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)"}],"inputs":[{"pathname":"/foo/bar"}],"expected_obj":{"pathname":"/foo/*"},"expected_match":{"pathname":{"input":"/foo/bar","groups":{"0":"bar"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -634,6 +669,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/*"}],"inputs":[{"pathname":"/foo/bar"}],"expected_match":{"pathname":{"input":"/foo/bar","groups":{"0":"bar"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -652,6 +688,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)"}],"inputs":[{"pathname":"/foo/bar/baz"}],"expected_obj":{"pathname":"/foo/*"},"expected_match":{"pathname":{"input":"/foo/bar/baz","groups":{"0":"bar/baz"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -670,6 +707,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/*"}],"inputs":[{"pathname":"/foo/bar/baz"}],"expected_match":{"pathname":{"input":"/foo/bar/baz","groups":{"0":"bar/baz"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -688,6 +726,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)"}],"inputs":[{"pathname":"/foo/"}],"expected_obj":{"pathname":"/foo/*"},"expected_match":{"pathname":{"input":"/foo/","groups":{"0":""}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -706,6 +745,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/*"}],"inputs":[{"pathname":"/foo/"}],"expected_match":{"pathname":{"input":"/foo/","groups":{"0":""}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -724,6 +764,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)"}],"inputs":[{"pathname":"/foo"}],"expected_obj":{"pathname":"/foo/*"},"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -742,6 +783,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/*"}],"inputs":[{"pathname":"/foo"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -760,6 +802,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar(.*)"}],"inputs":[{"pathname":"/foo/bar"}],"expected_match":{"pathname":{"input":"/foo/bar","groups":{"bar":"bar"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -778,6 +821,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar(.*)"}],"inputs":[{"pathname":"/foo/bar/baz"}],"expected_match":{"pathname":{"input":"/foo/bar/baz","groups":{"bar":"bar/baz"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -796,6 +840,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar(.*)"}],"inputs":[{"pathname":"/foo/"}],"expected_match":{"pathname":{"input":"/foo/","groups":{"bar":""}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -814,6 +859,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar(.*)"}],"inputs":[{"pathname":"/foo"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -832,6 +878,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar?"}],"inputs":[{"pathname":"/foo/bar"}],"expected_match":{"pathname":{"input":"/foo/bar","groups":{"bar":"bar"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -850,6 +897,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar?"}],"inputs":[{"pathname":"/foo"}],"//":"The `null` below is translated to undefined in the test harness.","expected_match":{"pathname":{"input":"/foo","groups":{"bar":null}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -868,6 +916,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar?"}],"inputs":[{"pathname":"/foo/"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -886,6 +935,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar?"}],"inputs":[{"pathname":"/foobar"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -904,6 +954,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar?"}],"inputs":[{"pathname":"/foo/bar/baz"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -922,6 +973,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar+"}],"inputs":[{"pathname":"/foo/bar"}],"expected_match":{"pathname":{"input":"/foo/bar","groups":{"bar":"bar"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -940,6 +992,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar+"}],"inputs":[{"pathname":"/foo/bar/baz"}],"expected_match":{"pathname":{"input":"/foo/bar/baz","groups":{"bar":"bar/baz"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -958,6 +1011,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar+"}],"inputs":[{"pathname":"/foo"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -976,6 +1030,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar+"}],"inputs":[{"pathname":"/foo/"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -994,6 +1049,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar+"}],"inputs":[{"pathname":"/foobar"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1012,6 +1068,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar*"}],"inputs":[{"pathname":"/foo/bar"}],"expected_match":{"pathname":{"input":"/foo/bar","groups":{"bar":"bar"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1030,6 +1087,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar*"}],"inputs":[{"pathname":"/foo/bar/baz"}],"expected_match":{"pathname":{"input":"/foo/bar/baz","groups":{"bar":"bar/baz"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1048,6 +1106,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar*"}],"inputs":[{"pathname":"/foo"}],"//":"The `null` below is translated to undefined in the test harness.","expected_match":{"pathname":{"input":"/foo","groups":{"bar":null}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1066,6 +1125,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar*"}],"inputs":[{"pathname":"/foo/"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1084,6 +1144,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/:bar*"}],"inputs":[{"pathname":"/foobar"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1102,6 +1163,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)?"}],"inputs":[{"pathname":"/foo/bar"}],"expected_obj":{"pathname":"/foo/*?"},"expected_match":{"pathname":{"input":"/foo/bar","groups":{"0":"bar"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1120,6 +1182,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/*?"}],"inputs":[{"pathname":"/foo/bar"}],"expected_match":{"pathname":{"input":"/foo/bar","groups":{"0":"bar"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1138,6 +1201,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)?"}],"inputs":[{"pathname":"/foo/bar/baz"}],"expected_obj":{"pathname":"/foo/*?"},"expected_match":{"pathname":{"input":"/foo/bar/baz","groups":{"0":"bar/baz"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1156,6 +1220,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/*?"}],"inputs":[{"pathname":"/foo/bar/baz"}],"expected_match":{"pathname":{"input":"/foo/bar/baz","groups":{"0":"bar/baz"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1174,6 +1239,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)?"}],"inputs":[{"pathname":"/foo"}],"expected_obj":{"pathname":"/foo/*?"},"//":"The `null` below is translated to undefined in the test harness.","expected_match":{"pathname":{"input":"/foo","groups":{"0":null}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1192,6 +1258,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/*?"}],"inputs":[{"pathname":"/foo"}],"//":"The `null` below is translated to undefined in the test harness.","expected_match":{"pathname":{"input":"/foo","groups":{"0":null}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1210,6 +1277,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)?"}],"inputs":[{"pathname":"/foo/"}],"expected_obj":{"pathname":"/foo/*?"},"expected_match":{"pathname":{"input":"/foo/","groups":{"0":""}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1228,6 +1296,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/*?"}],"inputs":[{"pathname":"/foo/"}],"expected_match":{"pathname":{"input":"/foo/","groups":{"0":""}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1246,6 +1315,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)?"}],"inputs":[{"pathname":"/foobar"}],"expected_obj":{"pathname":"/foo/*?"},"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1264,6 +1334,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/*?"}],"inputs":[{"pathname":"/foobar"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1282,6 +1353,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)?"}],"inputs":[{"pathname":"/fo"}],"expected_obj":{"pathname":"/foo/*?"},"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1300,6 +1372,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/*?"}],"inputs":[{"pathname":"/fo"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1318,6 +1391,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)+"}],"inputs":[{"pathname":"/foo/bar"}],"expected_obj":{"pathname":"/foo/*+"},"expected_match":{"pathname":{"input":"/foo/bar","groups":{"0":"bar"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1336,6 +1410,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/*+"}],"inputs":[{"pathname":"/foo/bar"}],"expected_match":{"pathname":{"input":"/foo/bar","groups":{"0":"bar"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1354,6 +1429,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)+"}],"inputs":[{"pathname":"/foo/bar/baz"}],"expected_obj":{"pathname":"/foo/*+"},"expected_match":{"pathname":{"input":"/foo/bar/baz","groups":{"0":"bar/baz"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1372,6 +1448,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/*+"}],"inputs":[{"pathname":"/foo/bar/baz"}],"expected_match":{"pathname":{"input":"/foo/bar/baz","groups":{"0":"bar/baz"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1390,6 +1467,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)+"}],"inputs":[{"pathname":"/foo"}],"expected_obj":{"pathname":"/foo/*+"},"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1408,6 +1486,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/*+"}],"inputs":[{"pathname":"/foo"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1426,6 +1505,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)+"}],"inputs":[{"pathname":"/foo/"}],"expected_obj":{"pathname":"/foo/*+"},"expected_match":{"pathname":{"input":"/foo/","groups":{"0":""}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1444,6 +1524,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/*+"}],"inputs":[{"pathname":"/foo/"}],"expected_match":{"pathname":{"input":"/foo/","groups":{"0":""}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1462,6 +1543,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)+"}],"inputs":[{"pathname":"/foobar"}],"expected_obj":{"pathname":"/foo/*+"},"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1480,6 +1562,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/*+"}],"inputs":[{"pathname":"/foobar"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1498,6 +1581,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)+"}],"inputs":[{"pathname":"/fo"}],"expected_obj":{"pathname":"/foo/*+"},"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1516,6 +1600,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/*+"}],"inputs":[{"pathname":"/fo"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1534,6 +1619,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)*"}],"inputs":[{"pathname":"/foo/bar"}],"expected_obj":{"pathname":"/foo/**"},"expected_match":{"pathname":{"input":"/foo/bar","groups":{"0":"bar"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1552,6 +1638,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/**"}],"inputs":[{"pathname":"/foo/bar"}],"expected_match":{"pathname":{"input":"/foo/bar","groups":{"0":"bar"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1570,6 +1657,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)*"}],"inputs":[{"pathname":"/foo/bar/baz"}],"expected_obj":{"pathname":"/foo/**"},"expected_match":{"pathname":{"input":"/foo/bar/baz","groups":{"0":"bar/baz"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1588,6 +1676,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/**"}],"inputs":[{"pathname":"/foo/bar/baz"}],"expected_match":{"pathname":{"input":"/foo/bar/baz","groups":{"0":"bar/baz"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1606,6 +1695,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)*"}],"inputs":[{"pathname":"/foo"}],"expected_obj":{"pathname":"/foo/**"},"//":"The `null` below is translated to undefined in the test harness.","expected_match":{"pathname":{"input":"/foo","groups":{"0":null}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1624,6 +1714,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/**"}],"inputs":[{"pathname":"/foo"}],"//":"The `null` below is translated to undefined in the test harness.","expected_match":{"pathname":{"input":"/foo","groups":{"0":null}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1642,6 +1733,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)*"}],"inputs":[{"pathname":"/foo/"}],"expected_obj":{"pathname":"/foo/**"},"expected_match":{"pathname":{"input":"/foo/","groups":{"0":""}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1660,6 +1752,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/**"}],"inputs":[{"pathname":"/foo/"}],"expected_match":{"pathname":{"input":"/foo/","groups":{"0":""}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1678,6 +1771,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)*"}],"inputs":[{"pathname":"/foobar"}],"expected_obj":{"pathname":"/foo/**"},"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1696,6 +1790,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/**"}],"inputs":[{"pathname":"/foobar"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1714,6 +1809,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/(.*)*"}],"inputs":[{"pathname":"/fo"}],"expected_obj":{"pathname":"/foo/**"},"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1732,6 +1828,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/**"}],"inputs":[{"pathname":"/fo"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1750,6 +1847,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo{/bar}"}],"inputs":[{"pathname":"/foo/bar"}],"expected_obj":{"pathname":"/foo/bar"},"expected_match":{"pathname":{"input":"/foo/bar","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1768,6 +1866,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo{/bar}"}],"inputs":[{"pathname":"/foo/bar/baz"}],"expected_obj":{"pathname":"/foo/bar"},"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1786,6 +1885,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo{/bar}"}],"inputs":[{"pathname":"/foo"}],"expected_obj":{"pathname":"/foo/bar"},"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1804,6 +1904,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo{/bar}"}],"inputs":[{"pathname":"/foo/"}],"expected_obj":{"pathname":"/foo/bar"},"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1822,6 +1923,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo{/bar}?"}],"inputs":[{"pathname":"/foo/bar"}],"expected_match":{"pathname":{"input":"/foo/bar","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1840,6 +1942,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo{/bar}?"}],"inputs":[{"pathname":"/foo/bar/baz"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1858,6 +1961,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo{/bar}?"}],"inputs":[{"pathname":"/foo"}],"expected_match":{"pathname":{"input":"/foo","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1876,6 +1980,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo{/bar}?"}],"inputs":[{"pathname":"/foo/"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1894,6 +1999,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo{/bar}+"}],"inputs":[{"pathname":"/foo/bar"}],"expected_match":{"pathname":{"input":"/foo/bar","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1912,6 +2018,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo{/bar}+"}],"inputs":[{"pathname":"/foo/bar/bar"}],"expected_match":{"pathname":{"input":"/foo/bar/bar","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1930,6 +2037,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo{/bar}+"}],"inputs":[{"pathname":"/foo/bar/baz"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1948,6 +2056,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo{/bar}+"}],"inputs":[{"pathname":"/foo"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1966,6 +2075,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo{/bar}+"}],"inputs":[{"pathname":"/foo/"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -1984,6 +2094,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo{/bar}*"}],"inputs":[{"pathname":"/foo/bar"}],"expected_match":{"pathname":{"input":"/foo/bar","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2002,6 +2113,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo{/bar}*"}],"inputs":[{"pathname":"/foo/bar/bar"}],"expected_match":{"pathname":{"input":"/foo/bar/bar","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2020,6 +2132,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo{/bar}*"}],"inputs":[{"pathname":"/foo/bar/baz"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2038,6 +2151,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo{/bar}*"}],"inputs":[{"pathname":"/foo"}],"expected_match":{"pathname":{"input":"/foo","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2056,6 +2170,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo{/bar}*"}],"inputs":[{"pathname":"/foo/"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2074,6 +2189,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"protocol":"(cafÃ©)"}],"expected_obj":"error"}
 Component: protocol
 PASS urlPatternComponent is "(cafÃ©)"
 Component: username
@@ -2094,6 +2210,7 @@ WARN: shouldBe() expects function or string arguments
 FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"username":"(cafÃ©)"}],"expected_obj":"error"}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2114,6 +2231,7 @@ WARN: shouldBe() expects function or string arguments
 FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"password":"(cafÃ©)"}],"expected_obj":"error"}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2134,6 +2252,7 @@ WARN: shouldBe() expects function or string arguments
 FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"hostname":"(cafÃ©)"}],"expected_obj":"error"}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2154,6 +2273,7 @@ WARN: shouldBe() expects function or string arguments
 FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"(cafÃ©)"}],"expected_obj":"error"}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2174,6 +2294,7 @@ WARN: shouldBe() expects function or string arguments
 FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"search":"(cafÃ©)"}],"expected_obj":"error"}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2194,6 +2315,7 @@ WARN: shouldBe() expects function or string arguments
 FAIL urlPatternComponent should be undefined (of type undefined). Was (cafÃ©) (of type string).
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"hash":"(cafÃ©)"}],"expected_obj":"error"}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2214,6 +2336,7 @@ WARN: shouldBe() expects function or string arguments
 FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
 Component: hash
 PASS urlPatternComponent is "(cafÃ©)"
+Testing: {"pattern":[{"protocol":":cafÃ©"}],"inputs":[{"protocol":"foo"}],"expected_match":{"protocol":{"input":"foo","groups":{"cafÃ©":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is ":cafÃ©"
 Component: username
@@ -2232,6 +2355,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"username":":cafÃ©"}],"inputs":[{"username":"foo"}],"expected_match":{"username":{"input":"foo","groups":{"cafÃ©":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2250,6 +2374,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"password":":cafÃ©"}],"inputs":[{"password":"foo"}],"expected_match":{"password":{"input":"foo","groups":{"cafÃ©":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2268,6 +2393,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"hostname":":cafÃ©"}],"inputs":[{"hostname":"foo"}],"expected_match":{"hostname":{"input":"foo","groups":{"cafÃ©":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2286,6 +2412,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/:cafÃ©"}],"inputs":[{"pathname":"/foo"}],"expected_match":{"pathname":{"input":"/foo","groups":{"cafÃ©":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2304,6 +2431,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"search":":cafÃ©"}],"inputs":[{"search":"foo"}],"expected_match":{"search":{"input":"foo","groups":{"cafÃ©":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2322,6 +2450,7 @@ Component: search
 PASS urlPatternComponent is ":cafÃ©"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"hash":":cafÃ©"}],"inputs":[{"hash":"foo"}],"expected_match":{"hash":{"input":"foo","groups":{"cafÃ©":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2340,6 +2469,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is ":cafÃ©"
+Testing: {"pattern":[{"protocol":":℘"}],"inputs":[{"protocol":"foo"}],"expected_match":{"protocol":{"input":"foo","groups":{"℘":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is ":℘"
 Component: username
@@ -2358,6 +2488,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"username":":℘"}],"inputs":[{"username":"foo"}],"expected_match":{"username":{"input":"foo","groups":{"℘":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2376,6 +2507,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"password":":℘"}],"inputs":[{"password":"foo"}],"expected_match":{"password":{"input":"foo","groups":{"℘":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2394,6 +2526,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"hostname":":℘"}],"inputs":[{"hostname":"foo"}],"expected_match":{"hostname":{"input":"foo","groups":{"℘":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2412,6 +2545,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/:℘"}],"inputs":[{"pathname":"/foo"}],"expected_match":{"pathname":{"input":"/foo","groups":{"℘":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2430,6 +2564,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"search":":℘"}],"inputs":[{"search":"foo"}],"expected_match":{"search":{"input":"foo","groups":{"℘":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2448,6 +2583,7 @@ Component: search
 PASS urlPatternComponent is ":℘"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"hash":":℘"}],"inputs":[{"hash":"foo"}],"expected_match":{"hash":{"input":"foo","groups":{"℘":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2466,6 +2602,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is ":℘"
+Testing: {"pattern":[{"protocol":":㐀"}],"inputs":[{"protocol":"foo"}],"expected_match":{"protocol":{"input":"foo","groups":{"㐀":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is ":㐀"
 Component: username
@@ -2484,6 +2621,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"username":":㐀"}],"inputs":[{"username":"foo"}],"expected_match":{"username":{"input":"foo","groups":{"㐀":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2502,6 +2640,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"password":":㐀"}],"inputs":[{"password":"foo"}],"expected_match":{"password":{"input":"foo","groups":{"㐀":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2520,6 +2659,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"hostname":":㐀"}],"inputs":[{"hostname":"foo"}],"expected_match":{"hostname":{"input":"foo","groups":{"㐀":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2538,6 +2678,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/:㐀"}],"inputs":[{"pathname":"/foo"}],"expected_match":{"pathname":{"input":"/foo","groups":{"㐀":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2556,6 +2697,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"search":":㐀"}],"inputs":[{"search":"foo"}],"expected_match":{"search":{"input":"foo","groups":{"㐀":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2574,6 +2716,7 @@ Component: search
 PASS urlPatternComponent is ":㐀"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"hash":":㐀"}],"inputs":[{"hash":"foo"}],"expected_match":{"hash":{"input":"foo","groups":{"㐀":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2592,6 +2735,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is ":㐀"
+Testing: {"pattern":[{"protocol":"(.*)"}],"inputs":[{"protocol":"cafÃ©"}],"expected_obj":{"protocol":"*"},"expected_match":null}
 Component: protocol
 FAIL urlPatternComponent should be *. Was (.*).
 Component: username
@@ -2610,6 +2754,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"protocol":"(.*)"}],"inputs":[{"protocol":"cafe"}],"expected_obj":{"protocol":"*"},"expected_match":{"protocol":{"input":"cafe","groups":{"0":"cafe"}}}}
 Component: protocol
 FAIL urlPatternComponent should be *. Was (.*).
 Component: username
@@ -2628,6 +2773,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"protocol":"foo-bar"}],"inputs":[{"protocol":"foo-bar"}],"expected_match":{"protocol":{"input":"foo-bar","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "foo-bar"
 Component: username
@@ -2646,6 +2792,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"username":"caf%C3%A9"}],"inputs":[{"username":"cafÃ©"}],"expected_match":{"username":{"input":"caf%C3%A9","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2664,6 +2811,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"username":"cafÃ©"}],"inputs":[{"username":"cafÃ©"}],"expected_obj":{"username":"caf%C3%A9"},"expected_match":{"username":{"input":"caf%C3%A9","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2682,6 +2830,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"username":"caf%c3%a9"}],"inputs":[{"username":"cafÃ©"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2700,6 +2849,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"password":"caf%C3%A9"}],"inputs":[{"password":"cafÃ©"}],"expected_match":{"password":{"input":"caf%C3%A9","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2718,6 +2868,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"password":"cafÃ©"}],"inputs":[{"password":"cafÃ©"}],"expected_obj":{"password":"caf%C3%A9"},"expected_match":{"password":{"input":"caf%C3%A9","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2736,6 +2887,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"password":"caf%c3%a9"}],"inputs":[{"password":"cafÃ©"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2754,6 +2906,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"hostname":"xn--caf-dma.com"}],"inputs":[{"hostname":"cafÃ©.com"}],"expected_match":{"hostname":{"input":"xn--caf-dma.com","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2772,6 +2925,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"hostname":"cafÃ©.com"}],"inputs":[{"hostname":"cafÃ©.com"}],"expected_obj":{"hostname":"xn--caf-dma.com"},"expected_match":{"hostname":{"input":"xn--caf-dma.com","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2790,6 +2944,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"port":""}],"inputs":[{"protocol":"http","port":"80"}],"exactly_empty_components":["port"],"expected_match":{"protocol":{"input":"http","groups":{"0":"http"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2808,6 +2963,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"protocol":"http","port":"80"}],"inputs":[{"protocol":"http","port":"80"}],"exactly_empty_components":["port"],"expected_match":{"protocol":{"input":"http","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "http"
 Component: username
@@ -2826,6 +2982,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"protocol":"http","port":"80{20}?"}],"inputs":[{"protocol":"http","port":"80"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "http"
 Component: username
@@ -2844,6 +3001,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"protocol":"http","port":"80 "}],"inputs":[{"protocol":"http","port":"80"}],"expected_obj":"error"}
 Component: protocol
 PASS urlPatternComponent is "http"
 Component: username
@@ -2864,6 +3022,7 @@ WARN: shouldBe() expects function or string arguments
 FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"port":"80"}],"inputs":[{"protocol":"http","port":"80"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2882,6 +3041,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"protocol":"http{s}?","port":"80"}],"inputs":[{"protocol":"http","port":"80"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "http{s}?"
 Component: username
@@ -2900,6 +3060,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"port":"80"}],"inputs":[{"port":"80"}],"expected_match":{"port":{"input":"80","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2918,6 +3079,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"port":"(.*)"}],"inputs":[{"port":"invalid80"}],"expected_obj":{"port":"*"},"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2936,6 +3098,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar"}],"inputs":[{"pathname":"/foo/./bar"}],"expected_match":{"pathname":{"input":"/foo/bar","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2954,6 +3117,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/baz"}],"inputs":[{"pathname":"/foo/bar/../baz"}],"expected_match":{"pathname":{"input":"/foo/baz","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2972,6 +3136,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/caf%C3%A9"}],"inputs":[{"pathname":"/cafÃ©"}],"expected_match":{"pathname":{"input":"/caf%C3%A9","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -2990,6 +3155,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/cafÃ©"}],"inputs":[{"pathname":"/cafÃ©"}],"expected_obj":{"pathname":"/caf%C3%A9"},"expected_match":{"pathname":{"input":"/caf%C3%A9","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3008,6 +3174,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/caf%c3%a9"}],"inputs":[{"pathname":"/cafÃ©"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3026,6 +3193,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar"}],"inputs":[{"pathname":"foo/bar"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3044,6 +3212,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar"}],"inputs":[{"pathname":"foo/bar","baseURL":"https://example.com"}],"expected_match":{"protocol":{"input":"https","groups":{"0":"https"}},"hostname":{"input":"example.com","groups":{"0":"example.com"}},"pathname":{"input":"/foo/bar","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3062,6 +3231,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/../bar"}],"inputs":[{"pathname":"/bar"}],"expected_obj":{"pathname":"/bar"},"expected_match":{"pathname":{"input":"/bar","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3080,6 +3250,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"./foo/bar","baseURL":"https://example.com"}],"inputs":[{"pathname":"foo/bar","baseURL":"https://example.com"}],"exactly_empty_components":["port"],"expected_obj":{"pathname":"/foo/bar"},"expected_match":{"protocol":{"input":"https","groups":{}},"hostname":{"input":"example.com","groups":{}},"pathname":{"input":"/foo/bar","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -3098,6 +3269,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"","baseURL":"https://example.com"}],"inputs":[{"pathname":"/","baseURL":"https://example.com"}],"exactly_empty_components":["port"],"expected_obj":{"pathname":"/"},"expected_match":{"protocol":{"input":"https","groups":{}},"hostname":{"input":"example.com","groups":{}},"pathname":{"input":"/","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -3116,6 +3288,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}],"inputs":[{"pathname":"./bar","baseURL":"https://example.com/foo/"}],"exactly_empty_components":["port"],"expected_obj":{"pathname":"/bar"},"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -3134,6 +3307,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}],"inputs":[{"pathname":"./bar","baseURL":"https://example.com/foo/"}],"exactly_empty_components":["port"],"expected_obj":{"pathname":"/bar"},"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -3152,6 +3326,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"b","baseURL":"https://example.com/foo/"}],"inputs":[{"pathname":"./b","baseURL":"https://example.com/foo/"}],"exactly_empty_components":["port"],"expected_obj":{"pathname":"/foo/b"},"expected_match":{"protocol":{"input":"https","groups":{}},"hostname":{"input":"example.com","groups":{}},"pathname":{"input":"/foo/b","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -3170,6 +3345,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"foo/bar"}],"inputs":["https://example.com/foo/bar"],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3188,6 +3364,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"foo/bar","baseURL":"https://example.com"}],"inputs":["https://example.com/foo/bar"],"exactly_empty_components":["port"],"expected_obj":{"pathname":"/foo/bar"},"expected_match":{"protocol":{"input":"https","groups":{}},"hostname":{"input":"example.com","groups":{}},"pathname":{"input":"/foo/bar","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -3206,6 +3383,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":":name.html","baseURL":"https://example.com"}],"inputs":["https://example.com/foo.html"],"exactly_empty_components":["port"],"expected_obj":{"pathname":"/:name.html"},"expected_match":{"protocol":{"input":"https","groups":{}},"hostname":{"input":"example.com","groups":{}},"pathname":{"input":"/foo.html","groups":{"name":"foo"}}}}
 Component: protocol
 PASS urlPatternComponent is "https"
 Component: username
@@ -3224,6 +3402,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"search":"q=caf%C3%A9"}],"inputs":[{"search":"q=cafÃ©"}],"expected_match":{"search":{"input":"q=caf%C3%A9","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3242,6 +3421,7 @@ Component: search
 PASS urlPatternComponent is "q=caf%C3%A9"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"search":"q=cafÃ©"}],"inputs":[{"search":"q=cafÃ©"}],"expected_obj":{"search":"q=caf%C3%A9"},"expected_match":{"search":{"input":"q=caf%C3%A9","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3260,6 +3440,7 @@ Component: search
 FAIL urlPatternComponent should be q=caf%C3%A9. Was q=cafÃ©.
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"search":"q=caf%c3%a9"}],"inputs":[{"search":"q=cafÃ©"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3278,6 +3459,7 @@ Component: search
 PASS urlPatternComponent is "q=caf%c3%a9"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"hash":"caf%C3%A9"}],"inputs":[{"hash":"cafÃ©"}],"expected_match":{"hash":{"input":"caf%C3%A9","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3296,6 +3478,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "caf%C3%A9"
+Testing: {"pattern":[{"hash":"cafÃ©"}],"inputs":[{"hash":"cafÃ©"}],"expected_obj":{"hash":"caf%C3%A9"},"expected_match":{"hash":{"input":"caf%C3%A9","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3314,6 +3497,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 FAIL urlPatternComponent should be caf%C3%A9. Was cafÃ©.
+Testing: {"pattern":[{"hash":"caf%c3%a9"}],"inputs":[{"hash":"cafÃ©"}],"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3332,6 +3516,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "caf%c3%a9"
+Testing: {"pattern":[{"protocol":"about","pathname":"(blank|sourcedoc)"}],"inputs":["about:blank"],"expected_match":{"protocol":{"input":"about","groups":{}},"pathname":{"input":"blank","groups":{"0":"blank"}}}}
 Component: protocol
 PASS urlPatternComponent is "about"
 Component: username
@@ -3350,6 +3535,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"protocol":"data","pathname":":number([0-9]+)"}],"inputs":["data:8675309"],"expected_match":{"protocol":{"input":"data","groups":{}},"pathname":{"input":"8675309","groups":{"number":"8675309"}}}}
 Component: protocol
 PASS urlPatternComponent is "data"
 Component: username
@@ -3368,6 +3554,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/(\\m)"}],"expected_obj":"error"}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3388,6 +3575,7 @@ WARN: shouldBe() expects function or string arguments
 FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo!"}],"inputs":[{"pathname":"/foo!"}],"expected_match":{"pathname":{"input":"/foo!","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3406,6 +3594,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo\\:"}],"inputs":[{"pathname":"/foo:"}],"expected_match":{"pathname":{"input":"/foo:","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3424,6 +3613,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo\\{"}],"inputs":[{"pathname":"/foo{"}],"expected_obj":{"pathname":"/foo%7B"},"expected_match":{"pathname":{"input":"/foo%7B","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3442,6 +3632,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo\\("}],"inputs":[{"pathname":"/foo("}],"expected_match":{"pathname":{"input":"/foo(","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3460,6 +3651,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"protocol":"javascript","pathname":"var x = 1;"}],"inputs":[{"protocol":"javascript","pathname":"var x = 1;"}],"expected_match":{"protocol":{"input":"javascript","groups":{}},"pathname":{"input":"var x = 1;","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "javascript"
 Component: username
@@ -3478,6 +3670,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"var x = 1;"}],"inputs":[{"protocol":"javascript","pathname":"var x = 1;"}],"expected_obj":{"pathname":"var%20x%20=%201;"},"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3496,6 +3689,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"protocol":"javascript","pathname":"var x = 1;"}],"inputs":[{"baseURL":"javascript:var x = 1;"}],"expected_match":{"protocol":{"input":"javascript","groups":{}},"pathname":{"input":"var x = 1;","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "javascript"
 Component: username
@@ -3514,6 +3708,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"protocol":"(data|javascript)","pathname":"var x = 1;"}],"inputs":[{"protocol":"javascript","pathname":"var x = 1;"}],"expected_match":{"protocol":{"input":"javascript","groups":{"0":"javascript"}},"pathname":{"input":"var x = 1;","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "(data|javascript)"
 Component: username
@@ -3532,6 +3727,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"protocol":"(https|javascript)","pathname":"var x = 1;"}],"inputs":[{"protocol":"javascript","pathname":"var x = 1;"}],"expected_obj":{"pathname":"var%20x%20=%201;"},"expected_match":null}
 Component: protocol
 PASS urlPatternComponent is "(https|javascript)"
 Component: username
@@ -3550,6 +3746,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"var x = 1;"}],"inputs":[{"pathname":"var x = 1;"}],"expected_obj":{"pathname":"var%20x%20=%201;"},"expected_match":{"pathname":{"input":"var%20x%20=%201;","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3568,6 +3765,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar"}],"inputs":["./foo/bar","https://example.com"],"expected_match":{"hostname":{"input":"example.com","groups":{"0":"example.com"}},"pathname":{"input":"/foo/bar","groups":{}},"protocol":{"input":"https","groups":{"0":"https"}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3586,6 +3784,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":[{"pathname":"/foo/bar"}],"inputs":[{"pathname":"/foo/bar"},"https://example.com"],"expected_match":"error"}
 Component: protocol
 PASS urlPatternComponent is "*"
 Component: username
@@ -3604,6 +3803,7 @@ Component: search
 PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
+Testing: {"pattern":["https://example.com:8080/foo?bar#baz"],"inputs":[{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}],"expected_obj":{"protocol":"https","username":"*","password":"*","hostname":"example.com","port":"8080","pathname":"/foo","search":"bar","hash":"baz"},"expected_match":{"protocol":{"input":"https","groups":{}},"hostname":{"input":"example.com","groups":{}},"port":{"input":"8080","groups":{}},"pathname":{"input":"/foo","groups":{}},"search":{"input":"bar","groups":{}},"hash":{"input":"baz","groups":{}}}}
 FAIL successfullyParsed should be true. Was false.
 Some tests failed.
 

--- a/LayoutTests/fast/urlpattern/urlpattern-component.html
+++ b/LayoutTests/fast/urlpattern/urlpattern-component.html
@@ -2883,6 +2883,8 @@ function executeURLPatternConstructor(jsonArray) {
   // Iterate through each object in the array
   jsonArray.forEach(entry => {
 
+    debug("Testing: " + JSON.stringify(entry));
+
     const pattern = new URLPattern(...entry.pattern);
 
     entry.expected_obj = entry.expected_obj || {};

--- a/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.h
@@ -63,7 +63,7 @@ private:
     void addToken(TokenType currentType, size_t nextPosition, size_t valuePosition);
     void addToken(TokenType currentType);
 
-    ExceptionOr<void> processTokenizingError(size_t nextPosition, size_t valuePosition);
+    ExceptionOr<void> processTokenizingError(size_t nextPosition, size_t valuePosition, const String&);
 };
 
 } // namespace URLPatternUtilities


### PR DESCRIPTION
#### 55c279735d5117f113f22590f07b9f075bef3f1b
<pre>
Add more descriptive error details to better diagnose URLPattern test failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=283384">https://bugs.webkit.org/show_bug.cgi?id=283384</a>
<a href="https://rdar.apple.com/140233854">rdar://140233854</a>

Reviewed by Sihui Liu.

It would be helpful to know why Tokenizer::processTokenizingError occurred and thus a reason / string should be forwarded. OpenSource/LayoutTests/fast/urlpattern/urlpattern-component.html also should better track which test case is being executed.

* LayoutTests/fast/urlpattern/urlpattern-component-expected.txt:
* LayoutTests/fast/urlpattern/urlpattern-component.html:
* Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp:
(WebCore::URLPatternUtilities::Tokenizer::processTokenizingError):
(WebCore::URLPatternUtilities::Tokenizer::tokenize):
* Source/WebCore/Modules/url-pattern/URLPatternTokenizer.h:

Canonical link: <a href="https://commits.webkit.org/286836@main">https://commits.webkit.org/286836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaee907fa0041b423c8c364e425193d1962e7ca7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81801 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28518 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4567 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60503 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/18547 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50476 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40803 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47879 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23787 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26841 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68989 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83224 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4616 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3114 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68778 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4772 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66262 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68035 "Found 1 new API test failure: /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16991 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12027 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10124 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4563 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7378 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4582 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6341 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->