### PR TITLE
Missing style invalidation in View Transitions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-flat-transform-ancestor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-flat-transform-ancestor.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
 <link rel="match" href="new-content-flat-transform-ancestor-ref.html">
-<meta name="fuzzy" content="maxDifference=0-63; totalPixels=0-510" />
+<meta name="fuzzy" content="maxDifference=0-63; totalPixels=0-512">
 <script src="/common/rendering-utils.js"></script>
 <script src="/common/reftest-wait.js"></script>
 <script src="../../../../../resources/ui-helper.js"></script>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1727,8 +1727,6 @@ webkit.org/b/274766 http/wpt/webauthn/public-key-credential-get-success-u2f.http
 
 webkit.org/b/258228 [ Sonoma+ Debug ] accessibility/mac/text-input-session-notifications.html [ Skip ]
 
-webkit.org/b/274852 imported/w3c/web-platform-tests/css/css-view-transitions/new-content-flat-transform-ancestor.html [ ImageOnlyFailure ]
-
 # rdar://129424261 (REGRESSION (279443@main): [ Sonoma Release ] WindowServer watchdog timeout on Intel machine)
 [ Release x86_64 ] http/tests/webgpu/webgpu/idl/constructable.html [ Skip ]
 [ Release x86_64 ] http/tests/webgpu/webgpu/idl/constants/flags.html [ Skip ]

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -730,7 +730,7 @@ public:
     inline bool hasTransformOrPerspective() const;
 
     bool capturedInViewTransition() const { return m_stateBitfields.hasFlag(StateFlag::CapturedInViewTransition); }
-    void setCapturedInViewTransition(bool);
+    bool setCapturedInViewTransition(bool);
 
     // When the document element is captured, the captured contents uses the RenderView
     // instead. Returns the capture state with this adjustment applied.

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -967,8 +967,11 @@ bool Styleable::capturedInViewTransition() const
 void Styleable::setCapturedInViewTransition(AtomString captureName)
 {
     element.setViewTransitionCapturedName(pseudoElementIdentifier, captureName);
-    if (CheckedPtr renderer = this->renderer())
-        renderer->setCapturedInViewTransition(!captureName.isNull());
+    if (CheckedPtr renderer = this->renderer()) {
+        bool changed = renderer->setCapturedInViewTransition(!captureName.isNull());
+        if (changed)
+            element.invalidateStyleAndLayerComposition();
+    }
 }
 
 


### PR DESCRIPTION
#### a2e838aaa252b3894115d589edbd2056fe2cfb02
<pre>
Missing style invalidation in View Transitions
<a href="https://bugs.webkit.org/show_bug.cgi?id=283391">https://bugs.webkit.org/show_bug.cgi?id=283391</a>
<a href="https://rdar.apple.com/140244893">rdar://140244893</a>

Reviewed by Matt Woodrow.

Fixing bug 267252 removes some spurious cases where RenderStyles report as different
when they are actually the same. This reveals missing style invalidation bugs in other
parts of the code.

Here in View Transitions we see that the `capturedInViewTransition` state on a RenderObject
affects whether it makes a RenderLayer (via `requiresRenderingConsolidationForViewTransition()`)
and whether `forceToFlat` is set in StyleAdjuster. So when `capturedInViewTransition` changes,
we need to force a style update on the element.

This fixes css/css-view-transitions/element-stops-grouping-after-animation.html when the patch
for 267252 is applied.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-flat-transform-ancestor.html: slight tolerance increase for intel.
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::setCapturedInViewTransition):
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::setCapturedInViewTransition):

Canonical link: <a href="https://commits.webkit.org/286871@main">https://commits.webkit.org/286871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b3506839a020e606400472d3b55ad4fb80758f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81919 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28626 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79461 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4676 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60601 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18632 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66391 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/40899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47975 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23889 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26949 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24227 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83333 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4724 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68864 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4880 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68123 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17011 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12120 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10220 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4671 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4690 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8125 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6449 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->