### PR TITLE
Add partitionKey attribute on Cookie class

### DIFF
--- a/Source/WebCore/platform/Cookie.h
+++ b/Source/WebCore/platform/Cookie.h
@@ -60,6 +60,7 @@ struct Cookie {
             && value.isNull()
             && domain.isNull()
             && path.isNull()
+            && partitionKey.isNull()
             && !created
             && !expires
             && !httpOnly
@@ -80,6 +81,7 @@ struct Cookie {
     String value;
     String domain;
     String path;
+    String partitionKey;
     // Creation and expiration dates are expressed as milliseconds since the UNIX epoch.
     double created { 0 };
     std::optional<double> expires;
@@ -98,11 +100,12 @@ struct Cookie {
 
     SameSitePolicy sameSite { SameSitePolicy::None };
 
-    Cookie(String&& name, String&& value, String&& domain, String&& path, double created, std::optional<double> expires, bool httpOnly, bool secure, bool session, String&& comment, URL&& commentURL, Vector<uint16_t> ports, SameSitePolicy sameSite)
+    Cookie(String&& name, String&& value, String&& domain, String&& path, String&& partitionKey, double created, std::optional<double> expires, bool httpOnly, bool secure, bool session, String&& comment, URL&& commentURL, Vector<uint16_t> ports, SameSitePolicy sameSite)
         : name(WTFMove(name))
         , value(WTFMove(value))
         , domain(WTFMove(domain))
         , path(WTFMove(path))
+        , partitionKey(WTFMove(partitionKey))
         , created(created)
         , expires(expires)
         , httpOnly(httpOnly)
@@ -115,8 +118,8 @@ struct Cookie {
     {
     }
 
-    Cookie isolatedCopy() const & { return { name.isolatedCopy(), value.isolatedCopy(), domain.isolatedCopy(), path.isolatedCopy(), created, expires, httpOnly, secure, session, comment.isolatedCopy(), commentURL.isolatedCopy(), ports, sameSite }; }
-    Cookie isolatedCopy() && { return { WTFMove(name).isolatedCopy(), WTFMove(value).isolatedCopy(), WTFMove(domain).isolatedCopy(), WTFMove(path).isolatedCopy(), created, expires, httpOnly, secure, session, WTFMove(comment).isolatedCopy(), WTFMove(commentURL).isolatedCopy(), WTFMove(ports), sameSite }; }
+    Cookie isolatedCopy() const & { return { name.isolatedCopy(), value.isolatedCopy(), domain.isolatedCopy(), path.isolatedCopy(), partitionKey.isolatedCopy(), created, expires, httpOnly, secure, session, comment.isolatedCopy(), commentURL.isolatedCopy(), ports, sameSite }; }
+    Cookie isolatedCopy() && { return { WTFMove(name).isolatedCopy(), WTFMove(value).isolatedCopy(), WTFMove(domain).isolatedCopy(), WTFMove(path).isolatedCopy(), WTFMove(partitionKey).isolatedCopy(), created, expires, httpOnly, secure, session, WTFMove(comment).isolatedCopy(), WTFMove(commentURL).isolatedCopy(), WTFMove(ports), sameSite }; }
 };
 
 struct CookieHash {

--- a/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
@@ -25,6 +25,7 @@
 
 #import "config.h"
 #import "Cookie.h"
+#import <pal/spi/cf/CFNetworkSPI.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 // FIXME: Remove NS_ASSUME_NONNULL_BEGIN/END and all _Nullable annotations once we remove the NSHTTPCookie forward declaration below.
@@ -113,6 +114,7 @@ Cookie::Cookie(NSHTTPCookie *cookie)
     , value { cookie.value }
     , domain { cookie.domain }
     , path { cookie.path }
+    , partitionKey { cookie._storagePartition }
     , created { cookieCreated(cookie) }
     , expires { cookieExpiry(cookie) }
     , httpOnly { static_cast<bool>(cookie.HTTPOnly) }
@@ -146,6 +148,9 @@ Cookie::operator NSHTTPCookie * _Nullable () const
 
     if (!path.isNull())
         [properties setObject:(NSString *)path forKey:NSHTTPCookiePath];
+
+    if (!partitionKey.isNull())
+        [properties setObject:(NSString *)partitionKey forKey:@"StoragePartition"];
 
     if (!value.isNull())
         [properties setObject:(NSString *)value forKey:NSHTTPCookieValue];

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1756,6 +1756,7 @@ struct WebCore::Cookie {
     String value;
     String domain;
     String path;
+    String partitionKey;
     double created;
     std::optional<double> expires;
     bool httpOnly;


### PR DESCRIPTION
#### 7ac2980ca7a683335b371c9650404a668b6a85f2
<pre>
Add partitionKey attribute on Cookie class
<a href="https://bugs.webkit.org/show_bug.cgi?id=283542">https://bugs.webkit.org/show_bug.cgi?id=283542</a>
<a href="https://rdar.apple.com/140388054">rdar://140388054</a>

Reviewed by Charlie Wolfe and Sihui Liu.

This is work toward supporting opt-in partitioned cookies.

No new tests, no change in behavior.

* Source/WebCore/platform/Cookie.h:
(WebCore::Cookie::isNull const):
(WebCore::Cookie::Cookie):
(WebCore::Cookie::isolatedCopy const):
(WebCore::Cookie::isolatedCopy):
* Source/WebCore/platform/network/cocoa/CookieCocoa.mm:
(WebCore::Cookie::operator NSHTTPCookie * _Nullable  const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/287278@main">https://commits.webkit.org/287278@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20c51cb3c22d11f49efc10e3359acc7ac70fa408

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82240 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28885 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60821 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18777 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50779 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66607 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41093 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24104 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27212 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69286 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83596 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3394 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69032 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5144 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66569 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68294 "Found 1 new API test failure: /TestWebKit:WebKit.GetInjectedBundleInitializationUserDataCallback (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12307 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10414 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12194 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4934 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7746 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4949 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8387 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6712 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->