### PR TITLE
Various CSS/Style value type improvements

### DIFF
--- a/Source/WTF/wtf/text/TextStream.h
+++ b/Source/WTF/wtf/text/TextStream.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2004, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +32,7 @@
 #include <wtf/OptionSet.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -259,6 +261,36 @@ TextStream& streamSizedContainer(TextStream& ts, const SizedContainer& sizedCont
         ts << ", ...";
 
     return ts << "]";
+}
+
+template<typename T> TextStream& streamSpaceSeparatedForTupleLike(TextStream& ts, const T& tupleLike)
+{
+    auto separator = ""_s;
+    auto caller = WTF::makeVisitor(
+        [&](const auto& value) {
+            ts << std::exchange(separator, " "_s);
+            ts << value;
+        }
+    );
+
+    WTF::apply([&](const auto& ...x) { (..., caller(x)); }, tupleLike);
+
+    return ts;
+}
+
+template<typename T> TextStream& streamCommaSeparatedForTupleLike(TextStream& ts, const T& tupleLike)
+{
+    auto separator = ""_s;
+    auto caller = WTF::makeVisitor(
+        [&](const auto& value) {
+            ts << std::exchange(separator, ", "_s);
+            ts << value;
+        }
+    );
+
+    WTF::apply([&](const auto& ...x) { (..., caller(x)); }, tupleLike);
+
+    return ts;
 }
 
 template<typename ItemType, size_t inlineCapacity>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -888,6 +888,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/CSSValueList.h
     css/CSSVariableData.h
     css/CSSVariableReferenceValue.h
+    css/ComputedStyleDependencies.h
     css/Counter.h
     css/DeprecatedCSSOMCounter.h
     css/DeprecatedCSSOMPrimitiveValue.h
@@ -958,7 +959,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/values/primitives/CSSNone.h
     css/values/primitives/CSSPosition.h
     css/values/primitives/CSSPrimitiveNumericRange.h
+    css/values/primitives/CSSPrimitiveNumericTypes+EvaluateCalc.h
     css/values/primitives/CSSPrimitiveNumericTypes.h
+    css/values/primitives/CSSSymbol.h
     css/values/primitives/CSSUnevaluatedCalc.h
 
     css/values/shapes/CSSBasicShape.h
@@ -2608,6 +2611,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     style/values/primitives/StyleNone.h
     style/values/primitives/StylePosition.h
+    style/values/primitives/StylePrimitiveNumericTypes+CSSTypeTransform.h
     style/values/primitives/StylePrimitiveNumericTypes.h
 
     style/values/shapes/StyleBasicShape.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -638,7 +638,6 @@ css/CSSStyleRule.cpp
 css/CSSStyleSheet.cpp
 css/CSSStyleSheetObservableArray.cpp
 css/CSSToStyleMap.cpp
-css/CSSValue.cpp
 css/CSSValueList.cpp
 css/CSSValueList.h
 css/CSSVariableReferenceValue.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -950,6 +950,7 @@ css/CSSVariableData.cpp
 css/CSSVariableReferenceValue.cpp
 css/CSSViewValue.cpp
 css/CSSViewTransitionRule.cpp
+css/ComputedStyleDependencies.cpp
 css/ComputedStyleExtractor.cpp
 css/DOMCSSNamespace.cpp
 css/DOMCSSPaintWorklet.cpp
@@ -1134,10 +1135,12 @@ css/values/images/CSSGradient.cpp
 css/values/motion/CSSRayFunction.cpp
 css/values/primitives/CSSNone.cpp
 css/values/primitives/CSSPosition.cpp
+css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.cpp
 css/values/primitives/CSSPrimitiveNumericTypes+ComputedStyleDependencies.cpp
 css/values/primitives/CSSPrimitiveNumericTypes+Serialization.cpp
 css/values/primitives/CSSPrimitiveNumericTypes+SymbolReplacement.cpp
 css/values/primitives/CSSPrimitiveNumericTypes.cpp
+css/values/primitives/CSSSymbol.cpp
 css/values/primitives/CSSUnevaluatedCalc.cpp
 css/values/shapes/CSSCircleFunction.cpp
 css/values/shapes/CSSEllipseFunction.cpp
@@ -3087,6 +3090,7 @@ style/UserAgentStyle.cpp
 style/values/backgrounds/StyleBorderRadius.cpp
 style/values/color-adjust/StyleColorScheme.cpp
 style/values/images/StyleGradient.cpp
+style/values/primitives/StyleNone.cpp
 style/values/primitives/StylePosition.cpp
 style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp
 style/values/shapes/StyleBasicShape.cpp

--- a/Source/WebCore/css/CSSBasicShapeValue.cpp
+++ b/Source/WebCore/css/CSSBasicShapeValue.cpp
@@ -33,6 +33,7 @@
 
 #include "CSSPrimitiveNumericTypes+CSSValueVisitation.h"
 #include "CSSPrimitiveNumericTypes+ComputedStyleDependencies.h"
+#include "CSSPrimitiveNumericTypes+Hashing.h"
 #include "CSSPrimitiveNumericTypes+Serialization.h"
 #include "CSSPrimitiveNumericTypes.h"
 
@@ -51,6 +52,17 @@ bool CSSBasicShapeValue::equals(const CSSBasicShapeValue& other) const
 IterationStatus CSSBasicShapeValue::customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
 {
     return CSS::visitCSSValueChildren(func, m_shape);
+}
+
+void CSSBasicShapeValue::customCollectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const
+{
+    CSS::collectComputedStyleDependencies(dependencies, m_shape);
+}
+
+bool CSSBasicShapeValue::addDerivedHash(Hasher& hasher) const
+{
+    CSS::addHash(hasher, m_shape);
+    return true;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSBasicShapeValue.h
+++ b/Source/WebCore/css/CSSBasicShapeValue.h
@@ -48,6 +48,8 @@ public:
     bool equals(const CSSBasicShapeValue&) const;
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>&) const;
+    void customCollectComputedStyleDependencies(ComputedStyleDependencies&) const;
+    bool addDerivedHash(Hasher&) const;
 
 private:
     CSSBasicShapeValue(CSS::BasicShape&& shape)

--- a/Source/WebCore/css/CSSColorSchemeValue.cpp
+++ b/Source/WebCore/css/CSSColorSchemeValue.cpp
@@ -27,6 +27,12 @@
 
 #if ENABLE(DARK_MODE_CSS)
 
+#include "CSSPrimitiveNumericTypes+CSSValueVisitation.h"
+#include "CSSPrimitiveNumericTypes+ComputedStyleDependencies.h"
+#include "CSSPrimitiveNumericTypes+Hashing.h"
+#include "CSSPrimitiveNumericTypes+Serialization.h"
+#include "CSSPrimitiveNumericTypes.h"
+
 namespace WebCore {
 
 Ref<CSSColorSchemeValue> CSSColorSchemeValue::create(CSS::ColorScheme colorScheme)
@@ -53,6 +59,17 @@ bool CSSColorSchemeValue::equals(const CSSColorSchemeValue& other) const
 IterationStatus CSSColorSchemeValue::customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
 {
     return CSS::visitCSSValueChildren(func, m_colorScheme);
+}
+
+void CSSColorSchemeValue::customCollectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const
+{
+    CSS::collectComputedStyleDependencies(dependencies, m_colorScheme);
+}
+
+bool CSSColorSchemeValue::addDerivedHash(Hasher& hasher) const
+{
+    CSS::addHash(hasher, m_colorScheme);
+    return true;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSColorSchemeValue.h
+++ b/Source/WebCore/css/CSSColorSchemeValue.h
@@ -35,11 +35,14 @@ class CSSColorSchemeValue final : public CSSValue {
 public:
     static Ref<CSSColorSchemeValue> create(CSS::ColorScheme);
 
+    const CSS::ColorScheme& colorScheme() const { return m_colorScheme; }
+
     String customCSSText() const;
     bool equals(const CSSColorSchemeValue&) const;
-    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>&) const;
 
-    const CSS::ColorScheme& colorScheme() const { return m_colorScheme; }
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>&) const;
+    void customCollectComputedStyleDependencies(ComputedStyleDependencies&) const;
+    bool addDerivedHash(Hasher&) const;
 
 private:
     CSSColorSchemeValue(CSS::ColorScheme);

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -30,6 +30,7 @@
 #include "CSSFontFaceSource.h"
 #include "CSSFontSelector.h"
 #include "CSSParser.h"
+#include "CSSPrimitiveNumericTypes+EvaluateCalc.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSPropertyParserConsumer+Font.h"
 #include "CSSPropertyParserHelpers.h"

--- a/Source/WebCore/css/CSSGradientValue.h
+++ b/Source/WebCore/css/CSSGradientValue.h
@@ -46,6 +46,8 @@ public:
     RefPtr<StyleImage> createStyleImage(const Style::BuilderState&) const;
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>&) const;
+    void customCollectComputedStyleDependencies(ComputedStyleDependencies&) const;
+    bool addDerivedHash(Hasher&) const;
 
 private:
     CSSGradientValue(CSS::Gradient&& gradient)

--- a/Source/WebCore/css/CSSPathValue.cpp
+++ b/Source/WebCore/css/CSSPathValue.cpp
@@ -33,6 +33,7 @@
 
 #include "CSSPrimitiveNumericTypes+CSSValueVisitation.h"
 #include "CSSPrimitiveNumericTypes+ComputedStyleDependencies.h"
+#include "CSSPrimitiveNumericTypes+Hashing.h"
 #include "CSSPrimitiveNumericTypes+Serialization.h"
 #include "CSSPrimitiveNumericTypes.h"
 
@@ -51,6 +52,17 @@ bool CSSPathValue::equals(const CSSPathValue& other) const
 IterationStatus CSSPathValue::customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
 {
     return CSS::visitCSSValueChildren(func, m_path);
+}
+
+void CSSPathValue::customCollectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const
+{
+    CSS::collectComputedStyleDependencies(dependencies, m_path);
+}
+
+bool CSSPathValue::addDerivedHash(Hasher& hasher) const
+{
+    CSS::addHash(hasher, m_path);
+    return true;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSPathValue.h
+++ b/Source/WebCore/css/CSSPathValue.h
@@ -50,6 +50,8 @@ public:
     bool equals(const CSSPathValue&) const;
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>&) const;
+    void customCollectComputedStyleDependencies(ComputedStyleDependencies&) const;
+    bool addDerivedHash(Hasher&) const;
 
 private:
     CSSPathValue(CSS::PathFunction&& path)

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -1780,7 +1780,7 @@ bool CSSPrimitiveValue::addDerivedHash(Hasher& hasher) const
 }
 
 // https://drafts.css-houdini.org/css-properties-values-api/#dependency-cycles
-void CSSPrimitiveValue::collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const
+void CSSPrimitiveValue::customCollectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const
 {
     auto unit = primitiveUnitType();
     switch (unit) {

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -237,9 +237,8 @@ public:
     // True if computeNonCalcLengthDouble would produce identical results when resolved against both these styles.
     static bool equalForLengthResolution(const RenderStyle&, const RenderStyle&);
 
-    void collectComputedStyleDependencies(ComputedStyleDependencies&) const;
-
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>&) const;
+    void customCollectComputedStyleDependencies(ComputedStyleDependencies&) const;
 
 private:
     friend class CSSValuePool;

--- a/Source/WebCore/css/CSSRayValue.cpp
+++ b/Source/WebCore/css/CSSRayValue.cpp
@@ -30,10 +30,11 @@
 #include "CSSRayValue.h"
 
 #include "CSSPrimitiveNumericTypes+CSSValueVisitation.h"
+#include "CSSPrimitiveNumericTypes+ComputedStyleDependencies.h"
+#include "CSSPrimitiveNumericTypes+Hashing.h"
 #include "CSSPrimitiveNumericTypes+Serialization.h"
+#include "CSSPrimitiveNumericTypes.h"
 #include "CSSPrimitiveValueMappings.h"
-#include "CSSValueKeywords.h"
-#include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
@@ -57,6 +58,18 @@ bool CSSRayValue::equals(const CSSRayValue& other) const
 IterationStatus CSSRayValue::customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
 {
     return CSS::visitCSSValueChildren(func, m_ray);
+}
+
+void CSSRayValue::customCollectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const
+{
+    CSS::collectComputedStyleDependencies(dependencies, m_ray);
+}
+
+bool CSSRayValue::addDerivedHash(Hasher& hasher) const
+{
+    add(hasher, m_coordinateBox);
+    CSS::addHash(hasher, m_ray);
+    return true;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSRayValue.h
+++ b/Source/WebCore/css/CSSRayValue.h
@@ -42,13 +42,15 @@ public:
         return adoptRef(*new CSSRayValue(WTFMove(ray), coordinateBox));
     }
 
-
     const CSS::RayFunction& ray() const { return m_ray; }
     CSSBoxType coordinateBox() const { return m_coordinateBox; }
 
     String customCSSText() const;
     bool equals(const CSSRayValue&) const;
+
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>&) const;
+    void customCollectComputedStyleDependencies(ComputedStyleDependencies&) const;
+    bool addDerivedHash(Hasher&) const;
 
 private:
     CSSRayValue(CSS::RayFunction ray, CSSBoxType coordinateBox)

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -285,37 +285,14 @@ ComputedStyleDependencies CSSValue::computedStyleDependencies() const
 
 void CSSValue::collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const
 {
-    // FIXME: Unclear why it's OK that we do not cover CSSValuePair, CSSQuadValue, CSSRectValue, CSSBorderImageSliceValue, CSSBorderImageWidthValue, and others here. Probably should use visitDerived unless they don't allow the primitive values that can have dependencies. May want to base this on a traverseValues or forEachValue function instead.
-    // FIXME: Consider a non-recursive algorithm for walking this tree of dependencies.
-    if (auto* asList = dynamicDowncast<CSSValueContainingVector>(*this)) {
-        for (auto& listValue : *asList)
-            listValue.collectComputedStyleDependencies(dependencies);
-        return;
-    }
-    if (auto* asPrimitiveValue = dynamicDowncast<CSSPrimitiveValue>(*this))
-        asPrimitiveValue->collectComputedStyleDependencies(dependencies);
-}
-
-bool CSSValue::canResolveDependenciesWithConversionData(const ComputedStyleDependencies& dependencies, const CSSToLengthConversionData& conversionData)
-{
-    if (!dependencies.rootProperties.isEmpty() && !conversionData.rootStyle())
-        return false;
-
-    if (!dependencies.properties.isEmpty() && !conversionData.style())
-        return false;
-
-    if (dependencies.containerDimensions && !conversionData.elementForContainerUnitResolution())
-        return false;
-
-    if (dependencies.viewportDimensions && !conversionData.renderView())
-        return false;
-
-    return true;
+    return visitDerived([&](auto& value) {
+        return value.customCollectComputedStyleDependencies(dependencies);
+    });
 }
 
 bool CSSValue::canResolveDependenciesWithConversionData(const CSSToLengthConversionData& conversionData) const
 {
-    return canResolveDependenciesWithConversionData(computedStyleDependencies(), conversionData);
+    return computedStyleDependencies().canResolveDependenciesWithConversionData(conversionData);
 }
 
 bool CSSValue::equals(const CSSValue& other) const

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -148,9 +148,7 @@ public:
     // What properties does this value rely on (eg, font-size for em units)
     ComputedStyleDependencies computedStyleDependencies() const;
     void collectComputedStyleDependencies(ComputedStyleDependencies&) const;
-
-    // Checks to see if the provided conversion data is sufficient to resolve the provided dependencies.
-    static bool canResolveDependenciesWithConversionData(const ComputedStyleDependencies&, const CSSToLengthConversionData&);
+    void customCollectComputedStyleDependencies(ComputedStyleDependencies&) const { }
 
     // Checks to see if the provided conversion data is sufficient to resolve the dependencies of the CSSValue.
     bool canResolveDependenciesWithConversionData(const CSSToLengthConversionData&) const;

--- a/Source/WebCore/css/CSSValueList.cpp
+++ b/Source/WebCore/css/CSSValueList.cpp
@@ -298,6 +298,12 @@ IterationStatus CSSValueContainingVector::customVisitChildren(const Function<Ite
     return IterationStatus::Continue;
 }
 
+void CSSValueContainingVector::customCollectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const
+{
+    for (auto& value : *this)
+        value.collectComputedStyleDependencies(dependencies);
+}
+
 } // namespace WebCore
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/CSSValueList.h
+++ b/Source/WebCore/css/CSSValueList.h
@@ -80,6 +80,7 @@ public:
     const CSSValue* itemWithoutBoundsCheck(unsigned index) const { return &(*this)[index]; }
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>&) const;
+    void customCollectComputedStyleDependencies(ComputedStyleDependencies&) const;
 
 protected:
     friend bool CSSValue::addHash(Hasher&) const;

