### PR TITLE
ANGLE translator fuzzer runs with resources incompatible with the output

### DIFF
--- a/Source/ThirdParty/ANGLE/WebKit/TranslatorFuzzer.cpp
+++ b/Source/ThirdParty/ANGLE/WebKit/TranslatorFuzzer.cpp
@@ -169,30 +169,13 @@ bool initializeTranslators()
                 TCompiler* translator = ConstructCompiler(type, spec, output);
                 ShBuiltInResources resources;
                 sh::InitBuiltInResources(&resources);
-                // Enable all the extensions to have more coverage
-                resources.OES_standard_derivatives        = 1;
-                resources.OES_EGL_image_external          = 1;
-                resources.OES_EGL_image_external_essl3    = 1;
-                resources.NV_EGL_stream_consumer_external = 1;
-                resources.ARB_texture_rectangle           = 1;
-                resources.EXT_blend_func_extended         = 1;
-                resources.EXT_conservative_depth          = 1;
-                resources.EXT_draw_buffers                = 1;
-                resources.EXT_frag_depth                  = 1;
-                resources.EXT_shader_texture_lod          = 1;
-                resources.EXT_shader_framebuffer_fetch    = 1;
-                resources.NV_shader_framebuffer_fetch     = 1;
-                resources.ARM_shader_framebuffer_fetch    = 1;
-                resources.EXT_YUV_target                  = 1;
-                resources.APPLE_clip_distance             = 1;
-                resources.MaxDualSourceDrawBuffers        = 1;
-                resources.EXT_gpu_shader5                 = 1;
-                resources.MaxClipDistances                = 1;
-                resources.EXT_shadow_samplers             = 1;
-                resources.EXT_clip_cull_distance          = 1;
-                resources.ANGLE_clip_cull_distance        = 1;
-                resources.EXT_primitive_bounding_box      = 1;
-                resources.OES_primitive_bounding_box      = 1;
+                const bool any = true;
+                const bool msl = output == SH_MSL_METAL_OUTPUT;
+#define ENABLE_EXTENSION(name, forced) if ((forced)) resources.name = 1;
+                FOR_EACH_SH_BUILT_IN_RESOURCES_EXTENSION_OPTION(ENABLE_EXTENSION);
+#undef ENABLE_EXTENSION
+                resources.MaxDualSourceDrawBuffers = 1;
+                resources.MaxDrawBuffers = 8;
                 if (!translator->Init(resources))
                     return false;
                 translators[translatorsCount++] = { translator, type, spec, output };

--- a/Source/ThirdParty/ANGLE/WebKit/TranslatorFuzzerDumpTestCase.cpp
+++ b/Source/ThirdParty/ANGLE/WebKit/TranslatorFuzzerDumpTestCase.cpp
@@ -143,6 +143,13 @@ int main(int argc, const char * argv[])
         filterOptions(header.output, header.options);
         std::cout << "TEST(CompilerWorksTest, Test" << i << ")";
         std::cout << testContent1;
+        const bool any = true;
+        const bool msl = header.output == SH_MSL_METAL_OUTPUT;
+#define COUT_EXTENSION(NAME, FORCE) if ((FORCE)) std::cout << "    resources." #NAME " = 1;" << std::endl;
+        FOR_EACH_SH_BUILT_IN_RESOURCES_EXTENSION_OPTION(COUT_EXTENSION);
+#undef COUT_EXTENSION
+        std::cout << "    resources.MaxDualSourceDrawBuffers = 1;" << std::endl;
+        std::cout << "    resources.MaxDrawBuffers = 8;" << std::endl;
 #define COUT_OPTION(NAME, I, ALLOW, FORCE) if (header.options.NAME) std::cout << "    options." #NAME " = true;" << std::endl;
         FOR_EACH_SH_COMPILE_OPTIONS_BOOL_OPTION(COUT_OPTION);
 #undef COUT_OPTION

--- a/Source/ThirdParty/ANGLE/WebKit/TranslatorFuzzerSupport.h
+++ b/Source/ThirdParty/ANGLE/WebKit/TranslatorFuzzerSupport.h
@@ -113,6 +113,64 @@
 void filterOptions(ShShaderOutput output, ShCompileOptions& options);
 ShShaderOutput resolveShaderOutput(ShShaderOutput output);
 
