### PR TITLE
[CSS] Move nesting selector resolving at parsing time

### DIFF
--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -74,6 +74,7 @@ ExceptionOr<unsigned> CSSGroupingRule::insertRule(const String& ruleString, unsi
         newRule = CSSParserImpl::parseNestedDeclarations(parserContext(), ruleString);
         if (!newRule)
             return Exception { ExceptionCode::SyntaxError };
+
     }
 
     if (newRule->isImportRule() || newRule->isNamespaceRule()) {
@@ -93,6 +94,7 @@ ExceptionOr<unsigned> CSSGroupingRule::insertRule(const String& ruleString, unsi
     CSSStyleSheet::RuleMutationScope mutationScope(this);
 
     m_groupRule->wrapperInsertRule(index, newRule.releaseNonNull());
+    resolveChildSelectors();
 
     m_childRuleCSSOMWrappers.insert(index, RefPtr<CSSRule>());
     return index;

--- a/Source/WebCore/css/CSSRule.h
+++ b/Source/WebCore/css/CSSRule.h
@@ -55,6 +55,7 @@ public:
     bool hasStyleRuleAncestor() const;
     CSSParserEnum::NestedContext nestedContext() const;
     virtual RefPtr<StyleRuleWithNesting> prepareChildStyleRuleForNesting(StyleRule&);
+    virtual void resolveChildSelectors() { };
     virtual void getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>&) { }
 
     WEBCORE_EXPORT ExceptionOr<void> setCssText(const String&);

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -34,6 +34,7 @@
 #include "RuleSet.h"
 #include "StyleProperties.h"
 #include "StyleRule.h"
+#include "wtf/Assertions.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -264,8 +265,15 @@ ExceptionOr<unsigned> CSSStyleRule::insertRule(const String& ruleString, unsigne
         styleSheet->contents().clearHasNestingRulesCache();
 
     downcast<StyleRuleWithNesting>(m_styleRule)->nestedRules().insert(index, newRule.releaseNonNull());
+    resolveChildSelectors();
+
     m_childRuleCSSOMWrappers.insert(index, RefPtr<CSSRule>());
     return index;
+}
+
+void CSSStyleRule::resolveChildSelectors()
+{
+    ASSERT_NOT_REACHED();
 }
 
 ExceptionOr<void> CSSStyleRule::deleteRule(unsigned index)

--- a/Source/WebCore/css/CSSStyleRule.h
+++ b/Source/WebCore/css/CSSStyleRule.h
@@ -68,6 +68,7 @@ private:
     String cssTextInternal(StringBuilder& declarations, StringBuilder& rules) const;
     void reattach(StyleRuleBase&) final;
     void getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>&) final;
+    void resolveChildSelectors() override final;
 
     String generateSelectorText() const;
     Vector<Ref<StyleRuleBase>> nestedRules() const;

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -374,9 +374,9 @@ StyleRuleWithNesting::StyleRuleWithNesting(StyleRule&& styleRule)
     setType(StyleRuleType::StyleWithNesting);
 }
 
-Ref<StyleRuleWithNesting> StyleRuleWithNesting::create(Ref<StyleProperties>&& properties, bool hasDocumentSecurityOrigin, CSSSelectorList&& selectors, Vector<Ref<StyleRuleBase>>&& nestedRules)
+Ref<StyleRuleWithNesting> StyleRuleWithNesting::create(Ref<StyleProperties>&& properties, bool hasDocumentSecurityOrigin, CSSSelectorList&& originalSelectorList, CSSSelectorList&& resolvedSelectorList, Vector<Ref<StyleRuleBase>>&& nestedRules)
 {
-    return adoptRef(*new StyleRuleWithNesting(WTFMove(properties), hasDocumentSecurityOrigin, WTFMove(selectors), WTFMove(nestedRules)));
+    return adoptRef(*new StyleRuleWithNesting(WTFMove(properties), hasDocumentSecurityOrigin, WTFMove(originalSelectorList), WTFMove(resolvedSelectorList), WTFMove(nestedRules)));
 }
 
 Ref<StyleRuleWithNesting> StyleRuleWithNesting::create(StyleRule&& styleRule)
