### PR TITLE
AX: A new AccessibilityMenuListPopup is created and never cleaned up for every clearChildren-addChildren cycle of AccessibilityMenuList, causing a memory leak

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -403,7 +403,6 @@ accessibility/AccessibilityList.cpp
 accessibility/AccessibilityListBox.cpp
 accessibility/AccessibilityListBoxOption.cpp
 accessibility/AccessibilityMathMLElement.cpp
-accessibility/AccessibilityMenuList.cpp
 accessibility/AccessibilityMenuListOption.cpp
 accessibility/AccessibilityMenuListPopup.cpp
 accessibility/AccessibilityNodeObject.cpp

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -795,8 +795,8 @@ Ref<AccessibilityRenderObject> AXObjectCache::createObjectFromRenderer(RenderObj
 
     if (is<RenderListBox>(renderer))
         return AccessibilityListBox::create(AXID::generate(), renderer);
-    if (auto* renderMenuList = dynamicDowncast<RenderMenuList>(renderer))
-        return AccessibilityMenuList::create(AXID::generate(), *renderMenuList);
+    if (CheckedPtr renderMenuList = dynamicDowncast<RenderMenuList>(renderer))
+        return AccessibilityMenuList::create(AXID::generate(), *renderMenuList, *this);
 
     bool isAnonymous = false;
 #if USE(ATSPI)

--- a/Source/WebCore/accessibility/AccessibilityMenuList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuList.cpp
@@ -33,14 +33,19 @@
 
 namespace WebCore {
 
-AccessibilityMenuList::AccessibilityMenuList(AXID axID, RenderMenuList& renderer)
+AccessibilityMenuList::AccessibilityMenuList(AXID axID, RenderMenuList& renderer, AXObjectCache& cache)
     : AccessibilityRenderObject(axID, renderer)
+    , m_popup(downcast<AccessibilityMenuListPopup>(*cache.create(AccessibilityRole::MenuListPopup)))
 {
+    m_popup->setParent(this);
+
+    addChild(m_popup.ptr());
+    m_childrenInitialized = true;
 }
 
-Ref<AccessibilityMenuList> AccessibilityMenuList::create(AXID axID, RenderMenuList& renderer)
+Ref<AccessibilityMenuList> AccessibilityMenuList::create(AXID axID, RenderMenuList& renderer, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityMenuList(axID, renderer));
+    return adoptRef(*new AccessibilityMenuList(axID, renderer, cache));
 }
 
 bool AccessibilityMenuList::press()
@@ -49,7 +54,7 @@ bool AccessibilityMenuList::press()
         return false;
 
 #if !PLATFORM(IOS_FAMILY)
-    auto element = this->element();
+    RefPtr element = this->element();
     AXObjectCache::AXNotification notification = AXObjectCache::AXPressDidFail;
     if (CheckedPtr menuList = dynamicDowncast<RenderMenuList>(renderer()); menuList && element && !element->isDisabledFormControl()) {
         if (menuList->popupIsVisible())
@@ -58,39 +63,34 @@ bool AccessibilityMenuList::press()
             menuList->showPopup();
         notification = AXObjectCache::AXPressDidSucceed;
     }
-    if (auto cache = axObjectCache())
-        cache->postNotification(element, notification);
+    if (CheckedPtr cache = axObjectCache())
+        cache->postNotification(element.get(), notification);
     return true;
 #endif
     return false;
 }
 
+void AccessibilityMenuList::updateChildrenIfNecessary()
+{
+    // Typically for AccessibilityNodeObject subclasses, updateChildrenIfNecessary() is what
+    // calls addChildren(), which in turn passes m_subtreeDirty down the tree as objects are inserted.
+    // However, we purposely never allow our children to be cleared or become unitialized, which
+    // by the definition of the AccessibilityNodeObject::updateChildrenIfNecessary() means addChildren()
+    // will never be called. (We add our only child, m_popup, once in the constructor).
+    //
+    // Despite this, we still want to pass down the m_subtreeDirty flag if we have it set, so do that here.
+    if (m_subtreeDirty)
+        m_popup->setNeedsToUpdateSubtree();
+
+    m_subtreeDirty = false;
+}
+
 void AccessibilityMenuList::addChildren()
 {
-    auto clearDirtySubtree = makeScopeExit([&] {
-        m_subtreeDirty = false;
-    });
-
-    if (!m_renderer)
-        return;
-    
-    AXObjectCache* cache = axObjectCache();
-    if (!cache)
-        return;
-    
-    auto list = cache->create(AccessibilityRole::MenuListPopup);
-    if (!list)
-        return;
-
-    downcast<AccessibilityMockObject>(*list).setParent(this);
-    if (list->isIgnored()) {
-        cache->remove(list->objectID());
-        return;
-    }
-
-    m_childrenInitialized = true;
-    addChild(list);
-    list->addChildren();
+    // This class sets its children once in the constructor, and should never
+    // have dirty or uninitialized children afterwards.
+    ASSERT(m_childrenInitialized);
+    ASSERT(!m_childrenDirty);
 }
 
 bool AccessibilityMenuList::isCollapsed() const
