### PR TITLE
[scroll-animations] disconnecting an element that originated a progress-based timeline should unregister that timeline

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7359,8 +7359,6 @@ imported/w3c/web-platform-tests/dom/events/scrolling/input-text-scroll-event-whe
 # webkit.org/b/263870 [scroll-animations] some WPT tests are timing out
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-with-scroll-timeline-in-auto-subtree.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/css/deferred-timeline-composited.html [ Skip ]
-imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-range-animation.html [ Skip ]
-imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animation.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-root-scroller.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/constructor-no-document.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/updating-the-finished-state.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
@@ -4,9 +4,9 @@ PASS scroll-timeline-name is referenceable in animation-timeline on that element
 FAIL scroll-timeline-name is not referenceable in animation-timeline on that element's siblings assert_equals: Animation with unknown timeline name holds current time at zero expected "50px" but got "none"
 PASS scroll-timeline-name on an element which is not a scroll-container
 FAIL Change in scroll-timeline-name to match animation timeline updates animation. assert_equals: expected null but got object "[object DocumentTimeline]"
-FAIL Change in scroll-timeline-name to no longer match animation timeline updates animation. assert_equals: expected "75px" but got "none"
+FAIL Change in scroll-timeline-name to no longer match animation timeline updates animation. assert_equals: Failed to remove timeline expected null but got object "[object ScrollTimeline]"
 FAIL Timeline lookup updates candidate when closer match available. assert_equals: Timeline not updated expected "B" but got "A"
-FAIL Timeline lookup updates candidate when match becomes available. assert_equals: expected "50px" but got "none"
+PASS Timeline lookup updates candidate when match becomes available.
 FAIL scroll-timeline-axis is block assert_equals: expected "50" but got "0"
 FAIL scroll-timeline-axis is inline assert_equals: expected "50" but got "0"
 PASS scroll-timeline-axis is x

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-inactive-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-inactive-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Animation does not apply when the timeline is inactive because there is not scroll range
-FAIL Animation does not apply when timeline is initially inactive promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: scroller"
+FAIL Animation does not apply when timeline is initially inactive assert_equals: expected "0px" but got "100px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-range-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-range-animation-expected.txt
@@ -1,12 +1,10 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS Animation with ranges [initial, initial]
-TIMEOUT Animation with ranges [0%, 100%] Test timed out
-NOTRUN Animation with ranges [10%, 100%]
-NOTRUN Animation with ranges [0%, 50%]
-NOTRUN Animation with ranges [10%, 50%]
-NOTRUN Animation with ranges [150px, 75em]
-NOTRUN Animation with ranges [calc(1% + 135px), calc(70em + 50px)]
-NOTRUN Animation with ranges [calc(1% + 135px), calc(70em + 50px)] (scoped)
+PASS Animation with ranges [0%, 100%]
+PASS Animation with ranges [10%, 100%]
+PASS Animation with ranges [0%, 50%]
+PASS Animation with ranges [10%, 50%]
+PASS Animation with ranges [150px, 75em]
+PASS Animation with ranges [calc(1% + 135px), calc(70em + 50px)]
+FAIL Animation with ranges [calc(1% + 135px), calc(70em + 50px)] (scoped) assert_equals: expected "0" but got "100"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
@@ -7,6 +7,6 @@ FAIL Dynamically re-attaching assert_equals: expected "100px" but got "0px"
 FAIL Dynamically detaching assert_equals: expected "0px" but got "100px"
 FAIL Removing/inserting element with attaching timeline assert_equals: expected "100px" but got "0px"
 FAIL Ancestor attached element becoming display:none/block assert_equals: expected "100px" but got "0px"
-FAIL A deferred timeline appearing dynamically in the ancestor chain assert_equals: expected "0px" but got "100px"
+FAIL A deferred timeline appearing dynamically in the ancestor chain assert_equals: expected "100px" but got "0px"
 PASS Animations prefer non-deferred timelines
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animation-expected.txt
@@ -1,20 +1,18 @@
 
-Harness Error (TIMEOUT), message = null
-
 FAIL Animation with ranges [initial, initial] assert_equals: expected "0" but got "100"
