### PR TITLE
FileReader adds xhr log entry to Network tab of Web Inspector, causing the browser to run out of memory and reload the document.

### DIFF
--- a/LayoutTests/inspector/network/no-request-from-FileReader-expected.txt
+++ b/LayoutTests/inspector/network/no-request-from-FileReader-expected.txt
@@ -1,0 +1,20 @@
+Tests that certain kinds of requests are not sent to the frontend.
+
+
+== Running test suite: Network.NoRequest.FileReader
+-- Running test case: Network.NoRequest.FileReader.readAsArrayBuffer
+Requesting via FileReader.prototype.readAsArrayBuffer...
+PASS: Should not notify the frontend.
+
+-- Running test case: Network.NoRequest.FileReader.readAsBinaryString
+Requesting via FileReader.prototype.readAsBinaryString...
+PASS: Should not notify the frontend.
+
+-- Running test case: Network.NoRequest.FileReader.readAsDataURL
+Requesting via FileReader.prototype.readAsDataURL...
+PASS: Should not notify the frontend.
+
+-- Running test case: Network.NoRequest.FileReader.readAsText
+Requesting via FileReader.prototype.readAsText...
+PASS: Should not notify the frontend.
+

--- a/LayoutTests/inspector/network/no-request-from-FileReader.html
+++ b/LayoutTests/inspector/network/no-request-from-FileReader.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function readFile(method) {
+    let fileReader = new FileReader;
+    fileReader.addEventListener("loadend", (event) => {
+        TestPage.dispatchEventToFrontend("TestPage-FileReader-loadend-" + method);
+    });
+    fileReader[method](new Blob(['test']));
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Network.NoRequest.FileReader");
+
+    for (const method of ["readAsArrayBuffer", "readAsBinaryString", "readAsDataURL", "readAsText"]) {
+        suite.addTestCase({
+            name: `Network.NoRequest.FileReader.${method}`,
+            async test() {
+                let requestURL = null;
+
+                let listener = WI.Frame.addEventListener(WI.Frame.Event.ResourceWasAdded, (event) => {
+                    requestURL = event.data.resource.url;
+                });
+
+                InspectorTest.log(`Requesting via FileReader.prototype.${method}...`);
+                await Promise.all([
+                    InspectorTest.awaitEvent(`TestPage-FileReader-loadend-${method}`),
+                    InspectorTest.evaluateInPage(`readFile("${method}")`),
+                ]);
+
+                InspectorTest.expectNull(requestURL, "Should not notify the frontend.");
+
+                WI.Frame.removeEventListener(WI.Frame.Event.ResourceWasAdded, listener);
+            },
+        });
+    }
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that certain kinds of requests are not sent to the frontend.</p>
+</body>
+</html>

--- a/Source/WebCore/fileapi/FileReaderLoader.cpp
+++ b/Source/WebCore/fileapi/FileReaderLoader.cpp
@@ -102,6 +102,7 @@ void FileReaderLoader::start(ScriptExecutionContext* scriptExecutionContext, con
     // Construct and load the request.
     ResourceRequest request(m_urlForReading);
     request.setHTTPMethod("GET"_s);
+    request.setHiddenFromInspector(true);
 
     ThreadableLoaderOptions options;
     options.sendLoadCallbacks = SendCallbackPolicy::SendCallbacks;


### PR DESCRIPTION
#### ef5a68bffdb025bd8ad2560fe67b567902c1c73b
<pre>
FileReader adds xhr log entry to Network tab of Web Inspector, causing the browser to run out of memory and reload the document.
<a href="https://bugs.webkit.org/show_bug.cgi?id=282345">https://bugs.webkit.org/show_bug.cgi?id=282345</a>

Reviewed by BJ Burg.

It&apos;s not really accurate to treat these as network activity (at least from the perspective of the Network Tab).

* Source/WebCore/fileapi/FileReaderLoader.cpp:
(WebCore::FileReaderLoader::start):

* LayoutTests/inspector/network/no-request-from-FileReader.html: Added.
* LayoutTests/inspector/network/no-request-from-FileReader-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/286861@main">https://commits.webkit.org/286861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58fd048e4578a8234834f79ebc3fe82cf3d48655

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81812 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28526 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79361 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60515 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18556 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80311 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50481 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66295 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40815 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47884 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23794 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26849 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/68995 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83232 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4624 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68787 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4780 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66268 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68043 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17007 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12032 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10130 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4571 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7386 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4590 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8025 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6349 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->