### PR TITLE
Event listener process map for extensions needs to support site isolation (per frame processes).

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -406,7 +406,7 @@ bool WebExtensionContext::unload(NSError **outError)
 
     m_actionsToPerformAfterBackgroundContentLoads.clear();
     m_backgroundContentEventListeners.clear();
-    m_eventListenerPages.clear();
+    m_eventListenerFrames.clear();
     m_installReason = InstallReason::None;
     m_previousVersion = nullString();
     m_safeToLoadBackgroundContent = false;
@@ -3479,6 +3479,19 @@ void WebExtensionContext::loadBackgroundWebViewDuringLoad()
             loadBackgroundWebView();
     } else
         loadBackgroundWebView();
+}
+
+bool WebExtensionContext::isBackgroundPage(WebCore::FrameIdentifier frameIdentifier) const
+{
+    RefPtr frame = WebFrameProxy::webFrame(frameIdentifier);
+    if (!frame)
+        return false;
+
+    RefPtr page = frame->page();
+    if (!page)
+        return false;
+
+    return isBackgroundPage(page->identifier());
 }
 
 bool WebExtensionContext::isBackgroundPage(WebPageProxyIdentifier pageProxyIdentifier) const

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -829,7 +829,7 @@ bool WebExtensionTab::shouldGrantPermissionsOnUserGesture() const
     return [m_delegate shouldGrantPermissionsOnUserGestureForWebExtensionContext:m_extensionContext->wrapper()];
 }
 
-WebExtensionTab::WebProcessProxySet WebExtensionTab::processes(WebExtensionEventListenerType type, WebExtensionContentWorldType contentWorldType) const
+WebExtensionTab::WebProcessProxySet WebExtensionTab::processes(WebExtensionEventListenerType listenerType, WebExtensionContentWorldType contentWorldType) const
 {
     if (!isValid())
         return { };
@@ -838,17 +838,9 @@ WebExtensionTab::WebProcessProxySet WebExtensionTab::processes(WebExtensionEvent
     if (!webView)
         return { };
 
-    if (!extensionContext()->pageListensForEvent(*webView._page, type, contentWorldType))
-        return { };
-
-    WebProcessProxySet result;
-
-    webView._page->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
-        if (webProcess.canSendMessage())
-            result.addVoid(webProcess);
+    return extensionContext()->processes({ listenerType }, { contentWorldType }, [&](auto& page, auto& frame) {
+        return webView._page.get() == &page;
     });
-
-    return result;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -74,8 +74,8 @@ messages -> WebExtensionContext {
 #endif
 
     // Event APIs
-    [EnabledIf='isLoaded()'] AddListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionContentWorldType contentWorldType)
-    [EnabledIf='isLoaded()'] RemoveListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionContentWorldType contentWorldType, size_t removedCount)
+    [EnabledIf='isLoaded()'] AddListener(WebCore::FrameIdentifier frameIdentifier, WebKit::WebExtensionEventListenerType listenerType, WebKit::WebExtensionContentWorldType contentWorldType)
+    [EnabledIf='isLoaded()'] RemoveListener(WebCore::FrameIdentifier frameIdentifier, WebKit::WebExtensionEventListenerType listenerType, WebKit::WebExtensionContentWorldType contentWorldType, size_t removedCount)
 
     // Extensions APIs
     [EnabledIf='isLoaded()'] ExtensionIsAllowedIncognitoAccess() -> (bool result)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
@@ -91,18 +91,18 @@ void WebExtensionAPIEvent::invokeListenersWithArgument(id argument1, id argument
         listener->call(argument1, argument2, argument3);
 }
 
-void WebExtensionAPIEvent::addListener(WebPage& page, RefPtr<WebExtensionCallbackHandler> listener)
+void WebExtensionAPIEvent::addListener(WebFrame& frame, RefPtr<WebExtensionCallbackHandler> listener)
 {
-    m_pageProxyIdentifier = page.webPageProxyIdentifier();
+    m_frameIdentifier = frame.frameID();
     m_listeners.append(listener);
 
     if (!hasExtensionContext())
         return;
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(page.webPageProxyIdentifier(), m_type, contentWorldType()), extensionContext().identifier());
+    WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(*m_frameIdentifier, m_type, contentWorldType()), extensionContext().identifier());
 }
 
