### PR TITLE
REGRESSION(286479@main): [GStreamer][WebRTC] Broke webrtc/captureCanvas-webrtc.html

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
@@ -69,11 +69,6 @@ RTCRtpCapabilities RealtimeOutgoingAudioSourceGStreamer::rtpCapabilities() const
     return registryScanner.audioRtpCapabilities(GStreamerRegistryScanner::Configuration::Encoding);
 }
 
-bool RealtimeOutgoingAudioSourceGStreamer::linkTee()
-{
-    return gst_element_link(m_liveSync.get(), m_tee.get());
-}
-
 GRefPtr<GstPad> RealtimeOutgoingAudioSourceGStreamer::outgoingSourcePad() const
 {
     if (WEBKIT_IS_MEDIA_STREAM_SRC(m_outgoingSource.get()))

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h
@@ -48,7 +48,6 @@ private:
     void initialize();
 
     RTCRtpCapabilities rtpCapabilities() const final;
-    bool linkTee() final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
@@ -96,7 +96,7 @@ protected:
     std::optional<RealtimeMediaSourceSettings> m_initialSettings;
     GRefPtr<GstElement> m_bin;
     GRefPtr<GstElement> m_outgoingSource;
-    GRefPtr<GstElement> m_liveSync;
+    GRefPtr<GstElement> m_preProcessor;
     GRefPtr<GstElement> m_tee;
     GRefPtr<GstElement> m_rtpFunnel;
     GRefPtr<GstElement> m_rtpCapsfilter;
@@ -116,7 +116,7 @@ private:
 
     void stopOutgoingSource();
 
-    virtual bool linkTee() = 0;
+    bool linkSource();
     virtual RTCRtpCapabilities rtpCapabilities() const = 0;
     void codecPreferencesChanged();
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
@@ -98,11 +98,6 @@ RTCRtpCapabilities RealtimeOutgoingVideoSourceGStreamer::rtpCapabilities() const
     return registryScanner.videoRtpCapabilities(GStreamerRegistryScanner::Configuration::Encoding);
 }
 
-bool RealtimeOutgoingVideoSourceGStreamer::linkTee()
-{
-    return gst_element_link_many(m_liveSync.get(), m_preProcessor.get(), m_tee.get(), nullptr);
-}
-
 GRefPtr<GstPad> RealtimeOutgoingVideoSourceGStreamer::outgoingSourcePad() const
 {
     if (WEBKIT_IS_MEDIA_STREAM_SRC(m_outgoingSource.get()))

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h
@@ -49,8 +49,6 @@ private:
     void initializePreProcessor();
 
     RTCRtpCapabilities rtpCapabilities() const final;
-    bool linkTee() final;
-    GRefPtr<GstElement> m_preProcessor;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 0b855998667a997ebe78b3edb63bcf417e0abd3c
<pre>
REGRESSION(286479@main): [GStreamer][WebRTC] Broke webrtc/captureCanvas-webrtc.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=283411">https://bugs.webkit.org/show_bug.cgi?id=283411</a>

Reviewed by Xabier Rodriguez-Calvar.

The outgoing tracks no longer require a livesync element since the WebRTC pipeline and playback
pipeline share the same clock.

* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingAudioSourceGStreamer::linkTee): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::RealtimeOutgoingMediaSourceGStreamer):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::start):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::stopOutgoingSource):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::linkSource):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::configurePacketizers):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::teardown):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingVideoSourceGStreamer::linkTee): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/286895@main">https://commits.webkit.org/286895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fc4a690b20d7636179918dc66818b930524f08a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81855 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28567 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79402 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60549 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18590 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40848 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23833 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26890 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69034 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24171 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83273 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4665 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68820 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4821 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66306 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68077 "Found 1 new API test failure: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/open-window-default-size (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17031 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12069 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10167 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4612 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7427 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4631 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8066 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6390 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->