### PR TITLE
Implement CanvasRenderingContext2D letterSpacing/wordSpacing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.letter_spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.letter_spacing-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset assert_true: ctx.letterSpacing == default_value expected true got false
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.word_spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.word_spacing-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset assert_true: ctx.wordSpacing == default_value expected true got false
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.absolute.spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.absolute.spacing-expected.txt
@@ -2,5 +2,5 @@
 Testing letter spacing and word spacing with absolute length
 Actual output:
 
-FAIL Testing letter spacing and word spacing with absolute length assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Testing letter spacing and word spacing with absolute length
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.font-relative.spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.font-relative.spacing-expected.txt
@@ -2,5 +2,5 @@
 Testing letter spacing and word spacing with font-relative length
 Actual output:
 
-FAIL Testing letter spacing and word spacing with font-relative length assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Testing letter spacing and word spacing with font-relative length
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.invalid.spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.invalid.spacing-expected.txt
@@ -2,5 +2,5 @@
 Testing letter spacing and word spacing with invalid units
 Actual output:
 
-FAIL Testing letter spacing and word spacing with invalid units assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Testing letter spacing and word spacing with invalid units
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.letterSpacing.change.font-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.letterSpacing.change.font-expected.txt
@@ -2,5 +2,5 @@
 Set letter spacing and word spacing to font dependent value and verify it works after font change.
 Actual output:
 
-FAIL Set letter spacing and word spacing to font dependent value and verify it works after font change. assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Set letter spacing and word spacing to font dependent value and verify it works after font change.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.letterSpacing.measure-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.letterSpacing.measure-expected.txt
@@ -2,5 +2,5 @@
 Testing letter spacing with different length units
 Actual output:
 
-FAIL Testing letter spacing with different length units assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Testing letter spacing with different length units
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.nonfinite.spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.nonfinite.spacing-expected.txt
@@ -2,5 +2,5 @@
 Testing letter spacing and word spacing with nonfinite inputs
 Actual output:
 
-FAIL Testing letter spacing and word spacing with nonfinite inputs assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Testing letter spacing and word spacing with nonfinite inputs
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.wordSpacing.change.font-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.wordSpacing.change.font-expected.txt
@@ -2,5 +2,5 @@
 Set word spacing and word spacing to font dependent value and verify it works after font change.
 Actual output:
 
-FAIL Set word spacing and word spacing to font dependent value and verify it works after font change. assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Set word spacing and word spacing to font dependent value and verify it works after font change.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.wordSpacing.measure-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.wordSpacing.measure-expected.txt
@@ -2,5 +2,5 @@
 Testing word spacing with different length units
 Actual output:
 
-FAIL Testing word spacing with different length units assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Testing word spacing with different length units
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.letter_spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.letter_spacing-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset assert_true: ctx.letterSpacing == default_value expected true got false
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.letter_spacing.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.letter_spacing.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset assert_true: ctx.letterSpacing == default_value expected true got false
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.word_spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.word_spacing-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset assert_true: ctx.wordSpacing == default_value expected true got false
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.word_spacing.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.word_spacing.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset assert_true: ctx.wordSpacing == default_value expected true got false
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.absolute.spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.absolute.spacing-expected.txt
@@ -3,5 +3,5 @@
 Testing letter spacing and word spacing with absolute length
 
 
-FAIL Testing letter spacing and word spacing with absolute length assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Testing letter spacing and word spacing with absolute length
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.absolute.spacing.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.absolute.spacing.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Testing letter spacing and word spacing with absolute length assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Testing letter spacing and word spacing with absolute length
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.font-relative.spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.font-relative.spacing-expected.txt
@@ -3,5 +3,5 @@
 Testing letter spacing and word spacing with font-relative length
 
 
-FAIL Testing letter spacing and word spacing with font-relative length assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Testing letter spacing and word spacing with font-relative length
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.font-relative.spacing.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.font-relative.spacing.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Testing letter spacing and word spacing with font-relative length assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Testing letter spacing and word spacing with font-relative length
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.invalid.spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.invalid.spacing-expected.txt
@@ -3,5 +3,5 @@
 Testing letter spacing and word spacing with invalid units
 
 
