### PR TITLE
VideoMediaSampleRenderer can resolve its `WhenHasAvailableVideoFrame` callback with a flushed frame.

### DIFF
--- a/LayoutTests/media/media-rvfc-paused-mp4-expected.txt
+++ b/LayoutTests/media/media-rvfc-paused-mp4-expected.txt
@@ -1,0 +1,12 @@
+
+EVENT(loadedmetadata)
+EXPECTED (0 == '0') OK
+EXPECTED (0 == '0') OK
+EXPECTED (320 == '320') OK
+EXPECTED (240 == '240') OK
+EVENT(seeked)
+EXPECTED (6.009 == '6.009') OK
+EXPECTED (6.009 == '6.009') OK
+EXPECTED (320 == '320') OK
+EXPECTED (240 == '240') OK
+

--- a/LayoutTests/media/media-rvfc-paused-mp4.html
+++ b/LayoutTests/media/media-rvfc-paused-mp4.html
@@ -1,0 +1,43 @@
+<html>
+<head>
+<title>requestVideoFrameCallback with paused webm</title>
+<script src="../resources/testharness.js"></script>
+<script src=video-test.js></script>
+<script src=utilities.js></script>
+<script>
+    async function init()
+    {
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        let v = document.getElementsByTagName('video')[0];
+        v.src = "content/test-video-only.mp4";
+        const loadedMetadataPromise = waitFor(v, 'loadedmetadata');
+        const frame1 = await waitForVideoFrame(v);
+        await loadedMetadataPromise;
+        testExpected(v.currentTime, 0);
+        testExpected(frame1[1].mediaTime, 0);
+        testExpected(frame1[1].width, 320);
+        testExpected(frame1[1].height, 240);
+
+        // time of the last video frame.
+        v.currentTime = 6.009;
+
+        const seekPromise = waitFor(v, 'seeked');
+        const frame2 = await waitForVideoFrame(v);
+        testExpected(v.currentTime, 6.009);
+        testExpected(frame2[1].mediaTime, 6.009);
+        testExpected(frame2[1].width, 320);
+        testExpected(frame2[1].height, 240);
+
+        await seekPromise;
+
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
+</script>
+</head>
+<body onload="init();">
+<video/>
+</body>
+</html>

--- a/LayoutTests/media/media-rvfc-paused-offscreen-mp4-expected.txt
+++ b/LayoutTests/media/media-rvfc-paused-offscreen-mp4-expected.txt
@@ -1,0 +1,11 @@
+EVENT(loadedmetadata)
+EXPECTED (0 == '0') OK
+EXPECTED (0 == '0') OK
+EXPECTED (320 == '320') OK
+EXPECTED (240 == '240') OK
+EVENT(seeked)
+EXPECTED (6.009 == '6.009') OK
+EXPECTED (6.009 == '6.009') OK
+EXPECTED (320 == '320') OK
+EXPECTED (240 == '240') OK
+

--- a/LayoutTests/media/media-rvfc-paused-offscreen-mp4.html
+++ b/LayoutTests/media/media-rvfc-paused-offscreen-mp4.html
@@ -1,0 +1,42 @@
+<html>
+<head>
+<title>requestVideoFrameCallback with paused webm</title>
+<script src="../resources/testharness.js"></script>
+<script src=video-test.js></script>
+<script src=utilities.js></script>
+<script>
+    async function init()
+    {
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        let v = document.createElement('video');
+        v.src = "content/test-video-only.mp4";
+        const loadedMetadataPromise = waitFor(v, 'loadedmetadata');
+        const frame1 = await waitForVideoFrame(v);
+        await loadedMetadataPromise;
+        testExpected(v.currentTime, 0);
+        testExpected(frame1[1].mediaTime, 0);
+        testExpected(frame1[1].width, 320);
+        testExpected(frame1[1].height, 240);
+
+        // time of the last video frame.
+        v.currentTime = 6.009;
+
+        const seekPromise = waitFor(v, 'seeked');
+        const frame2 = await waitForVideoFrame(v);
+        testExpected(v.currentTime, 6.009);
+        testExpected(frame2[1].mediaTime, 6.009);
+        testExpected(frame2[1].width, 320);
+        testExpected(frame2[1].height, 240);
+
+        await seekPromise;
+
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
+</script>
+</head>
+<body onload="init();">
+</body>
+</html>

--- a/LayoutTests/media/media-rvfc-paused-offscreen-webm-expected.txt
+++ b/LayoutTests/media/media-rvfc-paused-offscreen-webm-expected.txt
@@ -1,0 +1,11 @@
+EVENT(loadedmetadata)
+EXPECTED (0 == '0') OK
+EXPECTED (0 == '0') OK
+EXPECTED (320 == '320') OK
+EXPECTED (180 == '180') OK
+EVENT(seeked)
+EXPECTED (2.672 == '2.672') OK
+EXPECTED (2.672 == '2.672') OK
+EXPECTED (320 == '320') OK
+EXPECTED (180 == '180') OK
+

--- a/LayoutTests/media/media-rvfc-paused-offscreen-webm.html
+++ b/LayoutTests/media/media-rvfc-paused-offscreen-webm.html
@@ -1,0 +1,42 @@
+<html>
+<head>
+<title>requestVideoFrameCallback with paused webm offscreen</title>
+<script src="../resources/testharness.js"></script>
+<script src=video-test.js></script>
+<script src=utilities.js></script>
+<script>
+    async function init()
+    {
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        let v = document.createElement('video');
+        v.src = "content/test-vp8-hiddenframes.webm";
+        const loadedMetadataPromise = waitFor(v, 'loadedmetadata');
+        const frame1 = await waitForVideoFrame(v);
+        await loadedMetadataPromise;
+        testExpected(v.currentTime, 0);
+        testExpected(frame1[1].mediaTime, 0);
+        testExpected(frame1[1].width, 320);
+        testExpected(frame1[1].height, 180);
+
+        // duration of the last frame.
+        v.currentTime = v.duration - 0.038;
+
+        const seekPromise = waitFor(v, 'seeked');
+        const frame2 = await waitForVideoFrame(v);
+        testExpected(v.currentTime, v.duration - 0.038);
+        testExpected(frame2[1].mediaTime, v.duration - 0.038);
+        testExpected(frame2[1].width, 320);
+        testExpected(frame2[1].height, 180);
+
+        await seekPromise;
+
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
+</script>
+</head>
+<body onload="init();">
+</body>
+</html>

--- a/LayoutTests/media/media-rvfc-paused-webm-expected.txt
+++ b/LayoutTests/media/media-rvfc-paused-webm-expected.txt
@@ -1,0 +1,12 @@
+
+EVENT(loadedmetadata)
+EXPECTED (0 == '0') OK
+EXPECTED (0 == '0') OK
+EXPECTED (320 == '320') OK
+EXPECTED (180 == '180') OK
+EVENT(seeked)
+EXPECTED (2.672 == '2.672') OK
+EXPECTED (2.672 == '2.672') OK
+EXPECTED (320 == '320') OK
+EXPECTED (180 == '180') OK
+

--- a/LayoutTests/media/media-rvfc-paused-webm.html
+++ b/LayoutTests/media/media-rvfc-paused-webm.html
@@ -1,0 +1,43 @@
+<html>
+<head>
+<title>requestVideoFrameCallback with paused webm</title>
+<script src="../resources/testharness.js"></script>
+<script src=video-test.js></script>
+<script src=utilities.js></script>
+<script>
+    async function init()
+    {
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        let v = document.getElementsByTagName('video')[0];
+        v.src = "content/test-vp8-hiddenframes.webm";
+        const loadedMetadataPromise = waitFor(v, 'loadedmetadata');
+        const frame1 = await waitForVideoFrame(v);
+        await loadedMetadataPromise;
+        testExpected(v.currentTime, 0);
+        testExpected(frame1[1].mediaTime, 0);
+        testExpected(frame1[1].width, 320);
+        testExpected(frame1[1].height, 180);
+
+        // duration of the last frame.
+        v.currentTime = v.duration - 0.038;
+
+        const seekPromise = waitFor(v, 'seeked');
+        const frame2 = await waitForVideoFrame(v);
+        testExpected(v.currentTime, v.duration - 0.038);
+        testExpected(frame2[1].mediaTime, v.duration - 0.038);
+        testExpected(frame2[1].width, 320);
+        testExpected(frame2[1].height, 180);
+
+        await seekPromise;
+
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
+</script>
+</head>
+<body onload="init();">
+<video/>
+</body>
+</html>

--- a/LayoutTests/media/media-vp8-hiddenframes.html
+++ b/LayoutTests/media/media-vp8-hiddenframes.html
@@ -4,7 +4,8 @@
 <title>webm file with alternate reference frame</title>
 <script src="../resources/testharness.js"></script>
 <script>window.requirePixelDump = true</script>
-<script src=video-test.js></script>
+<script src="video-test.js"></script>
+<script src="utilities.js"></script>
 <script>
     // VP8 files were generated such that alternative reference frames were used:
     // $ ffmpeg -i dragon.webm -c:v libvpx -vf scale=320:-1 -auto-alt-ref 1 -arnr-maxframes 5 -arnr-strength 3 -pass 1 test-vp8-hiddenframes.webm
@@ -19,14 +20,14 @@
         let v = document.getElementsByTagName('video')[0];
         v.src = "content/test-vp8-hiddenframes.webm";
         await waitFor(v, 'loadedmetadata', true);
-        let promise = new Promise(resolve => v.requestVideoFrameCallback(resolve));
+        await waitForVideoFrame(v); // make sure the first frame got displayed before waiting for the last one.
         // duration of the last frame.
         v.currentTime = v.duration - 0.038;
+        let promise = new Promise(resolve => v.requestVideoFrameCallback(resolve));
         await waitFor(v, 'seeked', true);
         v.play();
         await waitFor(v, 'ended', true);
-        // FIXME: await promise; // this promise is never resolved due to webkit.org/b/282782 and webkit.org/b/282797
-        await sleepFor(1000);
+        await promise;
 
         if (window.testRunner)
             testRunner.notifyDone();

--- a/LayoutTests/media/utilities.js
+++ b/LayoutTests/media/utilities.js
@@ -56,7 +56,7 @@ const delay = ms => new Promise(res => setTimeout(res, ms));
 
 function waitForVideoFrame(video, cb) {
     const p = new Promise((resolve) => {
-        video.requestVideoFrameCallback((now, metadata) => resolve(now, metadata));
+        video.requestVideoFrameCallback((now, metadata) => resolve([now, metadata]));
     });
     if (cb)
         p.then(cb);
@@ -67,7 +67,7 @@ function waitForVideoFrameUntil(video, time, cb) {
     const p = new Promise(resolve => {
         const callback = ((now, metadata) => {
             if (metadata.mediaTime >= time) {
-                resolve(now, metadata);
+                resolve([now, metadata]);
                 return;
             }
             video.requestVideoFrameCallback(callback);

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1182,6 +1182,11 @@ webkit.org/b/282791 media/media-vp8-hiddenframes.html [ ImageOnlyFailure ]
 webkit.org/b/282827 media/media-video-videorange.html [ Failure ]
 webkit.org/b/282827 media/media-video-videorange-offscreen.html [ Failure ]
 
+webkit.org/b/283457 media/media-rvfc-paused-mp4.html [ Failure ]
+webkit.org/b/283457 media/media-rvfc-paused-offscreen-mp4.html [ Failure ]
+webkit.org/b/283457 media/media-rvfc-paused-offscreen-webm.html [ Failure ]
+webkit.org/b/283457 media/media-rvfc-paused-webm.html [ Failure ]
+
 # GStreamer (< 1.24) doesn't set the track's id to the container's value.
 webkit.org/b/265919 media/track/media-audio-track.html [ Failure ]
 webkit.org/b/265919 media/track/media-source-audio-track.html [ Failure ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3717,6 +3717,9 @@ webkit.org/b/242273 fast/events/ios/dragstart-on-image-by-long-pressing.html [ P
 # Requires platform support (see rdar://94324932).
 http/tests/media/media-source/mediasource-rvfc.html [ Skip ]
 
+webkit.org/b/283448 media/media-rvfc-paused-mp4.html [ Failure ]
+webkit.org/b/283448 media/media-rvfc-paused-offscreen-mp4.html [ Failure ]
+
 webkit.org/b/242825 editing/selection/ios/hide-selection-in-tiny-contenteditable.html [ Pass Failure ]
 
 webkit.org/b/242840 fast/text/international/system-language/han-text-style.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1166,6 +1166,8 @@ media/media-source/media-source-webm-configuration-vp9-header-color.html [ Failu
 media/media-source/media-source-vp8-webm-error.html [ Skip ]
 media/media-source/media-source-vp8-webm-error-offscreen.html [ Skip ]
 http/tests/media/video-webm-stall-seek.html [ Skip ]
+media/media-rvfc-paused-offscreen-webm.html [ Skip ]
+media/media-rvfc-paused-webm.html [ Skip ]
 
 # Managed MediaSource isn't enabled on WK1
 media/media-source/media-managedmse-append.html [ Skip ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -656,6 +656,9 @@ webkit.org/b/259658 http/tests/media/video-play-stall.html [ Pass Failure ]
 webkit.org/b/136708 http/tests/media/video-play-stall-seek.html
 webkit.org/b/136708 media/media-fullscreen-not-in-document.html
 
+webkit.org/b/283448 media/media-rvfc-paused-mp4.html [ Failure ]
+webkit.org/b/283448 media/media-rvfc-paused-offscreen-mp4.html [ Failure ]
+
 webkit.org/b/236722 http/tests/media/video-play-waiting.html [ Timeout ]
 
 # This test requires generation of progress events during loading

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -746,7 +746,9 @@ void MediaPlayerPrivateWebM::setHasAvailableVideoFrame(bool hasAvailableVideoFra
     if (auto player = m_player.get())
         player->firstVideoFrameAvailable();
 
-    checkNewVideoFrameMetadata(currentTime());
+    if (m_isGatheringVideoFrameMetadata)
+        checkNewVideoFrameMetadata(currentTime());
+
     if (m_seekState == WaitingForAvailableFame)
         maybeCompleteSeek();
 


### PR DESCRIPTION
#### 284f68f80bbb6d1f192c62f2b33acf0268232657
<pre>
VideoMediaSampleRenderer can resolve its `WhenHasAvailableVideoFrame` callback with a flushed frame.
<a href="https://bugs.webkit.org/show_bug.cgi?id=283443">https://bugs.webkit.org/show_bug.cgi?id=283443</a>
<a href="https://rdar.apple.com/140301261">rdar://140301261</a>

Reviewed by Jer Noble and Youenn Fablet.

If we decoded the video frame while we were in the middle of a flush, we would continue to notify the client
that a frame was available, even though that frame is flushed.

When we queue the task to notify the client that a frame has been decoded, we now pass the current flushId value, if it changes when the task runs, drop the message.

We also add some minimal logging.

Added tests.

* LayoutTests/media/media-rvfc-paused-mp4-expected.txt: Added.
* LayoutTests/media/media-rvfc-paused-mp4.html: Added.
* LayoutTests/media/media-rvfc-paused-offscreen-mp4-expected.txt: Added.
* LayoutTests/media/media-rvfc-paused-offscreen-mp4.html: Added.
* LayoutTests/media/media-rvfc-paused-offscreen-webm-expected.txt: Added.
* LayoutTests/media/media-rvfc-paused-offscreen-webm.html: Added.
* LayoutTests/media/media-rvfc-paused-webm-expected.txt: Added.
* LayoutTests/media/media-rvfc-paused-webm.html: Added.
* LayoutTests/media/media-vp8-hiddenframes.html: Remove FIXME and now use rVFC promise as the issue preventing its used was fixed in 286853@main
* LayoutTests/media/utilities.js:
(waitForVideoFrame): Promise was incorrectly resolved with two elements. Can only have one, return an array.
(waitForVideoFrameUntil): Ditto.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm: FlyBy: only perform a readback if we need to and not whenever a frame is available.
(WebCore::MediaPlayerPrivateWebM::setHasAvailableVideoFrame):
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::decodeNextSample):
(WebCore::VideoMediaSampleRenderer::decodedFrameAvailable):
(WebCore::VideoMediaSampleRenderer::maybeQueueFrameForDisplay):
(WebCore::VideoMediaSampleRenderer::purgeDecodedSampleQueue):
(WebCore::VideoMediaSampleRenderer::flush): Cancel timer before purging the compressed queue, to reduce the chance of having a midflight display.
(WebCore::VideoMediaSampleRenderer::notifyHasAvailableVideoFrame):

Canonical link: <a href="https://commits.webkit.org/286949@main">https://commits.webkit.org/286949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac3afb9269ad99dd9af73dd5dcd4edc186c9af66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82296 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28947 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79786 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5002 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18826 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50819 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66646 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41133 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/48209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24146 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27278 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/69323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24490 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83672 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5049 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69083 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66618 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68335 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17073 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12346 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10446 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4996 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/5011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/8449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6774 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->