### PR TITLE
[Visual Bidi Selection] Set selection to visually- and logically-contiguous boundaries when ending range adjustment

### DIFF
--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-expected.txt
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-expected.txt
@@ -5,6 +5,7 @@ This test verifies that the text selection appears visually contiguous when sele
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 PASS isVisuallyContiguous is true
+PASS getSelection().toString() is "مثل هذا النص, is right to left"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection.html
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection.html
@@ -40,14 +40,17 @@ addEventListener("load", async () => {
 
     isVisuallyContiguous = await UIHelper.isSelectionVisuallyContiguous();
     await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder().end().takeResult());
+    await UIHelper.ensurePresentationUpdate();
 
     shouldBeTrue("isVisuallyContiguous");
+    shouldBeEqualToString("getSelection().toString()", "مثل هذا النص, is right to left");
+
     finishJSTest();
 });
 </script>
 </head>
 <body>
-    <p>Arabic, <span class="stop">مثل</span> هذا النص, is right to <span class="start">left</span>.</p>
+    <p>Arabic, مثل هذا <span class="stop">النص</span>, is right to <span class="start">left</span>.</p>
     <div id="description"></div>
     <div id="console"></div>
 </body>

--- a/Source/WebCore/editing/Editing.h
+++ b/Source/WebCore/editing/Editing.h
@@ -106,7 +106,12 @@ Element* elementIfEquivalent(const Element&, Node&);
 
 bool positionBeforeOrAfterNodeIsCandidate(Node&);
 
+// -------------------------------------------------------------------------
+// SimpleRange
+// -------------------------------------------------------------------------
+
 WEBCORE_EXPORT HashSet<RefPtr<HTMLImageElement>> visibleImageElementsInRangeWithNonLoadedImages(const SimpleRange&);
+WEBCORE_EXPORT SimpleRange adjustToVisuallyContiguousRange(const SimpleRange&);
 
 // -------------------------------------------------------------------------
 // Position

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -639,6 +639,10 @@ public:
 
     WEBCORE_EXPORT void closeTyping();
 
+#if PLATFORM(IOS_FAMILY)
+    bool shouldDrawVisuallyContiguousBidiSelection() const;
+#endif
+
 private:
     bool canDeleteRange(const SimpleRange&) const;
     bool canSmartReplaceWithPasteboard(Pasteboard&);

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -168,7 +168,6 @@ public:
     void willBeRemovedFromFrame();
 
     void updateAppearanceAfterUpdatingRendering();
-    void scheduleAppearanceUpdateAfterStyleChange();
 
     enum class RevealSelectionAfterUpdate : bool { NotForced, Forced };
     void setNeedsSelectionUpdate(RevealSelectionAfterUpdate = RevealSelectionAfterUpdate::NotForced);

--- a/Source/WebCore/editing/RenderedPosition.cpp
+++ b/Source/WebCore/editing/RenderedPosition.cpp
@@ -127,7 +127,7 @@ unsigned char RenderedPosition::bidiLevelOnRight() const
     return box ? box->bidiLevel() : 0;
 }
 
