### PR TITLE
[JSC] Loop unrolling

### DIFF
--- a/JSTests/microbenchmarks/loop-unrolling-1.js
+++ b/JSTests/microbenchmarks/loop-unrolling-1.js
@@ -1,0 +1,23 @@
+function assert(actual, expected) {
+    for (let i = 0; i < actual.length; i++) {
+        if (actual[i] != expected[i])
+            throw new Error("bad actual=" + actual[i] + " but expected=" + expected[i]);
+    }
+}
+
+function test(a) {
+    for (let i = 0; i < 4; i++) {
+        a[i] = 1;
+    }
+    return a;
+}
+noInline(test);
+
+let expected;
+for (let i = 0; i < 1e5; i++) {
+    let a = [0, 0, 0, 0];
+    let res = test(a);
+    if (i == 0)
+        expected = res;
+    assert(res, expected);
+}

--- a/JSTests/microbenchmarks/loop-unrolling-2.js
+++ b/JSTests/microbenchmarks/loop-unrolling-2.js
@@ -1,0 +1,27 @@
+function assert(actual, expected) {
+    for (let i = 0; i < actual.length; i++) {
+        if (actual[i] != expected[i])
+            throw new Error("bad actual=" + actual[i] + " but expected=" + expected[i]);
+    }
+}
+
+function test(a) {
+    for (let i = 0; i < 4; i++) {
+        a[i] = 1;
+        for (let i = 0; i < 4; i++) {
+            a[i] = 1;
+        }
+    }
+    return a;
+}
+noInline(test);
+
+let expected;
+for (let i = 0; i < 1e5; i++) {
+    let a = [0, 0, 0, 0];
+    let res = test(a);
+    if (i == 0)
+        expected = res;
+    assert(res, expected);
+}
+

--- a/JSTests/microbenchmarks/loop-unrolling-3.js
+++ b/JSTests/microbenchmarks/loop-unrolling-3.js
@@ -1,0 +1,27 @@
+function assert(actual, expected) {
+    for (let i = 0; i < actual.length; i++) {
+        if (actual[i] != expected[i])
+            throw new Error("bad actual=" + actual[i] + " but expected=" + expected[i]);
+    }
+}
+
+function test(a) {
+    for (let i = 0; i < 4; i++) {
+        if (i % 2 == 0)
+            a[i] = 1;
+        else
+            a[i] = 2;
+    }
+    return a;
+}
+noInline(test);
+
+let expected;
+for (let i = 0; i < 1e5; i++) {
+    let a = [0, 0, 0, 0];
+    let res = test(a);
+    if (i == 0)
+        expected = res;
+    assert(res, expected);
+}
+

--- a/JSTests/microbenchmarks/loop-unrolling-4.js
+++ b/JSTests/microbenchmarks/loop-unrolling-4.js
@@ -1,0 +1,27 @@
+function assert(actual, expected) {
+    for (let i = 0; i < actual.length; i++) {
+        if (actual[i] != expected[i])
+            throw new Error("bad actual=" + actual[i] + " but expected=" + expected[i]);
+    }
+}
+
+function test(s) {
+    let len = 4;
+    var a = new Array(len);
+    for (var i = 0; i < len; i++) {
+        a[i] = s[i];
+    }
+    // FIXME: why read a[0] is not eliminated but a[1] does?
+    s[0] = a[0] ^ a[1];
+    return s;
+}
+noInline(test);
+
+let expected;
+for (let i = 0; i < 1e5; i++) {
+    let a = [0, 0];
+    let res = test(a);
+    if (i == 0)
+        expected = res;
+    assert(res, expected);
+}

--- a/JSTests/microbenchmarks/loop-unrolling-array-clone-big.js
+++ b/JSTests/microbenchmarks/loop-unrolling-array-clone-big.js
@@ -1,0 +1,27 @@
+//@skip if $memoryLimited
+let arr = Array(20).fill(0)
+
+for (let i = 0; i < arr.length; ++i) {
+    arr[i] = i;
+}
+
+function main(arr, i) {
+    "use strict";
+    var copy = new Array(i);
+    while (i--)
+        copy[i] = arr[i];
+    return copy;
+}
+noInline(main)
+
+const expected = 49995000
+
+for (let i = 0; i < 1e4; ++i) {
+    let r = main(arr, 20)
+    if (r.length != 20)
+        throw "Bad length"
+    for (let i = 0; i < r.length; ++i) {
+        if (r[i] != i)
+            throw "Error: expected " + i + " got " + r
+    }
+}

--- a/JSTests/microbenchmarks/loop-unrolling-array-clone-small.js
+++ b/JSTests/microbenchmarks/loop-unrolling-array-clone-small.js
@@ -1,0 +1,28 @@
+//@skip if $memoryLimited
+let arr = Array(20).fill(0)
+
+for (let i = 0; i < arr.length; ++i) {
+    arr[i] = i;
+}
+
+function main(arr, i) {
+    "use strict";
+    var copy = new Array(i);
+    while (i--) {
+        copy[i] = arr[i];
+    }
+    return copy;
+}
+noInline(main)
+
+const expected = 49995000
+
+for (let i = 0; i < 1e4; ++i) {
+    let r = main(arr, 20)
+    if (r.length != 20)
+        throw "Bad length"
+    for (let i = 0; i < r.length; ++i) {
+        if (r[i] != i)
+            throw "Error: expected " + i + " got " + r[i] + ": " + r
+    }
+}

--- a/JSTests/microbenchmarks/loop-unrolling-constant-small.js
+++ b/JSTests/microbenchmarks/loop-unrolling-constant-small.js
@@ -1,0 +1,32 @@
+//@skip if $memoryLimited
+let arr = Array(1000).fill(0)
+
+for (let i = 0; i < arr.length; ++i) {
+    arr[i] = i;
+}
+
+function main(b, d) {
+    "use strict";
+
+    b = b | 0
+    d = d | 0
+
+    if (arr.length != 1000 || b < 0 || d < 0)
+        return;
+
+    let sum = 0
+
+    for (let i = 0; i < 16; ++i) {
+        sum += arr[i] | 0
+    }
+    return sum
+}
+noInline(main)
+
+const expected = 120
+
+for (let i = 0; i < 1e4; ++i) {
+    let r = main(5, 16)
+    if (r != expected)
+        throw "Error: expected " + expected + " got " + r
+}

--- a/JSTests/microbenchmarks/loop-unrolling-core-sha1.js
+++ b/JSTests/microbenchmarks/loop-unrolling-core-sha1.js
@@ -1,0 +1,21 @@
+function core_sha1(x)
+{
+    let result = 0
+    for(var i = 0; i < 10; i = (i * 100 + 1) / 100 + 1)
+    {
+        for(var j = 0; j < 20; j++)
+        {
+            if(j < 16) result = 0
+            else result = 1
+        }
+    }
+
+  return result
+}
+noInline(core_sha1)
+
+for (let i = 0; i < 1000; ++i) {
+    let result = core_sha1([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15])
+    if (result != 1)
+        throw "unexpected result: " + result
+}