@@ -384,10 +384,10 @@ Ref<StyleRuleWithNesting> StyleRuleWithNesting::create(StyleRule&& styleRule)
     return adoptRef(*new StyleRuleWithNesting(WTFMove(styleRule)));
 }
 
-StyleRuleWithNesting::StyleRuleWithNesting(Ref<StyleProperties>&& properties, bool hasDocumentSecurityOrigin, CSSSelectorList&& selectors, Vector<Ref<StyleRuleBase>>&& nestedRules)
-    : StyleRule(WTFMove(properties), hasDocumentSecurityOrigin, WTFMove(selectors))
+StyleRuleWithNesting::StyleRuleWithNesting(Ref<StyleProperties>&& properties, bool hasDocumentSecurityOrigin, CSSSelectorList&& originalSelectorList, CSSSelectorList&& resolvedSelectorList, Vector<Ref<StyleRuleBase>>&& nestedRules)
+    : StyleRule(WTFMove(properties), hasDocumentSecurityOrigin, WTFMove(resolvedSelectorList))
     , m_nestedRules(WTFMove(nestedRules))
-    , m_originalSelectorList(selectorList())
+    , m_originalSelectorList(WTFMove(originalSelectorList))
 {
     setType(StyleRuleType::StyleWithNesting);
 }
@@ -406,8 +406,8 @@ StyleRulePage::StyleRulePage(const StyleRulePage& o)
 {
 }
 
-StyleRuleNestedDeclarations::StyleRuleNestedDeclarations(Ref<StyleProperties>&& properties)
-    : StyleRule(WTFMove(properties), false, { })
+StyleRuleNestedDeclarations::StyleRuleNestedDeclarations(Ref<StyleProperties>&& properties, CSSSelectorList&& selectors)
+    : StyleRule(WTFMove(properties), false, WTFMove(selectors))
 {
     setType(StyleRuleType::NestedDeclarations);
 }
@@ -614,9 +614,9 @@ Ref<StyleRuleProperty> StyleRuleProperty::create(Descriptor&& descriptor)
     return adoptRef(*new StyleRuleProperty(WTFMove(descriptor)));
 }
 
-Ref<StyleRuleScope> StyleRuleScope::create(CSSSelectorList&& scopeStart, CSSSelectorList&& scopeEnd, Vector<Ref<StyleRuleBase>>&& rules)
+Ref<StyleRuleScope> StyleRuleScope::create(CSSSelectorList&& originalScopeStart, CSSSelectorList&& originalScopeEnd, CSSSelectorList&& resolvedScopeStart, CSSSelectorList&& resolvedScopeEnd, Vector<Ref<StyleRuleBase>>&& rules)
 {
-    return adoptRef(*new StyleRuleScope(WTFMove(scopeStart), WTFMove(scopeEnd), WTFMove(rules)));
+    return adoptRef(*new StyleRuleScope(WTFMove(originalScopeStart), WTFMove(originalScopeEnd), WTFMove(resolvedScopeStart), WTFMove(resolvedScopeEnd), WTFMove(rules)));
 }
 
 StyleRuleScope::~StyleRuleScope() = default;
@@ -626,10 +626,12 @@ Ref<StyleRuleScope> StyleRuleScope::copy() const
     return adoptRef(*new StyleRuleScope(*this));
 }
 
-StyleRuleScope::StyleRuleScope(CSSSelectorList&& scopeStart, CSSSelectorList&& scopeEnd, Vector<Ref<StyleRuleBase>>&& rules)
+StyleRuleScope::StyleRuleScope(CSSSelectorList&& originalScopeStart, CSSSelectorList&& originalScopeEnd, CSSSelectorList&& resolvedScopeStart, CSSSelectorList&& resolvedScopeEnd, Vector<Ref<StyleRuleBase>>&& rules)
     : StyleRuleGroup(StyleRuleType::Scope, WTFMove(rules))
