### PR TITLE
Pack CSS::PrimitiveNumeric

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -958,6 +958,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/values/primitives/CSSNone.h
     css/values/primitives/CSSPosition.h
     css/values/primitives/CSSPrimitiveNumericRange.h
+    css/values/primitives/CSSPrimitiveNumericTypes+EvaluateCalc.h
     css/values/primitives/CSSPrimitiveNumericTypes.h
     css/values/primitives/CSSSymbol.h
     css/values/primitives/CSSUnevaluatedCalc.h

--- a/Source/WebCore/css/CSSGradientValue.cpp
+++ b/Source/WebCore/css/CSSGradientValue.cpp
@@ -50,6 +50,11 @@ template<typename TupleLike> static bool styleImageIsUncacheableOnTupleLike(cons
     return WTF::apply([&](const auto& ...x) { return (styleImageIsUncacheable(x) || ...); }, tupleLike);
 }
 
+template<typename VariantLike> static bool styleImageIsUncacheableOnVariantLike(const VariantLike& variantLike)
+{
+    return WTF::switchOn(variantLike, [](const auto& alternative) { return styleImageIsUncacheable(alternative); });
+}
+
 template<typename CSSType> struct StyleImageIsUncacheable<std::optional<CSSType>> {
     bool operator()(const auto& value) { return value && styleImageIsUncacheable(*value); }
 };
