### PR TITLE
[block-step-sizing] Update block-step-insert to new spec values.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-computed-expected.txt
@@ -1,4 +1,5 @@
 
-PASS Property block-step-insert value 'margin'
-PASS Property block-step-insert value 'padding'
+PASS Property block-step-insert value 'margin-box'
+PASS Property block-step-insert value 'padding-box'
+PASS Property block-step-insert value 'content-box'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-computed.html
@@ -18,8 +18,9 @@
 <body>
 <div id="target"></div>
 <script>
-    test_computed_value("block-step-insert", "margin");
-    test_computed_value("block-step-insert", "padding");
+    test_computed_value("block-step-insert", "margin-box");
+    test_computed_value("block-step-insert", "padding-box");
+    test_computed_value("block-step-insert", "content-box");
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-invalid-expected.txt
@@ -6,7 +6,9 @@ PASS e.style['block-step-insert'] = "10%" should not set the property value
 PASS e.style['block-step-insert'] = "20" should not set the property value
 PASS e.style['block-step-insert'] = "none" should not set the property value
 PASS e.style['block-step-insert'] = "border-box" should not set the property value
-PASS e.style['block-step-insert'] = "margin-box" should not set the property value
 PASS e.style['block-step-insert'] = "margin padding" should not set the property value
 PASS e.style['block-step-insert'] = "padding margin" should not set the property value
+PASS e.style['block-step-insert'] = "margin" should not set the property value
+PASS e.style['block-step-insert'] = "padding" should not set the property value
+PASS e.style['block-step-insert'] = "content" should not set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-invalid.html
@@ -25,9 +25,11 @@
     test_invalid_value("block-step-insert", "20");
     test_invalid_value("block-step-insert", "none");
     test_invalid_value("block-step-insert", "border-box");
-    test_invalid_value('block-step-insert', "margin-box");
     test_invalid_value("block-step-insert", "margin padding");
     test_invalid_value("block-step-insert", "padding margin");
+    test_invalid_value('block-step-insert', "margin");
+    test_invalid_value("block-step-insert", "padding")
+    test_invalid_value("block-step-insert", "content")
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-valid-expected.txt
@@ -1,4 +1,5 @@
 
-PASS e.style['block-step-insert'] = "margin" should set the property value
-PASS e.style['block-step-insert'] = "padding" should set the property value
+PASS e.style['block-step-insert'] = "margin-box" should set the property value
+PASS e.style['block-step-insert'] = "padding-box" should set the property value
+PASS e.style['block-step-insert'] = "content-box" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-valid.html
@@ -18,8 +18,9 @@
 <body>
 <div id="target"></div>
 <script>
-    test_valid_value("block-step-insert", "margin");
-    test_valid_value("block-step-insert", "padding");
+    test_valid_value("block-step-insert", "margin-box");
+    test_valid_value("block-step-insert", "padding-box");
+    test_valid_value("block-step-insert", "content-box")
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
@@ -44,8 +44,12 @@ PASS background-repeat (type: discrete) has testAccumulation function
 PASS background-repeat: "round" onto "space"
 PASS background-repeat: "space" onto "round"
 PASS block-step-insert (type: discrete) has testAccumulation function
-PASS block-step-insert: "padding" onto "margin"
-PASS block-step-insert: "margin" onto "padding"
+PASS block-step-insert: "padding-box" onto "margin-box"
+PASS block-step-insert: "margin-box" onto "padding-box"
+PASS block-step-insert: "content-box" onto "margin-box"
+PASS block-step-insert: "margin-box" onto "content-box"
+PASS block-step-insert: "content-box" onto "padding-box"
+PASS block-step-insert: "padding-box" onto "content-box"
 PASS block-step-size (type: length) has testAccumulation function
 PASS block-step-size: length
 PASS block-step-size: length of rem

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
@@ -44,8 +44,12 @@ PASS background-repeat (type: discrete) has testAddition function
 PASS background-repeat: "round" onto "space"
 PASS background-repeat: "space" onto "round"
 PASS block-step-insert (type: discrete) has testAddition function