-RenderedPosition RenderedPosition::leftBoundaryOfBidiRun(unsigned char bidiLevelOfRun)
+RenderedPosition RenderedPosition::leftBoundaryOfBidiRun(unsigned char bidiLevelOfRun) const
 {
     if (!m_box || bidiLevelOfRun > m_box->bidiLevel())
         return RenderedPosition();
@@ -144,7 +144,7 @@ RenderedPosition RenderedPosition::leftBoundaryOfBidiRun(unsigned char bidiLevel
     return RenderedPosition();
 }
 
-RenderedPosition RenderedPosition::rightBoundaryOfBidiRun(unsigned char bidiLevelOfRun)
+RenderedPosition RenderedPosition::rightBoundaryOfBidiRun(unsigned char bidiLevelOfRun) const
 {
     if (!m_box || bidiLevelOfRun > m_box->bidiLevel())
         return RenderedPosition();

--- a/Source/WebCore/editing/RenderedPosition.h
+++ b/Source/WebCore/editing/RenderedPosition.h
@@ -52,11 +52,13 @@ public:
 
     bool isNull() const { return !m_renderer; }
     InlineIterator::LineBoxIterator lineBox() const { return m_box ? m_box->lineBox() : InlineIterator::LineBoxIterator(); }
+    InlineIterator::LeafBoxIterator box() const { return m_box; }
+    unsigned offset() const { return m_offset; }
 
     unsigned char bidiLevelOnLeft() const;
     unsigned char bidiLevelOnRight() const;
-    RenderedPosition leftBoundaryOfBidiRun(unsigned char bidiLevelOfRun);
-    RenderedPosition rightBoundaryOfBidiRun(unsigned char bidiLevelOfRun);
+    RenderedPosition leftBoundaryOfBidiRun(unsigned char bidiLevelOfRun) const;
+    RenderedPosition rightBoundaryOfBidiRun(unsigned char bidiLevelOfRun) const;
 
     enum ShouldMatchBidiLevel { MatchBidiLevel, IgnoreBidiLevel };
     bool atLeftBoundaryOfBidiRun() const { return atLeftBoundaryOfBidiRun(IgnoreBidiLevel, 0); }

--- a/Source/WebCore/editing/ios/EditorIOS.mm
+++ b/Source/WebCore/editing/ios/EditorIOS.mm
@@ -359,6 +359,12 @@ bool Editor::writingSuggestionsSupportsSuffix()
     return false;
 }
 
+bool Editor::shouldDrawVisuallyContiguousBidiSelection() const
+{
+    CheckedPtr client = this->client();
+    return client && client->shouldDrawVisuallyContiguousBidiSelection();
+}
+
 } // namespace WebCore
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/page/EditorClient.h
+++ b/Source/WebCore/page/EditorClient.h
@@ -206,6 +206,10 @@ public:
 
     virtual void willChangeSelectionForAccessibility() { }
     virtual void didChangeSelectionForAccessibility() { }
+
+#if PLATFORM(IOS_FAMILY)
+    virtual bool shouldDrawVisuallyContiguousBidiSelection() const { return false; }
+#endif
 };
 
 }

