### PR TITLE
Support chaining pseudos after element-backed pseudo-elements

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -948,8 +948,7 @@ imported/w3c/web-platform-tests/html/rendering/widgets/appearance/appearance-ani
 imported/w3c/web-platform-tests/html/rendering/widgets/appearance/appearance-transition-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-selection.html [ Pass Failure ]
 
-# Needs support for chaining pseudo-elements after ::details-content.
-imported/w3c/web-platform-tests/html/rendering/the-details-element/details-pseudo-elements-004.html [ ImageOnlyFailure ]
+# Needs support for ::first-letter after ::details-content.
 imported/w3c/web-platform-tests/html/rendering/the-details-element/details-pseudo-elements-005.html [ ImageOnlyFailure ]
 
 # Cross-Origin-Embedder-Policy: credentialless is not supported.

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1482,7 +1482,8 @@ static FunctionType constructFragmentsInternal(const CSSSelector* rootSelector, 
             case CSSSelector::PseudoElement::ViewTransition:
             case CSSSelector::PseudoElement::UserAgentPart:
             case CSSSelector::PseudoElement::UserAgentPartLegacyAlias:
-                ASSERT(!fragment->pseudoElementSelector);
+                if (fragment->pseudoElementSelector)
+                    return FunctionType::CannotCompile;
                 fragment->pseudoElementSelector = selector;
                 break;
             case CSSSelector::PseudoElement::WebKitUnknown:


### PR DESCRIPTION
#### 7144b8334a41031f230f925f063a63800a6975c2
<pre>
Support chaining pseudos after element-backed pseudo-elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=283446">https://bugs.webkit.org/show_bug.cgi?id=283446</a>
<a href="https://rdar.apple.com/140328987">rdar://140328987</a>

Reviewed by NOBODY (OOPS!).

See <a href="https://drafts.csswg.org/css-pseudo-4/#element-like">https://drafts.csswg.org/css-pseudo-4/#element-like</a>

* LayoutTests/TestExpectations:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::isPseudoClassValidAfterPseudoElement):
(WebCore::isTreeAbidingPseudoElement):
(WebCore::isSimpleSelectorValidAfterPseudoElement):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::constructFragmentsInternal):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7144b8334a41031f230f925f063a63800a6975c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82024 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28725 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4775 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60692 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements.html imported/w3c/web-platform-tests/css/css-scoping/slotted-parsing.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18690 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80510 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66470 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40968 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48057 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23966 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements.html imported/w3c/web-platform-tests/css/css-scoping/slotted-parsing.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27048 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69166 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24304 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements.html imported/w3c/web-platform-tests/css/css-scoping/slotted-parsing.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83432 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4823 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3274 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements.html imported/w3c/web-platform-tests/css/css-scoping/slotted-parsing.html ipc/create-connection-and-send-async.html webrtc/vp9-profile2.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68931 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements.html imported/w3c/web-platform-tests/css/css-scoping/slotted-parsing.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4979 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66438 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68195 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12194 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10291 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements.html imported/w3c/web-platform-tests/css/css-scoping/slotted-parsing.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4770 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7585 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4789 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8224 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6548 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->