### PR TITLE
[GTK][WPE] Further adoption of std::array in GObject signals and properties

### DIFF
--- a/Source/JavaScriptCore/API/glib/JSCWeakValue.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCWeakValue.cpp
@@ -59,9 +59,7 @@ struct _JSCWeakValuePrivate {
     JSC::JSWeakValue weakValueRef;
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-static guint signals[LAST_SIGNAL] = { 0, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(JSCWeakValue, jsc_weak_value, G_TYPE_OBJECT, GObject)
 

--- a/Source/WebCore/platform/graphics/gstreamer/TextCombinerPadGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TextCombinerPadGStreamer.cpp
@@ -46,9 +46,7 @@ enum {
     N_PROPERTIES,
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 #define webkit_text_combiner_pad_parent_class parent_class
 WEBKIT_DEFINE_TYPE(WebKitTextCombinerPad, webkit_text_combiner_pad, GST_TYPE_GHOST_PAD);
@@ -70,9 +68,7 @@ static gboolean webkitTextCombinerPadEvent(GstPad* pad, GstObject* parent, GstEv
                 gst_tag_list_insert(combinerPad->priv->tags.get(), tags, GST_TAG_MERGE_REPLACE);
         }
 
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
         g_object_notify_by_pspec(G_OBJECT(pad), sObjProperties[PROP_PAD_TAGS]);
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         break;
     }
     default:
@@ -155,7 +151,6 @@ static void webkit_text_combiner_pad_class_init(WebKitTextCombinerPadClass* klas
     gobjectClass->get_property = GST_DEBUG_FUNCPTR(webkitTextCombinerPadGetProperty);
     gobjectClass->set_property = GST_DEBUG_FUNCPTR(webkitTextCombinerPadSetProperty);
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
     sObjProperties[PROP_PAD_TAGS] =
         g_param_spec_boxed("tags", nullptr, nullptr, GST_TYPE_TAG_LIST,
             static_cast<GParamFlags>(G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
@@ -163,9 +158,8 @@ static void webkit_text_combiner_pad_class_init(WebKitTextCombinerPadClass* klas
     sObjProperties[PROP_INNER_COMBINER_PAD] =
         g_param_spec_object("inner-combiner-pad", nullptr, nullptr, GST_TYPE_PAD,
             static_cast<GParamFlags>(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
-    g_object_class_install_properties(gobjectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(gobjectClass, N_PROPERTIES, sObjProperties.data());
 }
 
 GstPad* webKitTextCombinerPadLeakInternalPadRef(WebKitTextCombinerPad* pad)

--- a/Source/WebKit/Shared/API/glib/WebKitURIRequest.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitURIRequest.cpp
@@ -32,9 +32,7 @@ enum {
     N_PROPERTIES,
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK/WPE port
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 using namespace WebCore;
 
@@ -101,7 +99,7 @@ static void webkit_uri_request_class_init(WebKitURIRequestClass* requestClass)
             "about:blank",
             static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT));
 
-    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties.data());
 }
 
 /**

--- a/Source/WebKit/UIProcess/API/glib/WebKitGeolocationManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitGeolocationManager.cpp
@@ -53,7 +53,7 @@ enum {
     N_PROPERTIES,
 };
 
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 enum {
     START,
@@ -366,7 +366,7 @@ static void webkit_geolocation_manager_class_init(WebKitGeolocationManagerClass*
             FALSE,
             WEBKIT_PARAM_READABLE);
 
-    g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties.data());
 
     /**
      * WebKitGeolocationManager::start:

--- a/Source/WebKit/UIProcess/API/gtk/WebKitPrintCustomWidget.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitPrintCustomWidget.cpp
@@ -72,7 +72,7 @@ struct _WebKitPrintCustomWidgetPrivate {
     GRefPtr<GtkWidget> widget;
 };
 
-static guint signals[LAST_SIGNAL] = { 0, };
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_TYPE(WebKitPrintCustomWidget, webkit_print_custom_widget, G_TYPE_OBJECT)
 

--- a/Source/WebKit/WPEPlatform/wpe/WPEBuffer.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBuffer.cpp
@@ -65,7 +65,7 @@ enum {
     N_PROPERTIES
 };
 
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 static void wpeBufferSetProperty(GObject* object, guint propId, const GValue* value, GParamSpec* paramSpec)
 {
@@ -155,7 +155,7 @@ static void wpe_buffer_class_init(WPEBufferClass* bufferClass)
             0, G_MAXINT, 0,
             static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
 
-    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties.data());
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.cpp
@@ -51,7 +51,7 @@ enum {
     N_PROPERTIES
 };
 
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 static void wpeBufferSHMSetProperty(GObject* object, guint propId, const GValue* value, GParamSpec* paramSpec)
 {
@@ -142,7 +142,7 @@ static void wpe_buffer_shm_class_init(WPEBufferSHMClass* bufferSHMClass)
             0, G_MAXUINT, 0,
             static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
 
-    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties.data());
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
@@ -71,7 +71,7 @@ enum {
     LAST_SIGNAL
 };
 
-static guint signals[LAST_SIGNAL] = { 0, };
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 /**
  * wpe_display_error_quark:

--- a/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp
@@ -179,8 +179,8 @@ enum {
     N_PROPERTIES
 };
 
-static guint signals[LAST_SIGNAL] = { 0, };
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
+static std::array<unsigned, LAST_SIGNAL> signals;
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 static void wpeInputMethodContextSetProperty(GObject* object, guint propId, const GValue* value, GParamSpec* paramSpec)
 {
@@ -256,7 +256,7 @@ static void wpe_input_method_context_class_init(WPEInputMethodContextClass* klas
             WPE_INPUT_HINT_NONE,
             static_cast<GParamFlags>(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY));
 
-    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties.data());
 
      /**
      * WPEInputMethodContextClass::preedit-started:

--- a/Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp
@@ -62,7 +62,7 @@ enum {
     N_PROPERTIES
 };
 
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 static void wpeScreenSetProperty(GObject* object, guint propId, const GValue* value, GParamSpec* paramSpec)
 {
@@ -252,7 +252,7 @@ static void wpe_screen_class_init(WPEScreenClass* screenClass)
             -1, G_MAXINT, -1,
             WEBKIT_PARAM_READWRITE);
 
-    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties.data());
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
@@ -110,7 +110,7 @@ enum {
     LAST_SIGNAL
 };
 
-static guint signals[LAST_SIGNAL] = { 0, };
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(WPESettings, wpe_settings, G_TYPE_OBJECT, GObject)
 

--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
@@ -67,7 +67,7 @@ enum {
     N_PROPERTIES
 };
 
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 static void wpeToplevelSetProperty(GObject* object, guint propId, const GValue* value, GParamSpec* paramSpec)
 {
@@ -113,7 +113,7 @@ static void wpe_toplevel_class_init(WPEToplevelClass* toplevelClass)
             WPE_TYPE_DISPLAY,
             static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
 
-    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties.data());
 }
 
 void wpeToplevelAddView(WPEToplevel* toplevel, WPEView* view)

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -92,7 +92,7 @@ enum {
     N_PROPERTIES
 };
 
-static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
+static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
 enum {
     CLOSED,
@@ -106,7 +106,7 @@ enum {
     LAST_SIGNAL
 };
 
-static guint signals[LAST_SIGNAL] = { 0, };
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 static void wpeViewSetProperty(GObject* object, guint propId, const GValue* value, GParamSpec* paramSpec)
 {
@@ -322,7 +322,7 @@ static void wpe_view_class_init(WPEViewClass* viewClass)
             FALSE,
             WEBKIT_PARAM_READABLE);
 
-    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties);
+    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties.data());
 
     /**
      * WPEView::closed:

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitScriptWorld.cpp
@@ -53,9 +53,7 @@ struct _WebKitScriptWorldPrivate {
     CString name;
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK/WPE port
-static guint signals[LAST_SIGNAL] = { 0, };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitScriptWorld, webkit_script_world, G_TYPE_OBJECT, GObject)
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp
@@ -128,7 +128,7 @@ struct _WebKitWebExtensionPrivate {
 #endif
 };
 
-static guint signals[LAST_SIGNAL] = { 0, };
+static std::array<unsigned, LAST_SIGNAL> signals;
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitWebExtension, webkit_web_extension, G_TYPE_OBJECT, GObject)
 


### PR DESCRIPTION
#### b7e8b52797ec35be5dbe613f5213d847bbe9ae5a
<pre>
[GTK][WPE] Further adoption of std::array in GObject signals and properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=283482">https://bugs.webkit.org/show_bug.cgi?id=283482</a>

Reviewed by Adrian Perez de Castro.

* Source/JavaScriptCore/API/glib/JSCWeakValue.cpp:
* Source/WebCore/platform/graphics/gstreamer/TextCombinerPadGStreamer.cpp:
(webkitTextCombinerPadEvent):
(webkit_text_combiner_pad_class_init):
* Source/WebKit/Shared/API/glib/WebKitURIRequest.cpp:
(webkit_uri_request_class_init):
* Source/WebKit/UIProcess/API/glib/WebKitGeolocationManager.cpp:
(webkit_geolocation_manager_class_init):
* Source/WebKit/UIProcess/API/gtk/WebKitPrintCustomWidget.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEBuffer.cpp:
(wpe_buffer_class_init):
* Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.cpp:
(wpe_buffer_shm_class_init):
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp:
(wpe_input_method_context_class_init):
* Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp:
(wpe_screen_class_init):
* Source/WebKit/WPEPlatform/wpe/WPESettings.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp:
(wpe_toplevel_class_init):
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_class_init):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitScriptWorld.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp:

Canonical link: <a href="https://commits.webkit.org/286904@main">https://commits.webkit.org/286904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/363ffc523ccdb9cb8c36e870453a83dbd0d1b185

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56500 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30381 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82046 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28747 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79582 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4797 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60702 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/18707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80532 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/50676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/66493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40983 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/48078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/23990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27070 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/70653 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/69187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/24328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83454 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/76744 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4845 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3293 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/68946 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5001 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/66461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/68210 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12215 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/10313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/98996 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11992 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4792 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21639 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4811 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8246 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6570 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->