### PR TITLE
Get GraphicsLayer.h out of some hot include paths

### DIFF
--- a/Source/WebCore/Modules/ShapeDetection/BarcodeDetector.cpp
+++ b/Source/WebCore/Modules/ShapeDetection/BarcodeDetector.cpp
@@ -33,6 +33,7 @@
 #include "Document.h"
 #include "ImageBitmap.h"
 #include "ImageBitmapOptions.h"
+#include "ImageBuffer.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSDetectedBarcode.h"
 #include "Page.h"

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -80,6 +80,11 @@ DetachedImageBitmap::~DetachedImageBitmap() = default;
 
 DetachedImageBitmap& DetachedImageBitmap::operator=(DetachedImageBitmap&&) = default;
 
+size_t DetachedImageBitmap::memoryCost() const
+{
+    return m_bitmap->memoryCost();
+}
+
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(ImageBitmap);
 
 static inline RenderingMode bufferRenderingMode(ScriptExecutionContext& scriptExecutionContext)
@@ -161,6 +166,11 @@ RefPtr<ImageBuffer> ImageBitmap::createImageBuffer(ScriptExecutionContext& scrip
     return createImageBuffer(scriptExecutionContext, size, bufferRenderingMode(scriptExecutionContext), colorSpace, resolutionScale);
 }
 
+ImageBuffer* ImageBitmap::buffer() const
+{
+    return m_bitmap.get();
+}
+
 std::optional<DetachedImageBitmap> ImageBitmap::detach()
 {
     if (!m_bitmap)
@@ -172,6 +182,11 @@ std::optional<DetachedImageBitmap> ImageBitmap::detach()
     if (!serializedBitmap)
         return std::nullopt;
     return DetachedImageBitmap { makeUniqueRefFromNonNullUniquePtr(WTFMove(serializedBitmap)), originClean(), premultiplyAlpha(), forciblyPremultiplyAlpha() };
+}
+
+void ImageBitmap::close()
+{
+    takeImageBuffer();
 }
 
 #if USE(SKIA)

--- a/Source/WebCore/html/ImageBitmap.h
+++ b/Source/WebCore/html/ImageBitmap.h
@@ -27,7 +27,6 @@
 
 #include "ExceptionOr.h"
 #include "IDLTypes.h"
-#include "ImageBuffer.h"
 #include "ScriptWrappable.h"
 #include <atomic>
 #include <wtf/RefCounted.h>
@@ -45,11 +44,14 @@ class Blob;
 class CachedImage;
 class CanvasBase;
 class CSSStyleImageValue;
+class DestinationColorSpace;
+class FloatSize;
 class HTMLCanvasElement;
 class HTMLImageElement;
 class HTMLVideoElement;
 class ImageBitmapImageObserver;
 class ImageData;
+class ImageBuffer;
 class IntRect;
 class IntSize;
 #if ENABLE(OFFSCREEN_CANVAS)
@@ -58,10 +60,12 @@ class OffscreenCanvas;
 class PendingImageBitmap;
 class RenderElement;
 class ScriptExecutionContext;
+class SerializedImageBuffer;
 class SVGImageElement;
 #if ENABLE(WEB_CODECS)
 class WebCodecsVideoFrame;
 #endif
+enum class RenderingMode : bool;
 
 struct ImageBitmapOptions;
 
@@ -72,7 +76,7 @@ public:
     DetachedImageBitmap(DetachedImageBitmap&&);
     WEBCORE_EXPORT ~DetachedImageBitmap();
     DetachedImageBitmap& operator=(DetachedImageBitmap&&);
-    size_t memoryCost() const { return m_bitmap->memoryCost(); }
+    size_t memoryCost() const;
 private:
     DetachedImageBitmap(UniqueRef<SerializedImageBuffer>, bool originClean, bool premultiplyAlpha, bool forciblyPremultiplyAlpha);
     UniqueRef<SerializedImageBuffer> m_bitmap;
@@ -121,7 +125,7 @@ public:
 
     ~ImageBitmap();
 
-    ImageBuffer* buffer() const { return m_bitmap.get(); }
+    ImageBuffer* buffer() const;
 
     RefPtr<ImageBuffer> takeImageBuffer();
 