-FAIL Testing letter spacing and word spacing with invalid units assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Testing letter spacing and word spacing with invalid units
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.invalid.spacing.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.invalid.spacing.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Testing letter spacing and word spacing with invalid units assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Testing letter spacing and word spacing with invalid units
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.change.font-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.change.font-expected.txt
@@ -3,5 +3,5 @@
 Set letter spacing and word spacing to font dependent value and verify it works after font change.
 
 
-FAIL Set letter spacing and word spacing to font dependent value and verify it works after font change. assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Set letter spacing and word spacing to font dependent value and verify it works after font change.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.change.font.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.change.font.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Set letter spacing and word spacing to font dependent value and verify it works after font change. assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Set letter spacing and word spacing to font dependent value and verify it works after font change.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.measure-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.measure-expected.txt
@@ -3,5 +3,5 @@
 Testing letter spacing with different length units
 
 
-FAIL Testing letter spacing with different length units assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Testing letter spacing with different length units
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.measure.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.measure.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Testing letter spacing with different length units assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Testing letter spacing with different length units
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.nonfinite.spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.nonfinite.spacing-expected.txt
@@ -3,5 +3,5 @@
 Testing letter spacing and word spacing with nonfinite inputs
 
 
-FAIL Testing letter spacing and word spacing with nonfinite inputs assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Testing letter spacing and word spacing with nonfinite inputs
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.nonfinite.spacing.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.nonfinite.spacing.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Testing letter spacing and word spacing with nonfinite inputs assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Testing letter spacing and word spacing with nonfinite inputs
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.change.font-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.change.font-expected.txt
@@ -3,5 +3,5 @@
 Set word spacing and word spacing to font dependent value and verify it works after font change.
 
 
-FAIL Set word spacing and word spacing to font dependent value and verify it works after font change. assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Set word spacing and word spacing to font dependent value and verify it works after font change.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.change.font.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.change.font.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Set word spacing and word spacing to font dependent value and verify it works after font change. assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Set word spacing and word spacing to font dependent value and verify it works after font change.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.measure-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.measure-expected.txt
@@ -3,5 +3,5 @@
 Testing word spacing with different length units
 
 
-FAIL Testing word spacing with different length units assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Testing word spacing with different length units
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.measure.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.measure.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Testing word spacing with different length units assert_equals: ctx.letterSpacing === '0px' (got [undefined], expected 0px[string]) expected (string) "0px" but got (undefined) undefined
+PASS Testing word spacing with different length units
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
@@ -501,12 +501,12 @@ PASS CanvasRenderingContext2D interface: attribute font
 PASS CanvasRenderingContext2D interface: attribute textAlign
 PASS CanvasRenderingContext2D interface: attribute textBaseline
 PASS CanvasRenderingContext2D interface: attribute direction
-FAIL CanvasRenderingContext2D interface: attribute letterSpacing assert_true: The prototype object must have a property "letterSpacing" expected true got false
+PASS CanvasRenderingContext2D interface: attribute letterSpacing
 FAIL CanvasRenderingContext2D interface: attribute fontKerning assert_true: The prototype object must have a property "fontKerning" expected true got false
 FAIL CanvasRenderingContext2D interface: attribute fontStretch assert_true: The prototype object must have a property "fontStretch" expected true got false
 FAIL CanvasRenderingContext2D interface: attribute fontVariantCaps assert_true: The prototype object must have a property "fontVariantCaps" expected true got false
 FAIL CanvasRenderingContext2D interface: attribute textRendering assert_true: The prototype object must have a property "textRendering" expected true got false
-FAIL CanvasRenderingContext2D interface: attribute wordSpacing assert_true: The prototype object must have a property "wordSpacing" expected true got false
+PASS CanvasRenderingContext2D interface: attribute wordSpacing
 PASS CanvasRenderingContext2D interface: operation closePath()
 PASS CanvasRenderingContext2D interface: operation moveTo(unrestricted double, unrestricted double)
 PASS CanvasRenderingContext2D interface: operation lineTo(unrestricted double, unrestricted double)