-PASS block-step-insert: "padding" onto "margin"
-PASS block-step-insert: "margin" onto "padding"
+PASS block-step-insert: "padding-box" onto "margin-box"
+PASS block-step-insert: "margin-box" onto "padding-box"
+PASS block-step-insert: "content-box" onto "margin-box"
+PASS block-step-insert: "margin-box" onto "content-box"
+PASS block-step-insert: "content-box" onto "padding-box"
+PASS block-step-insert: "padding-box" onto "content-box"
 PASS block-step-size (type: length) has testAddition function
 PASS block-step-size: length
 PASS block-step-size: length of rem

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
@@ -56,9 +56,15 @@ PASS background-repeat uses discrete animation when animating between "space" an
 PASS background-repeat uses discrete animation when animating between "space" and "round" with effect easing
 PASS background-repeat uses discrete animation when animating between "space" and "round" with keyframe easing
 PASS block-step-insert (type: discrete) has testInterpolation function
-PASS block-step-insert uses discrete animation when animating between "margin" and "padding" with linear easing
-PASS block-step-insert uses discrete animation when animating between "margin" and "padding" with effect easing
-PASS block-step-insert uses discrete animation when animating between "margin" and "padding" with keyframe easing
+PASS block-step-insert uses discrete animation when animating between "margin-box" and "padding-box" with linear easing
+PASS block-step-insert uses discrete animation when animating between "margin-box" and "padding-box" with effect easing
+PASS block-step-insert uses discrete animation when animating between "margin-box" and "padding-box" with keyframe easing
+PASS block-step-insert uses discrete animation when animating between "margin-box" and "content-box" with linear easing
+PASS block-step-insert uses discrete animation when animating between "margin-box" and "content-box" with effect easing
+PASS block-step-insert uses discrete animation when animating between "margin-box" and "content-box" with keyframe easing
+PASS block-step-insert uses discrete animation when animating between "padding-box" and "content-box" with linear easing
+PASS block-step-insert uses discrete animation when animating between "padding-box" and "content-box" with effect easing
+PASS block-step-insert uses discrete animation when animating between "padding-box" and "content-box" with keyframe easing
 PASS block-step-size (type: length) has testInterpolation function
 PASS block-step-size supports animating as a length
 PASS block-step-size supports animating as a length of rem

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
@@ -107,7 +107,7 @@ const gCSSProperties1 = {
   'block-step-insert': {
     // https://drafts.csswg.org/css-rhythm/#block-step-insert
     types: [
-      { type: 'discrete', options: [ [ 'margin', 'padding' ] ] }
+      { type: 'discrete', options: [ [ 'margin-box', 'padding-box'], ['margin-box', 'content-box'], ['padding-box', 'content-box'] ] }
     ]
   },
   'block-step-size': {

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -213,9 +213,11 @@ template<> constexpr OutlineIsAuto fromCSSValueID(CSSValueID valueID)
 
 template<> constexpr BlockStepInsert fromCSSValueID(CSSValueID valueID)
 {
-    if (valueID == CSSValueMargin)
-        return BlockStepInsert::Margin;
-    return BlockStepInsert::Padding;
+    if (valueID == CSSValueMarginBox)
+        return BlockStepInsert::MarginBox;
+    if (valueID == CSSValuePaddingBox)
+        return BlockStepInsert::PaddingBox;
+    return BlockStepInsert::ContentBox;
 }
 
 constexpr CSSValueID toCSSValueID(CompositeOperator e, CSSPropertyID propertyID)

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -282,8 +282,9 @@
         },
         "block-step-insert": {
             "values": [
-                "margin",
-                "padding"
+                "margin-box",
+                "padding-box",
+                "content-box"
             ],
             "codegen-properties": {
                 "settings-flag": "cssRhythmicSizingEnabled",

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -948,9 +948,6 @@ padding-box
 // text
 -webkit-text
 
-// block-step-insert
-margin
-
 //
 // CSS_PROP_MASK_CLIP
 //

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -3606,7 +3606,17 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         }
         return CSSPrimitiveValue::create(CSSValueNone);
     case CSSPropertyBlockStepInsert:
-        return style.blockStepInsert() == BlockStepInsert::Margin ? CSSPrimitiveValue::create(CSSValueMargin) : CSSPrimitiveValue::create(CSSValuePadding);
+        switch (style.blockStepInsert()) {
+        case BlockStepInsert::MarginBox:
+            return CSSPrimitiveValue::create(CSSValueMarginBox);
+        case BlockStepInsert::PaddingBox:
+            return CSSPrimitiveValue::create(CSSValuePaddingBox);
+        case BlockStepInsert::ContentBox:
+            return CSSPrimitiveValue::create(CSSValueContentBox);
+        default:
+            ASSERT_NOT_REACHED();
+            return CSSPrimitiveValue::create(CSSValueNone);
+        }
     case CSSPropertyBlockStepSize: {
         auto blockStepSize = style.blockStepSize();
         if (!blockStepSize)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -113,7 +113,7 @@ enum class AutoRepeatType : uint8_t;
 enum class BackfaceVisibility : uint8_t;
 enum class BlendMode : uint8_t;
 enum class FlowDirection : uint8_t;
-enum class BlockStepInsert : bool;
+enum class BlockStepInsert : uint8_t;
 enum class BorderCollapse : bool;
 enum class BorderStyle : uint8_t;
 enum class BoxAlignment : uint8_t;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -85,8 +85,9 @@ TextStream& operator<<(TextStream& ts, BackfaceVisibility visibility)
 TextStream& operator<<(TextStream& ts, BlockStepInsert blockStepInsert)
 {
     switch (blockStepInsert) {
-    case BlockStepInsert::Margin: ts << "margin"; break;
-    case BlockStepInsert::Padding: ts << "padding"; break;
+    case BlockStepInsert::MarginBox: ts << "margin-box"; break;
+    case BlockStepInsert::PaddingBox: ts << "padding-box"; break;
+    case BlockStepInsert::ContentBox: ts << "content-box"; break;
     }
     return ts;
 }

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -1197,9 +1197,11 @@ enum class ContentVisibility : uint8_t {
     Hidden,
 };
 
-enum class BlockStepInsert : bool {
-    Margin,
-    Padding
+// Stored as unsigned : 2 in StyleRareNonInheritedData
+enum class BlockStepInsert : uint8_t {
+    MarginBox,
+    PaddingBox,
+    ContentBox
 };
 
 enum class FieldSizing : bool {

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -337,7 +337,7 @@ constexpr AspectRatioType RenderStyle::initialAspectRatioType() { return AspectR
 constexpr BackfaceVisibility RenderStyle::initialBackfaceVisibility() { return BackfaceVisibility::Visible; }
 inline StyleColor RenderStyle::initialBackgroundColor() { return Color::transparentBlack; }
 inline BlockEllipsis RenderStyle::initialBlockEllipsis() { return { }; }
-constexpr BlockStepInsert RenderStyle::initialBlockStepInsert() { return BlockStepInsert::Margin; }
+constexpr BlockStepInsert RenderStyle::initialBlockStepInsert() { return BlockStepInsert::MarginBox; }
 inline std::optional<Length> RenderStyle::initialBlockStepSize() { return std::nullopt; }
 constexpr BorderCollapse RenderStyle::initialBorderCollapse() { return BorderCollapse::Separate; }
 inline LengthSize RenderStyle::initialBorderRadius() { return { zeroLength(), zeroLength() }; }

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -205,7 +205,7 @@ public:
     std::optional<Style::ScopedName> positionAnchor;
 
     std::optional<Length> blockStepSize;
-    unsigned blockStepInsert : 1; // BlockStepInsert
+    unsigned blockStepInsert : 2; // BlockStepInsert
 
     unsigned overscrollBehaviorX : 2; // OverscrollBehavior
     unsigned overscrollBehaviorY : 2; // OverscrollBehavior


### PR DESCRIPTION
#### 22751c7a6daf0665bf8d50505c7ec42e15ea7ea6
<pre>
[block-step-sizing] Update block-step-insert to new spec values.
<a href="https://bugs.webkit.org/show_bug.cgi?id=283509">https://bugs.webkit.org/show_bug.cgi?id=283509</a>
<a href="https://rdar.apple.com/140362634">rdar://140362634</a>

Reviewed by Tim Nguyen.

The CSSWG resolved to update the values to block-step-insert in the following issue:
<a href="https://github.com/w3c/csswg-drafts/issues/10486">https://github.com/w3c/csswg-drafts/issues/10486</a>

This patch updates the code to match these new values in the spec. This also required
some modifications to existing tests and expectations.

* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-computed.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-invalid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-rhythm/parsing/block-step-insert-valid.html:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::fromCSSValueID):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::initialBlockStepInsert):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:

Canonical link: <a href="https://commits.webkit.org/287003@main">https://commits.webkit.org/287003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fab00062a3ce71bc42d11327c1fdd26b10fd8cae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82512 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29121 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79985 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60973 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18914 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66867 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41276 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48330 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24332 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27464 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69423 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83874 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5231 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3525 "Found 2 new test failures: ipc/create-media-source-with-invalid-constraints-crash.html webrtc/vp8-then-h264.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69201 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5387 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66776 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68454 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17107 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12456 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10567 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5179 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7932 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5171 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8603 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6956 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->