### PR TITLE
Poor performance of querySelectorAll() with descendant selectors (:has())

### DIFF
--- a/LayoutTests/fast/selectors/has-queryselector-performance-expected.txt
+++ b/LayoutTests/fast/selectors/has-queryselector-performance-expected.txt
@@ -1,0 +1,2 @@
+This test passes if it doesn't time out.
+

--- a/LayoutTests/fast/selectors/has-queryselector-performance.html
+++ b/LayoutTests/fast/selectors/has-queryselector-performance.html
@@ -1,0 +1,19 @@
+<body>This test passes if it doesn't time out.
+<script>
+window.testRunner?.dumpAsText();
+
+function buildTree(parent, width, depth)
+{
+    if (!depth)
+        return;
+
+    for (let i = 0; i < width; ++i) {
+        const div = document.createElement("div");
+        buildTree(div, width, depth - 1);
+        parent.appendChild(div);
+    }
+}
+
+buildTree(document.body, 5, 5);
+document.querySelectorAll(":has(foo) div")
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-css-nesting-shared-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-css-nesting-shared-expected.txt
@@ -7,8 +7,8 @@ PASS add .test to trigger2 - check subject2_1
 PASS add .test to trigger2 - check subject2_2
 PASS remove .test from trigger2 - check subject2_1
 PASS remove .test from trigger2 - check subject2_2
-FAIL add .test to trigger3 - check subject3_1 assert_equals: expected "rgb(0, 0, 255)" but got "rgb(128, 128, 128)"
-FAIL add .test to trigger3 - check subject3_2 assert_equals: expected "rgb(135, 206, 235)" but got "rgb(128, 128, 128)"
+PASS add .test to trigger3 - check subject3_1
+PASS add .test to trigger3 - check subject3_2
 PASS remove .test from trigger3 - check subject3_1
 PASS remove .test from trigger3 - check subject3_2
 

--- a/Source/WebCore/dom/SelectorQuery.h
+++ b/Source/WebCore/dom/SelectorQuery.h
@@ -43,6 +43,10 @@ class ContainerNode;
 class Document;
 class Element;
 
+namespace Style {
+struct SelectorMatchingState;
+};
+
 class SelectorDataList {
 public:
     explicit SelectorDataList(const CSSSelectorList&);
@@ -62,8 +66,8 @@ private:
 #endif
     };
 
-    bool selectorMatches(const SelectorData&, Element&, const ContainerNode& rootNode) const;
-    Element* selectorClosest(const SelectorData&, Element&, const ContainerNode& rootNode) const;
+    bool selectorMatches(const SelectorData&, Element&, const ContainerNode& rootNode, Style::SelectorMatchingState* = nullptr) const;
+    Element* selectorClosest(const SelectorData&, Element&, const ContainerNode& rootNode, Style::SelectorMatchingState* = nullptr) const;
 
     template <typename OutputType> void execute(ContainerNode& rootNode, OutputType&) const;
     template <typename OutputType> void executeFastPathForIdSelector(const ContainerNode& rootNode, const SelectorData&, const CSSSelector* idSelector, OutputType&) const;


### PR DESCRIPTION
#### cdba6f7e0a3223ec112881792d3b690b7640c1c0
<pre>
Poor performance of querySelectorAll() with descendant selectors (:has())
<a href="https://bugs.webkit.org/show_bug.cgi?id=283222">https://bugs.webkit.org/show_bug.cgi?id=283222</a>
<a href="https://rdar.apple.com/140093151">rdar://140093151</a>

Reviewed by Alan Baradlay.

We should provide a shared state when checking selector against multiple elements in SelectorChecker
so it benefits from caching optimizations like style resolution does.

This also revealed a bug in the caching implementation (WPT css/selectors/has-relative-argument.html).

* LayoutTests/fast/selectors/has-queryselector-performance-expected.txt: Added.
* LayoutTests/fast/selectors/has-queryselector-performance.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-css-nesting-shared-expected.txt:

Set the matchedInsideScope bit unconditionally. If we are trying to match the scope selector we have already matched
something inside the scope.

Test the element before skipping the subtree. The element itself may match even if descendants are known to fail.

Provide SelectorMatchingState when checking multiple element using the (non-compiled) slow path.
This allows caching across tests which is important for :has() performance.

* Source/WebCore/dom/SelectorQuery.h:

Canonical link: <a href="https://commits.webkit.org/286908@main">https://commits.webkit.org/286908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/720c80ed4b041b0df7e604a2e7e76452ce116cdc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82029 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28730 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4780 "Built successfully") | [💥 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60685 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18691 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66474 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40970 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48058 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23970 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27053 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69167 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83437 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4828 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68933 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4984 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68197 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17045 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12195 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10294 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4775 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7590 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4794 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8229 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6553 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->