### PR TITLE
[WebDriver][win] WebDriver launches MiniBrowser for automation

### DIFF
--- a/Source/WebDriver/SessionHost.cpp
+++ b/Source/WebDriver/SessionHost.cpp
@@ -105,12 +105,10 @@ void SessionHost::dispatchMessage(const String& message)
     responseHandler(WTFMove(response));
 }
 
-#if !USE(GLIB)
 bool SessionHost::isRemoteBrowser() const
 {
-    return false;
+    return m_isRemoteBrowser;
 }
-#endif
 
 #if ENABLE(WEBDRIVER_BIDI)
 void SessionHost::addBrowserTerminatedObserver(const BrowserTerminatedObserver& observer)

--- a/Source/WebDriver/SessionHost.h
+++ b/Source/WebDriver/SessionHost.h
@@ -39,6 +39,10 @@ typedef struct _GSubprocess GSubprocess;
 #include <JavaScriptCore/RemoteInspectorConnectionClient.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+
+#if PLATFORM(WIN)
+#include <wtf/win/Win32Handle.h>
+#endif
 #endif
 
 namespace WebDriver {
@@ -135,16 +139,19 @@ private:
 
     String m_targetIp;
     uint16_t m_targetPort { 0 };
+    bool m_isRemoteBrowser { false };
 
 #if USE(GLIB)
     Function<void (bool, std::optional<String>)> m_startSessionCompletionHandler;
     GRefPtr<GSubprocess> m_browser;
     RefPtr<SocketConnection> m_socketConnection;
     GRefPtr<GCancellable> m_cancellable;
-    bool m_isRemoteBrowser { false };
 #elif USE(INSPECTOR_SOCKET_SERVER)
     Function<void(bool, std::optional<String>)> m_startSessionCompletionHandler;
     std::optional<Inspector::ConnectionID> m_clientID;
+#if PLATFORM(WIN)
+    WTF::Win32Handle m_browserHandle;
+#endif
 #endif
 };
 

--- a/Source/WebDriver/glib/SessionHostGlib.cpp
+++ b/Source/WebDriver/glib/SessionHostGlib.cpp
@@ -392,9 +392,4 @@ void SessionHost::sendMessageToBackend(const String& message)
     m_socketConnection->sendMessage("SendMessageToBackend", g_variant_new("(tts)", m_connectionID, m_target.id, message.utf8().data()));
 }
 
-bool SessionHost::isRemoteBrowser() const
-{
-    return m_isRemoteBrowser;
-}
-
 } // namespace WebDriver

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -432,13 +432,7 @@ Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::closeBrowsingCont
     if (!page)
         SYNC_FAIL_WITH_PREDEFINED_ERROR(WindowNotFound);
 
-#if PLATFORM(WIN) // FIXME: also PLATFORM(PLAYSTATION) should be added
-    // We don't have to close page/window/application, but want to disconnect to automation frontend.
-    terminate();
-#else
     page->closePage();
-#endif
-
     return { };
 }
 

--- a/Source/WebKit/UIProcess/win/AutomationClientWin.h
+++ b/Source/WebKit/UIProcess/win/AutomationClientWin.h
@@ -30,6 +30,8 @@
 #if ENABLE(REMOTE_INSPECTOR)
 #include "APIAutomationClient.h"
 #include "APIAutomationSessionClient.h"
+#include "APIUIClient.h"
+#include "WebView.h"
 #include <JavaScriptCore/RemoteInspectorServer.h>
 #endif
 
@@ -46,8 +48,14 @@ public:
     void requestNewPageWithOptions(WebKit::WebAutomationSession&, API::AutomationSessionBrowsingContextOptions, CompletionHandler<void(WebKit::WebPageProxy*)>&&) override;
     void didDisconnectFromRemote(WebKit::WebAutomationSession&) override;
 
+    void retainWebView(Ref<WebView>&&);
+    void releaseWebView(WebPageProxy*);
+
 private:
     String m_sessionIdentifier;
+
+    static void close(WKPageRef, const void*);
+    HashSet<Ref<WebView>> m_webViews;
 };
 
 class AutomationClient final : public API::AutomationClient, Inspector::RemoteInspector::Client {

--- a/Source/WebKit/UIProcess/win/WebView.cpp
+++ b/Source/WebKit/UIProcess/win/WebView.cpp
@@ -111,7 +111,7 @@ LRESULT WebView::wndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         break;
     case WM_DESTROY:
         m_isBeingDestroyed = true;
-        close();
+        closeInternal();
         break;
     case WM_ERASEBKGND:
         lResult = 1;
@@ -778,15 +778,13 @@ bool WebView::shouldInitializeTrackPointHack()
 
 void WebView::close()
 {
-    if (m_window) {
-        // We can't check IsWindow(m_window) here, because that will return true even while
-        // we're already handling WM_DESTROY. So we check !m_isBeingDestroyed instead.
-        if (!m_isBeingDestroyed)
-            DestroyWindow(m_window);
-        // Either we just destroyed m_window, or it's in the process of being destroyed. Either
-        // way, we clear it out to make sure we don't try to use it later.
-        m_window = 0;
-    }
+    if (m_window && !m_isBeingDestroyed)
+        DestroyWindow(m_window);
+}
+
+void WebView::closeInternal()
+{
+    m_window = 0;
     setParentWindow(0);
     m_page->close();
 }

--- a/Source/WebKit/UIProcess/win/WebView.h
+++ b/Source/WebKit/UIProcess/win/WebView.h
@@ -79,6 +79,8 @@ public:
 
     DrawingAreaProxy* drawingArea() { return page() ? page()->drawingArea() : nullptr; }
 
+    void close();
+
 private:
     WebView(RECT, const API::PageConfiguration&, HWND parentWindow);
 
@@ -115,7 +117,7 @@ private:
 
     bool shouldInitializeTrackPointHack();
 
-    void close();
+    void closeInternal();
 
     HCURSOR cursorToShow() const;
     void updateNativeCursor();


### PR DESCRIPTION
#### 7e00247af20ab27c5d35dc61e7372cc0edbb9175
<pre>
[WebDriver][win] WebDriver launches MiniBrowser for automation
<a href="https://bugs.webkit.org/show_bug.cgi?id=282972">https://bugs.webkit.org/show_bug.cgi?id=282972</a>

Reviewed by Fujii Hironori.

The win port WebDriver supports connecting to a browser
that is already running.
However, win port WebDriver has not yet implemented
the feature of launching the browser by itself.
This makes it difficult to run the WebDriverTests.

This change adds a feature to the WebDriver to launch
a browser to connect if target is not specified.

Before this change, the --target(-t) option is
mandatory for win port WebDriver.

This change allows the --target option to be omitted.
In that case, the WebDriver will scan freeport and
launching a MiniBrowser that listens on 127.0.0.1:(freeport).
This MiniBrowser is hidden, but WebDriver can connect to
and automate it.

Canonical link: <a href="https://commits.webkit.org/287053@main">https://commits.webkit.org/287053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ced1da5d486a34ad09bbfc9c2fa0c374f0c7bdb6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78136 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82794 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29398 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5464 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/61187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19105 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67965 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41501 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48535 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24733 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27736 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69630 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84157 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5502 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3720 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69409 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5659 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68664 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17130 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12664 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10904 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5451 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/8203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5440 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8872 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7229 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->