@@ -625,12 +625,12 @@ PASS CanvasRenderingContext2D interface: document.createElement("canvas").getCon
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "textAlign" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "textBaseline" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "direction" with the proper type
-FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "letterSpacing" with the proper type assert_inherits: property "letterSpacing" not found in prototype chain
+PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "letterSpacing" with the proper type
 FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "fontKerning" with the proper type assert_inherits: property "fontKerning" not found in prototype chain
 FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "fontStretch" with the proper type assert_inherits: property "fontStretch" not found in prototype chain
 FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "fontVariantCaps" with the proper type assert_inherits: property "fontVariantCaps" not found in prototype chain
 FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "textRendering" with the proper type assert_inherits: property "textRendering" not found in prototype chain
-FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "wordSpacing" with the proper type assert_inherits: property "wordSpacing" not found in prototype chain
+PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "wordSpacing" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "closePath()" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "moveTo(unrestricted double, unrestricted double)" with the proper type
 PASS CanvasRenderingContext2D interface: calling moveTo(unrestricted double, unrestricted double) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError
@@ -812,12 +812,12 @@ PASS OffscreenCanvasRenderingContext2D interface: attribute font
 PASS OffscreenCanvasRenderingContext2D interface: attribute textAlign
 PASS OffscreenCanvasRenderingContext2D interface: attribute textBaseline
 PASS OffscreenCanvasRenderingContext2D interface: attribute direction
-FAIL OffscreenCanvasRenderingContext2D interface: attribute letterSpacing assert_true: The prototype object must have a property "letterSpacing" expected true got false
+PASS OffscreenCanvasRenderingContext2D interface: attribute letterSpacing
 FAIL OffscreenCanvasRenderingContext2D interface: attribute fontKerning assert_true: The prototype object must have a property "fontKerning" expected true got false
 FAIL OffscreenCanvasRenderingContext2D interface: attribute fontStretch assert_true: The prototype object must have a property "fontStretch" expected true got false
 FAIL OffscreenCanvasRenderingContext2D interface: attribute fontVariantCaps assert_true: The prototype object must have a property "fontVariantCaps" expected true got false
 FAIL OffscreenCanvasRenderingContext2D interface: attribute textRendering assert_true: The prototype object must have a property "textRendering" expected true got false
