### PR TITLE
Fix pas_log formatting for size_t and uintptr_t

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/jit_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/jit_heap.c
@@ -80,7 +80,7 @@ void* jit_heap_try_allocate(size_t size)
     static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_JIT_HEAPS);
     void* result;
     if (verbose)
-        pas_log("jit heap allocating %lu\n", size);
+        pas_log("jit heap allocating %zu\n", size);
     result = (void*)jit_try_allocate_common_primitive_impl(size, 1, pas_always_compact_allocation_mode).begin;
     if (verbose)
         pas_log("jit heap done allocating, returning %p\n", result);
@@ -91,7 +91,7 @@ void jit_heap_shrink(void* object, size_t new_size)
 {
     static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_JIT_HEAPS);
     if (verbose)
-        pas_log("jit heap trying to shrink %p to %lu\n", object, new_size);
+        pas_log("jit heap trying to shrink %p to %zu\n", object, new_size);
     /* NOTE: the shrink call will fail (return false) for segregated allocations, and that's fine because we
        only use segregated allocations for smaller sizes (so the amount of potential memory savings from
        shrinking is small). */

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
@@ -74,7 +74,7 @@ static PAS_ALWAYS_INLINE bool pas_bitfit_page_allocation_satisfies_alignment(
     aligned_offset = PAS_ROUND_UP_TO_POWER_OF_2(begin_offset, alignment);
 
     if (verbose) {
-        pas_log("begin_offset = %lu, end_offset = %lu, size = %lu\n",
+        pas_log("begin_offset = %zu, end_offset = %zu, size = %zu\n",
                 begin_offset, end_offset, size);
     }
 
@@ -234,12 +234,12 @@ static PAS_ALWAYS_INLINE pas_bitfit_allocation_result pas_bitfit_page_finish_all
     begin = (uintptr_t)pas_bitfit_page_boundary(page, page_config) + offset_in_page;
 
     if (verbose) {
-        pas_log("%p: bitfit allocated %p of size %lu in %p\n",
+        pas_log("%p: bitfit allocated %p of size %zu in %p\n",
                 (void*)pthread_self(), (void*)begin, size, page);
     }
 
     if (verbose) {
-        pas_log("Bits after allocating %p (size %lu, offset %lu in %p):\n",
+        pas_log("Bits after allocating %p (size %zu, offset %zu in %p):\n",
                 (void*)begin, size, offset_in_page, page);
         pas_bitfit_page_log_bits(page, offset_in_page, offset_in_page + size);
     }
@@ -271,7 +271,7 @@ static PAS_ALWAYS_INLINE pas_bitfit_allocation_result pas_bitfit_page_allocate(
     uintptr_t largest_available_bits;
 
     if (verbose)
-        pas_log("In page %p allocating size = %lu, alignment = %lu.\n", page, size, alignment);
+        pas_log("In page %p allocating size = %zu, alignment = %zu.\n", page, size, alignment);
 
     PAS_ASSERT(page_config.base.is_enabled);
     PAS_TESTING_ASSERT(pas_is_aligned(size, pas_page_base_config_min_align(page_config.base)));
@@ -565,7 +565,7 @@ static PAS_ALWAYS_INLINE uintptr_t pas_bitfit_page_deallocate_with_page_impl(
     owner = pas_compact_atomic_bitfit_view_ptr_load(&page->owner);
 
     if (verbose) {
-        pas_log("Bits before deallocate_impl (mode = %s) of %p (offset = %lu in %p), "
+        pas_log("Bits before deallocate_impl (mode = %s) of %p (offset = %zu in %p), "
                 "num_live_bits = %u\n",
                 pas_bitfit_page_deallocate_with_page_impl_mode_get_string(mode), (void*)begin, offset,
                 page, page->num_live_bits);
@@ -592,7 +592,7 @@ static PAS_ALWAYS_INLINE uintptr_t pas_bitfit_page_deallocate_with_page_impl(
         }
 
         if (verbose)
-            pas_log("Shrinking to new_size = %lu, new_num_bits = %lu\n", new_size, new_num_bits);
+            pas_log("Shrinking to new_size = %zu, new_num_bits = %zu\n", new_size, new_num_bits);
         
         break;
     }
@@ -751,7 +751,7 @@ static PAS_ALWAYS_INLINE uintptr_t pas_bitfit_page_deallocate_with_page_impl(
                             bit_index_in_word + new_num_bits;
 
                         if (verbose)
-                            pas_log("start_of_free = %lu\n", start_of_free);
+                            pas_log("start_of_free = %zu\n", start_of_free);
 
                         modified_word_index = PAS_BITVECTOR_WORD64_INDEX(start_of_free);
                         modified_bit_index_in_word = PAS_BITVECTOR_BIT_SHIFT64(start_of_free);
@@ -815,7 +815,7 @@ static PAS_ALWAYS_INLINE uintptr_t pas_bitfit_page_deallocate_with_page_impl(
                 }
 
                 if (verbose)
-                    pas_log("num_bits = %lu\n", num_bits);
+                    pas_log("num_bits = %zu\n", num_bits);
                 break;
             }
         }
@@ -836,7 +836,7 @@ static PAS_ALWAYS_INLINE uintptr_t pas_bitfit_page_deallocate_with_page_impl(
         modified_offset = offset + (new_num_bits << page_config.base.min_align_shift);
 
         if (verbose) {
-            pas_log("%p: bitfit deallocated %p of size %lu in %p with modified_offset = %lu\n",
+            pas_log("%p: bitfit deallocated %p of size %zu in %p with modified_offset = %zu\n",
                     (void*)pthread_self(), (void*)begin, size, page, modified_offset);
         }
         
@@ -882,8 +882,8 @@ static PAS_ALWAYS_INLINE uintptr_t pas_bitfit_page_deallocate_with_page_impl(
             pas_bitfit_view_note_partial_emptiness(owner, page);
         
         if (verbose) {
-            pas_log("Bits afer deallocate_impl (mode = %s) with size %lu, offset = %lu, "
-                    "modified_offset = %lu in %p\n",
+            pas_log("Bits afer deallocate_impl (mode = %s) with size %zu, offset = %zu, "
+                    "modified_offset = %zu in %p\n",
                     pas_bitfit_page_deallocate_with_page_impl_mode_get_string(mode), size, offset,
                     modified_offset, page);
             pas_bitfit_page_log_bits(

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -1472,7 +1472,7 @@ pas_local_allocator_try_allocate_with_free_bits(
             pas_log("current_word = %llx\n", (unsigned long long)current_word);
         found_bit_index = (uintptr_t)__builtin_clzll(current_word);
         if (verbose)
-            pas_log("found_bit_index = %lu\n", found_bit_index);
+            pas_log("found_bit_index = %zu\n", found_bit_index);
         current_word &= ~(0x8000000000000000llu >> found_bit_index);
         if (verbose)
             pas_log("new current_word = %llx\n", (unsigned long long)current_word);

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page.h
@@ -275,7 +275,7 @@ pas_segregated_page_number_of_objects(unsigned object_size,
     if (verbose) {
         pas_log("first object offset = %u\n", pas_segregated_page_offset_from_page_boundary_to_first_object_exclusive(object_size, page_config));
         pas_log("end of last object offset = %u\n", pas_segregated_page_offset_from_page_boundary_to_end_of_last_object_exclusive(object_size, page_config));
-        pas_log("payload offset = %lu\n", pas_segregated_page_config_payload_offset_for_role(page_config, role));
+        pas_log("payload offset = %zu\n", pas_segregated_page_config_payload_offset_for_role(page_config, role));
         pas_log("object_size = %u, so number_of_objects = %u\n", object_size, result);
     }
     

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_handle_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_handle_inlines.h
@@ -42,7 +42,7 @@ pas_segregated_shared_handle_partial_view_ptr_for_index(
     
     index >>= page_config.sharing_shift;
     if (verbose)
-        pas_log("sharing index = %lu\n", index);
+        pas_log("sharing index = %zu\n", index);
     PAS_ASSERT(index < pas_segregated_shared_handle_num_views(page_config));
     return handle->partial_views + index;
 }
@@ -75,7 +75,7 @@ pas_segregated_shared_handle_partial_view_for_object(
     index = pas_page_base_index_of_object_at_offset_from_page_boundary(offset, page_config.base);
 
     if (verbose)
-        pas_log("offset = %lu, index = %lu\n", offset, index);
+        pas_log("offset = %zu, index = %zu\n", offset, index);
 
     return pas_segregated_shared_handle_partial_view_for_index(handle, index, page_config);
 }


### PR DESCRIPTION
#### c39daa0ab4e373eed4f82c8745a2deb541057225
<pre>
Fix pas_log formatting for size_t and uintptr_t
<a href="https://bugs.webkit.org/show_bug.cgi?id=283312">https://bugs.webkit.org/show_bug.cgi?id=283312</a>

Reviewed by Yusuke Suzuki.

Fixes a number of errors when building on Windows due to pas_log
using %lu for size_t and uintptr_t types.

* Source/bmalloc/libpas/src/libpas/jit_heap.c:
(jit_heap_try_allocate):
(jit_heap_shrink):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h:
(pas_bitfit_page_allocation_satisfies_alignment):
(pas_bitfit_page_finish_allocation):
(pas_bitfit_page_allocate):
(pas_bitfit_page_deallocate_with_page_impl):
* Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h:
(pas_local_allocator_try_allocate_with_free_bits):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page.h:
(pas_segregated_page_number_of_objects):
* Source/bmalloc/libpas/src/libpas/pas_segregated_shared_handle_inlines.h:
(pas_segregated_shared_handle_partial_view_ptr_for_index):
(pas_segregated_shared_handle_partial_view_for_object):

Canonical link: <a href="https://commits.webkit.org/286873@main">https://commits.webkit.org/286873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/983311c750971ecf97e8627985e682d47fc606f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77317 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81889 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28599 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4649 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60578 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18610 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50546 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66366 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40877 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47948 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23865 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26922 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/70503 "Found 4 new JSC stress test failures: stress/get-by-val-hoist-above-structure-2.js.ftl-no-cjit-b3o0, stress/get-by-val-hoist-above-structure.js.ftl-eager-no-cjit-b3o1, wasm.yaml/wasm/modules/wasm-imports-js-exports.js.wasm-aggressive-inline, wasm.yaml/wasm/modules/wasm-imports-js-exports.js.wasm-no-cjit (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69060 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24203 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83306 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76595 "Found 1 new JSC stress test failure: stress/get-by-val-hoist-above-structure.js.ftl-eager-no-cjit-b3o1 (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4697 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3190 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68846 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4853 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66337 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68121 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17015 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12098 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10199 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98848 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4644 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21618 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4663 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8098 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6422 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->