### PR TITLE
Simplify wrapper CSS/Style value types

### DIFF
--- a/Source/WebCore/css/CSSGradientValue.cpp
+++ b/Source/WebCore/css/CSSGradientValue.cpp
@@ -110,18 +110,6 @@ template<> struct StyleImageIsUncacheable<GradientColorInterpolationMethod> {
     constexpr bool operator()(const auto&) { return false; }
 };
 
-template<> struct StyleImageIsUncacheable<TwoComponentPositionHorizontal> {
-    bool operator()(const auto& value) { return styleImageIsUncacheable(value.offset); }
-};
-
-template<> struct StyleImageIsUncacheable<TwoComponentPositionVertical> {
-    bool operator()(const auto& value) { return styleImageIsUncacheable(value.offset); }
-};
-
-template<> struct StyleImageIsUncacheable<Position> {
-    bool operator()(const auto& value) { return styleImageIsUncacheable(value.value); }
-};
-
 template<typename CSSType> struct StyleImageIsUncacheable<GradientColorStop<CSSType>> {
     bool operator()(const auto& value)
     {
@@ -135,6 +123,10 @@ template<typename CSSType> struct StyleImageIsUncacheable<GradientColorStop<CSST
 
 template<typename CSSType> requires (TreatAsTupleLike<CSSType>) struct StyleImageIsUncacheable<CSSType> {
     bool operator()(const auto& value) { return styleImageIsUncacheableOnTupleLike(value); }
+};
+
+template<typename CSSType> requires (TreatAsTypeWrapper<CSSType>) struct StyleImageIsUncacheable<CSSType> {
+    bool operator()(const auto& value) { return styleImageIsUncacheable(get<0>(value)); }
 };
 
 } // namespace (anonymous)

--- a/Source/WebCore/css/values/primitives/CSSPosition.cpp
+++ b/Source/WebCore/css/values/primitives/CSSPosition.cpp
@@ -25,12 +25,6 @@
 #include "config.h"
 #include "CSSPosition.h"
 
-#include "CSSPrimitiveNumericTypes+CSSValueVisitation.h"
-#include "CSSPrimitiveNumericTypes+ComputedStyleDependencies.h"
-#include "CSSPrimitiveNumericTypes+Serialization.h"
-#include "CSSValueKeywords.h"
-#include <wtf/text/StringBuilder.h>
-
 namespace WebCore {
 namespace CSS {
 
@@ -57,57 +51,6 @@ bool isCenterPosition(const Position& position)
             return false;
         }
     );
-}
-
-// MARK: - TwoComponentPositionHorizontal
-
-void Serialize<TwoComponentPositionHorizontal>::operator()(StringBuilder& builder, const TwoComponentPositionHorizontal& component)
-{
-    serializationForCSS(builder, component.offset);
-}
-
-void ComputedStyleDependenciesCollector<TwoComponentPositionHorizontal>::operator()(ComputedStyleDependencies& dependencies, const TwoComponentPositionHorizontal& component)
-{
-    collectComputedStyleDependencies(dependencies, component.offset);
-}
-
-IterationStatus CSSValueChildrenVisitor<TwoComponentPositionHorizontal>::operator()(const Function<IterationStatus(CSSValue&)>& func, const TwoComponentPositionHorizontal& component)
-{
-    return visitCSSValueChildren(func, component.offset);
-}
-
-// MARK: - TwoComponentPositionVertical
-
-void Serialize<TwoComponentPositionVertical>::operator()(StringBuilder& builder, const TwoComponentPositionVertical& component)
-{
-    serializationForCSS(builder, component.offset);
-}
-
-void ComputedStyleDependenciesCollector<TwoComponentPositionVertical>::operator()(ComputedStyleDependencies& dependencies, const TwoComponentPositionVertical& component)
-{
-    collectComputedStyleDependencies(dependencies, component.offset);
-}
-
-IterationStatus CSSValueChildrenVisitor<TwoComponentPositionVertical>::operator()(const Function<IterationStatus(CSSValue&)>& func, const TwoComponentPositionVertical& component)
-{
-    return visitCSSValueChildren(func, component.offset);
-}
-
-// MARK: - Position
-
-void Serialize<Position>::operator()(StringBuilder& builder, const Position& position)
-{
-    serializationForCSS(builder, position.value);
-}
-
-void ComputedStyleDependenciesCollector<Position>::operator()(ComputedStyleDependencies& dependencies, const Position& position)
-{
-    collectComputedStyleDependencies(dependencies, position.value);
-}
-
-IterationStatus CSSValueChildrenVisitor<Position>::operator()(const Function<IterationStatus(CSSValue&)>& func, const Position& position)
-{
-    return visitCSSValueChildren(func, position.value);
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/primitives/CSSPosition.h
+++ b/Source/WebCore/css/values/primitives/CSSPosition.h
@@ -37,12 +37,18 @@ using Center = Constant<CSSValueCenter>;
 
 struct TwoComponentPositionHorizontal {
     std::variant<Left, Right, Center, LengthPercentage<>> offset;
+
     bool operator==(const TwoComponentPositionHorizontal&) const = default;
 };
+DEFINE_CSS_TYPE_WRAPPER(TwoComponentPositionHorizontal, offset);
+
 struct TwoComponentPositionVertical {
     std::variant<Top, Bottom, Center, LengthPercentage<>> offset;
+
     bool operator==(const TwoComponentPositionVertical&) const = default;
 };
+DEFINE_CSS_TYPE_WRAPPER(TwoComponentPositionVertical, offset);
+
 using TwoComponentPosition              = SpaceSeparatedTuple<TwoComponentPositionHorizontal, TwoComponentPositionVertical>;
 
 using FourComponentPositionHorizontal   = SpaceSeparatedTuple<std::variant<Left, Right>, LengthPercentage<>>;
@@ -79,20 +85,9 @@ struct Position {
 
     std::variant<TwoComponentPosition, FourComponentPosition> value;
 };
+DEFINE_CSS_TYPE_WRAPPER(Position, value);
 
 bool isCenterPosition(const Position&);
-
-template<> struct Serialize<TwoComponentPositionHorizontal> { void operator()(StringBuilder&, const TwoComponentPositionHorizontal&); };
-template<> struct ComputedStyleDependenciesCollector<TwoComponentPositionHorizontal> { void operator()(ComputedStyleDependencies&, const TwoComponentPositionHorizontal&); };
-template<> struct CSSValueChildrenVisitor<TwoComponentPositionHorizontal> { IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const TwoComponentPositionHorizontal&); };
-
-template<> struct Serialize<TwoComponentPositionVertical> { void operator()(StringBuilder&, const TwoComponentPositionVertical&); };
-template<> struct ComputedStyleDependenciesCollector<TwoComponentPositionVertical> { void operator()(ComputedStyleDependencies&, const TwoComponentPositionVertical&); };
-template<> struct CSSValueChildrenVisitor<TwoComponentPositionVertical> { IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const TwoComponentPositionVertical&); };
-
-template<> struct Serialize<Position> { void operator()(StringBuilder&, const Position&); };
-template<> struct ComputedStyleDependenciesCollector<Position> { void operator()(ComputedStyleDependencies&, const Position&); };
-template<> struct CSSValueChildrenVisitor<Position> { IterationStatus operator()(const Function<IterationStatus(CSSValue&)>&, const Position&); };
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/shapes/CSSShapeFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSShapeFunction.h
@@ -65,11 +65,8 @@ struct ToPosition {
 
     bool operator==(const ToPosition&) const = default;
 };
