### PR TITLE
REGRESSION (284079@main): [ MacOS Wk1 ] 5X imported/w3c/web-platform-tests & 4X http/tests/xmlhttprequest tests are constant crashes

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2988,18 +2988,6 @@ imported/w3c/web-platform-tests/clipboard-apis/clipboard-item.https.html [ Skip 
 
 webkit.org/b/281594 imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-load-error-events.html [ Pass Failure ]
 
-# webkit.org/b/282889 REGRESSION (284079@main): [ MacOS Wk1 ] 5X imported/w3c/web-platform-tests & 4X http/tests/xmlhttprequest tests are constant crashes 
-[ Sonoma+ ] http/tests/xmlhttprequest/access-control-and-redirects-async.html [ Skip ]
-[ Sonoma+ ] http/tests/xmlhttprequest/access-control-preflight-not-successful.html [ Skip ]
-[ Sonoma+ ] http/tests/xmlhttprequest/on-network-timeout-error-during-preflight.html [ Skip ]
-[ Sonoma+ ] http/tests/xmlhttprequest/simple-cross-origin-denied-events-post.html [ Skip ]
-[ Sonoma+ ] imported/w3c/web-platform-tests/cors/preflight-failure.htm [ Skip ]
-[ Sonoma+ ] imported/w3c/web-platform-tests/xhr/access-control-and-redirects-async.any.html [ Skip ]
-[ Sonoma+ ] imported/w3c/web-platform-tests/xhr/access-control-and-redirects-async.any.worker.html [ Skip ]
-[ Sonoma+ ] imported/w3c/web-platform-tests/xhr/event-error-order.sub.html [ Skip ]
-[ Sonoma+ ] imported/w3c/web-platform-tests/xhr/send-authentication-basic-cors.htm [ Skip ]
-[ Sonoma+ ] imported/w3c/web-platform-tests/xhr/send-network-error-async-events.sub.htm [ Skip ]
-
 # webkit.org/b/281923  [ Sequoia+ ] 3 tests in http/tests/cookies/same-site are constant failure (failure in EWS)
 [ Sequoia+ ] http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html [ Failure ]
 [ Sequoia+ ] http/tests/cookies/same-site/popup-cross-site-post.html [ Failure ]

--- a/Source/WebCore/loader/CrossOriginPreflightChecker.h
+++ b/Source/WebCore/loader/CrossOriginPreflightChecker.h
@@ -58,7 +58,7 @@ private:
     void redirectReceived(CachedResource&, ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&) final;
 
     static void handleLoadingFailure(DocumentThreadableLoader&, unsigned long, const ResourceError&);
-    static void validatePreflightResponse(DocumentThreadableLoader&, ResourceRequest&&, ResourceLoaderIdentifier, const ResourceResponse&);
+    static void validatePreflightResponse(DocumentThreadableLoader&, ResourceRequest&&, std::optional<ResourceLoaderIdentifier>, const ResourceResponse&);
     Ref<DocumentThreadableLoader> protectedLoader() const;
 
     SingleThreadWeakRef<DocumentThreadableLoader> m_loader;

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -978,7 +978,7 @@ void DocumentLoader::responseReceived(const ResourceResponse& response, Completi
         return;
 
     ASSERT(m_identifierForLoadWithoutResourceLoader || m_mainResource);
-    ResourceLoaderIdentifier identifier = m_identifierForLoadWithoutResourceLoader ? *m_identifierForLoadWithoutResourceLoader : *m_mainResource->identifier();
+    ResourceLoaderIdentifier identifier = m_identifierForLoadWithoutResourceLoader ? *m_identifierForLoadWithoutResourceLoader : *m_mainResource->resourceLoaderIdentifier();
 
     if (m_substituteData.isValid() || !platformStrategies()->loaderStrategy()->havePerformedSecurityChecks(response)) {
         auto url = response.url();
@@ -1101,7 +1101,7 @@ bool DocumentLoader::disallowDataRequest() const
         return false;
 
     if (RefPtr currentDocument = frame()->document()) {
-        ResourceLoaderIdentifier identifier = m_identifierForLoadWithoutResourceLoader ? *m_identifierForLoadWithoutResourceLoader : *m_mainResource->identifier();
+        ResourceLoaderIdentifier identifier = m_identifierForLoadWithoutResourceLoader ? *m_identifierForLoadWithoutResourceLoader : *m_mainResource->resourceLoaderIdentifier();
         currentDocument->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Not allowed to navigate top frame to data URL '"_s, m_response.url().stringCenterEllipsizedToLength(), "'."_s), identifier.toUInt64());
     }
     DOCUMENTLOADER_RELEASE_LOG("continueAfterContentPolicy: cannot show URL");

--- a/Source/WebCore/loader/DocumentThreadableLoader.h
+++ b/Source/WebCore/loader/DocumentThreadableLoader.h
@@ -102,7 +102,7 @@ class CachedRawResource;
         void makeSimpleCrossOriginAccessRequest(ResourceRequest&&);
         void makeCrossOriginAccessRequestWithPreflight(ResourceRequest&&);
         void preflightSuccess(ResourceRequest&&);
-        void preflightFailure(ResourceLoaderIdentifier, const ResourceError&);
+        void preflightFailure(std::optional<ResourceLoaderIdentifier>, const ResourceError&);
 
         void loadRequest(ResourceRequest&&, SecurityCheckPolicy);
         bool isAllowedRedirect(const URL&);

--- a/Source/WebCore/loader/cache/CachedRawResource.cpp
+++ b/Source/WebCore/loader/cache/CachedRawResource.cpp
@@ -231,8 +231,8 @@ void CachedRawResource::redirectReceived(ResourceRequest&& request, const Resour
 void CachedRawResource::responseReceived(const ResourceResponse& newResponse)
 {
     CachedResourceHandle protectedThis { this };
-    if (!m_identifier)
-        m_identifier = m_loader->identifier();
+    if (!m_resourceLoaderIdentifier)
+        m_resourceLoaderIdentifier = m_loader->identifier();
     CachedResource::responseReceived(newResponse);
     CachedResourceClientWalker<CachedRawResourceClient> walker(*this);
     while (CachedRawResourceClient* c = walker.next())
@@ -267,8 +267,8 @@ void CachedRawResource::switchClientsToRevalidatedResource()
 {
     ASSERT(m_loader);
     // If we're in the middle of a successful revalidation, responseReceived() hasn't been called, so we haven't set m_identifier.
-    ASSERT(!m_identifier);
-    downcast<CachedRawResource>(*resourceToRevalidate()).m_identifier = m_loader->identifier();
+    ASSERT(!m_resourceLoaderIdentifier);
+    downcast<CachedRawResource>(*resourceToRevalidate()).m_resourceLoaderIdentifier = m_loader->identifier();
     CachedResource::switchClientsToRevalidatedResource();
 }
 

--- a/Source/WebCore/loader/cache/CachedRawResource.h
+++ b/Source/WebCore/loader/cache/CachedRawResource.h
@@ -40,7 +40,7 @@ public:
     void setDataBufferingPolicy(DataBufferingPolicy);
 
     // FIXME: This is exposed for the InspectorInstrumentation for preflights in DocumentThreadableLoader. It's also really lame.
-    std::optional<ResourceLoaderIdentifier> identifier() const { return m_identifier; }
+    std::optional<ResourceLoaderIdentifier> resourceLoaderIdentifier() const { return m_resourceLoaderIdentifier; }
 
     void clear();
 
@@ -74,7 +74,7 @@ private:
     void previewResponseReceived(const ResourceResponse&) final;
 #endif
 
-    Markable<ResourceLoaderIdentifier> m_identifier;
+    Markable<ResourceLoaderIdentifier> m_resourceLoaderIdentifier;
 
     struct RedirectPair {
     public:


### PR DESCRIPTION
#### 71c1b82e44649d192e2681002b07e9586ec3e5dc
<pre>
REGRESSION (284079@main): [ MacOS Wk1 ] 5X imported/w3c/web-platform-tests &amp; 4X http/tests/xmlhttprequest tests are constant crashes
<a href="https://rdar.apple.com/139585982">rdar://139585982</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=282889">https://bugs.webkit.org/show_bug.cgi?id=282889</a>

Reviewed by Chris Dumez.

Rename CachedRawResource::identifier() to CachedRawResource::resourceLoaderIdentifier().
This clarifies why this identifier may not always be there in case of failure.

Add a check in DocumentThreadableLoader::preflightFailure for the identifier since we now pass an optional.

* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/loader/CrossOriginPreflightChecker.cpp:
(WebCore::CrossOriginPreflightChecker::validatePreflightResponse):
(WebCore::CrossOriginPreflightChecker::notifyFinished):
(WebCore::CrossOriginPreflightChecker::redirectReceived):
* Source/WebCore/loader/CrossOriginPreflightChecker.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::responseReceived):
(WebCore::DocumentLoader::disallowDataRequest const):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::responseReceived):
(WebCore::DocumentThreadableLoader::dataReceived):
(WebCore::DocumentThreadableLoader::notifyFinished):
(WebCore::DocumentThreadableLoader::preflightFailure):
* Source/WebCore/loader/DocumentThreadableLoader.h:
* Source/WebCore/loader/cache/CachedRawResource.cpp:
(WebCore::CachedRawResource::responseReceived):
(WebCore::CachedRawResource::switchClientsToRevalidatedResource):
* Source/WebCore/loader/cache/CachedRawResource.h:

Canonical link: <a href="https://commits.webkit.org/286901@main">https://commits.webkit.org/286901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43c443a20b7ed8c454e3892df0dd9314d88d5935

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82030 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28731 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79566 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65632 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4781 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60688 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18692 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40971 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48060 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23973 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27054 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69170 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24311 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83438 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3276 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68935 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4985 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66445 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68199 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17037 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12196 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10297 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4776 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4795 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8230 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6554 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->