### PR TITLE
Make LegacyCustomProtocolManager ref-counted

### DIFF
--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
@@ -44,6 +44,16 @@ ASCIILiteral LegacyCustomProtocolManager::supplementName()
     return "LegacyCustomProtocolManager"_s;
 }
 
+void LegacyCustomProtocolManager::ref() const
+{
+    m_networkProcess->ref();
+}
+
+void LegacyCustomProtocolManager::deref() const
+{
+    m_networkProcess->deref();
+}
+
 LegacyCustomProtocolManager::LegacyCustomProtocolManager(NetworkProcess& networkProcess)
     : m_networkProcess(networkProcess)
 {

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
@@ -60,6 +60,9 @@ class LegacyCustomProtocolManager : public NetworkProcessSupplement, public IPC:
 public:
     explicit LegacyCustomProtocolManager(NetworkProcess&);
 
+    void ref() const;
+    void deref() const;
+
     static ASCIILiteral supplementName();
 
     void registerScheme(const String&);

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.messages.in
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> LegacyCustomProtocolManager NotRefCounted {
+messages -> LegacyCustomProtocolManager {
     DidFailWithError(WebKit::LegacyCustomProtocolID customProtocolID, WebCore::ResourceError error)
     DidLoadData(WebKit::LegacyCustomProtocolID customProtocolID, std::span<const uint8_t> data)
     DidReceiveResponse(WebKit::LegacyCustomProtocolID customProtocolID, WebCore::ResourceResponse response, enum:uint8_t WebKit::CacheStoragePolicy cacheStoragePolicy)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -688,7 +688,7 @@ void NetworkConnectionToWebProcess::preconnectTo(std::optional<WebCore::Resource
     };
 
 #if ENABLE(LEGACY_CUSTOM_PROTOCOL_MANAGER)
-    if (protectedNetworkProcess()->supplement<LegacyCustomProtocolManager>()->supportsScheme(loadParameters.request.url().protocol().toString())) {
+    if (protectedNetworkProcess()->protectedLegacyCustomProtocolManager()->supportsScheme(loadParameters.request.url().protocol().toString())) {
         completionHandler(internalError(loadParameters.request.url()));
         return;
     }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -167,7 +167,7 @@ NetworkProcess::NetworkProcess(AuxiliaryProcessInitializationParameters&& parame
     addSupplementWithoutRefCountedCheck<AuthenticationManager>();
     addSupplement<WebCookieManager>();
 #if ENABLE(LEGACY_CUSTOM_PROTOCOL_MANAGER)
-    addSupplement<LegacyCustomProtocolManager>();
+    addSupplementWithoutRefCountedCheck<LegacyCustomProtocolManager>();
 #endif
 #if HAVE(LSDATABASECONTEXT)
     addSupplement<LaunchServicesDatabaseObserver>();
@@ -202,6 +202,13 @@ DownloadManager& NetworkProcess::downloadManager()
 {
     return m_downloadManager;
 }
+
+#if ENABLE(LEGACY_CUSTOM_PROTOCOL_MANAGER)
+RefPtr<LegacyCustomProtocolManager> NetworkProcess::protectedLegacyCustomProtocolManager()
+{
+    return supplement<LegacyCustomProtocolManager>();
+}
+#endif
 
 void NetworkProcess::removeNetworkConnectionToWebProcess(NetworkConnectionToWebProcess& connection)
 {
@@ -1504,7 +1511,7 @@ void NetworkProcess::preconnectTo(PAL::SessionID sessionID, WebPageProxyIdentifi
 
 #if ENABLE(SERVER_PRECONNECT)
 #if ENABLE(LEGACY_CUSTOM_PROTOCOL_MANAGER)
-    if (supplement<LegacyCustomProtocolManager>()->supportsScheme(url.protocol().toString()))
+    if (protectedLegacyCustomProtocolManager()->supportsScheme(url.protocol().toString()))
         return;
 #endif
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -105,6 +105,7 @@ struct SoupNetworkProxySettings;
 namespace WebKit {
 
 class AuthenticationManager;
+class LegacyCustomProtocolManager;
 class NetworkConnectionToWebProcess;
 class NetworkProcessSupplement;
 class NetworkProximityManager;
@@ -184,6 +185,10 @@ public:
     AuthenticationManager& authenticationManager();
     Ref<AuthenticationManager> protectedAuthenticationManager();
     DownloadManager& downloadManager();
+
+#if ENABLE(LEGACY_CUSTOM_PROTOCOL_MANAGER)
+    RefPtr<LegacyCustomProtocolManager> protectedLegacyCustomProtocolManager();
+#endif
 
     void setSession(PAL::SessionID, std::unique_ptr<NetworkSession>&&);
     NetworkSession* networkSession(PAL::SessionID) const final;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1473,7 +1473,7 @@ NetworkSessionCocoa::NetworkSessionCocoa(NetworkProcess& networkProcess, const N
 #endif
 
 #if ENABLE(LEGACY_CUSTOM_PROTOCOL_MANAGER)
-    networkProcess.supplement<LegacyCustomProtocolManager>()->registerProtocolClass(configuration);
+    networkProcess.protectedLegacyCustomProtocolManager()->registerProtocolClass(configuration);
 #endif
 
     configuration._timingDataOptions = _TimingDataOptionsEnableW3CNavigationTiming;


### PR DESCRIPTION
#### c121f217fdff8d97e7011e0e136b6c84b4b4743b
<pre>
Make LegacyCustomProtocolManager ref-counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=283525">https://bugs.webkit.org/show_bug.cgi?id=283525</a>
<a href="https://rdar.apple.com/140375472">rdar://140375472</a>

Reviewed by NOBODY (OOPS!).

As part of our effort to eventually make IPC::MessageReceiver
ref-counted, we&apos;re making each of its subclasses ref-counted.
LegacyCustomProtocolManager is one of them.

* Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm:
(LegacyCustomProtocolManager::networkProcessCreated):
(+[WKCustomProtocol canInitWithRequest:]):
(-[WKCustomProtocol initWithRequest:cachedResponse:client:]):
(-[WKCustomProtocol startLoading]):
(-[WKCustomProtocol stopLoading]):
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp:
(WebKit::LegacyCustomProtocolManager::ref const):
(WebKit::LegacyCustomProtocolManager::deref const):
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h:
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.messages.in:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::preconnectTo):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::protectedLegacyCustomProtocolManager):
(WebKit::NetworkProcess::preconnectTo):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::NetworkSessionCocoa):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c121f217fdff8d97e7011e0e136b6c84b4b4743b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78095 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82750 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29355 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5423 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61157 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19076 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81162 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67772 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41469 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48509 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27695 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25032 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84112 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5461 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3692 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-hierarchy.html accessibility/combobox/aria-combobox-no-owns.html accessibility/combobox/mac/aria-combobox-activedescendant.html accessibility/combobox/mac/combobox-activedescendant-notifications.html accessibility/combobox/mac/combobox-inherited-role.html accessibility/custom-elements/autocomplete.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69383 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5618 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67043 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68638 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12633 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10856 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5410 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8162 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5399 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8831 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7187 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->