### PR TITLE
AX: Test output for attributed strings is missing many style attributes (text color, text shadow, sub/superscript, underline, and linethrough), meaning we have no test coverage for them

### DIFF
--- a/LayoutTests/accessibility/mac/attributed-string-for-text-marker-range-using-webarea-expected.txt
+++ b/LayoutTests/accessibility/mac/attributed-string-for-text-marker-range-using-webarea-expected.txt
@@ -1,22 +1,34 @@
 Tests that using the WebArea to retrieve AttributedStrings from element TextMarkerRanges works properly.
 
-"AXFont - {
+"Attributes in range {0, 15}:
+AXFont: {
     AXFontFamily = Times;
     AXFontName = "Times-Roman";
     AXFontSize = 16;
-}, This is a test."
-"AXFont - {
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+This is a test."
+"Attributes in range {0, 23}:
+AXFont: {
     AXFontFamily = Times;
     AXFontName = "Times-Roman";
     AXFontSize = 16;
-}, This is a test.
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+This is a test.
 
 Second"
-"AXFont - {
+"Attributes in range {0, 34}:
+AXFont: {
     AXFontFamily = Times;
     AXFontName = "Times-Roman";
     AXFontSize = 16;
-}, This is a test.
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+This is a test.
 
 Second paragraph."
 

