### PR TITLE
Remove redundant caching in Quirks

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -204,13 +204,7 @@ bool Quirks::needsAutoplayPlayPauseEvents() const
 // - iOS PiP
 bool Quirks::needsSeekingSupportDisabled() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.needsSeekingSupportDisabledQuirk)
-        m_quirksData.needsSeekingSupportDisabledQuirk = isNetflix();
-
-    return *m_quirksData.needsSeekingSupportDisabledQuirk;
+    return needsQuirks() && isNetflix();
 }
 
 // netflix.com https://bugs.webkit.org/show_bug.cgi?id=193301
@@ -246,14 +240,7 @@ bool Quirks::hasBrokenEncryptedMediaAPISupportQuirk() const
 #if ENABLE(THUNDER)
     return false;
 #else
-
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.hasBrokenEncryptedMediaAPISupportQuirk)
-        m_quirksData.hasBrokenEncryptedMediaAPISupportQuirk = isYouTube();
-
-    return *m_quirksData.hasBrokenEncryptedMediaAPISupportQuirk;
+    return needsQuirks() && isYouTube();
 #endif
 }
 
@@ -593,10 +580,7 @@ bool Quirks::shouldDispatchedSimulatedMouseEventsAssumeDefaultPrevented(EventTar
     if (!needsQuirks() || !shouldDispatchSimulatedMouseEvents(target))
         return false;
 
-    if (!m_quirksData.shouldDispatchedSimulatedMouseEventsAssumeDefaultPreventedQuirk)
-        m_quirksData.shouldDispatchedSimulatedMouseEventsAssumeDefaultPreventedQuirk = isAmazon() || isSoundCloud();
-
-    if (!m_quirksData.shouldDispatchedSimulatedMouseEventsAssumeDefaultPreventedQuirk.value())
+    if (!isAmazon() || !isSoundCloud())
         return false;
 
     RefPtr element = dynamicDowncast<Element>(target);
@@ -775,13 +759,7 @@ bool Quirks::needsPrimeVideoUserSelectNoneQuirk() const
 // NOTE: Also remove `BuilderConverter::convertScrollbarWidth` and related code when removing this quirk.
 bool Quirks::needsScrollbarWidthThinDisabledQuirk() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.needsScrollbarWidthThinDisabledQuirk)
-        m_quirksData.needsScrollbarWidthThinDisabledQuirk = isYouTube();
-
-    return *m_quirksData.needsScrollbarWidthThinDisabledQuirk;
+    return needsQuirks() && isYouTube();
 }
 
 // spotify.com rdar://138918575
@@ -842,13 +820,7 @@ bool Quirks::needsWeChatScrollingQuirk() const
 bool Quirks::needsGoogleMapsScrollingQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.needsGoogleMapsScrollingQuirk)
-        m_quirksData.needsGoogleMapsScrollingQuirk = isGoogleMaps();
-
-    return *m_quirksData.needsGoogleMapsScrollingQuirk;
+    return needsQuirks() && isGoogleMaps();
 #else
     return false;
 #endif
@@ -879,10 +851,7 @@ bool Quirks::shouldSilenceResizeObservers() const
     if (!page || !page->isTakingSnapshotsForApplicationSuspension())
         return false;
 
-    if (!m_quirksData.shouldSilenceResizeObservers)
-        m_quirksData.shouldSilenceResizeObservers = isYouTube();
-
-    return *m_quirksData.shouldSilenceResizeObservers;
+    return isYouTube();
 #else
     return false;
 #endif
@@ -1021,13 +990,7 @@ bool Quirks::shouldOpenAsAboutBlank(const String& stringToOpen) const
 bool Quirks::needsPreloadAutoQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.needsPreloadAutoQuirk)
-        m_quirksData.needsPreloadAutoQuirk = isVimeo();
-
-    return *m_quirksData.needsPreloadAutoQuirk;
+    return needsQuirks() && isVimeo();
 #else
     return false;
 #endif
