### PR TITLE
[Gardening]: REGRESSION(286884@main?): [macOS Debug] imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.html is consistent crash(flaky in EWS)

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1940,3 +1940,6 @@ webkit.org/b/283210 http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavai
 # webkit.org/b/283445 REGRESSION(286802@main?): [macOS Debug wk2] ASSERTION FAILED: !m_messageReceiverMapCount in webrtc/vp8-then-h264.html
 [ Debug ] webrtc/vp8-then-h264.html [ Skip ]
 [ Debug ] webrtc/vp8-then-h264-gpu-process-crash.html [ Skip ]
+
+# webkit.org/b/283537 REGRESSION(286884@main?): [macOS Debug] imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.html is consistent crash(flaky in EWS)
+[ Debug ] imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.html [ Skip ]


### PR DESCRIPTION
#### 250aaac9300e21b64a5a898d8e8eae6dacb0810e
<pre>
[Gardening]: REGRESSION(286884@main?): [macOS Debug] imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.html is consistent crash(flaky in EWS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=283537">https://bugs.webkit.org/show_bug.cgi?id=283537</a>
<a href="https://rdar.apple.com/140385278">rdar://140385278</a>

Unreviewed test gardening

Skipping the test due to false-positive failures in EWS

* LayoutTests/platform/mac-wk2/TestExpectations:
</pre>