--- a/JSTests/microbenchmarks/loop-unrolling-variable-large.js
+++ b/JSTests/microbenchmarks/loop-unrolling-variable-large.js
@@ -1,0 +1,32 @@
+//@skip if $memoryLimited
+let arr = Array(10000).fill(0)
+
+for (let i = 0; i < arr.length; ++i) {
+    arr[i] = i;
+}
+
+function main(b, d) {
+    "use strict";
+
+    b = b | 0
+    d = d | 0
+
+    if (arr.length != 10000 || b < 0 || d < 0)
+        return;
+
+    let sum = 0
+
+    for (let i = 0; i < d; ++i) {
+        sum += arr[i] | 0
+    }
+    return sum
+}
+noInline(main)
+
+const expected = 49995000
+
+for (let i = 0; i < 1e4; ++i) {
+    let r = main(5, 10000)
+    if (r != expected)
+        throw "Error: expected " + expected + " got " + r
+}

--- a/JSTests/microbenchmarks/loop-unrolling-variable-medium-dep.js
+++ b/JSTests/microbenchmarks/loop-unrolling-variable-medium-dep.js
@@ -1,0 +1,33 @@
+//@skip if $memoryLimited
+let arr = Array(1000).fill(0)
+
+for (let i = 0; i < arr.length; ++i) {
+    arr[i] = i;
+}
+
+function main(b, d) {
+    "use strict";
+
+    b = b | 0
+    d = d | 0
+
+    if (arr.length != 1000 || b < 0 || d < 0)
+        return;
+
+    let sum = 0
+
+    for (let i = 1; i < d; ++i) {
+        arr[i] = ((arr[i - 1] | 0) + 1) | 0
+        sum += arr[i]
+    }
+    return sum
+}
+noInline(main)
+
+const expected = 499500
+
+for (let i = 0; i < 1e4; ++i) {
+    let r = main(5, 1000)
+    if (r != expected)
+        throw "Error: expected " + expected + " got " + r
+}

--- a/JSTests/microbenchmarks/loop-unrolling-variable-medium.js
+++ b/JSTests/microbenchmarks/loop-unrolling-variable-medium.js
@@ -1,0 +1,32 @@
+//@skip if $memoryLimited
+let arr = Array(1000).fill(0)
+
+for (let i = 0; i < arr.length; ++i) {
+    arr[i] = i;
+}
+
+function main(b, d) {
+    "use strict";
+
+    b = b | 0
+    d = d | 0
+
+    if (arr.length != 1000 || b < 0 || d < 0)
+        return;
+
+    let sum = 0
+
+    for (let i = 0; i < d; ++i) {
+        sum += arr[i] | 0
+    }
+    return sum
+}
+noInline(main)
+
+const expected = 499500
+
+for (let i = 0; i < 1e4; ++i) {
+    let r = main(5, 1000)
+    if (r != expected)
+        throw "Error: expected " + expected + " got " + r
+}

--- a/JSTests/microbenchmarks/loop-unrolling-variable-small.js
+++ b/JSTests/microbenchmarks/loop-unrolling-variable-small.js
@@ -1,0 +1,32 @@
+//@skip if $memoryLimited
+let arr = Array(1000).fill(0)
+
+for (let i = 0; i < arr.length; ++i) {
+    arr[i] = i;
+}
+
+function main(b, d) {
+    "use strict";
+
+    b = b | 0
+    d = d | 0
+
+    if (arr.length != 1000 || b < 0 || d < 0)
+        return;
+
+    let sum = 0
+
+    for (let i = 0; i < d; ++i) {
+        sum += arr[i] | 0
+    }
+    return sum
+}
+noInline(main)
+
+const expected = 120
+
+for (let i = 0; i < 1e4; ++i) {
+    let r = main(5, 16)
+    if (r != expected)
+        throw "Error: expected " + expected + " got " + r
+}

--- a/JSTests/stress/loop-unrolling-osr-exit.js
+++ b/JSTests/stress/loop-unrolling-osr-exit.js
@@ -1,0 +1,55 @@
+//@ runDefault("--useDollarVM=1")
+function assert(actual, expected) {
+    for (let i = 0; i < actual.length; i++) {
+        if (actual[i] != expected[i])
+            throw new Error("bad actual=" + actual[i] + " but expected=" + expected[i]);
+    }
+}
+
+function func1(a) {
+    for (let i = 0; i < 4;) {
+        a[i] = 1;
+        // FIXME: ForceOSRExit can break the loop graph in CFG simplification.
+        // We may need other ways to trigger OSR exits for loop unrolling.
+        if ($vm.ftlTrue()) OSRExit();
+        i++;
+    }
+    return a;
+}
+noInline(func1);
+
+function func2(a) {
+    for (let i = 0; i < 4;) {
+        a[i] = 1;
+        i++;
+        if ($vm.ftlTrue()) OSRExit();
+    }
+    return a;
+}
+noInline(func2);
+
+function func3(a) {
+    for (let i = 0; i < 4;) {
+        if ($vm.ftlTrue()) OSRExit();
+        a[i] = 1;
+        i++;
+    }
+    return a;
+}
+noInline(func3);
+
+function test(func) {
+    let expected;
+    for (let i = 0; i < 1e5; i++) {
+        let a = [0, 0, 0, 0];
+        let res = func(a);
+        if (i == 0)
+            expected = res;
+        assert(res, expected);
+    }
+}
+
+test(func1);
+// test(func2);
+// test(func3);
+

--- a/JSTests/stress/loop-unrolling-overflow.js
+++ b/JSTests/stress/loop-unrolling-overflow.js
@@ -1,0 +1,40 @@
+function assert(actual, expected) {
+    for (let i = 0; i < actual.length; i++) {
+        if (actual[i] != expected[i])
+            throw new Error("bad actual=" + actual[i] + " but expected=" + expected[i]);
+    }
+}
+
+let int_max = 2 ** 31 - 1;
+let update = 2 ** 30;
+let update2 = 2 ** 30 - 1;
+
+function overflow(a) {
+    for (let i = 0; i <= int_max; i = i + update) {
+        a[i % 4] = i;
+    }
+    return a;
+}
+noInline(overflow);
+
+function underflow(a) {
+    for (let i = 0; i >= -int_max; i = i - update2) {
+        a[Math.abs(i) % 4] = i;
+    }
+    return a;
+}
+noInline(underflow);
+
+function test(func) {
+    let expected;
+    for (let i = 0; i < 1e5; i++) {
+        let a = [0, 0, 0, 0];
+        let res = func(a);
+        if (i == 0)
+            expected = res;
+        assert(res, expected);
+    }
+}
+
+test(overflow);
+test(underflow);