@@ -134,7 +138,7 @@ public:
 
     std::optional<DetachedImageBitmap> detach();
     bool isDetached() const { return !m_bitmap; }
-    void close() { takeImageBuffer(); }
+    void close();
 
 #if USE(SKIA)
     void prepareForCrossThreadTransfer();

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -30,6 +30,7 @@
 #include "BitmapImageSource.h"
 #include "GeometryUtilities.h"
 #include "GraphicsContext.h"
+#include "ImageBuffer.h"
 #include "ImageObserver.h"
 #include "NativeImageSource.h"
 

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
@@ -36,6 +36,7 @@
 #include "GraphicsContext.h"
 #include "HostWindow.h"
 #include "Image.h"
+#include "ImageBuffer.h"
 #include "ImageObserver.h"
 #include "NotImplemented.h"
 #include "PixelBuffer.h"

--- a/Source/WebCore/platform/graphics/Pattern.cpp
+++ b/Source/WebCore/platform/graphics/Pattern.cpp
@@ -28,6 +28,8 @@
 #include "Pattern.h"
 
 #include "Image.h"
+#include "ImageBuffer.h"
+#include "NativeImage.h"
 
 namespace WebCore {
 
@@ -47,6 +49,26 @@ Pattern::~Pattern() = default;
 void Pattern::setPatternSpaceTransform(const AffineTransform& patternSpaceTransform)
 {
     m_parameters.patternSpaceTransform = patternSpaceTransform;
+}
+
+const SourceImage& Pattern::tileImage() const
+{
+    return m_tileImage;
+}
+
+RefPtr<NativeImage> Pattern::tileNativeImage() const
+{
+    return m_tileImage.nativeImage();
+}
+
+RefPtr<ImageBuffer> Pattern::tileImageBuffer() const
+{
+    return m_tileImage.imageBuffer();
+}
+
+void Pattern::setTileImage(SourceImage&& tileImage)
+{
+    m_tileImage = WTFMove(tileImage);
 }
 
 }

