### PR TITLE
Add an option to enumerate all speakers when microphones are enumerated

### DIFF
--- a/LayoutTests/fast/mediastream/enumerate-speaker.html
+++ b/LayoutTests/fast/mediastream/enumerate-speaker.html
@@ -23,8 +23,10 @@
     }, "Before gum, no audiooutput is exposed");
 
     promise_test(async (test) => {
+        window.internals.settings.setExposeSpeakersWithoutMicrophoneEnabled(false);
+
         await navigator.mediaDevices.getUserMedia({ audio:true, video:true })
-        const devices = await navigator.mediaDevices.enumerateDevices();
+        let devices = await navigator.mediaDevices.enumerateDevices();
         assert_true(devices.length > 2, "after getting permission, more than 1 camera and 1 microphone are exposed");
         devices.forEach((device) => {
             assert_not_equals(device.deviceId.length == 0 , "device.deviceId is empty before permission to capture");
@@ -37,7 +39,7 @@
         const mic2 = deviceFromLabel(devices, "Mock audio device 2");
         const speaker1 = deviceFromLabel(devices, "Mock speaker device 1");
         const speaker2 = deviceFromLabel(devices, "Mock speaker device 2");
-        const speaker3 = deviceFromLabel(devices, "Mock speaker device 3");
+        let speaker3 = deviceFromLabel(devices, "Mock speaker device 3");
 
         assert_equals(speaker1.kind, "audiooutput", "speaker1");
         assert_not_equals(speaker1.groupId, "", "speaker1 groupId");
@@ -49,6 +51,14 @@
 
         assert_equals(speaker1.groupId, mic1.groupId, "device 1");
         assert_equals(speaker2.groupId, mic2.groupId, "device 2");
+
+        window.internals.settings.setExposeSpeakersWithoutMicrophoneEnabled(true);
+
+        devices = await navigator.mediaDevices.enumerateDevices();
+        speaker3 = deviceFromLabel(devices, "Mock speaker device 3");
+        assert_equals(speaker3.kind, "audiooutput", "speaker3");
+        assert_not_equals(speaker1.groupId, speaker3.groupId, "speaker3.groupId 1");
+        assert_not_equals(speaker2.groupId, speaker3.groupId, "speaker3.groupId 2");
     }, "audiooutput devices");
     </script>
 </head>

--- a/LayoutTests/http/tests/media/media-stream/enumerate-devices-source-id.html
+++ b/LayoutTests/http/tests/media/media-stream/enumerate-devices-source-id.html
@@ -35,7 +35,7 @@
                 if (originInfo[device.deviceId] != device.kind)
                     testFailed(`: duplicate device IDs for ${device.kind} and ${originInfo[device.deviceId]} in ${origin}/${self.origin}`);
 
-                if (Object.keys(originInfo).length > 7)
+                if (Object.keys(originInfo).length > 8)
                     testFailed(`: more than seven unique device IDs in ${origin}/${self.origin}`);
             }
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2809,7 +2809,6 @@ ExperimentalSandboxEnabled:
     WebKit:
       default: false
 
-# FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
 ExposeSpeakersEnabled:
   type: bool
   status: testable
@@ -2818,13 +2817,25 @@ ExposeSpeakersEnabled:
   humanReadableDescription: "Allow speaker device selection"
   condition: ENABLE(MEDIA_STREAM)
   defaultValue:
-    WebKitLegacy:
-      default: false
     WebKit:
       default: false
     WebCore:
       default: false
 
+ExposeSpeakersWithoutMicrophoneEnabled:
+  type: bool
+  status: testable
+  category: media
+  humanReadableName: "Allow selection of speaker device without related microphone"
+  humanReadableDescription: "Allow selection of speaker device without related microphone"
+  condition: ENABLE(MEDIA_STREAM)
+  defaultValue:
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
+# FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
 ExtendedAudioDescriptionsEnabled:
   type: bool
   status: preview
@@ -5603,8 +5614,6 @@ PerElementSpeakerSelectionEnabled:
   humanReadableDescription: "Allow per media element speaker device selection"
   condition: ENABLE(MEDIA_STREAM)
   defaultValue:
-    WebKitLegacy:
-      default: false
     WebKit:
       default: false
     WebCore:

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -309,12 +309,25 @@ static inline bool checkSpeakerAccess(const Document& document)
         && PermissionsPolicy::isFeatureEnabled(PermissionsPolicy::Feature::SpeakerSelection, document, PermissionsPolicy::ShouldReportViolation::No);
 }
 
