### PR TITLE
[scroll-animations] scroll timelines should use the document's scrolling element as their default and root source

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7359,7 +7359,6 @@ imported/w3c/web-platform-tests/dom/events/scrolling/input-text-scroll-event-whe
 # webkit.org/b/263870 [scroll-animations] some WPT tests are timing out
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-with-scroll-timeline-in-auto-subtree.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/css/deferred-timeline-composited.html [ Skip ]
-imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-root-scroller.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/constructor-no-document.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/updating-the-finished-state.html [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-expected.txt
@@ -1,0 +1,5 @@
+
+PASS CSS animation correctly uses the <html> element as the source for the default scroll() timeline
+PASS CSS animation correctly uses the <html> element as the source for the root scroll() timeline
+PASS CSS animation correctly uses the <html> element as the source for the nearest scroll() timeline
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-quirks-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-quirks-mode-expected.txt
@@ -1,0 +1,5 @@
+
+PASS CSS animation correctly uses the <body> element as the source for the default scroll() timeline in quirks mode
+PASS CSS animation correctly uses the <body> element as the source for the root scroll() timeline in quirks mode
+PASS CSS animation correctly uses the <body> element as the source for the nearest scroll() timeline in quirks mode
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-quirks-mode.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-quirks-mode.html
@@ -1,0 +1,50 @@
+<html>
+<title>The scroll() timeline source in quirks mode</title>
+<link rel="help" href="https://drafts.csswg.org/scroll-animations-1/#scroll-notation">
+<link rel="help" href="https://drafts.csswg.org/css-animations-2/#animation-timeline">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  @keyframes move {
+    to { margin-left: 100px }
+  }
+
+  .animated {
+    animation: move 1s linear;
+  }
+
+  #default {
+    animation-timeline: scroll();
+  }
+
+  #root {
+    animation-timeline: scroll(root);
+  }
+
+  #nearest {
+    animation-timeline: scroll(nearest);
+  }
+</style>
+
+<div class="animated" id="default"></div>
+<div class="animated" id="root"></div>
+<div class="animated" id="nearest"></div>
+
+<script>
+"use strict";
+
+const timelineSourceTest = type => {
+  test(() => {
+    const target = document.getElementById(type);
+    const animations = target.getAnimations();
+    assert_equals(animations.length, 1);
+    assert_equals(animations[0].timeline.source, document.body);
+  }, `CSS animation correctly uses the <body> element as the source for the ${type} scroll() timeline in quirks mode`);
+};
+
+timelineSourceTest("default");
+timelineSourceTest("root");
+timelineSourceTest("nearest");
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-scrollable-body-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-scrollable-body-expected.txt
@@ -1,0 +1,5 @@
+
+PASS CSS animation correctly uses the <body> element as the source for the self scroll() timeline
+PASS CSS animation correctly uses the <html> element as the source for the nearest scroll() timeline
+PASS CSS animation correctly uses the <html> element as the source for the root scroll() timeline
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-scrollable-body-quirks-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-scrollable-body-quirks-mode-expected.txt
@@ -1,0 +1,5 @@
+
+PASS CSS animation correctly uses the <body> element as the source for the self scroll() timeline in quirks mode
+PASS CSS animation correctly uses the <body> element as the source for the nearest scroll() timeline in quirks mode
+PASS CSS animation correctly uses the <body> element as the source for the root scroll() timeline in quirks mode
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-scrollable-body-quirks-mode.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-scrollable-body-quirks-mode.html
@@ -1,0 +1,48 @@
+<html>
+<title>The scroll() timeline source in quirks mode with a scrollable &lt;body> in quirks mode</title>
+<link rel="help" href="https://drafts.csswg.org/scroll-animations-1/#scroll-notation">
+<link rel="help" href="https://drafts.csswg.org/css-animations-2/#animation-timeline">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+
+@keyframes move {
+  to { margin-left: 100px }
+}
+
+html {
+  height: 100px;
+  padding: 20px;
+}
+
+body {
+  height: 110vh;
+  overflow: auto;
+
+  animation: 1s move linear, 1s move linear, 1s move linear;
+  animation-timeline: scroll(self), scroll(nearest), scroll(root);
+}
+
+body::after {
+  content: "";
+  display: block;
+  height: 110%;
+}
+</style>
+<body>
+<script>
+"use strict";
+
+const timelineSourceTest = data => {
+  test(() => {
+    assert_equals(document.body.getAnimations()[data.index].timeline.source, document.body);
+  }, `CSS animation correctly uses the <body> element as the source for the ${data.keyword} scroll() timeline in quirks mode`);
+};
+
+timelineSourceTest({ index: 0, keyword: "self" });
+timelineSourceTest({ index: 1, keyword: "nearest" });
+timelineSourceTest({ index: 1, keyword: "root" });
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-scrollable-body.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-scrollable-body.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<title>The scroll() timeline source in quirks mode with a scrollable &lt;body></title>
+<link rel="help" href="https://drafts.csswg.org/scroll-animations-1/#scroll-notation">
+<link rel="help" href="https://drafts.csswg.org/css-animations-2/#animation-timeline">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+
+@keyframes move {
+  to { margin-left: 100px }
+}
+
+html {
+  height: 100px;
+  padding: 20px;
+}
+
+body {
+  height: 110vh;
+  overflow: auto;
+
+  animation: 1s move linear, 1s move linear, 1s move linear;
+  animation-timeline: scroll(self), scroll(nearest), scroll(root);
+}
+
+body::after {
+  content: "";
+  display: block;
+  height: 110%;
+}
+</style>
+<body>
+<script>
+"use strict";
+
+const timelineSourceTest = data => {
+  test(() => {
+    assert_equals(document.body.getAnimations()[data.index].timeline.source, data.expectedSource);
+  }, `CSS animation correctly uses the <${data.expectedSource.localName}> element as the source for the ${data.keyword} scroll() timeline`);
+};
+
+timelineSourceTest({ index: 0, keyword: "self", expectedSource: document.body });
+timelineSourceTest({ index: 1, keyword: "nearest", expectedSource: document.documentElement });
+timelineSourceTest({ index: 1, keyword: "root", expectedSource: document.documentElement });
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<title>The scroll() timeline source</title>
+<link rel="help" href="https://drafts.csswg.org/scroll-animations-1/#scroll-notation">
+<link rel="help" href="https://drafts.csswg.org/css-animations-2/#animation-timeline">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  @keyframes move {
+    to { margin-left: 100px }
+  }
+
+  .animated {
+    animation: move 1s linear;
+  }
+
+  #default {
+    animation-timeline: scroll();
+  }
+
+  #root {
+    animation-timeline: scroll(root);
+  }
+
+  #nearest {
+    animation-timeline: scroll(nearest);
+  }
+</style>
+
+<div class="animated" id="default"></div>
+<div class="animated" id="root"></div>
+<div class="animated" id="nearest"></div>
+
+<script>
+"use strict";
+
+const timelineSourceTest = type => {
+  test(() => {
+    const target = document.getElementById(type);
+    const animations = target.getAnimations();
+    assert_equals(animations.length, 1);
+    assert_equals(animations[0].timeline.source, document.documentElement);
+  }, `CSS animation correctly uses the <html> element as the source for the ${type} scroll() timeline`);
+};
+
+timelineSourceTest("default");
+timelineSourceTest("root");
+timelineSourceTest("nearest");
+
+</script>

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -49,8 +49,7 @@ public:
     static Ref<ScrollTimeline> create(const AtomString&, ScrollAxis);
     static Ref<ScrollTimeline> createFromCSSValue(const CSSScrollValue&);
 
