### PR TITLE
DerivedSources.make pattern rules don't work when a file's name has more than one "."

### DIFF
--- a/Source/JavaScriptCore/DerivedSources.make
+++ b/Source/JavaScriptCore/DerivedSources.make
@@ -52,6 +52,8 @@ PLATFORM_HEADER_DIR := $(realpath $(BUILT_PRODUCTS_DIR)$(WK_LIBRARY_HEADERS_FOLD
 PLATFORM_HEADER_DEPENDENCIES := $(filter $(PLATFORM_HEADER_DIR)/%,$(realpath $(shell $(call platform_h_compiler_command,-M) | $(PERL) -e "local \$$/; my (\$$target, \$$deps) = split(/:/, <>); print split(/\\\\/, \$$deps);")))
 FEATURE_AND_PLATFORM_DEFINE_DEPENDENCIES = DerivedSources.make $(PLATFORM_HEADER_DEPENDENCIES)
 
+to-pattern = $(join $(basename $1), $(subst .,%,$(suffix $1)))
+
 # --------
 
 VPATH = \
@@ -149,7 +151,7 @@ JavaScriptCore_BUILTINS_SOURCES = \
 JavaScriptCore_BUILTINS_DEPENDENCIES_LIST : $(JavaScriptCore_SCRIPTS_DIR)/UpdateContents.py DerivedSources.make
 	$(PYTHON) $(JavaScriptCore_SCRIPTS_DIR)/UpdateContents.py '$(JavaScriptCore_BUILTINS_SOURCES) $(BUILTINS_GENERATOR_SCRIPTS)' $@
 
-JSC_BUILTINS_FILES_PATTERNS = $(subst .,%,$(JSC_BUILTINS_FILES))
+JSC_BUILTINS_FILES_PATTERNS = $(call to-pattern, $(JSC_BUILTINS_FILES))
 
 $(JSC_BUILTINS_FILES_PATTERNS) : $(BUILTINS_GENERATOR_SCRIPTS) $(JavaScriptCore_BUILTINS_SOURCES) JavaScriptCore_BUILTINS_DEPENDENCIES_LIST
 	$(PYTHON) $(JavaScriptCore_SCRIPTS_DIR)/generate-js-builtins.py --combined --output-directory . --framework JavaScriptCore $(JavaScriptCore_BUILTINS_SOURCES)
@@ -275,7 +277,7 @@ BYTECODE_FILES = \
     InitWasm.asm \
     BytecodeDumperGenerated.cpp \
 #
-BYTECODE_FILES_PATTERNS = $(subst .,%,$(BYTECODE_FILES))
+BYTECODE_FILES_PATTERNS = $(call to-pattern, $(BYTECODE_FILES))
 
 all : $(BYTECODE_FILES)
 
@@ -354,7 +356,7 @@ INSPECTOR_DISPATCHER_FILES = \
     inspector/InspectorProtocolObjects.cpp \
     inspector/InspectorProtocolObjects.h \
 #
-INSPECTOR_DISPATCHER_FILES_PATTERNS = $(subst .,%,$(INSPECTOR_DISPATCHER_FILES))
+INSPECTOR_DISPATCHER_FILES_PATTERNS = $(call to-pattern, $(INSPECTOR_DISPATCHER_FILES))
 
 all : $(INSPECTOR_DISPATCHER_FILES)
 
@@ -377,7 +379,7 @@ AIR_OPCODE_FILES = \
     AirOpcodeUtils.h \
     AirOpcodeGenerated.h \
 #
-AIR_OPCODE_FILES_PATTERNS = $(subst .,%,$(AIR_OPCODE_FILES))
+AIR_OPCODE_FILES_PATTERNS = $(call to-pattern, $(AIR_OPCODE_FILES))
 
 all : $(AIR_OPCODE_FILES)
 

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -53,6 +53,8 @@ PLATFORM_HEADER_DIR := $(realpath $(BUILT_PRODUCTS_DIR)$(WK_LIBRARY_HEADERS_FOLD
 PLATFORM_HEADER_DEPENDENCIES := $(filter $(PLATFORM_HEADER_DIR)/%,$(realpath $(shell $(call platform_h_compiler_command,-M) | $(PERL) -e "local \$$/; my (\$$target, \$$deps) = split(/:/, <>); print split(/\\\\/, \$$deps);")))
 FEATURE_AND_PLATFORM_DEFINE_DEPENDENCIES = $(WebCore)/DerivedSources.make $(PLATFORM_HEADER_DEPENDENCIES)
 
+to-pattern = $(join $(basename $1), $(subst .,%,$(suffix $1)))
+
 # --------
 
 JS_BINDING_IDLS := \
@@ -1938,7 +1940,7 @@ CSS_PROPERTY_NAME_FILES = \
     StylePropertyShorthandFunctions.cpp \
     StylePropertyShorthandFunctions.h \
 #
-CSS_PROPERTY_NAME_FILES_PATTERNS = $(subst .,%,$(CSS_PROPERTY_NAME_FILES))
+CSS_PROPERTY_NAME_FILES_PATTERNS = $(call to-pattern, $(CSS_PROPERTY_NAME_FILES))
 
 all : $(CSS_PROPERTY_NAME_FILES)
 $(CSS_PROPERTY_NAME_FILES_PATTERNS) : $(WEBCORE_CSS_PROPERTY_NAMES) $(WebCore)/css/process-css-properties.py $(FEATURE_AND_PLATFORM_DEFINE_DEPENDENCIES)
@@ -1949,7 +1951,7 @@ CSS_VALUE_KEYWORD_FILES = \
     CSSValueKeywords.h \
     CSSValueKeywords.cpp \
 #
-CSS_VALUE_KEYWORD_FILES_PATTERNS = $(subst .,%,$(CSS_VALUE_KEYWORD_FILES))
+CSS_VALUE_KEYWORD_FILES_PATTERNS = $(call to-pattern, $(CSS_VALUE_KEYWORD_FILES))
 
 all : $(CSS_VALUE_KEYWORD_FILES)
 $(CSS_VALUE_KEYWORD_FILES_PATTERNS) : $(WEBCORE_CSS_VALUE_KEYWORDS) $(WebCore)/css/process-css-values.py $(FEATURE_AND_PLATFORM_DEFINE_DEPENDENCIES)
@@ -1971,7 +1973,7 @@ CSS_PSEUDO_SELECTOR_FILES = \
     UserAgentParts.h \
 
 #
-CSS_PSEUDO_SELECTOR_FILES_PATTERNS = $(subst .,%,$(CSS_PSEUDO_SELECTOR_FILES))
+CSS_PSEUDO_SELECTOR_FILES_PATTERNS = $(call to-pattern, $(CSS_PSEUDO_SELECTOR_FILES))
 all : $(CSS_PSEUDO_SELECTOR_FILES)
 $(CSS_PSEUDO_SELECTOR_FILES_PATTERNS) : $(WEBCORE_CSS_PSEUDO_SELECTORS) $(WebCore)/css/process-css-pseudo-selectors.py $(FEATURE_AND_PLATFORM_DEFINE_DEPENDENCIES)
 	$(PERL) -pe '' $(WEBCORE_CSS_PSEUDO_SELECTORS) > CSSPseudoSelectors.json
@@ -2024,7 +2026,7 @@ HTTP_HEADER_NAMES_FILES = \
     HTTPHeaderNames.gperf \
     HTTPHeaderNames.h \
 #
-HTTP_HEADER_NAMES_FILES_PATTERNS = $(subst .,%,$(HTTP_HEADER_NAMES_FILES))
+HTTP_HEADER_NAMES_FILES_PATTERNS = $(call to-pattern, $(HTTP_HEADER_NAMES_FILES))
 
 all : $(HTTP_HEADER_NAMES_FILES)
 $(HTTP_HEADER_NAMES_FILES_PATTERNS) : $(WebCore)/platform/network/HTTPHeaderNames.in $(WebCore)/platform/network/create-http-header-name-table
@@ -2119,7 +2121,7 @@ USER_AGENT_STYLE_SHEETS = \
 #
 
 USER_AGENT_STYLE_SHEETS_FILES = UserAgentStyleSheets.h UserAgentStyleSheetsData.cpp
-USER_AGENT_STYLE_SHEETS_FILES_PATTERNS = $(subst .,%,$(USER_AGENT_STYLE_SHEETS_FILES))
+USER_AGENT_STYLE_SHEETS_FILES_PATTERNS = $(call to-pattern, $(USER_AGENT_STYLE_SHEETS_FILES))
 
 all : $(USER_AGENT_STYLE_SHEETS_FILES)
 
@@ -2228,7 +2230,7 @@ USER_AGENT_SCRIPTS_FILES = \
     UserAgentScripts.h \
     UserAgentScriptsData.cpp \
 #
-USER_AGENT_SCRIPTS_FILES_PATTERNS = $(subst .,%,$(USER_AGENT_SCRIPTS_FILES))
+USER_AGENT_SCRIPTS_FILES_PATTERNS = $(call to-pattern, $(USER_AGENT_SCRIPTS_FILES))
 
 all : $(USER_AGENT_SCRIPTS_FILES)
 
@@ -2243,7 +2245,7 @@ PLUG_INS_RESOURCES = $(WebCore)/Resources/plugIns.js
 
 # order matters -- make-css-file-arrays.pl takes the header and then the source file path
 PLUG_INS_RESOURCES_FILES = PlugInsResources.h PlugInsResourcesData.cpp
-PLUG_INS_RESOURCES_FILES_PATTERNS = $(subst .,%,$(PLUG_INS_RESOURCES_FILES))
+PLUG_INS_RESOURCES_FILES_PATTERNS = $(call to-pattern, $(PLUG_INS_RESOURCES_FILES))
 
 all : $(PLUG_INS_RESOURCES_FILES)
 
@@ -2256,7 +2258,7 @@ WEBKIT_FONT_FAMILY_NAME_FILES = \
     WebKitFontFamilyNames.cpp \
     WebKitFontFamilyNames.h \
 #
-WEBKIT_FONT_FAMILY_NAME_FILES_PATTERNS = $(subst .,%,$(WEBKIT_FONT_FAMILY_NAME_FILES))
+WEBKIT_FONT_FAMILY_NAME_FILES_PATTERNS = $(call to-pattern, $(WEBKIT_FONT_FAMILY_NAME_FILES))
 
 all : $(WEBKIT_FONT_FAMILY_NAME_FILES)
 $(WEBKIT_FONT_FAMILY_NAME_FILES_PATTERNS): $(WebCore)/dom/make_names.pl $(WebCore)/bindings/scripts/Hasher.pm $(WebCore)/bindings/scripts/StaticString.pm $(WebCore)/css/WebKitFontFamilyNames.in
@@ -2273,7 +2275,7 @@ HTML_TAG_FILES = \
     HTMLNames.cpp \
     HTMLNames.h \
 #
-HTML_TAG_FILES_PATTERNS = $(subst .,%,$(HTML_TAG_FILES))
+HTML_TAG_FILES_PATTERNS = $(call to-pattern, $(HTML_TAG_FILES))
 
 all : $(HTML_TAG_FILES)
 
@@ -2281,7 +2283,7 @@ $(HTML_TAG_FILES_PATTERNS) : $(WebCore)/dom/make_names.pl $(WebCore)/bindings/sc
 	$(PERL) $< --elements $(WebCore)/html/HTMLTagNames.in --attrs $(WebCore)/html/HTMLAttributeNames.in --factory --wrapperFactory
 
 XML_NS_NAMES_FILES = XMLNSNames.cpp XMLNSNames.h
-XML_NS_NAMES_FILES_PATTERNS = $(subst .,%,$(XML_NS_NAMES_FILES))
+XML_NS_NAMES_FILES_PATTERNS = $(call to-pattern, $(XML_NS_NAMES_FILES))
 
 all : $(XML_NS_NAMES_FILES)
 
@@ -2289,7 +2291,7 @@ $(XML_NS_NAMES_FILES_PATTERNS) : $(WebCore)/dom/make_names.pl $(WebCore)/binding
 	$(PERL) $< --attrs $(WebCore)/xml/xmlnsattrs.in
 
 XML_NAMES_FILES = XMLNames.cpp XMLNames.h
-XML_NAMES_FILES_PATTERNS = $(subst .,%,$(XML_NAMES_FILES))
+XML_NAMES_FILES_PATTERNS = $(call to-pattern, $(XML_NAMES_FILES))
 
 all : $(XML_NAMES_FILES)
 
@@ -2309,7 +2311,7 @@ SVG_TAG_FILES = \
     SVGNames.cpp \
     SVGNames.h \
 #
-SVG_TAG_FILES_PATTERNS = $(subst .,%,$(SVG_TAG_FILES))
+SVG_TAG_FILES_PATTERNS = $(call to-pattern, $(SVG_TAG_FILES))
 
 all : $(SVG_TAG_FILES)
 
@@ -2317,7 +2319,7 @@ $(SVG_TAG_FILES_PATTERNS) : $(WebCore)/dom/make_names.pl $(WebCore)/bindings/scr
 	$(PERL) $< --elements $(WebCore)/svg/svgtags.in --attrs $(WebCore)/svg/svgattrs.in --factory --wrapperFactory
 
 XLINK_NAMES_FILES = XLinkNames.cpp XLinkNames.h
-XLINK_NAMES_FILES_PATTERNS = $(subst .,%,$(XLINK_NAMES_FILES))
+XLINK_NAMES_FILES_PATTERNS = $(call to-pattern, $(XLINK_NAMES_FILES))
 
 all : $(XLINK_NAMES_FILES)
 
@@ -2335,7 +2337,7 @@ EVENT_FACTORY_FILES = \
     EventHeaders.h \
     EventInterfaces.h \
 #
-EVENT_FACTORY_PATTERNS = $(subst .,%,$(EVENT_FACTORY_FILES))
+EVENT_FACTORY_PATTERNS = $(call to-pattern, $(EVENT_FACTORY_FILES))
 
 all : $(EVENT_FACTORY_FILES)
 $(EVENT_FACTORY_PATTERNS) : $(WebCore)/dom/make_event_factory.pl $(EVENT_INTERFACES)
@@ -2348,7 +2350,7 @@ EVENT_TARGET_FACTORY_FILES = \
     EventTargetHeaders.h \
     EventTargetInterfaces.h \
 #
-EVENT_TARGET_FACTORY_PATTERNS = $(subst .,%,$(EVENT_TARGET_FACTORY_FILES))
+EVENT_TARGET_FACTORY_PATTERNS = $(call to-pattern, $(EVENT_TARGET_FACTORY_FILES))
 
 all : $(EVENT_TARGET_FACTORY_FILES)
 $(EVENT_TARGET_FACTORY_PATTERNS) : $(WebCore)/dom/make_event_factory.pl $(EVENT_TARGET_FACTORY)
@@ -2364,7 +2366,7 @@ EVENT_NAME_FILES = \
     EventNames.cpp \
     EventNames.h \
 #
-EVENT_NAME_FILES_PATTERNS = $(subst .,%,$(EVENT_NAME_FILES))
+EVENT_NAME_FILES_PATTERNS = $(call to-pattern, $(EVENT_NAME_FILES))
 
 all : $(EVENT_NAME_FILES)
 $(EVENT_NAME_FILES_PATTERNS) : $(WebCore)/dom/make-event-names.py $(EVENT_NAME_JSON)
@@ -2383,7 +2385,7 @@ MATH_ML_GENERATED_FILES = \
     MathMLNames.cpp \
     MathMLNames.h \
 #
-MATH_ML_GENERATED_PATTERNS = $(subst .,%,$(MATH_ML_GENERATED_FILES))
+MATH_ML_GENERATED_PATTERNS = $(call to-pattern, $(MATH_ML_GENERATED_FILES))
 
 all : $(MATH_ML_GENERATED_FILES)
 $(MATH_ML_GENERATED_PATTERNS) : $(WebCore)/dom/make_names.pl $(WebCore)/bindings/scripts/Hasher.pm $(WebCore)/bindings/scripts/StaticString.pm $(WebCore)/mathml/mathtags.in $(WebCore)/mathml/mathattrs.in
@@ -2424,7 +2426,7 @@ TAG_NAME_GENERATED_FILES = \
     TagName.cpp \
     TagName.h \
 #
-TAG_NAME_GENERATED_PATTERNS = $(subst .,%,$(TAG_NAME_GENERATED_FILES))
+TAG_NAME_GENERATED_PATTERNS = $(call to-pattern, $(TAG_NAME_GENERATED_FILES))
 
 all : $(TAG_NAME_GENERATED_FILES)
 $(TAG_NAME_GENERATED_PATTERNS) : $(DOM_NAME_ENUM_DEPS)
@@ -2434,7 +2436,7 @@ NODE_NAME_GENERATED_FILES = \
     NodeName.cpp \
     NodeName.h \
 #
-NODE_NAME_GENERATED_PATTERNS = $(subst .,%,$(NODE_NAME_GENERATED_FILES))
+NODE_NAME_GENERATED_PATTERNS = $(call to-pattern, $(NODE_NAME_GENERATED_FILES))
 
 all : $(NODE_NAME_GENERATED_FILES)
 $(NODE_NAME_GENERATED_PATTERNS) : $(DOM_NAME_ENUM_DEPS)
@@ -2444,7 +2446,7 @@ NAMESPACE_GENERATED_FILES = \
     Namespace.cpp \
     Namespace.h \
 #
-NAMESPACE_GENERATED_PATTERNS = $(subst .,%,$(NAMESPACE_GENERATED_FILES))
+NAMESPACE_GENERATED_PATTERNS = $(call to-pattern, $(NAMESPACE_GENERATED_FILES))
 
 all : $(NAMESPACE_GENERATED_FILES)
 $(NAMESPACE_GENERATED_PATTERNS) : $(DOM_NAME_ENUM_DEPS)
@@ -2522,7 +2524,7 @@ IDL_INTERMEDIATE_FILES = \
     $(PAINTWORKLETGLOBALSCOPE_CONSTRUCTORS_FILE) \
     $(AUDIOWORKLETGLOBALSCOPE_CONSTRUCTORS_FILE)
 #
-IDL_INTERMEDIATE_PATTERNS = $(subst .,%,$(IDL_INTERMEDIATE_FILES))
+IDL_INTERMEDIATE_PATTERNS = $(call to-pattern, $(IDL_INTERMEDIATE_FILES))
 
 IDL_FILE_NAMES_LIST = IDLFileNamesList.txt
 $(IDL_FILE_NAMES_LIST) : $(JS_BINDING_IDLS)
@@ -2650,7 +2652,7 @@ WebCore_BUILTINS_WRAPPERS += \
     WebCoreJSBuiltinInternals.h \
     WebCoreJSBuiltinInternals.cpp \
 #
-WebCore_BUILTINS_WRAPPERS_PATTERNS = $(subst .,%,$(WebCore_BUILTINS_WRAPPERS))
+WebCore_BUILTINS_WRAPPERS_PATTERNS = $(call to-pattern, $(WebCore_BUILTINS_WRAPPERS))
 
 # Adding/removing scripts should trigger regeneration, but changing which builtins are
 # generated should not affect other builtins when not passing '--combined' to the generator.

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -126,6 +126,8 @@ else
     DELETE = rm -f
 endif
 
+to-pattern = $(join $(basename $1), $(subst .,%,$(suffix $1)))
+
 MESSAGE_RECEIVERS = \
 	NetworkProcess/NetworkBroadcastChannelRegistry \
 	NetworkProcess/NetworkConnectionToWebProcess \
@@ -377,7 +379,7 @@ MESSAGE_RECEIVER_FILES := $(addsuffix MessageReceiver.cpp,$(notdir $(MESSAGE_REC
 MESSAGES_FILES := $(addsuffix Messages.h,$(notdir $(MESSAGE_RECEIVERS)))
 
 GENERATED_MESSAGES_FILES := $(MESSAGE_RECEIVER_FILES) $(MESSAGES_FILES) MessageNames.h MessageNames.cpp MessageArgumentDescriptions.cpp
-GENERATED_MESSAGES_FILES_AS_PATTERNS := $(subst .,%,$(GENERATED_MESSAGES_FILES))
+GENERATED_MESSAGES_FILES_AS_PATTERNS := $(call to-pattern, $(GENERATED_MESSAGES_FILES))
 
 MESSAGES_IN_FILES := $(addsuffix .messages.in,$(MESSAGE_RECEIVERS))
 
@@ -460,7 +462,7 @@ AUTOMATION_PROTOCOL_OUTPUT_FILES = \
     AutomationProtocolObjects.h \
     AutomationProtocolObjects.cpp \
 #
-AUTOMATION_PROTOCOL_OUTPUT_PATTERNS = $(subst .,%,$(AUTOMATION_PROTOCOL_OUTPUT_FILES))
+AUTOMATION_PROTOCOL_OUTPUT_PATTERNS = $(call to-pattern, $(AUTOMATION_PROTOCOL_OUTPUT_FILES))
 
 # JSON-RPC Frontend Dispatchers, Backend Dispatchers, Type Builders
 $(AUTOMATION_PROTOCOL_OUTPUT_PATTERNS) : $(AUTOMATION_PROTOCOL_INPUT_FILES) $(AUTOMATION_PROTOCOL_GENERATOR_SCRIPTS)
@@ -496,7 +498,7 @@ WEB_PREFERENCES_TEMPLATES = \
     $(WebKit2)/Scripts/PreferencesTemplates/WebPreferencesStoreDefaultsMap.cpp.erb \
 #
 WEB_PREFERENCES_FILES = $(basename $(notdir $(WEB_PREFERENCES_TEMPLATES)))
-WEB_PREFERENCES_PATTERNS = $(subst .cpp,%cpp, $(subst .h,%h, $(subst .in,%in, $(WEB_PREFERENCES_FILES))))
+WEB_PREFERENCES_PATTERNS = $(call to-pattern, $(WEB_PREFERENCES_FILES))
 
 all : $(WEB_PREFERENCES_FILES)
 
@@ -863,7 +865,7 @@ GENERATED_SERIALIZERS_OUTPUT_FILES = \
     WebKitPlatformGeneratedSerializers.mm \
 #
 
-GENERATED_SERIALIZERS_OUTPUT_PATTERNS = $(subst .,%,$(GENERATED_SERIALIZERS_OUTPUT_FILES))
+GENERATED_SERIALIZERS_OUTPUT_PATTERNS = $(call to-pattern, $(GENERATED_SERIALIZERS_OUTPUT_FILES))
 
 $(GENERATED_SERIALIZERS_OUTPUT_PATTERNS) : $(WebKit2)/Scripts/generate-serializers.py $(SERIALIZATION_DESCRIPTION_FILES) $(WebKit2)/DerivedSources.make $(WEBCORE_SERIALIZATION_DESCRIPTION_FILES_FULLPATH)
 	$(PYTHON) $(WebKit2)/Scripts/generate-serializers.py mm $(filter %.in,$^)


### PR DESCRIPTION
#### ec535f99e01ed62746ba04899359f01b391a2cae
<pre>
DerivedSources.make pattern rules don&apos;t work when a file&apos;s name has more than one &quot;.&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=283380">https://bugs.webkit.org/show_bug.cgi?id=283380</a>
<a href="https://rdar.apple.com/140231317">rdar://140231317</a>

Reviewed by Alexey Proskuryakov.

In our DerivedSources Makefiles, we represent scripts that generate
multiple outputs by transforming output lists to a list of patterns
using $(subst ...). For example:

    GENERATED_PROCESS_SYNC_CLIENT_OUTPUT_FILES = \
            ProcessSyncClient.cpp \
            ProcessSyncClient.h \
            ProcessSyncData.h \
            ProcessSyncData.serialization.in \

    GENERATED_PROCESS_SYNC_CLIENT_OUTPUT_PATTERNS = $(subst .,%,$(GENERATED_PROCESS_SYNC_CLIENT_OUTPUT_FILES))

However, if a file name has multiple &quot;.&quot; characters, this generates an
invalid pattern string, e.g. &quot;ProcessSyncData%serialization%in&apos; in the
above example. As a result, Make doesn&apos;t know how to make the file it is
based on. The build fails if and only if Make considers this file before
the rule has finished running on behalf of one of the other output files.

We have deployed targeted fixes before, but the issue is subtle enough
that it&apos;s easy to copy-paste existing code and re-introduce the issue in
new rules. Replace all $(subst ...) recipes with an implementation that
separates the basename and extname, and only transforms the extname.

* Source/JavaScriptCore/DerivedSources.make:
* Source/WebCore/DerivedSources.make:
* Source/WebKit/DerivedSources.make:

Canonical link: <a href="https://commits.webkit.org/286966@main">https://commits.webkit.org/286966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55340b54894bdd8aba69b692ae91b4bf973403f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81786 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28504 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79339 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60499 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18549 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50469 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66279 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40799 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47872 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23777 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26827 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/70707 "Found 5 new JSC stress test failures: stress/get-by-val-hoist-above-structure-2.js.mini-mode, stress/get-by-val-hoist-above-structure.js.ftl-eager-no-cjit-b3o1, stress/get-by-val-hoist-above-structure.js.ftl-no-cjit-no-put-stack-validate, stress/get-by-val-hoist-above-structure.js.ftl-no-cjit-small-pool, stress/get-by-val-hoist-above-structure.js.ftl-no-cjit-validate-sampling-profiler (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68982 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24112 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83210 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76798 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4602 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3102 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68774 "Found 1 new test failure: fast/text/crash-word-spacing-infinite.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4758 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68031 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/16990 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12017 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10114 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98753 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12038 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4549 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7364 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21605 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4568 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8003 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6327 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->