-template<size_t I> const auto& get(const ToPosition& value)
-{
-    if constexpr (!I)
-        return value.offset;
-}
+DEFINE_CSS_TYPE_WRAPPER(ToPosition, offset);
+
 template<> struct Serialize<ToPosition> { void operator()(StringBuilder&, const ToPosition&); };
 
 // <by-coordinate-pair> = by <coordinate-pair>
@@ -80,11 +77,8 @@ struct ByCoordinatePair {
 
     bool operator==(const ByCoordinatePair&) const = default;
 };
-template<size_t I> const auto& get(const ByCoordinatePair& value)
-{
-    if constexpr (!I)
-        return value.offset;
-}
+DEFINE_CSS_TYPE_WRAPPER(ByCoordinatePair, offset);
+
 template<> struct Serialize<ByCoordinatePair> { void operator()(StringBuilder&, const ByCoordinatePair&); };
 
 // <relative-control-point> = [<coordinate-pair> [from [start | end | origin]]?]
@@ -136,11 +130,8 @@ struct MoveCommand {
 
     bool operator==(const MoveCommand&) const = default;
 };
-template<size_t I> const auto& get(const MoveCommand& value)
-{
-    if constexpr (!I)
-        return value.toBy;
-}
+DEFINE_CSS_TYPE_WRAPPER(MoveCommand, toBy);
+
 template<> struct Serialize<MoveCommand> { void operator()(StringBuilder&, const MoveCommand&); };
 
 // <line-command> = line [to <position>] | [by <coordinate-pair>]
