### PR TITLE
[LFC] Turn LayoutIntegration::BoxTree into BoxTreeUpdater

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1426,7 +1426,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     layout/formattingContexts/inline/text/TextUtil.h
 
-    layout/integration/LayoutIntegrationBoxTree.h
+    layout/integration/LayoutIntegrationBoxTreeUpdater.h
 
     layout/integration/flex/LayoutIntegrationFlexLayout.h
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1913,7 +1913,7 @@ layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
 layout/integration/inline/LayoutIntegrationLineLayout.cpp
 layout/integration/inline/LayoutIntegrationPagination.cpp
 layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
-layout/integration/LayoutIntegrationBoxTree.cpp
+layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
 layout/integration/LayoutIntegrationCoverage.cpp
 layout/integration/LayoutIntegrationFormattingContextLayout.cpp
 layout/integration/LayoutIntegrationUtils.cpp

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -123,6 +123,12 @@ BoxGeometryUpdater::BoxGeometryUpdater(Layout::LayoutState& layoutState, const L
 {
 }
 
+void BoxGeometryUpdater::clear()
+{
+    m_rootLayoutBox = nullptr;
+    m_nestedListMarkerOffsets.clear();
+}
+
 void BoxGeometryUpdater::setListMarkerOffsetForMarkerOutside(const RenderListMarker& listMarker)
 {
     auto& layoutBox = *listMarker.layoutBox();

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.h
@@ -28,7 +28,7 @@
 #include "FormattingConstraints.h"
 #include "InlineFormattingConstraints.h"
 #include "LayoutBoxGeometry.h"
-#include "LayoutIntegrationBoxTree.h"
+#include "LayoutIntegrationBoxTreeUpdater.h"
 #include "LayoutState.h"
 
 namespace WebCore {
@@ -46,6 +46,8 @@ namespace LayoutIntegration {
 class BoxGeometryUpdater {
 public:
     BoxGeometryUpdater(Layout::LayoutState&, const Layout::ElementBox& rootLayoutBox);
+
+    void clear();
 
     void setFormattingContextRootGeometry(LayoutUnit availableLogicalWidth);
     void setFormattingContextContentGeometry(std::optional<LayoutUnit> availableLogicalWidth, std::optional<Layout::IntrinsicWidthMode>);

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.h
@@ -25,22 +25,8 @@
 
 #pragma once
 
-#include "LayoutInitialContainingBlock.h"
-#include <wtf/HashMap.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/UniqueRef.h>
-#include <wtf/Vector.h>
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-namespace LayoutIntegration {
-class BoxTree;
-}
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::LayoutIntegration::BoxTree> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -57,26 +43,27 @@ namespace LayoutIntegration {
 struct InlineContent;
 #endif
 
-class BoxTree : public CanMakeWeakPtr<BoxTree> {
+class BoxTreeUpdater {
 public:
-    BoxTree(RenderBlock&);
-    ~BoxTree();
+    BoxTreeUpdater(RenderBlock&);
+    ~BoxTreeUpdater();
+
+    CheckedRef<Layout::ElementBox> build();
+    void tearDown();
 
     static void updateStyle(const RenderObject&);
-    void updateContent(const RenderText&);
+    static void updateContent(const RenderText&);
 
     const Layout::Box& insert(const RenderElement& parent, RenderObject& child, const RenderObject* beforeChild = nullptr);
     UniqueRef<Layout::Box> remove(const RenderElement& parent, RenderObject& child);
 
+private:
     const RenderBlock& rootRenderer() const { return m_rootRenderer; }
     RenderBlock& rootRenderer() { return m_rootRenderer; }
 
     const Layout::ElementBox& rootLayoutBox() const;
     Layout::ElementBox& rootLayoutBox();
 
-    bool contains(const RenderElement&) const;
-
-private:
     Layout::InitialContainingBlock& initialContainingBlock();
 
     static UniqueRef<Layout::Box> createLayoutBox(RenderObject&);

--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
@@ -47,13 +47,17 @@ namespace LayoutIntegration {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FlexLayout);
 
 FlexLayout::FlexLayout(RenderFlexibleBox& flexBoxRenderer)
-    : m_boxTree(flexBoxRenderer)
+    : m_flexBox(BoxTreeUpdater { flexBoxRenderer }.build())
     , m_layoutState(flexBoxRenderer.view().layoutState())
 {
 }
 
 FlexLayout::~FlexLayout()
 {
+    auto& renderer = flexBoxRenderer();
+    m_flexBox = nullptr;
+
+    BoxTreeUpdater { renderer }.tearDown();
 }
 
 static inline Layout::ConstraintsForFlexContent constraintsForFlexContent(const Layout::ElementBox& flexContainer)

--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "LayoutIntegrationBoxTree.h"
+#include "LayoutIntegrationBoxTreeUpdater.h"
 #include "LayoutState.h"
 #include "RenderObjectEnums.h"
 #include <wtf/CheckedPtr.h>
@@ -65,16 +65,16 @@ public:
 private:
     void updateRenderers();
 
-    const Layout::ElementBox& flexBox() const { return m_boxTree.rootLayoutBox(); }
-    Layout::ElementBox& flexBox() { return m_boxTree.rootLayoutBox(); }
+    const Layout::ElementBox& flexBox() const { return *m_flexBox; }
+    Layout::ElementBox& flexBox() { return *m_flexBox; }
 
-    const RenderFlexibleBox& flexBoxRenderer() const { return downcast<RenderFlexibleBox>(m_boxTree.rootRenderer()); }
-    RenderFlexibleBox& flexBoxRenderer() { return downcast<RenderFlexibleBox>(m_boxTree.rootRenderer()); }
+    const RenderFlexibleBox& flexBoxRenderer() const { return downcast<RenderFlexibleBox>(*m_flexBox->rendererForIntegration()); }
+    RenderFlexibleBox& flexBoxRenderer() { return downcast<RenderFlexibleBox>(*m_flexBox->rendererForIntegration()); }
 
     Layout::LayoutState& layoutState() { return *m_layoutState; }
     const Layout::LayoutState& layoutState() const { return *m_layoutState; }
 
-    BoxTree m_boxTree;
+    CheckedPtr<Layout::ElementBox> m_flexBox;
     WeakPtr<Layout::LayoutState> m_layoutState;
 };
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
@@ -29,7 +29,6 @@
 #include "InlineDamage.h"
 #include "InlineDisplayBox.h"
 #include "LayoutBoxGeometry.h"
-#include "LayoutIntegrationBoxTree.h"
 #include "LayoutIntegrationInlineContent.h"
 #include "LayoutState.h"
 #include "RenderBlockFlowInlines.h"
@@ -93,9 +92,8 @@ static std::tuple<float, float> glyphOverflowInInlineDirection(size_t firstTextB
     return { leadingOverflow(), trailingOverflow() };
 }
 
-InlineContentBuilder::InlineContentBuilder(const RenderBlockFlow& blockFlow, BoxTree& boxTree)
+InlineContentBuilder::InlineContentBuilder(const RenderBlockFlow& blockFlow)
     : m_blockFlow(blockFlow)
-    , m_boxTree(boxTree)
 {
 }
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.h
@@ -35,12 +35,11 @@ class RenderBlockFlow;
 
 namespace LayoutIntegration {
 
-class BoxTree;
 struct InlineContent;
 
 class InlineContentBuilder {
 public:
-    InlineContentBuilder(const RenderBlockFlow&, BoxTree&);
+    InlineContentBuilder(const RenderBlockFlow&);
 
     FloatRect build(Layout::InlineLayoutResult&&, InlineContent&, const Layout::InlineDamage*) const;
     void updateLineOverflow(InlineContent&) const;
@@ -50,7 +49,6 @@ private:
     void computeIsFirstIsLastBoxAndBidiReorderingForInlineContent(InlineDisplay::Boxes&) const;
 
     const RenderBlockFlow& m_blockFlow;
-    BoxTree& m_boxTree;
 };
 
 }

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
@@ -37,12 +37,12 @@
 namespace WebCore {
 namespace LayoutIntegration {
 
-InlineContentPainter::InlineContentPainter(PaintInfo& paintInfo, const LayoutPoint& paintOffset, const RenderInline* inlineBoxWithLayer, const InlineContent& inlineContent, const BoxTree& boxTree)
+InlineContentPainter::InlineContentPainter(PaintInfo& paintInfo, const LayoutPoint& paintOffset, const RenderInline* inlineBoxWithLayer, const InlineContent& inlineContent, const RenderBlockFlow& root)
     : m_paintInfo(paintInfo)
     , m_paintOffset(paintOffset)
     , m_inlineBoxWithLayer(inlineBoxWithLayer)
     , m_inlineContent(inlineContent)
-    , m_boxTree(boxTree)
+    , m_root(root)
 {
     m_damageRect = m_paintInfo.rect;
     m_damageRect.moveBy(-m_paintOffset);
@@ -107,7 +107,7 @@ void InlineContentPainter::paintDisplayBox(const InlineDisplay::Box& box)
 
 void InlineContentPainter::paint()
 {
-    auto layerPaintScope = LayerPaintScope { m_boxTree, m_inlineBoxWithLayer };
+    auto layerPaintScope = LayerPaintScope { m_inlineBoxWithLayer };
     auto lastBoxLineIndex = std::optional<size_t> { };
 
     auto paintLineEndingEllipsisIfApplicable = [&](std::optional<size_t> currentLineIndex) {
@@ -157,9 +157,8 @@ LayoutPoint InlineContentPainter::flippedContentOffsetIfNeeded(const RenderBox& 
     return m_paintOffset;
 }
 
-LayerPaintScope::LayerPaintScope(const BoxTree& boxTree, const RenderInline* inlineBoxWithLayer)
-    : m_boxTree(boxTree)
-    , m_inlineBoxWithLayer(inlineBoxWithLayer ? inlineBoxWithLayer->layoutBox() : nullptr)
+LayerPaintScope::LayerPaintScope(const RenderInline* inlineBoxWithLayer)
+    : m_inlineBoxWithLayer(inlineBoxWithLayer ? inlineBoxWithLayer->layoutBox() : nullptr)
 {
 }
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "LayoutIntegrationBoxTree.h"
+#include "LayoutIntegrationBoxTreeUpdater.h"
 #include "LayoutPoint.h"
 #include "LayoutRect.h"
 #include <wtf/WeakListHashSet.h>
@@ -52,7 +52,7 @@ struct InlineContent;
 
 class InlineContentPainter {
 public:
-    InlineContentPainter(PaintInfo&, const LayoutPoint& paintOffset, const RenderInline* inlineBoxWithLayer, const InlineContent&, const BoxTree&);
+    InlineContentPainter(PaintInfo&, const LayoutPoint& paintOffset, const RenderInline* inlineBoxWithLayer, const InlineContent&, const RenderBlockFlow& root);
 
     void paint();
 
@@ -60,24 +60,23 @@ private:
     void paintDisplayBox(const InlineDisplay::Box&);
     void paintEllipsis(size_t lineIndex);
     LayoutPoint flippedContentOffsetIfNeeded(const RenderBox&) const;
-    const RenderBlock& root() const { return m_boxTree.rootRenderer(); }
+    const RenderBlock& root() const { return m_root; }
 
     PaintInfo& m_paintInfo;
     const LayoutPoint m_paintOffset;
     LayoutRect m_damageRect;
     const RenderInline* m_inlineBoxWithLayer { nullptr };
     const InlineContent& m_inlineContent;
-    const BoxTree& m_boxTree;
+    const RenderBlockFlow& m_root;
     SingleThreadWeakListHashSet<RenderInline> m_outlineObjects;
 };
 
 class LayerPaintScope {
 public:
-    LayerPaintScope(const BoxTree&, const RenderInline* inlineBoxWithLayer);
+    LayerPaintScope(const RenderInline* inlineBoxWithLayer);
     bool includes(const InlineDisplay::Box&);
 
 private:
-    const BoxTree& m_boxTree;
     const Layout::ElementBox* const m_inlineBoxWithLayer;
     const Layout::ElementBox* m_currentExcludedInlineBox { nullptr };
 };

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
@@ -33,7 +33,7 @@
 #include "InlineIteratorLineBox.h"
 #include "InlineIteratorTextBox.h"
 #include "LayoutIntegrationBoxGeometryUpdater.h"
-#include "LayoutIntegrationBoxTree.h"
+#include "LayoutIntegrationBoxTreeUpdater.h"
 #include "LayoutPoint.h"
 #include "LayoutState.h"
 #include "RenderObjectEnums.h"
@@ -121,8 +121,8 @@ public:
     InlineIterator::LineBoxIterator firstLineBox() const;
     InlineIterator::LineBoxIterator lastLineBox() const;
 
-    const RenderBlockFlow& flow() const { return downcast<RenderBlockFlow>(m_boxTree.rootRenderer()); }
-    RenderBlockFlow& flow() { return downcast<RenderBlockFlow>(m_boxTree.rootRenderer()); }
+    const RenderBlockFlow& flow() const { return downcast<RenderBlockFlow>(*m_rootLayoutBox->rendererForIntegration()); }
+    RenderBlockFlow& flow() { return downcast<RenderBlockFlow>(*m_rootLayoutBox->rendererForIntegration()); }
 
     static void releaseCaches(RenderView&);
 
@@ -151,14 +151,14 @@ private:
 
     Layout::InlineDamage& ensureLineDamage();
 
-    const Layout::ElementBox& rootLayoutBox() const;
-    Layout::ElementBox& rootLayoutBox();
+    const Layout::ElementBox& rootLayoutBox() const { return *m_rootLayoutBox; }
+    Layout::ElementBox& rootLayoutBox() { return *m_rootLayoutBox; }
     void clearInlineContent();
     void releaseCachesAndResetDamage();
 
     LayoutUnit physicalBaselineForLine(const InlineDisplay::Line&) const;
     
-    BoxTree m_boxTree;
+    CheckedPtr<Layout::ElementBox> m_rootLayoutBox;
     WeakPtr<Layout::LayoutState> m_layoutState;
     Layout::BlockFormattingState& m_blockFormattingState;
     Layout::InlineContentCache& m_inlineContentCache;

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -409,6 +409,19 @@ bool Box::isDescendantOf(const ElementBox& ancestor) const
     return false;
 }
 
+bool Box::isInFormattingContextEstablishedBy(const ElementBox& formattingContextRoot) const
+{
+    ASSERT(formattingContextRoot.establishesFormattingContext());
+
+    auto* ancestor = &parent();
+    while (true) {
+        if (ancestor->establishesFormattingContext())
+            break;
+        ancestor = &ancestor->parent();
+    }
+    return ancestor == &formattingContextRoot;
+}
+
 bool Box::isOverflowVisible() const
 {
     auto isOverflowVisible = m_style.overflowX() == Overflow::Visible || m_style.overflowY() == Overflow::Visible;

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -164,6 +164,7 @@ public:
     const Box* previousInFlowOrFloatingSibling() const;
     const Box* previousOutOfFlowSibling() const;
     bool isDescendantOf(const ElementBox&) const;
+    bool isInFormattingContextEstablishedBy(const ElementBox& formattingContextRoot) const;
 
     // FIXME: This is currently needed for style updates.
     Box* nextSibling() { return m_nextSibling.get(); }


### PR DESCRIPTION
#### faed9492377495621bccf49d4120ed93cf683520
<pre>
[LFC] Turn LayoutIntegration::BoxTree into BoxTreeUpdater
<a href="https://bugs.webkit.org/show_bug.cgi?id=283409">https://bugs.webkit.org/show_bug.cgi?id=283409</a>
<a href="https://rdar.apple.com/140266421">rdar://140266421</a>

Reviewed by Alan Baradlay.

Make it transient type that is not tied to the lifetime of a LineLayout.

This will allow more flexibity in where the layout box tree building happens.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::BoxGeometryUpdater::clear):
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.h:
* Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp: Removed.
* Source/WebCore/layout/integration/LayoutIntegrationBoxTree.h: Removed.
* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp:
(WebCore::LayoutIntegration::FlexLayout::FlexLayout):
(WebCore::LayoutIntegration::FlexLayout::~FlexLayout):
* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp:
(WebCore::LayoutIntegration::InlineContentBuilder::InlineContentBuilder):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp:
(WebCore::LayoutIntegration::InlineContentPainter::InlineContentPainter):
(WebCore::LayoutIntegration::InlineContentPainter::paint):
(WebCore::LayoutIntegration::LayerPaintScope::LayerPaintScope):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h:
(WebCore::LayoutIntegration::InlineContentPainter::root const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::LineLayout):
(WebCore::LayoutIntegration::m_boxGeometryUpdater):
(WebCore::LayoutIntegration::LineLayout::~LineLayout):
(WebCore::LayoutIntegration::LineLayout::contains const):
(WebCore::LayoutIntegration::LineLayout::updateStyle):
(WebCore::LayoutIntegration::LineLayout::updateOverflow):
(WebCore::LayoutIntegration::LineLayout::constructContent):
(WebCore::LayoutIntegration::LineLayout::paint):
(WebCore::LayoutIntegration::LineLayout::hitTest):
(WebCore::LayoutIntegration::LineLayout::insertedIntoTree):
(WebCore::LayoutIntegration::LineLayout::removedFromTree):
(WebCore::LayoutIntegration::LineLayout::updateTextContent):
(WebCore::LayoutIntegration::LineLayout::rootLayoutBox const): Deleted.
(WebCore::LayoutIntegration::LineLayout::rootLayoutBox): Deleted.
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h:
* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::isInFormattingContextEstablishedBy const):

Move here from BoxTree.

* Source/WebCore/layout/layouttree/LayoutBox.h:

Canonical link: <a href="https://commits.webkit.org/286856@main">https://commits.webkit.org/286856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e912ab88c0439f1a95afc83dd5846b66e73a66ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81851 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28563 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79398 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4612 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60548 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18587 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66333 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40847 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47920 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23831 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26886 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69032 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83269 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3155 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68819 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4817 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66304 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68076 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17006 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12066 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10165 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4608 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7423 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4627 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8062 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6386 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->