+#define FOR_EACH_SH_BUILT_IN_RESOURCES_EXTENSION_OPTION(MACRO) \
+    MACRO(OES_standard_derivatives, any) \
+    MACRO(OES_EGL_image_external, any) \
+    MACRO(OES_EGL_image_external_essl3, !msl) \
+    MACRO(NV_EGL_stream_consumer_external, !msl) \
+    MACRO(ARB_texture_rectangle, !msl) \
+    MACRO(EXT_blend_func_extended, any) \
+    MACRO(EXT_conservative_depth, any) \
+    MACRO(EXT_draw_buffers, any) \
+    MACRO(EXT_frag_depth, any) \
+    MACRO(EXT_shader_texture_lod, any) \
+    MACRO(EXT_shader_framebuffer_fetch, !msl) \
+    MACRO(EXT_shader_framebuffer_fetch_non_coherent, !msl) \
+    MACRO(NV_shader_framebuffer_fetch, !msl) \
+    MACRO(NV_shader_noperspective_interpolation, any) \
+    MACRO(ARM_shader_framebuffer_fetch, !msl) \
+    MACRO(ARM_shader_framebuffer_fetch_depth_stencil, !msl) \
+    MACRO(OVR_multiview, !msl) \
+    MACRO(OVR_multiview2, !msl) \
+    MACRO(EXT_multisampled_render_to_texture, any) \
+    MACRO(EXT_multisampled_render_to_texture2, !msl) \
+    MACRO(EXT_YUV_target, !msl) \
+    MACRO(EXT_geometry_shader, !msl) \
+    MACRO(OES_geometry_shader, !msl) \
+    MACRO(OES_shader_io_blocks, !msl) \
+    MACRO(EXT_shader_io_blocks, !msl) \
+    MACRO(EXT_gpu_shader5, !msl) \
+    MACRO(OES_gpu_shader5, !msl) \
+    MACRO(EXT_shader_non_constant_global_initializers, !msl) \
+    MACRO(OES_texture_storage_multisample_2d_array, !msl) \
+    MACRO(OES_texture_3D, any) \
+    MACRO(ANGLE_shader_pixel_local_storage, any) \
+    MACRO(ANGLE_texture_multisample, !msl) \
+    MACRO(ANGLE_multi_draw, !msl) \
+    MACRO(ANGLE_base_vertex_base_instance, any) \
+    MACRO(WEBGL_video_texture, !msl) \
+    MACRO(APPLE_clip_distance, any) \
+    MACRO(OES_texture_cube_map_array, !msl) \
+    MACRO(EXT_texture_cube_map_array, !msl) \
+    MACRO(EXT_texture_query_lod, !msl) \
+    MACRO(EXT_texture_shadow_lod, any) \
+    MACRO(EXT_shadow_samplers, !msl) \
+    MACRO(OES_shader_multisample_interpolation, any) \
+    MACRO(OES_shader_image_atomic, !msl) \
+    MACRO(EXT_tessellation_shader, !msl) \
+    MACRO(OES_tessellation_shader, !msl) \
+    MACRO(OES_texture_buffer, !msl) \
+    MACRO(EXT_texture_buffer, !msl) \
+    MACRO(OES_sample_variables, any) \
+    MACRO(EXT_clip_cull_distance, !msl) \
+    MACRO(ANGLE_clip_cull_distance, any) \
+    MACRO(EXT_primitive_bounding_box, !msl) \
+    MACRO(OES_primitive_bounding_box, !msl) \
+    MACRO(EXT_separate_shader_objects, !msl) \
+    MACRO(ANGLE_base_vertex_base_instance_shader_builtin, any) \
+    MACRO(ANDROID_extension_pack_es31a, !msl) \
+    MACRO(KHR_blend_equation_advanced, !msl)
+
 struct GLSLDumpHeader {
     static constexpr int kHeaderSize = 128;
     static constexpr int kBaseOptionsSize = offsetof(ShCompileOptions, metal);


### PR DESCRIPTION
#### 0f6c7e4175f921ca35157e448b1708d468dffe35
<pre>
ANGLE translator fuzzer runs with resources incompatible with the output
<a href="https://bugs.webkit.org/show_bug.cgi?id=283406">https://bugs.webkit.org/show_bug.cgi?id=283406</a>
<a href="https://rdar.apple.com/140263046">rdar://140263046</a>

Reviewed by Tadeu Zagallo.

Filter the resources based on the output type. As an example, MSL output
does not support ARB_texture_rectangle, so fuzzer finding
texture2DRect() asserts needlessly. The backend does not enable this.

Only filter MSL extensions correctly for now.

* Source/ThirdParty/ANGLE/WebKit/TranslatorFuzzer.cpp:
(sh::initializeTranslators):
* Source/ThirdParty/ANGLE/WebKit/TranslatorFuzzerDumpTestCase.cpp:
* Source/ThirdParty/ANGLE/WebKit/TranslatorFuzzerSupport.h:

Canonical link: <a href="https://commits.webkit.org/286907@main">https://commits.webkit.org/286907@main</a>
</pre>
