### PR TITLE
WebExtensions code added significantly to build time.

### DIFF
--- a/Source/WebKit/Shared/Extensions/Cocoa/WebExtensionFrameIdentifierCocoa.mm
+++ b/Source/WebKit/Shared/Extensions/Cocoa/WebExtensionFrameIdentifierCocoa.mm
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WebExtensionFrameIdentifier.h"
+
+#import "WKFrameInfoPrivate.h"
+#import "_WKFrameHandle.h"
+
+namespace WebKit {
+
+WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(WKFrameInfo *frameInfo)
+{
+    if (frameInfo.isMainFrame)
+        return WebExtensionFrameConstants::MainFrameIdentifier;
+
+    // FIXME: <rdar://117932176> Stop using FrameIdentifier/_WKFrameHandle for WebExtensionFrameIdentifier,
+    // which needs to be just one number and probably should only be generated in the UI process
+    // to prevent collisions with numbers generated in different web content processes, especially with site isolation.
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    auto identifier = frameInfo._handle.frameID;
+ALLOW_DEPRECATED_DECLARATIONS_END
+    if (!WebExtensionFrameIdentifier::isValidIdentifier(identifier)) {
+        ASSERT_NOT_REACHED();
+        return WebExtensionFrameConstants::NoneIdentifier;
+    }
+
+    return WebExtensionFrameIdentifier { identifier };
+}
+
+}

--- a/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebExtensionFrameIdentifier.h"
+
+#include "FrameInfoData.h"
+#include "WebFrame.h"
+#include "WebPage.h"
+#include <WebCore/Frame.h>
+
+namespace WebKit {
+
+WebCore::FrameIdentifier toWebCoreFrameIdentifier(const WebExtensionFrameIdentifier& identifier, const WebPage& page)
+{
+    if (isMainFrame(identifier))
+        return page.mainWebFrame().frameID();
+
+    return { ObjectIdentifier<WebCore::FrameIdentifierType> { identifier.toUInt64() }, WebCore::Process::identifier() };
+}
+
+bool matchesFrame(const WebExtensionFrameIdentifier& identifier, const WebFrame& frame)
+{
+    if (RefPtr coreFrame = frame.coreFrame(); coreFrame && coreFrame->isMainFrame() && isMainFrame(identifier))
+        return true;
+
+    if (RefPtr page = frame.page(); page && &page->mainWebFrame() == &frame && isMainFrame(identifier))
+        return true;
+
+    return frame.frameID().object().toUInt64() == identifier.toUInt64();
+}
+
+WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(std::optional<WebCore::FrameIdentifier> frameIdentifier)
+{
+    if (!frameIdentifier) {
+        ASSERT_NOT_REACHED();
+        return WebExtensionFrameConstants::NoneIdentifier;
+    }
+
+    auto identifierAsUInt64 = frameIdentifier->object().toUInt64();
+    if (!WebExtensionFrameIdentifier::isValidIdentifier(identifierAsUInt64)) {
+        ASSERT_NOT_REACHED();
+        return WebExtensionFrameConstants::NoneIdentifier;
+    }
+
+    return WebExtensionFrameIdentifier { identifierAsUInt64 };
+}
+
+WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(const WebFrame& frame)
+{
+    if (RefPtr coreFrame = frame.coreFrame(); coreFrame && coreFrame->isMainFrame())
+        return WebExtensionFrameConstants::MainFrameIdentifier;
+
+    if (RefPtr page = frame.page(); page && &page->mainWebFrame() == &frame)
+        return WebExtensionFrameConstants::MainFrameIdentifier;
+
+    return toWebExtensionFrameIdentifier(std::optional { frame.frameID() });
+}
+
+WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(const FrameInfoData& frameInfoData)
+{
+    if (frameInfoData.isMainFrame)
+        return WebExtensionFrameConstants::MainFrameIdentifier;
+
+    return toWebExtensionFrameIdentifier(frameInfoData.frameID);
+}
+
+std::optional<WebExtensionFrameIdentifier> toWebExtensionFrameIdentifier(double identifier)
+{
+    if (identifier == WebExtensionFrameConstants::MainFrame)
+        return WebExtensionFrameConstants::MainFrameIdentifier;
+
+    if (identifier == WebExtensionFrameConstants::None)
+        return WebExtensionFrameConstants::NoneIdentifier;
+
+    if (!std::isfinite(identifier) || identifier <= 0 || identifier >= static_cast<double>(WebExtensionFrameConstants::NoneIdentifier.toUInt64()))
+        return std::nullopt;
+
+    double integral;
+    if (std::modf(identifier, &integral) != 0.0) {
+        // Only integral numbers can be used.
+        return std::nullopt;
+    }
+
+    auto identifierAsUInt64 = static_cast<uint64_t>(identifier);
+    if (!WebExtensionFrameIdentifier::isValidIdentifier(identifierAsUInt64)) {
+        ASSERT_NOT_REACHED();
+        return std::nullopt;
+    }
+
+    return WebExtensionFrameIdentifier { identifierAsUInt64 };
+}
+
+}

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
@@ -39,6 +39,10 @@
 #import "WebExtensionMessageSenderParameters.h"
 #import <objc/runtime.h>
 