-    virtual Element* source() const { return m_source.get(); }
-    Element* sourceElementForProgressCalculation() const;
+    virtual Element* source() const;
     void setSource(const Element*);
 
     ScrollAxis axis() const { return m_axis; }
@@ -65,7 +64,6 @@ public:
     AnimationTimeline::ShouldUpdateAnimationsAndSendEvents documentWillUpdateAnimationsAndSendEvents() override;
 
     AnimationTimelinesController* controller() const override;
-    static ScrollableArea* scrollableAreaForSourceRenderer(RenderElement*, Ref<Document>);
 
     std::optional<WebAnimationTime> currentTime(const TimelineRange&) override;
     TimelineRange defaultRange() const override;
@@ -83,6 +81,8 @@ protected:
     };
     static float floatValueForOffset(const Length&, float);
     virtual Data computeTimelineData(const TimelineRange&) const;
+
+    static ScrollableArea* scrollableAreaForSourceRenderer(const RenderElement*, Document&);
 
 private:
     enum class Scroller : uint8_t { Nearest, Root, Self };


### PR DESCRIPTION
#### 2d9d00fde2da68e148583639633bba2e871a73fc
<pre>
[scroll-animations] scroll timelines should use the document&apos;s scrolling element as their default and root source
<a href="https://bugs.webkit.org/show_bug.cgi?id=283412">https://bugs.webkit.org/show_bug.cgi?id=283412</a>
<a href="https://rdar.apple.com/140268956">rdar://140268956</a>

