### PR TITLE
Add ImageDataSettings.storageFormat

### DIFF
--- a/LayoutTests/fast/canvas/imagedata-storageformat-disabled-expected.txt
+++ b/LayoutTests/fast/canvas/imagedata-storageformat-disabled-expected.txt
@@ -1,0 +1,15 @@
+Tests that ImageDataSettings with CanvasPixelFormatEnabled=false ignores storageFormat.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS created_imageData_uint8.data.constructor is Uint8ClampedArray
+PASS gotten_imageData_uint8.data.constructor is Uint8ClampedArray
+PASS created_imageData_float16.data.constructor is Uint8ClampedArray
+PASS gotten_imageData_float16.data.constructor is Uint8ClampedArray
+PASS created_imageData_foo.data.constructor is Uint8ClampedArray
+PASS gotten_imageData_foo.data.constructor is Uint8ClampedArray
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/imagedata-storageformat-disabled.html
+++ b/LayoutTests/fast/canvas/imagedata-storageformat-disabled.html
@@ -1,0 +1,36 @@
+<!-- webkit-test-runner [ CanvasPixelFormatEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("Tests that ImageDataSettings with CanvasPixelFormatEnabled=false ignores storageFormat.");
+
+var canvas = document.createElement("canvas");
+canvas.width = 10;
+canvas.height = 10;
+var context = canvas.getContext("2d");
+
+var created_imageData_uint8 = context.createImageData(1, 1, { storageFormat: "uint8" });
+shouldBe('created_imageData_uint8.data.constructor', 'Uint8ClampedArray');
+
+var gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { storageFormat: "uint8" });
+shouldBe('gotten_imageData_uint8.data.constructor', 'Uint8ClampedArray');
+
+var created_imageData_float16 = context.createImageData(1, 1, { storageFormat: "float16" });
+shouldBe('created_imageData_float16.data.constructor', 'Uint8ClampedArray');
+
+var gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { storageFormat: "float16" });
+shouldBe('gotten_imageData_float16.data.constructor', 'Uint8ClampedArray');
+
+var created_imageData_foo = context.createImageData(1, 1, { storageFormat: "foo" });
+shouldBe('created_imageData_foo.data.constructor', 'Uint8ClampedArray');
+
+var gotten_imageData_foo = context.getImageData(0, 0, 1, 1, { storageFormat: "foo" });
+shouldBe('gotten_imageData_foo.data.constructor', 'Uint8ClampedArray');
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/imagedata-storageformat-enabled-expected.txt
+++ b/LayoutTests/fast/canvas/imagedata-storageformat-enabled-expected.txt
@@ -1,0 +1,15 @@
+Tests that ImageDataSettings contains storageFormat.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS created_imageData_uint8.data.constructor is Uint8ClampedArray
+PASS gotten_imageData_uint8.data.constructor is Uint8ClampedArray
+PASS created_imageData_float16.data.constructor is Uint8ClampedArray
+PASS gotten_imageData_float16.data.constructor is Uint8ClampedArray
+PASS context.createImageData(1, 1, { storageFormat: "foo" }) threw exception TypeError: Type error.
+PASS context.getImageData(0, 0, 1, 1, { storageFormat: "foo" }) threw exception TypeError: Type error.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/imagedata-storageformat-enabled.html
+++ b/LayoutTests/fast/canvas/imagedata-storageformat-enabled.html
@@ -1,0 +1,33 @@
+<!-- webkit-test-runner [ CanvasPixelFormatEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("Tests that ImageDataSettings contains storageFormat.");
+
+var canvas = document.createElement("canvas");
+canvas.width = 10;
+canvas.height = 10;
+var context = canvas.getContext("2d");
+
+var created_imageData_uint8 = context.createImageData(1, 1, { storageFormat: "uint8" });
+shouldBe('created_imageData_uint8.data.constructor', 'Uint8ClampedArray');
+var gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { storageFormat: "uint8" });
+shouldBe('gotten_imageData_uint8.data.constructor', 'Uint8ClampedArray');
+
+var created_imageData_float16 = context.createImageData(1, 1, { storageFormat: "float16" });
+// FIXME: This should eventually become Float16Array.
+shouldBe('created_imageData_float16.data.constructor', 'Uint8ClampedArray');
+var gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { storageFormat: "float16" });
+// FIXME: This should eventually become Float16Array.
+shouldBe('gotten_imageData_float16.data.constructor', 'Uint8ClampedArray');
+
+shouldThrowErrorName(`context.createImageData(1, 1, { storageFormat: "foo" })`, "TypeError")
+shouldThrowErrorName(`context.getImageData(0, 0, 1, 1, { storageFormat: "foo" })`, "TypeError")
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1329,6 +1329,7 @@ set(WebCore_NON_SVG_IDL_FILES
     html/ImageBitmapOptions.idl
     html/ImageData.idl
     html/ImageDataSettings.idl
+    html/ImageDataStorageFormat.idl
     html/InvokerElement.idl
     html/MediaController.idl
     html/MediaEncryptedEvent.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1664,6 +1664,7 @@ $(PROJECT_DIR)/html/ImageBitmap.idl
 $(PROJECT_DIR)/html/ImageBitmapOptions.idl
 $(PROJECT_DIR)/html/ImageData.idl
 $(PROJECT_DIR)/html/ImageDataSettings.idl
+$(PROJECT_DIR)/html/ImageDataStorageFormat.idl
 $(PROJECT_DIR)/html/InvokerElement.idl
 $(PROJECT_DIR)/html/MediaController.idl
 $(PROJECT_DIR)/html/MediaEncryptedEvent.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1709,6 +1709,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageData.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageData.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageDataSettings.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageDataSettings.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageDataStorageFormat.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageDataStorageFormat.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageResource.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageResource.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageSmoothingQuality.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1343,6 +1343,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/html/ImageBitmapOptions.idl \
     $(WebCore)/html/ImageData.idl \
     $(WebCore)/html/ImageDataSettings.idl \
+    $(WebCore)/html/ImageDataStorageFormat.idl \
     $(WebCore)/html/InvokerElement.idl \
     $(WebCore)/html/MediaController.idl \
     $(WebCore)/html/MediaEncryptedEvent.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1336,6 +1336,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/ImageBitmap.h
     html/ImageData.h
     html/ImageDataSettings.h
+    html/ImageDataStorageFormat.h
     html/ImageDocument.h
     html/InputMode.h
     html/LinkIconCollector.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -4061,6 +4061,7 @@ JSImageBitmapRenderingContextSettings.cpp
 JSImageCapture.cpp
 JSImageData.cpp
 JSImageDataSettings.cpp
+JSImageDataStorageFormat.cpp
 JSImageSmoothingQuality.cpp
 JSInputDeviceInfo.cpp
 JSInputEvent.cpp

--- a/Source/WebCore/html/ImageDataSettings.h
+++ b/Source/WebCore/html/ImageDataSettings.h
@@ -25,12 +25,14 @@
 
 #pragma once
 
+#include "ImageDataStorageFormat.h"
 #include "PredefinedColorSpace.h"
 
 namespace WebCore {
 
 struct ImageDataSettings {
     std::optional<PredefinedColorSpace> colorSpace;
+    ImageDataStorageFormat storageFormat { ImageDataStorageFormat::Uint8 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/ImageDataSettings.idl
+++ b/Source/WebCore/html/ImageDataSettings.idl
@@ -26,4 +26,5 @@
 // https://html.spec.whatwg.org/multipage/canvas.html#imagedatasettings
 dictionary ImageDataSettings {
     [EnabledBySetting=CanvasColorSpaceEnabled] PredefinedColorSpace colorSpace;
+    [EnabledBySetting=CanvasPixelFormatEnabled] ImageDataStorageFormat storageFormat = "uint8";
 };

--- a/Source/WebCore/html/ImageDataStorageFormat.h
+++ b/Source/WebCore/html/ImageDataStorageFormat.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class ImageDataStorageFormat : bool {
+    Uint8,
+    Float16,
+};
+
+}

--- a/Source/WebCore/html/ImageDataStorageFormat.idl
+++ b/Source/WebCore/html/ImageDataStorageFormat.idl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://github.com/w3c/ColorWeb-CG/blob/main/canvas_float.md with Chromium renaming (subject to change)
+enum ImageDataStorageFormat {
+    "uint8",
+    "float16",
+};


### PR DESCRIPTION
#### 3a6f4d0b3924f4643b4df54e89fb685d7b58bc84
<pre>
Add ImageDataSettings.storageFormat
<a href="https://bugs.webkit.org/show_bug.cgi?id=283539">https://bugs.webkit.org/show_bug.cgi?id=283539</a>
<a href="https://rdar.apple.com/problem/140386529">rdar://problem/140386529</a>

Reviewed by Cameron McCormack.

This will be used to determine the pixel format of the data
stored in an ImageData object; this is necessary to
eventually support HDR.

This patch only adds the ImageDataStorageFormat type (it&apos;s
not trivial to add an idl file!) and its use in
ImageDataSettings, but is still ignored otherwise.

* LayoutTests/fast/canvas/imagedata-storageformat-disabled-expected.txt: Added.
* LayoutTests/fast/canvas/imagedata-storageformat-disabled.html: Added.
* LayoutTests/fast/canvas/imagedata-storageformat-enabled-expected.txt: Added.
* LayoutTests/fast/canvas/imagedata-storageformat-enabled.html: Added.
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/ImageDataSettings.h:
* Source/WebCore/html/ImageDataSettings.idl:
* Source/WebCore/html/ImageDataStorageFormat.h: Copied from Source/WebCore/html/ImageDataSettings.h.
* Source/WebCore/html/ImageDataStorageFormat.idl: Copied from Source/WebCore/html/ImageDataSettings.h.

Canonical link: <a href="https://commits.webkit.org/287119@main">https://commits.webkit.org/287119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/022719462081e3e55ce1038bd28b697ad5bf0bba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83048 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29652 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80520 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61381 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19302 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81454 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68969 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41694 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48742 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25103 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27989 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69837 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84414 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3906 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69608 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5914 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67368 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68862 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17169 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12888 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11229 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5699 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8458 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5689 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9122 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7475 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->