### PR TITLE
[GTK][WPE] Increase adoption of std::array for GObject signals and properties

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp
@@ -74,7 +74,7 @@ struct _WebKitAutomationSessionPrivate {
     CString id;
 };
 
-static guint signals[LAST_SIGNAL] = { 0, };
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitAutomationSession, webkit_automation_session, G_TYPE_OBJECT, GObject)
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitFindController.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFindController.cpp
@@ -79,7 +79,7 @@ struct _WebKitFindControllerPrivate {
     WebKitWebView* webView;
 };
 
-static guint signals[LAST_SIGNAL] = { 0, };
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitFindController, webkit_find_controller, G_TYPE_OBJECT, GObject)
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitGeolocationManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitGeolocationManager.cpp
@@ -243,7 +243,7 @@ struct _WebKitGeolocationManagerPrivate {
     std::unique_ptr<GeoclueGeolocationProvider> geoclueProvider;
 };
 
-static guint signals[LAST_SIGNAL] = { 0, };
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitGeolocationManager, webkit_geolocation_manager, G_TYPE_OBJECT, GObject)
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -136,7 +136,7 @@ enum {
     N_PROPERTIES,
 };
 
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 enum {
 #if !ENABLE(2022_GLIB_API)
@@ -290,7 +290,7 @@ struct _WebKitWebContextPrivate {
     CString timeZoneOverride;
 };
 
-static guint signals[LAST_SIGNAL] = { 0, };
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitWebContext, webkit_web_context, G_TYPE_OBJECT, GObject)
 
@@ -631,7 +631,7 @@ static void webkit_web_context_class_init(WebKitWebContextClass* webContextClass
             nullptr,
             static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
 
-    g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties.data());
 
 #if !ENABLE(2022_GLIB_API)
     /**

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp
@@ -68,7 +68,7 @@ enum {
     N_PROPERTIES,
 };
 
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 struct _WebKitWebResourcePrivate {
     RefPtr<WebFrameProxy> frame;
@@ -79,7 +79,7 @@ struct _WebKitWebResourcePrivate {
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitWebResource, webkit_web_resource, G_TYPE_OBJECT, GObject)
 
-static guint signals[LAST_SIGNAL] = { 0, };
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 static void webkitWebResourceGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
 {
@@ -127,7 +127,7 @@ static void webkit_web_resource_class_init(WebKitWebResourceClass* resourceClass
             WEBKIT_TYPE_URI_RESPONSE,
             WEBKIT_PARAM_READABLE);
 
-    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties.data());
 
     /**
      * WebKitWebResource::sent-request:

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebEditor.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebEditor.cpp
@@ -50,7 +50,7 @@ struct _WebKitWebEditorPrivate {
     WebKitWebPage* webPage;
 };
 
-static guint signals[LAST_SIGNAL] = { 0, };
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitWebEditor, webkit_web_editor, G_TYPE_OBJECT, GObject)
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.cpp
@@ -46,7 +46,7 @@ enum {
     LAST_SIGNAL
 };
 
-static guint signals[LAST_SIGNAL] = { 0, };
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 G_DEFINE_TYPE(WebKitWebFormManager, webkit_web_form_manager, G_TYPE_OBJECT)
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
@@ -98,7 +98,7 @@ enum {
     N_PROPERTIES,
 };
 
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 struct _WebKitWebPagePrivate {
     WebPage* webPage;
@@ -109,7 +109,7 @@ struct _WebKitWebPagePrivate {
     HashMap<WebKitScriptWorld*, GRefPtr<WebKitWebFormManager>> formManagerMap;
 };
 
-static guint signals[LAST_SIGNAL] = { 0, };
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitWebPage, webkit_web_page, G_TYPE_OBJECT, GObject)
 
@@ -518,7 +518,7 @@ static void webkit_web_page_class_init(WebKitWebPageClass* klass)
             0,
             WEBKIT_PARAM_READABLE);
 
-    g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties.data());
 
     /**
      * WebKitWebPage::document-loaded:

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebProcessExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebProcessExtension.cpp
@@ -130,7 +130,7 @@ struct _WebKitWebProcessExtensionPrivate {
 #endif
 };
 
-static guint signals[LAST_SIGNAL] = { 0, };
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitWebProcessExtension, webkit_web_process_extension, G_TYPE_OBJECT, GObject)
 


### PR DESCRIPTION
#### b701aea46e937e817f86911cfd8e1ca3f44d962d
<pre>
[GTK][WPE] Increase adoption of std::array for GObject signals and properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=283416">https://bugs.webkit.org/show_bug.cgi?id=283416</a>

Reviewed by Adrian Perez de Castro.

* Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitFindController.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitGeolocationManager.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
(webkit_web_context_class_init):
* Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp:
(webkit_web_resource_class_init):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebEditor.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp:
(webkit_web_page_class_init):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebProcessExtension.cpp:

Canonical link: <a href="https://commits.webkit.org/286859@main">https://commits.webkit.org/286859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86da271ef46baa715bb4346da5264b31c1042617

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81869 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28581 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4630 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60560 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18598 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50532 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/66348 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40859 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47934 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26904 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69046 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24184 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83287 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4679 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3170 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68830 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4835 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66319 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68087 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12081 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10180 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11966 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4626 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4645 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8080 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6404 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->