### PR TITLE
Fix Bugzilla pre-collapsed comments

### DIFF
--- a/Websites/bugs.webkit.org/js/comments.js
+++ b/Websites/bugs.webkit.org/js/comments.js
@@ -61,7 +61,6 @@ function collapse_comment(link, comment, comment_id) {
 
 function expand_comment(link, comment, comment_id) {
     link.innerHTML = "[&minus;]";
-    YAHOO.util.Dom.addClass('cr' + comment_id, 'collapsed');
     YAHOO.util.Dom.removeClass('c' + comment_id, 'bz_default_collapsed');
     YAHOO.util.Dom.removeClass(comment, 'collapsed');
     YAHOO.util.Dom.removeClass('comment_tag_' + comment_id, 'collapsed');

--- a/Websites/bugs.webkit.org/template/en/custom/bug/comments.html.tmpl
+++ b/Websites/bugs.webkit.org/template/en/custom/bug/comments.html.tmpl
@@ -162,15 +162,16 @@
           <a href="show_bug.cgi?id=[% bug.bug_id FILTER html %]#c[% comment.count FILTER html %]">
             [%- comment_label FILTER html %]</a>
           <span class="bz_comment_time torelativedatetime" data-ts="[%+ comment.creation_ts FILTER html %]">[%+ comment.creation_ts FILTER time %]</span>
+          
+          [% IF comment.collapsed %]
+            <span id="cr[% comment.count FILTER css_class_quote %]" class="bz_comment_collapse_reason"
+               title="[% comment.author.name || comment.author.login FILTER html %]
+                      [%~ %] [[% comment.creation_ts FILTER time %]]">
+              Comment hidden ([% comment.tags.join(', ') FILTER html %])
+            </span>
+          [% END %]
         </div>
 
-        [% IF comment.collapsed %]
-          <span id="cr[% comment.count FILTER css_class_quote %]" class="bz_comment_collapse_reason"
-             title="[% comment.author.name || comment.author.login FILTER html %]
-                    [%~ %] [[% comment.creation_ts FILTER time %]]">
-            Comment hidden ([% comment.tags.join(', ') FILTER html %])
-          </span>
-        [% END %]
       </div>
 
       [% IF user.is_timetracker &&


### PR DESCRIPTION
#### 30885147a1df984f0346ed31df8b52f2b902ca1b
<pre>
Fix Bugzilla pre-collapsed comments
<a href="https://bugs.webkit.org/show_bug.cgi?id=283513">https://bugs.webkit.org/show_bug.cgi?id=283513</a>

Reviewed by Alexey Proskuryakov.

Removes the behavior to add the &quot;collapse&quot; class name to the element that
describes the reason for the comment being collapsed.

Canonical link: <a href="https://commits.webkit.org/286932@main">https://commits.webkit.org/286932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cbb6a70aa09d31c9d2874215e356a07a1cd8837

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77526 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30442 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82117 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28808 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60755 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18743 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50723 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66539 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41021 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48124 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27132 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69234 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83516 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68980 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5062 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66506 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68245 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12260 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10358 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12011 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4853 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4872 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8307 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6631 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->