### PR TITLE
[OpenXR] Suppress unsafe-buffer-usage warnings

### DIFF
--- a/Source/WebCore/platform/xr/openxr/OpenXRInputSource.cpp
+++ b/Source/WebCore/platform/xr/openxr/OpenXRInputSource.cpp
@@ -108,7 +108,9 @@ XrResult OpenXRInputSource::suggestBindings(SuggestedBindings& bindings) const
         RETURN_RESULT_IF_FAILED(createBinding(profile.path, m_pointerAction, makeString(m_subactionPathName, OPENXR_INPUT_AIM_PATH), bindings), m_instance);
 
         // Suggest binding for button actions.
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // WPE port
         const OpenXRButton* buttons;
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         size_t buttonsSize;
         if (m_handeness == XRHandedness::Left) {
             buttons = profile.leftButtons;
@@ -137,7 +139,9 @@ XrResult OpenXRInputSource::suggestBindings(SuggestedBindings& bindings) const
 
         // Suggest binding for axis actions.
         for (size_t i = 0; i < profile.axesSize; ++i) {
+            WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // WPE port
             const auto& axis = profile.axes[i];
+            WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             auto action = m_axisActions.get(axis.type);
             ASSERT(action != XR_NULL_HANDLE);
             RETURN_RESULT_IF_FAILED(createBinding(profile.path, action, makeString(m_subactionPathName, span(axis.path)), bindings), m_instance);
@@ -221,9 +225,11 @@ XrResult OpenXRInputSource::updateInteractionProfile()
     m_profiles.clear();
     for (auto& profile : openXRInputProfiles) {
         if (!strncmp(profile.path, buffer, writtenCount)) {
+            WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // WPE port
             for (size_t i = 0; i < profile.profileIdsSize; ++i)
                 m_profiles.append(String::fromUTF8(profile.profileIds[i]));
             break;
+            WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         }
     }
 


### PR DESCRIPTION
#### d2178342d085c633e8463db7ac00417571c9a57d
<pre>
[OpenXR] Suppress unsafe-buffer-usage warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=283415">https://bugs.webkit.org/show_bug.cgi?id=283415</a>

Reviewed by Adrian Perez de Castro.

* Source/WebCore/platform/xr/openxr/OpenXRInputSource.cpp:
(PlatformXR::OpenXRInputSource::suggestBindings const):
(PlatformXR::OpenXRInputSource::updateInteractionProfile):

Canonical link: <a href="https://commits.webkit.org/286857@main">https://commits.webkit.org/286857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/366afa8874372f4d6d98dd8e0923bd726e7834f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81868 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28580 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4629 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60559 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18597 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66346 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40858 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47933 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/23844 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26903 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/69045 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/24182 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83286 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4678 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3169 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68829 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4834 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66317 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/68086 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12079 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10178 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11965 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4625 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4644 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8079 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6403 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->