+#if PLATFORM(IOS_FAMILY)
+#import <UIKit/UIKit.h>
+#endif
+
 namespace WebKit {
 
 static NSString *classToClassString(Class classType, bool plural = false)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -41,6 +41,7 @@
 #import <WebCore/WebCoreCALayerExtras.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/BlockObjCExceptions.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -304,6 +304,7 @@ Shared/Authentication/AuthenticationManager.cpp
 
 Shared/Databases/IndexedDB/IDBUtilities.cpp
 
+Shared/Extensions/WebExtensionFrameIdentifier.cpp
 Shared/Extensions/WebExtensionPermission.cpp
 Shared/Extensions/WebExtensionUtilities.cpp
 

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -162,6 +162,8 @@ Shared/Authentication/cocoa/ClientCertificateAuthenticationXPCConstants.cpp
 Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.mm
 Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
 
+Shared/Extensions/Cocoa/WebExtensionFrameIdentifierCocoa.mm
+
 Shared/Cocoa/APIDataCocoa.mm
 Shared/Cocoa/APIObject.mm
 Shared/Cocoa/ARKitSoftLink.mm

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm
@@ -35,6 +35,7 @@
 #import "APIHTTPCookieStore.h"
 #import "CocoaHelpers.h"
 #import "WKWebViewConfiguration.h"
+#import "WKWebViewPrivate.h"
 #import "WKWebsiteDataStoreInternal.h"
 #import "WebExtensionContextProxyMessages.h"
 #import "WebExtensionCookieParameters.h"

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm
@@ -32,7 +32,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-#import "WKFrameInfo.h"
+#import "WKFrameInfoPrivate.h"
 #import "WKWebViewPrivate.h"
 #import "WebExtensionFrameIdentifier.h"
 #import "WebExtensionFrameParameters.h"
@@ -50,7 +50,7 @@ static WebExtensionFrameParameters frameParametersForFrame(_WKFrameTreeNode *fra
     auto *frameURL = frameInfo.request.URL;
 
     return {
-        (bool)frameInfo._errorOccurred,
+        frameInfo._errorOccurred,
         extensionContext->hasPermission(frameURL, tab) ? std::optional(frameURL) : std::nullopt,
         parentFrame ? toWebExtensionFrameIdentifier(parentFrame.info) : WebExtensionFrameConstants::NoneIdentifier,
         includeFrameIdentifier ? std::optional(toWebExtensionFrameIdentifier(frameInfo)) : std::nullopt

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -50,6 +50,7 @@
 #import "WebExtensionTabParameters.h"
 #import "WebPageProxy.h"
 #import "WebProcessProxy.h"
+#import <WebCore/LocalizedStrings.h>
 #import <wtf/BlockPtr.h>
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm
@@ -81,6 +81,11 @@ WebExtensionMessagePort::WebExtensionMessagePort(WebExtensionContext& extensionC
 {
 }
 
+WebExtensionMessagePort::~WebExtensionMessagePort()
+{
+    remove();
+}
+
 bool WebExtensionMessagePort::operator==(const WebExtensionMessagePort& other) const
 {
     return this == &other || (m_extensionContext == other.m_extensionContext && m_applicationIdentifier == other.m_applicationIdentifier && m_channelIdentifier == other.m_channelIdentifier);

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -30,6 +30,7 @@
 
 #include "WebExtensionPermission.h"
 #include "WebExtensionUtilities.h"
+#include <WebCore/LocalizedStrings.h>
 #include <WebCore/TextResourceDecoder.h>
 #include <wtf/Language.h>
 #include <wtf/text/StringToIntegerConversion.h>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -137,11 +137,6 @@ WebExtensionContext::WebProcessProxySet WebExtensionContext::processes(EventList
     return result;
 }
 
-WebExtensionMessagePort::~WebExtensionMessagePort()
-{
-    remove();
-}
-
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -91,6 +91,7 @@ OBJC_CLASS NSArray;
 OBJC_CLASS NSDate;
 OBJC_CLASS NSDictionary;
 OBJC_CLASS NSMapTable;
+OBJC_CLASS NSMutableArray;
 OBJC_CLASS NSMutableDictionary;
 OBJC_CLASS NSNumber;
 OBJC_CLASS NSString;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
@@ -46,6 +46,7 @@ namespace WebKit {
 
 class WebExtensionContext;
 class WebExtensionTab;
+struct WebExtensionScriptInjectionParameters;
 
 namespace WebExtensionDynamicScripts {
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.cpp
@@ -30,6 +30,7 @@
 
 #import "WebProcessMessages.h"
 #import "WebProcessPool.h"
+#import <WebCore/LocalizedStrings.h>
 #import <WebCore/PublicSuffixStore.h>
 #import <wtf/HashMap.h>
 #import <wtf/HashSet.h>

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4207,6 +4207,7 @@
 		1C9F4C2A29E538550015819E /* RemoteTextDetectorProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteTextDetectorProxy.cpp; sourceTree = "<group>"; };
 		1C9F4C2B29E538550015819E /* RemoteTextDetectorProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteTextDetectorProxy.h; sourceTree = "<group>"; };
 		1CA45DF62C5D7375003A3F52 /* _WKWebExtension.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtension.mm; sourceTree = "<group>"; };
+		1CA583E72CEFFDBD002C6DAD /* WebExtensionFrameIdentifier.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionFrameIdentifier.cpp; sourceTree = "<group>"; };
 		1CA8B935127C774E00576C2B /* WebInspectorUIProxyMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebInspectorUIProxyMac.mm; sourceTree = "<group>"; };
 		1CA8B943127C882A00576C2B /* WebInspectorUIProxyMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebInspectorUIProxyMessageReceiver.cpp; sourceTree = "<group>"; };
 		1CA8B944127C882A00576C2B /* WebInspectorUIProxyMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebInspectorUIProxyMessages.h; sourceTree = "<group>"; };
@@ -8418,6 +8419,20 @@
 		FEE43FD11E67AFC60077D6D1 /* WebInspectorInterruptDispatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebInspectorInterruptDispatcher.h; sourceTree = "<group>"; };
 		FEE43FD21E67AFC60077D6D1 /* WebInspectorInterruptDispatcher.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebInspectorInterruptDispatcher.messages.in; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		1CA583EB2CF00409002C6DAD /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				WebExtensionFrameIdentifierCocoa.mm,
+			);
+			target = 8DC2EF4F0486A6940098B216 /* WebKit */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		1CA583E92CEFFE9D002C6DAD /* Cocoa */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (1CA583EB2CF00409002C6DAD /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Cocoa; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		2D56C1C428A367A00081BD25 /* Frameworks */ = {
@@ -13804,6 +13819,7 @@
 		B6114A8A293AE03600380B1B /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				1CA583E92CEFFE9D002C6DAD /* Cocoa */,
 				B6217BB0299C39F000498BF8 /* _WKWebExtensionLocalization.h */,
 				B6217BB1299C3AE300498BF8 /* _WKWebExtensionLocalization.mm */,
 				B6D75B1C2B1FD0BE00BC932E /* _WKWebExtensionRegisteredScriptsSQLiteStore.h */,
@@ -13841,6 +13857,7 @@
 				1C2BBF922B82BC5D001DBDFC /* WebExtensionError.h */,
 				B6114A8B293AE05200380B1B /* WebExtensionEventListenerType.h */,
 				8696CE2F297EB3C90081C800 /* WebExtensionEventListenerType.serialization.in */,
+				1CA583E72CEFFDBD002C6DAD /* WebExtensionFrameIdentifier.cpp */,
 				1C4A14C52ABB710E00A1018C /* WebExtensionFrameIdentifier.h */,
 				33B5A80B2AFD298100A15D40 /* WebExtensionFrameParameters.h */,
 				33B5A80D2AFD2B2300A15D40 /* WebExtensionFrameParameters.serialization.in */,
@@ -18215,6 +18232,9 @@
 				37F7407912721F740093869B /* PBXTargetDependency */,
 				2D11BA052126A5AE006F8878 /* PBXTargetDependency */,
 				7B9FC5BD28A5233B007570E7 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				1CA583E92CEFFE9D002C6DAD /* Cocoa */,
 			);
 			name = WebKit;
 			productInstallPath = "$(HOME)/Library/Frameworks";

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
@@ -31,7 +31,6 @@
 #include "JSWebExtensionWrappable.h"
 #include "WebExtensionAPIObject.h"
 #include "WebExtensionEventListenerType.h"
-#include "WebPage.h"
 
 OBJC_CLASS JSValue;
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
@@ -31,7 +31,6 @@
 #include "JSWebExtensionWrappable.h"
 #include "WebExtensionAPIObject.h"
 #include "WebExtensionEventListenerType.h"
-#include "WebPage.h"
 
 OBJC_CLASS JSValue;
 OBJC_CLASS NSDictionary;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
@@ -31,7 +31,6 @@
 #include "JSWebExtensionWrappable.h"
 #include "WebExtensionAPIObject.h"
 #include "WebExtensionEventListenerType.h"
-#include "WebPage.h"
 
 OBJC_CLASS JSValue;
 OBJC_CLASS NSDictionary;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -39,6 +39,7 @@
 #import <wtf/ObjectIdentifier.h>
 #import <wtf/Range.h>
 #import <wtf/RangeSet.h>
+#import <wtf/Scope.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/text/MakeString.h>

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -49,9 +49,11 @@
 #include "WebEventConversion.h"
 #include "WebEventModifier.h"
 #include "WebEventType.h"
+#include "WebFrame.h"
 #include "WebHitTestResultData.h"
 #include "WebKeyboardEvent.h"
 #include "WebMouseEvent.h"
+#include "WebPage.h"
 #include "WebPageProxyMessages.h"
 #include <CoreGraphics/CoreGraphics.h>
 #include <PDFKit/PDFKit.h>
@@ -80,6 +82,7 @@
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/ImmediateActionStage.h>
 #include <WebCore/LocalFrame.h>
+#include <WebCore/LocalizedStrings.h>
 #include <WebCore/NotImplemented.h>
 #include <WebCore/Page.h>
 #include <WebCore/PageOverlay.h>


### PR DESCRIPTION
#### 8eba9e87b29363ca7470f3622ac05bba95a874b0
<pre>
WebExtensions code added significantly to build time.
<a href="https://webkit.org/b/283543">https://webkit.org/b/283543</a>
<a href="https://rdar.apple.com/140362875">rdar://140362875</a>

Reviewed by Simon Fraser.

Stop inlining most of WebExtensionFrameIdentifier.h, so Webpage.h does not get included in a lot of places.
Remove some other includes and clean up some other things.

* Source/WebKit/Shared/Extensions/Cocoa/WebExtensionFrameIdentifierCocoa.mm: Added.
(WebKit::toWebExtensionFrameIdentifier):
* Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.cpp: Copied from Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h.
(WebKit::toWebCoreFrameIdentifier):
(WebKit::matchesFrame):
(WebKit::toWebExtensionFrameIdentifier):
* Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h:
(WebKit::toWebCoreFrameIdentifier): Deleted.
(WebKit::matchesFrame): Deleted.
(WebKit::toWebExtensionFrameIdentifier): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
* Source/WebKit/Sources.txt:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm:
(WebKit::frameParametersForFrame):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm:
(WebKit::WebExtensionMessagePort::~WebExtensionMessagePort):
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionMessagePort::~WebExtensionMessagePort): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.cpp:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:

Canonical link: <a href="https://commits.webkit.org/286970@main">https://commits.webkit.org/286970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96b2f19e4726844f8c5fc422561e24cbc72c89d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77755 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/56789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82404 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29029 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5089 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/18863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80821 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50882 "Found 60 new test failures: accessibility/ios-simulator/aria-details-toggle-summary.html accessibility/ios-simulator/has-touch-event-listener-with-shadow.html accessibility/ios-simulator/strong-password-field.html accessibility/visible-character-range-vertical-rl.html animations/animation-composite-order-notimeline.html compositing/backing/backing-store-attachment-animated-transform-inside-fixed.html compositing/backing/no-backing-for-perspective.html compositing/blend-mode/tiled-to-non-tiled-with-blend-mode.html compositing/masks/clip-path-on-tiled-toggle.html compositing/masks/reference-clip-path-on-composited-image.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41212 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48241 "Found 60 new test failures: imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any.html imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any.worker.html imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_X25519.https.any.html imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_X25519.https.any.worker.html imported/w3c/web-platform-tests/clipboard-apis/clipboard-item.https.html imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.html imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.serviceworker.html imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.sharedworker.html imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.worker.html imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.html ... (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27365 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/69368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24569 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83763 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5134 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3461 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69134 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5290 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68383 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12401 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10485 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12039 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5082 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/5090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/8527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6859 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->