### PR TITLE
[JSC] Add `finishCreation` to `JSIteratorHelper`

### DIFF
--- a/Source/JavaScriptCore/runtime/JSIteratorHelper.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorHelper.cpp
@@ -33,13 +33,18 @@ namespace JSC {
 
 const ClassInfo JSIteratorHelper::s_info = { "Iterator Helper"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSIteratorHelper) };
 
+void JSIteratorHelper::finishCreation(VM& vm, JSValue generator, JSValue underlyingIterator)
+{
+    Base::finishCreation(vm);
+    internalField(Field::Generator).set(vm, this, generator);
+    internalField(Field::UnderlyingIterator).set(vm, this, underlyingIterator);
+}
+
 JSIteratorHelper* JSIteratorHelper::createWithInitialValues(VM& vm, Structure* structure)
 {
     auto values = initialValues();
     JSIteratorHelper* result = new (NotNull, allocateCell<JSIteratorHelper>(vm)) JSIteratorHelper(vm, structure);
-    result->finishCreation(vm);
-    result->internalField(Field::Generator).set(vm, result, values[0]);
-    result->internalField(Field::UnderlyingIterator).set(vm, result, values[1]);
+    result->finishCreation(vm, values[0], values[1]);
     return result;
 }
 
@@ -47,9 +52,7 @@ JSIteratorHelper* JSIteratorHelper::create(VM& vm, Structure* structure, JSValue
 {
     ASSERT(generator.isObject() && (underlyingIterator.isObject() || underlyingIterator.isNull()));
     JSIteratorHelper* result = new (NotNull, allocateCell<JSIteratorHelper>(vm)) JSIteratorHelper(vm, structure);
-    result->finishCreation(vm);
-    result->internalField(Field::Generator).set(vm, result, generator);
-    result->internalField(Field::UnderlyingIterator).set(vm, result, underlyingIterator);
+    result->finishCreation(vm, generator, underlyingIterator);
     return result;
 }
 

--- a/Source/JavaScriptCore/runtime/JSIteratorHelper.h
+++ b/Source/JavaScriptCore/runtime/JSIteratorHelper.h
@@ -66,6 +66,8 @@ public:
 
 private:
     JSIteratorHelper(VM&, Structure*);
+
+    void finishCreation(VM&, JSValue generator, JSValue underlyingIterator);
 };
 
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSIteratorHelper);


### PR DESCRIPTION
#### 32bd202a312fcaab54abdade3ee42dc213d19978
<pre>
[JSC] Add `finishCreation` to `JSIteratorHelper`
<a href="https://bugs.webkit.org/show_bug.cgi?id=283548">https://bugs.webkit.org/show_bug.cgi?id=283548</a>

Reviewed by Yusuke Suzuki.

This patch adds `finishCreation` to `JSIteratorHelper`

* Source/JavaScriptCore/runtime/JSIteratorHelper.cpp:
(JSC::JSIteratorHelper::finishCreation):
(JSC::JSIteratorHelper::createWithInitialValues):
(JSC::JSIteratorHelper::create):
* Source/JavaScriptCore/runtime/JSIteratorHelper.h:

Canonical link: <a href="https://commits.webkit.org/287026@main">https://commits.webkit.org/287026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8fba7bb2e5cde08e019abcac63011d42b3e057a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82660 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29268 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5338 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61089 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19015 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51080 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67416 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41396 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48442 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24549 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27611 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71155 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69537 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84022 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77247 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5377 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3634 "Found 2 new test failures: ipc/create-media-source-with-invalid-constraints-crash.html webrtc/vp8-then-h264.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69309 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5533 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66939 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68563 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17115 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12563 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10748 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/99558 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5325 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21750 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5317 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8749 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7102 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->