@@ -110,15 +110,15 @@ bool AccessibilityMenuList::isCollapsed() const
 
 bool AccessibilityMenuList::canSetFocusAttribute() const
 {
-    if (!node())
-        return false;
-
-    return !downcast<Element>(*node()).isDisabledFormControl();
+    RefPtr element = this->element();
+    return element && !element->isDisabledFormControl();
 }
 
 void AccessibilityMenuList::didUpdateActiveOption(int optionIndex)
 {
-    Ref<Document> document(m_renderer->document());
+    RefPtr document = m_renderer ? &m_renderer->document() : nullptr;
+    if (!document)
+        return;
 
     const auto& childObjects = unignoredChildren();
     if (!childObjects.isEmpty()) {
@@ -133,11 +133,11 @@ void AccessibilityMenuList::didUpdateActiveOption(int optionIndex)
         // You can reproduce the issue in the GTK+ port by removing this check and running
         // accessibility/insert-selected-option-into-select-causes-crash.html (will crash).
         int popupChildrenSize = static_cast<int>(childObjects[0]->unignoredChildren().size());
-        if (auto* accessibilityMenuListPopup = dynamicDowncast<AccessibilityMenuListPopup>(*childObjects[0]); accessibilityMenuListPopup && optionIndex >= 0 && optionIndex < popupChildrenSize)
+        if (RefPtr accessibilityMenuListPopup = dynamicDowncast<AccessibilityMenuListPopup>(*childObjects[0]); accessibilityMenuListPopup && optionIndex >= 0 && optionIndex < popupChildrenSize)
             accessibilityMenuListPopup->didUpdateActiveOption(optionIndex);
     }
 
-    if (auto* cache = document->axObjectCache())
+    if (CheckedPtr cache = document->axObjectCache())
         cache->deferMenuListValueChange(element());
 }
 

--- a/Source/WebCore/accessibility/AccessibilityMenuList.h
+++ b/Source/WebCore/accessibility/AccessibilityMenuList.h
@@ -29,26 +29,33 @@
 
 namespace WebCore {
 
+class AccessibilityMenuListPopup;
 class RenderMenuList;
 
 class AccessibilityMenuList final : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityMenuList> create(AXID, RenderMenuList&);
+    static Ref<AccessibilityMenuList> create(AXID, RenderMenuList&, AXObjectCache&);
 
-    bool isCollapsed() const override;
-    bool press() override;
+    bool isCollapsed() const final;
+    bool press() final;
 
     void didUpdateActiveOption(int optionIndex);
 
 private:
-    explicit AccessibilityMenuList(AXID, RenderMenuList&);
+    explicit AccessibilityMenuList(AXID, RenderMenuList&, AXObjectCache&);
 
     bool isMenuList() const final { return true; }
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::PopUpButton; }
 
-    bool canSetFocusAttribute() const override;
+    bool canSetFocusAttribute() const final;
+    void addChildren() final;
+    void updateChildrenIfNecessary() final;
+    // This class' children are initialized once in the constructor with m_popup.
+    void clearChildren() final { };
+    void setNeedsToUpdateChildren() final { };
 
-    void addChildren() override;
+    // FIXME: Nothing calls AXObjectCache::remove for m_popup.
+    Ref<AccessibilityMenuListPopup> m_popup;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilitySpinButton.h
+++ b/Source/WebCore/accessibility/AccessibilitySpinButton.h
@@ -54,6 +54,7 @@ private:
     LayoutRect elementRect() const override;
 
     WeakPtr<SpinButtonElement, WeakPtrImplWithEventTargetData> m_spinButtonElement;
+    // FIXME: Nothing calls AXObjectCache::remove for m_incrementor and m_decrementor.
     Ref<AccessibilitySpinButtonPart> m_incrementor;
     Ref<AccessibilitySpinButtonPart> m_decrementor;
 };


### PR DESCRIPTION
#### 291a726050b82ba5edb9f41bf4137ebbeadad477
<pre>
AX: A new AccessibilityMenuListPopup is created and never cleaned up for every clearChildren-addChildren cycle of AccessibilityMenuList, causing a memory leak
<a href="https://bugs.webkit.org/show_bug.cgi?id=283468">https://bugs.webkit.org/show_bug.cgi?id=283468</a>
<a href="https://rdar.apple.com/140323875">rdar://140323875</a>

Reviewed by Chris Fleizach.

Prior to this commit, every time an AccessibilityMenuList calls clearChildren() and addChildren(), we would create
a brand new AccessibilityMenuListPopup object with an associated object wrapper, without cleaning up the popup
from the last cycle, leaking it.

With this commit, we now create the AccessibilityMenuListPopup up-front in the AccessibilityMenuList constructor, and
maintain it between clearChildren-addChildren cycles. This is also better because it keeps the popup wrapper more stable
for ATs, i.e. we are no longer at risk of sending a notification with a popup, then calling clearChildren,
effectively detaching the popup the AT has a reference to, making it useless to the AT if it tries to respond to the notification.

This commit does not fully fix the memory leak, just greatly reduces it, leaking one object total instead of one object
per clearChildren-addChildren cycle. Because nothing calls AXObjectCache::remove on the new AccessibilityMenuList::m_popup
field, it gets leaked. I will be addressing this in a later commit once I think of a good pattern to solve this problem
holistically, since several classes have this bug in slightly different ways.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::createObjectFromRenderer):
* Source/WebCore/accessibility/AccessibilityMenuList.cpp:
(WebCore::AccessibilityMenuList::AccessibilityMenuList):
(WebCore::AccessibilityMenuList::create):
(WebCore::AccessibilityMenuList::press):
(WebCore::AccessibilityMenuList::addChildren):
(WebCore::AccessibilityMenuList::canSetFocusAttribute const):
(WebCore::AccessibilityMenuList::didUpdateActiveOption):
* Source/WebCore/accessibility/AccessibilityMenuList.h:
* Source/WebCore/accessibility/AccessibilitySpinButton.h:

Canonical link: <a href="https://commits.webkit.org/286973@main">https://commits.webkit.org/286973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcb29687aecf8235fc6f7c71a78be6f84d15d569

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56790 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82405 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29030 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60914 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/18864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66707 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41213 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48242 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24224 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27366 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69358 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83764 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5135 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3462 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69135 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5291 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68384 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17089 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12402 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10487 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5083 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5091 "Build is in progress. Recent messages:") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/8528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6860 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->