### PR TITLE
Add message check support to StreamServerConnection

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -46,6 +46,8 @@
 #include "RemoteVideoFrameObjectHeap.h"
 #endif
 
+#define MESSAGE_CHECK(assertion, connection) MESSAGE_CHECK_OPTIONAL_CONNECTION_BASE(assertion, connection)
+
 namespace WebKit {
 
 using namespace WebCore;
@@ -454,6 +456,13 @@ Ref<RemoteVideoFrameObjectHeap> RemoteGraphicsContextGL::protectedVideoFrameObje
 }
 #endif
 
+void RemoteGraphicsContextGL::messageCheck(bool assertion)
+{
+    MESSAGE_CHECK(assertion, m_streamConnection);
+}
+
 } // namespace WebKit
+
+#undef MESSAGE_CHECK
 
 #endif // ENABLE(GPU_PROCESS) && ENABLE(WEBGL)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -166,6 +166,7 @@ private:
     bool webXRPromptAccepted() const;
     Ref<IPC::StreamConnectionWorkQueue> protectedWorkQueue() const { return m_workQueue; }
     RefPtr<GCGLContext> protectedContext();
+    void messageCheck(bool);
 
 protected:
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -324,19 +324,19 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void GetInternalformativ(uint32_t target, uint32_t internalformat, uint32_t pname, size_t paramsSize) -> (std::span<const int32_t> params) Synchronous
     void SetDrawingBufferColorSpace(WebCore::DestinationColorSpace arg0)
 #if ENABLE(WEBXR)
-    [EnabledIf='webXRPromptAccepted()'] void CreateExternalImage(uint32_t externalImage, WebCore::GraphicsContextGL::ExternalImageSource arg0, uint32_t internalFormat, int32_t layer) NotStreamEncodable
-    [EnabledIf='webXRPromptAccepted()'] void DeleteExternalImage(uint32_t handle)
-    [EnabledIf='webXRPromptAccepted()'] void BindExternalImage(uint32_t target, uint32_t arg1)
-    [EnabledIf='webXRPromptAccepted()'] void CreateExternalSync(uint32_t externalSync, WebCore::GraphicsContextGL::ExternalSyncSource arg0) NotStreamEncodable
+    void CreateExternalImage(uint32_t externalImage, WebCore::GraphicsContextGL::ExternalImageSource arg0, uint32_t internalFormat, int32_t layer) NotStreamEncodable
+    void DeleteExternalImage(uint32_t handle)
+    void BindExternalImage(uint32_t target, uint32_t arg1)
+    void CreateExternalSync(uint32_t externalSync, WebCore::GraphicsContextGL::ExternalSyncSource arg0) NotStreamEncodable
 #endif
-    [EnabledIf='webXRPromptAccepted()'] void DeleteExternalSync(uint32_t arg0)
+    void DeleteExternalSync(uint32_t arg0)
 #if ENABLE(WEBXR)
