### PR TITLE
[SOUP] Further span adoption in WebKitDirectoryInputStream

### DIFF
--- a/Source/WebKit/NetworkProcess/soup/WebKitDirectoryInputStream.cpp
+++ b/Source/WebKit/NetworkProcess/soup/WebKitDirectoryInputStream.cpp
@@ -28,6 +28,8 @@
 
 #include "WebKitDirectoryInputStreamData.h"
 #include <glib/gi18n-lib.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/glib/GSpanExtras.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/WTFGType.h>
 
@@ -140,6 +142,7 @@ static gssize webkitDirectoryInputStreamRead(GInputStream* input, void* buffer, 
         return 0;
 
     gsize totalBytesRead = 0;
+    auto destinationSpan = unsafeMakeSpan(static_cast<uint8_t*>(buffer), count);
     while (totalBytesRead < count) {
         if (!stream->priv->buffer) {
             stream->priv->buffer = adoptGRef(webkitDirectoryInputStreamReadNextFile(stream, cancellable, error));
@@ -150,14 +153,13 @@ static gssize webkitDirectoryInputStreamRead(GInputStream* input, void* buffer, 
             }
         }
 
-        gsize bufferSize;
-        auto* bufferData = g_bytes_get_data(stream->priv->buffer.get(), &bufferSize);
-        gsize bytesRead = std::min(bufferSize, count - totalBytesRead);
-        memcpy(static_cast<char*>(buffer) + totalBytesRead, bufferData, bytesRead);
-        if (bytesRead == bufferSize)
+        auto sourceSpan = span(stream->priv->buffer);
+        unsigned bytesRead = std::min(sourceSpan.size(), count - totalBytesRead);
+        memcpySpan(destinationSpan.subspan(totalBytesRead, bytesRead), sourceSpan.subspan(0, bytesRead));
+        if (bytesRead == sourceSpan.size())
             stream->priv->buffer = nullptr;
         else
-            stream->priv->buffer = adoptGRef(g_bytes_new_from_bytes(stream->priv->buffer.get(), bytesRead, bufferSize - bytesRead));
+            stream->priv->buffer = adoptGRef(g_bytes_new_from_bytes(stream->priv->buffer.get(), bytesRead, sourceSpan.size() - bytesRead));
         totalBytesRead += bytesRead;
     }
 


### PR DESCRIPTION
#### 10ad3724b9dfed188b5178108bcf9db4c2e7dbd7
<pre>
[SOUP] Further span adoption in WebKitDirectoryInputStream
<a href="https://bugs.webkit.org/show_bug.cgi?id=283488">https://bugs.webkit.org/show_bug.cgi?id=283488</a>

Reviewed by Adrian Perez de Castro.

Instead of directly doing memcpy(), leverage use of std::span and memcpySpan().

* Source/WebKit/NetworkProcess/soup/WebKitDirectoryInputStream.cpp:
(webkitDirectoryInputStreamRead):

Canonical link: <a href="https://commits.webkit.org/286947@main">https://commits.webkit.org/286947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/003fa15d963fa7b741d3db49909486d925b6b696

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30563 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/82263 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28919 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65830 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60843 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18809 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66631 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41113 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48195 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27250 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/69308 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83643 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5021 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69071 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5178 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68323 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12330 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10432 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12025 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4968 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/4983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/8421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6746 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->