-    , m_originalScopeStart(WTFMove(scopeStart))
-    , m_originalScopeEnd(WTFMove(scopeEnd))
+    , m_scopeStart(WTFMove(resolvedScopeStart))
+    , m_scopeEnd(WTFMove(resolvedScopeEnd))
+    , m_originalScopeStart(WTFMove(originalScopeStart))
+    , m_originalScopeEnd(WTFMove(originalScopeEnd))
 {
 }
 

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -167,7 +167,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRuleWithNesting);
 class StyleRuleWithNesting final : public StyleRule {
     WTF_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleRuleWithNesting);
 public:
-    static Ref<StyleRuleWithNesting> create(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&& nestedRules);
+    static Ref<StyleRuleWithNesting> create(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&& original, CSSSelectorList&& resolved, Vector<Ref<StyleRuleBase>>&& nestedRules);
     static Ref<StyleRuleWithNesting> create(StyleRule&&);
     Ref<StyleRuleWithNesting> copy() const;
     ~StyleRuleWithNesting();
@@ -182,7 +182,7 @@ protected:
     StyleRuleWithNesting(const StyleRuleWithNesting&);
 
 private:
-    StyleRuleWithNesting(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&& nestedRules);
+    StyleRuleWithNesting(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&& original, CSSSelectorList&& resolved, Vector<Ref<StyleRuleBase>>&& nestedRules);
     StyleRuleWithNesting(StyleRule&&);
 
     Vector<Ref<StyleRuleBase>> m_nestedRules;
@@ -191,13 +191,13 @@ private:
 
 class StyleRuleNestedDeclarations final : public StyleRule {
 public:
-    static Ref<StyleRuleNestedDeclarations> create(Ref<StyleProperties>&& properties) { return adoptRef(*new StyleRuleNestedDeclarations(WTFMove(properties))); }
+    static Ref<StyleRuleNestedDeclarations> create(Ref<StyleProperties>&& properties, CSSSelectorList&& selectors) { return adoptRef(*new StyleRuleNestedDeclarations(WTFMove(properties), WTFMove(selectors))); }
     ~StyleRuleNestedDeclarations() = default;
     Ref<StyleRuleNestedDeclarations> copy() const { return adoptRef(*new StyleRuleNestedDeclarations(*this)); }
 
     String debugDescription() const;
 private:
-    explicit StyleRuleNestedDeclarations(Ref<StyleProperties>&&);
+    explicit StyleRuleNestedDeclarations(Ref<StyleProperties>&&, CSSSelectorList&&);
     StyleRuleNestedDeclarations(const StyleRuleNestedDeclarations&) = default;
 };
 