-TIMEOUT Animation with ranges [cover 0%, cover 100%] Test timed out
-NOTRUN Animation with ranges [contain 0%, contain 100%]
-NOTRUN Animation with ranges [entry 0%, entry 100%]
-NOTRUN Animation with ranges [exit 0%, exit 100%]
-NOTRUN Animation with ranges [contain -50%, entry 200%]
-NOTRUN Animation with ranges [entry 0%, exit 100%]
-NOTRUN Animation with ranges [cover 20px, cover 100px]
-NOTRUN Animation with ranges [contain 20px, contain 100px]
-NOTRUN Animation with ranges [entry 20px, entry 100px]
-NOTRUN Animation with ranges [entry-crossing 20px, entry-crossing 100px]
-NOTRUN Animation with ranges [exit 20px, exit 80px]
-NOTRUN Animation with ranges [exit-crossing 20px, exit-crossing 80px]
-NOTRUN Animation with ranges [contain 20px, contain calc(100px - 10%)]
-NOTRUN Animation with ranges [exit 2em, exit 8em]
-NOTRUN Animation with ranges [exit 2em, exit 8em] (scoped)
+FAIL Animation with ranges [cover 0%, cover 100%] assert_equals: expected "0" but got "100"
+FAIL Animation with ranges [contain 0%, contain 100%] assert_equals: expected "0" but got "100"
+FAIL Animation with ranges [entry 0%, entry 100%] assert_equals: expected "50" but got "0"
+FAIL Animation with ranges [exit 0%, exit 100%] assert_equals: expected "0" but got "100"
+FAIL Animation with ranges [contain -50%, entry 200%] assert_equals: expected "0" but got "-1"
+FAIL Animation with ranges [entry 0%, exit 100%] assert_equals: expected "0" but got "100"
+FAIL Animation with ranges [cover 20px, cover 100px] assert_equals: expected "0" but got "100"
+FAIL Animation with ranges [contain 20px, contain 100px] assert_equals: expected "0" but got "100"
+FAIL Animation with ranges [entry 20px, entry 100px] assert_equals: expected "0" but got "100"
+FAIL Animation with ranges [entry-crossing 20px, entry-crossing 100px] assert_equals: expected "0" but got "100"
+FAIL Animation with ranges [exit 20px, exit 80px] assert_equals: expected "0" but got "100"
+FAIL Animation with ranges [exit-crossing 20px, exit-crossing 80px] assert_equals: expected "0" but got "100"
+FAIL Animation with ranges [contain 20px, contain calc(100px - 10%)] assert_equals: expected "0" but got "100"
+FAIL Animation with ranges [exit 2em, exit 8em] assert_equals: expected "0" but got "100"
+FAIL Animation with ranges [exit 2em, exit 8em] (scoped) assert_equals: expected "0" but got "100"
 

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -575,6 +575,23 @@ bool AnimationTimelinesController::isPendingTimelineAttachment(const WebAnimatio
     });
 }
 
+void AnimationTimelinesController::unregisterNamedTimelinesAssociatedWithElement(const Element& element)
+{
+    HashSet<AtomString> namesToClear;
+
+    for (auto& entry : m_nameToTimelineMap) {
+        auto& timelines = entry.value;
+        timelines.removeAllMatching([&] (const auto& timeline) {
+            return originatingElement(timeline) == &element;
+        });
+        if (timelines.isEmpty())
+            namesToClear.add(entry.key);
+    }
+
+    for (auto& name : namesToClear)
+        m_nameToTimelineMap.remove(name);
+}
+
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 AcceleratedEffectStackUpdater& AnimationTimelinesController::acceleratedEffectStackUpdater()
 {

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -86,6 +86,7 @@ public:
     void setTimelineForName(const AtomString&, const Element&, WebAnimation&);
     void updateNamedTimelineMapForTimelineScope(const TimelineScope&, const Element&);
     void updateTimelineForTimelineScope(const Ref<ScrollTimeline>&, const AtomString&);
+    void unregisterNamedTimelinesAssociatedWithElement(const Element&);
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     AcceleratedEffectStackUpdater* existingAcceleratedEffectStackUpdater() const { return m_acceleratedEffectStackUpdater.get(); }

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -302,6 +302,8 @@ void Styleable::willChangeRenderer() const
 void Styleable::cancelStyleOriginatedAnimations() const
 {
     cancelStyleOriginatedAnimations({ });
+    if (CheckedPtr timelinesController = element.protectedDocument()->timelinesController())
+        timelinesController->unregisterNamedTimelinesAssociatedWithElement(element);
 }
 
 void Styleable::cancelStyleOriginatedAnimations(const WeakStyleOriginatedAnimations& animationsToCancelSilently) const


### PR DESCRIPTION
#### f7146076edb1f70a396a41a77c93a183e7145ff3
<pre>
[scroll-animations] disconnecting an element that originated a progress-based timeline should unregister that timeline
<a href="https://bugs.webkit.org/show_bug.cgi?id=283400">https://bugs.webkit.org/show_bug.cgi?id=283400</a>
<a href="https://rdar.apple.com/140260419">rdar://140260419</a>

Reviewed by Anne van Kesteren.

Ensure we unregister all named timelines associated with an element that gets disconnected.

This was the reason why two WPT tests were timing out:

- scroll-animations/css/scroll-timeline-range-animation.html
- scroll-animations/css/view-timeline-range-animation.html

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-inactive-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-range-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animation-expected.txt:
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::unregisterNamedTimelinesAssociatedWithElement):
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::cancelStyleOriginatedAnimations const):

Canonical link: <a href="https://commits.webkit.org/286955@main">https://commits.webkit.org/286955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a56b9166c4857a888368e8e0debcebafdd847367

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82361 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28912 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79750 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4967 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18801 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66624 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41184 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48190 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24119 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27243 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69303 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24462 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83636 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5014 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3410 "Found 1 new test failure: ipc/create-connection-and-send-async.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69061 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68318 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12329 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10427 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12028 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4961 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4976 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8414 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6739 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->