### PR TITLE
[WebM] requestVideoFrameCallback may only works once.

### DIFF
--- a/LayoutTests/media/media-rvfc-playing-webm-expected.txt
+++ b/LayoutTests/media/media-rvfc-playing-webm-expected.txt
@@ -1,0 +1,3 @@
+
+EVENT(loadedmetadata)
+

--- a/LayoutTests/media/media-rvfc-playing-webm.html
+++ b/LayoutTests/media/media-rvfc-playing-webm.html
@@ -1,0 +1,65 @@
+<html>
+<head>
+<title>requestVideoFrameCallback with playing webm</title>
+<script src="../resources/testharness.js"></script>
+<script src=video-test.js></script>
+<script src=utilities.js></script>
+<script>
+    var lastPresentationTime = -Number.MAX_NUMBER;
+    var lastDisplayTime = -Number.MAX_NUMBER;
+    var lastPresentedFrames = -Number.MAX_NUMBER;
+    var lastMediaTime = -Number.MAX_NUMBER;
+    var frame;
+
+    async function init()
+    {
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        findMediaElement();
+
+        video.src = "content/test-vp8.webm";
+        const tooLongTimeout = setTimeout(failTest.bind(null, "timeout"), 5000);
+
+        await waitFor(video, 'loadedmetadata');
+        video.play();
+
+        let counter = 0;
+        while (counter++ < 10) {
+            frame = await waitForVideoFrame(video);
+            if (frame[1].presentationTime <= lastPresentationTime) {
+                testExpected(frame[1].presentationTime, lastPresentationTime, ">");
+                failTest("presentationTime isn't monotonically increasing");
+            }
+            lastPresentationTime = frame[1].presentationTime;
+
+            if (frame[1].expectedDisplayTime <= lastDisplayTime) {
+                testExpected(frame[1].expectedDisplayTime, lastDisplayTime, ">");
+                failTest("expectedDisplayTime isn't monotonically increasing");
+            }
+            lastDisplayTime = frame[1].expectedDisplayTime;
+
+            if (frame[1].presentedFrames <= lastPresentedFrames) {
+                testExpected(frame[1].presentedFrames, lastPresentedFrames, ">");
+                failTest("mediaTime isn't monotonically increasing");
+            }
+            lastPresentedFrames = frame[1].presentedFrames;
+
+            if (frame[1].mediaTime <= lastMediaTime) {
+                testExpected(frame[1].mediaTime, lastMediaTime, ">");
+                failTest("mediaTime isn't monotonically increasing");
+            }
+            lastMediaTime = frame[1].mediaTime;
+        }
+
+        clearTimeout(tooLongTimeout);
+
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
+</script>
+</head>
+<body onload="init();">
+<video muted/>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1168,6 +1168,7 @@ media/media-source/media-source-vp8-webm-error-offscreen.html [ Skip ]
 http/tests/media/video-webm-stall-seek.html [ Skip ]
 media/media-rvfc-paused-offscreen-webm.html [ Skip ]
 media/media-rvfc-paused-webm.html [ Skip ]
+media/media-rvfc-playing-webm.html [ Skip ]
 
 # Managed MediaSource isn't enabled on WK1
 media/media-source/media-managedmse-append.html [ Skip ]

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -255,14 +255,12 @@ private:
     void setVideoRenderer(WebSampleBufferVideoRendering *);
     void stageVideoRenderer(WebSampleBufferVideoRendering *);
 
-    void registerNotifyWhenHasAvailableVideoFrame();
-        
     void startVideoFrameMetadataGathering() final;
     void stopVideoFrameMetadataGathering() final;
     std::optional<VideoFrameMetadata> videoFrameMetadata() final { return std::exchange(m_videoFrameMetadata, { }); }
     void setResourceOwner(const ProcessIdentity& resourceOwner) final { m_resourceOwner = resourceOwner; }
 
-    void checkNewVideoFrameMetadata(MediaTime);
+    void checkNewVideoFrameMetadata(const MediaTime& presentationTime, double displayTime);
 
     // WebAVSampleBufferListenerParent
     // Methods are called on the WebMResourceClient's WorkQueue
@@ -351,7 +349,6 @@ private:
     bool m_isGatheringVideoFrameMetadata { false };
     std::optional<VideoFrameMetadata> m_videoFrameMetadata;
     uint64_t m_lastConvertedSampleCount { 0 };
-    uint64_t m_sampleCount { 0 };
     ProcessIdentity m_resourceOwner;
 
     FloatSize m_naturalSize;


### PR DESCRIPTION
#### 2f99587301ddbd1cb13f42c6406b5b4da0d66db9
<pre>
[WebM] requestVideoFrameCallback may only works once.
<a href="https://bugs.webkit.org/show_bug.cgi?id=283533">https://bugs.webkit.org/show_bug.cgi?id=283533</a>
<a href="https://rdar.apple.com/140384096">rdar://140384096</a>

Reviewed by Jer Noble.

The MediaPlayerPrivateWebM could have registered multiple times to get new video frames notifications
which upon resolving would clear the last callback.
Pending frames wouldn&apos;t trigger the requestVideoFrameCallback&apos;s callback call as a result.

We also improve the accuracy of the metadata values returned by capturing the display&apos;s presentationTime
at the time it actually is pushed to the layer.
We also attached to the new video frame callback the frame&apos;s presentationTime and the displayTime.
And we now track the actual number of frames pushed to the layer.

Added test.

* LayoutTests/media/media-rvfc-playing-webm-expected.txt: Added.
* LayoutTests/media/media-rvfc-playing-webm.html: Added.
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::updateLastImage):
(WebCore::MediaPlayerPrivateWebM::setHasAvailableVideoFrame):
(WebCore::MediaPlayerPrivateWebM::enqueueSample):
(WebCore::MediaPlayerPrivateWebM::checkNewVideoFrameMetadata):
(WebCore::MediaPlayerPrivateWebM::setVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::registerNotifyWhenHasAvailableVideoFrame): Deleted.
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::initializeDecompressionSession):
(WebCore::VideoMediaSampleRenderer::maybeQueueFrameForDisplay):
(WebCore::VideoMediaSampleRenderer::totalDisplayedFrames const):
(WebCore::VideoMediaSampleRenderer::notifyWhenHasAvailableVideoFrame):
(WebCore::VideoMediaSampleRenderer::notifyHasAvailableVideoFrame):

Canonical link: <a href="https://commits.webkit.org/286994@main">https://commits.webkit.org/286994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6f043f1ef383f8f6db571f70efe6fede5b6ee68

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82356 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28993 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5053 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60892 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18844 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80785 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50852 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66684 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41181 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48225 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24195 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27329 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69341 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83724 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5098 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69115 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5254 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66671 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68364 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17103 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12372 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10468 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5046 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7828 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5055 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8493 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6823 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->