@@ -409,7 +409,7 @@ private:
 
 class StyleRuleScope final : public StyleRuleGroup {
 public:
-    static Ref<StyleRuleScope> create(CSSSelectorList&&, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&&);
+    static Ref<StyleRuleScope> create(CSSSelectorList&& originalScopeStart, CSSSelectorList&& originalScopeEnd, CSSSelectorList&& resolvedScopeStart, CSSSelectorList&& resolvedScopeEnd, Vector<Ref<StyleRuleBase>>&&);
     ~StyleRuleScope();
     Ref<StyleRuleScope> copy() const;
 
@@ -417,13 +417,11 @@ public:
     const CSSSelectorList& scopeEnd() const { return m_scopeEnd; }
     const CSSSelectorList& originalScopeStart() const { return m_originalScopeStart; }
     const CSSSelectorList& originalScopeEnd() const { return m_originalScopeEnd; }
-    void setScopeStart(CSSSelectorList&& scopeStart) { m_scopeStart = WTFMove(scopeStart); }
-    void setScopeEnd(CSSSelectorList&& scopeEnd) { m_scopeEnd = WTFMove(scopeEnd); }
     WeakPtr<const StyleSheetContents> styleSheetContents() const;
     void setStyleSheetContents(const StyleSheetContents&);
 
 private:
-    StyleRuleScope(CSSSelectorList&&, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&&);
+    StyleRuleScope(CSSSelectorList&& originalScopeStart, CSSSelectorList&& originalScopeEnd, CSSSelectorList&& resolvedScopeStart,CSSSelectorList&& resolvedScopeEnd, Vector<Ref<StyleRuleBase>>&&);
     StyleRuleScope(const StyleRuleScope&);
 
     // Resolved selector lists

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -204,6 +204,7 @@ private:
     // https://bugs.webkit.org/show_bug.cgi?id=265566
     unsigned m_styleRuleNestingLevel { 0 };
     unsigned m_ruleListNestingLevel { 0 };
+    Vector<const CSSSelectorList*> m_selectorListStack;
     Vector<CSSParserEnum::NestedContextType, 16> m_ancestorRuleTypeStack;
     std::optional<CSSParserEnum::NestedContextType> lastAncestorRuleType() const
     {

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -31,8 +31,7 @@ namespace Style {
 class RuleSetBuilder {
 public:
     enum class ShrinkToFit : bool { Enable, Disable };
-    enum class ShouldResolveNesting : bool { No, Yes };
-    RuleSetBuilder(RuleSet&, const MQ::MediaQueryEvaluator&, Resolver* = nullptr, ShrinkToFit = ShrinkToFit::Enable, ShouldResolveNesting = ShouldResolveNesting::No);
+    RuleSetBuilder(RuleSet&, const MQ::MediaQueryEvaluator&, Resolver* = nullptr, ShrinkToFit = ShrinkToFit::Enable);
     ~RuleSetBuilder();
 
     void addRulesFromSheet(const StyleSheetContents&, const MQ::MediaQueryList& sheetQuery = { });
@@ -41,8 +40,8 @@ public:
 private:
     RuleSetBuilder(const MQ::MediaQueryEvaluator&);
 
-    void addStyleRule(StyleRuleWithNesting&);
-    void addStyleRule(StyleRuleNestedDeclarations&);
+    void addStyleRule(const StyleRuleWithNesting&);
+    void addStyleRule(const StyleRuleNestedDeclarations&);
     void addRulesFromSheetContents(const StyleSheetContents&);
     void addChildRules(const Vector<Ref<StyleRuleBase>>&);
     void addChildRule(Ref<StyleRuleBase>);
@@ -89,7 +88,6 @@ private:
     RuleSet::CascadeLayerIdentifier m_currentCascadeLayerIdentifier { 0 };
     Vector<const CSSSelectorList*> m_selectorListStack;
     Vector<CSSParserEnum::NestedContextType> m_ancestorStack;
-    const ShouldResolveNesting m_shouldResolveNesting { ShouldResolveNesting::No };
 
     RuleSet::ContainerQueryIdentifier m_currentContainerQueryIdentifier { 0 };
     RuleSet::ScopeRuleIdentifier m_currentScopeIdentifier { 0 };

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -248,7 +248,7 @@ std::optional<DynamicMediaQueryEvaluationChanges> ScopeRuleSets::evaluateDynamic
 
 void ScopeRuleSets::appendAuthorStyleSheets(const Vector<RefPtr<CSSStyleSheet>>& styleSheets, MQ::MediaQueryEvaluator* mediaQueryEvaluator, InspectorCSSOMWrappers& inspectorCSSOMWrappers)
 {
-    RuleSetBuilder builder(*m_authorStyle, *mediaQueryEvaluator, &m_styleResolver, RuleSetBuilder::ShrinkToFit::Enable, RuleSetBuilder::ShouldResolveNesting::Yes);
+    RuleSetBuilder builder(*m_authorStyle, *mediaQueryEvaluator, &m_styleResolver, RuleSetBuilder::ShrinkToFit::Enable);
 
     RefPtr<CSSStyleSheet> previous;
     for (auto& cssSheet : styleSheets) {


### PR DESCRIPTION
#### 267217e21bc2c472ed9bbb3d52499b695b7a682d
<pre>
[CSS] Move nesting selector resolving at parsing time
<a href="https://bugs.webkit.org/show_bug.cgi?id=270810">https://bugs.webkit.org/show_bug.cgi?id=270810</a>
<a href="https://rdar.apple.com/124398506">rdar://124398506</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleWithNesting::create):
(WebCore::StyleRuleWithNesting::StyleRuleWithNesting):
(WebCore::StyleRuleScope::create):
(WebCore::StyleRuleScope::StyleRuleScope):
* Source/WebCore/css/StyleRule.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::createNestedDeclarationsRule):
(WebCore::CSSParserImpl::consumeScopeRule):
(WebCore::CSSParserImpl::consumeStyleRule):
* Source/WebCore/css/parser/CSSParserImpl.h:
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::RuleSetBuilder):
(WebCore::Style::m_shrinkToFit):
(WebCore::Style::RuleSetBuilder::addChildRule):
(WebCore::Style::RuleSetBuilder::addStyleRule):
(WebCore::Style::m_shouldResolveNesting): Deleted.
* Source/WebCore/style/RuleSetBuilder.h:
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ScopeRuleSets::appendAuthorStyleSheets):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/267217e21bc2c472ed9bbb3d52499b695b7a682d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77515 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82100 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28797 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79632 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4847 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60737 "Found 11 new test failures: css2.1/t0402-syntax-06-f.html fast/css/cssom-insertrule-crash.html imported/w3c/web-platform-tests/css/css-cascade/at-scope-relative-syntax.html imported/w3c/web-platform-tests/css/css-nesting/cssom.html imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting-ident-recovery.html imported/w3c/web-platform-tests/css/css-nesting/invalidation-004.html imported/w3c/web-platform-tests/css/css-nesting/mixed-declarations-rules.html imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-cssom.html imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching.html imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18735 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80582 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50712 "Found 1 new test failure: css2.1/t0402-syntax-06-f.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66530 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41013 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48113 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24026 "Found 9 new test failures: css2.1/t0402-syntax-06-f.html imported/w3c/web-platform-tests/css/css-nesting/cssom.html imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting-ident-recovery.html imported/w3c/web-platform-tests/css/css-nesting/invalidation-004.html imported/w3c/web-platform-tests/css/css-nesting/mixed-declarations-rules.html imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-cssom.html imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching.html imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html imported/w3c/web-platform-tests/css/css-syntax/custom-property-rule-ambiguity.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27121 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69223 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24364 "Found 9 new test failures: css2.1/t0402-syntax-06-f.html imported/w3c/web-platform-tests/css/css-nesting/cssom.html imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting-ident-recovery.html imported/w3c/web-platform-tests/css/css-nesting/invalidation-004.html imported/w3c/web-platform-tests/css/css-nesting/mixed-declarations-rules.html imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-cssom.html imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching.html imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html imported/w3c/web-platform-tests/css/css-syntax/custom-property-rule-ambiguity.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83528 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4895 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3333 "Found 14 new test failures: css2.1/t0402-syntax-06-f.html fast/css/cssom-insertrule-crash.html fast/css/cssom-mutation-stylerule.html imported/w3c/web-platform-tests/css/css-cascade/at-scope-relative-syntax.html imported/w3c/web-platform-tests/css/css-nesting/cssom.html imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting-ident-recovery.html imported/w3c/web-platform-tests/css/css-nesting/invalidation-004.html imported/w3c/web-platform-tests/css/css-nesting/mixed-declarations-rules.html imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-cssom.html imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68999 "Found 9 new test failures: css2.1/t0402-syntax-06-f.html imported/w3c/web-platform-tests/css/css-nesting/cssom.html imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting-ident-recovery.html imported/w3c/web-platform-tests/css/css-nesting/invalidation-004.html imported/w3c/web-platform-tests/css/css-nesting/mixed-declarations-rules.html imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-cssom.html imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching.html imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html imported/w3c/web-platform-tests/css/css-syntax/custom-property-rule-ambiguity.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5051 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66497 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68253 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12254 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10349 "Found 9 new test failures: css2.1/t0402-syntax-06-f.html imported/w3c/web-platform-tests/css/css-nesting/cssom.html imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting-ident-recovery.html imported/w3c/web-platform-tests/css/css-nesting/invalidation-004.html imported/w3c/web-platform-tests/css/css-nesting/mixed-declarations-rules.html imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-cssom.html imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching.html imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html imported/w3c/web-platform-tests/css/css-syntax/custom-property-rule-ambiguity.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4842 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7657 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4861 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8296 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6620 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->