### PR TITLE
AX: Remove redundant AXObjectCache::m_idsInUse HashSet

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -752,37 +752,37 @@ Ref<AccessibilityRenderObject> AXObjectCache::createObjectFromRenderer(RenderObj
     RefPtr node = renderer.node();
     if (auto* element = dynamicDowncast<Element>(node.get())) {
         if (isAccessibilityList(*element))
-            return AccessibilityList::create(generateNewObjectID(), renderer);
+            return AccessibilityList::create(AXID::generate(), renderer);
 
         if (isAccessibilityARIATable(*element))
-            return AccessibilityARIATable::create(generateNewObjectID(), renderer);
+            return AccessibilityARIATable::create(AXID::generate(), renderer);
         if (isAccessibilityARIAGridRow(*element))
-            return AccessibilityARIAGridRow::create(generateNewObjectID(), renderer);
+            return AccessibilityARIAGridRow::create(AXID::generate(), renderer);
         if (isAccessibilityARIAGridCell(*element))
-            return AccessibilityARIAGridCell::create(generateNewObjectID(), renderer);
+            return AccessibilityARIAGridCell::create(AXID::generate(), renderer);
 
         if (isAccessibilityTree(*element))
-            return AccessibilityTree::create(generateNewObjectID(), renderer);
+            return AccessibilityTree::create(AXID::generate(), renderer);
         if (isAccessibilityTreeItem(*element))
-            return AccessibilityTreeItem::create(generateNewObjectID(), renderer);
+            return AccessibilityTreeItem::create(AXID::generate(), renderer);
 
         if (is<HTMLLabelElement>(*element) && hasRole(*element, nullAtom()))
-            return AccessibilityLabel::create(generateNewObjectID(), renderer);
+            return AccessibilityLabel::create(AXID::generate(), renderer);
 
 #if PLATFORM(IOS_FAMILY)
         if (is<HTMLMediaElement>(*element) && hasRole(*element, nullAtom()))
-            return AccessibilityMediaObject::create(generateNewObjectID(), renderer);
+            return AccessibilityMediaObject::create(AXID::generate(), renderer);
 #endif
     }
 
     if (renderer.isRenderOrLegacyRenderSVGRoot())
-        return AccessibilitySVGRoot::create(generateNewObjectID(), renderer, this);
+        return AccessibilitySVGRoot::create(AXID::generate(), renderer, this);
 
     if (is<SVGElement>(node) || is<RenderSVGInlineText>(renderer))
-        return AccessibilitySVGObject::create(generateNewObjectID(), renderer, this);
+        return AccessibilitySVGObject::create(AXID::generate(), renderer, this);
 
     if (auto* renderImage = toSimpleImage(renderer))
-        return AXImage::create(generateNewObjectID(), *renderImage);
+        return AXImage::create(AXID::generate(), *renderImage);
 
 #if ENABLE(MATHML)
     // The mfenced element creates anonymous RenderMathMLOperators which should be treated
@@ -790,13 +790,13 @@ Ref<AccessibilityRenderObject> AXObjectCache::createObjectFromRenderer(RenderObj
     // inclusion and role mapping is not bypassed.
     bool isAnonymousOperator = renderer.isAnonymous() && is<RenderMathMLOperator>(renderer);
     if (isAnonymousOperator || is<MathMLElement>(node))
-        return AccessibilityMathMLElement::create(generateNewObjectID(), renderer, isAnonymousOperator);
+        return AccessibilityMathMLElement::create(AXID::generate(), renderer, isAnonymousOperator);
 #endif
 
     if (is<RenderListBox>(renderer))
-        return AccessibilityListBox::create(generateNewObjectID(), renderer);
+        return AccessibilityListBox::create(AXID::generate(), renderer);
     if (auto* renderMenuList = dynamicDowncast<RenderMenuList>(renderer))
-        return AccessibilityMenuList::create(generateNewObjectID(), *renderMenuList);
+        return AccessibilityMenuList::create(AXID::generate(), *renderMenuList);
 
     bool isAnonymous = false;
 #if USE(ATSPI)
@@ -808,52 +808,52 @@ Ref<AccessibilityRenderObject> AXObjectCache::createObjectFromRenderer(RenderObj
     // We don't want to consider these tables (since they are typically wrapped by an actual <table> element),
     // so only create an AccessibilityTable when !is<HTMLTableSectionElement>.
     if ((is<RenderTable>(renderer) && !isAnonymous && !is<HTMLTableSectionElement>(node.get())) || isAccessibilityTable(node.get()))
-        return AccessibilityTable::create(generateNewObjectID(), renderer);
+        return AccessibilityTable::create(AXID::generate(), renderer);
     if ((is<RenderTableRow>(renderer) && !isAnonymous) || isAccessibilityTableRow(node.get()))
-        return AccessibilityTableRow::create(generateNewObjectID(), renderer);
+        return AccessibilityTableRow::create(AXID::generate(), renderer);
     if ((is<RenderTableCell>(renderer) && !isAnonymous) || isAccessibilityTableCell(node.get()))
-        return AccessibilityTableCell::create(generateNewObjectID(), renderer);
+        return AccessibilityTableCell::create(AXID::generate(), renderer);
 
     // Progress indicator.
     if (is<RenderProgress>(renderer) || is<RenderMeter>(renderer)
         || is<HTMLProgressElement>(node) || is<HTMLMeterElement>(node))
-        return AccessibilityProgressIndicator::create(generateNewObjectID(), renderer);
+        return AccessibilityProgressIndicator::create(AXID::generate(), renderer);
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     if (auto* renderAttachment = dynamicDowncast<RenderAttachment>(renderer))
-        return AccessibilityAttachment::create(generateNewObjectID(), *renderAttachment);
+        return AccessibilityAttachment::create(AXID::generate(), *renderAttachment);
 #endif
 
     // input type=range
     if (is<RenderSlider>(renderer))
-        return AccessibilitySlider::create(generateNewObjectID(), renderer);
+        return AccessibilitySlider::create(AXID::generate(), renderer);
 
-    return AccessibilityRenderObject::create(generateNewObjectID(), renderer);
+    return AccessibilityRenderObject::create(AXID::generate(), renderer);
 }
 
 Ref<AccessibilityNodeObject> AXObjectCache::createFromNode(Node& node)
 {
     if (auto* element = dynamicDowncast<Element>(node)) {
         if (isAccessibilityList(*element))
-            return AccessibilityList::create(generateNewObjectID(), *element);
+            return AccessibilityList::create(AXID::generate(), *element);
         if (isAccessibilityTable(element))
-            return AccessibilityTable::create(generateNewObjectID(), *element);
+            return AccessibilityTable::create(AXID::generate(), *element);
         if (isAccessibilityTableRow(element))
-            return AccessibilityTableRow::create(generateNewObjectID(), *element);
+            return AccessibilityTableRow::create(AXID::generate(), *element);
         if (isAccessibilityTableCell(element))
-            return AccessibilityTableCell::create(generateNewObjectID(), *element);
+            return AccessibilityTableCell::create(AXID::generate(), *element);
         if (isAccessibilityTree(*element))
-            return AccessibilityTree::create(generateNewObjectID(), *element);
+            return AccessibilityTree::create(AXID::generate(), *element);
         if (isAccessibilityTreeItem(*element))
-            return AccessibilityTreeItem::create(generateNewObjectID(), *element);
+            return AccessibilityTreeItem::create(AXID::generate(), *element);
         if (isAccessibilityARIATable(*element))
-            return AccessibilityARIATable::create(generateNewObjectID(), *element);
+            return AccessibilityARIATable::create(AXID::generate(), *element);
         if (isAccessibilityARIAGridRow(*element))
-            return AccessibilityARIAGridRow::create(generateNewObjectID(), *element);
+            return AccessibilityARIAGridRow::create(AXID::generate(), *element);
         if (isAccessibilityARIAGridCell(*element))
-            return AccessibilityARIAGridCell::create(generateNewObjectID(), *element);
+            return AccessibilityARIAGridCell::create(AXID::generate(), *element);
     }
-    return AccessibilityNodeObject::create(generateNewObjectID(), node);
+    return AccessibilityNodeObject::create(AXID::generate(), node);
 }
 
 void AXObjectCache::cacheAndInitializeWrapper(AccessibilityObject& newObject, DOMObjectVariant domObject)
@@ -888,9 +888,9 @@ AccessibilityObject* AXObjectCache::getOrCreate(Widget& widget)
 
     RefPtr<AccessibilityObject> newObject;
     if (auto* scrollView = dynamicDowncast<ScrollView>(widget))
-        newObject = AccessibilityScrollView::create(generateNewObjectID(), *scrollView);
+        newObject = AccessibilityScrollView::create(AXID::generate(), *scrollView);
     else if (auto* scrollbar = dynamicDowncast<Scrollbar>(widget))
-        newObject = AccessibilityScrollbar::create(generateNewObjectID(), *scrollbar);
+        newObject = AccessibilityScrollbar::create(AXID::generate(), *scrollbar);
 
     // Will crash later if we have two objects for the same widget.
     ASSERT(!get(widget));
@@ -930,9 +930,9 @@ AccessibilityObject* AXObjectCache::getOrCreate(Node& node, IsPartOfRelation isP
         if (select->usesMenuList()) {
             if (!optionElement || !select->renderer())
                 return nullptr;
-            object = AccessibilityMenuListOption::create(generateNewObjectID(), *optionElement);
+            object = AccessibilityMenuListOption::create(AXID::generate(), *optionElement);
         } else
-            object = AccessibilityListBoxOption::create(generateNewObjectID(), downcast<HTMLElement>(node));
+            object = AccessibilityListBoxOption::create(AXID::generate(), downcast<HTMLElement>(node));
         cacheAndInitializeWrapper(*object, &node);
         return object.get();
     }
@@ -1102,28 +1102,28 @@ AccessibilityObject* AXObjectCache::create(AccessibilityRole role)
     RefPtr<AccessibilityObject> object;
     switch (role) {
     case AccessibilityRole::ImageMapLink:
-        object = AccessibilityImageMapLink::create(generateNewObjectID());
+        object = AccessibilityImageMapLink::create(AXID::generate());
         break;
     case AccessibilityRole::Column:
-        object = AccessibilityTableColumn::create(generateNewObjectID());
+        object = AccessibilityTableColumn::create(AXID::generate());
         break;
     case AccessibilityRole::TableHeaderContainer:
-        object = AccessibilityTableHeaderContainer::create(generateNewObjectID());
+        object = AccessibilityTableHeaderContainer::create(AXID::generate());
         break;
     case AccessibilityRole::RemoteFrame:
-        object = AXRemoteFrame::create(generateNewObjectID());
+        object = AXRemoteFrame::create(AXID::generate());
         break;
     case AccessibilityRole::SliderThumb:
-        object = AccessibilitySliderThumb::create(generateNewObjectID());
+        object = AccessibilitySliderThumb::create(AXID::generate());
         break;
     case AccessibilityRole::MenuListPopup:
-        object = AccessibilityMenuListPopup::create(generateNewObjectID());
+        object = AccessibilityMenuListPopup::create(AXID::generate());
         break;
     case AccessibilityRole::SpinButton:
-        object = AccessibilitySpinButton::create(generateNewObjectID(), *this);
+        object = AccessibilitySpinButton::create(AXID::generate(), *this);
         break;
     case AccessibilityRole::SpinButtonPart:
-        object = AccessibilitySpinButtonPart::create(generateNewObjectID());
+        object = AccessibilitySpinButtonPart::create(AXID::generate());
         break;
     default:
         break;
@@ -1156,11 +1156,9 @@ void AXObjectCache::remove(std::optional<AXID> axID)
     removeAllRelations(*axID);
     object->detach(AccessibilityDetachmentType::ElementDestroyed);
 
-    m_idsInUse.remove(*axID);
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     m_geometryManager->remove(*axID);
 #endif
-    ASSERT(m_objects.size() >= m_idsInUse.size());
 }
 
 void AXObjectCache::remove(RenderObject* renderer)
@@ -1211,16 +1209,6 @@ void AXObjectCache::remove(Widget* view)
     remove(m_widgetObjectMapping.takeOptional(*view));
     if (auto* scrollView = dynamicDowncast<ScrollView>(*view))
         m_deferredScrollbarUpdateChangeList.remove(*scrollView);
-}
-
-AXID AXObjectCache::generateNewObjectID()
-{
-    AXID axID = AXID::generate();
-    while (m_idsInUse.contains(axID))
-        axID = AXID::generate();
-
-    m_idsInUse.add(axID);
-    return axID;
 }
 
 void AXObjectCache::handleTextChanged(AccessibilityObject* object)
@@ -2955,7 +2943,8 @@ VisiblePosition AXObjectCache::visiblePositionForTextMarkerData(const TextMarker
         return { };
 
     auto* cache = renderer->document().axObjectCache();
-    if (cache && !cache->m_idsInUse.contains(*textMarkerData.axObjectID()))
+    // Return an empty position if the object associated with the text marker has been destroyed.
+    if (!cache || !cache->objectForID(*textMarkerData.axObjectID()))
         return { };
 
     return visiblePosition;

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -687,8 +687,6 @@ private:
     AccessibilityObject* focusedObjectForNode(Node*);
     static AccessibilityObject* focusedImageMapUIElement(HTMLAreaElement&);
 
-    AXID generateNewObjectID();
-
     void notificationPostTimerFired();
 
     void liveRegionChangedNotificationPostTimerFired();
@@ -801,8 +799,6 @@ private:
     // Accessed on and off the main thread.
     static std::atomic<bool> gAccessibilityThreadTextApisEnabled;
 #endif
-
-    HashSet<AXID> m_idsInUse;
 
     Timer m_notificationPostTimer;
     Vector<std::pair<Ref<AccessibilityObject>, AXNotification>> m_notificationsToPost;


### PR DESCRIPTION
#### bd2128d85acf5e768fe6bcdb677455a924592ccd
<pre>
AX: Remove redundant AXObjectCache::m_idsInUse HashSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=283461">https://bugs.webkit.org/show_bug.cgi?id=283461</a>
<a href="https://rdar.apple.com/140319280">rdar://140319280</a>

Reviewed by Chris Fleizach.

AXObjectCache::m_idsInUse is currently used in two ways:

  1. AXObjectCache::generateNewObjectID, to ensure we don&apos;t generate an
     object ID that already belongs to some existing object

  2. In AXObjectCache::visiblePositionForTextMarkerData to ensure that
     when we reconstitute a text marker given to us by an AT, that the
     object still exists (i.e. wasn&apos;t destroyed between when we handed
     off the text marker and when the AT gave it back to us).

Point 1 is completely unnecessary. ObjectIdentifier::generate() inherently does not generate duplicate IDs.

Point 2 can be handled simply by checking whether AXObjectCache::objectForID returns a non-null object, which leans on
data structure: HashMap&lt;AXID, Ref&lt;AccessibilityObject&gt;&gt; m_objects.

Removing AXObjectCache::m_idsInUse saves 17mb of memory on <a href="https://html.spec.whatwg.org">https://html.spec.whatwg.org</a> and makes object creation
and deletion more efficient.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::createObjectFromRenderer):
(WebCore::AXObjectCache::createFromNode):
(WebCore::AXObjectCache::getOrCreate):
(WebCore::AXObjectCache::create):
(WebCore::AXObjectCache::remove):
(WebCore::AXObjectCache::visiblePositionForTextMarkerData):
(WebCore::AXObjectCache::generateNewObjectID): Deleted.
* Source/WebCore/accessibility/AXObjectCache.h:

Canonical link: <a href="https://commits.webkit.org/286926@main">https://commits.webkit.org/286926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65aa209efba409ab6d142aff4e686744b4e4d0b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81997 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28699 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60651 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18668 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66444 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40948 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48031 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23941 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27022 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69142 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83406 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4797 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3252 "Found 2 new test failures: ipc/create-connection-and-send-async.html webrtc/vp9-profile2.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68911 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-animations/animation-offscreen-to-onscreen.html imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-offscreen-child-translated.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-intrinsic-aspect-ratio.html imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text-hidden.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4953 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68174 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17057 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12169 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10266 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4744 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7559 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4763 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8198 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6522 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->