--- a/Source/WebCore/css/ComputedStyleDependencies.cpp
+++ b/Source/WebCore/css/ComputedStyleDependencies.cpp
@@ -1,0 +1,50 @@
+
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ComputedStyleDependencies.h"
+
+#include "CSSToLengthConversionData.h"
+
+namespace WebCore {
+
+bool ComputedStyleDependencies::canResolveDependenciesWithConversionData(const CSSToLengthConversionData& conversionData) const
+{
+    if (!rootProperties.isEmpty() && !conversionData.rootStyle())
+        return false;
+
+    if (!properties.isEmpty() && !conversionData.style())
+        return false;
+
+    if (containerDimensions && !conversionData.elementForContainerUnitResolution())
+        return false;
+
+    if (viewportDimensions && !conversionData.renderView())
+        return false;
+
+    return true;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/ComputedStyleDependencies.h
+++ b/Source/WebCore/css/ComputedStyleDependencies.h
@@ -25,6 +25,8 @@
 
 namespace WebCore {
 
+class CSSToLengthConversionData;
+
 enum CSSPropertyID : uint16_t;
 
 struct ComputedStyleDependencies {
@@ -35,6 +37,9 @@ struct ComputedStyleDependencies {
     bool anchors { false };
 
     bool isComputationallyIndependent() const { return properties.isEmpty() && rootProperties.isEmpty() && !containerDimensions && !anchors; }
+
+    // Checks to see if the provided conversion data is sufficient to resolve the provided dependencies.
+    bool canResolveDependenciesWithConversionData(const CSSToLengthConversionData&) const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/calc/CSSCalcTree+Copy.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+Copy.h
@@ -29,8 +29,6 @@
 namespace WebCore {
 namespace CSSCalc {
 
-struct Tree;
-
 // Makes a copy of the tree.
 Tree copy(const Tree&);
 Anchor::Side copy(const Anchor::Side&);

--- a/Source/WebCore/css/color/CSSColorConversion+Normalize.h
+++ b/Source/WebCore/css/color/CSSColorConversion+Normalize.h
@@ -86,7 +86,7 @@ auto normalizeAndClampNumericComponentsIntoCanonicalRepresentation(const CSS::No
 template<typename Descriptor, unsigned Index, typename Raw>
 auto normalizeAndClampNumericComponentsIntoCanonicalRepresentation(const CSS::PrimitiveNumeric<Raw>& value) -> GetCSSColorParseTypeWithCalcComponentResult<typename Descriptor::Canonical, Index>
 {
-    return WTF::switchOn(value.value,
+    return WTF::switchOn(value,
         [](Raw value) -> GetCSSColorParseTypeWithCalcComponentResult<typename Descriptor::Canonical, Index> {
             return normalizeAndClampNumericComponents<Descriptor, Index>(value);
         },
@@ -147,7 +147,7 @@ auto normalizeNumericComponentsIntoCanonicalRepresentation(const CSS::None& none
 template<typename Descriptor, unsigned Index, typename Raw>
 auto normalizeNumericComponentsIntoCanonicalRepresentation(const CSS::PrimitiveNumeric<Raw>& value) -> GetCSSColorParseTypeWithCalcComponentResult<typename Descriptor::Canonical, Index>
 {
-    return WTF::switchOn(value.value,
+    return WTF::switchOn(value,
         [](Raw value) -> GetCSSColorParseTypeWithCalcComponentResult<typename Descriptor::Canonical, Index> {
             return normalizeNumericComponents<Descriptor, Index>(value);
         },

--- a/Source/WebCore/css/color/CSSColorDescriptors.h
+++ b/Source/WebCore/css/color/CSSColorDescriptors.h
@@ -25,10 +25,12 @@
 
 #pragma once
 
+#include "CSSPrimitiveNumericTypes+EvaluateCalc.h"
 #include "CSSPrimitiveNumericTypes.h"
 #include "CSSValueKeywords.h"
 #include "Color.h"
 #include "ColorTypes.h"
+#include "StylePrimitiveNumericTypes+CSSTypeTransform.h"
 #include "StylePrimitiveNumericTypes.h"
 #include <optional>
 #include <variant>

--- a/Source/WebCore/css/color/CSSRelativeColorResolver.h
+++ b/Source/WebCore/css/color/CSSRelativeColorResolver.h
@@ -30,8 +30,8 @@
 #include "CSSColorConversion+ToTypedColor.h"
 #include "CSSColorDescriptors.h"
 #include "CSSPrimitiveNumericTypes+SymbolReplacement.h"
-#include "StylePrimitiveNumericTypes+Conversions.h"
 #include "Color.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
 #include <optional>
 
 namespace WebCore {

--- a/Source/WebCore/css/color/CSSUnresolvedRelativeColor.h
+++ b/Source/WebCore/css/color/CSSUnresolvedRelativeColor.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CSSColorDescriptors.h"
+#include "CSSPrimitiveNumericTypes+EvaluateCalc.h"
 #include "CSSRelativeColorResolver.h"
 #include "CSSRelativeColorSerialization.h"
 #include "CSSUnresolvedColorResolutionState.h"

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+AngleDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+AngleDefinitions.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "CSSPrimitiveNumericTypes+Canonicalization.h"
 #include "CSSPropertyParserConsumer+MetaConsumerDefinitions.h"
 
 namespace WebCore {
@@ -47,7 +48,7 @@ struct AngleValidator {
     template<auto R> static bool isValid(CSS::AngleRaw<R> raw, CSSPropertyParserOptions)
     {
         return isValidDimensionValue(raw, [&] {
-            auto canonicalValue = CSS::canonicalizeAngle(raw.value, raw.type);
+            auto canonicalValue = CSS::canonicalize(raw);
             return canonicalValue >= raw.range.min && canonicalValue <= raw.range.max;
         });
     }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h
@@ -47,7 +47,7 @@ struct CSSPrimitiveValueResolverBase {
         return CSSPrimitiveValue::create(value.value, value.type);
     }
 
-    template<typename IntType, CSS::Range integerRange> static RefPtr<CSSPrimitiveValue> resolve(CSS::IntegerRaw<IntType, integerRange> value, const CSSCalcSymbolTable&, CSSPropertyParserOptions)
+    template<CSS::Range R, typename IntType> static RefPtr<CSSPrimitiveValue> resolve(CSS::IntegerRaw<R, IntType> value, const CSSCalcSymbolTable&, CSSPropertyParserOptions)
     {
         return CSSPrimitiveValue::createInteger(value.value);
     }
@@ -59,7 +59,7 @@ struct CSSPrimitiveValueResolverBase {
 
     template<typename T> static RefPtr<CSSPrimitiveValue> resolve(CSS::PrimitiveNumeric<T> value, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
     {
-        return WTF::switchOn(WTFMove(value.value), [&](auto&& value) { return resolve(WTFMove(value), symbolTable, options); });
+        return WTF::switchOn(WTFMove(value), [&](auto&& value) { return resolve(WTFMove(value), symbolTable, options); });
     }
 };
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
@@ -563,10 +563,8 @@ static std::optional<CSSUnresolvedColorMix::Component> consumeColorMixComponent(
 
 static bool hasNonCalculatedZeroPercentage(const CSSUnresolvedColorMix::Component& mixComponent)
 {
-    if (auto percentage = mixComponent.percentage) {
-        if (auto* rawValue = percentage->raw())
-            return rawValue->value == 0.0;
-    }
+    if (auto percentage = mixComponent.percentage)
+        return percentage->isKnownZero();
     return false;
 }
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -84,7 +84,7 @@ template<typename Result, typename... Ts> static Result forwardVariantTo(std::va
 
 template<typename T> static Ref<CSSPrimitiveValue> resolveToCSSPrimitiveValue(CSS::PrimitiveNumeric<T>&& primitive)
 {
-    return WTF::switchOn(WTFMove(primitive.value), [](auto&& alternative) { return CSSPrimitiveValueResolverBase::resolve(WTFMove(alternative), { }, { }); }).releaseNonNull();
+    return WTF::switchOn(WTFMove(primitive), [](auto&& alternative) { return CSSPrimitiveValueResolverBase::resolve(WTFMove(alternative), { }, { }); }).releaseNonNull();
 }
 
 static CSSParserMode parserMode(ScriptExecutionContext& context)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+FrequencyDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+FrequencyDefinitions.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "CSSPrimitiveNumericTypes+Canonicalization.h"
 #include "CSSPropertyParserConsumer+MetaConsumerDefinitions.h"
 
 namespace WebCore {
@@ -45,7 +46,7 @@ struct FrequencyValidator {
     template<auto R> static bool isValid(CSS::FrequencyRaw<R> raw, CSSPropertyParserOptions)
     {
         return isValidDimensionValue(raw, [&] {
-            auto canonicalValue = CSS::canonicalizeFrequency(raw.value, raw.type);
+            auto canonicalValue = CSS::canonicalize(raw);
             return canonicalValue >= raw.range.min && canonicalValue <= raw.range.max;
         });
     }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
@@ -74,18 +74,18 @@ enum class ShapeKeyword : bool { Circle, Ellipse };
 
 // MARK: Deprecated <gradient> values
 
-template<CSSValueID zeroValue, CSSValueID oneHundredValue> static std::optional<CSS::PercentageOrNumber> consumeDeprecatedGradientPositionComponent(CSSParserTokenRange& range, const CSSParserContext& context)
+template<CSSValueID zeroValue, CSSValueID oneHundredValue> static std::optional<CSS::NumberOrPercentage<>> consumeDeprecatedGradientPositionComponent(CSSParserTokenRange& range, const CSSParserContext& context)
 {
     if (range.peek().type() == IdentToken) {
         if (consumeIdent<zeroValue>(range))
-            return CSS::PercentageOrNumber { CSS::Percentage<> { CSS::PercentageRaw<> { 0 } } };
+            return CSS::NumberOrPercentage<> { CSS::Percentage<> { CSS::PercentageRaw<> { 0 } } };
         if (consumeIdent<oneHundredValue>(range))
-            return CSS::PercentageOrNumber { CSS::Percentage<> { CSS::PercentageRaw<> { 100 } } };
+            return CSS::NumberOrPercentage<> { CSS::Percentage<> { CSS::PercentageRaw<> { 100 } } };
         if (consumeIdent<CSSValueCenter>(range))
-            return CSS::PercentageOrNumber { CSS::Percentage<> { CSS::PercentageRaw<> { 50 } } };
+            return CSS::NumberOrPercentage<> { CSS::Percentage<> { CSS::PercentageRaw<> { 50 } } };
         return std::nullopt;
     }
-    return MetaConsumer<CSS::Percentage<>, CSS::Number<>>::consume(range, context, { }, { });
+    return MetaConsumer<CSS::Number<>, CSS::Percentage<>>::consume(range, context, { }, { });
 }
 
 static std::optional<CSS::DeprecatedGradientPosition> consumeDeprecatedGradientPosition(CSSParserTokenRange& range, const CSSParserContext& context)
@@ -131,7 +131,7 @@ static std::optional<CSS::GradientDeprecatedColorStop> consumeDeprecatedGradient
         position = CSS::NumberRaw<> { 1 };
         break;
     case CSSValueColorStop:
-        position = MetaConsumer<CSS::Percentage<>, CSS::Number<>>::consume(args, context, { }, { });
+        position = MetaConsumer<CSS::Number<>, CSS::Percentage<>>::consume(args, context, { }, { });
         if (!position)
             return std::nullopt;
         if (!consumeCommaIncludingWhitespace(args))
@@ -434,7 +434,7 @@ template<CSSValueID Name> static RefPtr<CSSValue> consumePrefixedLinearGradient(
     };
 
     if (auto angle = MetaConsumer<CSS::Angle<>>::consume(range, context, { }, angleConsumeOptions)) {
-        gradientLine = WTF::switchOn(WTFMove(angle->value), [](auto&& value) -> CSS::PrefixedLinearGradient::GradientLine { return value; });
+        gradientLine = WTF::switchOn(WTFMove(*angle), [](auto&& value) -> CSS::PrefixedLinearGradient::GradientLine { return value; });
         if (!consumeCommaIncludingWhitespace(range))
             return nullptr;
     } else if (auto keywordGradientLine = consumeKeywordGradientLine(range)) {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Integer.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Integer.cpp
@@ -34,25 +34,24 @@
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
 
-template<typename IntType, CSS::Range R>
-static RefPtr<CSSPrimitiveValue> consumeIntegerType(CSSParserTokenRange& range, const CSSParserContext& context)
+template<typename T> static RefPtr<CSSPrimitiveValue> consumeIntegerType(CSSParserTokenRange& range, const CSSParserContext& context)
 {
-    return CSSPrimitiveValueResolver<CSS::Integer<IntType, R>>::consumeAndResolve(range, context, { }, { }, { });
+    return CSSPrimitiveValueResolver<T>::consumeAndResolve(range, context, { }, { }, { });
 }
 
 RefPtr<CSSPrimitiveValue> consumeInteger(CSSParserTokenRange& range, const CSSParserContext& context)
 {
-    return consumeIntegerType<int, CSS::All>(range, context);
+    return consumeIntegerType<CSS::Integer<CSS::All, int>>(range, context);
 }
 
 RefPtr<CSSPrimitiveValue> consumeNonNegativeInteger(CSSParserTokenRange& range, const CSSParserContext& context)
 {
-    return consumeIntegerType<int, CSS::Range{0, CSS::Range::infinity}>(range, context);
+    return consumeIntegerType<CSS::Integer<CSS::Range{0, CSS::Range::infinity}, int>>(range, context);
 }
 
 RefPtr<CSSPrimitiveValue> consumePositiveInteger(CSSParserTokenRange& range, const CSSParserContext& context)
 {
-    return consumeIntegerType<unsigned, CSS::Range{1, CSS::Range::infinity}>(range, context);
+    return consumeIntegerType<CSS::Integer<CSS::Range{1, CSS::Range::infinity}, unsigned>>(range, context);
 }
 
 RefPtr<CSSPrimitiveValue> consumeInteger(CSSParserTokenRange& range, const CSSParserContext& context, const CSS::Range& valueRange)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h
@@ -52,14 +52,14 @@ template<typename Integer, typename Validator> struct NumberConsumerForIntegerVa
         if (!Validator::isValid(numberValue, options))
             return std::nullopt;
 
-        return typename Integer::Raw { clampTo<typename Integer::Raw::IntType>(range.consumeIncludingWhitespace().numericValue()) };
+        return typename Integer::Raw { clampTo<typename Integer::Raw::ValueType>(range.consumeIncludingWhitespace().numericValue()) };
     }
 };
 
-template<typename IntType, CSS::Range R>
-struct ConsumerDefinition<CSS::Integer<IntType, R>> {
-    using FunctionToken = FunctionConsumerForCalcValues<CSS::Integer<IntType, R>>;
-    using NumberToken = NumberConsumerForIntegerValues<CSS::Integer<IntType, R>, IntegerValidator>;
+template<CSS::Range R, typename IntType>
+struct ConsumerDefinition<CSS::Integer<R, IntType>> {
+    using FunctionToken = FunctionConsumerForCalcValues<CSS::Integer<R, IntType>>;
+    using NumberToken = NumberConsumerForIntegerValues<CSS::Integer<R, IntType>, IntegerValidator>;
 };
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ResolutionDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ResolutionDefinitions.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "CSSPrimitiveNumericTypes+Canonicalization.h"
 #include "CSSPropertyParserConsumer+MetaConsumerDefinitions.h"
 
 namespace WebCore {
@@ -47,7 +48,7 @@ struct ResolutionValidator {
     template<auto R> static bool isValid(CSS::ResolutionRaw<R> raw, CSSPropertyParserOptions)
     {
         return isValidDimensionValue(raw, [&] {
-            auto canonicalValue = CSS::canonicalizeResolution(raw.value, raw.type);
+            auto canonicalValue = CSS::canonicalize(raw);
             return canonicalValue >= raw.range.min && canonicalValue <= raw.range.max;
         });
     }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.cpp
@@ -47,12 +47,12 @@
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
 
-template<CSSValueID Name, typename T> CSS::BasicShape toBasicShape(T&& parameters)
+template<CSSValueID Name, typename T> static CSS::BasicShape toBasicShape(T&& parameters)
 {
     return CSS::BasicShape { CSS::FunctionNotation<Name, T> { WTFMove(parameters) } };
 }
 
-template<CSSValueID Name, typename T> std::optional<CSS::BasicShape> toBasicShape(std::optional<T>&& parameters)
+template<CSSValueID Name, typename T> static std::optional<CSS::BasicShape> toBasicShape(std::optional<T>&& parameters)
 {
     if (!parameters)
         return { };

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+TimeDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+TimeDefinitions.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "CSSPrimitiveNumericTypes+Canonicalization.h"
 #include "CSSPropertyParserConsumer+MetaConsumerDefinitions.h"
 
 namespace WebCore {
@@ -45,7 +46,7 @@ struct TimeValidator {
     template<auto R> static bool isValid(CSS::TimeRaw<R> raw, CSSPropertyParserOptions)
     {
         return isValidDimensionValue(raw, [&] {
-            auto canonicalValue = CSS::canonicalizeTime(raw.value, raw.type);
+            auto canonicalValue = CSS::canonicalize(raw);
             return canonicalValue >= raw.range.min && canonicalValue <= raw.range.max;
         });
     }

--- a/Source/WebCore/css/values/CSSValueTypes.cpp
+++ b/Source/WebCore/css/values/CSSValueTypes.cpp
@@ -25,8 +25,6 @@
 #include "config.h"
 #include "CSSValueTypes.h"
 
-#include <wtf/text/TextStream.h>
-
 namespace WebCore {
 namespace CSS {
 

--- a/Source/WebCore/css/values/CSSValueTypes.h
+++ b/Source/WebCore/css/values/CSSValueTypes.h
@@ -25,14 +25,18 @@
 #pragma once
 
 #include "CSSValueKeywords.h"
+#include "ComputedStyleDependencies.h"
 #include "RectEdges.h"
 #include <optional>
 #include <tuple>
 #include <utility>
 #include <variant>
+#include <wtf/Markable.h>
+#include <wtf/Hasher.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 
@@ -45,6 +49,15 @@ namespace CSS {
 // for CSS value type algorithms.
 // NOTE: This gets automatically specialized when using the CSS_TUPLE_LIKE_CONFORMANCE macro.
 template<class> inline constexpr bool TreatAsTupleLike = false;
+
+// Types can specialize this and set the value to true to be treated as a "type wrapper"
+// for CSS value type algorithms. "Type wrappers" must be simple structs with exactly one
+// member variable with the name "value".
+// NOTE: This gets automatically specialized when using the DEFINE_CSS_TYPE_WRAPPER macro.
+template<class> inline constexpr bool TreatAsTypeWrapper = false;
+
+#define DEFINE_CSS_TYPE_WRAPPER(t) \
+    template<> inline constexpr bool TreatAsTypeWrapper<t> = true;
 
 // Helper type used to represent a known constant identifier.
 template<CSSValueID C> struct Constant {
@@ -142,9 +155,11 @@ template<typename T, size_t inlineCapacity = 0> struct CommaSeparatedVector {
 // Wraps a fixed size list of elements of a single type, semantically marking them as serializing as "space separated".
 template<typename T, size_t N> struct SpaceSeparatedArray {
     using Array = std::array<T, N>;
+    using const_iterator = typename Array::const_iterator;
+    using const_reverse_iterator = typename Array::const_reverse_iterator;
     using value_type = T;
 
-    template<typename...Ts> requires (sizeof...(Ts) == N && WTF::all<std::is_same_v<T, Ts>...>)
+    template<typename...Ts> requires (sizeof...(Ts) == N && WTF::all<std::convertible_to<Ts, T>...>)
     constexpr SpaceSeparatedArray(Ts... values)
         : value { std::forward<Ts>(values)... }
     {
@@ -155,13 +170,22 @@ template<typename T, size_t N> struct SpaceSeparatedArray {
     {
     }
 
+    const_iterator begin() const { return value.begin(); }
+    const_iterator end() const { return value.end(); }
+    const_reverse_iterator rbegin() const { return value.rbegin(); }
+    const_reverse_iterator rend() const { return value.rend(); }
+
+    bool isEmpty() const { return value.isEmpty(); }
+    size_t size() const { return value.size(); }
+    const T& operator[](size_t i) const { return value[i]; }
+
     constexpr bool operator==(const SpaceSeparatedArray<T, N>&) const = default;
 
     std::array<T, N> value;
 };
 
 template<class T, class... Ts>
-    requires (WTF::all<std::is_same_v<T, Ts>...>)
+    requires (WTF::all<std::convertible_to<Ts, T>...>)
 SpaceSeparatedArray(T, Ts...) -> SpaceSeparatedArray<T, 1 + sizeof...(Ts)>;
 
 template<size_t I, typename T, size_t N> decltype(auto) get(const SpaceSeparatedArray<T, N>& array)
@@ -174,9 +198,11 @@ template<typename T> using SpaceSeparatedPair = SpaceSeparatedArray<T, 2>;
 // Wraps a fixed size list of elements of a single type, semantically marking them as serializing as "comma separated".
 template<typename T, size_t N> struct CommaSeparatedArray {
     using Array = std::array<T, N>;
+    using const_iterator = typename Array::const_iterator;
+    using const_reverse_iterator = typename Array::const_reverse_iterator;
     using value_type = T;
 
-    template<typename...Ts> requires (sizeof...(Ts) == N && WTF::all<std::is_same_v<T, Ts>...>)
+    template<typename...Ts> requires (sizeof...(Ts) == N && WTF::all<std::convertible_to<Ts, T>...>)
     constexpr CommaSeparatedArray(Ts... values)
         : value { std::forward<Ts>(values)... }
     {
@@ -187,6 +213,15 @@ template<typename T, size_t N> struct CommaSeparatedArray {
     {
     }
 
+    const_iterator begin() const { return value.begin(); }
+    const_iterator end() const { return value.end(); }
+    const_reverse_iterator rbegin() const { return value.rbegin(); }
+    const_reverse_iterator rend() const { return value.rend(); }
+
+    bool isEmpty() const { return value.isEmpty(); }
+    size_t size() const { return value.size(); }
+    const T& operator[](size_t i) const { return value[i]; }
+
     constexpr bool operator==(const CommaSeparatedArray<T, N>&) const = default;
 
     std::array<T, N> value;
@@ -194,7 +229,7 @@ template<typename T, size_t N> struct CommaSeparatedArray {
 
 
 template<class T, class... Ts>
-    requires (WTF::all<std::is_same_v<T, Ts>...>)
+    requires (WTF::all<std::convertible_to<Ts, T>...>)
 CommaSeparatedArray(T, Ts...) -> CommaSeparatedArray<T, 1 + sizeof...(Ts)>;
 
 template<size_t I, typename T, size_t N> decltype(auto) get(const CommaSeparatedArray<T, N>& array)
@@ -318,6 +353,183 @@ template<size_t I, typename T> decltype(auto) get(const Size<T>& size)
     return get<I>(size.value);
 }
 
+// MARK: - Hashing
+
+// All leaf types must implement the following conversions:
+//
+//    template<> struct WebCore::CSS::Hash<CSSType> {
+//        void operator()(Hasher&, const CSSType&);
+//    };
+
+template<typename CSSType> struct Hash;
+
+// Serialization Invokers
+template<typename CSSType> void addHash(Hasher& hasher, const CSSType& value)
+{
+    Hash<CSSType>{}(hasher, value);
+}
+
+template<typename CSSType> unsigned hash(const CSSType& value)
+{
+    Hasher hasher;
+    addHash(hasher, value);
+    return hasher.hash();
+}
+
+template<typename CSSType> auto hashTupleLike(Hasher& hasher, const CSSType& value)
+{
+    WTF::apply([&](const auto& ...x) { (..., addHash(hasher, x)); }, value);
+}
+
+template<typename CSSType> auto hashRangeLike(Hasher& hasher, const CSSType& value)
+{
+    for (const auto& element : value)
+        addHash(hasher, element);
+}
+
+// Constrained for `TreatAsTupleLike`.
+template<typename CSSType> requires (TreatAsTupleLike<CSSType>) struct Hash<CSSType> {
+    void operator()(Hasher& hasher, const CSSType& value)
+    {
+        hashTupleLike(hasher, value);
+    }
+};
+
+// Constrained for `TreatAsTypeWrapper`.
+template<typename CSSType> requires (TreatAsTypeWrapper<CSSType>) struct Hash<CSSType> {
+    void operator()(Hasher& hasher, const CSSType& value)
+    {
+        addHash(hasher, value.value);
+    }
+};
+
+// Specialization for `std::optional`.
+template<typename CSSType> struct Hash<std::optional<CSSType>> {
+    void operator()(Hasher& hasher, const std::optional<CSSType>& value)
+    {
+        if (!value)
+            return;
+        addHash(hasher, *value);
+    }
+};
+
+// Specialization for `Markable`.
+template<typename CSSType> struct Hash<Markable<CSSType>> {
+    void operator()(Hasher& hasher, const Markable<CSSType>& value)
+    {
+        if (!value)
+            return;
+        addHash(hasher, *value);
+    }
+};
+
+// Specialization for `std::variant`.
+template<typename... CSSTypes> struct Hash<std::variant<CSSTypes...>> {
+    void operator()(Hasher& hasher, const std::variant<CSSTypes...>& value)
+    {
+        WTF::switchOn(value, [&](const auto& alternative) { addHash(hasher, alternative); });
+    }
+};
+
+// Specialization for `Constant`.
+template<CSSValueID C> struct Hash<Constant<C>> {
+    constexpr void operator()(Hasher& hasher, const Constant<C>& value)
+    {
+        WTF::add(hasher, value.value);
+    }
+};
+
+// Specialization for `CustomIdentifier`.
+template<> struct Hash<CustomIdentifier> {
+    constexpr void operator()(Hasher& hasher, const CustomIdentifier& value)
+    {
+        WTF::add(hasher, value.value.existingHash());
+    }
+};
+
+// Specialization for `FunctionNotation`.
+template<CSSValueID Name, typename CSSType> struct Hash<FunctionNotation<Name, CSSType>> {
+    constexpr void operator()(Hasher& hasher, const FunctionNotation<Name, CSSType>& value)
+    {
+        addHash(hasher, value.parameters);
+    }
+};
+
+// Specialization for `SpaceSeparatedVector`.
+template<typename CSSType, size_t inlineCapacity> struct Hash<SpaceSeparatedVector<CSSType, inlineCapacity>> {
+    void operator()(Hasher& hasher, const SpaceSeparatedVector<CSSType, inlineCapacity>& value)
+    {
+        hashRangeLike(hasher, value.value);
+    }
+};
+
+// Specialization for `CommaSeparatedVector`.
+template<typename CSSType, size_t inlineCapacity> struct Hash<CommaSeparatedVector<CSSType, inlineCapacity>> {
+    void operator()(Hasher& hasher, const CommaSeparatedVector<CSSType, inlineCapacity>& value)
+    {
+        hashRangeLike(hasher, value.value);
+    }
+};
+
+// Specialization for `SpaceSeparatedArray`.
+template<typename CSSType, size_t N> struct Hash<SpaceSeparatedArray<CSSType, N>> {
+    void operator()(Hasher& hasher, const SpaceSeparatedArray<CSSType, N>& value)
+    {
+        hashTupleLike(hasher, value.value);
+    }
+};
+
+// Specialization for `CommaSeparatedArray`.
+template<typename CSSType, size_t N> struct Hash<CommaSeparatedArray<CSSType, N>> {
+    void operator()(Hasher& hasher, const CommaSeparatedArray<CSSType, N>& value)
+    {
+        hashTupleLike(hasher, value.value);
+    }
+};
+
+// Specialization for `SpaceSeparatedTuple`.
+template<typename... CSSTypes> struct Hash<SpaceSeparatedTuple<CSSTypes...>> {
+    void operator()(Hasher& hasher, const SpaceSeparatedTuple<CSSTypes...>& value)
+    {
+        hashTupleLike(hasher, value.value);
+    }
+};
+
+// Specialization for `CommaSeparatedTuple`.
+template<typename... CSSTypes> struct Hash<CommaSeparatedTuple<CSSTypes...>> {
+    void operator()(Hasher& hasher, const CommaSeparatedTuple<CSSTypes...>& value)
+    {
+        hashTupleLike(hasher, value.value);
+    }
+};
+
+// Specialization for `Point`.
+template<typename CSSType> struct Hash<Point<CSSType>> {
+    void operator()(Hasher& hasher, const Point<CSSType>& value)
+    {
+        addHash(hasher, value.value);
+    }
+};
+
+// Specialization for `Size`.
+template<typename CSSType> struct Hash<Size<CSSType>> {
+    void operator()(Hasher& hasher, const Size<CSSType>& value)
+    {
+        addHash(hasher, value.value);
+    }
+};
+
+// Specialization for `RectEdges`.
+template<typename CSSType> struct Hash<RectEdges<CSSType>> {
+    void operator()(Hasher& hasher, const RectEdges<CSSType>& value)
+    {
+        addHash(hasher, value.top());
+        addHash(hasher, value.right());
+        addHash(hasher, value.bottom());
+        addHash(hasher, value.left());
+    }
+};
+
 // MARK: - Serialization
 
 // All leaf types must implement the following conversions:
@@ -341,9 +553,27 @@ template<typename CSSType> String serializationForCSS(const CSSType& value)
     return builder.toString();
 }
 
+// Constrained for `TreatAsTypeWrapper`.
+template<typename CSSType> requires (TreatAsTypeWrapper<CSSType>) struct Serialize<CSSType> {
+    void operator()(StringBuilder& builder, const CSSType& value)
+    {
+        serializationForCSS(builder, value.value);
+    }
+};
+
 // Specialization for `std::optional`.
 template<typename CSSType> struct Serialize<std::optional<CSSType>> {
     void operator()(StringBuilder& builder, const std::optional<CSSType>& value)
+    {
+        if (!value)
+            return;
+        serializationForCSS(builder, *value);
+    }
+};
+
+// Specialization for `Markable`.
+template<typename CSSType> struct Serialize<Markable<CSSType>> {
+    void operator()(StringBuilder& builder, const Markable<CSSType>& value)
     {
         if (!value)
             return;
@@ -386,7 +616,7 @@ template<CSSValueID Name, typename CSSType> struct Serialize<FunctionNotation<Na
 template<typename CSSType, size_t inlineCapacity> struct Serialize<SpaceSeparatedVector<CSSType, inlineCapacity>> {
     void operator()(StringBuilder& builder, const SpaceSeparatedVector<CSSType, inlineCapacity>& value)
     {
-        builder.append(interleave(value.value, [](auto& builder, auto& element) { serializationForCSS(builder, element); }, ' '));
+        builder.append(interleave(value.value, [](auto& builder, const auto& element) { serializationForCSS(builder, element); }, ' '));
     }
 };
 
@@ -394,7 +624,7 @@ template<typename CSSType, size_t inlineCapacity> struct Serialize<SpaceSeparate
 template<typename CSSType, size_t inlineCapacity> struct Serialize<CommaSeparatedVector<CSSType, inlineCapacity>> {
     void operator()(StringBuilder& builder, const CommaSeparatedVector<CSSType, inlineCapacity>& value)
     {
-        builder.append(interleave(value.value, [](auto& builder, auto& element) { serializationForCSS(builder, element); }, ", "_s));
+        builder.append(interleave(value.value, [](auto& builder, const auto& element) { serializationForCSS(builder, element); }, ", "_s));
     }
 };
 
@@ -420,13 +650,13 @@ template<typename... CSSTypes> struct Serialize<SpaceSeparatedTuple<CSSTypes...>
     {
         auto separator = ""_s;
         auto caller = WTF::makeVisitor(
-            [&]<typename T>(std::optional<T>& css) {
+            [&]<typename T>(const std::optional<T>& css) {
                 if (!css)
                     return;
                 builder.append(std::exchange(separator, " "_s));
                 serializationForCSS(builder, *css);
             },
-            [&](auto& css) {
+            [&](const auto& css) {
                 builder.append(std::exchange(separator, " "_s));
                 serializationForCSS(builder, css);
             }
@@ -442,13 +672,13 @@ template<typename... CSSTypes> struct Serialize<CommaSeparatedTuple<CSSTypes...>
     {
         auto separator = ""_s;
         auto caller = WTF::makeVisitor(
-            [&]<typename T>(std::optional<T>& css) {
+            [&]<typename T>(const std::optional<T>& css) {
                 if (!css)
                     return;
                 builder.append(std::exchange(separator, ", "_s));
                 serializationForCSS(builder, *css);
             },
-            [&](auto& css) {
+            [&](const auto& css) {
                 builder.append(std::exchange(separator, ", "_s));
                 serializationForCSS(builder, css);
             }
@@ -506,6 +736,13 @@ template<typename CSSType> void collectComputedStyleDependencies(ComputedStyleDe
     ComputedStyleDependenciesCollector<CSSType>{}(dependencies, value);
 }
 
+template<typename CSSType> ComputedStyleDependencies collectComputedStyleDependencies(const CSSType& value)
+{
+    ComputedStyleDependencies dependencies;
+    collectComputedStyleDependencies(dependencies, value);
+    return dependencies;
+}
+
 template<typename CSSType> auto collectComputedStyleDependenciesOnTupleLike(ComputedStyleDependencies& dependencies, const CSSType& value)
 {
     WTF::apply([&](const auto& ...x) { (..., collectComputedStyleDependencies(dependencies, x)); }, value);
@@ -513,7 +750,7 @@ template<typename CSSType> auto collectComputedStyleDependenciesOnTupleLike(Comp
 
 template<typename CSSType> auto collectComputedStyleDependenciesOnRangeLike(ComputedStyleDependencies& dependencies, const CSSType& value)
 {
-    for (auto& element : value)
+    for (const auto& element : value)
         collectComputedStyleDependencies(dependencies, element);
 }
 
@@ -522,6 +759,14 @@ template<typename CSSType> requires (TreatAsTupleLike<CSSType>) struct ComputedS
     void operator()(ComputedStyleDependencies& dependencies, const CSSType& value)
     {
         collectComputedStyleDependenciesOnTupleLike(dependencies, value);
+    }
+};
+
+// Constrained for `TreatAsTypeWrapper`.
+template<typename CSSType> requires (TreatAsTypeWrapper<CSSType>) struct ComputedStyleDependenciesCollector<CSSType> {
+    void operator()(ComputedStyleDependencies& dependencies, const CSSType& value)
+    {
+        collectComputedStyleDependencies(dependencies, value.value);
     }
 };
 
@@ -535,11 +780,21 @@ template<typename CSSType> struct ComputedStyleDependenciesCollector<std::option
     }
 };
 
+// Specialization for `Markable`.
+template<typename CSSType> struct ComputedStyleDependenciesCollector<Markable<CSSType>> {
+    void operator()(ComputedStyleDependencies& dependencies, const Markable<CSSType>& value)
+    {
+        if (!value)
+            return;
+        collectComputedStyleDependencies(dependencies, *value);
+    }
+};
+
 // Specialization for `std::variant`.
 template<typename... CSSTypes> struct ComputedStyleDependenciesCollector<std::variant<CSSTypes...>> {
     void operator()(ComputedStyleDependencies& dependencies, const std::variant<CSSTypes...>& value)
     {
-        WTF::switchOn(value, [&](auto& alternative) { collectComputedStyleDependencies(dependencies, alternative); });
+        WTF::switchOn(value, [&](const auto& alternative) { collectComputedStyleDependencies(dependencies, alternative); });
     }
 };
 
@@ -691,9 +946,25 @@ template<typename CSSType> requires (TreatAsTupleLike<CSSType>) struct CSSValueC
     }
 };
 
+// Constrained for `TreatAsTypeWrapper`.
+template<typename CSSType> requires (TreatAsTypeWrapper<CSSType>) struct CSSValueChildrenVisitor<CSSType> {
+    IterationStatus operator()(const Function<IterationStatus(CSSValue&)>& func, const CSSType& value)
+    {
+        return visitCSSValueChildren(func, value.value);
+    }
+};
+
 // Specialization for `std::optional`.
 template<typename CSSType> struct CSSValueChildrenVisitor<std::optional<CSSType>> {
     IterationStatus operator()(const Function<IterationStatus(CSSValue&)>& func, const std::optional<CSSType>& value)
+    {
+        return value ? visitCSSValueChildren(func, *value) : IterationStatus::Continue;
+    }
+};
+
+// Specialization for `Markable`.
+template<typename CSSType> struct CSSValueChildrenVisitor<Markable<CSSType>> {
+    IterationStatus operator()(const Function<IterationStatus(CSSValue&)>& func, const Markable<CSSType>& value)
     {
         return value ? visitCSSValueChildren(func, *value) : IterationStatus::Continue;
     }
@@ -813,7 +1084,14 @@ template<typename CSSType> struct CSSValueChildrenVisitor<RectEdges<CSSType>> {
 
 // MARK: - Text Stream
 
+// Overload for `CustomIdentifier`.
 WTF::TextStream& operator<<(WTF::TextStream&, const CustomIdentifier&);
+
+// Overload for `FunctionNotation`.
+template<WebCore::CSSValueID Name, typename T> TextStream& operator<<(TextStream& ts, const FunctionNotation<Name, T>& value)
+{
+    return ts << nameLiteral(value.name) << "(" << value.parameters << ")";
+}
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/images/CSSGradient.h
+++ b/Source/WebCore/css/values/images/CSSGradient.h
@@ -36,7 +36,7 @@ namespace CSS {
 
 // MARK: - Common Types
 
-using DeprecatedGradientPosition = SpaceSeparatedArray<PercentageOrNumber, 2>;
+using DeprecatedGradientPosition = SpaceSeparatedArray<NumberOrPercentage<>, 2>;
 
 using Horizontal     = std::variant<Left, Right>;
 using Vertical       = std::variant<Top, Bottom>;
@@ -69,6 +69,7 @@ struct GradientColorInterpolationMethod {
 
 template<> struct ComputedStyleDependenciesCollector<GradientColorInterpolationMethod> { constexpr void operator()(ComputedStyleDependencies&, const GradientColorInterpolationMethod&) { } };
 template<> struct CSSValueChildrenVisitor<GradientColorInterpolationMethod> { constexpr IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const GradientColorInterpolationMethod&) { return IterationStatus::Continue; } };
+template<> struct Hash<GradientColorInterpolationMethod> { void operator()(Hasher&, const GradientColorInterpolationMethod&); };
 
 // MARK: - Gradient Color Stop Definitions.
 
@@ -99,7 +100,7 @@ using GradientLinearColorStopPosition = std::optional<LengthPercentage<>>;
 using GradientLinearColorStop = GradientColorStop<GradientLinearColorStopPosition>;
 using GradientLinearColorStopList = GradientColorStopList<GradientLinearColorStop>;
 
-using GradientDeprecatedColorStopPosition = PercentageOrNumber;
+using GradientDeprecatedColorStopPosition = NumberOrPercentage<>;
 using GradientDeprecatedColorStop = GradientColorStop<GradientDeprecatedColorStopPosition>;
 using GradientDeprecatedColorStopList = GradientColorStopList<GradientDeprecatedColorStop>;
 
@@ -114,6 +115,10 @@ template<> struct ComputedStyleDependenciesCollector<GradientDeprecatedColorStop
 template<> struct CSSValueChildrenVisitor<GradientAngularColorStop> { IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const GradientAngularColorStop&); };
 template<> struct CSSValueChildrenVisitor<GradientLinearColorStop> { IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const GradientLinearColorStop&); };
 template<> struct CSSValueChildrenVisitor<GradientDeprecatedColorStop> { IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const GradientDeprecatedColorStop&); };
+
+template<> struct Hash<GradientAngularColorStop> { void operator()(Hasher&, const GradientAngularColorStop&); };
+template<> struct Hash<GradientLinearColorStop> { void operator()(Hasher&, const GradientLinearColorStop&); };
+template<> struct Hash<GradientDeprecatedColorStop> { void operator()(Hasher&, const GradientDeprecatedColorStop&); };
 
 // MARK: - LinearGradient
 

--- a/Source/WebCore/css/values/primitives/CSSNone.cpp
+++ b/Source/WebCore/css/values/primitives/CSSNone.cpp
@@ -25,9 +25,6 @@
 #include "config.h"
 #include "CSSNone.h"
 
-#include "CSSValueKeywords.h"
-#include <wtf/text/StringBuilder.h>
-
 namespace WebCore {
 namespace CSS {
 

--- a/Source/WebCore/css/values/primitives/CSSNone.h
+++ b/Source/WebCore/css/values/primitives/CSSNone.h
@@ -43,11 +43,17 @@ struct None {
     constexpr bool operator==(const None&) const = default;
 };
 
+template<> struct Hash<NoneRaw> { void operator()(Hasher& hasher, const NoneRaw&) { WTF::add(hasher, CSSValueNone); } };
+template<> struct Hash<None> { void operator()(Hasher& hasher, const None&) { WTF::add(hasher, CSSValueNone); } };
+
 template<> struct Serialize<NoneRaw> { void operator()(StringBuilder&, const NoneRaw&); };
 template<> struct Serialize<None> { void operator()(StringBuilder&, const None&); };
 
 template<> struct ComputedStyleDependenciesCollector<NoneRaw> { constexpr void operator()(ComputedStyleDependencies&, const NoneRaw&) { } };
 template<> struct ComputedStyleDependenciesCollector<None> { constexpr void operator()(ComputedStyleDependencies&, const None&) { } };
+
+template<> struct CSSValueChildrenVisitor<NoneRaw> { constexpr IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const NoneRaw&) { return IterationStatus::Continue; } };
+template<> struct CSSValueChildrenVisitor<None> { constexpr IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const None&) { return IterationStatus::Continue; } };
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPosition.cpp
+++ b/Source/WebCore/css/values/primitives/CSSPosition.cpp
@@ -25,23 +25,17 @@
 #include "config.h"
 #include "CSSPosition.h"
 
-#include "CSSPrimitiveNumericTypes+CSSValueVisitation.h"
-#include "CSSPrimitiveNumericTypes+ComputedStyleDependencies.h"
-#include "CSSPrimitiveNumericTypes+Serialization.h"
-#include "CSSValueKeywords.h"
-#include <wtf/text/StringBuilder.h>
-
 namespace WebCore {
 namespace CSS {
 
 bool isCenterPosition(const Position& position)
 {
     auto isCenter = [](const auto& component) {
-        return WTF::switchOn(component.offset,
+        return WTF::switchOn(component.value,
             [](auto)   { return false; },
             [](Center) { return true;  },
             [](const LengthPercentage<>& value) {
-                return WTF::switchOn(value.value,
+                return WTF::switchOn(value,
                     [](const LengthPercentageRaw<>& raw) { return raw.type == CSSUnitType::CSS_PERCENTAGE && raw.value == 50.0; },
                     [](const UnevaluatedCalc<LengthPercentageRaw<>>&) { return false; }
                 );
@@ -57,57 +51,6 @@ bool isCenterPosition(const Position& position)
             return false;
         }
     );
-}
-
-// MARK: - TwoComponentPositionHorizontal
-
-void Serialize<TwoComponentPositionHorizontal>::operator()(StringBuilder& builder, const TwoComponentPositionHorizontal& component)
-{
-    serializationForCSS(builder, component.offset);
-}
-
-void ComputedStyleDependenciesCollector<TwoComponentPositionHorizontal>::operator()(ComputedStyleDependencies& dependencies, const TwoComponentPositionHorizontal& component)
-{
-    collectComputedStyleDependencies(dependencies, component.offset);
-}
-
-IterationStatus CSSValueChildrenVisitor<TwoComponentPositionHorizontal>::operator()(const Function<IterationStatus(CSSValue&)>& func, const TwoComponentPositionHorizontal& component)
-{
-    return visitCSSValueChildren(func, component.offset);
-}
-
-// MARK: - TwoComponentPositionVertical
-
-void Serialize<TwoComponentPositionVertical>::operator()(StringBuilder& builder, const TwoComponentPositionVertical& component)
-{
-    serializationForCSS(builder, component.offset);
-}
-
-void ComputedStyleDependenciesCollector<TwoComponentPositionVertical>::operator()(ComputedStyleDependencies& dependencies, const TwoComponentPositionVertical& component)
-{
-    collectComputedStyleDependencies(dependencies, component.offset);
-}
-
-IterationStatus CSSValueChildrenVisitor<TwoComponentPositionVertical>::operator()(const Function<IterationStatus(CSSValue&)>& func, const TwoComponentPositionVertical& component)
-{
-    return visitCSSValueChildren(func, component.offset);
-}
-
-// MARK: - Position
-
-void Serialize<Position>::operator()(StringBuilder& builder, const Position& position)
-{
-    serializationForCSS(builder, position.value);
-}
-
-void ComputedStyleDependenciesCollector<Position>::operator()(ComputedStyleDependencies& dependencies, const Position& position)
-{
-    collectComputedStyleDependencies(dependencies, position.value);
-}
-
-IterationStatus CSSValueChildrenVisitor<Position>::operator()(const Function<IterationStatus(CSSValue&)>& func, const Position& position)
-{
-    return visitCSSValueChildren(func, position.value);
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/primitives/CSSPosition.h
+++ b/Source/WebCore/css/values/primitives/CSSPosition.h
@@ -36,13 +36,17 @@ using Bottom = Constant<CSSValueBottom>;
 using Center = Constant<CSSValueCenter>;
 
 struct TwoComponentPositionHorizontal {
-    std::variant<Left, Right, Center, LengthPercentage<>> offset;
+    std::variant<Left, Right, Center, LengthPercentage<>> value;
     bool operator==(const TwoComponentPositionHorizontal&) const = default;
 };
+DEFINE_CSS_TYPE_WRAPPER(TwoComponentPositionHorizontal);
+
 struct TwoComponentPositionVertical {
-    std::variant<Top, Bottom, Center, LengthPercentage<>> offset;
+    std::variant<Top, Bottom, Center, LengthPercentage<>> value;
     bool operator==(const TwoComponentPositionVertical&) const = default;
 };
+DEFINE_CSS_TYPE_WRAPPER(TwoComponentPositionVertical);
+
 using TwoComponentPosition              = SpaceSeparatedTuple<TwoComponentPositionHorizontal, TwoComponentPositionVertical>;
 
 using FourComponentPositionHorizontal   = SpaceSeparatedTuple<std::variant<Left, Right>, LengthPercentage<>>;
@@ -79,20 +83,9 @@ struct Position {
 
     std::variant<TwoComponentPosition, FourComponentPosition> value;
 };
+DEFINE_CSS_TYPE_WRAPPER(Position);
 
 bool isCenterPosition(const Position&);
-
-template<> struct Serialize<TwoComponentPositionHorizontal> { void operator()(StringBuilder&, const TwoComponentPositionHorizontal&); };
-template<> struct ComputedStyleDependenciesCollector<TwoComponentPositionHorizontal> { void operator()(ComputedStyleDependencies&, const TwoComponentPositionHorizontal&); };
-template<> struct CSSValueChildrenVisitor<TwoComponentPositionHorizontal> { IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const TwoComponentPositionHorizontal&); };
-
-template<> struct Serialize<TwoComponentPositionVertical> { void operator()(StringBuilder&, const TwoComponentPositionVertical&); };
-template<> struct ComputedStyleDependenciesCollector<TwoComponentPositionVertical> { void operator()(ComputedStyleDependencies&, const TwoComponentPositionVertical&); };
-template<> struct CSSValueChildrenVisitor<TwoComponentPositionVertical> { IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const TwoComponentPositionVertical&); };
-
-template<> struct Serialize<Position> { void operator()(StringBuilder&, const Position&); };
-template<> struct ComputedStyleDependenciesCollector<Position> { void operator()(ComputedStyleDependencies&, const Position&); };
-template<> struct CSSValueChildrenVisitor<Position> { IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const Position&); };
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
@@ -49,7 +49,7 @@ inline constexpr auto All = Range { -Range::infinity, Range::infinity };
 inline constexpr auto Nonnegative = Range { 0, Range::infinity };
 
 // Clamps a floating point value to within `range`.
-template<Range range, std::floating_point T> constexpr float clampToRange(T value)
+template<Range range, std::floating_point T> constexpr T clampToRange(T value)
 {
     return std::clamp<T>(value, range.min, range.max);
 }

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueCreation.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueCreation.h
@@ -59,7 +59,7 @@ template<RawNumeric RawType> struct CSSValueCreation<UnevaluatedCalc<RawType>> {
 template<RawNumeric RawType> struct CSSValueCreation<PrimitiveNumeric<RawType>> {
     Ref<CSSValue> operator()(const PrimitiveNumeric<RawType>& value)
     {
-        return WTF::switchOn(value.value,
+        return WTF::switchOn(value,
             [](const typename PrimitiveNumeric<RawType>::Raw& raw) {
                 return CSSPrimitiveValue::create(raw.value, raw.type);
             },

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueVisitation.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueVisitation.h
@@ -41,6 +41,13 @@ template<RawNumeric RawType> struct CSSValueChildrenVisitor<RawType> {
 template<RawNumeric RawType> struct CSSValueChildrenVisitor<PrimitiveNumeric<RawType>> {
     IterationStatus operator()(const Function<IterationStatus(CSSValue&)>& func, const PrimitiveNumeric<RawType>& value)
     {
+        return WTF::switchOn(value, [&](const auto& value) { return visitCSSValueChildren(func, value); });
+    }
+};
+
+template<auto R> struct CSSValueChildrenVisitor<NumberOrPercentageResolvedToNumber<R>> {
+    IterationStatus operator()(const Function<IterationStatus(CSSValue&)>& func, const NumberOrPercentageResolvedToNumber<R>& value)
+    {
         return visitCSSValueChildren(func, value.value);
     }
 };

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.cpp
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSPrimitiveNumericTypes+Canonicalization.h"
+
+#include "CSSPrimitiveValue.h"
+#include "CSSToLengthConversionData.h"
+#include "FloatConversion.h"
+
+namespace WebCore {
+namespace CSS {
+
+// MARK: Angle
+
+double canonicalizeAngle(double value, CSSUnitType type)
+{
+    return CSSPrimitiveValue::computeAngle<CSSPrimitiveValue::AngleUnit::Degrees>(type, value);
+}
+
+// MARK: Length
+
+double canonicalizeLengthNoConversionDataRequired(double value, CSSUnitType type)
+{
+    return CSSPrimitiveValue::computeNonCalcLengthDouble({ }, type, value);
+}
+
+double canonicalizeLength(double value, CSSUnitType type, const CSSToLengthConversionData& conversionData)
+{
+    return CSSPrimitiveValue::computeNonCalcLengthDouble(conversionData, type, value);
+}
+
+float clampLengthToAllowedLimits(double value)
+{
+    return clampTo<float>(narrowPrecisionToFloat(value), minValueForCssLength, maxValueForCssLength);
+}
+
+float canonicalizeAndClampLengthNoConversionDataRequired(double value, CSSUnitType type)
+{
+    return clampLengthToAllowedLimits(canonicalizeLengthNoConversionDataRequired(value, type));
+}
+
+float canonicalizeAndClampLength(double value, CSSUnitType type, const CSSToLengthConversionData& conversionData)
+{
+    return clampLengthToAllowedLimits(canonicalizeLength(value, type, conversionData));
+}
+
+// MARK: Time
+
+double canonicalizeTime(double value, CSSUnitType type)
+{
+    return CSSPrimitiveValue::computeTime<CSSPrimitiveValue::TimeUnit::Seconds>(type, value);
+}
+
+// MARK: Frequency
+
+double canonicalizeFrequency(double value, CSSUnitType type)
+{
+    return CSSPrimitiveValue::computeFrequency<CSSPrimitiveValue::FrequencyUnit::Hz>(type, value);
+}
+
+// MARK: Resolution
+
+double canonicalizeResolution(double value, CSSUnitType type)
+{
+    return CSSPrimitiveValue::computeResolution<CSSPrimitiveValue::ResolutionUnit::Dppx>(type, value);
+}
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveNumericTypes.h"
+
+namespace WebCore {
+namespace CSS {
+
+// MARK: Angle
+
+double canonicalizeAngle(double value, CSSUnitType);
+
+template<auto R> double canonicalize(AngleRaw<R> raw)
+{
+    return canonicalizeAngle(raw.value, raw.type);
+}
+
+// MARK: Length
+
+double canonicalizeLengthNoConversionDataRequired(double, CSSUnitType);
+double canonicalizeLength(double, CSSUnitType, const CSSToLengthConversionData&);
+float clampLengthToAllowedLimits(double);
+float canonicalizeAndClampLengthNoConversionDataRequired(double, CSSUnitType);
+float canonicalizeAndClampLength(double, CSSUnitType, const CSSToLengthConversionData&);
+
+// MARK: Time
+
+double canonicalizeTime(double, CSSUnitType);
+
+template<auto R> double canonicalize(TimeRaw<R> raw)
+{
+    return canonicalizeTime(raw.value, raw.type);
+}
+
+// MARK: Frequency
+
+double canonicalizeFrequency(double, CSSUnitType);
+
+template<auto R> double canonicalize(FrequencyRaw<R> raw)
+{
+    return canonicalizeFrequency(raw.value, raw.type);
+}
+
+// MARK: Resolution
+
+double canonicalizeResolution(double, CSSUnitType);
+
+template<auto R> double canonicalize(ResolutionRaw<R> raw)
+{
+    return canonicalizeResolution(raw.value, raw.type);
+}
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+ComputedStyleDependencies.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+ComputedStyleDependencies.h
@@ -63,13 +63,17 @@ template<auto R> struct ComputedStyleDependenciesCollector<LengthPercentageRaw<R
 template<RawNumeric RawType> struct ComputedStyleDependenciesCollector<PrimitiveNumeric<RawType>> {
     void operator()(ComputedStyleDependencies& dependencies, const PrimitiveNumeric<RawType>& value)
     {
-        collectComputedStyleDependencies(dependencies, value.value);
+        WTF::switchOn(value, [&](const auto& value) { collectComputedStyleDependencies(dependencies, value); });
     }
 };
 
-// Symbol has trivially nothing to collect.
-template<> struct ComputedStyleDependenciesCollector<Symbol> { constexpr void operator()(ComputedStyleDependencies&, const SymbolRaw&) { } };
-template<> struct ComputedStyleDependenciesCollector<SymbolRaw> { constexpr void operator()(ComputedStyleDependencies&, const Symbol&) { } };
+// NumberOrPercentageResolvedToNumber trivially forwards to its inner variant.
+template<auto R> struct ComputedStyleDependenciesCollector<NumberOrPercentageResolvedToNumber<R>> {
+    void operator()(ComputedStyleDependencies& dependencies, const NumberOrPercentageResolvedToNumber<R>& value)
+    {
+        collectComputedStyleDependencies(dependencies, value.value);
+    }
+};
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Hashing.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Hashing.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveNumericTypes.h"
+
+namespace WebCore {
+namespace CSS {
+
+// MARK: - Hashing
+
+template<RawNumeric RawType> struct Hash<RawType> {
+    inline void operator()(Hasher& hasher, const RawType& value)
+    {
+        add(hasher, value.type);
+        add(hasher, value.value);
+    }
+};
+
+template<RawNumeric RawType> struct Hash<UnevaluatedCalc<RawType>> {
+    void operator()(Hasher& hasher, const UnevaluatedCalc<RawType>& calc)
+    {
+        add(hasher, calc.protectedCalc().ptr());
+    }
+};
+
+template<RawNumeric RawType> struct Hash<PrimitiveNumeric<RawType>> {
+    inline void operator()(Hasher& hasher, const PrimitiveNumeric<RawType>& value)
+    {
+        WTF::switchOn(value, [&](const auto& value) { addHash(hasher, value); });
+    }
+};
+
+template<auto R> struct Hash<NumberOrPercentageResolvedToNumber<R>> {
+    void operator()(Hasher& hasher, const NumberOrPercentageResolvedToNumber<R>& value)
+    {
+        addHash(hasher, value.value);
+    }
+};
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.cpp
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.cpp
@@ -26,27 +26,13 @@
 #include "CSSPrimitiveNumericTypes+Serialization.h"
 
 #include "CSSPrimitiveValue.h"
-#include "CSSValueKeywords.h"
-#include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 namespace CSS {
 
-// MARK: - Serialization
-
 void rawNumericSerialization(StringBuilder& builder, double value, CSSUnitType type)
 {
     formatCSSNumberValue(builder, value, CSSPrimitiveValue::unitTypeString(type));
-}
-
-void Serialize<SymbolRaw>::operator()(StringBuilder& builder, const SymbolRaw& value)
-{
-    builder.append(nameLiteralForSerialization(value.value));
-}
-
-void Serialize<Symbol>::operator()(StringBuilder& builder, const Symbol& value)
-{
-    builder.append(nameLiteralForSerialization(value.value));
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.cpp
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.cpp
@@ -25,66 +25,114 @@
 #include "config.h"
 #include "CSSPrimitiveNumericTypes.h"
 
-#include "CSSPrimitiveValue.h"
-#include "CSSToLengthConversionData.h"
-#include "FloatConversion.h"
-
 namespace WebCore {
 namespace CSS {
 
-// MARK: Angle
+// MARK: Unit Validation
 
-double canonicalizeAngle(double value, CSSUnitType type)
+bool isSupportedUnitForCategory(CSSUnitType unit, Calculation::Category category)
 {
-    return CSSPrimitiveValue::computeAngle<CSSPrimitiveValue::AngleUnit::Degrees>(type, value);
-}
+    switch (unit) {
+    case CSSUnitType::CSS_INTEGER:
+        return category == Calculation::Category::Integer
+            || category == Calculation::Category::Number;
+    case CSSUnitType::CSS_NUMBER:
+        return category == Calculation::Category::Number;
+    case CSSUnitType::CSS_PERCENTAGE:
+        return category == Calculation::Category::Percentage
+            || category == Calculation::Category::AnglePercentage
+            || category == Calculation::Category::LengthPercentage;
+    case CSSUnitType::CSS_EM:
+    case CSSUnitType::CSS_EX:
+    case CSSUnitType::CSS_PX:
+    case CSSUnitType::CSS_CM:
+    case CSSUnitType::CSS_MM:
+    case CSSUnitType::CSS_IN:
+    case CSSUnitType::CSS_PT:
+    case CSSUnitType::CSS_PC:
+    case CSSUnitType::CSS_Q:
+    case CSSUnitType::CSS_LH:
+    case CSSUnitType::CSS_CAP:
+    case CSSUnitType::CSS_CH:
+    case CSSUnitType::CSS_IC:
+    case CSSUnitType::CSS_RCAP:
+    case CSSUnitType::CSS_RCH:
+    case CSSUnitType::CSS_REM:
+    case CSSUnitType::CSS_REX:
+    case CSSUnitType::CSS_RIC:
+    case CSSUnitType::CSS_RLH:
+    case CSSUnitType::CSS_VW:
+    case CSSUnitType::CSS_VH:
+    case CSSUnitType::CSS_VMIN:
+    case CSSUnitType::CSS_VMAX:
+    case CSSUnitType::CSS_VB:
+    case CSSUnitType::CSS_VI:
+    case CSSUnitType::CSS_SVW:
+    case CSSUnitType::CSS_SVH:
+    case CSSUnitType::CSS_SVMIN:
+    case CSSUnitType::CSS_SVMAX:
+    case CSSUnitType::CSS_SVB:
+    case CSSUnitType::CSS_SVI:
+    case CSSUnitType::CSS_LVW:
+    case CSSUnitType::CSS_LVH:
+    case CSSUnitType::CSS_LVMIN:
+    case CSSUnitType::CSS_LVMAX:
+    case CSSUnitType::CSS_LVB:
+    case CSSUnitType::CSS_LVI:
+    case CSSUnitType::CSS_DVW:
+    case CSSUnitType::CSS_DVH:
+    case CSSUnitType::CSS_DVMIN:
+    case CSSUnitType::CSS_DVMAX:
+    case CSSUnitType::CSS_DVB:
+    case CSSUnitType::CSS_DVI:
+    case CSSUnitType::CSS_CQW:
+    case CSSUnitType::CSS_CQH:
+    case CSSUnitType::CSS_CQI:
+    case CSSUnitType::CSS_CQB:
+    case CSSUnitType::CSS_CQMIN:
+    case CSSUnitType::CSS_CQMAX:
+        return category == Calculation::Category::Length
+            || category == Calculation::Category::LengthPercentage;
+    case CSSUnitType::CSS_DEG:
+    case CSSUnitType::CSS_RAD:
+    case CSSUnitType::CSS_GRAD:
+    case CSSUnitType::CSS_TURN:
+        return category == Calculation::Category::Angle
+            || category == Calculation::Category::AnglePercentage;
+    case CSSUnitType::CSS_MS:
+    case CSSUnitType::CSS_S:
+        return category == Calculation::Category::Time;
+    case CSSUnitType::CSS_HZ:
+    case CSSUnitType::CSS_KHZ:
+        return category == Calculation::Category::Frequency;
+    case CSSUnitType::CSS_DPPX:
+    case CSSUnitType::CSS_X:
+    case CSSUnitType::CSS_DPI:
+    case CSSUnitType::CSS_DPCM:
+        return category == Calculation::Category::Resolution;
+    case CSSUnitType::CSS_FR:
+        return category == Calculation::Category::Flex;
 
-// MARK: Length
+    case CSSUnitType::CSS_ATTR:
+    case CSSUnitType::CSS_CALC:
+    case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
+    case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
+    case CSSUnitType::CSS_DIMENSION:
+    case CSSUnitType::CSS_FONT_FAMILY:
+    case CSSUnitType::CSS_IDENT:
+    case CSSUnitType::CSS_PROPERTY_ID:
+    case CSSUnitType::CSS_QUIRKY_EM:
+    case CSSUnitType::CSS_RGBCOLOR:
+    case CSSUnitType::CSS_STRING:
+    case CSSUnitType::CSS_UNKNOWN:
+    case CSSUnitType::CSS_UNRESOLVED_COLOR:
+    case CSSUnitType::CSS_URI:
+    case CSSUnitType::CSS_VALUE_ID:
+    case CSSUnitType::CustomIdent:
+        break;
+    }
 
-double canonicalizeLengthNoConversionDataRequired(double value, CSSUnitType type)
-{
-    return CSSPrimitiveValue::computeNonCalcLengthDouble({ }, type, value);
-}
-
-double canonicalizeLength(double value, CSSUnitType type, const CSSToLengthConversionData& conversionData)
-{
-    return CSSPrimitiveValue::computeNonCalcLengthDouble(conversionData, type, value);
-}
-
-static float clampLengthToAllowedLimits(double value)
-{
-    return clampTo<float>(narrowPrecisionToFloat(value), minValueForCssLength, maxValueForCssLength);
-}
-
-float canonicalizeAndClampLengthNoConversionDataRequired(double value, CSSUnitType type)
-{
-    return clampLengthToAllowedLimits(canonicalizeLengthNoConversionDataRequired(value, type));
-}
-
-float canonicalizeAndClampLength(double value, CSSUnitType type, const CSSToLengthConversionData& conversionData)
-{
-    return clampLengthToAllowedLimits(canonicalizeLength(value, type, conversionData));
-}
-
-// MARK: Time
-
-double canonicalizeTime(double value, CSSUnitType type)
-{
-    return CSSPrimitiveValue::computeTime<CSSPrimitiveValue::TimeUnit::Seconds>(type, value);
-}
-
-// MARK: Frequency
-
-double canonicalizeFrequency(double value, CSSUnitType type)
-{
-    return CSSPrimitiveValue::computeFrequency<CSSPrimitiveValue::FrequencyUnit::Hz>(type, value);
-}
-
-// MARK: Resolution
-
-double canonicalizeResolution(double value, CSSUnitType type)
-{
-    return CSSPrimitiveValue::computeResolution<CSSPrimitiveValue::ResolutionUnit::Dppx>(type, value);
+    return false;
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "CSSNone.h"
+#include "CSSSymbol.h"
 #include "CSSPrimitiveNumericRange.h"
 #include "CSSUnevaluatedCalc.h"
 #include "CSSUnits.h"
@@ -38,34 +39,46 @@ namespace CSS {
 // Concept for use in generic contexts to filter on *Raw types.
 template<typename T> concept RawNumeric = requires(T raw) {
     { raw.type } -> std::convertible_to<CSSUnitType>;
-    { raw.value } -> std::convertible_to<double>;
+    { raw.value } -> std::convertible_to<typename T::ValueType>;
 };
 
 // MARK: Number Primitives Raw
 
-template<typename T, Range R> struct IntegerRaw {
-    using IntType = T;
+template<Range R, typename T> struct IntegerRaw {
+    using ValueType = T;
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::Integer;
     static constexpr auto type = CSSUnitType::CSS_INTEGER;
-    IntType value;
+    ValueType value;
 
-    constexpr bool operator==(const IntegerRaw<T, R>&) const = default;
-};
-
-template<Range R = All> struct NumberRaw {
-    static constexpr auto range = R;
-    static constexpr auto category = Calculation::Category::Number;
-    static constexpr auto type = CSSUnitType::CSS_NUMBER;
-    double value;
-
-    constexpr NumberRaw(double value)
+    constexpr IntegerRaw(ValueType value)
         : value { value }
     {
     }
 
     // Constructor is required to allow generic code to uniformly initialize primitives with a CSSUnitType.
-    constexpr NumberRaw(CSSUnitType, double value)
+    constexpr IntegerRaw(CSSUnitType, ValueType value)
+        : value { value }
+    {
+    }
+
+    constexpr bool operator==(const IntegerRaw<R, T>&) const = default;
+};
+
+template<Range R = All> struct NumberRaw {
+    using ValueType = double;
+    static constexpr auto range = R;
+    static constexpr auto category = Calculation::Category::Number;
+    static constexpr auto type = CSSUnitType::CSS_NUMBER;
+    ValueType value;
+
+    constexpr NumberRaw(ValueType value)
+        : value { value }
+    {
+    }
+
+    // Constructor is required to allow generic code to uniformly initialize primitives with a CSSUnitType.
+    constexpr NumberRaw(CSSUnitType, ValueType value)
         : value { value }
     {
     }
@@ -76,18 +89,19 @@ template<Range R = All> struct NumberRaw {
 // MARK: Percentage Primitive Raw
 
 template<Range R = All> struct PercentageRaw {
+    using ValueType = double;
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::Percentage;
     static constexpr auto type = CSSUnitType::CSS_PERCENTAGE;
-    double value;
+    ValueType value;
 
-    constexpr PercentageRaw(double value)
+    constexpr PercentageRaw(ValueType value)
         : value { value }
     {
     }
 
     // Constructor is required to allow generic code to uniformly initialize primitives with a CSSUnitType.
-    constexpr PercentageRaw(CSSUnitType, double value)
+    constexpr PercentageRaw(CSSUnitType, ValueType value)
         : value { value }
     {
     }
@@ -98,69 +112,62 @@ template<Range R = All> struct PercentageRaw {
 // MARK: Dimension Primitives Raw
 
 template<Range R = All> struct AngleRaw {
+    using ValueType = double;
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::Angle;
     CSSUnitType type;
-    double value;
+    ValueType value;
 
     constexpr bool operator==(const AngleRaw<R>&) const = default;
 };
 
-double canonicalizeAngle(double value, CSSUnitType);
-
 template<Range R = All> struct LengthRaw {
+    using ValueType = double;
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::Length;
     CSSUnitType type;
-    double value;
+    ValueType value;
 
     constexpr bool operator==(const LengthRaw<R>&) const = default;
 };
 
-double canonicalizeLengthNoConversionDataRequired(double, CSSUnitType);
-double canonicalizeLength(double, CSSUnitType, const CSSToLengthConversionData&);
-float canonicalizeAndClampLengthNoConversionDataRequired(double, CSSUnitType);
-float canonicalizeAndClampLength(double, CSSUnitType, const CSSToLengthConversionData&);
-
 template<Range R = All> struct TimeRaw {
+    using ValueType = double;
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::Time;
     CSSUnitType type;
-    double value;
+    ValueType value;
 
     constexpr bool operator==(const TimeRaw<R>&) const = default;
 };
 
-double canonicalizeTime(double, CSSUnitType);
-
 template<Range R = All> struct FrequencyRaw {
+    using ValueType = double;
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::Frequency;
     CSSUnitType type;
-    double value;
+    ValueType value;
 
     constexpr bool operator==(const FrequencyRaw<R>&) const = default;
 };
 
-double canonicalizeFrequency(double, CSSUnitType);
-
 template<Range R = Nonnegative> struct ResolutionRaw {
+    using ValueType = double;
     static_assert(R.min >= 0, "<resolution> values must always have a minimum range of at least 0.");
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::Resolution;
     CSSUnitType type;
-    double value;
+    ValueType value;
 
     constexpr bool operator==(const ResolutionRaw<R>&) const = default;
 };
 
-double canonicalizeResolution(double, CSSUnitType);
-
 template<Range R = All> struct FlexRaw {
+    using ValueType = double;
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::Flex;
     static constexpr auto type = CSSUnitType::CSS_FR;
-    double value;
+    ValueType value;
 
     constexpr bool operator==(const FlexRaw<R>&) const = default;
 };
@@ -168,29 +175,23 @@ template<Range R = All> struct FlexRaw {
 // MARK: Dimension + Percentage Primitives Raw
 
 template<Range R = All> struct AnglePercentageRaw {
+    using ValueType = double;
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::AnglePercentage;
     CSSUnitType type;
-    double value;
+    ValueType value;
 
     constexpr bool operator==(const AnglePercentageRaw<R>&) const = default;
 };
 
 template<Range R = All> struct LengthPercentageRaw {
+    using ValueType = double;
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::LengthPercentage;
     CSSUnitType type;
-    double value;
+    ValueType value;
 
     constexpr bool operator==(const LengthPercentageRaw<R>&) const = default;
-};
-
-// MARK: Additional Numeric Adjacent Types Raw
-
-struct SymbolRaw {
-    CSSValueID value;
-
-    constexpr bool operator==(const SymbolRaw&) const = default;
 };
 
 // MARK: - Numeric Primitives (Raw + UnevaluatedCalc)
@@ -201,53 +202,175 @@ template<typename T> concept CSSNumeric = requires(T css) {
     requires RawNumeric<typename T::Raw>;
 };
 
+// Checks if the unit type is supported by the category.
+bool isSupportedUnitForCategory(CSSUnitType, Calculation::Category);
+
 template<RawNumeric T> struct PrimitiveNumeric {
     static constexpr auto range = T::range;
     static constexpr auto category = T::category;
     using Raw = T;
     using Calc = UnevaluatedCalc<T>;
 
-    PrimitiveNumeric(std::variant<T, UnevaluatedCalc<T>>&& value)
-        : value { WTFMove(value) }
+    PrimitiveNumeric(Raw raw)
     {
+        type = raw.type;
+        value.number = raw.value;
     }
 
-    PrimitiveNumeric(const std::variant<T, UnevaluatedCalc<T>>& value)
-        : value { value }
+    PrimitiveNumeric(UnevaluatedCalc<T> calc)
     {
+        type = CSSUnitType::CSS_CALC;
+        value.calc = &calc.protectedCalc().leakRef();
     }
 
-    PrimitiveNumeric(T&& value)
-        : value { WTFMove(value) }
+    PrimitiveNumeric(const PrimitiveNumeric& other)
     {
+        if (other.isCalc()) {
+            type = CSSUnitType::CSS_CALC;
+            value.calc = other.value.calc;
+            value.calc->ref();
+        } else {
+            type = other.type;
+            value.number = other.value.number;
+        }
     }
 
-    PrimitiveNumeric(const T& value)
-        : value { value }
+    PrimitiveNumeric(PrimitiveNumeric&& other)
     {
+        if (other.isCalc()) {
+            type = CSSUnitType::CSS_CALC;
+            value.calc = other.value.calc;
+
+            // Setting this to anything so that value is not double deref'd.
+            other.type = CSSUnitType::CSS_UNKNOWN;
+            other.value.calc = nullptr;
+        } else {
+            type = other.type;
+            value.number = other.value.number;
+        }
     }
 
-    PrimitiveNumeric(UnevaluatedCalc<T>&& value)
-        : value { WTFMove(value) }
+    PrimitiveNumeric& operator=(const PrimitiveNumeric& other)
     {
+        if (isCalc())
+            value.calc->deref();
+
+        if (other.isCalc()) {
+            type = CSSUnitType::CSS_CALC;
+            value.calc = other.value.calc;
+            value.calc->ref();
+        } else {
+            type = other.type;
+            value.number = other.value.number;
+        }
+
+        return *this;
     }
 
-    PrimitiveNumeric(const UnevaluatedCalc<T>& value)
-        : value { value }
+    PrimitiveNumeric& operator=(PrimitiveNumeric&& other)
     {
+        if (isCalc())
+            value.calc->deref();
+
+        if (other.isCalc()) {
+            type = CSSUnitType::CSS_CALC;
+            value.calc = other.value.calc;
+
+            // Setting this to anything so that value is not double deref'd.
+            other.type = CSSUnitType::CSS_UNKNOWN;
+            other.value.calc = nullptr;
+        } else {
+            type = other.type;
+            value.number = other.value.number;
+        }
+
+        return *this;
     }
 
-    bool operator==(const PrimitiveNumeric<T>&) const = default;
+    ~PrimitiveNumeric()
+    {
+        if (isCalc())
+            value.calc->deref();
+    }
 
-    const T* raw() const { return std::get_if<T>(&value); }
-    const UnevaluatedCalc<T>* calc() const { return std::get_if<Calc>(&value); }
+    bool operator==(const PrimitiveNumeric<T>& other) const
+    {
+        if (type != other.type)
+            return false;
 
-    std::variant<T, UnevaluatedCalc<T>> value;
+        if (isCalc())
+            return value.calc->equals(*other.value.calc);
+        return value.number == other.value.number;
+    }
+
+    const std::optional<Raw> raw() const
+    {
+        if (!isCalc())
+            return Raw { type, value.number };
+        return std::nullopt;
+    }
+
+    const std::optional<Calc> calc() const
+    {
+        if (isCalc())
+            return Calc { Ref(*value.calc) };
+        return std::nullopt;
+    }
+
+    template<typename F> decltype(auto) visit(F&& functor) const
+    {
+        if (isCalc())
+            return std::invoke(std::forward<F>(functor), Calc { Ref(*value.calc) });
+        return std::invoke(std::forward<F>(functor), Raw { type, value.number });
+    }
+
+    template<typename... F> decltype(auto) switchOn(F&&... functors) const
+    {
+        return visit(WTF::makeVisitor(std::forward<F>(functors)...));
+    }
+
+    bool isKnownZero() const { return !isCalc() && value.number == 0; }
+    bool isKnownNotZero() const { return !isCalc() && value.number != 0; }
+
+    bool isCalc() const { return type == CSSUnitType::CSS_CALC; }
+
+    static bool isSupported(CSSUnitType unit) { return isSupportedUnitForCategory(unit, category); }
+
+    struct MarkableTraits {
+        static bool isEmptyValue(const PrimitiveNumeric& value) { return value.isEmpty(); }
+        static PrimitiveNumeric emptyValue() { return PrimitiveNumeric(EmptyToken()); }
+    };
+
+private:
+    friend struct MarkableTraits;
+
+    struct EmptyToken { };
+    PrimitiveNumeric(EmptyToken)
+    {
+        type = CSSUnitType::CSS_UNKNOWN;
+        value.number = 0;
+    }
+
+    bool isEmpty() const { return type == CSSUnitType::CSS_UNKNOWN; }
+
+    // A std::variant is not used here to allow tighter packing.
+    // When type == CSSUnitType::CSS_CALC, value is calc.
+    // When type == CSSUnitType::CSS_UNKNOWN, value is empty (used by Markable).
+    // When type == anything else, value is number.
+
+    // FIXME: This could be even more packed types with only a single alternative (e.g. CSS::Number/CSS::Percentage/CSS::Flex),
+    // by using NaN encoding scheme for the `calc` case.
+
+    CSSUnitType type;
+    union {
+        typename Raw::ValueType number;
+        CSSCalcValue* calc;
+    } value;
 };
 
 // MARK: Number Primitive
 
-template<typename IntType, Range R> using Integer = PrimitiveNumeric<IntegerRaw<IntType, R>>;
+template<Range R, typename IntType> using Integer = PrimitiveNumeric<IntegerRaw<R, IntType>>;
 
 template<Range R = All> using Number = PrimitiveNumeric<NumberRaw<R>>;
 
@@ -269,52 +392,16 @@ template<Range R = All> using Flex = PrimitiveNumeric<FlexRaw<R>>;
 template<Range R = All> using AnglePercentage = PrimitiveNumeric<AnglePercentageRaw<R>>;
 template<Range R = All> using LengthPercentage = PrimitiveNumeric<LengthPercentageRaw<R>>;
 
-// MARK: Additional Numeric Adjacent Types
-
-struct Symbol {
-    using Raw = SymbolRaw;
-
-    constexpr Symbol(SymbolRaw&& value)
-        : value { value.value }
-    {
-    }
-
-    constexpr Symbol(const SymbolRaw& value)
-        : value { value.value }
-    {
-    }
-
-    constexpr bool operator==(const Symbol&) const = default;
-
-    CSSValueID value;
-};
-template<typename T> struct IsSymbol : public std::integral_constant<bool, std::is_same_v<T, Symbol>> { };
-
 // MARK: Additional Common Groupings
 
 // NOTE: This is spelled with an explicit "Or" to distinguish it from types like AnglePercentage/LengthPercentage that have behavior distinctions beyond just being a union of the two types (specifically, calc() has specific behaviors for those types).
-using PercentageOrNumber = std::variant<Percentage<>, Number<>>;
+template<Range R = All> using NumberOrPercentage = std::variant<Number<R>, Percentage<R>>;
 
-// MARK: - Requires Conversion Data
+template<Range R = All> struct NumberOrPercentageResolvedToNumber {
+    NumberOrPercentage<R> value;
 
-template<typename T> bool requiresConversionData(const PrimitiveNumeric<T>& primitive)
-{
-    return requiresConversionData(primitive.value);
-}
-
-// MARK: - Requires Conversion Data
-
-template<typename T> bool isUnevaluatedCalc(const PrimitiveNumeric<T>& primitive)
-{
-    return isUnevaluatedCalc(primitive.value);
-}
-
-// MARK: Simplify
-
-template<typename T> auto simplifyUnevaluatedCalc(const PrimitiveNumeric<T>& primitive, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) -> PrimitiveNumeric<T>
-{
-    return { simplifyUnevaluatedCalc(primitive.value, conversionData, symbolTable) };
-}
+    bool operator==(const NumberOrPercentageResolvedToNumber<R>&) const = default;
+};
 
 // MARK: - Type List Modifiers
 
@@ -402,3 +489,19 @@ template<typename TypeList> using MinusSymbol = typename MinusSymbolLazy<TypeLis
 
 } // namespace CSS
 } // namespace WebCore
+
+namespace WTF {
+
+// Overload WTF::switchOn to make it so CSS::PrimitiveNumeric<T> can be used directly.
+
+template<WebCore::CSS::RawNumeric T, class... F> ALWAYS_INLINE auto switchOn(const WebCore::CSS::PrimitiveNumeric<T>& value, F&&... f) -> decltype(value.switchOn(std::forward<F>(f)...))
+{
+    return value.switchOn(std::forward<F>(f)...);
+}
+
+template<WebCore::CSS::RawNumeric T, class... F> ALWAYS_INLINE auto switchOn(WebCore::CSS::PrimitiveNumeric<T>&& value, F&&... f) -> decltype(value.switchOn(std::forward<F>(f)...))
+{
+    return value.switchOn(std::forward<F>(f)...);
+}
+
+} // namespace WTF

--- a/Source/WebCore/css/values/primitives/CSSSymbol.cpp
+++ b/Source/WebCore/css/values/primitives/CSSSymbol.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSSymbol.h"
+
+namespace WebCore {
+namespace CSS {
+
+// MARK: - Serialization
+
+void Serialize<SymbolRaw>::operator()(StringBuilder& builder, const SymbolRaw& value)
+{
+    builder.append(nameLiteralForSerialization(value.value));
+}
+
+void Serialize<Symbol>::operator()(StringBuilder& builder, const Symbol& value)
+{
+    builder.append(nameLiteralForSerialization(value.value));
+}
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSSymbol.h
+++ b/Source/WebCore/css/values/primitives/CSSSymbol.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSValueTypes.h"
+
+namespace WebCore {
+namespace CSS {
+
+struct SymbolRaw {
+    CSSValueID value;
+
+    constexpr bool operator==(const SymbolRaw&) const = default;
+};
+
+struct Symbol {
+    using Raw = SymbolRaw;
+
+    CSSValueID value;
+
+    constexpr Symbol(SymbolRaw&& value)
+        : value { value.value }
+    {
+    }
+
+    constexpr Symbol(const SymbolRaw& value)
+        : value { value.value }
+    {
+    }
+
+    constexpr bool operator==(const Symbol&) const = default;
+};
+
+template<typename T> struct IsSymbol : public std::integral_constant<bool, std::is_same_v<T, Symbol>> { };
+
+template<> struct Hash<SymbolRaw> { void operator()(Hasher& hasher, const SymbolRaw& value) { WTF::add(hasher, value.value); } };
+template<> struct Hash<Symbol> { void operator()(Hasher& hasher, const Symbol& value) { WTF::add(hasher, value.value); } };
+
+template<> struct Serialize<SymbolRaw> { void operator()(StringBuilder&, const SymbolRaw&); };
+template<> struct Serialize<Symbol> { void operator()(StringBuilder&, const Symbol&); };
+
+template<> struct ComputedStyleDependenciesCollector<SymbolRaw> { constexpr void operator()(ComputedStyleDependencies&, const SymbolRaw&) { } };
+template<> struct ComputedStyleDependenciesCollector<Symbol> { constexpr void operator()(ComputedStyleDependencies&, const Symbol&) { } };
+
+template<> struct CSSValueChildrenVisitor<SymbolRaw> { constexpr IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const SymbolRaw&) { return IterationStatus::Continue; } };
+template<> struct CSSValueChildrenVisitor<Symbol> { constexpr IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const Symbol&) { return IterationStatus::Continue; } };
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
@@ -26,7 +26,6 @@
 #include "CSSUnevaluatedCalc.h"
 
 #include "CSSCalcSymbolTable.h"
-#include "FloatConversion.h"
 #include "StyleBuilderState.h"
 #include <wtf/text/StringBuilder.h>
 
@@ -58,36 +57,36 @@ Ref<CSSCalcValue> unevaluatedCalcSimplify(const Ref<CSSCalcValue>& calc, const C
     return calc->copySimplified(conversionData, symbolTable);
 }
 
-float unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const Style::BuilderState& state, Calculation::Category category)
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const Style::BuilderState& state, Calculation::Category category)
 {
     return unevaluatedCalcEvaluate(calc, state.cssToLengthConversionData(), { }, category);
 }
 
-float unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const Style::BuilderState& state, const CSSCalcSymbolTable& symbolTable, Calculation::Category category)
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const Style::BuilderState& state, const CSSCalcSymbolTable& symbolTable, Calculation::Category category)
 {
     return unevaluatedCalcEvaluate(calc, state.cssToLengthConversionData(), symbolTable, category);
 }
 
-float unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const CSSToLengthConversionData& conversionData, Calculation::Category category)
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const CSSToLengthConversionData& conversionData, Calculation::Category category)
 {
     return unevaluatedCalcEvaluate(calc, conversionData, { }, category);
 }
 
-float unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable, Calculation::Category category)
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable, Calculation::Category category)
 {
     ASSERT_UNUSED(category, calc->category() == category);
-    return narrowPrecisionToFloat(calc->doubleValue(conversionData, symbolTable));
+    return calc->doubleValue(conversionData, symbolTable);
 }
 
-float unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>& calc, Calculation::Category category)
+double unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>& calc, Calculation::Category category)
 {
     return unevaluatedCalcEvaluateNoConversionDataRequired(calc, { }, category);
 }
 
-float unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>& calc, const CSSCalcSymbolTable& symbolTable, Calculation::Category category)
+double unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>& calc, const CSSCalcSymbolTable& symbolTable, Calculation::Category category)
 {
     ASSERT_UNUSED(category, calc->category() == category);
-    return narrowPrecisionToFloat(calc->doubleValueNoConversionDataRequired(symbolTable));
+    return calc->doubleValueNoConversionDataRequired(symbolTable);
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
@@ -59,12 +59,12 @@ void unevaluatedCalcCollectComputedStyleDependencies(ComputedStyleDependencies&,
 
 Ref<CSSCalcValue> unevaluatedCalcSimplify(const Ref<CSSCalcValue>&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&);
 
-float unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const Style::BuilderState&, Calculation::Category);
-float unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const Style::BuilderState&, const CSSCalcSymbolTable&, Calculation::Category);
-float unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const CSSToLengthConversionData&, Calculation::Category);
-float unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&, Calculation::Category);
-float unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>&, Calculation::Category);
-float unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>&, const CSSCalcSymbolTable&, Calculation::Category);
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const Style::BuilderState&, Calculation::Category);
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const Style::BuilderState&, const CSSCalcSymbolTable&, Calculation::Category);
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const CSSToLengthConversionData&, Calculation::Category);
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&, Calculation::Category);
+double unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>&, Calculation::Category);
+double unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>&, const CSSCalcSymbolTable&, Calculation::Category);
 
 // `UnevaluatedCalc` annotates a `CSSCalcValue` with the raw value type that it
 // will be evaluated to, allowing the processing of calc in generic code.

--- a/Source/WebCore/css/values/shapes/CSSPathFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSPathFunction.cpp
@@ -58,5 +58,10 @@ IterationStatus CSSValueChildrenVisitor<Path::Data>::operator()(const Function<I
     return IterationStatus::Continue;
 }
 
+void Hash<Path::Data>::operator()(Hasher&, const Path::Data&)
+{
+    // FIXME: If hashing Path is ever useful, consider hashing and/or storing the hash for SVGPathByteStream.
+}
+
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/shapes/CSSPathFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSPathFunction.h
@@ -59,6 +59,7 @@ template<> struct Serialize<Path> { void operator()(StringBuilder&, const Path&)
 
 template<> struct ComputedStyleDependenciesCollector<Path::Data> { void operator()(ComputedStyleDependencies&, const Path::Data&); };
 template<> struct CSSValueChildrenVisitor<Path::Data> { IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const Path::Data&); };
+template<> struct Hash<Path::Data> { void operator()(Hasher&, const Path::Data&); };
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/platform/calc/CalculationValue.h
+++ b/Source/WebCore/platform/calc/CalculationValue.h
@@ -49,7 +49,7 @@ public:
     Calculation::Tree copyTree() const;
     Calculation::Child copyRoot() const;
 
-    bool operator==(const CalculationValue&) const;
+    WEBCORE_EXPORT bool operator==(const CalculationValue&) const;
 
 private:
     CalculationValue(Calculation::Tree&&);

--- a/Source/WebCore/rendering/shapes/LayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/LayoutShape.cpp
@@ -95,8 +95,8 @@ static inline FloatSize physicalSizeToLogical(const FloatSize& size, WritingMode
 Ref<const LayoutShape> LayoutShape::createShape(const Style::BasicShape& basicShape, const LayoutPoint& borderBoxOffset, const LayoutSize& logicalBoxSize, WritingMode writingMode, float margin)
 {
     bool horizontalWritingMode = writingMode.isHorizontal();
-    auto boxWidth = horizontalWritingMode ? logicalBoxSize.width() : logicalBoxSize.height();
-    auto boxHeight = horizontalWritingMode ? logicalBoxSize.height() : logicalBoxSize.width();
+    float boxWidth = horizontalWritingMode ? logicalBoxSize.width() : logicalBoxSize.height();
+    float boxHeight = horizontalWritingMode ? logicalBoxSize.height() : logicalBoxSize.width();
 
     auto shape = WTF::switchOn(basicShape,
         [&](const Style::CircleFunction& circle) -> Ref<LayoutShape> {

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -37,6 +37,7 @@
 #include "CSSFontSelector.h"
 #include "CSSFontStyleWithAngleValue.h"
 #include "CSSFontVariationValue.h"
+#include "CSSPrimitiveNumericTypes+EvaluateCalc.h"
 #include "CSSPrimitiveValueMappings.h"
 #include "CSSPropertyParserConsumer+Font.h"
 #include "CSSPropertyParserHelpers.h"
@@ -306,7 +307,7 @@ static ResolvedFontSize fontSizeFromUnresolvedFontSize(const CSSPropertyParserHe
             return { .size = 0.0f, .keyword = CSSValueInvalid };
         },
         [&](const CSS::LengthPercentage<CSS::Nonnegative>& lengthPercentage) -> ResolvedFontSize {
-            return WTF::switchOn(lengthPercentage.value,
+            return WTF::switchOn(lengthPercentage,
                 [&](const CSS::LengthPercentageRaw<CSS::Nonnegative>& lengthPercentage) -> ResolvedFontSize {
                     if (lengthPercentage.type == CSSUnitType::CSS_PERCENTAGE) {
                         return {

--- a/Source/WebCore/style/values/images/StyleGradient.cpp
+++ b/Source/WebCore/style/values/images/StyleGradient.cpp
@@ -698,7 +698,7 @@ static inline float positionFromValue(const LengthPercentage<>& coordinate, floa
     return evaluate(coordinate, widthOrHeight);
 }
 
-static inline float positionFromValue(const PercentageOrNumber& coordinate, float widthOrHeight)
+static inline float positionFromValue(const NumberOrPercentage<>& coordinate, float widthOrHeight)
 {
     return WTF::switchOn(coordinate,
         [&](Number<> number) -> float { return number.value; },
@@ -1196,7 +1196,7 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
     auto secondRadius = radial.parameters.gradientBox.secondRadius.value;
     auto aspectRatio = 1.0f;
 
-    WebCore::Gradient::RadialData data { firstPoint, secondPoint, firstRadius, secondRadius, aspectRatio };
+    WebCore::Gradient::RadialData data { firstPoint, secondPoint, narrowPrecisionToFloat(firstRadius), narrowPrecisionToFloat(secondRadius), aspectRatio };
     RadialGradientAdapter adapter { data, size };
     auto stops = computeStopsForDeprecatedVariants(adapter, radial, style);
 

--- a/Source/WebCore/style/values/images/StyleGradient.h
+++ b/Source/WebCore/style/values/images/StyleGradient.h
@@ -40,7 +40,7 @@ namespace Style {
 
 // MARK: - Common Types
 
-using DeprecatedGradientPosition = SpaceSeparatedArray<PercentageOrNumber, 2>;
+using DeprecatedGradientPosition = SpaceSeparatedArray<NumberOrPercentage<>, 2>;
 
 using Horizontal     = CSS::Horizontal;
 using Vertical       = CSS::Vertical;

--- a/Source/WebCore/style/values/primitives/StyleNone.cpp
+++ b/Source/WebCore/style/values/primitives/StyleNone.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleNone.h"
+
+namespace WebCore {
+namespace Style {
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, const None&)
+{
+    return ts << "none";
+}
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StyleNone.h
+++ b/Source/WebCore/style/values/primitives/StyleNone.h
@@ -39,7 +39,9 @@ struct None {
 
 template<> struct ToPrimaryCSSTypeMapping<CSS::NoneRaw> { using type = CSS::None; };
 
-template<> struct ToCSS<None> { constexpr auto operator()(const None&, const RenderStyle&) -> CSS::None { return { }; } };
+template<> struct ToCSS<None> {
+    constexpr auto operator()(const None&, const RenderStyle&) -> CSS::None { return { }; }
+};
 
 template<> struct ToStyle<CSS::None> {
     auto operator()(const CSS::None&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&) -> None { return { }; }
@@ -51,6 +53,8 @@ template<> struct Blending<None> {
     constexpr auto canBlend(const None&, const None&) -> bool { return true; }
     constexpr auto blend(const None&, const None&, const BlendingContext&) -> None { return { }; }
 };
+
+WTF::TextStream& operator<<(WTF::TextStream&, const None&);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePosition.cpp
+++ b/Source/WebCore/style/values/primitives/StylePosition.cpp
@@ -36,46 +36,46 @@ namespace Style {
 
 auto ToCSS<TwoComponentPositionHorizontal>::operator()(const TwoComponentPositionHorizontal& value, const RenderStyle& style) -> CSS::TwoComponentPositionHorizontal
 {
-    return { .offset = toCSS(value.offset, style) };
+    return { .value = toCSS(value.value, style) };
 }
 
 auto ToStyle<CSS::TwoComponentPositionHorizontal>::operator()(const CSS::TwoComponentPositionHorizontal& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> TwoComponentPositionHorizontal
 {
-    return WTF::switchOn(value.offset,
+    return WTF::switchOn(value.value,
         [&](CSS::Left) {
-            return TwoComponentPositionHorizontal { .offset = LengthPercentage<> { Percentage<> { 0 } } };
+            return TwoComponentPositionHorizontal { .value = LengthPercentage<> { Percentage<> { 0 } } };
         },
         [&](CSS::Right)  {
-            return TwoComponentPositionHorizontal { .offset = LengthPercentage<> { Percentage<> { 100 } } };
+            return TwoComponentPositionHorizontal { .value = LengthPercentage<> { Percentage<> { 100 } } };
         },
         [&](CSS::Center)  {
-            return TwoComponentPositionHorizontal { .offset = LengthPercentage<> { Percentage<> { 50 } } };
+            return TwoComponentPositionHorizontal { .value = LengthPercentage<> { Percentage<> { 50 } } };
         },
         [&](const CSS::LengthPercentage<>& value) {
-            return TwoComponentPositionHorizontal { .offset = toStyle(value, state, symbolTable) };
+            return TwoComponentPositionHorizontal { .value = toStyle(value, state, symbolTable) };
         }
     );
 }
 
 auto ToCSS<TwoComponentPositionVertical>::operator()(const TwoComponentPositionVertical& value, const RenderStyle& style) -> CSS::TwoComponentPositionVertical
 {
-    return { .offset = toCSS(value.offset, style) };
+    return { .value = toCSS(value.value, style) };
 }
 
 auto ToStyle<CSS::TwoComponentPositionVertical>::operator()(const CSS::TwoComponentPositionVertical& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> TwoComponentPositionVertical
 {
-    return WTF::switchOn(value.offset,
+    return WTF::switchOn(value.value,
         [&](CSS::Top) {
-            return TwoComponentPositionVertical { .offset = LengthPercentage<> { Percentage<> { 0 } } };
+            return TwoComponentPositionVertical { .value = LengthPercentage<> { Percentage<> { 0 } } };
         },
         [&](CSS::Bottom) {
-            return TwoComponentPositionVertical { .offset = LengthPercentage<> { Percentage<> { 100 } } };
+            return TwoComponentPositionVertical { .value = LengthPercentage<> { Percentage<> { 100 } } };
         },
         [&](CSS::Center) {
-            return TwoComponentPositionVertical { .offset = LengthPercentage<> { Percentage<> { 50 } } };
+            return TwoComponentPositionVertical { .value = LengthPercentage<> { Percentage<> { 50 } } };
         },
         [&](const CSS::LengthPercentage<>& value) {
-            return TwoComponentPositionVertical { .offset = toStyle(value, state, symbolTable) };
+            return TwoComponentPositionVertical { .value = toStyle(value, state, symbolTable) };
         }
     );
 }
@@ -125,12 +125,12 @@ FloatPoint evaluate(const Position& position, FloatSize referenceBox)
 
 float evaluate(const TwoComponentPositionHorizontal& component, float referenceWidth)
 {
-    return evaluate(component.offset, referenceWidth);
+    return evaluate(component.value, referenceWidth);
 }
 
 float evaluate(const TwoComponentPositionVertical& component, float referenceHeight)
 {
-    return evaluate(component.offset, referenceHeight);
+    return evaluate(component.value, referenceHeight);
 }
 
 } // namespace CSS

--- a/Source/WebCore/style/values/primitives/StylePosition.h
+++ b/Source/WebCore/style/values/primitives/StylePosition.h
@@ -37,30 +37,22 @@ using Bottom = CSS::Bottom;
 using Center = CSS::Center;
 
 struct TwoComponentPositionHorizontal {
-    LengthPercentage<> offset;
+    LengthPercentage<> value;
 
     bool operator==(const TwoComponentPositionHorizontal&) const = default;
 };
-template<size_t I> const auto& get(const TwoComponentPositionHorizontal& value)
-{
-    if constexpr (!I)
-        return value.offset;
-}
+DEFINE_STYLE_TYPE_WRAPPER(TwoComponentPositionHorizontal);
 
 struct TwoComponentPositionVertical {
-    LengthPercentage<> offset;
+    LengthPercentage<> value;
 
     bool operator==(const TwoComponentPositionVertical&) const = default;
 };
-template<size_t I> const auto& get(const TwoComponentPositionVertical& value)
-{
-    if constexpr (!I)
-        return value.offset;
-}
+DEFINE_STYLE_TYPE_WRAPPER(TwoComponentPositionVertical);
 
 struct Position  {
     Position(TwoComponentPositionHorizontal&& x, TwoComponentPositionVertical&& y)
-        : value { WTFMove(x.offset), WTFMove(y.offset) }
+        : value { WTFMove(x.value), WTFMove(y.value) }
     {
     }
 
@@ -113,5 +105,3 @@ float evaluate(const TwoComponentPositionVertical&, float referenceHeight);
 } // namespace WebCore
 
 STYLE_TUPLE_LIKE_CONFORMANCE(Position, 2)
-STYLE_TUPLE_LIKE_CONFORMANCE(TwoComponentPositionHorizontal, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(TwoComponentPositionVertical, 1)

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSTypeTransform.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSTypeTransform.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StylePrimitiveNumericTypes.h"
+#include <wtf/Brigand.h>
+
+namespace WebCore {
+namespace CSS {
+
+namespace TypeTransform {
+
+// MARK: - Type transforms
+
+namespace Type {
+
+// MARK: CSS type -> Style type mapping (Style type -> CSS type directly available via typename StyleType::CSS)
+
+template<typename> struct ToStyleMapping;
+template<auto R> struct ToStyleMapping<Number<R>> { using Style = Style::Number<R>; };
+template<auto R> struct ToStyleMapping<Percentage<R>> { using Style = Style::Percentage<R>; };
+template<auto R> struct ToStyleMapping<Angle<R>> { using Style = Style::Angle<R>; };
+template<auto R> struct ToStyleMapping<Length<R>> { using Style = Style::Length<R>; };
+template<auto R> struct ToStyleMapping<Time<R>> { using Style = Style::Time<R>; };
+template<auto R> struct ToStyleMapping<Frequency<R>> { using Style = Style::Frequency<R>; };
+template<auto R> struct ToStyleMapping<Resolution<R>> { using Style = Style::Resolution<R>; };
+template<auto R> struct ToStyleMapping<Flex<R>> { using Style = Style::Flex<R>; };
+template<auto R> struct ToStyleMapping<AnglePercentage<R>> { using Style = Style::AnglePercentage<R>; };
+template<auto R> struct ToStyleMapping<LengthPercentage<R>> { using Style = Style::LengthPercentage<R>; };
+template<> struct ToStyleMapping<None> { using Style = Style::None; };
+
+// MARK: Transform CSS type -> Style type.
+
+// Transform `css1`  -> `style1`
+template<typename T> struct CSSToStyleLazy {
+    using type = typename ToStyleMapping<T>::Style;
+};
+template<typename T> using CSSToStyle = typename CSSToStyleLazy<T>::type;
+
+// MARK: Transform Raw type -> Style type.
+
+// Transform `raw1`  -> `style1`
+template<typename T> struct RawToStyleLazy {
+    using type = typename ToStyleMapping<typename RawToCSSMapping<T>::CSS>::Style;
+};
+template<typename T> using RawToStyle = typename RawToStyleLazy<T>::type;
+
+} // namespace Type
+
+namespace List {
+
+// MARK: - List transforms
+
+// MARK: Transform CSS type list -> Style type list.
+
+// Transform `brigand::list<css1, css2, ...>`  -> `brigand::list<style1, style2, ...>`
+template<typename TypeList> struct CSSToStyleLazy {
+    using type = brigand::transform<TypeList, Type::CSSToStyleLazy<brigand::_1>>;
+};
+template<typename TypeList> using CSSToStyle = typename CSSToStyleLazy<TypeList>::type;
+
+// MARK: Transform Raw type list -> Style type list.
+
+// Transform `brigand::list<raw1, raw2, ...>`  -> `brigand::list<style1, style2, ...>`
+template<typename TypeList> struct RawToStyleLazy {
+    using type = brigand::transform<TypeList, Type::RawToStyleLazy<brigand::_1>>;
+};
+template<typename TypeList> using RawToStyle = typename RawToStyleLazy<TypeList>::type;
+
+} // namespace List
+
+} // namespace TypeTransform
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StylePrimitiveNumericTypes.h"
+#include "CalculationValue.h"
+#include <wtf/Forward.h>
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Conversion to `Calculation::Child`.
+
+inline Calculation::Child copyCalculation(Ref<CalculationValue> value)
+{
+    return value->copyRoot();
+}
+
+template<auto R> Calculation::Child copyCalculation(const Number<R>& value)
+{
+    return Calculation::number(value.value);
+}
+
+template<auto R> Calculation::Child copyCalculation(const Percentage<R>& value)
+{
+    return Calculation::percentage(value.value);
+}
+
+template<StyleNumericPrimitive Dimension> Calculation::Child copyCalculation(const Dimension& value)
+{
+    return Calculation::dimension(value.value);
+}
+
+template<StylePercentageDimension PercentageDimension> Calculation::Child copyCalculation(const PercentageDimension& value)
+{
+    return value.value.switchOn([](const auto& value) { return copyCalculation(value); });
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
@@ -26,16 +26,56 @@
 
 #include "FloatPoint.h"
 #include "FloatSize.h"
+#include "StylePrimitiveNumericTypes+Calculation.h"
 #include "StylePrimitiveNumericTypes.h"
 
 namespace WebCore {
 namespace Style {
 
+// MARK: - Number
+
+template<auto R> constexpr double evaluate(const Number<R>& number, double)
+{
+    return number.value;
+}
+
+template<auto R> constexpr float evaluate(const Number<R>& number, float)
+{
+    return narrowPrecisionToFloat(number.value);
+}
+
 // MARK: - Percentage
 
 template<auto R> constexpr float evaluate(const Percentage<R>& percentage, float referenceLength)
 {
-    return percentage.value / 100.0f * referenceLength;
+    return narrowPrecisionToFloat(percentage.value) / 100.0f * referenceLength;
+}
+
+template<auto R> constexpr double evaluate(const Percentage<R>& percentage, double referenceLength)
+{
+    return percentage.value / 100.0 * referenceLength;
+}
+
+// MARK: - StyleNumericPrimitive
+
+template<StyleNumericPrimitive T> constexpr float evaluate(const T& value, float)
+{
+    return value.value;
+}
+
+template<StyleNumericPrimitive T> constexpr double evaluate(const T& value, double)
+{
+    return value.value;
+}
+
+inline float evaluate(const CalculationValue& calculation, float referenceValue)
+{
+    return calculation.evaluate(referenceValue);
+}
+
+inline double evaluate(const CalculationValue& calculation, double referenceValue)
+{
+    return calculation.evaluate(referenceValue);
 }
 
 // MARK: - StylePercentageDimension (e.g. AnglePercentage/LengthPercentage)
@@ -43,14 +83,17 @@ template<auto R> constexpr float evaluate(const Percentage<R>& percentage, float
 template<StylePercentageDimension T> float evaluate(const T& value, float referenceValue)
 {
     return value.value.switchOn(
-        [&](typename T::Dimension dimension) -> float {
-            return dimension.value;
-        },
-        [&]<auto R>(Percentage<R> percentage) -> float {
-            return evaluate(percentage, referenceValue);
-        },
-        [&](const CalculationValue& calculation) -> float {
-            return calculation.evaluate(referenceValue);
+        [&](const auto& value) -> float {
+            return evaluate(value, referenceValue);
+        }
+    );
+}
+
+template<StylePercentageDimension T> double evaluate(const T& value, double referenceValue)
+{
+    return value.value.switchOn(
+        [&](const auto& value) -> double {
+            return evaluate(value, referenceValue);
         }
     );
 }

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveValue.h"
+#include "StylePrimitiveNumericTypes.h"
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+namespace Style {
+
+template<StyleNumericPrimitive T> WTF::TextStream& operator<<(WTF::TextStream& ts, const T& value)
+{
+    return ts << formatCSSNumberValue(value.value, CSSPrimitiveValue::unitTypeString(value.unit));
+}
+
+template<auto R> WTF::TextStream& operator<<(WTF::TextStream& ts, const AnglePercentage<R>& value)
+{
+    return value.value.switchOn(
+        [&](Angle<R> value) -> WTF::TextStream& {
+            return ts << formatCSSNumberValue(value.value, CSSPrimitiveValue::unitTypeString(value.unit));
+        },
+        [&](Percentage<R> value) -> WTF::TextStream& {
+            return ts << formatCSSNumberValue(value.value, CSSPrimitiveValue::unitTypeString(value.unit));
+        },
+        [&](Ref<CalculationValue> value) -> WTF::TextStream& {
+            return ts << value.get();
+        }
+    );
+}
+
+template<auto R> WTF::TextStream& operator<<(WTF::TextStream& ts, const LengthPercentage<R>& value)
+{
+    return value.value.switchOn(
+        [&](Length<R> value) -> WTF::TextStream& {
+            return ts << formatCSSNumberValue(value.value, CSSPrimitiveValue::unitTypeString(value.unit));
+        },
+        [&](Percentage<R> value) -> WTF::TextStream& {
+            return ts << formatCSSNumberValue(value.value, CSSPrimitiveValue::unitTypeString(value.unit));
+        },
+        [&](Ref<CalculationValue> value) -> WTF::TextStream& {
+            return ts << value.get();
+        }
+    );
+}
+
+template<auto R> WTF::TextStream& operator<<(WTF::TextStream& ts, const NumberOrPercentageResolvedToNumber<R>& value)
+{
+    return ts << formatCSSNumberValue(value.value, ""_s);
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
@@ -61,20 +61,11 @@ template<CSS::Range R = CSS::All> struct Number {
     using CSS = WebCore::CSS::Number<R>;
     using Raw = WebCore::CSS::NumberRaw<R>;
 
-    float value { 0 };
+    double value { 0 };
 
     constexpr bool operator==(const Number<R>&) const = default;
+    constexpr bool operator==(double other) const { return value == other; };
 };
-
-template<auto R> constexpr Number<R> canonicalizeNoConversionDataRequired(const CSS::NumberRaw<R>& raw)
-{
-    return { narrowPrecisionToFloat(raw.value) };
-}
-
-template<auto R> constexpr Number<R> canonicalize(const CSS::NumberRaw<R>& raw, const CSSToLengthConversionData&)
-{
-    return canonicalizeNoConversionDataRequired(raw);
-}
 
 // MARK: Percentage Primitive
 
@@ -84,19 +75,11 @@ template<CSS::Range R = CSS::All> struct Percentage {
     using CSS = WebCore::CSS::Percentage<R>;
     using Raw = WebCore::CSS::PercentageRaw<R>;
 
-    float value { 0 };
+    double value { 0 };
 
     constexpr bool operator==(const Percentage<R>&) const = default;
+    constexpr bool operator==(double other) const { return value == other; };
 };
-template<auto R> constexpr Percentage<R> canonicalizeNoConversionDataRequired(const CSS::PercentageRaw<R>& raw)
-{
-    return { narrowPrecisionToFloat(raw.value) };
-}
-
-template<auto R> constexpr Percentage<R> canonicalize(const CSS::PercentageRaw<R>& raw, const CSSToLengthConversionData&)
-{
-    return canonicalizeNoConversionDataRequired(raw);
-}
 
 // MARK: Dimension Primitives
 
@@ -106,19 +89,11 @@ template<CSS::Range R = CSS::All> struct Angle {
     using CSS = WebCore::CSS::Angle<R>;
     using Raw = WebCore::CSS::AngleRaw<R>;
 
-    float value { 0 };
+    double value { 0 };
 
     constexpr bool operator==(const Angle<R>&) const = default;
+    constexpr bool operator==(double other) const { return value == other; };
 };
-
-template<auto R> Angle<R> canonicalizeNoConversionDataRequired(const CSS::AngleRaw<R>& raw)
-{
-    return { narrowPrecisionToFloat(CSS::canonicalizeAngle(raw.value, raw.type)) };
-}
-template<auto R> Angle<R> canonicalize(const CSS::AngleRaw<R>& raw, const CSSToLengthConversionData&)
-{
-    return canonicalizeNoConversionDataRequired(raw);
-}
 
 template<CSS::Range R = CSS::All> struct Length {
     static constexpr auto range = R;
@@ -126,29 +101,12 @@ template<CSS::Range R = CSS::All> struct Length {
     using CSS = WebCore::CSS::Length<R>;
     using Raw = WebCore::CSS::LengthRaw<R>;
 
+    // NOTE: Unlike the other primitive numeric types, Length<> uses a `float`, not a `double` for its value type.
     float value { 0 };
-    bool quirk { false };
 
-    constexpr bool hasQuirk() const { return quirk; }
     constexpr bool operator==(const Length<R>&) const = default;
+    constexpr bool operator==(float other) const { return value == other; };
 };
-
-template<auto R> Length<R> canonicalizeNoConversionDataRequired(const CSS::LengthRaw<R>& raw)
-{
-    ASSERT(!requiresConversionData(raw));
-    return {
-        .value = CSS::canonicalizeAndClampLengthNoConversionDataRequired(raw.value, raw.type),
-        .quirk = raw.type == CSSUnitType::CSS_QUIRKY_EM
-    };
-}
-
-template<auto R> Length<R> canonicalize(const CSS::LengthRaw<R>& raw, const CSSToLengthConversionData& conversionData)
-{
-    return {
-        .value = CSS::canonicalizeAndClampLength(raw.value, raw.type, conversionData),
-        .quirk = raw.type == CSSUnitType::CSS_QUIRKY_EM
-    };
-}
 
 template<CSS::Range R = CSS::All> struct Time {
     static constexpr auto range = R;
@@ -156,20 +114,11 @@ template<CSS::Range R = CSS::All> struct Time {
     using CSS = WebCore::CSS::Time<R>;
     using Raw = WebCore::CSS::TimeRaw<R>;
 
-    float value { 0 };
+    double value { 0 };
 
     constexpr bool operator==(const Time<R>&) const = default;
+    constexpr bool operator==(double other) const { return value == other; };
 };
-
-template<auto R> Time<R> canonicalizeNoConversionDataRequired(const CSS::TimeRaw<R>& raw)
-{
-    return { narrowPrecisionToFloat(CSS::canonicalizeTime(raw.value, raw.type)) };
-}
-
-template<auto R> Time<R> canonicalize(const CSS::TimeRaw<R>& raw, const CSSToLengthConversionData&)
-{
-    return canonicalizeNoConversionDataRequired(raw);
-}
 
 template<CSS::Range R = CSS::All> struct Frequency {
     static constexpr auto range = R;
@@ -177,20 +126,11 @@ template<CSS::Range R = CSS::All> struct Frequency {
     using CSS = WebCore::CSS::Frequency<R>;
     using Raw = WebCore::CSS::FrequencyRaw<R>;
 
-    float value { 0 };
+    double value { 0 };
 
     constexpr bool operator==(const Frequency<R>&) const = default;
+    constexpr bool operator==(double other) const { return value == other; };
 };
-
-template<auto R> Frequency<R> canonicalizeNoConversionDataRequired(const CSS::FrequencyRaw<R>& raw)
-{
-    return { narrowPrecisionToFloat(CSS::canonicalizeFrequency(raw.value, raw.type)) };
-}
-
-template<auto R> Frequency<R> canonicalize(const CSS::FrequencyRaw<R>& raw, const CSSToLengthConversionData&)
-{
-    return canonicalizeNoConversionDataRequired(raw);
-}
 
 template<CSS::Range R = CSS::Nonnegative> struct Resolution {
     static_assert(R.min >= 0, "<resolution> values must always have a minimum range of at least 0.");
@@ -199,20 +139,11 @@ template<CSS::Range R = CSS::Nonnegative> struct Resolution {
     using CSS = WebCore::CSS::Resolution<R>;
     using Raw = WebCore::CSS::ResolutionRaw<R>;
 
-    float value { 0 };
+    double value { 0 };
 
     constexpr bool operator==(const Resolution<R>&) const = default;
+    constexpr bool operator==(double other) const { return value == other; };
 };
-
-template<auto R> Resolution<R> canonicalizeNoConversionDataRequired(const CSS::ResolutionRaw<R>& raw)
-{
-    return { narrowPrecisionToFloat(CSS::canonicalizeResolution(raw.value, raw.type)) };
-}
-
-template<auto R> Resolution<R> canonicalize(const CSS::ResolutionRaw<R>& raw, const CSSToLengthConversionData&)
-{
-    return canonicalizeNoConversionDataRequired(raw);
-}
 
 template<CSS::Range R = CSS::All> struct Flex {
     static constexpr auto range = R;
@@ -220,64 +151,70 @@ template<CSS::Range R = CSS::All> struct Flex {
     using CSS = WebCore::CSS::Flex<R>;
     using Raw = WebCore::CSS::FlexRaw<R>;
 
-    float value { 0 };
+    double value { 0 };
 
     constexpr bool operator==(const Flex<R>&) const = default;
+    constexpr bool operator==(double other) const { return value == other; };
 };
-
-template<auto R> constexpr Flex<R> canonicalizeNoConversionDataRequired(const CSS::FlexRaw<R>& raw)
-{
-    return { narrowPrecisionToFloat(raw.value) };
-}
-
-template<auto R> constexpr Flex<R> canonicalize(const CSS::FlexRaw<R>& raw, const CSSToLengthConversionData&)
-{
-    return canonicalizeNoConversionDataRequired(raw);
-}
 
 // MARK: Dimension + Percentage Primitives
 
-// Compact representation of std::variant<Angle, Percentage, Ref<CalculationValue>> that takes
-// up only 64 bits. Utilizes the knowledge that pointers are at most 48 bits, allowing for the
+template<typename T> struct PrimitivePercentageDimensionCalculationCategory;
+
+template<auto R> struct PrimitivePercentageDimensionCalculationCategory<Angle<R>> {
+    static constexpr auto category = Calculation::Category::AnglePercentage;
+};
+
+template<auto R> struct PrimitivePercentageDimensionCalculationCategory<Length<R>> {
+    static constexpr auto category = Calculation::Category::LengthPercentage;
+};
+
+// Compact representation of std::variant<Percentage<R>, Dimension<R>, Ref<CalculationValue>> that
+// takes up only 64 bits. Utilizes the knowledge that pointers are at most 48 bits, allowing for the
 // storage of the type tag in the remaining space.
+//
 // FIXME: Abstract into a generic CompactPointerVariant type.
-template<CSS::Range R = CSS::All> class AnglePercentageValue {
+
+template<typename D> class PrimitivePercentageDimension {
 public:
-    enum class Tag : uint8_t { Angle, Percentage, CalculationValue };
+    static constexpr auto R = D::range;
 
-    constexpr AnglePercentageValue(Angle<R> angle)
-        : m_data { encodedPayload(angle) | encodedTag(Tag::Angle) }
-    {
-    }
+    enum class Tag : uint8_t { Percentage, Dimension, CalculationValue };
 
-    constexpr AnglePercentageValue(Percentage<R> percentage)
+    constexpr PrimitivePercentageDimension(Percentage<R> percentage)
         : m_data { encodedPayload(percentage) | encodedTag(Tag::Percentage) }
     {
     }
 
-    AnglePercentageValue(Ref<CalculationValue>&& calculationValue)
+    constexpr PrimitivePercentageDimension(D dimension)
+        : m_data { encodedPayload(dimension) | encodedTag(Tag::Dimension) }
+    {
+    }
+
+
+    PrimitivePercentageDimension(Ref<CalculationValue>&& calculationValue)
         : m_data { encodedPayload(WTFMove(calculationValue)) | encodedTag(Tag::CalculationValue) }
     {
     }
 
-    AnglePercentageValue(Calculation::Child&& root)
-        : AnglePercentageValue(makeCalculationValue(WTFMove(root)))
+    PrimitivePercentageDimension(Calculation::Child&& root)
+        : PrimitivePercentageDimension(makeCalculationValue(WTFMove(root)))
     {
     }
 
-    AnglePercentageValue(const AnglePercentageValue<R>& other)
+    PrimitivePercentageDimension(const PrimitivePercentageDimension<D>& other)
         : m_data { other.m_data }
     {
         if (tag() == Tag::CalculationValue)
             refCalculationValue(); // Balanced by deref() in destructor.
     }
 
-    AnglePercentageValue(AnglePercentageValue<R>&& other)
+    PrimitivePercentageDimension(PrimitivePercentageDimension<D>&& other)
     {
         *this = WTFMove(other);
     }
 
-    AnglePercentageValue<R>& operator=(const AnglePercentageValue<R>& other)
+    PrimitivePercentageDimension<D>& operator=(const PrimitivePercentageDimension<D>& other)
     {
         if (*this == other)
             return *this;
@@ -293,7 +230,7 @@ public:
         return *this;
     }
 
-    AnglePercentageValue<R>& operator=(AnglePercentageValue<R>&& other)
+    PrimitivePercentageDimension<D>& operator=(PrimitivePercentageDimension<D>&& other)
     {
         if (*this == other)
             return *this;
@@ -307,7 +244,7 @@ public:
         return *this;
     }
 
-    ~AnglePercentageValue()
+    ~PrimitivePercentageDimension()
     {
         if (tag() == Tag::CalculationValue)
             derefCalculationValue(); // Balanced by leakRef() in encodedCalculationValue.
@@ -318,14 +255,14 @@ public:
         return decodedTag(m_data);
     }
 
-    constexpr bool isAngle() const
-    {
-        return tag() == Tag::Angle;
-    }
-
     constexpr bool isPercentage() const
     {
         return tag() == Tag::Percentage;
+    }
+
+    constexpr bool isDimension() const
+    {
+        return tag() == Tag::Dimension;
     }
 
     constexpr bool isCalculationValue() const
@@ -333,16 +270,16 @@ public:
         return tag() == Tag::CalculationValue;
     }
 
-    constexpr Angle<R> asAngle() const
-    {
-        ASSERT(tag() == Tag::Angle);
-        return decodedAngle(m_data);
-    }
-
     constexpr Percentage<R> asPercentage() const
     {
         ASSERT(tag() == Tag::Percentage);
         return decodedPercentage(m_data);
+    }
+
+    constexpr D asDimension() const
+    {
+        ASSERT(tag() == Tag::Dimension);
+        return decodedDimension(m_data);
     }
 
     Ref<CalculationValue> asCalculationValue() const
@@ -354,10 +291,10 @@ public:
     template<typename F> decltype(auto) visit(F&& functor) const
     {
         switch (tag()) {
-        case Tag::Angle:
-            return std::invoke(std::forward<F>(functor), asAngle());
         case Tag::Percentage:
             return std::invoke(std::forward<F>(functor), asPercentage());
+        case Tag::Dimension:
+            return std::invoke(std::forward<F>(functor), asDimension());
         case Tag::CalculationValue:
             return std::invoke(std::forward<F>(functor), asCalculationValue());
         }
@@ -372,17 +309,31 @@ public:
     constexpr bool isZero() const
     {
         switch (tag()) {
-        case Tag::Angle:
-            return asAngle().value == 0;
         case Tag::Percentage:
             return asPercentage().value == 0;
+        case Tag::Dimension:
+            return asDimension().value == 0;
         case Tag::CalculationValue:
             return false;
         }
         WTF_UNREACHABLE();
     }
 
-    constexpr bool operator==(const AnglePercentageValue<R>&) const = default;
+    bool operator==(const PrimitivePercentageDimension<D>& other) const
+    {
+        if (tag() != other.tag())
+            return false;
+
+        switch (tag()) {
+        case Tag::Percentage:
+            return asPercentage() == other.asPercentage();
+        case Tag::Dimension:
+            return asDimension() == other.asDimension();
+        case Tag::CalculationValue:
+            return asCalculationValue().get() == other.asCalculationValue().get();
+        }
+        WTF_UNREACHABLE();
+    }
 
 private:
 #if CPU(ADDRESS64)
@@ -392,32 +343,36 @@ private:
 #endif
     static constexpr uint64_t calculationValueSize = maxNumberOfBitsInPointer;
     static constexpr uint64_t calculationValueMask = (1ULL << calculationValueSize) - 1;
-    static constexpr uint64_t angleSize = sizeof(Angle<R>) * 8;
-    static constexpr uint64_t angleMask = (1ULL << angleSize) - 1;
-    static constexpr uint64_t percentageSize = sizeof(Percentage<R>) * 8;
+    static constexpr uint64_t percentageSize = sizeof(float) * 8;
     static constexpr uint64_t percentageMask = (1ULL << percentageSize) - 1;
+    static constexpr uint64_t dimensionSize = sizeof(float) * 8;
+    static constexpr uint64_t dimensionMask = (1ULL << dimensionSize) - 1;
     static constexpr uint64_t tagSize = sizeof(Tag) * 8;
-    static constexpr uint64_t tagShift = std::max({ calculationValueSize, angleSize, percentageSize });
+    static constexpr uint64_t tagShift = std::max({ percentageSize, dimensionSize, calculationValueSize });
     static_assert(tagShift + tagSize <= 64);
 
     static constexpr uint64_t movedFromValue()
     {
-        return encodedPayload(Angle<R> { 0 }) | encodedTag(Tag::Angle);
-    }
-
-    static uint64_t encodedPayload(Ref<CalculationValue>&& calculationValue)
-    {
-        return encodedCalculationValue(WTFMove(calculationValue));
-    }
-
-    static constexpr uint64_t encodedPayload(Angle<R> angle)
-    {
-        return encodedAngle(angle);
+        return encodedPayload(D { 0 }) | encodedTag(Tag::Dimension);
     }
 
     static constexpr uint64_t encodedPayload(Percentage<R> percentage)
     {
-        return encodedPercentage(percentage);
+        return static_cast<uint64_t>(std::bit_cast<uint32_t>(clampTo<float>(percentage.value)));
+    }
+
+    static constexpr uint64_t encodedPayload(D dimension)
+    {
+        return static_cast<uint64_t>(std::bit_cast<uint32_t>(clampTo<float>(dimension.value)));
+    }
+
+    static uint64_t encodedPayload(Ref<CalculationValue>&& calculationValue)
+    {
+#if CPU(ADDRESS64)
+        return std::bit_cast<uint64_t>(&calculationValue.leakRef()); // Balanced by deref() in destructor.
+#else
+        return std::bit_cast<uint32_t>(&calculationValue.leakRef()); // Balanced by deref() in destructor.
+#endif
     }
 
     static constexpr uint64_t encodedTag(Tag tag)
@@ -429,6 +384,30 @@ private:
     {
         return static_cast<Tag>(static_cast<uint8_t>(value >> tagShift));
     }
+
+    // Payload specific decoding.
+
+    static constexpr Percentage<R> decodedPercentage(uint64_t value)
+    {
+        return { std::bit_cast<float>(static_cast<uint32_t>(value & percentageMask)) };
+    }
+
+    static constexpr D decodedDimension(uint64_t value)
+    {
+        return { std::bit_cast<float>(static_cast<uint32_t>(value & dimensionMask)) };
+    }
+
+    static Ref<CalculationValue> decodedCalculationValue(uint64_t value)
+    {
+#if CPU(ADDRESS64)
+        Ref<CalculationValue> calculation = *std::bit_cast<CalculationValue*>(value & calculationValueMask);
+#else
+        Ref<CalculationValue> calculation = *std::bit_cast<CalculationValue*>(static_cast<uint32_t>(value & calculationValueMask));
+#endif
+        return calculation;
+    }
+
+    // CalculationValue specific handling.
 
     void refCalculationValue()
     {
@@ -450,53 +429,12 @@ private:
 #endif
     }
 
-    // Payload specific coding.
-
-    static uint64_t encodedCalculationValue(Ref<CalculationValue>&& calculationValue)
-    {
-#if CPU(ADDRESS64)
-        return std::bit_cast<uint64_t>(&calculationValue.leakRef()); // Balanced by deref() in destructor.
-#else
-        return std::bit_cast<uint32_t>(&calculationValue.leakRef()); // Balanced by deref() in destructor.
-#endif
-    }
-
-    static Ref<CalculationValue> decodedCalculationValue(uint64_t value)
-    {
-#if CPU(ADDRESS64)
-        Ref<CalculationValue> calculation = *std::bit_cast<CalculationValue*>(value & calculationValueMask);
-#else
-        Ref<CalculationValue> calculation = *std::bit_cast<CalculationValue*>(static_cast<uint32_t>(value & calculationValueMask));
-#endif
-        return calculation;
-    }
-
-    static constexpr uint64_t encodedAngle(Angle<R> angle)
-    {
-        return static_cast<uint64_t>(std::bit_cast<uint32_t>(angle.value));
-    }
-
-    static constexpr Angle<R> decodedAngle(uint64_t value)
-    {
-        return { std::bit_cast<float>(static_cast<uint32_t>(value & angleMask)) };
-    }
-
-    static constexpr uint64_t encodedPercentage(Percentage<R> percentage)
-    {
-        return static_cast<uint64_t>(std::bit_cast<uint32_t>(percentage.value));
-    }
-
-    static constexpr Percentage<R> decodedPercentage(uint64_t value)
-    {
-        return { std::bit_cast<float>(static_cast<uint32_t>(value & percentageMask)) };
-    }
-
     static Ref<CalculationValue> makeCalculationValue(Calculation::Child&& root)
     {
         return CalculationValue::create(
             Calculation::Tree {
                 .root = WTFMove(root),
-                .category = Calculation::Category::AnglePercentage,
+                .category = PrimitivePercentageDimensionCalculationCategory<D>::category,
                 .range = { R.min, R.max }
             }
         );
@@ -512,10 +450,10 @@ template<CSS::Range R = CSS::All> struct AnglePercentage {
     using Raw = WebCore::CSS::AnglePercentageRaw<R>;
     using Dimension = Angle<R>;
 
-    AnglePercentageValue<R> value;
+    PrimitivePercentageDimension<Angle<R>> value;
 
-    AnglePercentage(Angle<R> length)
-        : value { WTFMove(length) }
+    AnglePercentage(Angle<R> angle)
+        : value { WTFMove(angle) }
     {
     }
 
@@ -534,291 +472,17 @@ template<CSS::Range R = CSS::All> struct AnglePercentage {
     {
     }
 
-    constexpr bool operator==(const AnglePercentage<R>&) const = default;
-};
+    bool isPercentage() const { return value.isPercentage(); }
+    bool isAngle() const { return value.isDimension(); }
+    bool isCalculationValue() const { return value.isCalculationValue(); }
 
-template<auto R> AnglePercentage<R> canonicalizeNoConversionDataRequired(const CSS::AnglePercentageRaw<R>& raw)
-{
-    if (raw.type == CSSUnitType::CSS_PERCENTAGE)
-        return { canonicalizeNoConversionDataRequired(CSS::PercentageRaw<R> { raw.value }) };
-    return { canonicalizeNoConversionDataRequired(CSS::AngleRaw<R> { raw.type, raw.value }) };
-}
+    auto asPercentage() const -> Percentage<R> { return value.asPercentage(); }
+    auto asAngle() const -> Angle<R> { return value.asDimension(); }
+    auto asCalculationValue() const -> Ref<CalculationValue> { return value.asCalculationValue(); }
 
-template<auto R> AnglePercentage<R> canonicalize(const CSS::AnglePercentageRaw<R>& raw, const CSSToLengthConversionData&)
-{
-    return canonicalizeNoConversionDataRequired(raw);
-}
+    bool isZero() const { return value.isZero(); }
 
-
-// Compact representation of std::variant<Length, Percentage, Ref<CalculationValue>> that takes
-// up only 64 bits. Utilizes the knowledge that pointers are at most 48 bits, allowing for the
-// storage of the type tag in the remaining space.
-// FIXME: Abstract into a generic CompactPointerVariant type.
-template<CSS::Range R = CSS::All> class LengthPercentageValue {
-public:
-    enum class Tag : uint8_t { Length, Percentage, CalculationValue };
-
-    constexpr LengthPercentageValue(Length<R> length)
-        : m_data { encodedPayload(length) | encodedTag(Tag::Length) }
-    {
-    }
-
-    constexpr LengthPercentageValue(Percentage<R> percentage)
-        : m_data { encodedPayload(percentage) | encodedTag(Tag::Percentage) }
-    {
-    }
-
-    LengthPercentageValue(Ref<CalculationValue>&& calculationValue)
-        : m_data { encodedPayload(WTFMove(calculationValue)) | encodedTag(Tag::CalculationValue) }
-    {
-    }
-
-    LengthPercentageValue(Calculation::Child&& root)
-        : LengthPercentageValue(makeCalculationValue(WTFMove(root)))
-    {
-    }
-
-    LengthPercentageValue(const LengthPercentageValue<R>& other)
-        : m_data { other.m_data }
-    {
-        if (tag() == Tag::CalculationValue)
-            refCalculationValue(); // Balanced by deref() in destructor.
-    }
-
-    LengthPercentageValue(LengthPercentageValue<R>&& other)
-    {
-        *this = WTFMove(other);
-    }
-
-    LengthPercentageValue<R>& operator=(const LengthPercentageValue<R>& other)
-    {
-        if (*this == other)
-            return *this;
-
-        if (tag() == Tag::CalculationValue)
-            derefCalculationValue();
-
-        m_data = other.m_data;
-
-        if (tag() == Tag::CalculationValue)
-            refCalculationValue();
-
-        return *this;
-    }
-
-    LengthPercentageValue<R>& operator=(LengthPercentageValue<R>&& other)
-    {
-        if (*this == other)
-            return *this;
-
-        if (tag() == Tag::CalculationValue)
-            derefCalculationValue();
-
-        m_data = other.m_data;
-        other.m_data = movedFromValue();
-
-        return *this;
-    }
-
-    ~LengthPercentageValue()
-    {
-        if (tag() == Tag::CalculationValue)
-            derefCalculationValue(); // Balanced by leakRef() in encodedCalculationValue.
-    }
-
-    constexpr Tag tag() const
-    {
-        return decodedTag(m_data);
-    }
-
-    constexpr bool isLength() const
-    {
-        return tag() == Tag::Length;
-    }
-
-    constexpr bool isPercentage() const
-    {
-        return tag() == Tag::Percentage;
-    }
-
-    constexpr bool isCalculationValue() const
-    {
-        return tag() == Tag::CalculationValue;
-    }
-
-    constexpr Length<R> asLength() const
-    {
-        ASSERT(tag() == Tag::Length);
-        return decodedLength(m_data);
-    }
-
-    constexpr Percentage<R> asPercentage() const
-    {
-        ASSERT(tag() == Tag::Percentage);
-        return decodedPercentage(m_data);
-    }
-
-    Ref<CalculationValue> asCalculationValue() const
-    {
-        ASSERT(tag() == Tag::CalculationValue);
-        return decodedCalculationValue(m_data);
-    }
-
-    template<typename F> decltype(auto) visit(F&& functor) const
-    {
-        switch (tag()) {
-        case Tag::Length:
-            return std::invoke(std::forward<F>(functor), asLength());
-        case Tag::Percentage:
-            return std::invoke(std::forward<F>(functor), asPercentage());
-        case Tag::CalculationValue:
-            return std::invoke(std::forward<F>(functor), asCalculationValue());
-        }
-        WTF_UNREACHABLE();
-    }
-
-    template<typename... F> decltype(auto) switchOn(F&&... functors) const
-    {
-        return visit(WTF::makeVisitor(std::forward<F>(functors)...));
-    }
-
-    constexpr bool isZero() const
-    {
-        switch (tag()) {
-        case Tag::Length:
-            return asLength().value == 0;
-        case Tag::Percentage:
-            return asPercentage().value == 0;
-        case Tag::CalculationValue:
-            return false;
-        }
-        WTF_UNREACHABLE();
-    }
-
-    bool operator==(const LengthPercentageValue<R>&) const = default;
-
-private:
-#if CPU(ADDRESS64)
-    static constexpr unsigned maxNumberOfBitsInPointer = 48;
-#else
-    static constexpr unsigned maxNumberOfBitsInPointer = 32;
-#endif
-    static constexpr uint64_t calculationValueSize = maxNumberOfBitsInPointer;
-    static constexpr uint64_t calculationValueMask = (1ULL << calculationValueSize) - 1;
-    static constexpr uint64_t lengthValueSize = sizeof(float) * 8;
-    static constexpr uint64_t lengthValueMask = (1ULL << lengthValueSize) - 1;
-    static constexpr uint64_t lengthQuirkSize = sizeof(bool) * 8;
-    static constexpr uint64_t lengthQuirkShift = lengthValueSize;
-    static constexpr uint64_t lengthSize = lengthValueSize + lengthQuirkSize;
-    static constexpr uint64_t percentageSize = sizeof(Percentage<R>) * 8;
-    static constexpr uint64_t percentageMask = (1ULL << percentageSize) - 1;
-    static constexpr uint64_t tagSize = sizeof(Tag) * 8;
-    static constexpr uint64_t tagShift = std::max({ calculationValueSize, lengthSize, percentageSize });
-    static_assert(tagShift + tagSize <= 64);
-
-    static constexpr uint64_t movedFromValue()
-    {
-        return encodedPayload(Length<R> { 0 }) | encodedTag(Tag::Length);
-    }
-
-    static uint64_t encodedPayload(Ref<CalculationValue>&& calculationValue)
-    {
-        return encodedCalculationValue(WTFMove(calculationValue));
-    }
-
-    static constexpr uint64_t encodedPayload(Length<R> length)
-    {
-        return encodedLength(length);
-    }
-
-    static constexpr uint64_t encodedPayload(Percentage<R> percentage)
-    {
-        return encodedPercentage(percentage);
-    }
-
-    static constexpr uint64_t encodedTag(Tag tag)
-    {
-        return static_cast<uint64_t>(tag) << tagShift;
-    }
-
-    static constexpr Tag decodedTag(uint64_t value)
-    {
-        return static_cast<Tag>(static_cast<uint8_t>(value >> tagShift));
-    }
-
-    void refCalculationValue()
-    {
-        ASSERT(tag() == Tag::CalculationValue);
-#if CPU(ADDRESS64)
-        std::bit_cast<CalculationValue*>(m_data & calculationValueMask)->ref();
-#else
-        std::bit_cast<CalculationValue*>(static_cast<uint32_t>(m_data & calculationValueMask))->ref();
-#endif
-    }
-
-    void derefCalculationValue()
-    {
-        ASSERT(tag() == Tag::CalculationValue);
-#if CPU(ADDRESS64)
-        std::bit_cast<CalculationValue*>(m_data & calculationValueMask)->deref();
-#else
-        std::bit_cast<CalculationValue*>(static_cast<uint32_t>(m_data & calculationValueMask))->deref();
-#endif
-    }
-
-    // Payload specific coding.
-
-    static uint64_t encodedCalculationValue(Ref<CalculationValue>&& calculationValue)
-    {
-#if CPU(ADDRESS64)
-        return std::bit_cast<uint64_t>(&calculationValue.leakRef()); // Balanced by deref() in destructor.
-#else
-        return std::bit_cast<uint32_t>(&calculationValue.leakRef()); // Balanced by deref() in destructor.
-#endif
-    }
-
-    static Ref<CalculationValue> decodedCalculationValue(uint64_t value)
-    {
-#if CPU(ADDRESS64)
-        Ref<CalculationValue> calculation = *std::bit_cast<CalculationValue*>(value & calculationValueMask);
-#else
-        Ref<CalculationValue> calculation = *std::bit_cast<CalculationValue*>(static_cast<uint32_t>(value & calculationValueMask));
-#endif
-        return calculation;
-    }
-
-    static constexpr uint64_t encodedLength(Length<R> length)
-    {
-        return static_cast<uint64_t>(std::bit_cast<uint32_t>(length.value)) | (static_cast<uint64_t>(length.quirk) << lengthQuirkShift);
-    }
-
-    static constexpr Length<R> decodedLength(uint64_t value)
-    {
-        return { std::bit_cast<float>(static_cast<uint32_t>(value & lengthValueMask)), static_cast<bool>(value >> lengthQuirkShift) };
-    }
-
-    static constexpr uint64_t encodedPercentage(Percentage<R> percentage)
-    {
-        return static_cast<uint64_t>(std::bit_cast<uint32_t>(percentage.value));
-    }
-
-    static constexpr Percentage<R> decodedPercentage(uint64_t value)
-    {
-        return { std::bit_cast<float>(static_cast<uint32_t>(value & percentageMask)) };
-    }
-
-    static Ref<CalculationValue> makeCalculationValue(Calculation::Child&& root)
-    {
-        return CalculationValue::create(
-            Calculation::Tree {
-                .root = WTFMove(root),
-                .category = Calculation::Category::LengthPercentage,
-                .range = { R.min, R.max }
-            }
-        );
-    }
-
-    uint64_t m_data { 0 };
+    bool operator==(const AnglePercentage<R>&) const = default;
 };
 
 template<CSS::Range R = CSS::All> struct LengthPercentage {
@@ -828,7 +492,7 @@ template<CSS::Range R = CSS::All> struct LengthPercentage {
     using Raw = WebCore::CSS::LengthPercentageRaw<R>;
     using Dimension = Length<R>;
 
-    LengthPercentageValue<R> value;
+    PrimitivePercentageDimension<Length<R>> value;
 
     LengthPercentage(Length<R> length)
         : value { WTFMove(length) }
@@ -853,74 +517,65 @@ template<CSS::Range R = CSS::All> struct LengthPercentage {
     // CalculatedValue is intentionally not part of IPCData.
     using IPCData = std::variant<Length<R>, Percentage<R>>;
     LengthPercentage(IPCData&& data)
-        : value { WTF::switchOn(data, [&](auto&& data) -> LengthPercentageValue<R> { return { data }; }) }
+        : value { WTF::switchOn(data, [&](auto&& data) -> PrimitivePercentageDimension<Length<R>> { return { data }; }) }
     {
     }
 
     IPCData ipcData() const
     {
         switch (value.tag()) {
-        case LengthPercentageValue<R>::Tag::Length:
-            return value.asLength();
-        case LengthPercentageValue<R>::Tag::Percentage:
-            return value.asPercentage();
-        case LengthPercentageValue<R>::Tag::CalculationValue:
+        case PrimitivePercentageDimension<Length<R>>::Tag::Percentage:
+            return asPercentage();
+        case PrimitivePercentageDimension<Length<R>>::Tag::Dimension:
+            return asLength();
+        case PrimitivePercentageDimension<Length<R>>::Tag::CalculationValue:
             ASSERT_NOT_REACHED();
             return Length<R> { 0 };
         }
         WTF_UNREACHABLE();
     }
 
-    bool hasQuirk() const { return value.tag() == LengthPercentageValue<R>::Tag::Length && value.asLength().hasQuirk(); }
+    bool isPercentage() const { return value.isPercentage(); }
+    bool isLength() const { return value.isDimension(); }
+    bool isCalculationValue() const { return value.isCalculationValue(); }
 
-    constexpr bool operator==(const LengthPercentage<R>&) const = default;
+    auto asPercentage() const -> Percentage<R> { return value.asPercentage(); }
+    auto asLength() const -> Length<R> { return value.asDimension(); }
+    auto asCalculationValue() const -> Ref<CalculationValue> { return value.asCalculationValue(); }
+
+    bool isZero() const { return value.isZero(); }
+
+    bool operator==(const LengthPercentage<R>&) const = default;
 };
-
-template<auto R> LengthPercentage<R> canonicalizeNoConversionDataRequired(const CSS::LengthPercentageRaw<R>& raw)
-{
-    if (raw.type == CSSUnitType::CSS_PERCENTAGE)
-        return { canonicalizeNoConversionDataRequired(CSS::PercentageRaw<R> { raw.value }) };
-    return { canonicalizeNoConversionDataRequired(CSS::LengthRaw<R> { raw.type, raw.value }) };
-}
-
-template<auto R> LengthPercentage<R> canonicalize(const CSS::LengthPercentageRaw<R>& raw, const CSSToLengthConversionData& conversionData)
-{
-    if (raw.type == CSSUnitType::CSS_PERCENTAGE)
-        return { canonicalize(CSS::PercentageRaw<R> { raw.value }, conversionData) };
-    return { canonicalize(CSS::LengthRaw<R> { raw.type, raw.value }, conversionData) };
-}
-
-// MARK: - Conversion to `Calculation::Child`.
-
-inline Calculation::Child copyCalculation(Ref<CalculationValue> value)
-{
-    return value->copyRoot();
-}
-
-template<auto R> Calculation::Child copyCalculation(const Number<R>& value)
-{
-    return Calculation::number(value.value);
-}
-
-template<auto R> Calculation::Child copyCalculation(const Percentage<R>& value)
-{
-    return Calculation::percentage(value.value);
-}
-
-template<StyleNumericPrimitive Dimension> Calculation::Child copyCalculation(const Dimension& value)
-{
-    return Calculation::dimension(value.value);
-}
-
-template<StylePercentageDimension PercentageDimension> Calculation::Child copyCalculation(const PercentageDimension& value)
-{
-    return value.value.switchOn([](const auto& value) { return copyCalculation(value); });
-}
 
 // MARK: Additional Common Type and Groupings
 
 // NOTE: This is spelled with an explicit "Or" to distinguish it from types like AnglePercentage/LengthPercentage that have behavior distinctions beyond just being a union of the two types (specifically, calc() has specific behaviors for those types).
-using PercentageOrNumber = std::variant<Percentage<>, Number<>>;
+template<CSS::Range R = CSS::All> using NumberOrPercentage = std::variant<Number<R>, Percentage<R>>;
+
+template<CSS::Range R = CSS::All> struct NumberOrPercentageResolvedToNumber {
+    double value { 0 };
+
+    constexpr NumberOrPercentageResolvedToNumber(double value)
+        : value { value }
+    {
+    }
+
+    constexpr NumberOrPercentageResolvedToNumber(Number<R> number)
+        : value { number.value }
+    {
+    }
+
+    constexpr NumberOrPercentageResolvedToNumber(Percentage<R> percentage)
+        : value { percentage.value / 100.0 }
+    {
+    }
+
+    constexpr bool operator==(const NumberOrPercentageResolvedToNumber<R>&) const = default;
+    constexpr bool operator==(double other) const { return value == other; };
+};
+
+// MARK: - Standard type aliases (used by some scripts that require non-template type names)
 
 // Standard Numbers
 using NumberAll = Number<CSS::All>;
@@ -940,78 +595,13 @@ using LengthPercentageNonnegative = LengthPercentage<CSS::Nonnegative>;
 // Standard Percentages
 using Percentage0To100 = LengthPercentage<CSS::Range{0,100}>;
 
-// Standing Points
+// Standard Points
 using LengthPercentagePointAll = Point<LengthPercentageAll>;
 using LengthPercentagePointNonnegative = Point<LengthPercentageNonnegative>;
 
-// Standing Sizes
+// Standard Sizes
 using LengthPercentageSizeAll = Size<LengthPercentageAll>;
 using LengthPercentageSizeNonnegative = Size<LengthPercentageNonnegative>;
 
 } // namespace Style
-
-namespace CSS {
-namespace TypeTransform {
-
-// MARK: - Type transforms
-
-namespace Type {
-
-// MARK: CSS type -> Style type mapping (Style type -> CSS type directly available via typename StyleType::CSS)
-
-template<typename> struct CSSToStyleMapping;
-template<auto R> struct CSSToStyleMapping<Number<R>> { using Style = Style::Number<R>; };
-template<auto R> struct CSSToStyleMapping<Percentage<R>> { using Style = Style::Percentage<R>; };
-template<auto R> struct CSSToStyleMapping<Angle<R>> { using Style = Style::Angle<R>; };
-template<auto R> struct CSSToStyleMapping<Length<R>> { using Style = Style::Length<R>; };
-template<auto R> struct CSSToStyleMapping<Time<R>> { using Style = Style::Time<R>; };
-template<auto R> struct CSSToStyleMapping<Frequency<R>> { using Style = Style::Frequency<R>; };
-template<auto R> struct CSSToStyleMapping<Resolution<R>> { using Style = Style::Resolution<R>; };
-template<auto R> struct CSSToStyleMapping<Flex<R>> { using Style = Style::Flex<R>; };
-template<auto R> struct CSSToStyleMapping<AnglePercentage<R>> { using Style = Style::AnglePercentage<R>; };
-template<auto R> struct CSSToStyleMapping<LengthPercentage<R>> { using Style = Style::LengthPercentage<R>; };
-template<> struct CSSToStyleMapping<None> { using Style = Style::None; };
-
-// MARK: Transform CSS type -> Style type.
-
-// Transform `css1`  -> `style1`
-template<typename T> struct CSSToStyleLazy {
-    using type = typename CSSToStyleMapping<T>::Style;
-};
-template<typename T> using CSSToStyle = typename CSSToStyleLazy<T>::type;
-
-// MARK: Transform Raw type -> Style type.
-
-// Transform `raw1`  -> `style1`
-template<typename T> struct RawToStyleLazy {
-    using type = typename CSSToStyleMapping<typename RawToCSSMapping<T>::CSS>::Style;
-};
-template<typename T> using RawToStyle = typename RawToStyleLazy<T>::type;
-
-} // namespace Type
-
-namespace List {
-
-// MARK: - List transforms
-
-// MARK: Transform CSS type list -> Style type list.
-
-// Transform `brigand::list<css1, css2, ...>`  -> `brigand::list<style1, style2, ...>`
-template<typename TypeList> struct CSSToStyleLazy {
-    using type = brigand::transform<TypeList, Type::CSSToStyleLazy<brigand::_1>>;
-};
-template<typename TypeList> using CSSToStyle = typename CSSToStyleLazy<TypeList>::type;
-
-// MARK: Transform Raw type list -> Style type list.
-
-// Transform `brigand::list<raw1, raw2, ...>`  -> `brigand::list<style1, style2, ...>`
-template<typename TypeList> struct RawToStyleLazy {
-    using type = brigand::transform<TypeList, Type::RawToStyleLazy<brigand::_1>>;
-};
-template<typename TypeList> using RawToStyle = typename RawToStyleLazy<TypeList>::type;
-
-} // namespace List
-} // namespace TypeTransform
-
-} // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
@@ -239,7 +239,7 @@ private:
         return ArcToSegment {
             .rx = radius.width(),
             .ry = radius.height(),
-            .angle = arcCommand.rotation.value,
+            .angle = narrowPrecisionToFloat(arcCommand.rotation.value),
             .largeArc = std::holds_alternative<Large>(arcCommand.arcSize),
             .sweep = std::holds_alternative<Cw>(arcCommand.arcSweep),
             .targetPoint = evaluate(arcCommand.toBy, m_boxSize)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3056,26 +3056,24 @@ class WebCore::SVGPathByteStream {
 
 header: <WebCore/StylePrimitiveNumericTypes.h>
 [CustomHeader, Nested] struct WebCore::Style::Angle<WebCore::CSS::Nonnegative> {
-    float value;
+    double value;
 };
 [CustomHeader, Nested] struct WebCore::Style::Angle<WebCore::CSS::All> {
-    float value;
+    double value;
 };
 
 [CustomHeader, Nested] struct WebCore::Style::Length<WebCore::CSS::Nonnegative> {
     float value;
-    bool quirk;
 };
 [CustomHeader, Nested] struct WebCore::Style::Length<WebCore::CSS::All> {
     float value;
-    bool quirk;
 };
 
 [CustomHeader, Nested] struct WebCore::Style::Percentage<WebCore::CSS::Nonnegative> {
-    float value;
+    double value;
 };
 [CustomHeader, Nested] struct WebCore::Style::Percentage<WebCore::CSS::All> {
-    float value;
+    double value;
 };
 
 [CustomHeader, Nested] struct WebCore::Style::LengthPercentage<WebCore::CSS::All> {
@@ -3132,10 +3130,10 @@ header: <WebCore/StylePosition.h>
     WebCore::Style::Point<WebCore::Style::LengthPercentageAll> value;
 };
 [CustomHeader, Nested] struct WebCore::Style::TwoComponentPositionHorizontal {
-    WebCore::Style::LengthPercentageAll offset;
+    WebCore::Style::LengthPercentageAll value;
 };
 [CustomHeader, Nested] struct WebCore::Style::TwoComponentPositionVertical {
-    WebCore::Style::LengthPercentageAll offset;
+    WebCore::Style::LengthPercentageAll value;
 };
 
 header: <WebCore/StyleGradient.h>


### PR DESCRIPTION
#### c5533d84fff15c634b1f1ea051cea8fa20fdf965
<pre>
Various CSS/Style value type improvements
<a href="https://bugs.webkit.org/show_bug.cgi?id=283463">https://bugs.webkit.org/show_bug.cgi?id=283463</a>

Reviewed by NOBODY (OOPS!).

WIP.

* Source/WTF/wtf/text/TextStream.h:
(WTF::streamSpaceSeparatedForTupleLike):
(WTF::streamCommaSeparatedForTupleLike):
* Source/WebCore/Headers.cmake:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSBasicShapeValue.cpp:
(WebCore::CSSBasicShapeValue::customCollectComputedStyleDependencies const):
(WebCore::CSSBasicShapeValue::addDerivedHash const):
* Source/WebCore/css/CSSBasicShapeValue.h:
* Source/WebCore/css/CSSColorSchemeValue.cpp:
(WebCore::CSSColorSchemeValue::customCollectComputedStyleDependencies const):
(WebCore::CSSColorSchemeValue::addDerivedHash const):
* Source/WebCore/css/CSSColorSchemeValue.h:
* Source/WebCore/css/CSSFontFaceSet.cpp:
* Source/WebCore/css/CSSGradientValue.cpp:
(WebCore::CSSGradientValue::customCollectComputedStyleDependencies const):
(WebCore::CSSGradientValue::addDerivedHash const):
* Source/WebCore/css/CSSGradientValue.h:
* Source/WebCore/css/CSSPathValue.cpp:
(WebCore::CSSPathValue::customCollectComputedStyleDependencies const):
(WebCore::CSSPathValue::addDerivedHash const):
* Source/WebCore/css/CSSPathValue.h:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::customCollectComputedStyleDependencies const):
(WebCore::CSSPrimitiveValue::collectComputedStyleDependencies const): Deleted.
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/CSSRayValue.cpp:
(WebCore::CSSRayValue::customCollectComputedStyleDependencies const):
(WebCore::CSSRayValue::addDerivedHash const):
* Source/WebCore/css/CSSRayValue.h:
* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::collectComputedStyleDependencies const):
(WebCore::CSSValue::canResolveDependenciesWithConversionData const):
(WebCore::CSSValue::canResolveDependenciesWithConversionData): Deleted.
* Source/WebCore/css/CSSValue.h:
(WebCore::CSSValue::customCollectComputedStyleDependencies const):
* Source/WebCore/css/CSSValueList.cpp:
(WebCore::CSSValueContainingVector::customCollectComputedStyleDependencies const):
* Source/WebCore/css/CSSValueList.h:
* Source/WebCore/css/ComputedStyleDependencies.cpp: Copied from Source/WebCore/css/values/primitives/CSSNone.cpp.
(WebCore::ComputedStyleDependencies::canResolveDependenciesWithConversionData const):
* Source/WebCore/css/ComputedStyleDependencies.h:
* Source/WebCore/css/calc/CSSCalcTree+Copy.h:
* Source/WebCore/css/color/CSSColorConversion+Normalize.h:
(WebCore::normalizeAndClampNumericComponentsIntoCanonicalRepresentation):
(WebCore::normalizeNumericComponentsIntoCanonicalRepresentation):
* Source/WebCore/css/color/CSSColorDescriptors.h:
* Source/WebCore/css/color/CSSColorMixSerialization.cpp:
(WebCore::isCalc):
(WebCore::is50Percent):
(WebCore::sumTo100Percent):
(WebCore::subtractFrom100Percent):
* Source/WebCore/css/color/CSSRelativeColorResolver.h:
* Source/WebCore/css/color/CSSUnresolvedRelativeColor.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+AngleDefinitions.h:
(WebCore::CSSPropertyParserHelpers::AngleValidator::isValid):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h:
(WebCore::CSSPropertyParserHelpers::CSSPrimitiveValueResolverBase::resolve):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp:
(WebCore::CSSPropertyParserHelpers::hasNonCalculatedZeroPercentage):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
(WebCore::CSSPropertyParserHelpers::resolveToCSSPrimitiveValue):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+FrequencyDefinitions.h:
(WebCore::CSSPropertyParserHelpers::FrequencyValidator::isValid):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp:
(WebCore::CSSPropertyParserHelpers::consumeDeprecatedGradientPositionComponent):
(WebCore::CSSPropertyParserHelpers::consumeDeprecatedGradientColorStop):
(WebCore::CSSPropertyParserHelpers::consumePrefixedLinearGradient):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Integer.cpp:
(WebCore::CSSPropertyParserHelpers::consumeIntegerType):
(WebCore::CSSPropertyParserHelpers::consumeInteger):
(WebCore::CSSPropertyParserHelpers::consumeNonNegativeInteger):
(WebCore::CSSPropertyParserHelpers::consumePositiveInteger):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h:
(WebCore::CSSPropertyParserHelpers::NumberConsumerForIntegerValues::consume):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ResolutionDefinitions.h:
(WebCore::CSSPropertyParserHelpers::ResolutionValidator::isValid):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.cpp:
(WebCore::CSSPropertyParserHelpers::toBasicShape):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+TimeDefinitions.h:
(WebCore::CSSPropertyParserHelpers::TimeValidator::isValid):
* Source/WebCore/css/values/CSSValueTypes.cpp:
* Source/WebCore/css/values/CSSValueTypes.h:
(WebCore::CSS::SpaceSeparatedArray::begin const):
(WebCore::CSS::SpaceSeparatedArray::end const):
(WebCore::CSS::SpaceSeparatedArray::rbegin const):
(WebCore::CSS::SpaceSeparatedArray::rend const):
(WebCore::CSS::SpaceSeparatedArray::isEmpty const):
(WebCore::CSS::SpaceSeparatedArray::size const):
(WebCore::CSS::SpaceSeparatedArray::operator[] const):
(WebCore::CSS::CommaSeparatedArray::begin const):
(WebCore::CSS::CommaSeparatedArray::end const):
(WebCore::CSS::CommaSeparatedArray::rbegin const):
(WebCore::CSS::CommaSeparatedArray::rend const):
(WebCore::CSS::CommaSeparatedArray::isEmpty const):
(WebCore::CSS::CommaSeparatedArray::size const):
(WebCore::CSS::CommaSeparatedArray::operator[] const):
(WebCore::CSS::addHash):
(WebCore::CSS::hash):
(WebCore::CSS::hashTupleLike):
(WebCore::CSS::hashRangeLike):
(WebCore::CSS::Hash&lt;CSSType&gt;::operator()):
(WebCore::CSS::Hash&lt;std::optional&lt;CSSType&gt;&gt;::operator()):
(WebCore::CSS::Hash&lt;Markable&lt;CSSType&gt;&gt;::operator()):
(WebCore::CSS::Hash&lt;Constant&lt;C&gt;&gt;::operator()):
(WebCore::CSS::Hash&lt;CustomIdentifier&gt;::operator()):
(WebCore::CSS::Hash&lt;Point&lt;CSSType&gt;&gt;::operator()):
(WebCore::CSS::Hash&lt;Size&lt;CSSType&gt;&gt;::operator()):
(WebCore::CSS::Hash&lt;RectEdges&lt;CSSType&gt;&gt;::operator()):
(WebCore::CSS::Serialize&lt;CSSType&gt;::operator()):
(WebCore::CSS::Serialize&lt;Markable&lt;CSSType&gt;&gt;::operator()):
(WebCore::CSS::collectComputedStyleDependencies):
(WebCore::CSS::collectComputedStyleDependenciesOnRangeLike):
(WebCore::CSS::ComputedStyleDependenciesCollector&lt;CSSType&gt;::operator()):
(WebCore::CSS::ComputedStyleDependenciesCollector&lt;Markable&lt;CSSType&gt;&gt;::operator()):
(WebCore::CSS::CSSValueChildrenVisitor&lt;CSSType&gt;::operator()):
(WebCore::CSS::CSSValueChildrenVisitor&lt;Markable&lt;CSSType&gt;&gt;::operator()):
(WebCore::CSS::operator&lt;&lt;):
* Source/WebCore/css/values/images/CSSGradient.cpp:
(WebCore::CSS::Serialize&lt;GradientDeprecatedColorStop&gt;::operator):
(WebCore::CSS::hashColorStop):
(WebCore::CSS::Hash&lt;GradientAngularColorStop&gt;::operator):
(WebCore::CSS::Hash&lt;GradientLinearColorStop&gt;::operator):
(WebCore::CSS::Hash&lt;GradientDeprecatedColorStop&gt;::operator):
(WebCore::CSS::Hash&lt;GradientColorInterpolationMethod&gt;::operator):
(WebCore::CSS::Serialize&lt;LinearGradient&gt;::operator):
(WebCore::CSS::Serialize&lt;ConicGradient::GradientBox&gt;::operator):
* Source/WebCore/css/values/images/CSSGradient.h:
* Source/WebCore/css/values/primitives/CSSNone.cpp:
* Source/WebCore/css/values/primitives/CSSNone.h:
(WebCore::CSS::Hash&lt;NoneRaw&gt;::operator()):
(WebCore::CSS::Hash&lt;None&gt;::operator()):
(WebCore::CSS::CSSValueChildrenVisitor&lt;NoneRaw&gt;::operator()):
(WebCore::CSS::CSSValueChildrenVisitor&lt;None&gt;::operator()):
* Source/WebCore/css/values/primitives/CSSPosition.cpp:
(WebCore::CSS::isCenterPosition):
(WebCore::CSS::Serialize&lt;TwoComponentPositionHorizontal&gt;::operator): Deleted.
(WebCore::CSS::ComputedStyleDependenciesCollector&lt;TwoComponentPositionHorizontal&gt;::operator): Deleted.
(WebCore::CSS::CSSValueChildrenVisitor&lt;TwoComponentPositionHorizontal&gt;::operator): Deleted.
(WebCore::CSS::Serialize&lt;TwoComponentPositionVertical&gt;::operator): Deleted.
(WebCore::CSS::ComputedStyleDependenciesCollector&lt;TwoComponentPositionVertical&gt;::operator): Deleted.
(WebCore::CSS::CSSValueChildrenVisitor&lt;TwoComponentPositionVertical&gt;::operator): Deleted.
(WebCore::CSS::Serialize&lt;Position&gt;::operator): Deleted.
(WebCore::CSS::ComputedStyleDependenciesCollector&lt;Position&gt;::operator): Deleted.
(WebCore::CSS::CSSValueChildrenVisitor&lt;Position&gt;::operator): Deleted.
* Source/WebCore/css/values/primitives/CSSPosition.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h:
(WebCore::CSS::clampToRange):
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueCreation.h:
(WebCore::CSS::CSSValueCreation&lt;PrimitiveNumeric&lt;RawType&gt;&gt;::operator()):
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueVisitation.h:
(WebCore::CSS::CSSValueChildrenVisitor&lt;PrimitiveNumeric&lt;RawType&gt;&gt;::operator()):
(WebCore::CSS::CSSValueChildrenVisitor&lt;NumberOrPercentageResolvedToNumber&lt;R&gt;&gt;::operator()):
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.cpp: Copied from Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.cpp.
(WebCore::CSS::canonicalizeAngle):
(WebCore::CSS::canonicalizeLengthNoConversionDataRequired):
(WebCore::CSS::canonicalizeLength):
(WebCore::CSS::clampLengthToAllowedLimits):
(WebCore::CSS::canonicalizeAndClampLengthNoConversionDataRequired):
(WebCore::CSS::canonicalizeAndClampLength):
(WebCore::CSS::canonicalizeTime):
(WebCore::CSS::canonicalizeFrequency):
(WebCore::CSS::canonicalizeResolution):
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.h: Copied from Source/WebCore/css/values/shapes/CSSPathFunction.h.
(WebCore::CSS::canonicalize):
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+ComputedStyleDependencies.h:
(WebCore::CSS::ComputedStyleDependenciesCollector&lt;PrimitiveNumeric&lt;RawType&gt;&gt;::operator()):
(WebCore::CSS::ComputedStyleDependenciesCollector&lt;NumberOrPercentageResolvedToNumber&lt;R&gt;&gt;::operator()):
(WebCore::CSS::ComputedStyleDependenciesCollector&lt;Symbol&gt;::operator()): Deleted.
(WebCore::CSS::ComputedStyleDependenciesCollector&lt;SymbolRaw&gt;::operator()): Deleted.
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+EvaluateCalc.h:
(WebCore::CSS::requiresConversionData):
(WebCore::CSS::evaluateCalcIfNoConversionDataRequired):
(WebCore::CSS::isUnevaluatedCalc):
(WebCore::CSS::simplifyUnevaluatedCalc):
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Hashing.h: Copied from Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h.
(WebCore::CSS::Hash&lt;RawType&gt;::operator()):
(WebCore::CSS::Hash&lt;UnevaluatedCalc&lt;RawType&gt;&gt;::operator()):
(WebCore::CSS::Hash&lt;PrimitiveNumeric&lt;RawType&gt;&gt;::operator()):
(WebCore::CSS::Hash&lt;NumberOrPercentageResolvedToNumber&lt;R&gt;&gt;::operator()):
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.cpp:
(WebCore::CSS::Serialize&lt;SymbolRaw&gt;::operator): Deleted.
(WebCore::CSS::Serialize&lt;Symbol&gt;::operator): Deleted.
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h:
(WebCore::CSS::Serialize&lt;RawType&gt;::operator()):
(WebCore::CSS::Serialize&lt;PrimitiveNumeric&lt;RawType&gt;&gt;::operator()):
(WebCore::CSS::Serialize&lt;NumberOrPercentageResolvedToNumber&lt;R&gt;&gt;::operator()):
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.cpp:
(WebCore::CSS::isSupportedUnitForCategory):
(WebCore::CSS::canonicalizeAngle): Deleted.
(WebCore::CSS::canonicalizeLengthNoConversionDataRequired): Deleted.
(WebCore::CSS::canonicalizeLength): Deleted.
(WebCore::CSS::clampLengthToAllowedLimits): Deleted.
(WebCore::CSS::canonicalizeAndClampLengthNoConversionDataRequired): Deleted.
(WebCore::CSS::canonicalizeAndClampLength): Deleted.
(WebCore::CSS::canonicalizeTime): Deleted.
(WebCore::CSS::canonicalizeFrequency): Deleted.
(WebCore::CSS::canonicalizeResolution): Deleted.
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h:
(WebCore::CSS::requires):
(WebCore::CSS::IntegerRaw::IntegerRaw):
(WebCore::CSS::NumberRaw::NumberRaw):
(WebCore::CSS::PercentageRaw::PercentageRaw):
(WebCore::CSS::PrimitiveNumeric::PrimitiveNumeric):
(WebCore::CSS::PrimitiveNumeric::operator=):
(WebCore::CSS::PrimitiveNumeric::~PrimitiveNumeric):
(WebCore::CSS::PrimitiveNumeric::operator== const):
(WebCore::CSS::PrimitiveNumeric::raw const):
(WebCore::CSS::PrimitiveNumeric::calc const):
(WebCore::CSS::PrimitiveNumeric::visit const):
(WebCore::CSS::PrimitiveNumeric::switchOn const):
(WebCore::CSS::PrimitiveNumeric::isKnownZero const):
(WebCore::CSS::PrimitiveNumeric::isKnownNotZero const):
(WebCore::CSS::PrimitiveNumeric::isCalc const):
(WebCore::CSS::PrimitiveNumeric::isSupported):
(WebCore::CSS::PrimitiveNumeric::MarkableTraits::isEmptyValue):
(WebCore::CSS::PrimitiveNumeric::MarkableTraits::emptyValue):
(WebCore::CSS::PrimitiveNumeric::isEmpty const):
(WTF::switchOn):
(WebCore::CSS::Symbol::Symbol): Deleted.
(WebCore::CSS::requiresConversionData): Deleted.
(WebCore::CSS::isUnevaluatedCalc): Deleted.
(WebCore::CSS::simplifyUnevaluatedCalc): Deleted.
* Source/WebCore/css/values/primitives/CSSSymbol.cpp: Copied from Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.cpp.
(WebCore::CSS::Serialize&lt;SymbolRaw&gt;::operator):
(WebCore::CSS::Serialize&lt;Symbol&gt;::operator):
* Source/WebCore/css/values/primitives/CSSSymbol.h: Copied from Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h.
(WebCore::CSS::Symbol::Symbol):
(WebCore::CSS::Hash&lt;SymbolRaw&gt;::operator()):
(WebCore::CSS::Hash&lt;Symbol&gt;::operator()):
(WebCore::CSS::ComputedStyleDependenciesCollector&lt;SymbolRaw&gt;::operator()):
(WebCore::CSS::ComputedStyleDependenciesCollector&lt;Symbol&gt;::operator()):
(WebCore::CSS::CSSValueChildrenVisitor&lt;SymbolRaw&gt;::operator()):
(WebCore::CSS::CSSValueChildrenVisitor&lt;Symbol&gt;::operator()):
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp:
(WebCore::CSS::unevaluatedCalcEvaluate):
(WebCore::CSS::unevaluatedCalcEvaluateNoConversionDataRequired):
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h:
* Source/WebCore/css/values/shapes/CSSPathFunction.cpp:
(WebCore::CSS::Hash&lt;Path::Data&gt;::operator):
* Source/WebCore/css/values/shapes/CSSPathFunction.h:
* Source/WebCore/rendering/shapes/LayoutShape.cpp:
(WebCore::LayoutShape::createShape):
* Source/WebCore/style/StyleResolveForFont.cpp:
(WebCore::Style::fontSizeFromUnresolvedFontSize):
* Source/WebCore/style/values/StyleValueTypes.h:
(WebCore::Style::SpaceSeparatedArray::begin const):
(WebCore::Style::SpaceSeparatedArray::end const):
(WebCore::Style::SpaceSeparatedArray::rbegin const):
(WebCore::Style::SpaceSeparatedArray::rend const):
(WebCore::Style::SpaceSeparatedArray::isEmpty const):
(WebCore::Style::SpaceSeparatedArray::size const):
(WebCore::Style::SpaceSeparatedArray::operator[] const):
(WebCore::Style::CommaSeparatedArray::begin const):
(WebCore::Style::CommaSeparatedArray::end const):
(WebCore::Style::CommaSeparatedArray::rbegin const):
(WebCore::Style::CommaSeparatedArray::rend const):
(WebCore::Style::CommaSeparatedArray::isEmpty const):
(WebCore::Style::CommaSeparatedArray::size const):
(WebCore::Style::CommaSeparatedArray::operator[] const):
(WebCore::Style::ToCSS&lt;StyleType&gt;::operator()):
(WebCore::Style::ToStyle&lt;CSSType&gt;::operator()):
(WebCore::Style::Blending&lt;StyleType&gt;::canBlend):
(WebCore::Style::Blending&lt;StyleType&gt;::blend):
* Source/WebCore/style/values/images/StyleGradient.cpp:
(WebCore::Style::positionFromValue):
(WebCore::Style::createPlatformGradient):
* Source/WebCore/style/values/images/StyleGradient.h:
* Source/WebCore/style/values/primitives/StyleNone.cpp: Copied from Source/WebCore/css/calc/CSSCalcTree+Copy.h.
(WebCore::Style::operator&lt;&lt;):
* Source/WebCore/style/values/primitives/StyleNone.h:
(WebCore::Style::ToCSS&lt;None&gt;::operator()):
* Source/WebCore/style/values/primitives/StylePosition.cpp:
(WebCore::Style::ToCSS&lt;TwoComponentPositionHorizontal&gt;::operator):
(WebCore::Style::ToStyle&lt;CSS::TwoComponentPositionHorizontal&gt;::operator):
(WebCore::Style::ToCSS&lt;TwoComponentPositionVertical&gt;::operator):
(WebCore::Style::ToStyle&lt;CSS::TwoComponentPositionVertical&gt;::operator):
(WebCore::Style::evaluate):
* Source/WebCore/style/values/primitives/StylePosition.h:
(WebCore::Style::Position::Position):
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h:
(WebCore::Style::Blending&lt;LengthPercentage&lt;R&gt;&gt;::blend):
(WebCore::Style::Blending&lt;NumberOrPercentageResolvedToNumber&lt;R&gt;&gt;::canBlend):
(WebCore::Style::Blending&lt;NumberOrPercentageResolvedToNumber&lt;R&gt;&gt;::blend):
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSTypeTransform.h: Added.
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h: Copied from Source/WebCore/css/CSSColorSchemeValue.cpp.
(WebCore::Style::copyCalculation):
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
(WebCore::Style::canonicalizeNoConversionDataRequired):
(WebCore::Style::canonicalize):
(WebCore::Style::ToCSS&lt;Length&lt;R&gt;&gt;::operator()):
(WebCore::Style::ToCSS&lt;NumberOrPercentageResolvedToNumber&lt;R&gt;&gt;::operator()):
(WebCore::Style::ToStyle&lt;CSS::AnglePercentage&lt;R&gt;&gt;::operator()):
(WebCore::Style::ToStyle&lt;CSS::LengthPercentage&lt;R&gt;&gt;::operator()):
(WebCore::Style::ToStyle&lt;CSS::Length&lt;R&gt;&gt;::operator()):
(WebCore::Style::ToStyle&lt;CSS::PrimitiveNumeric&lt;RawType&gt;&gt;::operator()):
(WebCore::Style::ToStyle&lt;CSS::NumberOrPercentageResolvedToNumber&lt;R&gt;&gt;::operator()):
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h:
(WebCore::Style::evaluate):
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h: Added.
(WebCore::Style::operator&lt;&lt;):
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h:
(WebCore::Style::Number::operator== const):
(WebCore::Style::Percentage::operator== const):
(WebCore::Style::Angle::operator== const):
(WebCore::Style::Length::operator== const):
(WebCore::Style::Time::operator== const):
(WebCore::Style::Frequency::operator== const):
(WebCore::Style::Resolution::operator== const):
(WebCore::Style::Flex::operator== const):
(WebCore::Style::PrimitivePercentageDimension::PrimitivePercentageDimension):
(WebCore::Style::PrimitivePercentageDimension::operator=):
(WebCore::Style::PrimitivePercentageDimension::~PrimitivePercentageDimension):
(WebCore::Style::PrimitivePercentageDimension::isDimension const):
(WebCore::Style::PrimitivePercentageDimension::isCalculationValue const):
(WebCore::Style::PrimitivePercentageDimension::asDimension const):
(WebCore::Style::PrimitivePercentageDimension::visit const):
(WebCore::Style::PrimitivePercentageDimension::isZero const):
(WebCore::Style::PrimitivePercentageDimension::operator== const):
(WebCore::Style::PrimitivePercentageDimension::std::max):
(WebCore::Style::PrimitivePercentageDimension::movedFromValue):
(WebCore::Style::PrimitivePercentageDimension::encodedPayload):
(WebCore::Style::PrimitivePercentageDimension::decodedPercentage):
(WebCore::Style::PrimitivePercentageDimension::decodedDimension):
(WebCore::Style::PrimitivePercentageDimension::refCalculationValue):
(WebCore::Style::PrimitivePercentageDimension::derefCalculationValue):
(WebCore::Style::PrimitivePercentageDimension::makeCalculationValue):
(WebCore::Style::AnglePercentage::AnglePercentage):
(WebCore::Style::AnglePercentage::isPercentage const):
(WebCore::Style::AnglePercentage::isAngle const):
(WebCore::Style::AnglePercentage::isCalculationValue const):
(WebCore::Style::AnglePercentage::asPercentage const):
(WebCore::Style::AnglePercentage::asAngle const):
(WebCore::Style::AnglePercentage::asCalculationValue const):
(WebCore::Style::AnglePercentage::isZero const):
(WebCore::Style::LengthPercentage::LengthPercentage):
(WebCore::Style::LengthPercentage::ipcData const):
(WebCore::Style::LengthPercentage::isPercentage const):
(WebCore::Style::LengthPercentage::isLength const):
(WebCore::Style::LengthPercentage::isCalculationValue const):
(WebCore::Style::LengthPercentage::asPercentage const):
(WebCore::Style::LengthPercentage::asLength const):
(WebCore::Style::LengthPercentage::asCalculationValue const):
(WebCore::Style::LengthPercentage::isZero const):
(WebCore::Style::NumberOrPercentageResolvedToNumber::NumberOrPercentageResolvedToNumber):
(WebCore::Style::NumberOrPercentageResolvedToNumber::operator== const):
(WebCore::Style::canonicalizeNoConversionDataRequired): Deleted.
(WebCore::Style::canonicalize): Deleted.
(WebCore::Style::Length::hasQuirk const): Deleted.
(WebCore::Style::AnglePercentageValue::AnglePercentageValue): Deleted.
(WebCore::Style::AnglePercentageValue::operator=): Deleted.
(WebCore::Style::AnglePercentageValue::~AnglePercentageValue): Deleted.
(WebCore::Style::AnglePercentageValue::tag const): Deleted.
(WebCore::Style::AnglePercentageValue::isAngle const): Deleted.
(WebCore::Style::AnglePercentageValue::isPercentage const): Deleted.
(WebCore::Style::AnglePercentageValue::isCalculationValue const): Deleted.
(WebCore::Style::AnglePercentageValue::asAngle const): Deleted.
(WebCore::Style::AnglePercentageValue::asPercentage const): Deleted.
(WebCore::Style::AnglePercentageValue::asCalculationValue const): Deleted.
(WebCore::Style::AnglePercentageValue::visit const): Deleted.
(WebCore::Style::AnglePercentageValue::switchOn const): Deleted.
(WebCore::Style::AnglePercentageValue::isZero const): Deleted.
(WebCore::Style::AnglePercentageValue::std::max): Deleted.
(WebCore::Style::AnglePercentageValue::movedFromValue): Deleted.
(WebCore::Style::AnglePercentageValue::encodedPayload): Deleted.
(WebCore::Style::AnglePercentageValue::encodedTag): Deleted.
(WebCore::Style::AnglePercentageValue::decodedTag): Deleted.
(WebCore::Style::AnglePercentageValue::refCalculationValue): Deleted.
(WebCore::Style::AnglePercentageValue::derefCalculationValue): Deleted.
(WebCore::Style::AnglePercentageValue::encodedCalculationValue): Deleted.
(WebCore::Style::AnglePercentageValue::decodedCalculationValue): Deleted.
(WebCore::Style::AnglePercentageValue::encodedAngle): Deleted.
(WebCore::Style::AnglePercentageValue::decodedAngle): Deleted.
(WebCore::Style::AnglePercentageValue::encodedPercentage): Deleted.
(WebCore::Style::AnglePercentageValue::decodedPercentage): Deleted.
(WebCore::Style::AnglePercentageValue::makeCalculationValue): Deleted.
(WebCore::Style::LengthPercentageValue::LengthPercentageValue): Deleted.
(WebCore::Style::LengthPercentageValue::operator=): Deleted.
(WebCore::Style::LengthPercentageValue::~LengthPercentageValue): Deleted.
(WebCore::Style::LengthPercentageValue::tag const): Deleted.
(WebCore::Style::LengthPercentageValue::isLength const): Deleted.
(WebCore::Style::LengthPercentageValue::isPercentage const): Deleted.
(WebCore::Style::LengthPercentageValue::isCalculationValue const): Deleted.
(WebCore::Style::LengthPercentageValue::asLength const): Deleted.
(WebCore::Style::LengthPercentageValue::asPercentage const): Deleted.
(WebCore::Style::LengthPercentageValue::asCalculationValue const): Deleted.
(WebCore::Style::LengthPercentageValue::visit const): Deleted.
(WebCore::Style::LengthPercentageValue::switchOn const): Deleted.
(WebCore::Style::LengthPercentageValue::isZero const): Deleted.
(WebCore::Style::LengthPercentageValue::std::max): Deleted.
(WebCore::Style::LengthPercentageValue::movedFromValue): Deleted.
(WebCore::Style::LengthPercentageValue::encodedPayload): Deleted.
(WebCore::Style::LengthPercentageValue::encodedTag): Deleted.
(WebCore::Style::LengthPercentageValue::decodedTag): Deleted.
(WebCore::Style::LengthPercentageValue::refCalculationValue): Deleted.
(WebCore::Style::LengthPercentageValue::derefCalculationValue): Deleted.
(WebCore::Style::LengthPercentageValue::encodedCalculationValue): Deleted.
(WebCore::Style::LengthPercentageValue::decodedCalculationValue): Deleted.
(WebCore::Style::LengthPercentageValue::encodedLength): Deleted.
(WebCore::Style::LengthPercentageValue::decodedLength): Deleted.
(WebCore::Style::LengthPercentageValue::encodedPercentage): Deleted.
(WebCore::Style::LengthPercentageValue::decodedPercentage): Deleted.
(WebCore::Style::LengthPercentageValue::makeCalculationValue): Deleted.
(WebCore::Style::LengthPercentage::hasQuirk const): Deleted.
(WebCore::Style::copyCalculation): Deleted.
* Source/WebCore/style/values/shapes/StyleShapeFunction.cpp:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5533d84fff15c634b1f1ea051cea8fa20fdf965

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77509 "64 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30425 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82123 "Failed to checkout and rebase branch from PR 36951") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28791 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4841 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60731 "36 flakes 99 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18731 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50708 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66526 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41009 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48109 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24022 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27114 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/70697 "Found 3 new JSC stress test failures: stress/attribute-custom-accessor.js.dfg-eager, stress/get-by-val-hoist-above-structure.js.ftl-no-cjit-no-inline-validate, wasm.yaml/wasm/modules/wasm-imports-js-exports.js.wasm-no-cjit (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69219 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83498 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/76788 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3329 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68970 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5045 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68235 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12250 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10345 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/99040 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4836 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7651 "Found 3 new failures in css/typedom/transform/CSSRotate.cpp, css/values/primitives/CSSPrimitiveNumericTypes.h and found 2 fixed files: css/CSSValue.cpp, css/typedom/transform/CSSScale.cpp") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21651 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4855 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8290 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6614 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->