-    [EnabledIf='webXREnabled()'] void EnableRequiredWebXRExtensions() -> (bool returnValue) Synchronous
-    [EnabledIf='webXRPromptAccepted()'] void AddFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const float> horizontalSamplesLeft, std::span<const float> verticalSamples, std::span<const float> horizontalSamplesRight) -> (bool returnValue) Synchronous
-    [EnabledIf='webXRPromptAccepted()'] void EnableFoveation(uint32_t arg0)
-    [EnabledIf='webXRPromptAccepted()'] void DisableFoveation()
-    [EnabledIf='webXRPromptAccepted()'] void FramebufferDiscard(uint32_t target, std::span<const uint32_t> attachments)
-    [EnabledIf='webXRPromptAccepted()'] void FramebufferResolveRenderbuffer(uint32_t target, uint32_t attachment, uint32_t renderbuffertarget, uint32_t arg3)
+    void EnableRequiredWebXRExtensions() -> (bool returnValue) Synchronous
+    void AddFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const float> horizontalSamplesLeft, std::span<const float> verticalSamples, std::span<const float> horizontalSamplesRight) -> (bool returnValue) Synchronous
+    void EnableFoveation(uint32_t arg0)
+    void DisableFoveation()
+    void FramebufferDiscard(uint32_t target, std::span<const uint32_t> attachments)
+    void FramebufferResolveRenderbuffer(uint32_t target, uint32_t attachment, uint32_t renderbuffertarget, uint32_t arg3)
 #endif
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -1642,6 +1642,7 @@
     void createExternalImage(uint32_t name, WebCore::GraphicsContextGL::ExternalImageSource&& arg0, uint32_t internalFormat, int32_t layer)
     {
         assertIsCurrent(workQueue());
+        messageCheck(webXRPromptAccepted());
         auto result = protectedContext()->createExternalImage(WTFMove(arg0), internalFormat, layer);
         if (result)
             m_objectNames.add(name, result);
@@ -1649,6 +1650,7 @@
     void deleteExternalImage(uint32_t handle)
     {
         assertIsCurrent(workQueue());
+        messageCheck(webXRPromptAccepted());
         if (UNLIKELY(!handle))
             return;
         handle = m_objectNames.take(handle);
@@ -1657,6 +1659,7 @@
     void bindExternalImage(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
+        messageCheck(webXRPromptAccepted());
         if (arg1)
             arg1 = m_objectNames.get(arg1);
         protectedContext()->bindExternalImage(target, arg1);
@@ -1664,6 +1667,7 @@
     void createExternalSync(uint32_t name, WebCore::GraphicsContextGL::ExternalSyncSource&& arg0)
     {
         assertIsCurrent(workQueue());
+        messageCheck(webXRPromptAccepted());
         auto result = protectedContext()->createExternalSync(WTFMove(arg0));
         if (result)
             m_objectNames.add(name, result);
@@ -1672,6 +1676,7 @@
     void deleteExternalSync(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        messageCheck(webXRPromptAccepted());
         if (UNLIKELY(!arg0))
             return;
         arg0 = m_objectNames.take(arg0);
@@ -1681,6 +1686,7 @@
     void enableRequiredWebXRExtensions(CompletionHandler<void(bool)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
+        messageCheck(webXREnabled());
         bool returnValue = { };
         returnValue = protectedContext()->enableRequiredWebXRExtensions();
         completionHandler(returnValue);
@@ -1688,6 +1694,7 @@
     void addFoveation(WebCore::IntSize&& physicalSizeLeft, WebCore::IntSize&& physicalSizeRight, WebCore::IntSize&& screenSize, std::span<const float>&& horizontalSamplesLeft, std::span<const float>&& verticalSamples, std::span<const float>&& horizontalSamplesRight, CompletionHandler<void(bool)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
+        messageCheck(webXRPromptAccepted());
         bool returnValue = { };
         returnValue = protectedContext()->addFoveation(physicalSizeLeft, physicalSizeRight, screenSize, horizontalSamplesLeft, verticalSamples, horizontalSamplesRight);
         completionHandler(returnValue);
@@ -1695,6 +1702,7 @@
     void enableFoveation(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        messageCheck(webXRPromptAccepted());
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         protectedContext()->enableFoveation(arg0);
@@ -1702,16 +1710,19 @@
     void disableFoveation()
     {
         assertIsCurrent(workQueue());
+        messageCheck(webXRPromptAccepted());
         protectedContext()->disableFoveation();
     }
     void framebufferDiscard(uint32_t target, std::span<const uint32_t>&& attachments)
     {
         assertIsCurrent(workQueue());
+        messageCheck(webXRPromptAccepted());
         protectedContext()->framebufferDiscard(target, attachments);
     }
     void framebufferResolveRenderbuffer(uint32_t target, uint32_t attachment, uint32_t renderbuffertarget, uint32_t arg3)
     {
         assertIsCurrent(workQueue());
+        messageCheck(webXRPromptAccepted());
         if (arg3)
             arg3 = m_objectNames.get(arg3);
         protectedContext()->framebufferResolveRenderbuffer(target, attachment, renderbuffertarget, arg3);

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -258,7 +258,8 @@ bool StreamServerConnection::processOutOfStreamMessage(Decoder& decoder)
 bool StreamServerConnection::dispatchStreamMessage(Decoder& message, StreamMessageReceiver& receiver)
 {
     receiver.didReceiveStreamMessage(*this, message);
-    if (message.isValid())
+    auto didReceiveInvalidMessage = std::exchange(m_didReceiveInvalidMessage, false);
+    if (!didReceiveInvalidMessage && message.isValid())
         return true;
 
     Ref connection = m_connection;
@@ -279,6 +280,11 @@ bool StreamServerConnection::dispatchStreamMessage(Decoder& message, StreamMessa
     return false;
 }
 
+void StreamServerConnection::markCurrentlyDispatchedMessageAsInvalid()
+{
+    ASSERT(m_isProcessingStreamMessage);
+    m_didReceiveInvalidMessage = true;
+}
 
 RefPtr<StreamConnectionWorkQueue> StreamServerConnection::protectedWorkQueue() const
 {

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -91,6 +91,7 @@ public:
         HasMoreMessages
     };
     DispatchResult dispatchStreamMessages(size_t messageLimit);
+    void markCurrentlyDispatchedMessageAsInvalid();
 
     void open(StreamConnectionWorkQueue&);
     void invalidate();
@@ -143,6 +144,7 @@ private:
     ReceiversMap m_receivers WTF_GUARDED_BY_LOCK(m_receiversLock);
     uint64_t m_currentDestinationID { 0 };
     Semaphore m_clientWaitSemaphore;
+    bool m_didReceiveInvalidMessage { false };
 
     friend class StreamConnectionWorkQueue;
 };

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -44,7 +44,7 @@
 #include <wtf/WeakPtr.h>
 
 // Used by generate-gpup-webgl
-#define IPC_MESSAGE_ATTRIBUTE(x)
+#define IPC_MESSAGE_CHECK(x)
 
 namespace WebKit {
 
@@ -361,20 +361,20 @@ public:
     void setDrawingBufferColorSpace(const WebCore::DestinationColorSpace&) final;
 
 #if ENABLE(WEBXR)
-    GCGLExternalImage createExternalImage(WebCore::GraphicsContextGL::ExternalImageSource&&, GCGLenum internalFormat, GCGLint layer) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
-    void deleteExternalImage(GCGLExternalImage handle) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
-    void bindExternalImage(GCGLenum target, GCGLExternalImage) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
-    GCGLExternalSync createExternalSync(WebCore::GraphicsContextGL::ExternalSyncSource&&) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
+    GCGLExternalImage createExternalImage(WebCore::GraphicsContextGL::ExternalImageSource&&, GCGLenum internalFormat, GCGLint layer) IPC_MESSAGE_CHECK(webXRPromptAccepted()) final;
+    void deleteExternalImage(GCGLExternalImage handle) IPC_MESSAGE_CHECK(webXRPromptAccepted()) final;
+    void bindExternalImage(GCGLenum target, GCGLExternalImage) IPC_MESSAGE_CHECK(webXRPromptAccepted()) final;
+    GCGLExternalSync createExternalSync(WebCore::GraphicsContextGL::ExternalSyncSource&&) IPC_MESSAGE_CHECK(webXRPromptAccepted()) final;
 #endif
-    void deleteExternalSync(GCGLExternalSync) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
+    void deleteExternalSync(GCGLExternalSync) IPC_MESSAGE_CHECK(webXRPromptAccepted()) final;
 
 #if ENABLE(WEBXR)
-    bool enableRequiredWebXRExtensions() IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
-    bool addFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const GCGLfloat> horizontalSamplesLeft, std::span<const GCGLfloat> verticalSamples, std::span<const GCGLfloat> horizontalSamplesRight) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
-    void enableFoveation(PlatformGLObject arg0) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
-    void disableFoveation() IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
-    void framebufferDiscard(GCGLenum target, std::span<const GCGLenum> attachments) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
-    void framebufferResolveRenderbuffer(GCGLenum target, GCGLenum attachment, GCGLenum renderbuffertarget, PlatformGLObject arg3) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
+    bool enableRequiredWebXRExtensions() IPC_MESSAGE_CHECK(webXREnabled()) final;
+    bool addFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const GCGLfloat> horizontalSamplesLeft, std::span<const GCGLfloat> verticalSamples, std::span<const GCGLfloat> horizontalSamplesRight) IPC_MESSAGE_CHECK(webXRPromptAccepted()) final;
+    void enableFoveation(PlatformGLObject arg0) IPC_MESSAGE_CHECK(webXRPromptAccepted()) final;
+    void disableFoveation() IPC_MESSAGE_CHECK(webXRPromptAccepted()) final;
+    void framebufferDiscard(GCGLenum target, std::span<const GCGLenum> attachments) IPC_MESSAGE_CHECK(webXRPromptAccepted()) final;
+    void framebufferResolveRenderbuffer(GCGLenum target, GCGLenum attachment, GCGLenum renderbuffertarget, PlatformGLObject arg3) IPC_MESSAGE_CHECK(webXRPromptAccepted()) final;
 #endif
     // End of list used by generate-gpup-webgl script.
 

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -468,15 +468,15 @@ class cpp_func(object):
     name: str
     args: cpp_arg_list
     return_type: cpp_type
-    attr: str
+    message_check: str
     cond: str
     overload_suffix: str
 
-    def __init__(self, name: str, return_type: cpp_type, args: cpp_arg_list, attr: str, cond: str):
+    def __init__(self, name: str, return_type: cpp_type, args: cpp_arg_list, message_check: str, cond: str):
         self.name = name
         self.return_type = return_type
         self.args = args
-        self.attr = attr
+        self.message_check = message_check
         self.cond = cond
         self.overload_suffix = ""
 
@@ -621,13 +621,12 @@ non_stream_types = set({"WebCore::GraphicsContextGL::ExternalImageSource&&", "We
 
 class webkit_ipc_msg(object):
     cond: str
-    attr: str
+    message_check: str
     name: str
     in_args: cpp_arg_list
     out_args: cpp_arg_list
 
     def __init__(self, func: cpp_func):
-        self.attr = func.attr
         self.cond = func.cond
         self.name = webkit_ipc_msg_name(func)
         in_args, out_args = func.get_args_categories()
@@ -649,11 +648,10 @@ class webkit_ipc_msg(object):
             self.tags += ["NotStreamEncodable"]
 
     def __str__(self):
-        attr = f"[{self.attr}] " if self.attr else ""
         tags = f" {' '.join(self.tags)}" if self.tags else ""
         if len(self.out_args.args):
-            return f"\n    {attr}void {self.name}({str(self.in_args)}) -> ({str(self.out_args)}) Synchronous{tags}"
-        return f"\n    {attr}void {self.name}({str(self.in_args)}){tags}"
+            return f"\n    void {self.name}({str(self.in_args)}) -> ({str(self.out_args)}) Synchronous{tags}"
+        return f"\n    void {self.name}({str(self.in_args)}){tags}"
 
 
 class webkit_ipc_cpp_proxy_impl(object):
@@ -867,6 +865,7 @@ class webkit_ipc_cpp_impl(object):
     def __init__(self, cpp_func: cpp_func):
         self.cond = cpp_func.cond
         self.name = cpp_func.name
+        self.message_check = cpp_func.message_check
         self.is_create = is_create_func(cpp_func)
         self.is_delete = is_delete_func(cpp_func)
         self.overload_suffix = cpp_func.overload_suffix
@@ -879,6 +878,8 @@ class webkit_ipc_cpp_impl(object):
         self.return_value_expr = None
 
         self.pre_call_stmts += ["assertIsCurrent(workQueue());"]
+        if self.message_check:
+            self.pre_call_stmts += [f"messageCheck({self.message_check});"]
         self.process_return_value(cpp_func.return_type)
         in_args, out_args = cpp_func.get_args_categories()
         self.process_args(cpp_func.args.args, set(in_args), set(out_args))
@@ -1079,8 +1080,8 @@ def create_cpp_arg_list(args_specs: Iterable[str]):
     return cpp_arg_list([create_cpp_arg(arg_spec=e, arg_index=i) for i, e in enumerate(args_specs)])
 
 
-def create_cpp_func(name: str, return_spec: str, args_specs: List[str], attr: str, cond: str):
-    return cpp_func(name=name, return_type=get_cpp_type(return_spec), args=create_cpp_arg_list(args_specs), attr=attr, cond=cond)
+def create_cpp_func(name: str, return_spec: str, args_specs: List[str], message_check: str, cond: str):
+    return cpp_func(name=name, return_type=get_cpp_type(return_spec), args=create_cpp_arg_list(args_specs), message_check=message_check, cond=cond)
 
 
 def read_lines_until(lines: Iterable[str], match: str) -> Generator[str, None, None]:
@@ -1100,6 +1101,7 @@ def main():
     funcs = []
     unimplemented = []
     cond = ""
+    message_checks = {}
     for fn in functions_input_fns:
         with open(fn) as f:
             lines = iter(f.readlines())
@@ -1116,14 +1118,14 @@ def main():
                 if m:
                     cond=""
                     continue
-                m = re.match(r"\s*(\S+)\s+(\w+)\((.*?)\)\s+(IPC_MESSAGE_ATTRIBUTE\((\S+?)\)\s+)?final;", line)
+                m = re.match(r"\s*(\S+)\s+(\w+)\((.*?)\)\s+(IPC_MESSAGE_CHECK\((\S+?)\)\s+)?final;", line)
                 if m:
                     func_name = m[2]
                     func = create_cpp_func(
                         name=func_name,
                         return_spec=m[1],
                         args_specs=cpp_split_args_specs(m[3]),
-                        attr=m[5],
+                        message_check=m[5],
                         cond=cond
                     )
                     if func.is_implemented():


### PR DESCRIPTION
#### 773d3731d40eda83458bd4224800cf0ba4f3949f
<pre>
Add message check support to StreamServerConnection
<a href="https://bugs.webkit.org/show_bug.cgi?id=283399">https://bugs.webkit.org/show_bug.cgi?id=283399</a>
<a href="https://rdar.apple.com/140257762">rdar://140257762</a>

Reviewed by Kimmo Kinnunen.

MESSAGE_CHECK currently invokes markCurrentlyDispatchedMessageAsInvalid() on connection when check fails. To enable
message check on StreamServerConnection, add StreamServerConnection::markCurrentlyDispatchedMessageAsInvalid(). With
this change, RemoteGraphicsContextGL could do message check in message handler functions and we could remove EnabledIf
annotation in RemoteGraphicsContextGL.messages.in. EnabledIf currently overlaps with both EnabledBy and MESSAGE_CHECK,
and we will drop it soon to avoid confusion.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::messageCheck):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(createExternalImage):
(deleteExternalImage):
(bindExternalImage):
(createExternalSync):
(deleteExternalSync):
(enableRequiredWebXRExtensions):
(addFoveation):
(enableFoveation):
(disableFoveation):
(framebufferDiscard):
(framebufferResolveRenderbuffer):
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::dispatchStreamMessage):
(IPC::StreamServerConnection::markCurrentlyDispatchedMessageAsInvalid):
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Tools/Scripts/generate-gpup-webgl:
(cpp_func):
(cpp_func.__init__):
(webkit_ipc_msg):
(webkit_ipc_msg.__init__):
(webkit_ipc_msg.__str__):
(webkit_ipc_cpp_impl.__init__):
(create_cpp_arg_list):
(create_cpp_func):
(main):

Canonical link: <a href="https://commits.webkit.org/286924@main">https://commits.webkit.org/286924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5970e1d19d626ee006c8cce0c7f05c18691d98a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82109 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28801 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4851 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60743 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18741 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50714 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66535 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41017 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48115 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24031 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27125 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69225 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83509 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4899 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68973 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5055 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66502 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68238 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17056 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12259 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10354 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4846 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/4865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/8300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6624 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->