-FAIL OffscreenCanvasRenderingContext2D interface: attribute wordSpacing assert_true: The prototype object must have a property "wordSpacing" expected true got false
+PASS OffscreenCanvasRenderingContext2D interface: attribute wordSpacing
 PASS OffscreenCanvasRenderingContext2D interface: operation closePath()
 PASS OffscreenCanvasRenderingContext2D interface: operation moveTo(unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation lineTo(unrestricted double, unrestricted double)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
@@ -410,12 +410,12 @@ PASS OffscreenCanvasRenderingContext2D interface: attribute font
 PASS OffscreenCanvasRenderingContext2D interface: attribute textAlign
 PASS OffscreenCanvasRenderingContext2D interface: attribute textBaseline
 PASS OffscreenCanvasRenderingContext2D interface: attribute direction
-FAIL OffscreenCanvasRenderingContext2D interface: attribute letterSpacing assert_true: The prototype object must have a property "letterSpacing" expected true got false
+PASS OffscreenCanvasRenderingContext2D interface: attribute letterSpacing
 FAIL OffscreenCanvasRenderingContext2D interface: attribute fontKerning assert_true: The prototype object must have a property "fontKerning" expected true got false
 FAIL OffscreenCanvasRenderingContext2D interface: attribute fontStretch assert_true: The prototype object must have a property "fontStretch" expected true got false
 FAIL OffscreenCanvasRenderingContext2D interface: attribute fontVariantCaps assert_true: The prototype object must have a property "fontVariantCaps" expected true got false
 FAIL OffscreenCanvasRenderingContext2D interface: attribute textRendering assert_true: The prototype object must have a property "textRendering" expected true got false
-FAIL OffscreenCanvasRenderingContext2D interface: attribute wordSpacing assert_true: The prototype object must have a property "wordSpacing" expected true got false
+PASS OffscreenCanvasRenderingContext2D interface: attribute wordSpacing
 PASS OffscreenCanvasRenderingContext2D interface: operation closePath()
 PASS OffscreenCanvasRenderingContext2D interface: operation moveTo(unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation lineTo(unrestricted double, unrestricted double)

--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/html.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/html.idl
@@ -1460,12 +1460,12 @@ interface mixin CanvasTextDrawingStyles {
   attribute CanvasTextAlign textAlign; // (default: "start")
   attribute CanvasTextBaseline textBaseline; // (default: "alphabetic")
   attribute CanvasDirection direction; // (default: "inherit")
-  attribute double letterSpacing; // (default: 0)
+  attribute DOMString letterSpacing; // (default: "0px")
   attribute CanvasFontKerning fontKerning; // (default: "auto")
   attribute CanvasFontStretch fontStretch; // (default: "normal")
   attribute CanvasFontVariantCaps fontVariantCaps; // (default: "normal")
   attribute CanvasTextRendering textRendering; // (default: "auto")
-  attribute double wordSpacing; // (default: 0)
+  attribute DOMString wordSpacing; // (default: "0px")
 };
 
 interface mixin CanvasPath {

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
@@ -501,12 +501,12 @@ PASS CanvasRenderingContext2D interface: attribute font
 PASS CanvasRenderingContext2D interface: attribute textAlign
 PASS CanvasRenderingContext2D interface: attribute textBaseline
 PASS CanvasRenderingContext2D interface: attribute direction
-FAIL CanvasRenderingContext2D interface: attribute letterSpacing assert_true: The prototype object must have a property "letterSpacing" expected true got false
+PASS CanvasRenderingContext2D interface: attribute letterSpacing
 FAIL CanvasRenderingContext2D interface: attribute fontKerning assert_true: The prototype object must have a property "fontKerning" expected true got false
 FAIL CanvasRenderingContext2D interface: attribute fontStretch assert_true: The prototype object must have a property "fontStretch" expected true got false
 FAIL CanvasRenderingContext2D interface: attribute fontVariantCaps assert_true: The prototype object must have a property "fontVariantCaps" expected true got false
 FAIL CanvasRenderingContext2D interface: attribute textRendering assert_true: The prototype object must have a property "textRendering" expected true got false
-FAIL CanvasRenderingContext2D interface: attribute wordSpacing assert_true: The prototype object must have a property "wordSpacing" expected true got false
+PASS CanvasRenderingContext2D interface: attribute wordSpacing
 PASS CanvasRenderingContext2D interface: operation closePath()
 PASS CanvasRenderingContext2D interface: operation moveTo(unrestricted double, unrestricted double)
 PASS CanvasRenderingContext2D interface: operation lineTo(unrestricted double, unrestricted double)
@@ -625,12 +625,12 @@ PASS CanvasRenderingContext2D interface: document.createElement("canvas").getCon
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "textAlign" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "textBaseline" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "direction" with the proper type
-FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "letterSpacing" with the proper type assert_inherits: property "letterSpacing" not found in prototype chain
+PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "letterSpacing" with the proper type
 FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "fontKerning" with the proper type assert_inherits: property "fontKerning" not found in prototype chain
 FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "fontStretch" with the proper type assert_inherits: property "fontStretch" not found in prototype chain
 FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "fontVariantCaps" with the proper type assert_inherits: property "fontVariantCaps" not found in prototype chain
 FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "textRendering" with the proper type assert_inherits: property "textRendering" not found in prototype chain
-FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "wordSpacing" with the proper type assert_inherits: property "wordSpacing" not found in prototype chain
+PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "wordSpacing" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "closePath()" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "moveTo(unrestricted double, unrestricted double)" with the proper type
 PASS CanvasRenderingContext2D interface: calling moveTo(unrestricted double, unrestricted double) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError
@@ -812,12 +812,12 @@ PASS OffscreenCanvasRenderingContext2D interface: attribute font
 PASS OffscreenCanvasRenderingContext2D interface: attribute textAlign
 PASS OffscreenCanvasRenderingContext2D interface: attribute textBaseline
 PASS OffscreenCanvasRenderingContext2D interface: attribute direction
-FAIL OffscreenCanvasRenderingContext2D interface: attribute letterSpacing assert_true: The prototype object must have a property "letterSpacing" expected true got false
+PASS OffscreenCanvasRenderingContext2D interface: attribute letterSpacing
 FAIL OffscreenCanvasRenderingContext2D interface: attribute fontKerning assert_true: The prototype object must have a property "fontKerning" expected true got false
 FAIL OffscreenCanvasRenderingContext2D interface: attribute fontStretch assert_true: The prototype object must have a property "fontStretch" expected true got false
 FAIL OffscreenCanvasRenderingContext2D interface: attribute fontVariantCaps assert_true: The prototype object must have a property "fontVariantCaps" expected true got false
 FAIL OffscreenCanvasRenderingContext2D interface: attribute textRendering assert_true: The prototype object must have a property "textRendering" expected true got false
-FAIL OffscreenCanvasRenderingContext2D interface: attribute wordSpacing assert_true: The prototype object must have a property "wordSpacing" expected true got false
+PASS OffscreenCanvasRenderingContext2D interface: attribute wordSpacing
 PASS OffscreenCanvasRenderingContext2D interface: operation closePath()
 PASS OffscreenCanvasRenderingContext2D interface: operation moveTo(unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation lineTo(unrestricted double, unrestricted double)

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
@@ -409,12 +409,12 @@ PASS OffscreenCanvasRenderingContext2D interface: attribute font
 PASS OffscreenCanvasRenderingContext2D interface: attribute textAlign
 PASS OffscreenCanvasRenderingContext2D interface: attribute textBaseline
 PASS OffscreenCanvasRenderingContext2D interface: attribute direction
-FAIL OffscreenCanvasRenderingContext2D interface: attribute letterSpacing assert_true: The prototype object must have a property "letterSpacing" expected true got false
+PASS OffscreenCanvasRenderingContext2D interface: attribute letterSpacing
 FAIL OffscreenCanvasRenderingContext2D interface: attribute fontKerning assert_true: The prototype object must have a property "fontKerning" expected true got false
 FAIL OffscreenCanvasRenderingContext2D interface: attribute fontStretch assert_true: The prototype object must have a property "fontStretch" expected true got false
 FAIL OffscreenCanvasRenderingContext2D interface: attribute fontVariantCaps assert_true: The prototype object must have a property "fontVariantCaps" expected true got false
 FAIL OffscreenCanvasRenderingContext2D interface: attribute textRendering assert_true: The prototype object must have a property "textRendering" expected true got false
-FAIL OffscreenCanvasRenderingContext2D interface: attribute wordSpacing assert_true: The prototype object must have a property "wordSpacing" expected true got false
+PASS OffscreenCanvasRenderingContext2D interface: attribute wordSpacing
 PASS OffscreenCanvasRenderingContext2D interface: operation closePath()
 PASS OffscreenCanvasRenderingContext2D interface: operation moveTo(unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation lineTo(unrestricted double, unrestricted double)

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -214,6 +214,12 @@ void CanvasRenderingContext2D::setFontWithoutUpdatingStyle(const String& newFont
     modifiableState().font.initialize(document.fontSelector(), *fontCascade);
     ASSERT(state().font.realized());
     ASSERT(state().font.isPopulated());
+
+    // Recompute the word and the letter spacing for the new font.
+    String letterSpacing;
+    setLetterSpacing(std::exchange(modifiableState().letterSpacing, letterSpacing));
+    String wordSpacing;
+    setWordSpacing(std::exchange(modifiableState().wordSpacing, wordSpacing));
 }
 
 inline TextDirection CanvasRenderingContext2D::toTextDirection(Direction direction, const RenderStyle** computedStyle) const

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -150,6 +150,12 @@ public:
     String filterString() const { return state().filterString; }
     void setFilterString(const String&);
 
+    String letterSpacing() const { return state().letterSpacing; }
+    void setLetterSpacing(const String&);
+
+    String wordSpacing() const { return state().wordSpacing; }
+    void setWordSpacing(const String&);
+
     void save() { ++m_unrealizedSaveCount; }
     void restore();
 
@@ -264,6 +270,14 @@ public:
         bool isPopulated() const { return m_font.fonts(); }
 #endif
 
+        const FontCascade& fontCascade() const { return m_font; }
+
+        float letterSpacing() const { return m_font.letterSpacing(); }
+        void setLetterSpacing(const Length& letterSpacing) { m_font.setLetterSpacing(letterSpacing); }
+
+        float wordSpacing() const { return m_font.wordSpacing(); }
+        void setWordSpacing(const Length& wordSpacing) { m_font.setWordSpacing(wordSpacing); }
+
     private:
         void update(FontSelector&);
         void fontsNeedUpdate(FontSelector&) final;
@@ -300,6 +314,9 @@ public:
 
         String filterString;
         FilterOperations filterOperations;
+
+        String letterSpacing;
+        String wordSpacing;
 
         String unparsedFont;
         FontProxy font;

--- a/Source/WebCore/html/canvas/CanvasTextDrawingStyles.idl
+++ b/Source/WebCore/html/canvas/CanvasTextDrawingStyles.idl
@@ -30,4 +30,6 @@ interface mixin CanvasTextDrawingStyles {
     attribute CanvasTextAlign textAlign; // (default: "start")
     attribute CanvasTextBaseline textBaseline; // (default: "alphabetic")
     attribute CanvasDirection direction; // (default: "inherit")
+    attribute DOMString letterSpacing; // (default: "0px")
+    attribute DOMString wordSpacing; // (default: "0px")
 };

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
@@ -108,6 +108,11 @@ void OffscreenCanvasRenderingContext2D::setFont(const String& newFont)
     if (auto fontCascade = Style::resolveForUnresolvedFont(*unresolvedFont, WTFMove(fontDescription), context)) {
         ASSERT(context.cssFontSelector());
         modifiableState().font.initialize(*context.cssFontSelector(), *fontCascade);
+
+        String letterSpacing;
+        setLetterSpacing(std::exchange(modifiableState().letterSpacing, letterSpacing));
+        String wordSpacing;
+        setWordSpacing(std::exchange(modifiableState().wordSpacing, wordSpacing));
     }
 }
 


### PR DESCRIPTION
#### 00d61d715299f4a44a74385199c72f633cadee0d
<pre>
Implement CanvasRenderingContext2D letterSpacing/wordSpacing
<a href="https://bugs.webkit.org/show_bug.cgi?id=283408">https://bugs.webkit.org/show_bug.cgi?id=283408</a>

Reviewed by Said Abou-Hallawa.

Implement CanvasRenderingContext2D letterSpacing/wordSpacing [1, 2] by allowing to set these properties by string
on CanvasRenderingContext2D and as a computed Length on FontCascade. The CSS property parser is used to
convert the string value into the actual computed Length.

[1] <a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-letterspacing">https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-letterspacing</a>
[2] <a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-wordspacing">https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-wordspacing</a>

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.letter_spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.word_spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.absolute.spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.font-relative.spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.invalid.spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.letterSpacing.change.font-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.letterSpacing.measure-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.nonfinite.spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.wordSpacing.change.font-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.wordSpacing.measure-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.letter_spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.letter_spacing.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.word_spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.word_spacing.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.absolute.spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.absolute.spacing.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.font-relative.spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.font-relative.spacing.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.invalid.spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.invalid.spacing.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.change.font-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.change.font.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.measure-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.letterSpacing.measure.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.nonfinite.spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.nonfinite.spacing.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.change.font-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.change.font.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.measure-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.drawing.style.wordSpacing.measure.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/interfaces/html.idl:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt:
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::setFontWithoutUpdatingStyle):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::State::State):
(WebCore::CanvasRenderingContext2DBase::setLetterSpacing):
(WebCore::CanvasRenderingContext2DBase::setWordSpacing):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
(WebCore::CanvasRenderingContext2DBase::letterSpacing const):
(WebCore::CanvasRenderingContext2DBase::wordSpacing const):
* Source/WebCore/html/canvas/CanvasTextDrawingStyles.idl:
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp:
(WebCore::OffscreenCanvasRenderingContext2D::setFont):

Canonical link: <a href="https://commits.webkit.org/287661@main">https://commits.webkit.org/287661@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cdc199286416a291f35a29fd88e02e2f2c114a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84852 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31313 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82442 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62798 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20599 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83400 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52866 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73146 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43101 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50186 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27301 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29772 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71324 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86286 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7556 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5348 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71082 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68982 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70322 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17531 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14305 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13253 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7518 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13038 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7357 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10877 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9163 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->