### PR TITLE
Non-unified source build fix of November 2024 (part 4)

### DIFF
--- a/Source/WebCore/Modules/ShapeDetection/FaceDetector.cpp
+++ b/Source/WebCore/Modules/ShapeDetection/FaceDetector.cpp
@@ -32,6 +32,7 @@
 #include "FaceDetectorOptions.h"
 #include "ImageBitmap.h"
 #include "ImageBitmapOptions.h"
+#include "ImageBuffer.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSDetectedFace.h"
 #include "Page.h"

--- a/Source/WebCore/Modules/ShapeDetection/TextDetector.cpp
+++ b/Source/WebCore/Modules/ShapeDetection/TextDetector.cpp
@@ -31,6 +31,7 @@
 #include "Document.h"
 #include "ImageBitmap.h"
 #include "ImageBitmapOptions.h"
+#include "ImageBuffer.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSDetectedText.h"
 #include "Page.h"

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -37,6 +37,7 @@
 #include "CryptoKeyRSAComponents.h"
 #include "CryptoKeyRaw.h"
 #include "IDBValue.h"
+#include "ImageBuffer.h"
 #include "JSAudioWorkletGlobalScope.h"
 #include "JSBlob.h"
 #include "JSCryptoKey.h"

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -35,6 +35,7 @@
 
 #include "Event.h"
 #include "FrameSnapshotting.h"
+#include "ImageBuffer.h"
 #include "InspectorAnimationAgent.h"
 #include "InspectorCPUProfilerAgent.h"
 #include "InspectorClient.h"

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.h
@@ -35,7 +35,14 @@ class RenderBoxModelObject;
 class RenderElement;
 class RenderObject;
 class RenderInline;
+class RenderStyle;
 class RenderText;
+
+namespace Layout {
+class Box;
+class ElementBox;
+class InitialContainingBlock;
+}
 
 namespace LayoutIntegration {
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
@@ -157,6 +157,11 @@ LayoutPoint InlineContentPainter::flippedContentOffsetIfNeeded(const RenderBox& 
     return m_paintOffset;
 }
 
+const RenderBlock& InlineContentPainter::root() const
+{
+    return m_root;
+}
+
 LayerPaintScope::LayerPaintScope(const RenderInline* inlineBoxWithLayer)
     : m_inlineBoxWithLayer(inlineBoxWithLayer ? inlineBoxWithLayer->layoutBox() : nullptr)
 {

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
@@ -33,6 +33,7 @@
 namespace WebCore {
 
 class RenderBlock;
+class RenderBlockFlow;
 class RenderBox;
 class RenderInline;
 
@@ -60,7 +61,7 @@ private:
     void paintDisplayBox(const InlineDisplay::Box&);
     void paintEllipsis(size_t lineIndex);
     LayoutPoint flippedContentOffsetIfNeeded(const RenderBox&) const;
-    const RenderBlock& root() const { return m_root; }
+    const RenderBlock& root() const;
 
     PaintInfo& m_paintInfo;
     const LayoutPoint m_paintOffset;

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -34,6 +34,7 @@
 #include "Logging.h"
 #include "Quirks.h"
 #include "RenderElement.h"
+#include "RenderElementInlines.h"
 #include "RenderLayoutState.h"
 #include "RenderStyle.h"
 #include "RenderStyleInlines.h"

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -27,6 +27,7 @@
 #include "NavigateEvent.h"
 
 #include "AbortController.h"
+#include "CommonVM.h"
 #include "Element.h"
 #include "ExceptionCode.h"
 #include "HTMLBodyElement.h"

--- a/Source/WebCore/platform/graphics/CachedSubimage.cpp
+++ b/Source/WebCore/platform/graphics/CachedSubimage.cpp
@@ -28,6 +28,7 @@
 
 #include "GeometryUtilities.h"
 #include "GraphicsContext.h"
+#include "ImageBuffer.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.h
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ImageBuffer.h"
 #include "RenderReplaced.h"
 
 namespace WebCore {

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.h
@@ -20,9 +20,9 @@
 
 #pragma once
 
+#include "ImageBuffer.h"
 #include "RenderSVGResourceContainer.h"
 #include "SVGUnitTypes.h"
-
 #include <wtf/HashMap.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
@@ -21,6 +21,7 @@
 #include "RenderSVGResourcePattern.h"
 
 #include "ElementChildIteratorInlines.h"
+#include "ImageBuffer.h"
 #include "RenderLayer.h"
 #include "RenderSVGModelObjectInlines.h"
 #include "RenderSVGResourcePatternInlines.h"

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
@@ -19,16 +19,15 @@
 
 #pragma once
 
+#include "ImageBuffer.h"
 #include "LegacyRenderSVGResourceContainer.h"
 #include "SVGUnitTypes.h"
-
 #include <wtf/EnumeratedArray.h>
 #include <wtf/HashMap.h>
 
 namespace WebCore {
 
 class GraphicsContext;
-class ImageBuffer;
 class SVGClipPathElement;
 
 struct ClipperData {


### PR DESCRIPTION
#### e7db9995a39ed13599ae5e8fea9bbe98eb7ef561
<pre>
Non-unified source build fix of November 2024 (part 4)
<a href="https://bugs.webkit.org/show_bug.cgi?id=282804">https://bugs.webkit.org/show_bug.cgi?id=282804</a>

Unreviewed non-unified source build fix.

* Source/WebCore/Modules/ShapeDetection/FaceDetector.cpp:
* Source/WebCore/Modules/ShapeDetection/TextDetector.cpp:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp:
(WebCore::LayoutIntegration::InlineContentPainter::root const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h:
(WebCore::LayoutIntegration::InlineContentPainter::root const): Deleted.
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
* Source/WebCore/page/NavigateEvent.cpp:
* Source/WebCore/platform/graphics/CachedSubimage.cpp:
* Source/WebCore/rendering/RenderViewTransitionCapture.h:
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.h:
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h:

Canonical link: <a href="https://commits.webkit.org/286942@main">https://commits.webkit.org/286942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80daf85f56fd507c01115c0710e037dba2baf17b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77636 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/56670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30559 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/82256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28915 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65826 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/4970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/82256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/18806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80702 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/50801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/66626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/82256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/48193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/24121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27246 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/69306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/24464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83639 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/5017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/4970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/69076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/5174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/66588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/68327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17069 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/10429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/4964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/4979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/8417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/6742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->