### PR TITLE
Remove uses of legacyMainFrameProcess() in Web Extensions.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
@@ -52,6 +52,7 @@ void WebExtensionContext::addListener(WebPageProxyIdentifier identifier, WebExte
     if (!protectedExtension()->backgroundContentIsPersistent() && isBackgroundPage(identifier))
         m_backgroundContentEventListeners.add(type);
 
+    // FIXME: <https://webkit.org/b/281516> This map should be for frames not pages.
     auto result = m_eventListenerPages.add({ type, contentWorldType }, WeakPageCountedSet { });
     result.iterator->value.add(*page);
 }
@@ -71,6 +72,7 @@ void WebExtensionContext::removeListener(WebPageProxyIdentifier identifier, WebE
             m_backgroundContentEventListeners.remove(type);
     }
 
+    // FIXME: <https://webkit.org/b/281516> This map should be for frames not pages.
     auto iterator = m_eventListenerPages.find({ type, contentWorldType });
     if (iterator == m_eventListenerPages.end())
         return;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -841,11 +841,14 @@ WebExtensionTab::WebProcessProxySet WebExtensionTab::processes(WebExtensionEvent
     if (!extensionContext()->pageListensForEvent(*webView._page, type, contentWorldType))
         return { };
 
-    Ref process = webView._page->legacyMainFrameProcess();
-    if (!process->canSendMessage())
-        return { };
+    WebProcessProxySet result;
 
-    return { WTFMove(process) };
+    webView._page->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        if (webProcess.canSendMessage())
+            result.addVoid(webProcess);
+    });
+
+    return result;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -88,10 +88,15 @@ WebExtensionControllerParameters WebExtensionController::parameters() const
 
 WebExtensionController::WebProcessProxySet WebExtensionController::allProcesses() const
 {
-    WebProcessProxySet processes;
-    for (Ref page : m_pages)
-        processes.add(page->protectedLegacyMainFrameProcess());
-    return processes;
+    WebProcessProxySet result;
+
+    for (Ref page : m_pages) {
+        page->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+            result.addVoid(webProcess);
+        });
+    }
+
+    return result;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -95,7 +95,7 @@ public:
     using WebExtensionContextBaseURLMap = HashMap<String, Ref<WebExtensionContext>>;
     using WebExtensionURLSchemeHandlerMap = HashMap<String, Ref<WebExtensionURLSchemeHandler>>;
 
-    using WebProcessProxySet = WeakHashSet<WebProcessProxy>;
+    using WebProcessProxySet = HashSet<Ref<WebProcessProxy>>;
     using WebProcessPoolSet = WeakHashSet<WebProcessPool>;
     using WebPageProxySet = WeakHashSet<WebPageProxy>;
     using UserContentControllerProxySet = WeakHashSet<WebUserContentControllerProxy>;


### PR DESCRIPTION
#### ff1a4250dd4aaad9086608da78b0a4aa39eef70c
<pre>
Remove uses of legacyMainFrameProcess() in Web Extensions.
<a href="https://webkit.org/b/281521">https://webkit.org/b/281521</a>
<a href="https://rdar.apple.com/problem/137986764">rdar://problem/137986764</a>

Reviewed by Brian Weinstein.

Replace almost all uses of legacyMainFrameProcess() in Web Extension code, and track remaining
uses with more specific FIXMEs and bugs.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm:
(WebKit::WebExtensionContext::addListener):
(WebKit::WebExtensionContext::removeListener):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::addPopupPage):
(WebKit::WebExtensionContext::addExtensionTabPage):
(WebKit::WebExtensionContext::loadBackgroundWebView):
(WebKit::WebExtensionContext::processes const):
(WebKit::WebExtensionContext::loadInspectorBackgroundPage):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::processes const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::pageListensForEvent const):
(WebKit::WebExtensionContext::processes const):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::WebExtensionController::allProcesses const):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:

Canonical link: <a href="https://commits.webkit.org/286889@main">https://commits.webkit.org/286889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fc01b80f40a037c44fc99f0a59cb9b612bd2d9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81980 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28670 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60638 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18651 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66420 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40932 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48002 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26993 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69113 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24256 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83377 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4768 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3234 "Found 1 new test failure: webrtc/vp9-profile2.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68887 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66390 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68146 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12143 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10246 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11988 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4715 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7530 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4734 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8169 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6493 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->