-void WebExtensionAPIEvent::removeListener(WebPage& page, RefPtr<WebExtensionCallbackHandler> listener)
+void WebExtensionAPIEvent::removeListener(WebFrame& frame, RefPtr<WebExtensionCallbackHandler> listener)
 {
     auto removedCount = m_listeners.removeAllMatching([&](auto& entry) {
         return entry->callbackFunction() == listener->callbackFunction();
@@ -111,12 +111,12 @@ void WebExtensionAPIEvent::removeListener(WebPage& page, RefPtr<WebExtensionCall
     if (!removedCount)
         return;
 
-    ASSERT(page.webPageProxyIdentifier() == m_pageProxyIdentifier);
+    ASSERT(frame.frameID() == m_frameIdentifier);
 
     if (!hasExtensionContext())
         return;
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(*m_pageProxyIdentifier, m_type, contentWorldType(), removedCount), extensionContext().identifier());
+    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(*m_frameIdentifier, m_type, contentWorldType(), removedCount), extensionContext().identifier());
 }
 
 bool WebExtensionAPIEvent::hasListener(RefPtr<WebExtensionCallbackHandler> listener)
@@ -137,7 +137,7 @@ void WebExtensionAPIEvent::removeAllListeners()
     if (!hasExtensionContext())
         return;
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(*m_pageProxyIdentifier, m_type, contentWorldType(), removedCount), extensionContext().identifier());
+    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(*m_frameIdentifier, m_type, contentWorldType(), removedCount), extensionContext().identifier());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
@@ -316,7 +316,7 @@ id WebExtensionAPIMenus::createMenu(WebPage& page, WebFrame& frame, NSDictionary
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/create
 
-    m_pageProxyIdentifier = page.webPageProxyIdentifier();
+    m_frameIdentifier = frame.frameID();
 
     std::optional<WebExtensionMenuItemParameters> parameters;
     RefPtr<WebExtensionCallbackHandler> clickCallback;
@@ -334,7 +334,7 @@ id WebExtensionAPIMenus::createMenu(WebPage& page, WebFrame& frame, NSDictionary
 
         if (clickCallback) {
             if (m_clickHandlerMap.isEmpty())
-                WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(*m_pageProxyIdentifier, WebExtensionEventListenerType::MenusOnClicked, contentWorldType()), extensionContext().identifier());
+                WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(*m_frameIdentifier, WebExtensionEventListenerType::MenusOnClicked, contentWorldType()), extensionContext().identifier());
 
             m_clickHandlerMap.set(identifier, clickCallback.releaseNonNull());
         }
@@ -349,7 +349,7 @@ void WebExtensionAPIMenus::update(WebPage& page, WebFrame& frame, id identifier,
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/update
 
-    m_pageProxyIdentifier = page.webPageProxyIdentifier();
+    m_frameIdentifier = frame.frameID();
 
     if (!validateObject(identifier, @"identifier", [NSOrderedSet orderedSetWithObjects:NSString.class, NSNumber.class, nil], outExceptionString))
         return;
@@ -379,7 +379,7 @@ void WebExtensionAPIMenus::update(WebPage& page, WebFrame& frame, id identifier,
 
             if (clickCallback) {
                 if (m_clickHandlerMap.isEmpty())
-                    WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(*m_pageProxyIdentifier, WebExtensionEventListenerType::MenusOnClicked, contentWorldType()), extensionContext().identifier());
+                    WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(*m_frameIdentifier, WebExtensionEventListenerType::MenusOnClicked, contentWorldType()), extensionContext().identifier());
 
                 m_clickHandlerMap.set(newIdentifier, clickCallback.releaseNonNull());
             }