@@ -83,7 +88,7 @@ template<typename... CSSTypes> struct StyleImageIsUncacheable<CommaSeparatedTupl
 };
 
 template<typename... CSSTypes> struct StyleImageIsUncacheable<std::variant<CSSTypes...>> {
-    bool operator()(const auto& value) { return WTF::switchOn(value, [](const auto& alternative) { return styleImageIsUncacheable(alternative); }); }
+    bool operator()(const auto& value) { return styleImageIsUncacheableOnVariantLike(value); }
 };
 
 template<> struct StyleImageIsUncacheable<CSSUnitType> {
@@ -99,7 +104,7 @@ template<RawNumeric CSSType> struct StyleImageIsUncacheable<UnevaluatedCalc<CSST
 };
 
 template<RawNumeric CSSType> struct StyleImageIsUncacheable<PrimitiveNumeric<CSSType>> {
-    constexpr bool operator()(const auto& value) { return styleImageIsUncacheable(value.value); }
+    constexpr bool operator()(const auto& value) { return styleImageIsUncacheableOnVariantLike(value); }
 };
 
 template<CSSValueID C> struct StyleImageIsUncacheable<Constant<C>> {

--- a/Source/WebCore/css/calc/CSSCalcTree+Copy.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+Copy.h
@@ -29,8 +29,6 @@
 namespace WebCore {
 namespace CSSCalc {
 
-struct Tree;
-
 // Makes a copy of the tree.
 Tree copy(const Tree&);
 Anchor::Side copy(const Anchor::Side&);

--- a/Source/WebCore/css/color/CSSColorConversion+Normalize.h
+++ b/Source/WebCore/css/color/CSSColorConversion+Normalize.h
@@ -86,7 +86,7 @@ auto normalizeAndClampNumericComponentsIntoCanonicalRepresentation(const CSS::No
 template<typename Descriptor, unsigned Index, typename Raw>
 auto normalizeAndClampNumericComponentsIntoCanonicalRepresentation(const CSS::PrimitiveNumeric<Raw>& value) -> GetCSSColorParseTypeWithCalcComponentResult<typename Descriptor::Canonical, Index>
 {
-    return WTF::switchOn(value.value,
+    return WTF::switchOn(value,
         [](Raw value) -> GetCSSColorParseTypeWithCalcComponentResult<typename Descriptor::Canonical, Index> {
             return normalizeAndClampNumericComponents<Descriptor, Index>(value);
         },
@@ -147,7 +147,7 @@ auto normalizeNumericComponentsIntoCanonicalRepresentation(const CSS::None& none
 template<typename Descriptor, unsigned Index, typename Raw>
 auto normalizeNumericComponentsIntoCanonicalRepresentation(const CSS::PrimitiveNumeric<Raw>& value) -> GetCSSColorParseTypeWithCalcComponentResult<typename Descriptor::Canonical, Index>
 {
-    return WTF::switchOn(value.value,
+    return WTF::switchOn(value,
         [](Raw value) -> GetCSSColorParseTypeWithCalcComponentResult<typename Descriptor::Canonical, Index> {
             return normalizeNumericComponents<Descriptor, Index>(value);
         },

--- a/Source/WebCore/css/color/CSSColorDescriptors.h
+++ b/Source/WebCore/css/color/CSSColorDescriptors.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CSSPrimitiveNumericTypes+EvaluateCalc.h"
 #include "CSSPrimitiveNumericTypes.h"
 #include "CSSValueKeywords.h"
 #include "Color.h"

--- a/Source/WebCore/css/color/CSSRelativeColorResolver.h
+++ b/Source/WebCore/css/color/CSSRelativeColorResolver.h
@@ -30,8 +30,8 @@
 #include "CSSColorConversion+ToTypedColor.h"
 #include "CSSColorDescriptors.h"
 #include "CSSPrimitiveNumericTypes+SymbolReplacement.h"
-#include "StylePrimitiveNumericTypes+Conversions.h"
 #include "Color.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
 #include <optional>
 
 namespace WebCore {

--- a/Source/WebCore/css/color/CSSUnresolvedRelativeColor.h
+++ b/Source/WebCore/css/color/CSSUnresolvedRelativeColor.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CSSColorDescriptors.h"
+#include "CSSPrimitiveNumericTypes+EvaluateCalc.h"
 #include "CSSRelativeColorResolver.h"
 #include "CSSRelativeColorSerialization.h"
 #include "CSSUnresolvedColorResolutionState.h"

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h
@@ -47,7 +47,7 @@ struct CSSPrimitiveValueResolverBase {
         return CSSPrimitiveValue::create(value.value, value.type);
     }
 
-    template<typename IntType, CSS::Range integerRange> static RefPtr<CSSPrimitiveValue> resolve(CSS::IntegerRaw<IntType, integerRange> value, const CSSCalcSymbolTable&, CSSPropertyParserOptions)
+    template<CSS::Range R, typename IntType> static RefPtr<CSSPrimitiveValue> resolve(CSS::IntegerRaw<R, IntType> value, const CSSCalcSymbolTable&, CSSPropertyParserOptions)
     {
         return CSSPrimitiveValue::createInteger(value.value);
     }
@@ -59,7 +59,7 @@ struct CSSPrimitiveValueResolverBase {
 
     template<typename T> static RefPtr<CSSPrimitiveValue> resolve(CSS::PrimitiveNumeric<T> value, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
     {
-        return WTF::switchOn(WTFMove(value.value), [&](auto&& value) { return resolve(WTFMove(value), symbolTable, options); });
+        return WTF::switchOn(WTFMove(value), [&](auto&& value) { return resolve(WTFMove(value), symbolTable, options); });
     }
 };
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
@@ -563,10 +563,8 @@ static std::optional<CSSUnresolvedColorMix::Component> consumeColorMixComponent(
 
 static bool hasNonCalculatedZeroPercentage(const CSSUnresolvedColorMix::Component& mixComponent)
 {
-    if (auto percentage = mixComponent.percentage) {
-        if (auto* rawValue = percentage->raw())
-            return rawValue->value == 0.0;
-    }
+    if (auto percentage = mixComponent.percentage)
+        return percentage->isKnownZero();
     return false;
 }
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -84,7 +84,7 @@ template<typename Result, typename... Ts> static Result forwardVariantTo(std::va
 
 template<typename T> static Ref<CSSPrimitiveValue> resolveToCSSPrimitiveValue(CSS::PrimitiveNumeric<T>&& primitive)
 {
-    return WTF::switchOn(WTFMove(primitive.value), [](auto&& alternative) { return CSSPrimitiveValueResolverBase::resolve(WTFMove(alternative), { }, { }); }).releaseNonNull();
+    return WTF::switchOn(WTFMove(primitive), [](auto&& alternative) { return CSSPrimitiveValueResolverBase::resolve(WTFMove(alternative), { }, { }); }).releaseNonNull();
 }
 
 static CSSParserMode parserMode(ScriptExecutionContext& context)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
@@ -434,7 +434,7 @@ template<CSSValueID Name> static RefPtr<CSSValue> consumePrefixedLinearGradient(
     };
 
     if (auto angle = MetaConsumer<CSS::Angle<>>::consume(range, context, { }, angleConsumeOptions)) {
-        gradientLine = WTF::switchOn(WTFMove(angle->value), [](auto&& value) -> CSS::PrefixedLinearGradient::GradientLine { return value; });
+        gradientLine = WTF::switchOn(WTFMove(*angle), [](auto&& value) -> CSS::PrefixedLinearGradient::GradientLine { return value; });
         if (!consumeCommaIncludingWhitespace(range))
             return nullptr;
     } else if (auto keywordGradientLine = consumeKeywordGradientLine(range)) {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Integer.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Integer.cpp
@@ -34,25 +34,24 @@
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
 
-template<typename IntType, CSS::Range R>
-static RefPtr<CSSPrimitiveValue> consumeIntegerType(CSSParserTokenRange& range, const CSSParserContext& context)
+template<typename T> static RefPtr<CSSPrimitiveValue> consumeIntegerType(CSSParserTokenRange& range, const CSSParserContext& context)
 {
-    return CSSPrimitiveValueResolver<CSS::Integer<IntType, R>>::consumeAndResolve(range, context, { }, { }, { });
+    return CSSPrimitiveValueResolver<T>::consumeAndResolve(range, context, { }, { }, { });
 }
 
 RefPtr<CSSPrimitiveValue> consumeInteger(CSSParserTokenRange& range, const CSSParserContext& context)
 {
-    return consumeIntegerType<int, CSS::All>(range, context);
+    return consumeIntegerType<CSS::Integer<CSS::All, int>>(range, context);
 }
 
 RefPtr<CSSPrimitiveValue> consumeNonNegativeInteger(CSSParserTokenRange& range, const CSSParserContext& context)
 {
-    return consumeIntegerType<int, CSS::Range{0, CSS::Range::infinity}>(range, context);
+    return consumeIntegerType<CSS::Integer<CSS::Range{0, CSS::Range::infinity}, int>>(range, context);
 }
 
 RefPtr<CSSPrimitiveValue> consumePositiveInteger(CSSParserTokenRange& range, const CSSParserContext& context)
 {
-    return consumeIntegerType<unsigned, CSS::Range{1, CSS::Range::infinity}>(range, context);
+    return consumeIntegerType<CSS::Integer<CSS::Range{1, CSS::Range::infinity}, unsigned>>(range, context);
 }
 
 RefPtr<CSSPrimitiveValue> consumeInteger(CSSParserTokenRange& range, const CSSParserContext& context, const CSS::Range& valueRange)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h
@@ -52,14 +52,14 @@ template<typename Integer, typename Validator> struct NumberConsumerForIntegerVa
         if (!Validator::isValid(numberValue, options))
             return std::nullopt;
 
-        return typename Integer::Raw { clampTo<typename Integer::Raw::IntType>(range.consumeIncludingWhitespace().numericValue()) };
+        return typename Integer::Raw { clampTo<typename Integer::Raw::ValueType>(range.consumeIncludingWhitespace().numericValue()) };
     }
 };
 
-template<typename IntType, CSS::Range R>
-struct ConsumerDefinition<CSS::Integer<IntType, R>> {
-    using FunctionToken = FunctionConsumerForCalcValues<CSS::Integer<IntType, R>>;
-    using NumberToken = NumberConsumerForIntegerValues<CSS::Integer<IntType, R>, IntegerValidator>;
+template<CSS::Range R, typename IntType>
+struct ConsumerDefinition<CSS::Integer<R, IntType>> {
+    using FunctionToken = FunctionConsumerForCalcValues<CSS::Integer<R, IntType>>;
+    using NumberToken = NumberConsumerForIntegerValues<CSS::Integer<R, IntType>, IntegerValidator>;
 };
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/values/images/CSSGradient.cpp
+++ b/Source/WebCore/css/values/images/CSSGradient.cpp
@@ -85,7 +85,7 @@ void Serialize<GradientDeprecatedColorStop>::operator()(StringBuilder& builder, 
 
     WTF::switchOn(stop.position,
         [&](const Number<>& number) {
-            return WTF::switchOn(number.value,
+            return WTF::switchOn(number,
                 [&](NumberRaw<> raw) {
                     appendRaw(stop.color, raw);
                 },
@@ -95,7 +95,7 @@ void Serialize<GradientDeprecatedColorStop>::operator()(StringBuilder& builder, 
             );
         },
         [&](const Percentage<>& percentage) {
-            return WTF::switchOn(percentage.value,
+            return WTF::switchOn(percentage,
                 [&](PercentageRaw<> raw) {
                     appendRaw(stop.color, { raw.value / 100.0 });
                 },
@@ -189,7 +189,7 @@ void Serialize<LinearGradient>::operator()(StringBuilder& builder, const LinearG
 
     WTF::switchOn(gradient.gradientLine,
         [&](const Angle<>& angle) {
-            WTF::switchOn(angle.value,
+            WTF::switchOn(angle,
                 [&](const AngleRaw<>& angleRaw) {
                     if (CSSPrimitiveValue::computeDegrees(angleRaw.type, angleRaw.value) == 180)
                         return;
@@ -399,7 +399,7 @@ void Serialize<ConicGradient::GradientBox>::operator()(StringBuilder& builder, c
     bool wroteSomething = false;
 
     if (gradientBox.angle) {
-        WTF::switchOn(gradientBox.angle->value,
+        WTF::switchOn(*gradientBox.angle,
             [&](const AngleRaw<>& angleRaw) {
                 if (angleRaw.value) {
                     builder.append("from "_s);

--- a/Source/WebCore/css/values/primitives/CSSPosition.cpp
+++ b/Source/WebCore/css/values/primitives/CSSPosition.cpp
@@ -35,7 +35,7 @@ bool isCenterPosition(const Position& position)
             [](auto)   { return false; },
             [](Center) { return true;  },
             [](const LengthPercentage<>& value) {
-                return WTF::switchOn(value.value,
+                return WTF::switchOn(value,
                     [](const LengthPercentageRaw<>& raw) { return raw.type == CSSUnitType::CSS_PERCENTAGE && raw.value == 50.0; },
                     [](const UnevaluatedCalc<LengthPercentageRaw<>>&) { return false; }
                 );

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueCreation.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueCreation.h
@@ -59,7 +59,7 @@ template<RawNumeric RawType> struct CSSValueCreation<UnevaluatedCalc<RawType>> {
 template<RawNumeric RawType> struct CSSValueCreation<PrimitiveNumeric<RawType>> {
     Ref<CSSValue> operator()(const PrimitiveNumeric<RawType>& value)
     {
-        return WTF::switchOn(value.value,
+        return WTF::switchOn(value,
             [](const typename PrimitiveNumeric<RawType>::Raw& raw) {
                 return CSSPrimitiveValue::create(raw.value, raw.type);
             },

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueVisitation.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueVisitation.h
@@ -41,7 +41,7 @@ template<RawNumeric RawType> struct CSSValueChildrenVisitor<RawType> {
 template<RawNumeric RawType> struct CSSValueChildrenVisitor<PrimitiveNumeric<RawType>> {
     IterationStatus operator()(const Function<IterationStatus(CSSValue&)>& func, const PrimitiveNumeric<RawType>& value)
     {
-        return visitCSSValueChildren(func, value.value);
+        return WTF::switchOn(value, [&](const auto& value) { return visitCSSValueChildren(func, value); });
     }
 };
 

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+ComputedStyleDependencies.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+ComputedStyleDependencies.h
@@ -63,7 +63,7 @@ template<auto R> struct ComputedStyleDependenciesCollector<LengthPercentageRaw<R
 template<RawNumeric RawType> struct ComputedStyleDependenciesCollector<PrimitiveNumeric<RawType>> {
     void operator()(ComputedStyleDependencies& dependencies, const PrimitiveNumeric<RawType>& value)
     {
-        collectComputedStyleDependencies(dependencies, value.value);
+        WTF::switchOn(value, [&](const auto& value) { collectComputedStyleDependencies(dependencies, value); });
     }
 };
 

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h
@@ -35,16 +35,16 @@ namespace CSS {
 void rawNumericSerialization(StringBuilder&, double, CSSUnitType);
 
 template<RawNumeric RawType> struct Serialize<RawType> {
-    inline void operator()(StringBuilder& builder, const RawType& value)
+    void operator()(StringBuilder& builder, const RawType& value)
     {
         rawNumericSerialization(builder, value.value, value.type);
     }
 };
 
 template<RawNumeric RawType> struct Serialize<PrimitiveNumeric<RawType>> {
-    inline void operator()(StringBuilder& builder, const PrimitiveNumeric<RawType>& value)
+    void operator()(StringBuilder& builder, const PrimitiveNumeric<RawType>& value)
     {
-        serializationForCSS(builder, value.value);
+        WTF::switchOn(value, [&](const auto& value) { serializationForCSS(builder, value); });
     }
 };
 

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.cpp
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.cpp
@@ -87,5 +87,112 @@ double canonicalizeResolution(double value, CSSUnitType type)
     return CSSPrimitiveValue::computeResolution<CSSPrimitiveValue::ResolutionUnit::Dppx>(type, value);
 }
 
+// MARK: Unit Validation
+
+bool isSupportedUnitForCategory(CSSUnitType unit, Calculation::Category category)
+{
+    switch (unit) {
+    case CSSUnitType::CSS_INTEGER:
+        return category == Calculation::Category::Integer
+            || category == Calculation::Category::Number;
+    case CSSUnitType::CSS_NUMBER:
+        return category == Calculation::Category::Number;
+    case CSSUnitType::CSS_PERCENTAGE:
+        return category == Calculation::Category::Percentage
+            || category == Calculation::Category::AnglePercentage
+            || category == Calculation::Category::LengthPercentage;
+    case CSSUnitType::CSS_EM:
+    case CSSUnitType::CSS_EX:
+    case CSSUnitType::CSS_PX:
+    case CSSUnitType::CSS_CM:
+    case CSSUnitType::CSS_MM:
+    case CSSUnitType::CSS_IN:
+    case CSSUnitType::CSS_PT:
+    case CSSUnitType::CSS_PC:
+    case CSSUnitType::CSS_Q:
+    case CSSUnitType::CSS_LH:
+    case CSSUnitType::CSS_CAP:
+    case CSSUnitType::CSS_CH:
+    case CSSUnitType::CSS_IC:
+    case CSSUnitType::CSS_RCAP:
+    case CSSUnitType::CSS_RCH:
+    case CSSUnitType::CSS_REM:
+    case CSSUnitType::CSS_REX:
+    case CSSUnitType::CSS_RIC:
+    case CSSUnitType::CSS_RLH:
+    case CSSUnitType::CSS_VW:
+    case CSSUnitType::CSS_VH:
+    case CSSUnitType::CSS_VMIN:
+    case CSSUnitType::CSS_VMAX:
+    case CSSUnitType::CSS_VB:
+    case CSSUnitType::CSS_VI:
+    case CSSUnitType::CSS_SVW:
+    case CSSUnitType::CSS_SVH:
+    case CSSUnitType::CSS_SVMIN:
+    case CSSUnitType::CSS_SVMAX:
+    case CSSUnitType::CSS_SVB:
+    case CSSUnitType::CSS_SVI:
+    case CSSUnitType::CSS_LVW:
+    case CSSUnitType::CSS_LVH:
+    case CSSUnitType::CSS_LVMIN:
+    case CSSUnitType::CSS_LVMAX:
+    case CSSUnitType::CSS_LVB:
+    case CSSUnitType::CSS_LVI:
+    case CSSUnitType::CSS_DVW:
+    case CSSUnitType::CSS_DVH:
+    case CSSUnitType::CSS_DVMIN:
+    case CSSUnitType::CSS_DVMAX:
+    case CSSUnitType::CSS_DVB:
+    case CSSUnitType::CSS_DVI:
+    case CSSUnitType::CSS_CQW:
+    case CSSUnitType::CSS_CQH:
+    case CSSUnitType::CSS_CQI:
+    case CSSUnitType::CSS_CQB:
+    case CSSUnitType::CSS_CQMIN:
+    case CSSUnitType::CSS_CQMAX:
+        return category == Calculation::Category::Length
+            || category == Calculation::Category::LengthPercentage;
+    case CSSUnitType::CSS_DEG:
+    case CSSUnitType::CSS_RAD:
+    case CSSUnitType::CSS_GRAD:
+    case CSSUnitType::CSS_TURN:
+        return category == Calculation::Category::Angle
+            || category == Calculation::Category::AnglePercentage;
+    case CSSUnitType::CSS_MS:
+    case CSSUnitType::CSS_S:
+        return category == Calculation::Category::Time;
+    case CSSUnitType::CSS_HZ:
+    case CSSUnitType::CSS_KHZ:
+        return category == Calculation::Category::Frequency;
+    case CSSUnitType::CSS_DPPX:
+    case CSSUnitType::CSS_X:
+    case CSSUnitType::CSS_DPI:
+    case CSSUnitType::CSS_DPCM:
+        return category == Calculation::Category::Resolution;
+    case CSSUnitType::CSS_FR:
+        return category == Calculation::Category::Flex;
+
+    case CSSUnitType::CSS_ATTR:
+    case CSSUnitType::CSS_CALC:
+    case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
+    case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
+    case CSSUnitType::CSS_DIMENSION:
+    case CSSUnitType::CSS_FONT_FAMILY:
+    case CSSUnitType::CSS_IDENT:
+    case CSSUnitType::CSS_PROPERTY_ID:
+    case CSSUnitType::CSS_QUIRKY_EM:
+    case CSSUnitType::CSS_RGBCOLOR:
+    case CSSUnitType::CSS_STRING:
+    case CSSUnitType::CSS_UNKNOWN:
+    case CSSUnitType::CSS_UNRESOLVED_COLOR:
+    case CSSUnitType::CSS_URI:
+    case CSSUnitType::CSS_VALUE_ID:
+    case CSSUnitType::CustomIdent:
+        break;
+    }
+
+    return false;
+}
+
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h
@@ -39,34 +39,46 @@ namespace CSS {
 // Concept for use in generic contexts to filter on *Raw types.
 template<typename T> concept RawNumeric = requires(T raw) {
     { raw.type } -> std::convertible_to<CSSUnitType>;
-    { raw.value } -> std::convertible_to<double>;
+    { raw.value } -> std::convertible_to<typename T::ValueType>;
 };
 
 // MARK: Number Primitives Raw
 
-template<typename T, Range R> struct IntegerRaw {
-    using IntType = T;
+template<Range R, typename T> struct IntegerRaw {
+    using ValueType = T;
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::Integer;
     static constexpr auto type = CSSUnitType::CSS_INTEGER;
-    IntType value;
+    ValueType value;
 
-    constexpr bool operator==(const IntegerRaw<T, R>&) const = default;
-};
-
-template<Range R = All> struct NumberRaw {
-    static constexpr auto range = R;
-    static constexpr auto category = Calculation::Category::Number;
-    static constexpr auto type = CSSUnitType::CSS_NUMBER;
-    double value;
-
-    constexpr NumberRaw(double value)
+    constexpr IntegerRaw(ValueType value)
         : value { value }
     {
     }
 
     // Constructor is required to allow generic code to uniformly initialize primitives with a CSSUnitType.
-    constexpr NumberRaw(CSSUnitType, double value)
+    constexpr IntegerRaw(CSSUnitType, ValueType value)
+        : value { value }
+    {
+    }
+
+    constexpr bool operator==(const IntegerRaw<R, T>&) const = default;
+};
+
+template<Range R = All> struct NumberRaw {
+    using ValueType = double;
+    static constexpr auto range = R;
+    static constexpr auto category = Calculation::Category::Number;
+    static constexpr auto type = CSSUnitType::CSS_NUMBER;
+    ValueType value;
+
+    constexpr NumberRaw(ValueType value)
+        : value { value }
+    {
+    }
+
+    // Constructor is required to allow generic code to uniformly initialize primitives with a CSSUnitType.
+    constexpr NumberRaw(CSSUnitType, ValueType value)
         : value { value }
     {
     }
@@ -77,18 +89,19 @@ template<Range R = All> struct NumberRaw {
 // MARK: Percentage Primitive Raw
 
 template<Range R = All> struct PercentageRaw {
+    using ValueType = double;
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::Percentage;
     static constexpr auto type = CSSUnitType::CSS_PERCENTAGE;
-    double value;
+    ValueType value;
 
-    constexpr PercentageRaw(double value)
+    constexpr PercentageRaw(ValueType value)
         : value { value }
     {
     }
 
     // Constructor is required to allow generic code to uniformly initialize primitives with a CSSUnitType.
-    constexpr PercentageRaw(CSSUnitType, double value)
+    constexpr PercentageRaw(CSSUnitType, ValueType value)
         : value { value }
     {
     }
@@ -99,10 +112,11 @@ template<Range R = All> struct PercentageRaw {
 // MARK: Dimension Primitives Raw
 
 template<Range R = All> struct AngleRaw {
+    using ValueType = double;
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::Angle;
     CSSUnitType type;
-    double value;
+    ValueType value;
 
     constexpr bool operator==(const AngleRaw<R>&) const = default;
 };
@@ -110,10 +124,11 @@ template<Range R = All> struct AngleRaw {
 double canonicalizeAngle(double value, CSSUnitType);
 
 template<Range R = All> struct LengthRaw {
+    using ValueType = double;
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::Length;
     CSSUnitType type;
-    double value;
+    ValueType value;
 
     constexpr bool operator==(const LengthRaw<R>&) const = default;
 };
@@ -124,10 +139,11 @@ float canonicalizeAndClampLengthNoConversionDataRequired(double, CSSUnitType);
 float canonicalizeAndClampLength(double, CSSUnitType, const CSSToLengthConversionData&);
 
 template<Range R = All> struct TimeRaw {
+    using ValueType = double;
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::Time;
     CSSUnitType type;
-    double value;
+    ValueType value;
 
     constexpr bool operator==(const TimeRaw<R>&) const = default;
 };
@@ -135,10 +151,11 @@ template<Range R = All> struct TimeRaw {
 double canonicalizeTime(double, CSSUnitType);
 
 template<Range R = All> struct FrequencyRaw {
+    using ValueType = double;
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::Frequency;
     CSSUnitType type;
-    double value;
+    ValueType value;
 
     constexpr bool operator==(const FrequencyRaw<R>&) const = default;
 };
@@ -146,11 +163,12 @@ template<Range R = All> struct FrequencyRaw {
 double canonicalizeFrequency(double, CSSUnitType);
 
 template<Range R = Nonnegative> struct ResolutionRaw {
+    using ValueType = double;
     static_assert(R.min >= 0, "<resolution> values must always have a minimum range of at least 0.");
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::Resolution;
     CSSUnitType type;
-    double value;
+    ValueType value;
 
     constexpr bool operator==(const ResolutionRaw<R>&) const = default;
 };
@@ -158,10 +176,11 @@ template<Range R = Nonnegative> struct ResolutionRaw {
 double canonicalizeResolution(double, CSSUnitType);
 
 template<Range R = All> struct FlexRaw {
+    using ValueType = double;
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::Flex;
     static constexpr auto type = CSSUnitType::CSS_FR;
-    double value;
+    ValueType value;
 
     constexpr bool operator==(const FlexRaw<R>&) const = default;
 };
@@ -169,19 +188,21 @@ template<Range R = All> struct FlexRaw {
 // MARK: Dimension + Percentage Primitives Raw
 
 template<Range R = All> struct AnglePercentageRaw {
+    using ValueType = double;
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::AnglePercentage;
     CSSUnitType type;
-    double value;
+    ValueType value;
 
     constexpr bool operator==(const AnglePercentageRaw<R>&) const = default;
 };
 
 template<Range R = All> struct LengthPercentageRaw {
+    using ValueType = double;
     static constexpr auto range = R;
     static constexpr auto category = Calculation::Category::LengthPercentage;
     CSSUnitType type;
-    double value;
+    ValueType value;
 
     constexpr bool operator==(const LengthPercentageRaw<R>&) const = default;
 };
@@ -194,53 +215,193 @@ template<typename T> concept CSSNumeric = requires(T css) {
     requires RawNumeric<typename T::Raw>;
 };
 
+// Checks if the unit type is supported by the category.
+bool isSupportedUnitForCategory(CSSUnitType, Calculation::Category);
+
 template<RawNumeric T> struct PrimitiveNumeric {
     static constexpr auto range = T::range;
     static constexpr auto category = T::category;
     using Raw = T;
     using Calc = UnevaluatedCalc<T>;
 
-    PrimitiveNumeric(std::variant<T, UnevaluatedCalc<T>>&& value)
-        : value { WTFMove(value) }
+    PrimitiveNumeric(Raw raw)
     {
+        type = raw.type;
+        value.number = raw.value;
     }
 
-    PrimitiveNumeric(const std::variant<T, UnevaluatedCalc<T>>& value)
-        : value { value }
+    PrimitiveNumeric(UnevaluatedCalc<T> calc)
     {
+        type = CSSUnitType::CSS_CALC;
+        value.calc = &calc.protectedCalc().leakRef();
     }
 
-    PrimitiveNumeric(T&& value)
-        : value { WTFMove(value) }
+    PrimitiveNumeric(const PrimitiveNumeric& other)
     {
+        if (other.isCalc()) {
+            type = CSSUnitType::CSS_CALC;
+            value.calc = other.value.calc;
+            value.calc->ref();
+        } else {
+            type = other.type;
+            value.number = other.value.number;
+        }
     }
 
-    PrimitiveNumeric(const T& value)
-        : value { value }
+    PrimitiveNumeric(PrimitiveNumeric&& other)
     {
+        if (other.isCalc()) {
+            type = CSSUnitType::CSS_CALC;
+            value.calc = other.value.calc;
+
+            // Setting this to anything so that value is not double deref'd.
+            other.type = CSSUnitType::CSS_UNKNOWN;
+            other.value.calc = nullptr;
+        } else {
+            type = other.type;
+            value.number = other.value.number;
+        }
     }
 
-    PrimitiveNumeric(UnevaluatedCalc<T>&& value)
-        : value { WTFMove(value) }
+    PrimitiveNumeric& operator=(const PrimitiveNumeric& other)
     {
+        if (isCalc())
+            value.calc->deref();
+
+        if (other.isCalc()) {
+            type = CSSUnitType::CSS_CALC;
+            value.calc = other.value.calc;
+            value.calc->ref();
+        } else {
+            type = other.type;
+            value.number = other.value.number;
+        }
+
+        return *this;
     }
 
-    PrimitiveNumeric(const UnevaluatedCalc<T>& value)
-        : value { value }
+    PrimitiveNumeric& operator=(PrimitiveNumeric&& other)
     {
+        if (isCalc())
+            value.calc->deref();
+
+        if (other.isCalc()) {
+            type = CSSUnitType::CSS_CALC;
+            value.calc = other.value.calc;
+
+            // Setting this to anything so that value is not double deref'd.
+            other.type = CSSUnitType::CSS_UNKNOWN;
+            other.value.calc = nullptr;
+        } else {
+            type = other.type;
+            value.number = other.value.number;
+        }
+
+        return *this;
     }
 
-    bool operator==(const PrimitiveNumeric<T>&) const = default;
+    ~PrimitiveNumeric()
+    {
+        if (isCalc())
+            value.calc->deref();
+    }
 
-    const T* raw() const { return std::get_if<T>(&value); }
-    const UnevaluatedCalc<T>* calc() const { return std::get_if<Calc>(&value); }
+    bool operator==(const PrimitiveNumeric<T>& other) const
+    {
+        if (type != other.type)
+            return false;
 
-    std::variant<T, UnevaluatedCalc<T>> value;
+        if (isCalc())
+            return protectedCalc()->equals(other.protectedCalc());
+        return value.number == other.value.number;
+    }
+
+    std::optional<Raw> raw() const
+    {
+        if (!isCalc())
+            return asRaw();
+        return std::nullopt;
+    }
+
+    std::optional<Calc> calc() const
+    {
+        if (isCalc())
+            return asCalc();
+        return std::nullopt;
+    }
+
+    template<typename F> decltype(auto) visit(F&& functor) const
+    {
+        if (isCalc())
+            return std::invoke(std::forward<F>(functor), asCalc());
+        return std::invoke(std::forward<F>(functor), asRaw());
+    }
+
+    template<typename... F> decltype(auto) switchOn(F&&... functors) const
+    {
+        return visit(WTF::makeVisitor(std::forward<F>(functors)...));
+    }
+
+    bool isKnownZero() const { return !isCalc() && value.number == 0; }
+    bool isKnownNotZero() const { return !isCalc() && value.number != 0; }
+
+    bool isCalc() const { return type == CSSUnitType::CSS_CALC; }
+
+    static bool isSupported(CSSUnitType unit) { return isSupportedUnitForCategory(unit, category); }
+
+    struct MarkableTraits {
+        static bool isEmptyValue(const PrimitiveNumeric& value) { return value.isEmpty(); }
+        static PrimitiveNumeric emptyValue() { return PrimitiveNumeric(EmptyToken()); }
+    };
+
+private:
+    friend struct MarkableTraits;
+
+    struct EmptyToken { };
+    PrimitiveNumeric(EmptyToken)
+    {
+        type = CSSUnitType::CSS_UNKNOWN;
+        value.number = 0;
+    }
+
+    bool isEmpty() const { return type == CSSUnitType::CSS_UNKNOWN; }
+
+    Ref<CSSCalcValue> protectedCalc() const
+    {
+        ASSERT(isCalc());
+        return Ref(*value.calc);
+    }
+
+    Raw asRaw() const
+    {
+        ASSERT(!isCalc());
+        return Raw { type, value.number };
+    }
+
+    Calc asCalc() const
+    {
+        ASSERT(isCalc());
+        return Calc { protectedCalc() };
+    }
+
+    // A std::variant is not used here to allow tighter packing.
+    // When type == CSSUnitType::CSS_CALC, value is calc.
+    // When type == CSSUnitType::CSS_UNKNOWN, value is empty (used by Markable).
+    // When type == anything else, value is number.
+
+    // FIXME: This could be even more packed types with only a single alternative (e.g. CSS::Number/CSS::Percentage/CSS::Flex),
+    // by using NaN encoding scheme for the `calc` case.
+
+    CSSUnitType type;
+    union {
+        typename Raw::ValueType number;
+        CSSCalcValue* calc;
+    } value;
 };
 
 // MARK: Number Primitive
 
-template<typename IntType, Range R> using Integer = PrimitiveNumeric<IntegerRaw<IntType, R>>;
+template<Range R, typename IntType> using Integer = PrimitiveNumeric<IntegerRaw<R, IntType>>;
 
 template<Range R = All> using Number = PrimitiveNumeric<NumberRaw<R>>;
 
@@ -266,27 +427,6 @@ template<Range R = All> using LengthPercentage = PrimitiveNumeric<LengthPercenta
 
 // NOTE: This is spelled with an explicit "Or" to distinguish it from types like AnglePercentage/LengthPercentage that have behavior distinctions beyond just being a union of the two types (specifically, calc() has specific behaviors for those types).
 using PercentageOrNumber = std::variant<Percentage<>, Number<>>;
-
-// MARK: - Requires Conversion Data
-
-template<typename T> bool requiresConversionData(const PrimitiveNumeric<T>& primitive)
-{
-    return requiresConversionData(primitive.value);
-}
-
-// MARK: - Requires Conversion Data
-
-template<typename T> bool isUnevaluatedCalc(const PrimitiveNumeric<T>& primitive)
-{
-    return isUnevaluatedCalc(primitive.value);
-}
-
-// MARK: Simplify
-
-template<typename T> auto simplifyUnevaluatedCalc(const PrimitiveNumeric<T>& primitive, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) -> PrimitiveNumeric<T>
-{
-    return { simplifyUnevaluatedCalc(primitive.value, conversionData, symbolTable) };
-}
 
 // MARK: - Type List Modifiers
 
@@ -374,3 +514,19 @@ template<typename TypeList> using MinusSymbol = typename MinusSymbolLazy<TypeLis
 
 } // namespace CSS
 } // namespace WebCore
+
+namespace WTF {
+
+// Overload WTF::switchOn to make it so CSS::PrimitiveNumeric<T> can be used directly.
+
+template<WebCore::CSS::RawNumeric T, class... F> ALWAYS_INLINE auto switchOn(const WebCore::CSS::PrimitiveNumeric<T>& value, F&&... f) -> decltype(value.switchOn(std::forward<F>(f)...))
+{
+    return value.switchOn(std::forward<F>(f)...);
+}
+
+template<WebCore::CSS::RawNumeric T, class... F> ALWAYS_INLINE auto switchOn(WebCore::CSS::PrimitiveNumeric<T>&& value, F&&... f) -> decltype(value.switchOn(std::forward<F>(f)...))
+{
+    return value.switchOn(std::forward<F>(f)...);
+}
+
+} // namespace WTF

--- a/Source/WebCore/platform/calc/CalculationValue.h
+++ b/Source/WebCore/platform/calc/CalculationValue.h
@@ -49,7 +49,7 @@ public:
     Calculation::Tree copyTree() const;
     Calculation::Child copyRoot() const;
 
-    bool operator==(const CalculationValue&) const;
+    WEBCORE_EXPORT bool operator==(const CalculationValue&) const;
 
 private:
     CalculationValue(Calculation::Tree&&);

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -306,7 +306,7 @@ static ResolvedFontSize fontSizeFromUnresolvedFontSize(const CSSPropertyParserHe
             return { .size = 0.0f, .keyword = CSSValueInvalid };
         },
         [&](const CSS::LengthPercentage<CSS::Nonnegative>& lengthPercentage) -> ResolvedFontSize {
-            return WTF::switchOn(lengthPercentage.value,
+            return WTF::switchOn(lengthPercentage,
                 [&](const CSS::LengthPercentageRaw<CSS::Nonnegative>& lengthPercentage) -> ResolvedFontSize {
                     if (lengthPercentage.type == CSSUnitType::CSS_PERCENTAGE) {
                         return {

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -133,7 +133,7 @@ template<auto R> struct ToStyle<CSS::AnglePercentage<R>> {
     }
     auto operator()(const From& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) -> To
     {
-        return WTF::switchOn(value.value, [&](const auto& value) { return (*this)(value, conversionData, symbolTable); });
+        return WTF::switchOn(value, [&](const auto& value) { return (*this)(value, conversionData, symbolTable); });
     }
 
     auto operator()(const typename From::Raw& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
@@ -167,7 +167,7 @@ template<auto R> struct ToStyle<CSS::AnglePercentage<R>> {
     }
     auto operator()(const From& value, NoConversionDataRequiredToken token, const CSSCalcSymbolTable& symbolTable) -> To
     {
-        return WTF::switchOn(value.value, [&](const auto& value) { return (*this)(value, token, symbolTable); });
+        return WTF::switchOn(value, [&](const auto& value) { return (*this)(value, token, symbolTable); });
     }
 };
 template<auto R> struct ToStyle<CSS::LengthPercentage<R>> {
@@ -192,7 +192,7 @@ template<auto R> struct ToStyle<CSS::LengthPercentage<R>> {
     }
     auto operator()(const From& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) -> To
     {
-        return WTF::switchOn(value.value, [&](const auto& value) { return (*this)(value, conversionData, symbolTable); });
+        return WTF::switchOn(value, [&](const auto& value) { return (*this)(value, conversionData, symbolTable); });
     }
 
     auto operator()(const typename From::Raw& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
@@ -226,7 +226,7 @@ template<auto R> struct ToStyle<CSS::LengthPercentage<R>> {
     }
     auto operator()(const From& value, NoConversionDataRequiredToken token, const CSSCalcSymbolTable& symbolTable) -> To
     {
-        return WTF::switchOn(value.value, [&](const auto& value) { return (*this)(value, token, symbolTable); });
+        return WTF::switchOn(value, [&](const auto& value) { return (*this)(value, token, symbolTable); });
     }
 };
 
@@ -245,7 +245,7 @@ template<CSS::RawNumeric RawType> struct ToStyle<CSS::PrimitiveNumeric<RawType>>
     }
     auto operator()(const From& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) -> To
     {
-        return WTF::switchOn(value.value, [&](const auto& value) { return (*this)(value, conversionData, symbolTable); });
+        return WTF::switchOn(value, [&](const auto& value) { return (*this)(value, conversionData, symbolTable); });
     }
 
     auto operator()(const typename From::Raw& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
@@ -271,7 +271,7 @@ template<CSS::RawNumeric RawType> struct ToStyle<CSS::PrimitiveNumeric<RawType>>
     }
     auto operator()(const From& value, NoConversionDataRequiredToken token, const CSSCalcSymbolTable& symbolTable) -> To
     {
-        return WTF::switchOn(value.value, [&](const auto& value) { return (*this)(value, token, symbolTable); });
+        return WTF::switchOn(value, [&](const auto& value) { return (*this)(value, token, symbolTable); });
     }
 };
 


### PR DESCRIPTION
#### 2ba07c2f90a77ef03bdf17f7760d8e79851afb67
<pre>
Pack CSS::PrimitiveNumeric
<a href="https://bugs.webkit.org/show_bug.cgi?id=283507">https://bugs.webkit.org/show_bug.cgi?id=283507</a>

Reviewed by Darin Adler.

Packs CSS::PrimitiveNumeric so that it takes 16 bytes instead of 24 bytes.

The old structure was:

     CSS::PrimitiveNumeric {
         std::variant&lt;
             RawPrimitive           // { CSSUnitType type; double value; } // 16 bytes (including padding)
             CSSUnevaluatedCalc&lt;T&gt;  // { CSSCalcValue* calc;             } // 8 bytes
         &gt;
     }

With the std::variant&apos;s tag value and padding, this leads to waste.

The new structure is:

     CSS::PrimitiveNumeric {
         CSSUnitType type;  // 8 bytes (including padding)
         union {
             CSSCalcValue* calc;                // 8 bytes
             RawPrimitive::ValueType number;    // 8 bytes
         } value;
    }

We then use the following schema to ensure the correct alternative is used.

    When type == CSSUnitType::CSS_CALC, value is calc.
    When type == CSSUnitType::CSS_UNKNOWN, value is empty (used by Markable).
    When type == anything else, value is number.

* Source/WebCore/css/calc/CSSCalcTree+Copy.h:
    - Remove unnecessary forward.

* Source/WebCore/css/color/CSSColorConversion+Normalize.h:
    - Use direct WTF::switchOn.

* Source/WebCore/css/color/CSSColorDescriptors.h:
* Source/WebCore/css/color/CSSUnresolvedRelativeColor.h:
    - Add needed #include.

* Source/WebCore/css/color/CSSColorMixSerialization.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp:
    - Use new interface rather than std::variant functions.

* Source/WebCore/css/color/CSSRelativeColorResolver.h:
    - Fix sorting.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h:
    - Update for swapped order of CSS::Integer template arguments
    - Use direct WTF::switchOn.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp:
* Source/WebCore/css/values/images/CSSGradient.cpp:
* Source/WebCore/css/values/primitives/CSSPosition.cpp:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueCreation.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueVisitation.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+ComputedStyleDependencies.h:
* Source/WebCore/style/StyleResolveForFont.cpp:
    - Use direct WTF::switchOn.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Integer.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h:
    - Update for swapped order of CSS::Integer template arguments

* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+EvaluateCalc.h:
    - Move more calc functions here
    - Use direct WTF::switchOn.

* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h:
    - Remove unnecessary `inline` usage.
    - Use direct WTF::switchOn.

* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.cpp:
    - Add supported unit for assertions.

* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h:
    - Switch order of template arguments for CSS::Integer/CSS::IntegerRaw to have Range first.
    - Give each raw type a ValueType type definition, used by PrimitiveNumeric.
    - Replace std::variant based implementation of PrimitiveNumeric with a union + CSSUnitType
      based one.
    - Overload WTF::switchOn() for PrimitiveNumeric so it can continue to be used with minimal
      changes for callers.

* Source/WebCore/platform/calc/CalculationValue.h:
    - Export operator==, now used by WebKit, previously calc equality was done incorrectly via
      pointers.

Canonical link: <a href="https://commits.webkit.org/286978@main">https://commits.webkit.org/286978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ced7588e8137f599eb7ae69c95bc26de40624958

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77785 "14 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82436 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29057 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79904 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5119 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60932 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/18878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50905 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/66732 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41230 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48258 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24245 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27394 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83794 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77034 "Build is in progress. Recent messages:") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/5167 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/69154 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5323 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66721 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68393 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17090 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12418 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10505 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5110 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/5106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-11-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/6891 "Build was cancelled. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | 
<!--EWS-Status-Bubble-End-->