### PR TITLE
Get FileSystem.h out of SoftLinking.h

### DIFF
--- a/Source/WTF/wtf/cocoa/SoftLinking.h
+++ b/Source/WTF/wtf/cocoa/SoftLinking.h
@@ -27,7 +27,6 @@
 #import <dlfcn.h>
 #import <objc/runtime.h>
 #import <wtf/Assertions.h>
-#import <wtf/FileSystem.h>
 
 #pragma mark - Soft-link macros for use within a single source file
 

--- a/Source/WebCore/PAL/pal/cocoa/AccessibilitySoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/AccessibilitySoftLink.mm
@@ -27,6 +27,7 @@
 
 #if HAVE(ACCESSIBILITY_FRAMEWORK)
 
+#import <dispatch/dispatch.h>
 #import <wtf/SoftLinking.h>
 
 SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, Accessibility, PAL_EXPORT);

--- a/Source/WebCore/PAL/pal/cocoa/AppSSOSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/AppSSOSoftLink.mm
@@ -27,7 +27,10 @@
 
 #if HAVE(APP_SSO)
 
+#import <dispatch/dispatch.h>
 #import <wtf/SoftLinking.h>
+
+typedef NSString *NSErrorDomain;
 
 SOFT_LINK_PRIVATE_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, AppSSO, PAL_EXPORT);
 

--- a/Source/WebCore/PAL/pal/cocoa/CryptoKitPrivateSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/CryptoKitPrivateSoftLink.mm
@@ -27,6 +27,7 @@
 
 #if HAVE(RSA_BSSA)
 
+#import <Foundation/Foundation.h>
 #import <wtf/SoftLinking.h>
 
 SOFT_LINK_PRIVATE_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, CryptoKitPrivate, PAL_EXPORT);

--- a/Source/WebCore/PAL/pal/cocoa/QuartzCoreSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/QuartzCoreSoftLink.mm
@@ -25,6 +25,7 @@
 
 #include "config.h"
 
+#include <dispatch/dispatch.h>
 #include <pal/spi/cocoa/QuartzCoreSPI.h>
 #include <wtf/SoftLinking.h>
 

--- a/Source/WebCore/PAL/pal/cocoa/VisionSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/VisionSoftLink.mm
@@ -27,6 +27,7 @@
 
 #if HAVE(VISION)
 
+#import <dispatch/dispatch.h>
 #import <wtf/SoftLinking.h>
 
 SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, Vision, PAL_EXPORT)

--- a/Source/WebCore/PAL/pal/ios/SystemStatusSoftLink.mm
+++ b/Source/WebCore/PAL/pal/ios/SystemStatusSoftLink.mm
@@ -27,6 +27,7 @@
 
 #if HAVE(SYSTEM_STATUS)
 
+#import <Foundation/Foundation.h>
 #import <wtf/SoftLinking.h>
 
 SOFT_LINK_PRIVATE_FRAMEWORK_FOR_SOURCE(PAL, SystemStatus)

--- a/Source/WebCore/PAL/pal/mac/ScreenCaptureKitSoftLink.mm
+++ b/Source/WebCore/PAL/pal/mac/ScreenCaptureKitSoftLink.mm
@@ -26,6 +26,7 @@
 
 #if HAVE(SCREEN_CAPTURE_KIT)
 
+#import <dispatch/dispatch.h>
 #import <wtf/SoftLinking.h>
 
 SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, ScreenCaptureKit, PAL_EXPORT)

--- a/Source/WebCore/PAL/pal/spi/cocoa/RevealSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/RevealSPI.h
@@ -23,7 +23,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+#import <Foundation/Foundation.h>
 #import <objc/runtime.h>
+
 #if PLATFORM(MAC)
 #import <pal/spi/mac/NSImmediateActionGestureRecognizerSPI.h>
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm
@@ -24,6 +24,7 @@
  */
 
 #include "config.h"
+#include <wtf/FileSystem.h>
 #include <wtf/SoftLinking.h>
 
 namespace WebKit {


### PR DESCRIPTION
#### 82333e02424bb974217d946555656e995f354002
<pre>
Get FileSystem.h out of SoftLinking.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=283524">https://bugs.webkit.org/show_bug.cgi?id=283524</a>
<a href="https://rdar.apple.com/140374614">rdar://140374614</a>

Reviewed by Jer Noble.

SoftLinking.h including FileSystem.h pulls StringCommon.h into a lot of files:

662094 ms: /Volumes/Data/Development/system/webkit/OpenSource/WebKitBuild/Debug/usr/local/include/wtf/text/StringCommon.h (included 1189 times, avg 556 ms), included via:
  38x: SoftLinking.h SoftLinking.h FileSystem.h WTFString.h StringImpl.h

Fix that with a forward declare of NSErrorDomain, and an include in WebKitSwiftSoftLink.mm.

* Source/WTF/wtf/cocoa/SoftLinking.h:
* Source/WebCore/PAL/pal/cocoa/AccessibilitySoftLink.mm:
* Source/WebCore/PAL/pal/cocoa/AppSSOSoftLink.mm:
* Source/WebCore/PAL/pal/cocoa/CryptoKitPrivateSoftLink.mm:
* Source/WebCore/PAL/pal/cocoa/QuartzCoreSoftLink.mm:
* Source/WebCore/PAL/pal/cocoa/VisionSoftLink.mm:
* Source/WebCore/PAL/pal/ios/SystemStatusSoftLink.mm:
* Source/WebCore/PAL/pal/mac/ScreenCaptureKitSoftLink.mm:
* Source/WebCore/PAL/pal/spi/cocoa/RevealSPI.h:
* Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm:

Canonical link: <a href="https://commits.webkit.org/287011@main">https://commits.webkit.org/287011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81c062b15f6cdd7eec28565836ca3d0f8aa88f8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82571 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29180 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80044 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5251 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61015 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18942 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51009 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66950 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41318 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48372 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24394 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27523 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71067 "Found 3 new JSC stress test failures: stress/get-by-val-hoist-above-structure.js.ftl-no-cjit-small-pool, stress/get-by-val-hoist-above-structure.js.mini-mode, wasm.yaml/wasm/v8/regress/regress-824681.js.wasm-collect-continuously (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24744 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83933 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77158 "Found 1 new JSC stress test failure: stress/get-by-val-hoist-above-structure.js.ftl-eager-no-cjit-b3o1 (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5290 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3564 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69234 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5446 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68490 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17111 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12492 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10614 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/99471 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5238 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7991 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21722 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5230 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8662 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7015 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->