@@ -408,7 +408,7 @@ void WebExtensionAPIMenus::remove(id identifier, Ref<WebExtensionCallbackHandler
         m_clickHandlerMap.remove(identifier);
 
         if (m_clickHandlerMap.isEmpty())
-            WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(*m_pageProxyIdentifier, WebExtensionEventListenerType::MenusOnClicked, contentWorldType(), 1), extensionContext().identifier());
+            WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(*m_frameIdentifier, WebExtensionEventListenerType::MenusOnClicked, contentWorldType(), 1), extensionContext().identifier());
 
         callback->call();
     }, extensionContext().identifier());
@@ -427,7 +427,7 @@ void WebExtensionAPIMenus::removeAll(Ref<WebExtensionCallbackHandler>&& callback
         if (!m_clickHandlerMap.isEmpty()) {
             m_clickHandlerMap.clear();
 
-            WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(*m_pageProxyIdentifier, WebExtensionEventListenerType::MenusOnClicked, contentWorldType(), 1), extensionContext().identifier());
+            WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(*m_frameIdentifier, WebExtensionEventListenerType::MenusOnClicked, contentWorldType(), 1), extensionContext().identifier());
         }
 
         callback->call();

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm
@@ -57,7 +57,7 @@ void WebExtensionAPIWebNavigationEvent::invokeListenersWithArgument(id argument,
     }
 }
 
-void WebExtensionAPIWebNavigationEvent::addListener(WebPage& page, RefPtr<WebExtensionCallbackHandler> listener, NSDictionary *filter, NSString **outExceptionString)
+void WebExtensionAPIWebNavigationEvent::addListener(WebFrame& frame, RefPtr<WebExtensionCallbackHandler> listener, NSDictionary *filter, NSString **outExceptionString)
 {
     _WKWebExtensionWebNavigationURLFilter *parsedFilter;
     if (filter) {
@@ -66,13 +66,13 @@ void WebExtensionAPIWebNavigationEvent::addListener(WebPage& page, RefPtr<WebExt
             return;
     }
 
-    m_pageProxyIdentifier = page.webPageProxyIdentifier();
+    m_frameIdentifier = frame.frameID();
     m_listeners.append({ listener, parsedFilter });
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(*m_pageProxyIdentifier, m_type, contentWorldType()), extensionContext().identifier());
+    WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(*m_frameIdentifier, m_type, contentWorldType()), extensionContext().identifier());
 }
 
-void WebExtensionAPIWebNavigationEvent::removeListener(WebPage& page, RefPtr<WebExtensionCallbackHandler> listener)
+void WebExtensionAPIWebNavigationEvent::removeListener(WebFrame& frame, RefPtr<WebExtensionCallbackHandler> listener)
 {
     auto removedCount = m_listeners.removeAllMatching([&](auto& entry) {
         return entry.first->callbackFunction() == listener->callbackFunction();
@@ -81,9 +81,9 @@ void WebExtensionAPIWebNavigationEvent::removeListener(WebPage& page, RefPtr<Web
     if (!removedCount)
         return;
 
-    ASSERT(page.webPageProxyIdentifier() == m_pageProxyIdentifier);
+    ASSERT(frame.frameID() == m_frameIdentifier);
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(*m_pageProxyIdentifier, m_type, contentWorldType(), removedCount), extensionContext().identifier());
+    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(*m_frameIdentifier, m_type, contentWorldType(), removedCount), extensionContext().identifier());
 }
 
 bool WebExtensionAPIWebNavigationEvent::hasListener(RefPtr<WebExtensionCallbackHandler> listener)
@@ -98,7 +98,7 @@ void WebExtensionAPIWebNavigationEvent::removeAllListeners()
     if (m_listeners.isEmpty())
         return;
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(*m_pageProxyIdentifier, m_type, contentWorldType(), m_listeners.size()), extensionContext().identifier());
+    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(*m_frameIdentifier, m_type, contentWorldType(), m_listeners.size()), extensionContext().identifier());
 
     m_listeners.clear();
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm
@@ -63,7 +63,7 @@ void WebExtensionAPIWebRequestEvent::invokeListenersWithArgument(NSDictionary *a
     }
 }
 