--- a/Source/WebCore/platform/graphics/Pattern.h
+++ b/Source/WebCore/platform/graphics/Pattern.h
@@ -46,7 +46,6 @@ typedef sk_sp<SkShader> PlatformPatternPtr;
 
 namespace WebCore {
 
-class AffineTransform;
 class GraphicsContext;
 
 class Pattern final : public ThreadSafeRefCounted<Pattern> {
@@ -66,9 +65,12 @@ public:
     WEBCORE_EXPORT static Ref<Pattern> create(SourceImage&& tileImage, const Parameters& = { });
     WEBCORE_EXPORT ~Pattern();
 
-    const SourceImage& tileImage() const { return m_tileImage; }
-    RefPtr<NativeImage> tileNativeImage() const { return m_tileImage.nativeImage(); }
-    RefPtr<ImageBuffer> tileImageBuffer() const { return m_tileImage.imageBuffer(); }
+    WEBCORE_EXPORT const SourceImage& tileImage() const;
+    WEBCORE_EXPORT void setTileImage(SourceImage&&);
+
+    RefPtr<NativeImage> tileNativeImage() const;
+    RefPtr<ImageBuffer> tileImageBuffer() const;
+
     const Parameters& parameters() const { return m_parameters; }
 
     // Pattern space is an abstract space that maps to the default user space by the transformation 'userSpaceTransform'
@@ -78,7 +80,6 @@ public:
     PlatformPatternPtr createPlatformPattern(const AffineTransform& userSpaceTransform) const;
 #endif
 
-    void setTileImage(SourceImage&& tileImage) { m_tileImage = WTFMove(tileImage); }
     void setPatternSpaceTransform(const AffineTransform&);
 
     const AffineTransform& patternSpaceTransform() const { return m_parameters.patternSpaceTransform; };

--- a/Source/WebCore/platform/graphics/SourceImage.cpp
+++ b/Source/WebCore/platform/graphics/SourceImage.cpp
@@ -27,6 +27,8 @@
 #include "SourceImage.h"
 
 #include "GraphicsContext.h"
+#include "ImageBuffer.h"
+#include "NativeImage.h"
 
 namespace WebCore {
 
@@ -34,6 +36,8 @@ SourceImage::SourceImage(ImageVariant&& imageVariant)
     : m_imageVariant(WTFMove(imageVariant))
 {
 }
+
+SourceImage::~SourceImage() = default;
 
 bool SourceImage::operator==(const SourceImage& other) const
 {

--- a/Source/WebCore/platform/graphics/SourceImage.h
+++ b/Source/WebCore/platform/graphics/SourceImage.h
@@ -25,11 +25,13 @@
 
 #pragma once
 
-#include "ImageBuffer.h"
-#include "NativeImage.h"
+#include "IntSize.h"
 #include "RenderingResourceIdentifier.h"
 
 namespace WebCore {
+
+class ImageBuffer;
+class NativeImage;
 
 class WEBCORE_EXPORT SourceImage {
 public:
@@ -40,6 +42,7 @@ public:
     >;
 
     SourceImage(ImageVariant&&);
+    ~SourceImage();
 
     bool operator==(const SourceImage&) const;
 

--- a/Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
@@ -27,6 +27,7 @@
 #import "GraphicsLayerAsyncContentsDisplayDelegateCocoa.h"
 
 #import "GraphicsLayerCA.h"
+#import "ImageBuffer.h"
 #import "NativeImage.h"
 #import "WebCoreCALayerExtras.h"
 

--- a/Source/WebCore/platform/graphics/ca/cocoa/WebTiledBackingLayer.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/WebTiledBackingLayer.h
@@ -30,6 +30,7 @@ class IntRect;
 class PlatformCALayer;
 class TileController;
 class TiledBacking;
+enum class ContentsFormat : uint8_t;
 }
 
 @interface WebTiledBackingLayer : CALayer {

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoImageSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoImageSurfaceBackend.cpp
@@ -34,6 +34,7 @@
 
 #include "Color.h"
 #include "ImageBackingStore.h"
+#include "ImageBuffer.h"
 #include <cairo.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
@@ -31,6 +31,7 @@
 #include "CGSubimageCacheWithTimer.h"
 #include "GeometryUtilities.h"
 #include "GraphicsContextCG.h"
+#include "ImageBuffer.h"
 #include <limits>
 #include <pal/spi/cg/CoreGraphicsSPI.h>
 

--- a/Source/WebCore/platform/graphics/cg/PDFDocumentImage.cpp
+++ b/Source/WebCore/platform/graphics/cg/PDFDocumentImage.cpp
@@ -30,6 +30,7 @@
 
 #include "GeometryUtilities.h"
 #include "GraphicsContext.h"
+#include "ImageBuffer.h"
 #include "ImageObserver.h"
 #include <CoreGraphics/CGContext.h>
 #include <CoreGraphics/CGPDFDocument.h>

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "VideoMediaSampleRenderer.h"
 
+#import "IOSurface.h"
 #import "MediaSampleAVFObjC.h"
 #import "WebCoreDecompressionSession.h"
 #import "WebSampleBufferVideoRendering.h"
@@ -35,6 +36,7 @@
 #import <pal/spi/cocoa/AVFoundationSPI.h>
 #import <wtf/Locker.h>
 #import <wtf/MainThreadDispatcher.h>
+#import <wtf/NativePromise.h>
 
 #pragma mark - Soft Linking
 

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
@@ -32,6 +32,7 @@
 #import "ControlFactoryMac.h"
 #import "FloatRoundedRect.h"
 #import "GraphicsContextCG.h"
+#import "ImageBuffer.h"
 #import "LocalCurrentGraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
 #import "WebControlView.h"

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(MAC)
 
 #import "GraphicsContext.h"
+#import "ImageBuffer.h"
 #import "LocalDefaultSystemAppearance.h"
 #import "ProgressBarPart.h"
 #import <pal/spi/mac/CoreUISPI.h>

--- a/Source/WebCore/platform/graphics/skia/PatternSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PatternSkia.cpp
@@ -28,6 +28,8 @@
 
 #if USE(SKIA)
 #include "AffineTransform.h"
+#include "ImageBuffer.h"
+#include "NativeImage.h"
 #include <skia/core/SkImage.h>
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <skia/core/SkMatrix.h>

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -31,6 +31,7 @@
 #include "FloatRoundedRect.h"
 #include "GLContext.h"
 #include "GraphicsContext.h"
+#include "GraphicsTypesGL.h"
 #include "Image.h"
 #include "LengthFunctions.h"
 #include "TextureMapperFlags.h"

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -33,6 +33,7 @@
 #include "GeometryUtilities.h"
 #include "GraphicsContext.h"
 #include "HitTestResult.h"
+#include "ImageBuffer.h"
 #include "LayoutRepainter.h"
 #include "PointerEventsHitRules.h"
 #include "RenderElementInlines.h"


### PR DESCRIPTION
#### af0b4e780f10b1856612fe0018051522a06a8d2b
<pre>
Get GraphicsLayer.h out of some hot include paths
<a href="https://bugs.webkit.org/show_bug.cgi?id=283454">https://bugs.webkit.org/show_bug.cgi?id=283454</a>
<a href="https://rdar.apple.com/140314709">rdar://140314709</a>

Reviewed by Jer Noble.

GraphicsLayer.h is one of the more expensive headers, and it&apos;s included via these include paths:

  47x: DocumentInlines.h LocalDOMWindow.h DOMWindow.h ImageBitmap.h ImageBuffer.h ImageBufferBackend.h GraphicsLayerContentsDisplayDelegate.h
  36x: GraphicsContext.h GraphicsContextState.h SourceBrush.h Pattern.h SourceImage.h ImageBuffer.h ImageBufferBackend.h GraphicsLayerContentsDisplayDelegate.h
  27x: ElementInlines.h DocumentInlines.h LocalDOMWindow.h DOMWindow.h ImageBitmap.h ImageBuffer.h ImageBufferBackend.h GraphicsLayerContentsDisplayDelegate.h
  19x: ChromeClient.h GraphicsContext.h GraphicsContextState.h SourceBrush.h Pattern.h SourceImage.h ImageBuffer.h ImageBufferBackend.h GraphicsLayerContentsDisplayDelegate.h
  16x: Editor.h FrameSelection.h CaretAnimator.h RenderTheme.h GraphicsContext.h GraphicsContextState.h SourceBrush.h Pattern.h SourceImage.h ImageBuffer.h ImageBufferBackend.h GraphicsLayerContentsDisplayDelegate.h
  15x: LocalDOMWindow.h DOMWindow.h ImageBitmap.h ImageBuffer.h ImageBufferBackend.h GraphicsLayerContentsDisplayDelegate.h

Break the include chain by having ImageBitmap.h and SourceImage.h not include ImageBuffer.h, and fix the fallout.

* Source/WebCore/Modules/ShapeDetection/BarcodeDetector.cpp:
* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::DetachedImageBitmap::memoryCost const):
(WebCore::ImageBitmap::buffer const):
(WebCore::ImageBitmap::close):
* Source/WebCore/html/ImageBitmap.h:
(WebCore::DetachedImageBitmap::memoryCost const): Deleted.
* Source/WebCore/platform/graphics/BitmapImage.cpp:
* Source/WebCore/platform/graphics/GraphicsContextGL.cpp:
* Source/WebCore/platform/graphics/Pattern.cpp:
(WebCore::Pattern::tileImage const):
(WebCore::Pattern::tileNativeImage const):
(WebCore::Pattern::tileImageBuffer const):
(WebCore::Pattern::setTileImage):
* Source/WebCore/platform/graphics/Pattern.h:
* Source/WebCore/platform/graphics/SourceImage.cpp:
* Source/WebCore/platform/graphics/SourceImage.h:
* Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm:
* Source/WebCore/platform/graphics/ca/cocoa/WebTiledBackingLayer.h:
* Source/WebCore/platform/graphics/cg/NativeImageCG.cpp:
* Source/WebCore/platform/graphics/cg/PDFDocumentImage.cpp:
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
* Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm:
* Source/WebCore/platform/graphics/skia/PatternSkia.cpp:
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:

Canonical link: <a href="https://commits.webkit.org/286910@main">https://commits.webkit.org/286910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6303601a7a096f0de14fc2194102685ce56c78c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82019 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28720 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79555 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60667 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18686 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50649 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40963 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48051 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23961 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27043 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69160 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24299 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83427 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3269 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68927 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4974 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68191 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17046 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12188 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10286 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4765 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7580 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4784 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8219 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6543 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->