### PR TITLE
Mark message invalid when it fails enablement check or it is not handled

### DIFF
--- a/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp
@@ -51,12 +51,8 @@ void TestWithCVPixelBuffer::didReceiveMessage(IPC::Connection& connection, IPC::
         return IPC::handleMessageAsync<Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer>(connection, decoder, this, &TestWithCVPixelBuffer::receiveCVPixelBuffer);
 #endif
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    RELEASE_LOG_ERROR(IPC, "Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByAndConjunctionMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByAndConjunctionMessageReceiver.cpp
@@ -40,31 +40,19 @@ namespace WebKit {
 
 void TestWithEnabledByAndConjunction::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    bool runtimeEnablementCheckFailed = false;
-    UNUSED_VARIABLE(runtimeEnablementCheckFailed);
     auto sharedPreferences = sharedPreferencesForWebProcess();
     UNUSED_VARIABLE(sharedPreferences);
     if (!sharedPreferences || !(sharedPreferences->someFeature && sharedPreferences->otherFeature)) {
-#if ENABLE(IPC_TESTING_API)
-        if (connection.ignoreInvalidMessageForTesting())
-            return;
-#endif // ENABLE(IPC_TESTING_API)
-        ASSERT_NOT_REACHED_WITH_MESSAGE("Message %s received by a disabled message receiver TestWithEnabledByAndConjunction", IPC::description(decoder.messageName()).characters());
-        connection.markCurrentlyDispatchedMessageAsInvalid();
+        RELEASE_LOG_ERROR(IPC, "Message %s received by a disabled message receiver TestWithEnabledByAndConjunction", IPC::description(decoder.messageName()).characters());
+        decoder.markInvalid();
         return;
     }
     Ref protectedThis { *this };
     if (decoder.messageName() == Messages::TestWithEnabledByAndConjunction::AlwaysEnabled::name())
         return IPC::handleMessage<Messages::TestWithEnabledByAndConjunction::AlwaysEnabled>(connection, decoder, this, &TestWithEnabledByAndConjunction::alwaysEnabled);
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
-    if (runtimeEnablementCheckFailed)
-        connection.markCurrentlyDispatchedMessageAsInvalid();
+    RELEASE_LOG_ERROR(IPC, "Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByOrConjunctionMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledByOrConjunctionMessageReceiver.cpp
@@ -40,31 +40,19 @@ namespace WebKit {
 
 void TestWithEnabledByOrConjunction::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    bool runtimeEnablementCheckFailed = false;
-    UNUSED_VARIABLE(runtimeEnablementCheckFailed);
     auto sharedPreferences = sharedPreferencesForWebProcess();
     UNUSED_VARIABLE(sharedPreferences);
     if (!sharedPreferences || !(sharedPreferences->someFeature || sharedPreferences->otherFeature)) {
-#if ENABLE(IPC_TESTING_API)
-        if (connection.ignoreInvalidMessageForTesting())
-            return;
-#endif // ENABLE(IPC_TESTING_API)
-        ASSERT_NOT_REACHED_WITH_MESSAGE("Message %s received by a disabled message receiver TestWithEnabledByOrConjunction", IPC::description(decoder.messageName()).characters());
-        connection.markCurrentlyDispatchedMessageAsInvalid();
+        RELEASE_LOG_ERROR(IPC, "Message %s received by a disabled message receiver TestWithEnabledByOrConjunction", IPC::description(decoder.messageName()).characters());
+        decoder.markInvalid();
         return;
     }
     Ref protectedThis { *this };
     if (decoder.messageName() == Messages::TestWithEnabledByOrConjunction::AlwaysEnabled::name())
         return IPC::handleMessage<Messages::TestWithEnabledByOrConjunction::AlwaysEnabled>(connection, decoder, this, &TestWithEnabledByOrConjunction::alwaysEnabled);
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
-    if (runtimeEnablementCheckFailed)
-        connection.markCurrentlyDispatchedMessageAsInvalid();
+    RELEASE_LOG_ERROR(IPC, "Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessageReceiver.cpp
@@ -53,12 +53,8 @@ void TestWithIfMessage::didReceiveMessage(IPC::Connection& connection, IPC::Deco
         return IPC::handleMessage<Messages::TestWithIfMessage::LoadURL>(connection, decoder, this, &TestWithIfMessage::loadURL);
 #endif
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    RELEASE_LOG_ERROR(IPC, "Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp
@@ -47,12 +47,8 @@ void TestWithImageData::didReceiveMessage(IPC::Connection& connection, IPC::Deco
     if (decoder.messageName() == Messages::TestWithImageData::ReceiveImageData::name())
         return IPC::handleMessageAsync<Messages::TestWithImageData::ReceiveImageData>(connection, decoder, this, &TestWithImageData::receiveImageData);
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    RELEASE_LOG_ERROR(IPC, "Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
@@ -123,12 +123,8 @@ void TestWithLegacyReceiver::didReceiveMessage(IPC::Connection& connection, IPC:
         return IPC::handleMessage<Messages::TestWithLegacyReceiver::ExperimentalOperation>(connection, decoder, this, &TestWithLegacyReceiver::experimentalOperation);
 #endif
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    RELEASE_LOG_ERROR(IPC, "Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
 }
 
 bool TestWithLegacyReceiver::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
@@ -139,13 +135,9 @@ bool TestWithLegacyReceiver::didReceiveSyncMessage(IPC::Connection& connection, 
     if (decoder.messageName() == Messages::TestWithLegacyReceiver::TestMultipleAttributes::name())
         return IPC::handleMessageSynchronous<Messages::TestWithLegacyReceiver::TestMultipleAttributes>(connection, decoder, replyEncoder, this, &TestWithLegacyReceiver::testMultipleAttributes);
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
     UNUSED_PARAM(replyEncoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return false;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
+    RELEASE_LOG_ERROR(IPC, "Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
     return false;
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp
@@ -44,12 +44,8 @@ void TestWithSemaphore::didReceiveMessage(IPC::Connection& connection, IPC::Deco
     if (decoder.messageName() == Messages::TestWithSemaphore::ReceiveSemaphore::name())
         return IPC::handleMessageAsync<Messages::TestWithSemaphore::ReceiveSemaphore>(connection, decoder, this, &TestWithSemaphore::receiveSemaphore);
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    RELEASE_LOG_ERROR(IPC, "Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp
@@ -41,13 +41,8 @@ void TestWithStreamBatched::didReceiveStreamMessage(IPC::StreamServerConnection&
 {
     if (decoder.messageName() == Messages::TestWithStreamBatched::SendString::name())
         return IPC::handleMessage<Messages::TestWithStreamBatched::SendString>(connection, decoder, this, &TestWithStreamBatched::sendString);
-    UNUSED_PARAM(decoder);
-    UNUSED_PARAM(connection);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    RELEASE_LOG_ERROR(IPC, "Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp
@@ -42,12 +42,8 @@ void TestWithStreamBuffer::didReceiveMessage(IPC::Connection& connection, IPC::D
     if (decoder.messageName() == Messages::TestWithStreamBuffer::SendStreamBuffer::name())
         return IPC::handleMessage<Messages::TestWithStreamBuffer::SendStreamBuffer>(connection, decoder, this, &TestWithStreamBuffer::sendStreamBuffer);
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    RELEASE_LOG_ERROR(IPC, "Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
@@ -60,13 +60,8 @@ void TestWithStream::didReceiveStreamMessage(IPC::StreamServerConnection& connec
     if (decoder.messageName() == Messages::TestWithStream::SendAndReceiveMachSendRight::name())
         return IPC::handleMessageSynchronous<Messages::TestWithStream::SendAndReceiveMachSendRight>(connection, decoder, this, &TestWithStream::sendAndReceiveMachSendRight);
 #endif
-    UNUSED_PARAM(decoder);
-    UNUSED_PARAM(connection);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    RELEASE_LOG_ERROR(IPC, "Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessageReceiver.cpp
@@ -42,12 +42,8 @@ void TestWithStreamServerConnectionHandle::didReceiveMessage(IPC::Connection& co
     if (decoder.messageName() == Messages::TestWithStreamServerConnectionHandle::SendStreamServerConnection::name())
         return IPC::handleMessage<Messages::TestWithStreamServerConnectionHandle::SendStreamServerConnection>(connection, decoder, this, &TestWithStreamServerConnectionHandle::sendStreamServerConnection);
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    RELEASE_LOG_ERROR(IPC, "Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithWantsAsyncDispatchMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithWantsAsyncDispatchMessageReceiver.cpp
@@ -45,12 +45,8 @@ void TestWithWantsAsyncDispatch::didReceiveMessage(IPC::Connection& connection, 
     if (dispatchMessage(connection, decoder))
         return;
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    RELEASE_LOG_ERROR(IPC, "Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
 }
 
 bool TestWithWantsAsyncDispatch::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
@@ -59,13 +55,9 @@ bool TestWithWantsAsyncDispatch::didReceiveSyncMessage(IPC::Connection& connecti
     if (decoder.messageName() == Messages::TestWithWantsAsyncDispatch::TestSyncMessage::name())
         return IPC::handleMessageSynchronous<Messages::TestWithWantsAsyncDispatch::TestSyncMessage>(connection, decoder, replyEncoder, this, &TestWithWantsAsyncDispatch::testSyncMessage);
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
     UNUSED_PARAM(replyEncoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return false;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
+    RELEASE_LOG_ERROR(IPC, "Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
     return false;
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchMessageReceiver.cpp
@@ -45,12 +45,8 @@ void TestWithWantsDispatch::didReceiveMessage(IPC::Connection& connection, IPC::
     if (dispatchMessage(connection, decoder))
         return;
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    RELEASE_LOG_ERROR(IPC, "Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
 }
 
 bool TestWithWantsDispatch::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
@@ -61,13 +57,9 @@ bool TestWithWantsDispatch::didReceiveSyncMessage(IPC::Connection& connection, I
     if (dispatchSyncMessage(connection, decoder, replyEncoder))
         return true;
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
     UNUSED_PARAM(replyEncoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return false;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
+    RELEASE_LOG_ERROR(IPC, "Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
     return false;
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchNoSyncMessagesMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchNoSyncMessagesMessageReceiver.cpp
@@ -45,12 +45,8 @@ void TestWithWantsDispatchNoSyncMessages::didReceiveMessage(IPC::Connection& con
     if (dispatchMessage(connection, decoder))
         return;
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    RELEASE_LOG_ERROR(IPC, "Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
 }
 
 bool TestWithWantsDispatchNoSyncMessages::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
@@ -59,13 +55,9 @@ bool TestWithWantsDispatchNoSyncMessages::didReceiveSyncMessage(IPC::Connection&
     if (dispatchSyncMessage(connection, decoder, replyEncoder))
         return true;
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
     UNUSED_PARAM(replyEncoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return false;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
+    RELEASE_LOG_ERROR(IPC, "Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
     return false;
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
@@ -123,12 +123,8 @@ void TestWithoutAttributes::didReceiveMessage(IPC::Connection& connection, IPC::
         return IPC::handleMessage<Messages::TestWithoutAttributes::ExperimentalOperation>(connection, decoder, this, &TestWithoutAttributes::experimentalOperation);
 #endif
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    RELEASE_LOG_ERROR(IPC, "Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
 }
 
 bool TestWithoutAttributes::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
@@ -139,13 +135,9 @@ bool TestWithoutAttributes::didReceiveSyncMessage(IPC::Connection& connection, I
     if (decoder.messageName() == Messages::TestWithoutAttributes::TestMultipleAttributes::name())
         return IPC::handleMessageSynchronous<Messages::TestWithoutAttributes::TestMultipleAttributes>(connection, decoder, replyEncoder, this, &TestWithoutAttributes::testMultipleAttributes);
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
     UNUSED_PARAM(replyEncoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return false;
-#endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
+    RELEASE_LOG_ERROR(IPC, "Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
     return false;
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessageReceiver.cpp
@@ -52,8 +52,8 @@ void TestWithoutUsingIPCConnection::didReceiveMessageWithReplyHandler(IPC::Decod
         return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithArgumentAndEmptyReply);
     if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument::name())
         return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithArgumentAndReplyWithArgument);
-    UNUSED_PARAM(decoder);
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    RELEASE_LOG_ERROR(IPC, "Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
@@ -239,10 +239,10 @@ std::optional<WebKit::CoreIPCNSSomeFoundationType> ArgumentCoder<WebKit::CoreIPC
 void ArgumentCoder<WebKit::CoreIPCclass NSSomeOtherFoundationType>::encode(Encoder& encoder, const WebKit::CoreIPCclass NSSomeOtherFoundationType& instance)
 {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_DictionaryKey)>, RetainPtr<NSDictionary>>);
-    struct ShouldBeSameSizeAsclass NSSomeOtherFoundationType : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<WebKit::CoreIPCclass NSSomeOtherFoundationType>, false> {
+    struct ShouldBeSameSizeAsclass_NSSomeOtherFoundationType : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<WebKit::CoreIPCclass NSSomeOtherFoundationType>, false> {
         RetainPtr<NSDictionary> DictionaryKey;
     };
-    static_assert(sizeof(ShouldBeSameSizeAsclass NSSomeOtherFoundationType) == sizeof(WebKit::CoreIPCclass NSSomeOtherFoundationType));
+    static_assert(sizeof(ShouldBeSameSizeAsclass_NSSomeOtherFoundationType) == sizeof(WebKit::CoreIPCclass NSSomeOtherFoundationType));
     static_assert(MembersInCorrectOrder < 0
         , offsetof(WebKit::CoreIPCclass NSSomeOtherFoundationType, m_DictionaryKey)
     >::value);


### PR DESCRIPTION
#### ac6dcc85f22e9190982ed5f7a86f6383d113dcdc
<pre>
Mark message invalid when it fails enablement check or it is not handled
<a href="https://bugs.webkit.org/show_bug.cgi?id=283394">https://bugs.webkit.org/show_bug.cgi?id=283394</a>

Reviewed by Ryosuke Niwa.

The patch makes a few changes to make generated message receiver code more consistent:
1. Invoke Decoder::markInvalid(), instead of Connection::markCurrentlyDispatchedMessageAsInvalid() to mark message as
invalid. This enables us to mark a message dispatched to stream connection invalid.
2. Remove the checks for ignoreInvalidMessageForTesting, as Connection already checks that before notifying client about
invalid message (see Connection::dispatchMessage and StreamServerConnection::dispatchStreamMessage).
3. Convert ASSERT_NOT_REACHED_WITH_MESSAGE to RELEASE_LOG_ERROR and markInvalid(), as it makes little sense to crash
receiver process when it receives an invalid message (including message that cannot be handled). For invalid message,
the receiver proess may request the sender process to be killed, or just ignore the message if
ignoreInvalidMessageForTesting is true.

* Source/WebKit/Scripts/webkit/messages.py:
(async_message_statement):
(generate_enabled_by_for_receiver):
(generate_message_handler):
* Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp:
(WebKit::TestWithCVPixelBuffer::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledByAndConjunctionMessageReceiver.cpp:
(WebKit::TestWithEnabledByAndConjunction::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledByMessageReceiver.cpp:
(WebKit::TestWithEnabledBy::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledByOrConjunctionMessageReceiver.cpp:
(WebKit::TestWithEnabledByOrConjunction::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessageReceiver.cpp:
(WebKit::TestWithEnabledIf::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessageReceiver.cpp:
(WebKit::TestWithIfMessage::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp:
(WebKit::TestWithImageData::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp:
(WebKit::TestWithLegacyReceiver::didReceiveMessage):
(WebKit::TestWithLegacyReceiver::didReceiveSyncMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp:
(WebKit::TestWithSemaphore::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp:
(WebKit::TestWithStreamBatched::didReceiveStreamMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp:
(WebKit::TestWithStreamBuffer::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp:
(WebKit::TestWithStream::didReceiveStreamMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessageReceiver.cpp:
(WebKit::TestWithStreamServerConnectionHandle::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithWantsAsyncDispatchMessageReceiver.cpp:
(WebKit::TestWithWantsAsyncDispatch::didReceiveMessage):
(WebKit::TestWithWantsAsyncDispatch::didReceiveSyncMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchMessageReceiver.cpp:
(WebKit::TestWithWantsDispatch::didReceiveMessage):
(WebKit::TestWithWantsDispatch::didReceiveSyncMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithWantsDispatchNoSyncMessagesMessageReceiver.cpp:
(WebKit::TestWithWantsDispatchNoSyncMessages::didReceiveMessage):
(WebKit::TestWithWantsDispatchNoSyncMessages::didReceiveSyncMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp:
(WebKit::TestWithoutAttributes::didReceiveMessage):
(WebKit::TestWithoutAttributes::didReceiveSyncMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessageReceiver.cpp:
(WebKit::TestWithoutUsingIPCConnection::didReceiveMessageWithReplyHandler):
* Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp:
(IPC::NSSomeOtherFoundationType&gt;::encode):

Canonical link: <a href="https://commits.webkit.org/286885@main">https://commits.webkit.org/286885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d06bc8c5c36d0aab8de894d9aeb5f4f0bf783c8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81972 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28645 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4695 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60626 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18641 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66408 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40924 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/76869 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47993 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26968 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69104 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83352 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4743 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3225 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68879 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4899 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66378 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68137 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17022 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12133 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10236 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4690 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7505 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4709 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8144 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6468 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->