### PR TITLE
Unable to dump WebGPU shaders after 286825@main

### DIFF
--- a/Source/WebGPU/WGSL/ConstantValue.h
+++ b/Source/WebGPU/WGSL/ConstantValue.h
@@ -38,7 +38,7 @@ using half = __fp16;
 #else
 // Wrap a struct around the supported fp16 type.
 struct half {
-#if PLATFORM(__APPLE__)
+#if PLATFORM(COCOA)
     using f16 = __fp16;
 #else
     // _Float16 is the 16bit float type in C++23, and is often available

--- a/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
@@ -28,12 +28,12 @@
 
 #include "AST.h"
 #include "MetalFunctionWriter.h"
-#if PLATFORM(__APPLE__)
-#include <notify.h>
-#endif
 #include <wtf/DataLog.h>
 #include <wtf/text/StringBuilder.h>
 
+#if PLATFORM(COCOA)
+#include <notify.h>
+#endif
 namespace WGSL {
 
 namespace Metal {
@@ -50,7 +50,7 @@ static StringView metalCodePrologue()
 
 }
 
-#if PLATFORM(__APPLE__)
+#if PLATFORM(COCOA)
 static void dumpMetalCodeIfNeeded(StringBuilder& stringBuilder)
 {
     static bool dumpMetalCode = false;
@@ -76,7 +76,7 @@ String generateMetalCode(ShaderModule& shaderModule, PrepareResult& prepareResul
 
     Metal::emitMetalFunctions(stringBuilder, shaderModule, prepareResult, constantValues);
 
-#if PLATFORM(__APPLE__)
+#if PLATFORM(COCOA)
     dumpMetalCodeIfNeeded(stringBuilder);
 #endif
 


### PR DESCRIPTION
#### 9e68cdf074c796b7a8b777d7e083e3beabb212ed
<pre>
Unable to dump WebGPU shaders after 286825@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=283479">https://bugs.webkit.org/show_bug.cgi?id=283479</a>
<a href="https://rdar.apple.com/140335930">rdar://140335930</a>

Reviewed by Tadeu Zagallo.

PLATFORM(__APPLE__) is not a correct preprocessor condition.
Use PLATFORM(COCOA) instead.

* Source/WebGPU/WGSL/ConstantValue.h:
* Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp:
(WGSL::Metal::generateMetalCode):

Canonical link: <a href="https://commits.webkit.org/286912@main">https://commits.webkit.org/286912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ee6535edcd7b5b553df4e828705229b7c67e2f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82050 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28751 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4801 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60705 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18710 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50681 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66496 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40986 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48082 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27074 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69191 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83458 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4849 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3300 "Found 2 new test failures: ipc/create-connection-and-send-async.html webrtc/vp9-profile2.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68949 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66464 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68213 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12220 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10316 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11996 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4796 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4815 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8250 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6574 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->