-void WebExtensionAPIWebRequestEvent::addListener(WebPage& page, RefPtr<WebExtensionCallbackHandler> listener, NSDictionary *filter, id extraInfoSpec, NSString **outExceptionString)
+void WebExtensionAPIWebRequestEvent::addListener(WebFrame& frame, RefPtr<WebExtensionCallbackHandler> listener, NSDictionary *filter, id extraInfoSpec, NSString **outExceptionString)
 {
     _WKWebExtensionWebRequestFilter *parsedFilter;
     if (filter) {
@@ -72,13 +72,13 @@ void WebExtensionAPIWebRequestEvent::addListener(WebPage& page, RefPtr<WebExtens
             return;
     }
 
-    m_pageProxyIdentifier = page.webPageProxyIdentifier();
+    m_frameIdentifier = frame.frameID();
     m_listeners.append({ listener, parsedFilter });
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(*m_pageProxyIdentifier, m_type, contentWorldType()), extensionContext().identifier());
+    WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(*m_frameIdentifier, m_type, contentWorldType()), extensionContext().identifier());
 }
 
-void WebExtensionAPIWebRequestEvent::removeListener(WebPage& page, RefPtr<WebExtensionCallbackHandler> listener)
+void WebExtensionAPIWebRequestEvent::removeListener(WebFrame& frame, RefPtr<WebExtensionCallbackHandler> listener)
 {
     auto removedCount = m_listeners.removeAllMatching([&](auto& entry) {
         return entry.first->callbackFunction() == listener->callbackFunction();
@@ -87,9 +87,9 @@ void WebExtensionAPIWebRequestEvent::removeListener(WebPage& page, RefPtr<WebExt
     if (!removedCount)
         return;
 
-    ASSERT(page.webPageProxyIdentifier() == m_pageProxyIdentifier);
+    ASSERT(frame.frameID() == m_frameIdentifier);
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(*m_pageProxyIdentifier, m_type, contentWorldType(), removedCount), extensionContext().identifier());
+    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(*m_frameIdentifier, m_type, contentWorldType(), removedCount), extensionContext().identifier());
 }
 
 bool WebExtensionAPIWebRequestEvent::hasListener(RefPtr<WebExtensionCallbackHandler> listener)
@@ -104,7 +104,7 @@ void WebExtensionAPIWebRequestEvent::removeAllListeners()
     if (m_listeners.isEmpty())
         return;
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(*m_pageProxyIdentifier, m_type, contentWorldType(), m_listeners.size()), extensionContext().identifier());
+    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(*m_frameIdentifier, m_type, contentWorldType(), m_listeners.size()), extensionContext().identifier());
 
     m_listeners.clear();
 }

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
@@ -50,8 +50,8 @@ public:
 
     const ListenerVector& listeners() const { return m_listeners; }
 
-    void addListener(WebPage&, RefPtr<WebExtensionCallbackHandler>);
-    void removeListener(WebPage&, RefPtr<WebExtensionCallbackHandler>);
+    void addListener(WebFrame&, RefPtr<WebExtensionCallbackHandler>);
+    void removeListener(WebFrame&, RefPtr<WebExtensionCallbackHandler>);
     bool hasListener(RefPtr<WebExtensionCallbackHandler>);
 
     void removeAllListeners();
@@ -69,7 +69,7 @@ private:
         setPropertyPath(toAPIString(type), &parentObject);
     }
 
-    Markable<WebPageProxyIdentifier> m_pageProxyIdentifier;
+    Markable<WebCore::FrameIdentifier> m_frameIdentifier;
     WebExtensionEventListenerType m_type;
     ListenerVector m_listeners;
 };

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIMenus.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIMenus.h
@@ -60,7 +60,7 @@ private:
     enum class ForUpdate : bool { No, Yes };
     bool parseCreateAndUpdateProperties(ForUpdate, NSDictionary *, const URL& baseURL, std::optional<WebExtensionMenuItemParameters>&, RefPtr<WebExtensionCallbackHandler>&, NSString **outExceptionString);
 