@@ -154,11 +145,8 @@ struct LineCommand {
 
     bool operator==(const LineCommand&) const = default;
 };
-template<size_t I> const auto& get(const LineCommand& value)
-{
-    if constexpr (!I)
-        return value.toBy;
-}
+DEFINE_CSS_TYPE_WRAPPER(LineCommand, toBy);
+
 template<> struct Serialize<LineCommand> { void operator()(StringBuilder&, const LineCommand&); };
 
 // <horizontal-line-command> = hline [ to [ <length-percentage> | left | center | right | x-start | x-end ] | by <length-percentage> ]
@@ -185,21 +173,9 @@ struct HLineCommand {
 
     bool operator==(const HLineCommand&) const = default;
 };
-template<size_t I> const auto& get(const HLineCommand::To& value)
-{
-    if constexpr (!I)
-        return value.offset;
-}
-template<size_t I> const auto& get(const HLineCommand::By& value)
-{
-    if constexpr (!I)
-        return value.offset;
-}
-template<size_t I> const auto& get(const HLineCommand& value)
-{
-    if constexpr (!I)
-        return value.toBy;
-}
+DEFINE_CSS_TYPE_WRAPPER(HLineCommand::By, offset);
+DEFINE_CSS_TYPE_WRAPPER(HLineCommand::To, offset);
+DEFINE_CSS_TYPE_WRAPPER(HLineCommand, toBy);
 
 template<> struct Serialize<HLineCommand::To> { void operator()(StringBuilder&, const HLineCommand::To&); };
 template<> struct Serialize<HLineCommand::By> { void operator()(StringBuilder&, const HLineCommand::By&); };
@@ -228,21 +204,9 @@ struct VLineCommand {
 
     bool operator==(const VLineCommand&) const = default;
 };
-template<size_t I> const auto& get(const VLineCommand::To& value)
-{
-    if constexpr (!I)
-        return value.offset;
-}
-template<size_t I> const auto& get(const VLineCommand::By& value)
-{
-    if constexpr (!I)
-        return value.offset;
-}
-template<size_t I> const auto& get(const VLineCommand& value)
-{
-    if constexpr (!I)
-        return value.toBy;
-}
+DEFINE_CSS_TYPE_WRAPPER(VLineCommand::By, offset);
+DEFINE_CSS_TYPE_WRAPPER(VLineCommand::To, offset);
+DEFINE_CSS_TYPE_WRAPPER(VLineCommand, toBy);
 
 template<> struct Serialize<VLineCommand::To> { void operator()(StringBuilder&, const VLineCommand::To&); };
 template<> struct Serialize<VLineCommand::By> { void operator()(StringBuilder&, const VLineCommand::By&); };
@@ -294,11 +258,8 @@ template<size_t I> const auto& get(const CurveCommand::By& value)
     if constexpr (I == 2)
         return value.controlPoint2;
 }
-template<size_t I> const auto& get(const CurveCommand& value)
-{
-    if constexpr (!I)
-        return value.toBy;
-}
+DEFINE_CSS_TYPE_WRAPPER(CurveCommand, toBy);
+
 template<> struct Serialize<CurveCommand::To> { void operator()(StringBuilder&, const CurveCommand::To&); };
 template<> struct Serialize<CurveCommand::By> { void operator()(StringBuilder&, const CurveCommand::By&); };
 template<> struct Serialize<CurveCommand> { void operator()(StringBuilder&, const CurveCommand&); };