--- a/JSTests/stress/loop-unrolling.js
+++ b/JSTests/stress/loop-unrolling.js
@@ -1,0 +1,92 @@
+function assert(actual, expected) {
+    for (let i = 0; i < actual.length; i++) {
+        if (actual[i] != expected[i])
+            throw new Error("bad actual=" + actual[i] + " but expected=" + expected[i]);
+    }
+}
+
+function func1(a) {
+    for (let i = 0; i < 4; i++) {
+        a[i] = 1;
+    }
+    return a;
+}
+noInline(func1);
+
+function func2(a) {
+    for (let i = 0; i < 4; i++) {
+        a[i] = 1;
+        for (let i = 0; i < 4; i++) {
+            a[i] = 1;
+        }
+    }
+    return a;
+}
+noInline(func2);
+
+function func3(a) {
+    for (let i = 0; i < 4; i++) {
+        if (i % 2 == 0)
+            a[i] = 1;
+        else
+            a[i] = 2;
+    }
+    return a;
+}
+noInline(func3);
+
+function func4(s) {
+    let len = 4;
+    var a = new Array(len);
+    for (var i = 0; i < len; i++) {
+        a[i] = s[i];
+    }
+    s[0] = a[0] ^ a[1];
+    return s;
+}
+noInline(func4);
+
+function func5(a) {
+    for (let i = 0; i < 4;) {
+        a[i] = 1;
+        if (i > -1)
+            i += 1;
+    }
+    return a;
+}
+noInline(func5);
+
+function func6(a) {
+    for (let i = 3; i > 1; i /= 2) {
+        a[i] = 1;
+    }
+    return a;
+}
+noInline(func6);
+
+function func7(a) {
+    for (let i = 3; i < 4; i /= 0) {
+        a[i] = 1;
+    }
+    return a;
+}
+noInline(func7);
+
+function test(func) {
+    let expected;
+    for (let i = 0; i < 1e5; i++) {
+        let a = [0, 0, 0, 0];
+        let res = func(a);
+        if (i == 0)
+            expected = res;
+        assert(res, expected);
+    }
+}
+
+test(func1);
+test(func2);
+test(func3);
+test(func4);
+test(func5);
+test(func6);
+test(func7);

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2205,6 +2205,7 @@
 		FF41590C28FF3C6B00F80B96 /* WaiterListManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FF41590B28FF3C6B00F80B96 /* WaiterListManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFB951142C043CA800349750 /* OrderedHashTableHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FFB951132C043CA800349750 /* OrderedHashTableHelper.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFCC9A412BDD7C4700C75345 /* OrderedHashTable.h in Headers */ = {isa = PBXBuildFile; fileRef = FFCC9A402BDD7C4700C75345 /* OrderedHashTable.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FFE21FE52CC1BE1800DEC268 /* DFGLoopUnrollingPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = FFE21FE32CC1BE1800DEC268 /* DFGLoopUnrollingPhase.h */; };
 		FFF3373F2BCDF1240070D04B /* JSCBytecodeCacheVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = FFF3373E2BCDF1240070D04B /* JSCBytecodeCacheVersion.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFF4D5A32CE304CD006EA634 /* DeferredWorkTimerInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FFF4D5A22CE304C2006EA634 /* DeferredWorkTimerInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 /* End PBXBuildFile section */
@@ -6097,6 +6098,8 @@
 		FFB77C2828FF561B00F3C55B /* WaiterListManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WaiterListManager.cpp; sourceTree = "<group>"; };
 		FFB951132C043CA800349750 /* OrderedHashTableHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrderedHashTableHelper.h; sourceTree = "<group>"; };
 		FFCC9A402BDD7C4700C75345 /* OrderedHashTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrderedHashTable.h; sourceTree = "<group>"; };
+		FFE21FE32CC1BE1800DEC268 /* DFGLoopUnrollingPhase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DFGLoopUnrollingPhase.h; path = dfg/DFGLoopUnrollingPhase.h; sourceTree = "<group>"; };
+		FFE21FE42CC1BE1800DEC268 /* DFGLoopUnrollingPhase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DFGLoopUnrollingPhase.cpp; path = dfg/DFGLoopUnrollingPhase.cpp; sourceTree = "<group>"; };
 		FFF3373D2BCDF1240070D04B /* JSCBytecodeCacheVersion.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSCBytecodeCacheVersion.cpp; sourceTree = "<group>"; };
 		FFF3373E2BCDF1240070D04B /* JSCBytecodeCacheVersion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSCBytecodeCacheVersion.h; sourceTree = "<group>"; };
 		FFF4D5A22CE304C2006EA634 /* DeferredWorkTimerInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DeferredWorkTimerInlines.h; sourceTree = "<group>"; };
@@ -9187,6 +9190,8 @@
 				A7D89CED17A0B8CC00773AD8 /* DFGLivenessAnalysisPhase.h */,
 				A767B5B317A0B9650063D940 /* DFGLoopPreHeaderCreationPhase.cpp */,
 				A767B5B417A0B9650063D940 /* DFGLoopPreHeaderCreationPhase.h */,
+				FFE21FE42CC1BE1800DEC268 /* DFGLoopUnrollingPhase.cpp */,
+				FFE21FE32CC1BE1800DEC268 /* DFGLoopUnrollingPhase.h */,
 				0F5874EB194FEB1200AAB2C1 /* DFGMayExit.cpp */,
 				0F5874EC194FEB1200AAB2C1 /* DFGMayExit.h */,
 				0F1725FE1B48719A00AC3A55 /* DFGMinifiedGraph.cpp */,
@@ -10750,6 +10755,7 @@
 				79C4B15E1BA2158F00FD592E /* DFGLiveCatchVariablePreservationPhase.h in Headers */,
 				A7D89CFC17A0B8CC00773AD8 /* DFGLivenessAnalysisPhase.h in Headers */,
 				A767B5B617A0B9650063D940 /* DFGLoopPreHeaderCreationPhase.h in Headers */,