--- a/Source/WebCore/platform/ios/SelectionGeometry.cpp
+++ b/Source/WebCore/platform/ios/SelectionGeometry.cpp
@@ -62,7 +62,7 @@ SelectionGeometry::SelectionGeometry(const FloatQuad& quad, SelectionRenderingBe
 {
 }
 
-SelectionGeometry::SelectionGeometry(const FloatQuad& quad, SelectionRenderingBehavior behavior, TextDirection direction, int minX, int maxX, int maxY, int lineNumber, bool isLineBreak, bool isFirstOnLine, bool isLastOnLine, bool containsStart, bool containsEnd, bool isHorizontal, bool mayAppearLogicallyDiscontiguous)
+SelectionGeometry::SelectionGeometry(const FloatQuad& quad, SelectionRenderingBehavior behavior, TextDirection direction, int minX, int maxX, int maxY, int lineNumber, bool isLineBreak, bool isFirstOnLine, bool isLastOnLine, bool containsStart, bool containsEnd, bool isHorizontal)
     : m_quad(quad)
     , m_behavior(behavior)
     , m_direction(direction)
@@ -76,7 +76,6 @@ SelectionGeometry::SelectionGeometry(const FloatQuad& quad, SelectionRenderingBe
     , m_containsStart(containsStart)
     , m_containsEnd(containsEnd)
     , m_isHorizontal(isHorizontal)
-    , m_mayAppearLogicallyDiscontiguous(mayAppearLogicallyDiscontiguous)
 {
 }
 
@@ -182,9 +181,6 @@ TextStream& operator<<(TextStream& stream, const SelectionGeometry& rect)
 
     if (rect.behavior() == SelectionRenderingBehavior::UseIndividualQuads)
         stream.dumpProperty("using individual quads", true);
-
-    if (rect.mayAppearLogicallyDiscontiguous())
-        stream.dumpProperty("reverse bidi", true);
 
     stream.dumpProperty("page number", rect.pageNumber());
     return stream;

--- a/Source/WebCore/platform/ios/SelectionGeometry.h
+++ b/Source/WebCore/platform/ios/SelectionGeometry.h
@@ -42,7 +42,7 @@ public:
 
     // FIXME: We should move some of these arguments to an auxillary struct.
     SelectionGeometry(const FloatQuad&, SelectionRenderingBehavior, TextDirection, int, int, int, int, bool, bool, bool, bool, bool, bool, bool, int);
-    WEBCORE_EXPORT SelectionGeometry(const FloatQuad&, SelectionRenderingBehavior, TextDirection, int, int, int, int, bool, bool, bool, bool, bool, bool, bool /* mayAppearLogicallyDiscontiguous */);
+    WEBCORE_EXPORT SelectionGeometry(const FloatQuad&, SelectionRenderingBehavior, TextDirection, int, int, int, int, bool, bool, bool, bool, bool, bool);
     SelectionGeometry() = default;
     ~SelectionGeometry() = default;
 
@@ -71,7 +71,6 @@ public:
     bool isInFixedPosition() const { return m_isInFixedPosition; }
     int pageNumber() const { return m_pageNumber; }
     SelectionRenderingBehavior behavior() const { return m_behavior; }
-    bool mayAppearLogicallyDiscontiguous() const { return m_mayAppearLogicallyDiscontiguous; }
 
     void setLogicalLeft(int);
     void setLogicalWidth(int);
@@ -90,7 +89,6 @@ public:
     void setContainsEnd(bool containsEnd) { m_containsEnd = containsEnd; }
     void setIsHorizontal(bool isHorizontal) { m_isHorizontal = isHorizontal; }
     void setBehavior(SelectionRenderingBehavior behavior) { m_behavior = behavior; }
-    void setMayAppearLogicallyDiscontiguous(bool value) { m_mayAppearLogicallyDiscontiguous = value; }
 
     WEBCORE_EXPORT void move(float x, float y);
 
@@ -109,7 +107,6 @@ private:
     bool m_containsEnd { false };
     bool m_isHorizontal { true };
     bool m_isInFixedPosition { false };
-    bool m_mayAppearLogicallyDiscontiguous { false };
     int m_pageNumber { 0 };
 
     mutable std::optional<IntRect> m_cachedEnclosingRect;

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -30,6 +30,7 @@
 #include "AXObjectCache.h"
 #include "DocumentInlines.h"
 #include "Editing.h"
+#include "Editor.h"
 #include "ElementAncestorIteratorInlines.h"
 #include "FloatQuad.h"
 #include "FrameSelection.h"
@@ -2546,7 +2547,7 @@ static bool areOnSameLine(const SelectionGeometry& a, const SelectionGeometry& b
 
 static void makeBidiSelectionVisuallyContiguousIfNeeded(const SimpleRange& range, Vector<SelectionGeometry>& geometries)
 {
-    if (!range.startContainer().document().settings().visuallyContiguousBidiTextSelectionEnabled())
+    if (!range.startContainer().document().editor().shouldDrawVisuallyContiguousBidiSelection())
         return;
 
     FloatPoint selectionStartTop;
@@ -2597,7 +2598,6 @@ static void makeBidiSelectionVisuallyContiguousIfNeeded(const SimpleRange& range
         // For a single line selection, simply merge the end into the start and remove other selection geometries on the same line.
         startGeometry->setQuad({ selectionStartTop, selectionEndTop, selectionEndBottom, selectionStartBottom });
         startGeometry->setContainsEnd(true);
-        startGeometry->setMayAppearLogicallyDiscontiguous(true);
         geometries.append(WTFMove(*startGeometry));
         return;
     }
@@ -2637,7 +2637,6 @@ static void makeBidiSelectionVisuallyContiguousIfNeeded(const SimpleRange& range
         selectionEndBottom = endRect.maxXMaxYCorner();
     }
 
-    startGeometry->setMayAppearLogicallyDiscontiguous(true);
     startGeometry->setQuad({
         selectionStartTop,
         selectionExtents.p2(),
@@ -2645,7 +2644,6 @@ static void makeBidiSelectionVisuallyContiguousIfNeeded(const SimpleRange& range
         selectionStartBottom,
     });
 
-    endGeometry->setMayAppearLogicallyDiscontiguous(true);
     endGeometry->setQuad({
         selectionExtents.p1(),
         selectionEndTop,

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2516,7 +2516,6 @@ class WebCore::SelectionGeometry {
     bool containsStart();
     bool containsEnd();
     bool isHorizontal();
-    bool mayAppearLogicallyDiscontiguous();
 };
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.mm
@@ -123,7 +123,7 @@
 
 - (NSWritingDirection)writingDirection
 {
-    if (_selectionGeometry.direction() == WebCore::TextDirection::LTR || _selectionGeometry.mayAppearLogicallyDiscontiguous())
+    if (_selectionGeometry.direction() == WebCore::TextDirection::LTR)
         return NSWritingDirectionLeftToRight;
 
     return NSWritingDirectionRightToLeft;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -204,6 +204,10 @@ private:
     bool performTwoStepDrop(WebCore::DocumentFragment&, const WebCore::SimpleRange&, bool isMove) final;
     bool supportsGlobalSelection() final;
 
+#if PLATFORM(IOS_FAMILY)
+    bool shouldDrawVisuallyContiguousBidiSelection() const final;
+#endif
+
     WeakPtr<WebPage> m_page;
 };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/ios/WebEditorClientIOS.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ios/WebEditorClientIOS.mm
@@ -122,6 +122,11 @@ bool WebEditorClient::shouldRemoveDictationAlternativesAfterEditing() const
     return m_page->shouldRemoveDictationAlternativesAfterEditing();
 }
 
+bool WebEditorClient::shouldDrawVisuallyContiguousBidiSelection() const
+{
+    return m_page->shouldDrawVisuallyContiguousBidiSelection();
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1020,7 +1020,9 @@ public:
     void updateSelectionWithDelta(int64_t locationDelta, int64_t lengthDelta, CompletionHandler<void()>&&);
     void requestDocumentEditingContext(WebKit::DocumentEditingContextRequest&&, CompletionHandler<void(WebKit::DocumentEditingContext&&)>&&);
     bool shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection);
-#endif
+    bool shouldDrawVisuallyContiguousBidiSelection() const { return m_shouldDrawVisuallyContiguousBidiSelection; }
+    void setShouldDrawVisuallyContiguousBidiSelection(bool value);
+#endif // PLATFORM(IOS_FAMILY)
 
     void willChangeSelectionForAccessibility() { m_isChangingSelectionForAccessibility = true; }
     void didChangeSelectionForAccessibility() { m_isChangingSelectionForAccessibility = false; }
@@ -2765,6 +2767,7 @@ private:
     std::unique_ptr<WebCore::IgnoreSelectionChangeForScope> m_ignoreSelectionChangeScopeForDictation;
 
     bool m_isMobileDoctype { false };
+    bool m_shouldDrawVisuallyContiguousBidiSelection { false };
 #endif // PLATFORM(IOS_FAMILY)
 
     WebCore::Timer m_layerVolatilityTimer;


### PR DESCRIPTION
#### e59afa8f7cc66431f54539e0607a1f2948c8fb89
<pre>
[Visual Bidi Selection] Set selection to visually- and logically-contiguous boundaries when ending range adjustment
<a href="https://bugs.webkit.org/show_bug.cgi?id=283515">https://bugs.webkit.org/show_bug.cgi?id=283515</a>
<a href="https://rdar.apple.com/140378287">rdar://140378287</a>

Reviewed by Ryosuke Niwa and Abrar Rahman Protyasha.

Work towards visual bidi selection support, by limiting visually contiguous bidi selection behavior
to only when the user is selecting text with selection handles on iOS (i.e. range adjustment). When
range adjustment ends, we then snap the selection endpoints to the nearest bidi text run boundaries
that ensure both logical and visual contiguity. See below for more details.

* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-expected.txt:
* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection.html:

Augment an existing layout test to exercise the selection snapping behavior, by verifying that the
final selection is snapped to the start of the Arabic text within the (otherwise English) paragraph.

* Source/WebCore/editing/Editing.cpp:
(WebCore::visualDistanceOnSameLine):

Add a helper function to compute the number of characters (visually) between two `RenderedPosition`s
on the same line box.

(WebCore::visuallyClosestBidiBoundary):

Add a helper function to return the (visually) closest bidi boundary point around a given
`RenderedPosition`, at the given bidi level.

(WebCore::adjustToVisuallyContiguousRange):

Implement the core of the bidi selection snapping heuristic. This new editing helper function,
`adjustToVisuallyContiguousRange`, takes a `SimpleRange` and returns another `SimpleRange` that is
either expanded or contracted to maintain both visual and logical contiguity for bidi text.

This algorithm generally works by determining whether or not the start or end positions (separately)
need to be adjusted to the nearest bidi boundary in order to maintain visual and logical contiguity.
To achieve this, we first examine the line boxes in between the start and end positions for a
single-line selection, or alternately, between the &apos;selection start and logical end on the first
line&apos; and &apos;selection end and logical start on the last line&apos; for a multi-line selection. During this
traversal, we keep track of the minimum observed bidi level for any line box we traverse over — if
a selection endpoint has a bidi level exceeding this minimum bidi level, then it&apos;ll result in a
visual discontiguity.

Consider, for example, the case of selection endpoints within two nested bidi text runs with the
same bidi level (the selection starts in `bbbbb` and ends in `ddddd`). The entire text in logical
order is `aaaaa bbbbb ccccc ddddd`:

DIRECTION    ltr   rtl   ltr   rtl
            ----&gt; &lt;---- ----&gt; &lt;----
LEVEL         0     1     2     1
TEXT        aaaaa ddddd ccccc bbbbb
                    ^           ^
SELECTION          End        Start

Because the bidi level in between the start and end only *increases*, the selection is already
visually contiguous, so no endpoint adjustment is needed despite the fact that the selection spans
a combination of RTL and LTR text. This is because any bidi text that starts within the selected
range also ends in the same selected range. However, consider this other, vaguely similar-looking
scenario:

DIRECTION    ltr   rtl   ltr   rtl
            ----&gt; &lt;---- ----&gt; &lt;----
LEVEL         0     1     0     1
TEXT        aaaaa bbbbb ccccc ddddd
                    ^           ^
SELECTION         Start        End

Because the selection now encompasses a piece of text with a *lower* bidi level, both endpoints must
be adjusted to their respective boundaries in order to maintain both visual and logical contiguity;
the start must either move to the end of `aaaaa` or the beginning of `ccccc`, and the end must move
to the end of `ccccc` or the end of `ddddd`. This is because this second selected range contains a
run of text that logically continues before the start or after the end (in this example, before the
start).

For each selection endpoint that needs to be adjusted in order to land on a visually contiguous bidi
boundary, we then use the helper methods in `RenderedPosition` to identify the nearest 2 bidi
boundary points on the same line around the endpoint, and select the one that results in the least
amount of (visual) adjustment.

* Source/WebCore/editing/Editing.h:
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/FrameSelection.h:

Drive-by fix: delete this unused method declaration.

* Source/WebCore/editing/RenderedPosition.cpp:
(WebCore::RenderedPosition::leftBoundaryOfBidiRun const):
(WebCore::RenderedPosition::rightBoundaryOfBidiRun const):
(WebCore::RenderedPosition::leftBoundaryOfBidiRun): Deleted.
(WebCore::RenderedPosition::rightBoundaryOfBidiRun): Deleted.
* Source/WebCore/editing/RenderedPosition.h:
(WebCore::RenderedPosition::box const):
(WebCore::RenderedPosition::offset const):

Expose a couple of new getters on `RenderedPosition`, for use in the new helper function in
`Editing.cpp`.

* Source/WebCore/editing/ios/EditorIOS.mm:
(WebCore::Editor::shouldDrawVisuallyContiguousBidiSelection const):
* Source/WebCore/page/EditorClient.h:
(WebCore::EditorClient::shouldDrawVisuallyContiguousBidiSelection const):
* Source/WebCore/platform/ios/SelectionGeometry.cpp:
(WebCore::SelectionGeometry::SelectionGeometry):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/ios/SelectionGeometry.h:
(WebCore::SelectionGeometry::behavior const):
(WebCore::SelectionGeometry::setBehavior):
(WebCore::SelectionGeometry::mayAppearLogicallyDiscontiguous const): Deleted.
(WebCore::SelectionGeometry::setMayAppearLogicallyDiscontiguous): Deleted.

Remove this incorrect logic; see below for more details.

* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::makeBidiSelectionVisuallyContiguousIfNeeded):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.mm:
(-[WKTextSelectionRect writingDirection]):

Revert this hack to force LTR selection behavior when visually contiguous bidi selection is enabled.
This is incorrect because it doesn&apos;t take line direction into account in RTL paragraphs — in a
future change, I&apos;ll fix this properly by correctly setting the text direction of coalesced selection
geometries, based on the primary direction on each line.

* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/ios/WebEditorClientIOS.mm:
(WebKit::WebEditorClient::shouldDrawVisuallyContiguousBidiSelection const):

Add an editor client hook to determine whether or not we should draw visually contiguous bidi
selections; we currently only do this when the user is adjusting selection handles on iOS, but in a
future patch I&apos;ll update this to include more text interactions, such as tap-and-half, loupe, and
selecting with a mouse cursor using trackpad.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::setShouldDrawVisuallyContiguousBidiSelection):
(WebKit::WebPage::updateSelectionWithTouches):

Canonical link: <a href="https://commits.webkit.org/287021@main">https://commits.webkit.org/287021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d63eb2029fc5a57e6a7c8780755b5105e126f3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82622 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29230 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80095 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5300 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61061 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18989 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81040 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51053 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67319 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41363 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48416 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/24508 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27573 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69509 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83984 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5339 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3613 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69283 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5495 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68538 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17113 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12536 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10714 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5287 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8040 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5279 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8711 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->