@@ -343,11 +304,8 @@ template<size_t I> const auto& get(const SmoothCommand::By& value)
     if constexpr (I == 1)
         return value.controlPoint;
 }
-template<size_t I> const auto& get(const SmoothCommand& value)
-{
-    if constexpr (!I)
-        return value.toBy;
-}
+DEFINE_CSS_TYPE_WRAPPER(SmoothCommand, toBy);
+
 template<> struct Serialize<SmoothCommand::To> { void operator()(StringBuilder&, const SmoothCommand::To&); };
 template<> struct Serialize<SmoothCommand::By> { void operator()(StringBuilder&, const SmoothCommand::By&); };
 template<> struct Serialize<SmoothCommand> { void operator()(StringBuilder&, const SmoothCommand&); };
@@ -422,23 +380,11 @@ template<> struct Serialize<Shape> { void operator()(StringBuilder&, const Shape
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(ToPosition, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(ByCoordinatePair, 1)
 CSS_TUPLE_LIKE_CONFORMANCE(RelativeControlPoint, 2)
 CSS_TUPLE_LIKE_CONFORMANCE(AbsoluteControlPoint, 2)
-CSS_TUPLE_LIKE_CONFORMANCE(MoveCommand, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(LineCommand, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(HLineCommand::To, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(HLineCommand::By, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(HLineCommand, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(VLineCommand::To, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(VLineCommand::By, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(VLineCommand, 1)
 CSS_TUPLE_LIKE_CONFORMANCE(CurveCommand::To, 3)
 CSS_TUPLE_LIKE_CONFORMANCE(CurveCommand::By, 3)
-CSS_TUPLE_LIKE_CONFORMANCE(CurveCommand, 1)
 CSS_TUPLE_LIKE_CONFORMANCE(SmoothCommand::To, 2)
 CSS_TUPLE_LIKE_CONFORMANCE(SmoothCommand::By, 2)
-CSS_TUPLE_LIKE_CONFORMANCE(SmoothCommand, 1)
 CSS_TUPLE_LIKE_CONFORMANCE(ArcCommand, 5)
 CSS_TUPLE_LIKE_CONFORMANCE(Shape, 3)

--- a/Source/WebCore/style/values/primitives/StyleNone.h
+++ b/Source/WebCore/style/values/primitives/StyleNone.h
@@ -39,8 +39,10 @@ struct None {
 
 template<> struct ToPrimaryCSSTypeMapping<CSS::NoneRaw> { using type = CSS::None; };
 
+template<> struct ToCSSMapping<None> { using type = CSS::None; };
 template<> struct ToCSS<None> { constexpr auto operator()(const None&, const RenderStyle&) -> CSS::None { return { }; } };
 
+template<> struct ToStyleMapping<CSS::None> { using type = None; };
 template<> struct ToStyle<CSS::None> {
     auto operator()(const CSS::None&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&) -> None { return { }; }
     auto operator()(const CSS::None&, const BuilderState&, const CSSCalcSymbolTable&) -> None { return { }; }

--- a/Source/WebCore/style/values/primitives/StylePosition.cpp
+++ b/Source/WebCore/style/values/primitives/StylePosition.cpp
@@ -34,11 +34,6 @@
 namespace WebCore {
 namespace Style {
 
-auto ToCSS<TwoComponentPositionHorizontal>::operator()(const TwoComponentPositionHorizontal& value, const RenderStyle& style) -> CSS::TwoComponentPositionHorizontal
-{
-    return { .offset = toCSS(value.offset, style) };
-}
-
 auto ToStyle<CSS::TwoComponentPositionHorizontal>::operator()(const CSS::TwoComponentPositionHorizontal& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> TwoComponentPositionHorizontal
 {
     return WTF::switchOn(value.offset,
@@ -55,11 +50,6 @@ auto ToStyle<CSS::TwoComponentPositionHorizontal>::operator()(const CSS::TwoComp
             return TwoComponentPositionHorizontal { .offset = toStyle(value, state, symbolTable) };
         }
     );
-}
-
-auto ToCSS<TwoComponentPositionVertical>::operator()(const TwoComponentPositionVertical& value, const RenderStyle& style) -> CSS::TwoComponentPositionVertical
-{
-    return { .offset = toCSS(value.offset, style) };
 }
 
 auto ToStyle<CSS::TwoComponentPositionVertical>::operator()(const CSS::TwoComponentPositionVertical& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> TwoComponentPositionVertical

--- a/Source/WebCore/style/values/primitives/StylePosition.h
+++ b/Source/WebCore/style/values/primitives/StylePosition.h
@@ -41,22 +41,14 @@ struct TwoComponentPositionHorizontal {
 
     bool operator==(const TwoComponentPositionHorizontal&) const = default;
 };
-template<size_t I> const auto& get(const TwoComponentPositionHorizontal& value)
-{
-    if constexpr (!I)
-        return value.offset;
-}
+DEFINE_STYLE_TYPE_WRAPPER(TwoComponentPositionHorizontal, offset);
 
 struct TwoComponentPositionVertical {
     LengthPercentage<> offset;
 
     bool operator==(const TwoComponentPositionVertical&) const = default;
 };
-template<size_t I> const auto& get(const TwoComponentPositionVertical& value)
-{
-    if constexpr (!I)
-        return value.offset;
-}
+DEFINE_STYLE_TYPE_WRAPPER(TwoComponentPositionVertical, offset);
 
 struct Position  {
     Position(TwoComponentPositionHorizontal&& x, TwoComponentPositionVertical&& y)
@@ -94,12 +86,13 @@ template<size_t I> const auto& get(const Position& position)
 
 // MARK: - Conversion
 
-template<> struct ToCSS<TwoComponentPositionHorizontal> { auto operator()(const TwoComponentPositionHorizontal&, const RenderStyle&) -> CSS::TwoComponentPositionHorizontal; };
+// Specialization is needed for ToStyle to implement resolution of keyword value to <length-percentage>.
+template<> struct ToCSSMapping<TwoComponentPositionHorizontal> { using type = CSS::TwoComponentPositionHorizontal; };
 template<> struct ToStyle<CSS::TwoComponentPositionHorizontal> { auto operator()(const CSS::TwoComponentPositionHorizontal&, const BuilderState&, const CSSCalcSymbolTable&) -> TwoComponentPositionHorizontal; };
-
-template<> struct ToCSS<TwoComponentPositionVertical> { auto operator()(const TwoComponentPositionVertical&, const RenderStyle&) -> CSS::TwoComponentPositionVertical; };
+template<> struct ToCSSMapping<TwoComponentPositionVertical> { using type = CSS::TwoComponentPositionVertical; };
 template<> struct ToStyle<CSS::TwoComponentPositionVertical> { auto operator()(const CSS::TwoComponentPositionVertical&, const BuilderState&, const CSSCalcSymbolTable&) -> TwoComponentPositionVertical; };
 
+// Specialization is needed for both ToCSS and ToStyle due to differences in type structure.
 template<> struct ToCSS<Position> { auto operator()(const Position&, const RenderStyle&) -> CSS::Position; };
 template<> struct ToStyle<CSS::Position> { auto operator()(const CSS::Position&, const BuilderState&, const CSSCalcSymbolTable&) -> Position; };
 
@@ -113,5 +106,3 @@ float evaluate(const TwoComponentPositionVertical&, float referenceHeight);
 } // namespace WebCore
 
 STYLE_TUPLE_LIKE_CONFORMANCE(Position, 2)
-STYLE_TUPLE_LIKE_CONFORMANCE(TwoComponentPositionHorizontal, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(TwoComponentPositionVertical, 1)

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
@@ -948,6 +948,23 @@ using LengthPercentagePointNonnegative = Point<LengthPercentageNonnegative>;
 using LengthPercentageSizeAll = Size<LengthPercentageAll>;
 using LengthPercentageSizeNonnegative = Size<LengthPercentageNonnegative>;
 
+// MARK: CSS type -> Style type mapping
+
+template<auto R> struct ToStyleMapping<CSS::Number<R>>           { using type = Number<R>; };
+template<auto R> struct ToStyleMapping<CSS::Percentage<R>>       { using type = Percentage<R>; };
+template<auto R> struct ToStyleMapping<CSS::Angle<R>>            { using type = Angle<R>; };
+template<auto R> struct ToStyleMapping<CSS::Length<R>>           { using type = Length<R>; };
+template<auto R> struct ToStyleMapping<CSS::Time<R>>             { using type = Time<R>; };
+template<auto R> struct ToStyleMapping<CSS::Frequency<R>>        { using type = Frequency<R>; };
+template<auto R> struct ToStyleMapping<CSS::Resolution<R>>       { using type = Resolution<R>; };
+template<auto R> struct ToStyleMapping<CSS::Flex<R>>             { using type = Flex<R>; };
+template<auto R> struct ToStyleMapping<CSS::AnglePercentage<R>>  { using type = AnglePercentage<R>; };
+template<auto R> struct ToStyleMapping<CSS::LengthPercentage<R>> { using type = LengthPercentage<R>; };
+
+// MARK: Style type mapping -> CSS type mappings
+
+template<StyleNumeric T> struct ToCSSMapping<T>                  { using type = typename T::CSS; };
+
 } // namespace Style
 
 namespace CSS {
@@ -957,26 +974,11 @@ namespace TypeTransform {
 
 namespace Type {
 
-// MARK: CSS type -> Style type mapping (Style type -> CSS type directly available via typename StyleType::CSS)
-
-template<typename> struct CSSToStyleMapping;
-template<auto R> struct CSSToStyleMapping<Number<R>> { using Style = Style::Number<R>; };
-template<auto R> struct CSSToStyleMapping<Percentage<R>> { using Style = Style::Percentage<R>; };
-template<auto R> struct CSSToStyleMapping<Angle<R>> { using Style = Style::Angle<R>; };
-template<auto R> struct CSSToStyleMapping<Length<R>> { using Style = Style::Length<R>; };
-template<auto R> struct CSSToStyleMapping<Time<R>> { using Style = Style::Time<R>; };
-template<auto R> struct CSSToStyleMapping<Frequency<R>> { using Style = Style::Frequency<R>; };
-template<auto R> struct CSSToStyleMapping<Resolution<R>> { using Style = Style::Resolution<R>; };
-template<auto R> struct CSSToStyleMapping<Flex<R>> { using Style = Style::Flex<R>; };
-template<auto R> struct CSSToStyleMapping<AnglePercentage<R>> { using Style = Style::AnglePercentage<R>; };
-template<auto R> struct CSSToStyleMapping<LengthPercentage<R>> { using Style = Style::LengthPercentage<R>; };
-template<> struct CSSToStyleMapping<None> { using Style = Style::None; };
-
 // MARK: Transform CSS type -> Style type.
 
 // Transform `css1`  -> `style1`
 template<typename T> struct CSSToStyleLazy {
-    using type = typename CSSToStyleMapping<T>::Style;
+    using type = typename Style::ToStyleMapping<T>::type;
 };
 template<typename T> using CSSToStyle = typename CSSToStyleLazy<T>::type;
 
@@ -984,7 +986,7 @@ template<typename T> using CSSToStyle = typename CSSToStyleLazy<T>::type;
 
 // Transform `raw1`  -> `style1`
 template<typename T> struct RawToStyleLazy {
-    using type = typename CSSToStyleMapping<typename RawToCSSMapping<T>::CSS>::Style;
+    using type = typename Style::ToStyleMapping<typename RawToCSSMapping<T>::CSS>::type;
 };
 template<typename T> using RawToStyle = typename RawToStyleLazy<T>::type;
 

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.h
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.h
@@ -65,11 +65,7 @@ struct ToPosition {
 
     bool operator==(const ToPosition&) const = default;
 };
-template<size_t I> const auto& get(const ToPosition& value)
-{
-    if constexpr (!I)
-        return value.offset;
-}
+DEFINE_STYLE_TYPE_WRAPPER(ToPosition, offset);
 DEFINE_CSS_STYLE_MAPPING(CSS::ToPosition, ToPosition)
 
 // <by-coordinate-pair> = by <coordinate-pair>
@@ -80,11 +76,7 @@ struct ByCoordinatePair {
 
     bool operator==(const ByCoordinatePair&) const = default;
 };
-template<size_t I> const auto& get(const ByCoordinatePair& value)
-{
-    if constexpr (!I)
-        return value.offset;
-}
+DEFINE_STYLE_TYPE_WRAPPER(ByCoordinatePair, offset);
 DEFINE_CSS_STYLE_MAPPING(CSS::ByCoordinatePair, ByCoordinatePair)
 
 // <relative-control-point> = [<coordinate-pair> [from [start | end | origin]]?]
@@ -150,12 +142,7 @@ struct MoveCommand {
 
     bool operator==(const MoveCommand&) const = default;
 };
-template<size_t I> const auto& get(const MoveCommand& value)
-{
-    if constexpr (!I)
-        return value.toBy;
-}
-
+DEFINE_STYLE_TYPE_WRAPPER(MoveCommand, toBy);
 DEFINE_CSS_STYLE_MAPPING(CSS::MoveCommand, MoveCommand)
 
 // MARK: - Line Command
@@ -171,12 +158,7 @@ struct LineCommand {
 
     bool operator==(const LineCommand&) const = default;
 };
-template<size_t I> const auto& get(const LineCommand& value)
-{
-    if constexpr (!I)
-        return value.toBy;
-}
-
+DEFINE_STYLE_TYPE_WRAPPER(LineCommand, toBy);
 DEFINE_CSS_STYLE_MAPPING(CSS::LineCommand, LineCommand)
 
 // MARK: - HLine Command
@@ -204,22 +186,9 @@ struct HLineCommand {
 
     bool operator==(const HLineCommand&) const = default;
 };
-template<size_t I> const auto& get(const HLineCommand::To& value)
-{
-    if constexpr (!I)
-        return value.offset;
-}
-template<size_t I> const auto& get(const HLineCommand::By& value)
-{
-    if constexpr (!I)
-        return value.offset;
-}
-template<size_t I> const auto& get(const HLineCommand& value)
-{
-    if constexpr (!I)
-        return value.toBy;
-}
-
+DEFINE_CSS_TYPE_WRAPPER(HLineCommand::By, offset);
+DEFINE_CSS_TYPE_WRAPPER(HLineCommand::To, offset);
+DEFINE_CSS_TYPE_WRAPPER(HLineCommand, toBy);
 DEFINE_CSS_STYLE_MAPPING(CSS::HLineCommand::To, HLineCommand::To)
 DEFINE_CSS_STYLE_MAPPING(CSS::HLineCommand::By, HLineCommand::By)
 DEFINE_CSS_STYLE_MAPPING(CSS::HLineCommand, HLineCommand)
@@ -249,22 +218,9 @@ struct VLineCommand {
 
     bool operator==(const VLineCommand&) const = default;
 };
-template<size_t I> const auto& get(const VLineCommand::To& value)
-{
-    if constexpr (!I)
-        return value.offset;
-}
-template<size_t I> const auto& get(const VLineCommand::By& value)
-{
-    if constexpr (!I)
-        return value.offset;
-}
-template<size_t I> const auto& get(const VLineCommand& value)
-{
-    if constexpr (!I)
-        return value.toBy;
-}
-
+DEFINE_CSS_TYPE_WRAPPER(VLineCommand::By, offset);
+DEFINE_CSS_TYPE_WRAPPER(VLineCommand::To, offset);
+DEFINE_CSS_TYPE_WRAPPER(VLineCommand, toBy);
 DEFINE_CSS_STYLE_MAPPING(CSS::VLineCommand::To, VLineCommand::To)
 DEFINE_CSS_STYLE_MAPPING(CSS::VLineCommand::By, VLineCommand::By)
 DEFINE_CSS_STYLE_MAPPING(CSS::VLineCommand, VLineCommand)
@@ -299,11 +255,6 @@ struct CurveCommand {
 
     bool operator==(const CurveCommand&) const = default;
 };
-template<size_t I> const auto& get(const CurveCommand& value)
-{
-    if constexpr (!I)
-        return value.toBy;
-}
 template<size_t I> const auto& get(const CurveCommand::To& value)
 {
     if constexpr (!I)
@@ -322,6 +273,7 @@ template<size_t I> const auto& get(const CurveCommand::By& value)
     if constexpr (I == 2)
         return value.controlPoint2;
 }
+DEFINE_CSS_TYPE_WRAPPER(CurveCommand, toBy);
 
 DEFINE_CSS_STYLE_MAPPING(CSS::CurveCommand, CurveCommand)
 DEFINE_CSS_STYLE_MAPPING(CSS::CurveCommand::To, CurveCommand::To)
@@ -355,11 +307,6 @@ struct SmoothCommand {
 
     bool operator==(const SmoothCommand&) const = default;
 };
-template<size_t I> const auto& get(const SmoothCommand& value)
-{
-    if constexpr (!I)
-        return value.toBy;
-}
 template<size_t I> const auto& get(const SmoothCommand::To& value)
 {
     if constexpr (!I)
@@ -374,6 +321,7 @@ template<size_t I> const auto& get(const SmoothCommand::By& value)
     if constexpr (I == 1)
         return value.controlPoint;
 }
+DEFINE_CSS_TYPE_WRAPPER(SmoothCommand, toBy);
 
 DEFINE_CSS_STYLE_MAPPING(CSS::SmoothCommand, SmoothCommand)
 DEFINE_CSS_STYLE_MAPPING(CSS::SmoothCommand::To, SmoothCommand::To)
@@ -478,23 +426,11 @@ std::optional<Shape> makeShapeFromPath(const Path&);
 } // namespace Style
 } // namespace WebCore
 
-STYLE_TUPLE_LIKE_CONFORMANCE(ToPosition, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(ByCoordinatePair, 1)
 STYLE_TUPLE_LIKE_CONFORMANCE(RelativeControlPoint, 2)
 STYLE_TUPLE_LIKE_CONFORMANCE(AbsoluteControlPoint, 2)
-STYLE_TUPLE_LIKE_CONFORMANCE(MoveCommand, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(LineCommand, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(HLineCommand::To, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(HLineCommand::By, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(HLineCommand, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(VLineCommand::To, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(VLineCommand::By, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(VLineCommand, 1)
 STYLE_TUPLE_LIKE_CONFORMANCE(CurveCommand::To, 3)
 STYLE_TUPLE_LIKE_CONFORMANCE(CurveCommand::By, 3)
-STYLE_TUPLE_LIKE_CONFORMANCE(CurveCommand, 1)
 STYLE_TUPLE_LIKE_CONFORMANCE(SmoothCommand::To, 2)
 STYLE_TUPLE_LIKE_CONFORMANCE(SmoothCommand::By, 2)
-STYLE_TUPLE_LIKE_CONFORMANCE(SmoothCommand, 1)
 STYLE_TUPLE_LIKE_CONFORMANCE(ArcCommand, 5)
 STYLE_TUPLE_LIKE_CONFORMANCE(Shape, 3)


### PR DESCRIPTION
#### f17ff71335b99108331fc593f35f15852c8adc2c
<pre>
Simplify wrapper CSS/Style value types
<a href="https://bugs.webkit.org/show_bug.cgi?id=283495">https://bugs.webkit.org/show_bug.cgi?id=283495</a>

Reviewed by Darin Adler.

Simplify wrapper CSS/Style value types by adding a TreatAsTypeWrapper
as a peer to TreatAsTupleLike and do some adoption.

Also does some related renames for consistency:
  CSSToStyleMapping -&gt; ToStyleMapping
  StyleToCSSMapping -&gt; ToCSSMapping

* Source/WebCore/css/CSSGradientValue.cpp:
* Source/WebCore/css/values/CSSValueTypes.h:
* Source/WebCore/css/values/primitives/CSSPosition.cpp:
* Source/WebCore/css/values/primitives/CSSPosition.h:
* Source/WebCore/css/values/shapes/CSSShapeFunction.h:
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/primitives/StyleNone.h:
* Source/WebCore/style/values/primitives/StylePosition.cpp:
* Source/WebCore/style/values/primitives/StylePosition.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h:
* Source/WebCore/style/values/shapes/StyleShapeFunction.h:

Canonical link: <a href="https://commits.webkit.org/286936@main">https://commits.webkit.org/286936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/794ed6180d76eeaf3a34d6326927a6dff362da49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77517 "17 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82188 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28799 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79634 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4849 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18740 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66534 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/41056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48118 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24030 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27123 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69228 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83507 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4897 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68987 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66501 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68242 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17065 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12258 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10353 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4844 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7659 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4863 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8298 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6622 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->