@@ -1492,13 +1455,7 @@ bool Quirks::blocksReturnToFullscreenFromPictureInPictureQuirk() const
     // returns to fullscreen from picture-in-picture. This quirk disables the "return to fullscreen
     // from picture-in-picture" feature for those sites. We should remove the quirk once
     // rdar://problem/73167931 has been fixed.
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.blocksReturnToFullscreenFromPictureInPictureQuirk)
-        m_quirksData.blocksReturnToFullscreenFromPictureInPictureQuirk = isVimeo();
-
-    return *m_quirksData.blocksReturnToFullscreenFromPictureInPictureQuirk;
+    return needsQuirks() && isVimeo();
 #else
     return false;
 #endif
@@ -1509,13 +1466,7 @@ bool Quirks::blocksEnteringStandardFullscreenFromPictureInPictureQuirk() const
 #if ENABLE(FULLSCREEN_API) && ENABLE(VIDEO_PRESENTATION_MODE)
     // Vimeo enters fullscreen when starting playback from the inline play button while already in PIP.
     // This behavior is revealing a bug in the fullscreen handling. See rdar://107592139.
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.blocksEnteringStandardFullscreenFromPictureInPictureQuirk)
-        m_quirksData.blocksEnteringStandardFullscreenFromPictureInPictureQuirk = isVimeo();
-
-    return *m_quirksData.blocksEnteringStandardFullscreenFromPictureInPictureQuirk;
+    return needsQuirks() && isVimeo();
 #else
     return false;
 #endif
@@ -1528,13 +1479,7 @@ bool Quirks::shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFull
     // from fullscreen for the sites which cannot handle the event properly in that case.
     // We should remove once the quirks have been fixed.
     // <rdar://90393832> vimeo.com
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk)
-        m_quirksData.shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk = isESPN() || isVimeo();
-
-    return *m_quirksData.shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk;
+    return needsQuirks() && (isESPN() || isVimeo());
 #else
     return false;
 #endif
@@ -1567,13 +1512,7 @@ bool Quirks::shouldAllowNavigationToCustomProtocolWithoutUserGesture(StringView 
 #if PLATFORM(IOS) || PLATFORM(VISION)
 bool Quirks::allowLayeredFullscreenVideos() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.allowLayeredFullscreenVideos)
