### PR TITLE
[Navigation] Navigation.navigate() should trigger the 'beforeunload' event synchronously

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7432,17 +7432,6 @@ imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-204-205-download.html [ Failure Pass ]
 imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-204-205-download-then-same-document.html [ Failure Pass ]
 
-# beforeunload event listeners are not allowed on subframes.
-imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-cross-document.html [ Skip ]
-imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-beforeunload.html [ Skip ]
-imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/forward-beforeunload.html [ Skip ]
-imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-beforeunload.html [ Skip ]
-imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-beforeunload-unserializablestate.html [ Skip ]
-imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-beforeunload.html [ Skip ]
-imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-beforeunload.html [ Skip ]
-imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-beforeunload-unserializablestate.html [ Skip ]
-imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-beforeunload.html [ Skip ]
-
 webkit.org/b/282758 [ Debug ] imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-same-document-in-iframe.html [ Crash ]
 webkit.org/b/282758 [ Debug ] imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-same-document.html [ Crash ]
 webkit.org/b/282758 [ Debug ] imported/w3c/web-platform-tests/navigation-api/navigation-methods/forward-to-pruned-entry.html [ Crash ]

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-handler-throws-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-handler-throws-expected.txt
@@ -1,3 +1,6 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: a message
+
+Harness Error (FAIL), message = Unhandled rejection: a message
 
 PASS event.intercept() should abort if the handler throws
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-beforeunload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-beforeunload-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL back() inside onbeforeunload assert_equals: expected 2 but got 1
+PASS back() inside onbeforeunload
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/forward-beforeunload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/forward-beforeunload-expected.txt
@@ -1,8 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Cannot go back
-CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Cannot go back
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT forward() inside onbeforeunload Test timed out
+PASS forward() inside onbeforeunload
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-beforeunload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-beforeunload-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigate() inside onbeforeunload assert_not_equals: got disallowed value undefined
+PASS navigate() inside onbeforeunload
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-beforeunload-unserializablestate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-beforeunload-unserializablestate-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigate() with an unserializable state inside onbeforeunload "DataCloneError", not "InvalidStateError" assert_not_equals: got disallowed value undefined
+PASS navigate() with an unserializable state inside onbeforeunload "DataCloneError", not "InvalidStateError"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-beforeunload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-beforeunload-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigate() with an invalid URL inside onbeforeunload throws "SyntaxError", not "InvalidStateError" assert_not_equals: got disallowed value undefined
+PASS navigate() with an invalid URL inside onbeforeunload throws "SyntaxError", not "InvalidStateError"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-beforeunload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-beforeunload-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL reload() inside onbeforeunload assert_not_equals: got disallowed value undefined
+PASS reload() inside onbeforeunload
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-beforeunload-unserializablestate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-beforeunload-unserializablestate-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL reload() with an unserializable state inside onbeforeunload throws "DataCloneError", not "InvalidStateError" assert_not_equals: got disallowed value undefined
+PASS reload() with an unserializable state inside onbeforeunload throws "DataCloneError", not "InvalidStateError"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-beforeunload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-beforeunload-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL traverseTo() inside onbeforeunload assert_not_equals: got disallowed value undefined
+PASS traverseTo() inside onbeforeunload
 

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -113,6 +113,10 @@ public:
 
     NavigationHistoryBehavior navigationHistoryBehavior() const { return m_navigationHistoryBehavior; }
     void setNavigationHistoryBehavior(NavigationHistoryBehavior historyHandling) { m_navigationHistoryBehavior = historyHandling; }
+
+    bool isFromNavigationAPI() const { return m_isFromNavigationAPI; }
+    void setIsFromNavigationAPI(bool isFromNavigationAPI) { m_isFromNavigationAPI = isFromNavigationAPI; }
+
 private:
     Ref<Document> m_requester;
     Ref<SecurityOrigin> m_requesterSecurityOrigin;
@@ -136,6 +140,7 @@ private:
     bool m_isInitialFrameSrcLoad { false };
     std::optional<OptionSet<AdvancedPrivacyProtections>> m_advancedPrivacyProtections;
     NavigationHistoryBehavior m_navigationHistoryBehavior { NavigationHistoryBehavior::Auto };
+    bool m_isFromNavigationAPI { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -536,6 +536,7 @@ private:
     bool m_shouldRestoreScrollPositionAndViewState { false };
 
     bool m_errorOccurredInLoading { false };
+    bool m_doNotAbortNavigationAPI { false };
 };
 
 // This function is called by createWindow() in JSDOMWindowBase.cpp, for example, for