-    Markable<WebPageProxyIdentifier> m_pageProxyIdentifier;
+    Markable<WebCore::FrameIdentifier> m_frameIdentifier;
     RefPtr<WebExtensionAPIEvent> m_onClicked;
     ClickHandlerMap m_clickHandlerMap;
 #endif

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
@@ -52,8 +52,8 @@ public:
 
     const ListenerVector& listeners() const { return m_listeners; }
 
-    void addListener(WebPage&, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, NSString **outExceptionString);
-    void removeListener(WebPage&, RefPtr<WebExtensionCallbackHandler>);
+    void addListener(WebFrame&, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, NSString **outExceptionString);
+    void removeListener(WebFrame&, RefPtr<WebExtensionCallbackHandler>);
     bool hasListener(RefPtr<WebExtensionCallbackHandler>);
 
     void removeAllListeners();
@@ -71,7 +71,7 @@ private:
         setPropertyPath(toAPIString(type), &parentObject);
     }
 
-    Markable<WebPageProxyIdentifier> m_pageProxyIdentifier;
+    Markable<WebCore::FrameIdentifier> m_frameIdentifier;
     WebExtensionEventListenerType m_type;
     ListenerVector m_listeners;
 };

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
@@ -50,8 +50,8 @@ public:
 
     const ListenerVector& listeners() const { return m_listeners; }
 
-    void addListener(WebPage&, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, id extraInfoSpec, NSString **outExceptionString);
-    void removeListener(WebPage&, RefPtr<WebExtensionCallbackHandler>);
+    void addListener(WebFrame&, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, id extraInfoSpec, NSString **outExceptionString);
+    void removeListener(WebFrame&, RefPtr<WebExtensionCallbackHandler>);
     bool hasListener(RefPtr<WebExtensionCallbackHandler>);
 
     void invokeListenersWithArgument(NSDictionary *argument, WebExtensionTabIdentifier, WebExtensionWindowIdentifier, const ResourceLoadInfo&);
@@ -71,7 +71,7 @@ private:
         setPropertyPath(toAPIString(type), &parentObject);
     }
 
-    Markable<WebPageProxyIdentifier> m_pageProxyIdentifier;
+    Markable<WebCore::FrameIdentifier> m_frameIdentifier;
     WebExtensionEventListenerType m_type;
     ListenerVector m_listeners;
 };

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h
@@ -49,8 +49,8 @@ public:
 
     const ListenerVector& listeners() const { return m_listeners; }
 
-    void addListener(WebPage&, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, NSString **outExceptionString);
-    void removeListener(WebPage&, RefPtr<WebExtensionCallbackHandler>);
+    void addListener(WebFrame&, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, NSString **outExceptionString);
+    void removeListener(WebFrame&, RefPtr<WebExtensionCallbackHandler>);
     bool hasListener(RefPtr<WebExtensionCallbackHandler>);
 
     void removeAllListeners();
@@ -68,7 +68,7 @@ private:
         setPropertyPath(toAPIString(type), &parentObject);
     }
 
