### PR TITLE
[WebGPUSwift] Swift Implementation of copyTextureToBuffer

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -75,7 +75,7 @@ public:
     Ref<RenderPassEncoder> beginRenderPass(const WGPURenderPassDescriptor&);
     void copyBufferToBuffer(const Buffer& source, uint64_t sourceOffset, Buffer& destination, uint64_t destinationOffset, uint64_t size);
     void copyBufferToTexture(const WGPUImageCopyBuffer& source, const WGPUImageCopyTexture& destination, const WGPUExtent3D& copySize) HAS_SWIFTCXX_THUNK;
-    void copyTextureToBuffer(const WGPUImageCopyTexture& source, const WGPUImageCopyBuffer& destination, const WGPUExtent3D& copySize);
+    void copyTextureToBuffer(const WGPUImageCopyTexture& source, const WGPUImageCopyBuffer& destination, const WGPUExtent3D& copySize) HAS_SWIFTCXX_THUNK;
     void copyTextureToTexture(const WGPUImageCopyTexture& source, const WGPUImageCopyTexture& destination, const WGPUExtent3D& copySize);
     void clearBuffer(Buffer&, uint64_t offset, uint64_t size);
     Ref<CommandBuffer> finish(const WGPUCommandBufferDescriptor&);
@@ -133,8 +133,8 @@ private:
     NSString* errorValidatingImageCopyBuffer(const WGPUImageCopyBuffer&) const;
 private PUBLIC_IN_WEBGPU_SWIFT:
     NSString* errorValidatingCopyBufferToTexture(const WGPUImageCopyBuffer&, const WGPUImageCopyTexture&, const WGPUExtent3D&) const;
-private:
     NSString* errorValidatingCopyTextureToBuffer(const WGPUImageCopyTexture&, const WGPUImageCopyBuffer&, const WGPUExtent3D&) const;
+private:
     void discardCommandBuffer();
 
     RefPtr<CommandBuffer> protectedCachedCommandBuffer() const { return m_cachedCommandBuffer.get(); }

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -101,6 +101,7 @@ static MTLStoreAction storeAction(WGPUStoreOp storeOp, bool hasResolveTarget = f
 #if ENABLE(WEBGPU_SWIFT)
 
 DEFINE_SWIFTCXX_THUNK(WebGPU::CommandEncoder, copyBufferToTexture, void, const WGPUImageCopyBuffer&, const WGPUImageCopyTexture&, const WGPUExtent3D&);
+DEFINE_SWIFTCXX_THUNK(WebGPU::CommandEncoder, copyTextureToBuffer, void, const WGPUImageCopyTexture&, const WGPUImageCopyBuffer&, const WGPUExtent3D&);
 #endif
 
 
@@ -1392,6 +1393,7 @@ void CommandEncoder::makeSubmitInvalid(NSString* errorString)
         protectedCachedCommandBuffer()->makeInvalid(errorString ?: m_lastErrorString);
 }
 