--- a/Source/WebCore/loader/NavigationAction.h
+++ b/Source/WebCore/loader/NavigationAction.h
@@ -150,6 +150,9 @@ public:
     std::optional<NavigationNavigationType> navigationAPIType() const { return m_navigationAPIType; }
     void setNavigationAPIType(NavigationNavigationType navigationAPIType) { m_navigationAPIType = navigationAPIType; }
 
+    bool isFromNavigationAPI() const { return m_isFromNavigationAPI; }
+    void setIsFromNavigationAPI(bool isFromNavigationAPI) { m_isFromNavigationAPI = isFromNavigationAPI; }
+
 private:
     // Do not add a strong reference to the originating document or a subobject that holds the
     // originating document. See comment above the class for more details.
@@ -177,6 +180,7 @@ private:
     LockHistory m_lockHistory { LockHistory::No };
     LockBackForwardList m_lockBackForwardList { LockBackForwardList::No };
     NewFrameOpenerPolicy m_newFrameOpenerPolicy { NewFrameOpenerPolicy::Allow };
+    bool m_isFromNavigationAPI { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -336,17 +336,17 @@ public:
 
     std::optional<Ref<HistoryItem>> findBackForwardItemByKey(const LocalFrame& localFrame)
     {
-        auto entry = localFrame.window()->navigation().findEntryByKey(m_key);
+        RefPtr entry = localFrame.window()->navigation().findEntryByKey(m_key);
         if (!entry)
             return std::nullopt;
 
-        Ref historyItem = entry.value()->associatedHistoryItem();
+        Ref historyItem = entry->associatedHistoryItem();
 
         if (localFrame.isMainFrame())
             return historyItem;
 
         // FIXME: heuristic to fix disambigaute-* tests, we should find something more exact.
-        bool backwards = entry.value()->index() < localFrame.window()->navigation().currentEntry()->index();
+        bool backwards = entry->index() < localFrame.window()->navigation().currentEntry()->index();
 
         RefPtr page { localFrame.page() };
         auto items = page->checkedBackForward()->allItems();

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1146,6 +1146,10 @@ void LocalDOMWindow::stop()
         return;
 
     SetForScope isStopping { m_isStopping, true };
+
+    if (frame->document() && frame->document()->settings().navigationAPIEnabled())
+        protectedNavigation()->abortOngoingNavigationIfNeeded();
+
     // We must check whether the load is complete asynchronously, because we might still be parsing
     // the document until the callstack unwinds.
     frame->protectedLoader()->stopForUserCancel(true);

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -47,13 +47,14 @@ NavigateEvent::NavigateEvent(const AtomString& type, const NavigateEvent::Init& 
     , m_signal(init.signal)
     , m_formData(init.formData)
     , m_downloadRequest(init.downloadRequest)
-    , m_info(init.info)
     , m_canIntercept(init.canIntercept)
     , m_userInitiated(init.userInitiated)
     , m_hashChange(init.hashChange)
     , m_hasUAVisualTransition(init.hasUAVisualTransition)
     , m_abortController(abortController)
 {
+    Locker<JSC::JSLock> locker(commonVM().apiLock());
+    m_info.setWeakly(init.info);
 }
 
 Ref<NavigateEvent> NavigateEvent::create(const AtomString& type, const NavigateEvent::Init& init, AbortController* abortController)

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ActiveDOMObject.h"
 #include "EventTarget.h"
 #include "JSDOMPromiseDeferred.h"
 #include "LocalDOMWindowProperty.h"
@@ -119,7 +120,7 @@ public:
         RefPtr<DOMPromise> finished;
     };
 
-    const Vector<Ref<NavigationHistoryEntry>>& entries() const;
+    Vector<Ref<NavigationHistoryEntry>> entries() const;
     NavigationHistoryEntry* currentEntry() const;
     NavigationTransition* transition() { return m_transition.get(); };
     NavigationActivation* activation() { return m_activation.get(); };
@@ -152,7 +153,7 @@ public:
 
     void abortOngoingNavigationIfNeeded();
 
-    std::optional<Ref<NavigationHistoryEntry>> findEntryByKey(const String& key);
+    RefPtr<NavigationHistoryEntry> findEntryByKey(const String& key);
     bool suppressNormalScrollRestoration() const { return m_suppressNormalScrollRestorationDuringOngoingNavigation; }
 
     void setFocusChanged(FocusDidChange changed) { m_focusChangedDuringOngoingNavigation = changed; }
@@ -181,10 +182,13 @@ private:
     void notifyCommittedToEntry(NavigationAPIMethodTracker*, NavigationHistoryEntry*, NavigationNavigationType);
     Result apiMethodTrackerDerivedResult(const NavigationAPIMethodTracker&);
 
+    class NavigationHistoryEntryWrapper;
+    static std::optional<size_t> getEntryIndexOfHistoryItem(const Vector<NavigationHistoryEntryWrapper>& entries, const HistoryItem&, size_t start = 0);
+
     std::optional<size_t> m_currentEntryIndex;
     RefPtr<NavigationTransition> m_transition;
     RefPtr<NavigationActivation> m_activation;
-    Vector<Ref<NavigationHistoryEntry>> m_entries;
+    Vector<NavigationHistoryEntryWrapper> m_entries;
 
     RefPtr<NavigateEvent> m_ongoingNavigateEvent;
     FocusDidChange m_focusChangedDuringOngoingNavigation { FocusDidChange::No };

--- a/Source/WebCore/page/NavigationHistoryEntry.cpp
+++ b/Source/WebCore/page/NavigationHistoryEntry.cpp
@@ -41,7 +41,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(NavigationHistoryEntry);
 
 NavigationHistoryEntry::NavigationHistoryEntry(ScriptExecutionContext* context, Ref<HistoryItem>&& historyItem, String urlString, WTF::UUID key, RefPtr<SerializedScriptValue>&& state, WTF::UUID id)
-    : ContextDestructionObserver(context)
+    : ActiveDOMObject(context)
     , m_urlString(urlString)
     , m_key(key)
     , m_id(id)
@@ -50,13 +50,22 @@ NavigationHistoryEntry::NavigationHistoryEntry(ScriptExecutionContext* context, 
 {
 }
 
+Ref<NavigationHistoryEntry> NavigationHistoryEntry::create(ScriptExecutionContext* context, Ref<HistoryItem>&& historyItem)
+{
+    Ref entry = adoptRef(*new NavigationHistoryEntry(context, WTFMove(historyItem), historyItem->urlString(), historyItem->uuidIdentifier()));
+    entry->suspendIfNeeded();
+    return entry;
+}
+
 Ref<NavigationHistoryEntry> NavigationHistoryEntry::create(ScriptExecutionContext* context, const NavigationHistoryEntry& other)
 {
     Ref historyItem = other.m_associatedHistoryItem;
     RefPtr state = historyItem->navigationAPIStateObject();
     if (!state)
         state = other.m_state;
-    return adoptRef(*new NavigationHistoryEntry(context, WTFMove(historyItem), other.m_urlString, other.m_key, WTFMove(state), other.m_id));
+    Ref entry = adoptRef(*new NavigationHistoryEntry(context, WTFMove(historyItem), other.m_urlString, other.m_key, WTFMove(state), other.m_id));
+    entry->suspendIfNeeded();
+    return entry;
 }
 
 ScriptExecutionContext* NavigationHistoryEntry::scriptExecutionContext() const

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ActiveDOMObject.h"
 #include "ContextDestructionObserver.h"
 #include "EventHandler.h"
 #include "EventTarget.h"
@@ -39,14 +40,14 @@ namespace WebCore {
 
 class SerializedScriptValue;
 
-class NavigationHistoryEntry final : public RefCounted<NavigationHistoryEntry>, public EventTarget, public ContextDestructionObserver {
+class NavigationHistoryEntry final : public RefCounted<NavigationHistoryEntry>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(NavigationHistoryEntry);
 public:
-    using RefCounted<NavigationHistoryEntry>::ref;
-    using RefCounted<NavigationHistoryEntry>::deref;
-
-    static Ref<NavigationHistoryEntry> create(ScriptExecutionContext* context, Ref<HistoryItem>&& historyItem) { return adoptRef(*new NavigationHistoryEntry(context, WTFMove(historyItem), historyItem->urlString(), historyItem->uuidIdentifier())); }
+    static Ref<NavigationHistoryEntry> create(ScriptExecutionContext*, Ref<HistoryItem>&&);
     static Ref<NavigationHistoryEntry> create(ScriptExecutionContext*, const NavigationHistoryEntry&);
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     const String& url() const;
     String key() const;

--- a/Source/WebCore/page/NavigationHistoryEntry.idl
+++ b/Source/WebCore/page/NavigationHistoryEntry.idl
@@ -1,4 +1,5 @@
 [
+  ActiveDOMObject,
   EnabledBySetting=NavigationAPIEnabled,
   Exposed=Window
 ] interface NavigationHistoryEntry : EventTarget {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -690,6 +690,9 @@ void WebLocalFrameLoaderClient::dispatchDidFailProvisionalLoad(const ResourceErr
         request = documentLoader->request();
     }
 
+    if (m_frame->isMainFrame())
+        completePageTransitionIfNeeded();
+
     // Notify the UIProcess.
     webPage->send(Messages::WebPageProxy::DidFailProvisionalLoadForFrame(m_frame->info(), request, navigationID, m_localFrame->loader().provisionalLoadErrorBeingHandledURL().string(), error, willContinueLoading, UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get()), willInternallyHandleFailure));
 }


### PR DESCRIPTION
#### 4c2147c4b2aa67d561ab0b50feeefb8dc677cd35
<pre>
[Navigation] Navigation.navigate() should trigger the &apos;beforeunload&apos; event synchronously
<a href="https://bugs.webkit.org/show_bug.cgi?id=282593">https://bugs.webkit.org/show_bug.cgi?id=282593</a>
<a href="https://rdar.apple.com/139628818">rdar://139628818</a>

Reviewed by Rob Buis.

Navigation.navigate() should trigger the &apos;beforeunload&apos; event synchronously and quite
a few WPT tests were relying on this.

Fixing this enabled some more tests which exposed some pre-existing bugs that I&apos;m
fixing in the same PR so it doesn&apos;t look like regressions.

In particular, we dispatch events at NavigationHistoryEntry objects but the class
doesn&apos;t subclass ActiveDOMObject to keep the JS wrapper alive. We were also failing
to grab the JSLock in one place, which was causing assertions.

* LayoutTests/TestExpectations:
Unskip some tests that are now passing.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-handler-throws-expected.txt:
The output looks a bit worse but I don&apos;t think this is a regression. Rather, this looks like a timing change because
the navigation now happens sooner. I will investigate separately how to make this test fully pass.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-beforeunload-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/forward-beforeunload-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-beforeunload-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-beforeunload-unserializablestate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-beforeunload-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-beforeunload-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-beforeunload-unserializablestate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-beforeunload-expected.txt:
Rebaseline tests that are now passing.

* Source/WebCore/loader/FrameLoadRequest.h:
(WebCore::FrameLoadRequest::isFromNavigationAPI const):
(WebCore::FrameLoadRequest::setIsFromNavigationAPI):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::stopLoading):
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::loadWithDocumentLoader):
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/NavigationAction.h:
(WebCore::NavigationAction::isFromNavigationAPI const):
(WebCore::NavigationAction::setIsFromNavigationAPI):
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledHistoryNavigationByKey::findBackForwardItemByKey):
Make the navigation policy decision synchronous when the navigation is triggered via the navigation API.
This is the only way the navigation can proceed synchronously and fire the beforeunload event right away.

* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::stop):
When calling `window.stop()`, abort the pending navigation API navigation as tests are expecting this.

* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::NavigateEvent):
(WebCore::NavigateEvent::create):
* Source/WebCore/page/NavigateEvent.h:
* Source/WebCore/page/NavigateEvent.idl:
Make sure the grab the JSLock before initializing m_info. Without this, I was seeing assertions
in the layout tests.

* Source/WebCore/page/Navigation.cpp:
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/NavigationHistoryEntry.cpp:
(WebCore::NavigationHistoryEntry::NavigationHistoryEntry):
(WebCore::NavigationHistoryEntry::create):
* Source/WebCore/page/NavigationHistoryEntry.h:
* Source/WebCore/page/NavigationHistoryEntry.idl:
Make NavigationHistoryEntry an ActiveDOMObject and keep its JS wrapper alive as long as the
NavigationHistoryEntry is held by the navigation object. This is important since the navigation
object may dispatch events at the NavigationHistoryEntry. Without this change, some of the tests
were asserting that the JS wrapper was missing during the event dispatching.

* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
Obey the policyDecisionMode being PolicyDecisionMode::Synchronous and use the DecidePolicyForNavigationActionSync
synchronous IPC when the navigation is triggered by the Navigation API so that the navigation can
start synchronously and yet still obey the policy decision from the client.

* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDidFailProvisionalLoad):
Some of the tests abort the navigation during the provisional stage. This was hitting
an assertion in `WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone()`:
`ASSERT(!m_frame-&gt;isMainFrame() || webPage-&gt;corePage()-&gt;settings().suppressesIncrementalRendering() || m_didCompletePageTransition);`
The reason was the m_didCompletePageTransition wasn&apos;t reset to true and provisional load failure.
To address this issue, I now make sure to call `completePageTransitionIfNeeded()` in `dispatchDidFailProvisionalLoad()`.

Canonical link: <a href="https://commits.webkit.org/286919@main">https://commits.webkit.org/286919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21daa7d59e2da30209a8eb4eee2381c587ec2d4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56520 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82094 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28767 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4817 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60730 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18719 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80552 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41008 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48097 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24006 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27090 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69207 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24344 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83474 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4865 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3314 "Found 2 new test failures: ipc/create-connection-and-send-async.html webrtc/vp9-profile2.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68957 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5021 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66477 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68222 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17054 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12236 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10329 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4812 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7627 "Found 1 new failure in JSNavigationHistoryEntry.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4831 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8266 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6590 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->