-    Markable<WebPageProxyIdentifier> m_pageProxyIdentifier;
+    Markable<WebCore::FrameIdentifier> m_frameIdentifier;
     WebExtensionEventListenerType m_type;
     ListenerVector m_listeners;
 };

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIEvent.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIEvent.idl
@@ -27,8 +27,8 @@
     Conditional=WK_WEB_EXTENSIONS,
 ] interface WebExtensionAPIEvent {
 
-    [NeedsPage] void addListener([CallbackHandler] function listener);
-    [NeedsPage] void removeListener([CallbackHandler] function listener);
+    [NeedsFrame] void addListener([CallbackHandler] function listener);
+    [NeedsFrame] void removeListener([CallbackHandler] function listener);
     boolean hasListener([CallbackHandler] function listener);
 
 };

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigationEvent.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigationEvent.idl
@@ -28,8 +28,8 @@
     MainWorldOnly,
 ] interface WebExtensionAPIWebNavigationEvent {
 
-    [NeedsPage, RaisesException] void addListener([CallbackHandler] function listener, [NSDictionary, Optional] any filter);
-    [NeedsPage] void removeListener([CallbackHandler] function listener);
+    [NeedsFrame, RaisesException] void addListener([CallbackHandler] function listener, [NSDictionary, Optional] any filter);
+    [NeedsFrame] void removeListener([CallbackHandler] function listener);
     boolean hasListener([CallbackHandler] function listener);
 
 };

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequestEvent.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequestEvent.idl
@@ -28,8 +28,8 @@
     MainWorldOnly,
 ] interface WebExtensionAPIWebRequestEvent {
 
-    [NeedsPage, RaisesException] void addListener([CallbackHandler] function listener, [NSDictionary, Optional] any filter, [NSArray=NSString, Optional] array extraInfoSpec);
-    [NeedsPage] void removeListener([CallbackHandler] function listener);
+    [NeedsFrame, RaisesException] void addListener([CallbackHandler] function listener, [NSDictionary, Optional] any filter, [NSArray=NSString, Optional] array extraInfoSpec);
+    [NeedsFrame] void removeListener([CallbackHandler] function listener);
     boolean hasListener([CallbackHandler] function listener);
 
 };

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWindowsEvent.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWindowsEvent.idl
@@ -28,8 +28,8 @@
     MainWorldOnly,
 ] interface WebExtensionAPIWindowsEvent {
 
-    [NeedsPage, RaisesException] void addListener([CallbackHandler] function listener, [Optional, NSDictionary] any filter);
-    [NeedsPage] void removeListener([CallbackHandler] function listener);
+    [NeedsFrame, RaisesException] void addListener([CallbackHandler] function listener, [Optional, NSDictionary] any filter);
+    [NeedsFrame] void removeListener([CallbackHandler] function listener);
     boolean hasListener([CallbackHandler] function listener);
 
 };

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -139,7 +139,7 @@ RefPtr<LocalFrame> FindController::frameWithSelection(Page* page)
     return nullptr;
 }
 