+#if !ENABLE(WEBGPU_SWIFT)
 static bool hasValidDimensions(WGPUTextureDimension dimension, NSUInteger width, NSUInteger height, NSUInteger depth)
 {
     switch (dimension) {
@@ -1639,6 +1641,7 @@ void CommandEncoder::copyTextureToBuffer(const WGPUImageCopyTexture& source, con
         return;
     }
 }
+#endif
 
 static bool areCopyCompatible(WGPUTextureFormat format1, WGPUTextureFormat format2)
 {

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -47,7 +47,311 @@ public func CommandEncoder_copyBufferToTexture_thunk(commandEncoder: WebGPU.Comm
     commandEncoder.copyBufferToTexture(source: source, destination: destination, copySize: copySize)
 }
 
+@_expose(Cxx)
+public func CommandEncoder_copyTextureToBuffer_thunk(commandEncoder: WebGPU.CommandEncoder, source: WGPUImageCopyTexture, destination: WGPUImageCopyBuffer, copySize: WGPUExtent3D){
+    commandEncoder.copyTextureToBuffer(source: source, destination: destination, copySize: copySize)
+}
+
 extension WebGPU.CommandEncoder {
+    static func hasValidDimensions(dimension: WGPUTextureDimension, width: UInt, height: UInt, depth: UInt) -> Bool {
+        switch (dimension.rawValue) {
+            case WGPUTextureDimension_1D.rawValue:
+                return width != 0
+            case WGPUTextureDimension_2D.rawValue:
+                return width != 0 && height != 0
+            case WGPUTextureDimension_3D.rawValue:
+                return width != 0 && height != 0 && depth != 0
+            default:
+                return true
+        }
+        return true
+    }
+
+    public func copyTextureToBuffer(source: WGPUImageCopyTexture, destination: WGPUImageCopyBuffer, copySize: WGPUExtent3D) {
+        guard source.nextInChain == nil && destination.nextInChain == nil && destination.layout.nextInChain == nil else {
+            return
+        }
+
+        // https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copytexturetobuffer
+
+        guard prepareTheEncoderState() else {
+            self.generateInvalidEncoderStateError()
+            return;
+        }
+
+        let sourceTexture = WebGPU.fromAPI(source.texture);
+        let error = self.errorValidatingCopyTextureToBuffer(source, destination, copySize)
+        guard error != nil else {
+            self.makeInvalid(error)
+            return
+        }
+
+        let apiDestinationBuffer = WebGPU.fromAPI(destination.buffer)
+        sourceTexture.setCommandEncoder(self)
+        apiDestinationBuffer.setCommandEncoder(self, false)
+        apiDestinationBuffer.indirectBufferInvalidated()
+        guard !sourceTexture.isDestroyed() && !apiDestinationBuffer.isDestroyed() else {
+            return
+        }
+
+        var options = MTLBlitOption(rawValue: MTLBlitOptionNone.rawValue)
+        switch (source.aspect.rawValue) {
+        case WGPUTextureAspect_All.rawValue:
+            break
+        case WGPUTextureAspect_StencilOnly.rawValue:
+            options = MTLBlitOption.stencilFromDepthStencil
+        case WGPUTextureAspect_DepthOnly.rawValue:
+            options = MTLBlitOption.depthFromDepthStencil
+        case WGPUTextureAspect_Force32.rawValue:
+            return
+        default:
+            return
+        }
+
+        let logicalSize = sourceTexture.logicalMiplevelSpecificTextureExtent(source.mipLevel)
+        let widthForMetal = logicalSize.width < source.origin.x ? 0 : min(copySize.width, logicalSize.width - source.origin.x)
+        let heightForMetal = logicalSize.height < source.origin.y ? 0 : min(copySize.height, logicalSize.height - source.origin.y)
+        let depthForMetal = logicalSize.depthOrArrayLayers < source.origin.z ? 0 : min(copySize.depthOrArrayLayers, logicalSize.depthOrArrayLayers - source.origin.z)
+
+        guard let destinationBuffer = apiDestinationBuffer.buffer() else {
+            return
+        }
+        var destinationBytesPerRow = UInt(destination.layout.bytesPerRow)
+        if (destinationBytesPerRow == WGPU_COPY_STRIDE_UNDEFINED) {
+            destinationBytesPerRow = UInt(destinationBuffer.length)
+        }
+
+        let sourceTextureFormat = sourceTexture.format()
+        let aspectSpecificFormat = WebGPU.Texture.aspectSpecificFormat(sourceTextureFormat, source.aspect)
+        let blockSize = WebGPU.Texture.texelBlockSize(aspectSpecificFormat)
+        let textureDimension = sourceTexture.dimension()
+        var didOverflow: Bool
+        switch (textureDimension.rawValue) {
+            case WGPUTextureDimension_1D.rawValue:
+                if !blockSize.hasOverflowed() {
+                    var product: UInt32 = blockSize.value()
+                    (product, didOverflow) = product.multipliedReportingOverflow(by: self.m_device.ptr().limitsCopy().maxTextureDimension1D)
+                    if !didOverflow {
+                        destinationBytesPerRow = min(destinationBytesPerRow, UInt(product))
+                    }
+                }
+            case WGPUTextureDimension_2D.rawValue, WGPUTextureDimension_3D.rawValue:
+                if !blockSize.hasOverflowed() {
+                    var product: UInt32 = blockSize.value()
+                    (product, didOverflow) = product.multipliedReportingOverflow(by: self.m_device.ptr().limitsCopy().maxTextureDimension2D)
+                    if !didOverflow {
+                        destinationBytesPerRow = min(destinationBytesPerRow, UInt(product))
+                    }
+                }
+            case WGPUTextureDimension_Force32.rawValue:
+                break
+            default:
+                break
+        }
+
+        destinationBytesPerRow = WebGPU_Internal.roundUpToMultipleOfNonPowerOfTwoCheckedUInt32UnsignedLong(blockSize, destinationBytesPerRow)
+        if textureDimension.rawValue == WGPUTextureDimension_3D.rawValue && copySize.depthOrArrayLayers <= 1 && copySize.height <= 1 {
+            destinationBytesPerRow = 0
+        }
+
+        var rowsPerImage = destination.layout.rowsPerImage
+        if rowsPerImage == WGPU_COPY_STRIDE_UNDEFINED {
+            rowsPerImage = heightForMetal != 0 ? heightForMetal : 1
+        }
+        var destinationBytesPerImage = UInt(rowsPerImage)
+        (destinationBytesPerImage, didOverflow) = destinationBytesPerImage.multipliedReportingOverflow(by: destinationBytesPerRow)
+        guard !didOverflow else {
+            return
+        }
+
+        let maxDestinationBytesPerRow: UInt = textureDimension.rawValue == WGPUTextureDimension_3D.rawValue ? (2048 * blockSize.value()) : destinationBytesPerRow
+        if destinationBytesPerRow > maxDestinationBytesPerRow {
+            for z in 0..<copySize.depthOrArrayLayers {
+                var zPlusOriginZ = z
+                (zPlusOriginZ, didOverflow) = zPlusOriginZ.addingReportingOverflow(source.origin.z)
+                guard !didOverflow else {
+                    return
+                }
+                var zTimesDestinationBytesPerImage = z
+                guard destinationBytesPerImage <= UInt32.max else {
+                    return
+                }
+                (zTimesDestinationBytesPerImage, didOverflow) = zTimesDestinationBytesPerImage.multipliedReportingOverflow(by: UInt32(destinationBytesPerImage))
+                guard !didOverflow else {
+                    return
+                }
+                for y in 0..<copySize.height {
+                    var yPlusOriginY = source.origin.y
+                    (yPlusOriginY, didOverflow) = yPlusOriginY.addingReportingOverflow(y)
+                    guard !didOverflow else {
+                        return
+                    }
+                    var yTimesDestinationBytesPerImage = y
+                    guard destinationBytesPerImage <= UInt32.max else {
+                        return
+                    }
+                    (yTimesDestinationBytesPerImage, didOverflow) = yTimesDestinationBytesPerImage.multipliedReportingOverflow(by: UInt32(destinationBytesPerImage))
+                    guard !didOverflow else {
+                        return
+                    }
+                    let newSource = WGPUImageCopyTexture(
+                        nextInChain: nil,
+                        texture: source.texture,
+                        mipLevel: source.mipLevel,
+                        origin: WGPUOrigin3D(x: source.origin.x, y: yPlusOriginY, z: zPlusOriginZ),
+                        aspect: source.aspect
+                    )
+                    var tripleSum = UInt64(destination.layout.offset)
+                    (tripleSum, didOverflow) = tripleSum.addingReportingOverflow(UInt64(zTimesDestinationBytesPerImage))
+                    guard !didOverflow else {
+                        return
+                    }
+                    (tripleSum, didOverflow) = tripleSum.addingReportingOverflow(UInt64(yTimesDestinationBytesPerImage))
+                    guard !didOverflow else {
+                        return
+                    }
+                    let newDestination = WGPUImageCopyBuffer(
+                        nextInChain: nil,
+                        layout: WGPUTextureDataLayout(
+                            nextInChain: nil,
+                            offset: tripleSum,
+                            bytesPerRow: UInt32(WGPU_COPY_STRIDE_UNDEFINED),
+                            rowsPerImage: UInt32(WGPU_COPY_STRIDE_UNDEFINED)
+                        ),
+                        buffer: destination.buffer
+                    )
+                    self.copyTextureToBuffer(source: newSource, destination: newDestination, copySize: WGPUExtent3D(
+                        width: copySize.width,
+                        height: 1,
+                        depthOrArrayLayers: 1
+                    ))
+                }
+            }
+            return
+        }
+
+        guard let blitCommandEncoder = ensureBlitCommandEncoder() else {
+            return
+        }
+
+        for layer in 0..<copySize.depthOrArrayLayers {
+            var originZPlusLayer = UInt(source.origin.z)
+            (originZPlusLayer, didOverflow) = originZPlusLayer.addingReportingOverflow(UInt(layer))
+            guard !didOverflow else {
+                return
+            }
+            let sourceSlice = sourceTexture.dimension().rawValue == WGPUTextureDimension_3D.rawValue ? 0 : originZPlusLayer
+            if !sourceTexture.previouslyCleared(source.mipLevel, UInt32(sourceSlice)) {
+                clearTextureIfNeeded(source, sourceSlice)
+            }
+        }
+
+        guard Self.hasValidDimensions(dimension: sourceTexture.dimension(), width: UInt(widthForMetal), height: UInt(heightForMetal), depth: UInt(depthForMetal)) else {
+            return
+        }
+
+        guard destinationBuffer.length >= WebGPU.Texture.bytesPerRow(aspectSpecificFormat, widthForMetal, sourceTexture.sampleCount()) else {
+            return
+        }
+
+        switch (sourceTexture.dimension()) {
+            case WGPUTextureDimension_1D:
+                // https://developer.apple.com/documentation/metal/mtlblitcommandencoder/1400756-copyfromtexture?language=objc
+                // "When you copy to a 1D texture, height and depth must be 1."
+                let sourceSize = MTLSizeMake(Int(widthForMetal), 1, 1)
+                let sourceOrigin = MTLOriginMake(Int(source.origin.x), 0, 0)
+                for layer in 0..<copySize.depthOrArrayLayers {
+                    var layerTimesDestinationBytesPerImage = UInt(layer)
+                    (layerTimesDestinationBytesPerImage, didOverflow) = layerTimesDestinationBytesPerImage.multipliedReportingOverflow(by: destinationBytesPerImage)
+                    guard !didOverflow else {
+                        return
+                    }
+                    var destinationOffset = UInt(destination.layout.offset)
+                    (destinationOffset, didOverflow) = destinationOffset.addingReportingOverflow(layerTimesDestinationBytesPerImage)
+                    guard !didOverflow else {
+                        return
+                    }
+                    var sourceSlice = UInt(source.origin.z)
+                    (sourceSlice, didOverflow) = sourceSlice.addingReportingOverflow(UInt(layer))
+                    guard !didOverflow else {
+                        return
+                    }
+                    var widthTimesBlockSize = UInt(widthForMetal)
+                    (widthTimesBlockSize, didOverflow) = widthTimesBlockSize.multipliedReportingOverflow(by: blockSize.value())
+                    guard !didOverflow else {
+                        return
+                    }
+                    let sum = UInt(destinationOffset) + UInt(widthTimesBlockSize)
+                    if sum > destinationBuffer.length {
+                        continue
+                    }
+                    blitCommandEncoder.copy(
+                        from: sourceTexture.texture(),
+                        sourceSlice: Int(sourceSlice),
+                        sourceLevel: Int(source.mipLevel),
+                        sourceOrigin: sourceOrigin,
+                        sourceSize: sourceSize,
+                        to: destinationBuffer,
+                        destinationOffset: Int(destinationOffset),
+                        destinationBytesPerRow: Int(destinationBytesPerRow),
+                        destinationBytesPerImage: Int(destinationBytesPerImage),
+                        options: options)
+                }
+            case WGPUTextureDimension_2D:
+                // https://developer.apple.com/documentation/metal/mtlblitcommandencoder/1400756-copyfromtexture?language=objc
+                // "When you copy to a 2D texture, depth must be 1."
+                let sourceSize = MTLSizeMake(Int(widthForMetal), Int(heightForMetal), 1)
+                let sourceOrigin = MTLOriginMake(Int(source.origin.x), Int(source.origin.y), 0)
+                for layer in 0..<copySize.depthOrArrayLayers {
+                    var layerTimesBytesPerImage = UInt(layer)
+                    (layerTimesBytesPerImage, didOverflow) = layerTimesBytesPerImage.multipliedReportingOverflow(by: destinationBytesPerImage)
+                    guard !didOverflow else {
+                        return
+                    }
+                    var destinationOffset = UInt(destination.layout.offset)
+                    (destinationOffset, didOverflow) = destinationOffset.addingReportingOverflow(layerTimesBytesPerImage)
+                    guard !didOverflow else {
+                        return
+                    }
+                    var sourceSlice = UInt(source.origin.z)
+                    (sourceSlice, didOverflow) = sourceSlice.addingReportingOverflow(UInt(layer))
+                    guard !didOverflow else {
+                        return
+                    }
+                    blitCommandEncoder.copy(
+                        from: sourceTexture.texture(),
+                        sourceSlice: Int(sourceSlice),
+                        sourceLevel: Int(source.mipLevel),
+                        sourceOrigin: sourceOrigin,
+                        sourceSize: sourceSize,
+                        to: destinationBuffer,
+                        destinationOffset: Int(destinationOffset),
+                        destinationBytesPerRow: Int(destinationBytesPerRow),
+                        destinationBytesPerImage: Int(destinationBytesPerImage),
+                        options: options)
+                }
+            case WGPUTextureDimension_3D:
+                let sourceSize = MTLSizeMake(Int(widthForMetal), Int(heightForMetal), Int(depthForMetal))
+                let sourceOrigin = MTLOriginMake(Int(source.origin.x), Int(source.origin.y), Int(source.origin.z))
+                let destinationOffset = UInt(destination.layout.offset)
+                blitCommandEncoder.copy(
+                    from: sourceTexture.texture(),
+                    sourceSlice: 0,
+                    sourceLevel: Int(source.mipLevel),
+                    sourceOrigin: sourceOrigin,
+                    sourceSize: sourceSize,
+                    to: destinationBuffer,
+                    destinationOffset: Int(destinationOffset),
+                    destinationBytesPerRow: Int(destinationBytesPerRow),
+                    destinationBytesPerImage: Int(destinationBytesPerImage),
+                    options: options)
+            case WGPUTextureDimension_Force32:
+                return
+            default:
+                return
+        }
+    }
+
     public func copyBufferToTexture(source: WGPUImageCopyBuffer, destination: WGPUImageCopyTexture, copySize: WGPUExtent3D) {
         guard source.nextInChain == nil && source.layout.nextInChain == nil && destination.nextInChain == nil else {
             return

--- a/Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h
+++ b/Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h
@@ -30,9 +30,11 @@
 #include <Metal/Metal.h>
 #include <cstdint>
 #include <span>
+#include <wtf/StdLibExtras.h>
 
 using SpanConstUInt8 = std::span<const uint8_t>;
 using SpanUInt8 = std::span<uint8_t>;
+inline unsigned long roundUpToMultipleOfNonPowerOfTwoCheckedUInt32UnsignedLong(Checked<uint32_t> x, unsigned long y) { return WTF::roundUpToMultipleOfNonPowerOfTwo<unsigned long int, Checked<uint32_t>>(x, y); }
 
 // FIXME: rdar://140819194
 constexpr unsigned long int WGPU_COPY_STRIDE_UNDEFINED_ = WGPU_COPY_STRIDE_UNDEFINED;


### PR DESCRIPTION
#### 0c5b39edcadd77400638b26bb53961c37423cb01
<pre>
[WebGPUSwift] Swift Implementation of copyTextureToBuffer
<a href="https://rdar.apple.com/140317728">rdar://140317728</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=283458">https://bugs.webkit.org/show_bug.cgi?id=283458</a>

Reviewed by Geoffrey Garen.

1-to-1 replacement of the ObjectiveC version.

roundUpToMultipleOfNonPowerOfTwo had to be specialized as Swift does not support
templates.

Testing: Manual test using:
./LayoutTests/http/tests/webgpu/webgpu/api/operation/command_buffer/image_copy.html

* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.hasValidDimensions(_:width:height:depth:)):
(WebGPU.copyTextureToBuffer(_:destination:copySize:)):
* Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h:
(roundUpToMultipleOfNonPowerOfTwo_CheckedUInt32_UnsignedLongInt):

Canonical link: <a href="https://commits.webkit.org/287323@main">https://commits.webkit.org/287323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41868128f5286dd354944b1ead71894899d2e1cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32557 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/83808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/30368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6482 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/83808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/30368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82252 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/52006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/72160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/83808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/49354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/28744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/70468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/26722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/85203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6486 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/85203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6649 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/68032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/85203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/13499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12224 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6442 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/6379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/9841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/8171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->