-        m_quirksData.allowLayeredFullscreenVideos = isESPN();
-
-    return *m_quirksData.allowLayeredFullscreenVideos;
+    return needsQuirks() && isESPN();
 }
 #endif
 

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -37,7 +37,6 @@ struct WEBCORE_EXPORT QuirksData {
     std::optional<bool> isYouTube;
     std::optional<bool> isZoom;
 
-    std::optional<bool> hasBrokenEncryptedMediaAPISupportQuirk;
     std::optional<bool> implicitMuteWhenVolumeSetToZero;
     std::optional<bool> needsBingGestureEventQuirk;
     std::optional<bool> needsBodyScrollbarWidthNoneDisabledQuirk;
@@ -46,8 +45,6 @@ struct WEBCORE_EXPORT QuirksData {
     std::optional<bool> needsDisableDOMPasteAccessQuirk;
     std::optional<bool> needsMozillaFileTypeForDataTransferQuirk;
     std::optional<bool> needsRelaxedCorsMixedContentCheckQuirk;
-    std::optional<bool> needsScrollbarWidthThinDisabledQuirk;
-    std::optional<bool> needsSeekingSupportDisabledQuirk;
     std::optional<bool> needsVP9FullRangeFlagQuirk;
     std::optional<bool> needsVideoShouldMaintainAspectRatioQuirk;
     std::optional<bool> returnNullPictureInPictureElementDuringFullscreenChangeQuirk;
@@ -61,7 +58,6 @@ struct WEBCORE_EXPORT QuirksData {
     std::optional<bool> shouldDisableFetchMetadata;
     std::optional<bool> shouldDisableLazyIframeLoadingQuirk;
     std::optional<bool> shouldDisableWritingSuggestionsByDefaultQuirk;
-    std::optional<bool> shouldDispatchedSimulatedMouseEventsAssumeDefaultPreventedQuirk;
     std::optional<bool> shouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk;
     std::optional<bool> shouldEnableFontLoadingAPIQuirk;
     std::optional<bool> shouldExposeShowModalDialog;
@@ -77,9 +73,7 @@ struct WEBCORE_EXPORT QuirksData {
     std::optional<bool> needsFullscreenDisplayNoneQuirk;
     std::optional<bool> needsFullscreenObjectFitQuirk;
     std::optional<bool> needsGMailOverflowScrollQuirk;
-    std::optional<bool> needsGoogleMapsScrollingQuirk;
     std::optional<bool> needsIPadSkypeOverflowScrollQuirk;
-    std::optional<bool> needsPreloadAutoQuirk;
     std::optional<bool> needsYouTubeMouseOutQuirk;
     std::optional<bool> needsYouTubeOverflowScrollQuirk;
     std::optional<bool> shouldAvoidPastingImagesAsWebContent;
@@ -94,7 +88,6 @@ struct WEBCORE_EXPORT QuirksData {
 #if PLATFORM(IOS) || PLATFORM(VISION)
     std::optional<bool> allowLayeredFullscreenVideos;
     std::optional<bool> shouldSilenceMediaQueryListChangeEvents;
-    std::optional<bool> shouldSilenceResizeObservers;
     std::optional<bool> shouldSilenceWindowResizeEvents;
 #endif
 
@@ -147,12 +140,6 @@ struct WEBCORE_EXPORT QuirksData {
     std::optional<bool> requiresUserGestureToLoadInPictureInPictureQuirk;
     std::optional<bool> requiresUserGestureToPauseInPictureInPictureQuirk;
     std::optional<bool> shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk;
-    std::optional<bool> shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk;
-#endif
-
-#if ENABLE(FULLSCREEN_API) && ENABLE(VIDEO_PRESENTATION_MODE)
-    std::optional<bool> blocksEnteringStandardFullscreenFromPictureInPictureQuirk;
-    std::optional<bool> blocksReturnToFullscreenFromPictureInPictureQuirk;
 #endif
 };
 


### PR DESCRIPTION
#### c4c1c442a79e5557a00ecf8197b157e5f11b6fd9
<pre>
Remove redundant caching in Quirks
<a href="https://bugs.webkit.org/show_bug.cgi?id=283490">https://bugs.webkit.org/show_bug.cgi?id=283490</a>
<a href="https://rdar.apple.com/140347382">rdar://140347382</a>

Reviewed by Wenson Hsieh.

Methods like isYouTube() already implement their own caching on top of
QuirksData. There&apos;s no need to cache its results again one level up.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsSeekingSupportDisabled const):
(WebCore::Quirks::hasBrokenEncryptedMediaAPISupportQuirk const):
(WebCore::Quirks::shouldDispatchedSimulatedMouseEventsAssumeDefaultPrevented const):
(WebCore::Quirks::needsScrollbarWidthThinDisabledQuirk const):
(WebCore::Quirks::needsGoogleMapsScrollingQuirk const):
(WebCore::Quirks::shouldSilenceResizeObservers const):
(WebCore::Quirks::needsPreloadAutoQuirk const):
(WebCore::Quirks::blocksReturnToFullscreenFromPictureInPictureQuirk const):
(WebCore::Quirks::blocksEnteringStandardFullscreenFromPictureInPictureQuirk const):
(WebCore::Quirks::shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk const):
(WebCore::Quirks::allowLayeredFullscreenVideos const):
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/286917@main">https://commits.webkit.org/286917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d9947fd1de48edc290de42cdf7bc724899d4925

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82086 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28766 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79601 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4816 "Built successfully") | [💥 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60725 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18718 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50693 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66512 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41004 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48094 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24008 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27089 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69204 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83473 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4864 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3313 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68956 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5020 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66479 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68221 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17053 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12234 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10331 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4811 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7626 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4830 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8265 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6589 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->