-void FindController::updateFindUIAfterPageScroll(bool found, const String& string, OptionSet<FindOptions> options, unsigned maxMatchCount, DidWrap didWrap, std::optional<FrameIdentifier> idOfFrameContainingString, CompletionHandler<void(std::optional<WebCore::FrameIdentifier>, Vector<IntRect>&&, uint32_t, int32_t, bool)>&& completionHandler)
+void FindController::updateFindUIAfterPageScroll(bool found, const String& string, OptionSet<FindOptions> options, unsigned maxMatchCount, WebCore::DidWrap didWrap, std::optional<FrameIdentifier> idOfFrameContainingString, CompletionHandler<void(std::optional<WebCore::FrameIdentifier>, Vector<IntRect>&&, uint32_t, int32_t, bool)>&& completionHandler)
 {
     RefPtr selectedFrame = frameWithSelection(m_webPage->corePage());
 
@@ -248,7 +248,7 @@ void FindController::updateFindUIAfterPageScroll(bool found, const String& strin
     if (shouldSetSelection && (!wantsFindIndicator || !canShowFindIndicator || !updateFindIndicator(shouldShowOverlay)))
         hideFindIndicator();
 
-    completionHandler(idOfFrameContainingString, WTFMove(matchRects), matchCount, m_foundStringMatchIndex, didWrap == DidWrap::Yes);
+    completionHandler(idOfFrameContainingString, WTFMove(matchRects), matchCount, m_foundStringMatchIndex, didWrap == WebCore::DidWrap::Yes);
 }
 
 #if ENABLE(IMAGE_ANALYSIS)
@@ -300,7 +300,7 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
 
     bool found;
     std::optional<FrameIdentifier> idOfFrameContainingString;
-    DidWrap didWrap = DidWrap::No;
+    auto didWrap = WebCore::DidWrap::No;
 #if ENABLE(PDF_PLUGIN)
     if (pluginView) {
         found = pluginView->findString(string, coreOptions, maxMatchCount);
@@ -345,7 +345,7 @@ void FindController::findStringMatches(const String& string, OptionSet<FindOptio
 
     bool found = !m_findMatches.isEmpty();
     m_webPage->drawingArea()->dispatchAfterEnsuringUpdatedScrollPosition([protectedWebPage = RefPtr { m_webPage.get() }, found, string, options, maxMatchCount]() {
-        protectedWebPage->findController().updateFindUIAfterPageScroll(found, string, options, maxMatchCount, DidWrap::No, std::nullopt);
+        protectedWebPage->findController().updateFindUIAfterPageScroll(found, string, options, maxMatchCount, WebCore::DidWrap::No, std::nullopt);
     });
 }
 
@@ -366,7 +366,7 @@ void FindController::findRectsForStringMatches(const String& string, OptionSet<F
 
     bool found = !m_findMatches.isEmpty();
     m_webPage->drawingArea()->dispatchAfterEnsuringUpdatedScrollPosition([protectedWebPage = RefPtr { m_webPage.get() }, found, string, options, maxMatchCount] () {
-        protectedWebPage->findController().updateFindUIAfterPageScroll(found, string, options, maxMatchCount, DidWrap::No, std::nullopt);
+        protectedWebPage->findController().updateFindUIAfterPageScroll(found, string, options, maxMatchCount, WebCore::DidWrap::No, std::nullopt);
     });
 }
 


### PR DESCRIPTION
#### c03ef3c4cae3dc0b0be00c3475440a6cd9bd6f88
<pre>
Event listener process map for extensions needs to support site isolation (per frame processes).
<a href="https://webkit.org/b/281516">https://webkit.org/b/281516</a>
<a href="https://rdar.apple.com/problem/137985167">rdar://problem/137985167</a>

Reviewed by Brian Weinstein.

Have WebExtensionContext track event listeners by frame instead of page, so events can be
dispatched to specific frame processes instead of all processes for the page.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm:
(WebKit::WebExtensionContext::addListener):
(WebKit::WebExtensionContext::removeListener):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::unload):
(WebKit::WebExtensionContext::isBackgroundPage const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::processes const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::processes const):
(WebKit::WebExtensionContext::pageListensForEvent const): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm:
(WebKit::WebExtensionAPIEvent::addListener):
(WebKit::WebExtensionAPIEvent::removeListener):
(WebKit::WebExtensionAPIEvent::removeAllListeners):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm:
(WebKit::WebExtensionAPIMenus::createMenu):
(WebKit::WebExtensionAPIMenus::update):
(WebKit::WebExtensionAPIMenus::remove):
(WebKit::WebExtensionAPIMenus::removeAll):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm:
(WebKit::WebExtensionAPIWebNavigationEvent::addListener):
(WebKit::WebExtensionAPIWebNavigationEvent::removeListener):
(WebKit::WebExtensionAPIWebNavigationEvent::removeAllListeners):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm:
(WebKit::WebExtensionAPIWebRequestEvent::addListener):
(WebKit::WebExtensionAPIWebRequestEvent::removeListener):
(WebKit::WebExtensionAPIWebRequestEvent::removeAllListeners):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm:
(WebKit::WebExtensionAPIWindowsEvent::addListener):
(WebKit::WebExtensionAPIWindowsEvent::removeListener):
(WebKit::WebExtensionAPIWindowsEvent::removeAllListeners):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIMenus.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIEvent.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigationEvent.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequestEvent.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWindowsEvent.idl:
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::updateFindUIAfterPageScroll): Use WebCore::DidWrap. This was was build
error due to a change in unified sources and conflicting with WebFrameProxy.h.
(WebKit::FindController::findString): Ditto.
(WebKit::FindController::findStringMatches): Ditto.
(WebKit::FindController::findRectsForStringMatches): Ditto.

Canonical link: <a href="https://commits.webkit.org/286933@main">https://commits.webkit.org/286933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/045266b8e5eb119c7d898670644aac227cf5fead

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82141 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28828 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65731 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4878 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60759 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/18752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41031 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48137 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27153 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69246 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24391 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83537 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4926 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/69001 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5082 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68256 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12275 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10373 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12012 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4873 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4892 "Build is in progress. Recent messages:") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-11-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6651 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->