+static inline bool exposeSpeakersWithoutMicrophoneAccess(const Document& document)
+{
+    return document.frame() && document.frame()->settings().exposeSpeakersWithoutMicrophoneEnabled();
+}
+
+static inline bool haveMicrophoneDevice(const Vector<CaptureDeviceWithCapabilities>& devices, const String& deviceId)
+{
+    return std::any_of(devices.begin(), devices.end(), [&deviceId](auto& deviceWithCapabilities) {
+        auto& device = deviceWithCapabilities.device;
+        return device.persistentId() == deviceId && device.type() == CaptureDevice::DeviceType::Microphone;
+    });
+}
+
 void MediaDevices::exposeDevices(Vector<CaptureDeviceWithCapabilities>&& newDevices, MediaDeviceHashSalts&& deviceIDHashSalts, EnumerateDevicesPromise&& promise)
 {
     if (isContextStopped())
         return;
 
-    auto& document = *this->document();
+    Ref document = *this->document();
 
     bool canAccessCamera = checkCameraAccess(document);
     bool canAccessMicrophone = checkMicrophoneAccess(document);
@@ -338,11 +351,13 @@ void MediaDevices::exposeDevices(Vector<CaptureDeviceWithCapabilities>&& newDevi
             deviceId = center.hashStringWithSalt(newDevice.persistentId(), deviceIDHashSalts.ephemeralDeviceSalt);
         else
             deviceId = center.hashStringWithSalt(newDevice.persistentId(), deviceIDHashSalts.persistentDeviceSalt);
-        auto groupId = hashedGroupId(newDevice.groupId());
+        auto groupId = newDevice.groupId().isEmpty() ? emptyString() : hashedGroupId(newDevice.groupId());
 
         if (newDevice.type() == CaptureDevice::DeviceType::Speaker) {
-            m_audioOutputDeviceIdToPersistentId.add(deviceId, newDevice.persistentId());
-            devices.append(RefPtr<MediaDeviceInfo> { MediaDeviceInfo::create(newDevice.label(), WTFMove(deviceId), WTFMove(groupId), toMediaDeviceInfoKind(newDevice.type())) });
+            if (exposeSpeakersWithoutMicrophoneAccess(document) || haveMicrophoneDevice(newDevices, newDevice.groupId())) {
+                m_audioOutputDeviceIdToPersistentId.add(deviceId, newDevice.persistentId());
+                devices.append(RefPtr<MediaDeviceInfo> { MediaDeviceInfo::create(newDevice.label(), WTFMove(deviceId), WTFMove(groupId), toMediaDeviceInfoKind(newDevice.type())) });
+            }
         } else
             devices.append(RefPtr<InputDeviceInfo> { InputDeviceInfo::create(WTFMove(newDeviceWithCapabilities), WTFMove(deviceId), WTFMove(groupId)) });
     }

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -894,14 +894,6 @@ bool UserMediaPermissionRequestManagerProxy::wasGrantedVideoOrAudioAccess(FrameI
     return m_grantedFrames.contains(frameID);
 }
 
-static inline bool haveMicrophoneDevice(const Vector<CaptureDeviceWithCapabilities>& devices, const String& deviceID)
-{
-    return std::any_of(devices.begin(), devices.end(), [&deviceID](auto& deviceWithCapabilities) {
-        auto& device = deviceWithCapabilities.device;
-        return device.persistentId() == deviceID && device.type() == CaptureDevice::DeviceType::Microphone;
-    });
-}
-
 #if !USE(GLIB)
 void UserMediaPermissionRequestManagerProxy::platformGetMediaStreamDevices(bool revealIdsAndLabels, CompletionHandler<void(Vector<CaptureDeviceWithCapabilities>&&)>&& completionHandler)
 {
@@ -957,10 +949,6 @@ void UserMediaPermissionRequestManagerProxy::computeFilteredDeviceList(bool reve
                 if (device.type() == WebCore::CaptureDevice::DeviceType::Microphone && ++microphoneCount > defaultMaximumMicrophoneCount)
                     continue;
                 if (device.type() != WebCore::CaptureDevice::DeviceType::Camera && device.type() != WebCore::CaptureDevice::DeviceType::Microphone)
-                    continue;
-            } else {
-                // We only expose speakers tied to a microphone for the moment.
-                if (device.type() == WebCore::CaptureDevice::DeviceType::Speaker && !haveMicrophoneDevice(devicesWithCapabilities, device.groupId()))
                     continue;
             }
 


### PR DESCRIPTION
#### 6cb21fd129afdcb268ab2406cd68e7d0d6ce877d
<pre>
Add an option to enumerate all speakers when microphones are enumerated
<a href="https://rdar.apple.com/140269619">rdar://140269619</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=283413">https://bugs.webkit.org/show_bug.cgi?id=283413</a>

Reviewed by Jean-Yves Avenard.

We add an option to expose all speakers to a web page when microphone access is granted.
This aligns with Chrome and is handy to expose built-in speakers that are hard to relate with the built-in microphones as well as external speakers or monitors without microphone/

* LayoutTests/fast/mediastream/enumerate-speaker.html:
* LayoutTests/http/tests/media/media-stream/enumerate-devices-source-id.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::exposeSpeakersWithoutMicrophoneAccess):
(WebCore::haveMicrophoneDevice):
(WebCore::MediaDevices::exposeDevices):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::computeFilteredDeviceList):
(WebKit::haveMicrophoneDevice): Deleted.

Canonical link: <a href="https://commits.webkit.org/286905@main">https://commits.webkit.org/286905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5af2f37fce5ec3e857edd5102da51face16883e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81888 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28582 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79417 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4631 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60577 "Found 3 new test failures: imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-self.https.sub.html imported/w3c/web-platform-tests/fetch/api/request/multi-globals/construct-in-detached-frame.window.html imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getSettings.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18601 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50535 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66351 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40876 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47937 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23849 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26905 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/70485 "Found 4 new JSC stress test failures: stress/get-by-val-hoist-above-structure-2.js.ftl-eager-no-cjit-b3o1, stress/get-by-val-hoist-above-structure-2.js.ftl-no-cjit-b3o0, stress/get-by-val-hoist-above-structure-2.js.mini-mode, stress/get-by-val-hoist-above-structure.js.ftl-eager-no-cjit-b3o1 (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69049 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83288 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76578 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4680 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68833 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4836 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66322 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68090 "Found 2 new API test failures: /TestWebKit:WebKit.GetInjectedBundleInitializationUserDataCallback, /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17041 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12084 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10183 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98831 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4627 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7442 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21613 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4646 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8081 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6405 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->