--- a/LayoutTests/accessibility/mac/attributed-string/attributed-string-for-range-with-options.html
+++ b/LayoutTests/accessibility/mac/attributed-string/attributed-string-for-range-with-options.html
@@ -13,8 +13,41 @@ if (window.accessibilityController) {
     let output = "This test ensures that attributed string for text marker range works and only includes misspelled attribute when requested.\n\n";
 
     var text = null;
-    var expected1 = "AXFont - {\n    AXFontFamily = Times;\n    AXFontName = \"Times-Roman\";\n    AXFontSize = 16;\n}, word mizpelled word";
-    var expected2 = "AXFont - {\n    AXFontFamily = Times;\n    AXFontName = \"Times-Roman\";\n    AXFontSize = 16;\n}, Misspelled, AXFont - {\n    AXFontFamily = Times;\n    AXFontName = \"Times-Roman\";\n    AXFontSize = 16;\n}, AXFont - {\n    AXFontFamily = Times;\n    AXFontName = \"Times-Roman\";\n    AXFontSize = 16;\n}, word mizpelled word";
+    var expected1 = `Attributes in range {0, 19}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+word mizpelled word`;
+    var expected2 = `Attributes in range {0, 5}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Attributes in range {5, 9}:
+Misspelled, AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Attributes in range {14, 5}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+word mizpelled word`;
+
     let axElement = accessibilityController.accessibleElementById("content");
     let range = axElement.textMarkerRangeForElement(axElement);
     text = axElement.attributedStringForTextMarkerRangeWithOptions(range, false);
@@ -23,7 +56,15 @@ if (window.accessibilityController) {
     output += expect("text", "expected2");
 
     // Correct the misspelling and verify that the attributed string changes accordingly.
-    var expected3 = "AXFont - {\n    AXFontFamily = Times;\n    AXFontName = \"Times-Roman\";\n    AXFontSize = 16;\n}, word misspelled word";
+    var expected3 = `Attributes in range {0, 20}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+word misspelled word`;
     axElement.replaceTextInRange("ss", 7, 1);
     // Note that with replaceTextInRange(...), there is no need to await for the change to be reflected in the AX tree.
     range = axElement.textMarkerRangeForElement(axElement);
@@ -31,7 +72,23 @@ if (window.accessibilityController) {
     output += expect("text", "expected3");
 
     // Make another misspelling and verify.
-    var expected4 = "Misspelled, AXFont - {\n    AXFontFamily = Times;\n    AXFontName = \"Times-Roman\";\n    AXFontSize = 16;\n}, AXFont - {\n    AXFontFamily = Times;\n    AXFontName = \"Times-Roman\";\n    AXFontSize = 16;\n}, worz misspelled word";
+    var expected4 = `Attributes in range {0, 4}:
+Misspelled, AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Attributes in range {4, 16}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+worz misspelled word`;
     axElement.replaceTextInRange("z", 3, 1);
     range = axElement.textMarkerRangeForElement(axElement);
     text = axElement.attributedStringForTextMarkerRangeWithOptions(range, true);

--- a/LayoutTests/accessibility/mac/attributed-string/attributed-string-for-range.html
+++ b/LayoutTests/accessibility/mac/attributed-string/attributed-string-for-range.html
@@ -15,7 +15,31 @@ if (window.accessibilityController) {
     let output = "This test ensures that attributed string for text marker range works and does include misspelled attribute.\n\n";
 
     var text = null;
-    var expected = "AXFont - {\n    AXFontFamily = Times;\n    AXFontName = \"Times-Roman\";\n    AXFontSize = 16;\n}, Misspelled, AXFont - {\n    AXFontFamily = Times;\n    AXFontName = \"Times-Roman\";\n    AXFontSize = 16;\n}, AXFont - {\n    AXFontFamily = Times;\n    AXFontName = \"Times-Roman\";\n    AXFontSize = 16;\n}, word mispelled word";
+    var expected = `Attributes in range {0, 5}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Attributes in range {5, 9}:
+Misspelled, AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Attributes in range {14, 5}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+word mispelled word`;
 
     let axElement = accessibilityController.accessibleElementById("content");
     let range = axElement.textMarkerRangeForElement(axElement);

--- a/LayoutTests/accessibility/mac/attributed-string/attributed-string-text-styling.html
+++ b/LayoutTests/accessibility/mac/attributed-string/attributed-string-text-styling.html
@@ -15,22 +15,58 @@
     if (window.accessibilityController) {
         var textPlain = accessibilityController.accessibleElementById("text-plain");
         var textPlainRange = textPlain.textMarkerRangeForElement(textPlain);
-        var textPlainAttributes = "AXFont - {\n    AXFontFamily = Times;\n    AXFontName = \"Times-Roman\";\n    AXFontSize = 16;\n}, The";
+        var textPlainAttributes = `Attributes in range {0, 3}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+The`;
         shouldBe("textPlain.attributedStringForTextMarkerRange(textPlainRange)", "textPlainAttributes");
 
         var textBold = accessibilityController.accessibleElementById("text-bold");
         var textBoldRange = textBold.textMarkerRangeForElement(textBold);
-        var textBoldAttributes = "AXFont - {\n    AXFontBold = 1;\n    AXFontFamily = Times;\n    AXFontName = \"Times-Bold\";\n    AXFontSize = 16;\n}, Fox";
+        var textBoldAttributes = `Attributes in range {0, 3}:
+AXFont: {
+    AXFontBold = 1;
+    AXFontFamily = Times;
+    AXFontName = "Times-Bold";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Fox`;
         shouldBe("textBold.attributedStringForTextMarkerRange(textBoldRange)", "textBoldAttributes");
 
         var textItalic = accessibilityController.accessibleElementById("text-italic");
         var textItalicRange = textItalic.textMarkerRangeForElement(textItalic);
-        var textItalicAttributes = "AXFont - {\n    AXFontFamily = Times;\n    AXFontItalic = 1;\n    AXFontName = \"Times-Italic\";\n    AXFontSize = 16;\n}, Jumped";
+        var textItalicAttributes = `Attributes in range {0, 6}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontItalic = 1;
+    AXFontName = "Times-Italic";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Jumped`;
         shouldBe("textItalic.attributedStringForTextMarkerRange(textItalicRange)", "textItalicAttributes");
 
         var textBoldItalic = accessibilityController.accessibleElementById("text-bold-italic");
         var textBoldItalicRange = textBoldItalic.textMarkerRangeForElement(textBoldItalic);
-        var textBoldItalicAttributes = "AXFont - {\n    AXFontBold = 1;\n    AXFontFamily = Times;\n    AXFontItalic = 1;\n    AXFontName = \"Times-BoldItalic\";\n    AXFontSize = 16;\n}, Over";
+        var textBoldItalicAttributes = `Attributes in range {0, 4}:
+AXFont: {
+    AXFontBold = 1;
+    AXFontFamily = Times;
+    AXFontItalic = 1;
+    AXFontName = "Times-BoldItalic";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Over`;
         shouldBe("textBoldItalic.attributedStringForTextMarkerRange(textBoldItalicRange)", "textBoldItalicAttributes");
     }
 </script>

--- a/LayoutTests/accessibility/mac/content-editable-attributed-string-expected.txt
+++ b/LayoutTests/accessibility/mac/content-editable-attributed-string-expected.txt
@@ -1,48 +1,89 @@
 Tests that AttributedStrings are retrieved properly from line ranges within a contenteditable with children.
 
-All text in the contenteditable: "AXFont - {
+All text in the contenteditable: "Attributes in range {0, 22}:
+AXFont: {
     AXFontFamily = Times;
     AXFontName = "Times-Roman";
     AXFontSize = 16;
-}, AXFont - {
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Attributes in range {22, 8}:
+AXFont: {
     AXFontFamily = Times;
     AXFontName = "Times-Roman";
     AXFontSize = 16;
-}, AXFont - {
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0.933333 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+AXUnderline: YES
+AXUnderlineColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0.933333 1 )
+Attributes in range {30, 12}:
+AXFont: {
     AXFontFamily = Times;
     AXFontName = "Times-Roman";
     AXFontSize = 16;
-}, AXFont - {
-    AXFontFamily = Times;
-    AXFontName = "Times-Roman";
-    AXFontSize = 16;
-}, First line.
-Some text click me more text.
-Another line."
-First line: "AXFont - {
-    AXFontFamily = Times;
-    AXFontName = "Times-Roman";
-    AXFontSize = 16;
-}, First line."
-Second line: "AXFont - {
-    AXFontFamily = Times;
-    AXFontName = "Times-Roman";
-    AXFontSize = 16;
-}, AXFont - {
-    AXFontFamily = Times;
-    AXFontName = "Times-Roman";
-    AXFontSize = 16;
-}, AXFont - {
-    AXFontFamily = Times;
-    AXFontName = "Times-Roman";
-    AXFontSize = 16;
-}, Some text click me more text."
-third line: "AXFont - {
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Attributes in range {42, 13}:
+AXFont: {
     AXFontFamily = Times;
     AXFontItalic = 1;
     AXFontName = "Times-Italic";
     AXFontSize = 16;
-}, Another line."
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+First line.
+Some text click me more text.
+Another line."
+First line: "Attributes in range {0, 11}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+First line."
+Second line: "Attributes in range {0, 10}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Attributes in range {10, 8}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0.933333 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+AXUnderline: YES
+AXUnderlineColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0.933333 1 )
+Attributes in range {18, 11}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Some text click me more text."
+third line: "Attributes in range {0, 13}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontItalic = 1;
+    AXFontName = "Times-Italic";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Another line."
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/platform/mac/accessibility/mac/selected-text-range-unconnected-object-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/mac/selected-text-range-unconnected-object-expected.txt
@@ -4,22 +4,30 @@ Text Marker: [Length: 5]
 	START: AXRole: AXStaticText
 	END: AXRole: AXStaticText
 
-Text Marker Range Attributed Text: AXFont - {
+Text Marker Range Attributed Text: Attributes in range {0, 5}:
+AXFont: {
     AXFontFamily = Helvetica;
     AXFontName = Helvetica;
     AXFontSize = 11;
-}, Hello
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Hello
 
 Inserting 'world'
 Text Marker: [Length: 11]
 	START: AXRole: AXStaticText
 	END: AXRole: AXStaticText
 
-Text Marker Range Attributed Text: AXFont - {
+Text Marker Range Attributed Text: Attributes in range {0, 11}:
+AXFont: {
     AXFontFamily = Helvetica;
     AXFontName = Helvetica;
     AXFontSize = 11;
-}, Hello world
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+Hello world
 
 
 PASS successfullyParsed is true

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -2403,19 +2403,72 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::accessibilityElementForTe
     return nullptr;
 }
 
+static NSString *descriptionForColor(CGColorRef color)
+{
+    // This is a hack to get an OK description for a CGColor by crudely parsing its debug description, e.g.:
+    //
+    // <CGColor 0x13bf07670> <CGColorSpace 0x12be0ce40> [ (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1)] ( 0 0 0 0 )
+    // Ideally we convert it to a WebCore::Color and then call serializationForCSS(const Color&), but I can't
+    // get that to link succesfully, despite these symbols being WEBCORE_EXPORTed.
+    auto string = adoptNS([[NSMutableString alloc] init]);
+    [string appendFormat:@"%@", color];
+    NSArray *stringComponents = [string componentsSeparatedByString:@">"];
+    if (stringComponents.count)
+        return [[stringComponents objectAtIndex:stringComponents.count - 1] stringByReplacingOccurrencesOfString:@"]" withString:@""];
+    return nil;
+}
+
+static void appendColorDescription(RetainPtr<NSMutableString> string, NSString* attributeKey, NSDictionary<NSString *, id> *attributes)
+{
+    id color = [attributes objectForKey:attributeKey];
+    if (!color)
+        return;
+
+    if (CFGetTypeID(color) == CGColorGetTypeID())
+        [string appendFormat:@"%@:%@\n", attributeKey, descriptionForColor((CGColorRef)color)];
+}
+
 static JSRetainPtr<JSStringRef> createJSStringRef(id string)
 {
     auto mutableString = adoptNS([[NSMutableString alloc] init]);
-    id attributes = [string attributesAtIndex:0 effectiveRange:nil];
-    id attributeEnumerationBlock = ^(NSDictionary<NSString *, id> *attrs, NSRange range, BOOL *stop) {
-        BOOL misspelled = [[attrs objectForKey:NSAccessibilityMisspelledTextAttribute] boolValue];
+    id attributeEnumerationBlock = ^(NSDictionary<NSString *, id> *attributes, NSRange range, BOOL *stop) {
+        [mutableString appendFormat:@"Attributes in range %@:\n", NSStringFromRange(range)];
+        BOOL misspelled = [[attributes objectForKey:NSAccessibilityMisspelledTextAttribute] boolValue];
         if (misspelled)
-            misspelled = [[attrs objectForKey:NSAccessibilityMarkedMisspelledTextAttribute] boolValue];
+            misspelled = [[attributes objectForKey:NSAccessibilityMarkedMisspelledTextAttribute] boolValue];
         if (misspelled)
             [mutableString appendString:@"Misspelled, "];
         id font = [attributes objectForKey:(__bridge id)kAXFontTextAttribute];
         if (font)
-            [mutableString appendFormat:@"%@ - %@, ", (__bridge id)kAXFontTextAttribute, font];
+            [mutableString appendFormat:@"%@: %@\n", (__bridge id)kAXFontTextAttribute, font];
+
+        appendColorDescription(mutableString, NSAccessibilityForegroundColorTextAttribute, attributes);
+        appendColorDescription(mutableString, NSAccessibilityBackgroundColorTextAttribute, attributes);
+
+        int scriptState = [[attributes objectForKey:NSAccessibilitySuperscriptTextAttribute] intValue];
+        if (scriptState == -1) {
+            // -1 == subscript
+            [mutableString appendFormat:@"%@: -1\n", NSAccessibilitySuperscriptTextAttribute];
+        } else if (scriptState == 1) {
+            // 1 == superscript
+            [mutableString appendFormat:@"%@: 1\n", NSAccessibilitySuperscriptTextAttribute];
+        }
+
+        BOOL hasTextShadow = [[attributes objectForKey:NSAccessibilityShadowTextAttribute] boolValue];
+        if (hasTextShadow)
+            [mutableString appendFormat:@"%@: YES\n", NSAccessibilityShadowTextAttribute];
+
+        BOOL hasUnderline = [[attributes objectForKey:NSAccessibilityUnderlineTextAttribute] boolValue];
+        if (hasUnderline) {
+            [mutableString appendFormat:@"%@: YES\n", NSAccessibilityUnderlineTextAttribute];
+            appendColorDescription(mutableString, NSAccessibilityUnderlineColorTextAttribute, attributes);
+        }
+
+        BOOL hasLinethrough = [[attributes objectForKey:NSAccessibilityStrikethroughTextAttribute] boolValue];
+        if (hasLinethrough) {
+            [mutableString appendFormat:@"%@: YES\n", NSAccessibilityStrikethroughTextAttribute];
+            appendColorDescription(mutableString, NSAccessibilityStrikethroughColorTextAttribute, attributes);
+        }
     };
     [string enumerateAttributesInRange:NSMakeRange(0, [string length]) options:(NSAttributedStringEnumerationOptions)0 usingBlock:attributeEnumerationBlock];
     [mutableString appendString:[string string]];


### PR DESCRIPTION
#### 0fc4a7ef39c0ebd793c8a6e247989d3233af318f
<pre>
AX: Test output for attributed strings is missing many style attributes (text color, text shadow, sub/superscript, underline, and linethrough), meaning we have no test coverage for them
<a href="https://bugs.webkit.org/show_bug.cgi?id=283535">https://bugs.webkit.org/show_bug.cgi?id=283535</a>
<a href="https://rdar.apple.com/problem/140385001">rdar://problem/140385001</a>

Reviewed by Chris Fleizach.

With this commit, we now output foreground text color and background color, text shadow, sub/superscript, underline,
and linethrough styles for attributed strings. This will allow us to write tests ensuring their presence or lack thereof.

* LayoutTests/accessibility/mac/attributed-string-for-text-marker-range-using-webarea-expected.txt:
* LayoutTests/accessibility/mac/attributed-string/attributed-string-for-range-with-options.html:
* LayoutTests/accessibility/mac/attributed-string/attributed-string-for-range.html:
* LayoutTests/accessibility/mac/attributed-string/attributed-string-text-styling.html:
* LayoutTests/accessibility/mac/content-editable-attributed-string-expected.txt:
* LayoutTests/platform/mac/accessibility/mac/selected-text-range-unconnected-object-expected.txt:
Fix some tests that expected some hardcoded output, as there are now more attributes included in the output.

* Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm:
(descriptionForColor):
(appendColorDescription):
(createJSStringRef):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::descriptionForColor):
(WTR::appendColorDescription):
(WTR::createJSStringRef):

Canonical link: <a href="https://commits.webkit.org/286974@main">https://commits.webkit.org/286974@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8916d1342bead51daad3dc9a83e726dccc52cfbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82412 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29048 "Failed to checkout and rebase branch from PR 36988") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5097 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60915 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18868 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50885 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66708 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41215 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48243 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24226 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27373 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69359 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24574 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83771 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5142 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3472 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69136 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66702 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68385 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17091 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12405 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10488 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5090 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/5095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/8531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6867 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->