+				FFE21FE52CC1BE1800DEC268 /* DFGLoopUnrollingPhase.h in Headers */,
 				0F5874EE194FEB1200AAB2C1 /* DFGMayExit.h in Headers */,
 				0F2BDC451522801B00CD8910 /* DFGMinifiedGraph.h in Headers */,
 				0F2E892D16D02BAF009E4FD2 /* DFGMinifiedID.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -389,6 +389,7 @@ dfg/DFGLazyJSValue.cpp
 dfg/DFGLazyNode.cpp
 dfg/DFGLivenessAnalysisPhase.cpp
 dfg/DFGLoopPreHeaderCreationPhase.cpp
+dfg/DFGLoopUnrollingPhase.cpp
 dfg/DFGMayExit.cpp
 dfg/DFGMinifiedGraph.cpp
 dfg/DFGMinifiedNode.cpp

--- a/Source/JavaScriptCore/b3/B3SparseCollection.h
+++ b/Source/JavaScriptCore/b3/B3SparseCollection.h
@@ -62,6 +62,11 @@ public:
         return result;
     }
 
+    T* cloneAndAdd(const T& node)
+    {
+        return add(makeUnique<T>(node));
+    }
+
     template<typename... Arguments>
     T* addNew(Arguments&&... arguments)
     {

--- a/Source/JavaScriptCore/dfg/DFGBasicBlock.h
+++ b/Source/JavaScriptCore/dfg/DFGBasicBlock.h
@@ -163,6 +163,8 @@ struct BasicBlock : RefCounted<BasicBlock> {
     void removePredecessor(BasicBlock* block);
     void replacePredecessor(BasicBlock* from, BasicBlock* to);
 
+    Node* cloneAndAppend(Graph&, const Node*);
+
     template<typename... Params>
     Node* appendNode(Graph&, SpeculatedType, Params...);
     

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -1,0 +1,835 @@
+/*
+ * Cloneright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DFGLoopUnrollingPhase.h"
+
+#if ENABLE(DFG_JIT)
+
+#include "CodeOrigin.h"
+#include "DFGBasicBlock.h"
+#include "DFGBlockInsertionSet.h"
+#include "DFGCFAPhase.h"
+#include "DFGGraph.h"
+#include "DFGNaturalLoops.h"
+#include "DFGNodeOrigin.h"
+#include "DFGNodeType.h"
+#include "DFGPhase.h"
+#include <wtf/IndexMap.h>
+
+namespace JSC {
+namespace DFG {
+
+class LoopUnrollingPhase : public Phase {
+public:
+    static constexpr uint32_t maxUnrolledLoopCount = 2;
+    static constexpr uint32_t maxIterationCount = 4;
+    static constexpr uint32_t maxLoopNodeSize = 100;
+
+    using NaturalLoop = CPSNaturalLoop;
+
+    using ComparisonFunction = bool (*)(CheckedInt32, CheckedInt32);
+    using UpdateFunction = CheckedInt32 (*)(CheckedInt32, CheckedInt32);
+
+    struct LoopData {
+        uint32_t loopSize() { return loop->size(); }
+        BasicBlock* loopBody(uint32_t i) { return loop->at(i).node(); }
+        BasicBlock* header() const { return loop->header().node(); }
+        Node* condition() const { return tail->terminal()->child1().node(); }
+        bool isInductionVariable(Node* node) { return node->operand() == inductionVariable->operand(); }
+        void dump(PrintStream& out) const;
+
+        const NaturalLoop* loop { nullptr };
+        BasicBlock* preHeader { nullptr };
+        BasicBlock* tail { nullptr };
+        BasicBlock* next { nullptr };
+
+        // for (i = initialValue; condition(i, operand); i = update(i, updateValue)) { ... }
+        Node* inductionVariable { nullptr };
+        CheckedInt32 initialValue { INT_MIN };
+        CheckedInt32 operand { INT_MIN };
+        Node* update { nullptr };
+        CheckedInt32 updateValue { INT_MIN };
+        CheckedUint32 iterationCount { 0 };
+    };
+
+    LoopUnrollingPhase(Graph& graph)
+        : Phase(graph, "Loop Unrolling"_s)
+        , m_blockInsertionSet(graph)
+    {
+    }
+
+    bool run()
+    {
+        bool changed = false;
+
+        if (UNLIKELY(Options::verboseLoopUnrolling())) {
+            dataLogLn("Graph before Loop Unrolling Phase:");
+            m_graph.dump();
+        }
+
+        uint32_t unrolledCount = 0;
+        while (true) {
+            const NaturalLoop* loop = selectDeepestNestedLoop();
+            if (!loop || unrolledCount >= maxUnrolledLoopCount)
+                break;
+            if (!tryUnroll(loop))
+                break;
+
+            ++unrolledCount;
+            changed = true;
+        }
+
+        dataLogLnIf(Options::verboseLoopUnrolling(), "Successfully unrolled ", unrolledCount, " loops.");
+        return changed;
+    }
+
+    const NaturalLoop* selectDeepestNestedLoop()
+    {
+        m_graph.ensureCPSNaturalLoops();
+
+        const NaturalLoop* target = nullptr;
+        int32_t maxDepth = INT_MIN;
+        uint32_t loopCount = m_graph.m_cpsNaturalLoops->numLoops();
+        IndexMap<const NaturalLoop*, int32_t> depthCache(loopCount, INT_MIN);
+
+        for (uint32_t loopIndex = loopCount; loopIndex--;) {
+            const NaturalLoop& loop = m_graph.m_cpsNaturalLoops->loop(loopIndex);
+            ASSERT(loop.index() == loopIndex && depthCache[loopIndex] == INT_MIN);
+
+            int32_t depth = 0;
+            const NaturalLoop* current = &loop;
+            while (current) {
+                int32_t cachedDepth = depthCache[current->index()];
+                if (cachedDepth != INT_MIN) {
+                    depth += cachedDepth;
+                    break;
+                }
+                ++depth;
+                current = m_graph.m_cpsNaturalLoops->innerMostOuterLoop(*current);
+            }
+            depthCache[loopIndex] = depth;
+
+            if (depth > maxDepth) {
+                maxDepth = depth;
+                target = &loop;
+            }
+        }
+        return target;
+    }
+
+    bool tryUnroll(const NaturalLoop* loop)
+    {
+        if (UNLIKELY(Options::verboseLoopUnrolling())) {
+            const NaturalLoop* outerLoop = m_graph.m_cpsNaturalLoops->innerMostOuterLoop(*loop);
+            dataLogLnIf(Options::verboseLoopUnrolling(), "\nTry unroll innerMostLoop=", *loop, " with innerMostOuterLoop=", outerLoop ? *outerLoop : NaturalLoop());
+        }
+
+        LoopData data = { loop };
+
+        if (!shouldUnrollLoop(data))
+            return false;
+
+        // PreHeader                          PreHeader
+        //  |                                  |
+        // Header <---                        HeaderBodyTailGraph_0 <-- original loop
+        //  |        |      unrolled to        |
+        // Body      |   ================>    HeaderBodyTailGraph_1 <-- 1st copy
+        //  |        |                         |
+        // Tail ------                        ...
+        //  |                                  |
+        // Next                               HeaderBodyTailGraph_n <-- n_th copy
+        //                                     |
+        //                                    Next
+        //
+        // Note that NaturalLoop's body includes Header, Body, and Tail. The unrolling
+        // process appends the HeaderBodyTailGraph copies in reverse order (from n_th to 1st).
+
+        if (!locatePreHeader(data))
+            return false;
+        dataLogLnIf(Options::verboseLoopUnrolling(), "\tFound PreHeader with LoopData=", data);
+
+        if (!locateTail(data))
+            return false;
+        dataLogLnIf(Options::verboseLoopUnrolling(), "\tFound Tail with LoopData=", data);
+
+        if (!identifyInductionVariable(data))
+            return false;
+        dataLogLnIf(Options::verboseLoopUnrolling(), "\tFound InductionVariable with LoopData=", data);
+
+        if (!canCloneLoop(data))
+            return false;
+
+        BasicBlock* header = data.header();
+        unrollLoop(data);
+
+        if (UNLIKELY(Options::verboseLoopUnrolling())) {
+            dataLogLn("\tGraph after Loop Unrolling for loop");
+            m_graph.dump();
+        }
+
+        if (UNLIKELY(Options::printEachUnrolledLoop()))
+            dataLogLn("\tIn function ", m_graph.m_codeBlock->inferredName(), ", successfully unrolled the loop header=", *header);
+        return true;
+    }
+
+    bool locatePreHeader(LoopData& data)
+    {
+        BasicBlock* preHeader = nullptr;
+        BasicBlock* header = data.header();
+
+        // This is guaranteed because we expect the CFG not to have unreachable code. Therefore, a
+        // loop header must have a predecessor. (Also, we don't allow the root block to be a loop,
+        // which cuts out the one other way of having a loop header with only one predecessor.)
+        DFG_ASSERT(m_graph, header->at(0), header->predecessors.size() > 1, header->predecessors.size());
+
+        uint32_t preHeaderCount = 0;
+        for (uint32_t i = header->predecessors.size(); i--;) {
+            BasicBlock* predecessor = header->predecessors[i];
+            if (m_graph.m_cpsDominators->dominates(header, predecessor))
+                continue;
+
+            preHeader = predecessor;
+            ++preHeaderCount;
+        }
+
+        if (preHeaderCount != 1)
+            return false;
+
+        data.preHeader = preHeader;
+        return true;
+    }
+
+    bool locateTail(LoopData& data)
+    {
+        BasicBlock* header = data.header();
+        BasicBlock* tail = nullptr;
+
+        for (BasicBlock* predecessor : header->predecessors) {
+            if (!m_graph.m_cpsDominators->dominates(header, predecessor))
+                continue;
+
+            if (tail) {
+                dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *header, " since it contains two tails: ", *predecessor, " and ", *tail);
+                return false;
+            }
+
+            tail = predecessor;
+        }
+
+        if (!tail) {
+            dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *header, " since it has no tail");
+            return false;
+        }
+
+        // PreHeader                          PreHeader
+        //  |                                  |
+        // Header <---                        Header_0
+        //  |        |       unrolled to       |
+        //  |       Tail  =================>  Branch_0
+        //  |        |                         |
+        // Branch ----                        Tail_0
+        //  |                                  |
+        // Next                               ...
+        //                                     |
+        //                                    Header_n
+        //                                     |
+        //                                    Branch_n
+        //                                     |
+        //                                    Next
+        //
+        // FIXME: This is not supported yet. We should do it only if it's profitable.
+        if (!tail->terminal()->isBranch()) {
+            dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *header, " since it has a non-branch tail");
+            return false;
+        }
+
+        for (BasicBlock* successor : tail->successors()) {
+            if (data.loop->contains(successor))
+                continue;
+            data.next = successor;
+        }
+        data.tail = tail;
+        return true;
+    }
+
+    bool isSupportedConditionOp(NodeType op);
+    bool isSupportedUpdateOp(NodeType op);
+
+    ComparisonFunction comparisonFunction(Node* condition);
+    UpdateFunction updateFunction(Node* update);
+
+    bool identifyInductionVariable(LoopData& data)
+    {
+        Node* condition = data.condition();
+        auto isConditionValid = [&]() ALWAYS_INLINE_LAMBDA {
+            if (!isSupportedConditionOp(condition->op()))
+                return false;
+
+            // Condition left
+            Edge update = condition->child1();
+            if (!isSupportedUpdateOp(update->op()) || update.useKind() != Int32Use)
+                return false;
+            // FIXME: Currently, we assume the left operand is the induction variable.
+            if (update->child1()->op() != GetLocal)
+                return false;
+            if (!update->child2()->isInt32Constant())
+                return false;
+
+            // Condition right
+            Edge operand = condition->child2();
+            if (!operand->isInt32Constant() || operand.useKind() != Int32Use)
+                return false;
+
+            data.operand = condition->child2()->asInt32();
+            data.update = condition->child1().node();
+            data.updateValue = update->child2()->asInt32();
+            data.inductionVariable = condition->child1()->child1().node();
+            return true;
+        };
+        if (!isConditionValid()) {
+            dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *data.header(), " since the invalid loop condition node D@", condition->index());
+            return false;
+        }
+
+        auto isInitialValueValid = [&]() ALWAYS_INLINE_LAMBDA {
+            Node* initialization = nullptr;
+            for (Node* n : *data.preHeader) {
+                if (n->op() != SetLocal || !data.isInductionVariable(n))
+                    continue;
+                initialization = n;
+            }
+            if (!initialization || !initialization->child1()->isInt32Constant())
+                return false;
+            data.initialValue = initialization->child1()->asInt32();
+            return true;
+        };
+        if (!isInitialValueValid()) {
+            dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *data.header(), " since the initial value is invalid");
+            return false;
+        }
+
+        auto isInductionVariableValid = [&]() ALWAYS_INLINE_LAMBDA {
+            uint32_t updateCount = 0;
+            for (uint32_t i = 0; i < data.loopSize(); ++i) {
+                BasicBlock* body = data.loopBody(i);
+                for (Node* node : *body) {
+                    if (node->op() != SetLocal || !data.isInductionVariable(node))
+                        continue;
+                    dataLogLnIf(Options::verboseLoopUnrolling(), "Induction variable ", data.inductionVariable->index(), " is updated at node ", node->index(), " at ", *body);
+                    ++updateCount;
+                    // FIXME: Maybe we can extend this and do better here?
+                    if (updateCount != 1)
+                        return false;
+                    if (!m_graph.m_cpsDominators->dominates(data.tail, body))
+                        return false;
+                }
+            }
+            return true;
+        };
+        if (!isInductionVariableValid()) {
+            dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *data.header(), " since the induction variable is invalid");
+            return false;
+        }
+
+        // Compute the number of iterations in the loop.
+        {
+            CheckedUint32 iterationCount = 0;
+            auto compare = comparisonFunction(condition);
+            auto update = updateFunction(data.update);
+            for (CheckedInt32 i = data.initialValue; compare(i, data.operand);) {
+                if (iterationCount > maxIterationCount) {
+                    dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *data.header(), " since MaxIterationCount=", maxIterationCount);
+                    return false;
+                }
+                i = update(i, data.updateValue);
+                if (i.hasOverflowed()) {
+                    dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *data.header(), " since the induction variable overflowed after the update");
+                    return false;
+                }
+                ++iterationCount;
+            }
+            data.iterationCount = iterationCount;
+        }
+        return true;
+    }
+
+    bool shouldUnrollLoop(LoopData& data)
+    {
+        uint32_t totalNodeCount = 0;
+        for (uint32_t i = 0; i < data.loopSize(); ++i) {
+            BasicBlock* body = data.loopBody(i);
+            if (!body->isReachable) {
+                dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *data.header(), " since block ", *body, " is not reachable");
+                return false;
+            }
+
+            // FIXME: We may also need to check whether the block is valid using CFA.
+            // If the block is unreachable or invalid in the CFG, we can directly
+            // ignore the loop, avoiding unnecessary cloneability checks for nodes in invalid blocks.
+
+            totalNodeCount += body->size();
+            if (totalNodeCount > maxLoopNodeSize) {
+                dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *data.header(), " and loop node count=", totalNodeCount, " since MaxLoopNodeSize=", maxLoopNodeSize);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool canCloneLoop(LoopData& data)
+    {
+        HashSet<Node*> cloneableCache;
+        for (uint32_t i = 0; i < data.loopSize(); ++i) {
+            BasicBlock* body = data.loopBody(i);
+            for (Node* node : *body) {
+                if (!isNodeCloneable(cloneableCache, node)) {
+                    dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *data.header(), " since D@", node->index(), " with op ", node->op(), " is not cloneable");
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    BasicBlock* makeBlock(uint32_t executionCount = 0)
+    {
+        auto* block = m_blockInsertionSet.insert(m_graph.numBlocks(), executionCount);
+        block->cfaHasVisited = false;
+        block->cfaDidFinish = false;
+        return block;
+    }
+
+    void unrollLoop(LoopData& data)
+    {
+        BasicBlock* const header = data.header();
+        BasicBlock* const tail = data.tail;
+
+        const NodeOrigin tailTerminalOrigin = tail->terminal()->origin;
+        const CodeOrigin tailTerminalOriginSemantic = tailTerminalOrigin.semantic;
+        dataLogLnIf(Options::verboseLoopUnrolling(), "tailTerminalOriginSemantic ", tailTerminalOriginSemantic);
+
+        // Mapping from the origin to the clones.
+        UncheckedKeyHashMap<BasicBlock*, BasicBlock*> blockClones;
+        UncheckedKeyHashMap<Node*, Node*> nodeClones;
+
+        auto replaceOperands = [&](auto& nodes) ALWAYS_INLINE_LAMBDA {
+            for (uint32_t i = 0; i < nodes.size(); ++i) {
+                if (auto& node = nodes.at(i)) {
+                    auto itr = nodeClones.find(node);
+                    if (itr != nodeClones.end())
+                        node = itr->value;
+                }
+            }
+        };
+
+#if ASSERT_ENABLED
+        m_graph.initializeNodeOwners(); // This is only used for the debug assertion in cloneNodeImpl.
+#endif
+
+        BasicBlock* next = data.next;
+        for (uint32_t cloneCount = data.iterationCount - 1; cloneCount--;) {
+            blockClones.clear();
+            nodeClones.clear();
+
+            // 1. Initialize all block clones.
+            for (uint32_t i = 0; i < data.loopSize(); ++i) {
+                BasicBlock* body = data.loopBody(i);
+                blockClones.add(body, makeBlock(body->executionCount));
+            }
+
+            for (uint32_t i = 0; i < data.loopSize(); ++i) {
+                BasicBlock* const body = data.loopBody(i);
+                BasicBlock* const clone = blockClones.get(body);
+
+                // 2. Clone Phis.
+                clone->phis.resize(body->phis.size());
+                for (size_t i = 0; i < body->phis.size(); ++i) {
+                    Node* bodyPhi = body->phis[i];
+                    Node* phiClone = m_graph.addNode(bodyPhi->prediction(), bodyPhi->op(), bodyPhi->origin, OpInfo(bodyPhi->variableAccessData()));
+                    nodeClones.add(bodyPhi, phiClone);
+                    clone->phis[i] = phiClone;
+                }
+
+                // 3. Clone nodes.
+                for (uint32_t i = 0; i < body->size(); ++i) {
+                    Node* bodyNode = body->at(i);
+                    // Ignore the branch nodes at the end of the tail since we can directly jump to next (See step 5).
+                    if (body == tail && bodyNode->origin.semantic == tailTerminalOriginSemantic)
+                        continue;
+                    cloneNode(nodeClones, clone, bodyNode);
+                }
+
+                // 4. Clone variables and tail and head.
+                clone->variablesAtTail = body->variablesAtTail;
+                replaceOperands(clone->variablesAtTail);
+                clone->variablesAtHead = body->variablesAtHead;
+                replaceOperands(clone->variablesAtHead);
+
+                // 5. Clone successors. (predecessors will be fixed in resetReachability below)
+                if (body == tail)
+                    clone->appendNode(m_graph, SpecNone, Jump, tailTerminalOrigin, OpInfo(next));
+                else {
+                    for (uint32_t i = 0; i < body->numSuccessors(); ++i) {
+                        auto& successor = clone->successor(i);
+                        ASSERT(successor == body->successor(i));
+                        if (data.loop->contains(successor))
+                            successor = blockClones.get(successor);
+                    }
+                }
+            }
+
+            next = blockClones.get(header);
+        }
+
+        // 6. Replace the original loop tail branch with a jump to the last header clone.
+        {
+            for (Node* node : *tail) {
+                if (node->origin.semantic == tailTerminalOriginSemantic)
+                    node->removeWithoutChecks();
+            }
+            tail->appendNode(m_graph, SpecNone, Jump, tailTerminalOrigin, OpInfo(next));
+        }
+
+        // Done clone.
+        m_blockInsertionSet.execute();
+        m_graph.resetReachability();
+        m_graph.killUnreachableBlocks();
+        ASSERT(m_graph.m_form == LoadStore);
+    }
+
+    bool isNodeCloneable(HashSet<Node*>& cloneableCache, Node*);
+    Node* cloneNode(UncheckedKeyHashMap<Node*, Node*>& nodeClones, BasicBlock* into, Node*);
+    Node* cloneNodeImpl(UncheckedKeyHashMap<Node*, Node*>& nodeClones, BasicBlock* into, Node*);
+
+private:
+    BlockInsertionSet m_blockInsertionSet;
+};
+
+bool performLoopUnrolling(Graph& graph)
+{
+    return runPhase<LoopUnrollingPhase>(graph);
+}
+
+void LoopUnrollingPhase::LoopData::dump(PrintStream& out) const
+{
+    out.print(*loop);
+
+    out.print(" preHeader=");
+    if (preHeader)
+        out.print(*preHeader);
+    else
+        out.print("<null>");
+    out.print(", ");
+
+    out.print("tail=");
+    if (tail)
+        out.print(*tail);
+    else
+        out.print("<null>");
+    out.print(", ");
+
+    out.print("next=");
+    if (tail)
+        out.print(*next);
+    else
+        out.print("<null>");
+    out.print(", ");
+
+    out.print("inductionVariable=");
+    if (inductionVariable)
+        out.print("D@", inductionVariable->index());
+    else
+        out.print("<null>");
+    out.print(", ");
+
+    out.print("initValue=", initialValue, ", ");
+    out.print("operand=", operand, ", ");
+
+    out.print("update=");
+    if (update)
+        out.print("D@", update->index());
+    else
+        out.print("<null>");
+    out.print(", ");
+
+    out.print("updateValue=", updateValue, ", ");
+
+    out.print("iterationCount=", iterationCount);
+}
+
+bool LoopUnrollingPhase::isNodeCloneable(HashSet<Node*>& cloneableCache, Node* node)
+{
+    if (cloneableCache.contains(node))
+        return true;
+
+    bool result = true;
+    switch (node->op()) {
+    case Phi:
+        break;
+    case JSConstant:
+    case LoopHint:
+    case PhantomLocal:
+    case SetArgumentDefinitely:
+    case Jump:
+    case Branch:
+    case MovHint:
+    case ExitOK:
+    case ZombieHint:
+    case InvalidationPoint:
+    case Check:
+    case CheckVarargs:
+    case Flush:
+    case GetLocal:
+    case SetLocal:
+    case GetButterfly:
+    case CheckArray:
+    case AssertNotEmpty:
+    case CheckStructure:
+    case FilterCallLinkStatus:
+    case ArrayifyToStructure:
+    case NewArrayWithConstantSize:
+    case NewArrayWithSize:
+    case ValueToInt32:
+    case ArithAdd:
+    case ArithSub:
+    case ArithMul:
+    case ArithDiv:
+    case ArithMod:
+    case ArithBitAnd:
+    case ArithBitOr:
+    case ArithBitNot:
+    case ArithBitRShift:
+    case ArithBitLShift:
+    case ArithBitXor:
+    case BitURShift:
+    case CompareLess:
+    case CompareLessEq:
+    case CompareGreater:
+    case CompareGreaterEq:
+    case CompareEq:
+    case CompareStrictEq:
+    case PutByVal:
+    case PutByValAlias:
+    case GetByVal: {
+        m_graph.doToChildrenWithCheck(node, [&](Edge& edge) {
+            if (isNodeCloneable(cloneableCache, edge.node()))
+                return IterationStatus::Continue;
+            result = false;
+            return IterationStatus::Done;
+        });
+        break;
+    }
+    default:
+        result = false;
+    }
+
+    if (result)
+        cloneableCache.add(node);
+    return result;
+}
+
+Node* LoopUnrollingPhase::cloneNode(UncheckedKeyHashMap<Node*, Node*>& nodeClones, BasicBlock* into, Node* node)
+{
+    ASSERT(node);
+    auto itr = nodeClones.find(node);
+    if (itr != nodeClones.end())
+        return itr->value;
+    Node* result = cloneNodeImpl(nodeClones, into, node);
+    ASSERT(result);
+    nodeClones.add(node, result);
+    return result;
+}
+
+Node* LoopUnrollingPhase::cloneNodeImpl(UncheckedKeyHashMap<Node*, Node*>& nodeClones, BasicBlock* into, Node* node)
+{
+#if ASSERT_ENABLED
+    m_graph.doToChildren(node, [&](Edge& e) {
+        ASSERT(e.node()->owner == node->owner);
+    });
+#endif
+
+    auto cloneEdge = [&](Edge& edge) ALWAYS_INLINE_LAMBDA {
+        return edge ? Edge(cloneNode(nodeClones, into, edge.node()), edge.useKind()) : Edge();
+    };
+
+    switch (node->op()) {
+    case Phi: {
+        // Phi nodes should already be cloned in the step 2 of unrollLoop.
+        RELEASE_ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+    case Branch: {
+        Node* clone = into->cloneAndAppend(m_graph, node);
+        clone->setOpInfo(OpInfo(m_graph.m_branchData.add(WTFMove(*node->branchData()))));
+        clone->child1() = cloneEdge(node->child1());
+        return clone;
+    }
+    case PutByVal:
+    case GetByVal:
+    case PutByValAlias:
+    case CheckVarargs: {
+        if (node->hasVarArgs()) {
+            size_t firstChild = m_graph.m_varArgChildren.size();
+
+            uint32_t validChildrenCount = 0;
+            m_graph.doToChildren(node, [&](Edge& edge) {
+                m_graph.m_varArgChildren.append(cloneEdge(edge));
+                ++validChildrenCount;
+            });
+
+            uint32_t expectedCount = m_graph.numChildren(node);
+            for (uint32_t i = validChildrenCount; i < expectedCount; ++i)
+                m_graph.m_varArgChildren.append(Edge());
+
+            Node* clone = into->cloneAndAppend(m_graph, node);
+            clone->children.setFirstChild(firstChild);
+            return clone;
+        }
+        FALLTHROUGH;
+    }
+    case ExitOK:
+    case LoopHint:
+    case GetButterfly:
+    case JSConstant:
+    case Jump:
+    case CompareLess:
+    case CompareLessEq:
+    case CompareGreater:
+    case CompareGreaterEq:
+    case CompareEq:
+    case CompareStrictEq:
+    case CheckStructure:
+    case ArithBitNot:
+    case ArrayifyToStructure:
+    case ArithBitAnd:
+    case ArithBitOr:
+    case ArithBitRShift:
+    case ArithBitLShift:
+    case ArithBitXor:
+    case BitURShift:
+    case ArithAdd:
+    case ArithSub:
+    case ArithMul:
+    case ArithDiv:
+    case ArithMod:
+    case CheckArray:
+    case FilterCallLinkStatus:
+    case GetLocal:
+    case MovHint:
+    case Flush:
+    case ZombieHint:
+    case SetLocal:
+    case PhantomLocal:
+    case Check:
+    case AssertNotEmpty:
+    case SetArgumentDefinitely:
+    case NewArrayWithSize:
+    case NewArrayWithConstantSize:
+    case ValueToInt32:
+    case InvalidationPoint: {
+        Node* clone = into->cloneAndAppend(m_graph, node);
+        clone->child1() = cloneEdge(node->child1());
+        clone->child2() = cloneEdge(node->child2());
+        clone->child3() = cloneEdge(node->child3());
+        return clone;
+    }
+    default:
+        dataLogLnIf(Options::verboseLoopUnrolling(), "Could not clone node: ", node, " into ", into);
+        RELEASE_ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+}
+
+// FIXME: Add more condition and update operations if they are profitable.
+bool LoopUnrollingPhase::isSupportedConditionOp(NodeType op)
+{
+    switch (op) {
+    case CompareLess:
+    case CompareLessEq:
+    case CompareGreater:
+    case CompareGreaterEq:
+    case CompareEq:
+    case CompareStrictEq:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool LoopUnrollingPhase::isSupportedUpdateOp(NodeType op)
+{
+    switch (op) {
+    case ArithAdd:
+    case ArithSub:
+    case ArithMul:
+    case ArithDiv:
+        return true;
+    default:
+        return false;
+    }
+}
+
+LoopUnrollingPhase::ComparisonFunction LoopUnrollingPhase::comparisonFunction(Node* condition)
+{
+    switch (condition->op()) {
+    case CompareLess:
+        return [](auto a, auto b) { return a < b; };
+    case CompareLessEq:
+        return [](auto a, auto b) { return a <= b; };
+    case CompareGreater:
+        return [](auto a, auto b) { return a > b; };
+    case CompareGreaterEq:
+        return [](auto a, auto b) { return a >= b; };
+    case CompareEq:
+    case CompareStrictEq:
+        return [](auto a, auto b) { return a == b; };
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        return [](auto, auto) { return false; };
+    }
+}
+
+LoopUnrollingPhase::UpdateFunction LoopUnrollingPhase::updateFunction(Node* update)
+{
+    switch (update->op()) {
+    case ArithAdd:
+        return [](auto a, auto b) { return a + b; };
+    case ArithSub:
+        return [](auto a, auto b) { return a - b; };
+    case ArithMul:
+        return [](auto a, auto b) { return a * b; };
+    case ArithDiv:
+        return [](auto a, auto b) { return a / b; };
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        return [](auto, auto) { return CheckedInt32(); };
+    }
+}
+
+}
+} // namespace JSC::DFG
+
+#endif // ENABLE(DFG_JIT)

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.h
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,48 +20,18 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
-
-#include "DFGBasicBlock.h"
-#include "DFGGraph.h"
 
 #if ENABLE(DFG_JIT)
 
 namespace JSC { namespace DFG {
 
-inline Node* BasicBlock::cloneAndAppend(Graph& graph, const Node* node)
-{
-    Node* result = graph.cloneAndAdd(*node);
-    append(result);
-    return result;
-}
+class Graph;
 
-template<typename... Params>
-Node* BasicBlock::appendNode(Graph& graph, SpeculatedType type, Params... params)
-{
-    Node* result = graph.addNode(type, params...);
-    append(result);
-    return result;
-}
-
-template<typename... Params>
-Node* BasicBlock::appendNonTerminal(Graph& graph, SpeculatedType type, Params... params)
-{
-    Node* result = graph.addNode(type, params...);
-    insertBeforeTerminal(result);
-    return result;
-}
-
-template<typename... Params>
-Node* BasicBlock::replaceTerminal(Graph& graph, SpeculatedType type, Params... params)
-{
-    Node* result = graph.addNode(type, params...);
-    replaceTerminal(graph, result);
-    return result;
-}
+bool performLoopUnrolling(Graph&);
 
 } } // namespace JSC::DFG
 

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -324,7 +324,9 @@ public:
     enum VarArgTag { VarArg };
     
     Node() { }
-    
+
+    Node(const Node&) = default;
+
     Node(NodeType op, NodeOrigin nodeOrigin, const AdjacencyList& children)
         : origin(nodeOrigin)
         , children(children)
@@ -3627,6 +3629,11 @@ public:
     {
         m_opInfo = OpInfoWrapper();
         m_opInfo2 = OpInfoWrapper();
+    }
+
+    void setOpInfo(OpInfo info)
+    {
+        m_opInfo = info.m_value;
     }
 
     void dumpChildren(PrintStream& out)

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -51,6 +51,7 @@
 #include "DFGLiveCatchVariablePreservationPhase.h"
 #include "DFGLivenessAnalysisPhase.h"
 #include "DFGLoopPreHeaderCreationPhase.h"
+#include "DFGLoopUnrollingPhase.h"
 #include "DFGMovHintRemovalPhase.h"
 #include "DFGOSRAvailabilityAnalysisPhase.h"
 #include "DFGOSREntrypointCreationPhase.h"
@@ -369,6 +370,9 @@ Plan::CompilationPath Plan::compileInThreadImpl()
             m_finalizer = makeUnique<FailedFinalizer>(*this);
             return FailPath;
         }
+
+        if (Options::useLoopUnrolling())
+            RUN_PHASE(performLoopUnrolling);
         
         RUN_PHASE(performCleanUp); // Reduce the graph size a bit.
         RUN_PHASE(performCriticalEdgeBreaking);

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -565,6 +565,9 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useAllocationProfiling, false, Normal, "Allows toggling of bmalloc/libPAS allocation profiling features at JSC launch."_s) \
     v(Bool, dumpBaselineJITSizeStatistics, false, Normal, nullptr) \
     v(Bool, dumpDFGJITSizeStatistics, false, Normal, nullptr) \
+    v(Bool, useLoopUnrolling, true, Normal, nullptr) \
+    v(Bool, verboseLoopUnrolling, false, Normal, nullptr) \
+    v(Bool, printEachUnrolledLoop, false, Normal, nullptr) \
     v(Bool, verboseExecutablePoolAllocation, false, Normal, nullptr) \
     v(Bool, useHandlerIC, canUseHandlerIC(), Normal, nullptr) \
     v(Bool, useDataICInFTL, false, Normal, nullptr) \


### PR DESCRIPTION
#### 22ac06375c5a827734a281c528a643815c847589
<pre>
[JSC] Loop unrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=265884">https://bugs.webkit.org/show_bug.cgi?id=265884</a>
<a href="https://rdar.apple.com/119195561">rdar://119195561</a>

Reviewed by Yusuke Suzuki and Justin Michaud.

This patch, based on Justin&apos;s previous draft patch[1], adds a new loop
unrolling optimization phase to the FTL tier. The loop unrolling phase
enhances performance by reducing loop overhead in tightly nested loops
with a limited number of iterations, while maintaining the correctness
of the execution graph.

Changes:
* Introduced a new DFGLoopUnrollingPhase to optimize small, simple loops
  by unrolling them during DFG JIT compilation.
* Added infrastructure improvements in Graph, BasicBlock, and Node to
  facilitate cloning and unrolling.
* Integrated the phase into the DFG pipeline with configurable options
  (useLoopUnrolling, verboseLoopUnrolling, printEachUnrolledLoop).
* Added benchmarks to validate correctness and performance gains.

Future Work:
* Extend support to complex loops with nested structures and advanced
  control flows. See micro-benchmarks tests in [1].
* Enhance unrolling profitability metrics and speculative optimizations
  for dynamic iteration counts.
* Measure performance impact in real-world scenarios and expand profiling
  capabilities.

Microbenchmark Results:
                                              before                    after

Benchmarks with progressions:

loop-unrolling-1                          2.7693+-0.0279     ^      2.5839+-0.0396        ^ definitely 1.0718x faster
loop-unrolling-2                          3.4357+-0.0358     ^      2.7861+-0.0379        ^ definitely 1.2332x faster
loop-unrolling-3                          2.9092+-0.0304     ^      2.6302+-0.0362        ^ definitely 1.1061x faster

Future work benchmarks:

loop-unrolling-4                          3.1286+-0.0442            3.0581+-0.0490          might be 1.0230x faster
loop-unrolling-array-clone-small          0.8926+-0.0082            0.8918+-0.0082
loop-unrolling-core-sha1                  0.3992+-0.0066            0.3919+-0.0071          might be 1.0188x faster
loop-unrolling-variable-medium            5.9324+-0.0327            5.8792+-0.0220
loop-unrolling-variable-medium-dep        8.3997+-0.7200            8.1726+-0.6305          might be 1.0278x faster
loop-unrolling-array-clone-big            0.8996+-0.0095            0.8941+-0.0099
loop-unrolling-constant-small             0.4556+-0.0080            0.4506+-0.0119          might be 1.0111x faster
loop-unrolling-variable-large            53.8354+-0.0943           53.7705+-0.0802
loop-unrolling-variable-small             0.4518+-0.0075            0.4502+-0.0078

[1] <a href="https://github.com/WebKit/WebKit/pull/21342">https://github.com/WebKit/WebKit/pull/21342</a>

* JSTests/microbenchmarks/loop-unrolling-1.js: Added.
(assert):
(test):
* JSTests/microbenchmarks/loop-unrolling-2.js: Added.
(assert):
(test):
* JSTests/microbenchmarks/loop-unrolling-3.js: Added.
(assert):
(test):
* JSTests/microbenchmarks/loop-unrolling-4.js: Added.
(assert):
(test):
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/b3/B3SparseCollection.h:
(JSC::B3::SparseCollection::addNew):
* Source/JavaScriptCore/dfg/DFGBasicBlock.h:
* Source/JavaScriptCore/dfg/DFGBasicBlockInlines.h:
(JSC::DFG::BasicBlock::appendNode):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp: Added.
(JSC::DFG::LoopUnrollingPhase::LoopData::header const):
(JSC::DFG::LoopUnrollingPhase::LoopData::condition const):
(JSC::DFG::LoopUnrollingPhase::LoopData::isInductionVariable):
(JSC::DFG::LoopUnrollingPhase::LoopUnrollingPhase):
(JSC::DFG::LoopUnrollingPhase::run):
(JSC::DFG::LoopUnrollingPhase::selectDeepestNestedLoop):
(JSC::DFG::LoopUnrollingPhase::tryUnroll):
(JSC::DFG::LoopUnrollingPhase::locatePreHeader):
(JSC::DFG::LoopUnrollingPhase::locateTail):
(JSC::DFG::LoopUnrollingPhase::identifyInductionVariable):
(JSC::DFG::LoopUnrollingPhase::isValid):
(JSC::DFG::LoopUnrollingPhase::makeBlock):
(JSC::DFG::LoopUnrollingPhase::unrollLoop):
(JSC::DFG::performLoopUnrolling):
(JSC::DFG::LoopUnrollingPhase::LoopData::dump const):
(JSC::DFG::LoopUnrollingPhase::isNodeCloneable):
(JSC::DFG::LoopUnrollingPhase::cloneNode):
(JSC::DFG::LoopUnrollingPhase::cloneNodeImpl):
(JSC::DFG::LoopUnrollingPhase::isSupportedConditionOp):
(JSC::DFG::LoopUnrollingPhase::isSupportedUpdateOp):
(JSC::DFG::std::function&lt;bool):
(JSC::DFG::std::function&lt;CheckedInt32):
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.h: Copied from Source/JavaScriptCore/dfg/DFGBasicBlockInlines.h.
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::setOpInfo):
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::compileInThreadImpl):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/287398@main">https://commits.webkit.org/287398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4429054f93d65ea9e991d385dd3e6a3facb3bf6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79378 "21 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83987 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30513 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6667 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62087 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19970 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82445 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72321 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42396 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49488 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26508 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28917 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/72543 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70674 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26955 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85392 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/78566 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4635 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70339 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6818 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68198 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69586 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17367 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13633 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12498 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/100909 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6605 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24621 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6518 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9993 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8316 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->