Reviewed by Simon Fraser.

Our scroll timeline code assumed that the document element was the root-most scroller in all cases,
whereas in quirks mode it is the &lt;body&gt; element. This manifested itself in the WPT test
`scroll-animations/scroll-timelines/animation-with-root-scroller.html` which runs in quirks mode
and we&apos;d fail to return a valid `ScrollableArea` for `&lt;body&gt;` because `scrollableAreaForSourceRenderer()`
would only match against the document element. As a result, that test&apos;s animation would never resolve
its `ready` promise since the scroll timeline would never return a resolved current time.

We make several changes to address this.

First, we get rid of `sourceElementForProgressCalculation()` and instead resolve the correct source in
the `source()` getter accounting for the `Scroller` value set for anonymous timelines (those originated
by a `scroll()` value in CSS). This means that anonymous timelines will also report the right source
through the JS API and not just within our internal source resolution.

Then in `scrollableAreaForSourceRenderer()` we correctly check for the document&apos;s `scrollingElement()`
instead of the document element to look for the right `ScrollableArea`.

While working in `scrollableAreaForSourceRenderer()`, we also move it to the protected section since
it&apos;s only used from within `ScrollTimeline` and its subclass `ViewTimeline`. Additionally, we make
its element parameter `const` and change the `Ref&lt;&gt;` parameter to a bare reference per the guidelines,
creating a `Ref` as needed within the function&apos;s body.

Finally, we extend the WPT test coverage to check the anonymous timeline source is correct in quirks mode
and non-quirks mode, including when the `&lt;body&gt;` can be scrolled independently from the document viewport.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-quirks-mode-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-quirks-mode.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-scrollable-body-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-scrollable-body-quirks-mode-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-scrollable-body-quirks-mode.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source-scrollable-body.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-anonymous-source.html: Added.
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::source const):
(WebCore::ScrollTimeline::scrollableAreaForSourceRenderer):
(WebCore::ScrollTimeline::computeTimelineData const):
(WebCore::ScrollTimeline::sourceElementForProgressCalculation const): Deleted.
* Source/WebCore/animation/ScrollTimeline.h:
(WebCore::ScrollTimeline::source const): Deleted.

Canonical link: <a href="https://commits.webkit.org/286957@main">https://commits.webkit.org/286957@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57cd791d5c01222f981a2455ca01d53ce6044888

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30654 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/82373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/29003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79846 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5063 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/29003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80795 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/50866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/66694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/41190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/48231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/24205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/27339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/69347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/24553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/83735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5108 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/83735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/5264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/66681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/83735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/12384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/10474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12030 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5056 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/5065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/8503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/6833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->