### PR TITLE
[scroll-animations] Serialize normal value of animation-range as a string

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-normal-matches-cover-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-normal-matches-cover-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Changing the animation range updates the play state assert_equals: expected (string) "normal" but got (object) object "[object Object]"
+FAIL Changing the animation range updates the play state assert_approx_equals: values do not match for "currentTime at start of normal range" expected 0 +/- 0.125 but got 100
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-set-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-set-range-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Getting and setting the animation range assert_equals: Initial value for rangeStart expected (string) "normal" but got (object) object "[object Object]"
+FAIL Getting and setting the animation range assert_equals: Opacity with range set to [normal, normal] expected "0.5" but got "1"
 

--- a/Source/WebCore/animation/TimelineRange.cpp
+++ b/Source/WebCore/animation/TimelineRange.cpp
@@ -61,6 +61,8 @@ bool SingleTimelineRange::isOffsetValue(const CSSPrimitiveValue& value)
 
 TimelineRangeValue SingleTimelineRange::serialize() const
 {
+    if (name == Name::Normal)
+        return CSSPrimitiveValue::create(valueID(name))->stringValue();
     return TimelineRangeOffset { CSSPrimitiveValue::create(valueID(name))->stringValue(), offset.isPercentOrCalculated() ? CSSNumericFactory::percent(offset.percent()) : CSSNumericFactory::px(offset.value()) };
 }
 


### PR DESCRIPTION
#### ce3940b4672559f1e225f93166abd9c515c38fe2
<pre>
[scroll-animations] Serialize normal value of animation-range as a string
<a href="https://bugs.webkit.org/show_bug.cgi?id=283439">https://bugs.webkit.org/show_bug.cgi?id=283439</a>
<a href="https://rdar.apple.com/140297294">rdar://140297294</a>

Reviewed by Tim Nguyen.

We should serialize normal value of animation-range as a string rather than a
TimelineRangeOffset object.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-normal-matches-cover-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-set-range-expected.txt:
* Source/WebCore/animation/TimelineRange.cpp:
(WebCore::SingleTimelineRange::serialize const):

Canonical link: <a href="https://commits.webkit.org/286937@main">https://commits.webkit.org/286937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0073e65b50370cf5e9d9add45e0e48210846c50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77528 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82119 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28810 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79645 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4860 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60754 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18742 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41022 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48130 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24036 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27134 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69239 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83518 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4908 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3345 "Found 2 new test failures: ipc/create-connection-and-send-async.html webrtc/vp9-profile2.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68982 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66507 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68247 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12262 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10359 "Passed tests") | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/12017 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4855 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4874 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8309 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6633 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->