### PR TITLE
Replace EnabledIf with RELEASE_ASSERT for ModelProcessModelPlayer and PlatformXRSystemProxy

### DIFF
--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -80,6 +80,8 @@ bool ModelProcessModelPlayer::modelProcessEnabled() const
 void ModelProcessModelPlayer::didCreateLayer(WebCore::LayerHostingContextIdentifier identifier)
 {
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayer obtained new layerHostingContextIdentifier id=%" PRIu64, this, m_id.toUInt64());
+    RELEASE_ASSERT(modelProcessEnabled());
+
     m_layerHostingContextIdentifier = identifier;
     m_client->didUpdateLayerHostingContextIdentifier(*this, identifier);
 }
@@ -87,6 +89,8 @@ void ModelProcessModelPlayer::didCreateLayer(WebCore::LayerHostingContextIdentif
 void ModelProcessModelPlayer::didFinishLoading(const WebCore::FloatPoint3D& boundingBoxCenter, const WebCore::FloatPoint3D& boundingBoxExtents)
 {
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayer didFinishLoading id=%" PRIu64, this, m_id.toUInt64());
+    RELEASE_ASSERT(modelProcessEnabled());
+
     m_client->didFinishLoading(*this);
     m_client->didUpdateBoundingBox(*this, boundingBoxCenter, boundingBoxExtents);
 }
@@ -95,11 +99,15 @@ void ModelProcessModelPlayer::didFinishLoading(const WebCore::FloatPoint3D& boun
 /// Not to be confused with setEntityTransform().
 void ModelProcessModelPlayer::didUpdateEntityTransform(const WebCore::TransformationMatrix& transform)
 {
+    RELEASE_ASSERT(modelProcessEnabled());
+
     m_client->didUpdateEntityTransform(*this, transform);
 }
 
 void ModelProcessModelPlayer::didUpdateAnimationPlaybackState(bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp)
 {
+    RELEASE_ASSERT(modelProcessEnabled());
+
     m_paused = isPaused;
     m_effectivePlaybackRate = fmax(playbackRate, 0);
     m_duration = duration;
@@ -109,6 +117,8 @@ void ModelProcessModelPlayer::didUpdateAnimationPlaybackState(bool isPaused, dou
 
 void ModelProcessModelPlayer::didFinishEnvironmentMapLoading(bool succeeded)
 {
+    RELEASE_ASSERT(modelProcessEnabled());
+
     m_client->didFinishEnvironmentMapLoading(succeeded);
 }
 

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
@@ -23,11 +23,11 @@
 #if ENABLE(MODEL_PROCESS)
 
 messages -> ModelProcessModelPlayer {
-    [EnabledIf='modelProcessEnabled()'] DidCreateLayer(WebCore::LayerHostingContextIdentifier identifier)
-    [EnabledIf='modelProcessEnabled()'] DidFinishLoading(WebCore::FloatPoint3D center, WebCore::FloatPoint3D extents)
-    [EnabledIf='modelProcessEnabled()'] DidUpdateEntityTransform(WebCore::TransformationMatrix transform)
-    [EnabledIf='modelProcessEnabled()'] DidUpdateAnimationPlaybackState(bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp)
-    [EnabledIf='modelProcessEnabled()'] DidFinishEnvironmentMapLoading(bool succeeded)
+    DidCreateLayer(WebCore::LayerHostingContextIdentifier identifier)
+    DidFinishLoading(WebCore::FloatPoint3D center, WebCore::FloatPoint3D extents)
+    DidUpdateEntityTransform(WebCore::TransformationMatrix transform)
+    DidUpdateAnimationPlaybackState(bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp)
+    DidFinishEnvironmentMapLoading(bool succeeded)
 }
 
 #endif // ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
@@ -113,12 +113,16 @@ void PlatformXRSystemProxy::submitFrame()
 
 void PlatformXRSystemProxy::sessionDidEnd(XRDeviceIdentifier deviceIdentifier)
 {
+    RELEASE_ASSERT(webXREnabled());
+
     if (auto device = deviceByIdentifier(deviceIdentifier))
         device->sessionDidEnd();
 }
 
 void PlatformXRSystemProxy::sessionDidUpdateVisibilityState(XRDeviceIdentifier deviceIdentifier, PlatformXR::VisibilityState visibilityState)
 {
+    RELEASE_ASSERT(webXREnabled());
+
     if (auto device = deviceByIdentifier(deviceIdentifier))
         device->updateSessionVisibilityState(visibilityState);
 }

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.messages.in
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.messages.in
@@ -26,8 +26,8 @@
 #if ENABLE(WEBXR)
 
 messages -> PlatformXRSystemProxy NotRefCounted {
-    [EnabledIf='webXREnabled()'] SessionDidEnd(WebKit::XRDeviceIdentifier deviceIdentifier)
-    [EnabledIf='webXREnabled()'] SessionDidUpdateVisibilityState(WebKit::XRDeviceIdentifier deviceIdentifier, PlatformXR::VisibilityState visibilityState)
+    SessionDidEnd(WebKit::XRDeviceIdentifier deviceIdentifier)
+    SessionDidUpdateVisibilityState(WebKit::XRDeviceIdentifier deviceIdentifier, PlatformXR::VisibilityState visibilityState)
 }
 
 #endif


### PR DESCRIPTION
#### 306ff2dc43802343bd0b536d19c45b823807694e
<pre>
Replace EnabledIf with RELEASE_ASSERT for ModelProcessModelPlayer and PlatformXRSystemProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=283438">https://bugs.webkit.org/show_bug.cgi?id=283438</a>
<a href="https://rdar.apple.com/140295541">rdar://140295541</a>

Reviewed by Ryosuke Niwa.

It does not make much sense to add message check in web process since its main goal is to kill sender web process. In
this case, the message is sent by a trusted process and it is more likely something is wrong with the receiver web
process. This patch repalces them with RELEASE_ASSERT.

* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::didCreateLayer):
(WebKit::ModelProcessModelPlayer::didFinishLoading):
(WebKit::ModelProcessModelPlayer::didUpdateEntityTransform):
(WebKit::ModelProcessModelPlayer::didUpdateAnimationPlaybackState):
(WebKit::ModelProcessModelPlayer::didFinishEnvironmentMapLoading):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in:
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp:
(WebKit::PlatformXRSystemProxy::sessionDidEnd):
(WebKit::PlatformXRSystemProxy::sessionDidUpdateVisibilityState):
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.messages.in:

Canonical link: <a href="https://commits.webkit.org/286990@main">https://commits.webkit.org/286990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5545e65445abf666a6a8a76cc638e2ba5c63f029

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29095 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5165 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60956 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18898 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80906 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50935 "Found 2 new test failures: fast/forms/date/date-input-rendering-basic.html fast/forms/date/date-pseudo-elements.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66829 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41259 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48290 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27438 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83848 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5205 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3504 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69178 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5361 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66757 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68427 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17098 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12436 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/10536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/99386 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5153 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/99386 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5145 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8577 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6930 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->