### PR TITLE
[WPE] Avoid compiling damaging-related code when not needed

### DIFF
--- a/Source/WebCore/platform/graphics/Damage.h
+++ b/Source/WebCore/platform/graphics/Damage.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
+
 #include "FloatRect.h"
 #include "Region.h"
 #include <wtf/ForbidHeapAllocation.h>
@@ -123,3 +125,5 @@ static inline WTF::TextStream& operator<<(WTF::TextStream& ts, const Damage& dam
 }
 
 };
+
+#endif // ENABLE(WPE_PLATFORM) || PLATFORM(GTK)

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaCompositionLayer.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaCompositionLayer.h
@@ -88,7 +88,9 @@ public:
                     bool debugBorderChanged : 1;
                     bool scrollingNodeChanged : 1;
                     bool eventRegionChanged : 1;
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
                     bool damageChanged : 1;
+#endif
                 };
                 uint32_t value { 0 };
             };
@@ -126,7 +128,9 @@ public:
         WebCore::FloatSize contentsTilePhase;
         WebCore::FloatSize contentsTileSize;
         WebCore::FloatRoundedRect contentsClippingRect;
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
         WebCore::Damage damage;
+#endif
 
         float opacity { 0 };
         WebCore::Color solidColor;
@@ -236,8 +240,10 @@ public:
             staging.imageBacking = pending.imageBacking;
         if (pending.delta.animatedBackingStoreClientChanged)
             staging.animatedBackingStoreClient = pending.animatedBackingStoreClient;
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
         if (pending.delta.damageChanged)
             staging.damage = pending.damage;
+#endif
 
         pending.delta = { };
     }

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -142,8 +142,12 @@ private:
     Vector<RefPtr<BitmapTexture>> m_textures;
 };
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
 TextureMapperLayer::TextureMapperLayer(Damage::ShouldPropagate propagateDamage)
     : m_propagateDamage(propagateDamage)
+#else
+    TextureMapperLayer::TextureMapperLayer()
+#endif
 {
 }
 
@@ -351,12 +355,14 @@ void TextureMapperLayer::paint(TextureMapper& textureMapper)
     destroyFlattenedDescendantLayers();
 }
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
 void TextureMapperLayer::collectDamage(TextureMapper& textureMapper)
 {
     TextureMapperPaintOptions options(textureMapper);
     options.surface = textureMapper.currentSurface();
     collectDamageRecursive(options);
 }
+#endif
 
 void TextureMapperLayer::paintSelf(TextureMapperPaintOptions& options)
 {
@@ -427,6 +433,7 @@ void TextureMapperLayer::paintSelf(TextureMapperPaintOptions& options)
         contentsLayer->drawBorder(options.textureMapper, m_state.debugBorderColor, m_state.debugBorderWidth, m_state.contentsRect, transform);
 }
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
 void TextureMapperLayer::collectDamageSelf(TextureMapperPaintOptions& options)
 {
     if (!m_state.visible || !m_state.contentsVisible)
@@ -466,6 +473,7 @@ void TextureMapperLayer::collectDamageSelf(TextureMapperPaintOptions& options)
         clearDamage();
     }
 }
+#endif
 
 void TextureMapperLayer::paintBackdrop(TextureMapperPaintOptions& options)
 {
@@ -1027,6 +1035,7 @@ void TextureMapperLayer::paintFlattened(TextureMapperPaintOptions& options)
     paintSelf(options);
 }
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
 void TextureMapperLayer::collectDamageRecursive(TextureMapperPaintOptions& options)
 {
     if (!isVisible())
@@ -1039,6 +1048,7 @@ void TextureMapperLayer::collectDamageRecursive(TextureMapperPaintOptions& optio
     for (auto* child : m_children)
         child->collectDamageRecursive(options);
 }
+#endif
 
 void TextureMapperLayer::paintWith3DRenderingContext(TextureMapperPaintOptions& options)
 {
@@ -1093,13 +1103,17 @@ void TextureMapperLayer::addChild(TextureMapperLayer* childLayer)
     childLayer->m_parent = this;
     m_children.append(childLayer);
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     if (m_visitor)
         childLayer->acceptDamageVisitor(*m_visitor);
+#endif
 }
 
 void TextureMapperLayer::removeFromParent()
 {
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     dismissDamageVisitor();
+#endif
 
     if (m_parent) {
         size_t index = m_parent->m_children.find(this);
@@ -1114,7 +1128,9 @@ void TextureMapperLayer::removeAllChildren()
 {
     auto oldChildren = WTFMove(m_children);
     for (auto* child : oldChildren) {
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
         child->dismissDamageVisitor();
+#endif
         child->m_parent = nullptr;
     }
 }
@@ -1294,8 +1310,10 @@ bool TextureMapperLayer::descendantsOrSelfHaveRunningAnimations() const
 bool TextureMapperLayer::applyAnimationsRecursively(MonotonicTime time)
 {
     bool hasRunningAnimations = syncAnimations(time);
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     if (hasRunningAnimations) // FIXME Too broad?
         addDamage(layerRect());
+#endif
     if (m_state.replicaLayer)
         hasRunningAnimations |= m_state.replicaLayer->applyAnimationsRecursively(time);
     if (m_state.backdropLayer)
@@ -1324,6 +1342,7 @@ bool TextureMapperLayer::syncAnimations(MonotonicTime time)
     return applicationResults.hasRunningAnimations;
 }
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
 void TextureMapperLayer::acceptDamageVisitor(TextureMapperLayerDamageVisitor& visitor)
 {
     if (&visitor == m_visitor)
@@ -1360,6 +1379,7 @@ void TextureMapperLayer::recordDamage(const FloatRect& rect, const Transformatio
 
     m_visitor->recordDamage(transformedRect);
 }
+#endif
 
 FloatRect TextureMapperLayer::effectiveLayerRect() const
 {

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -43,16 +43,22 @@ class TextureMapperFlattenedLayer;
 class TextureMapperPaintOptions;
 class TextureMapperPlatformLayer;
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
 class TextureMapperLayerDamageVisitor {
 public:
     virtual void recordDamage(const FloatRect&) = 0;
 };
+#endif
 
 class TextureMapperLayer : public CanMakeWeakPtr<TextureMapperLayer> {
     WTF_MAKE_TZONE_ALLOCATED(TextureMapperLayer);
     WTF_MAKE_NONCOPYABLE(TextureMapperLayer);
 public:
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     WEBCORE_EXPORT TextureMapperLayer(Damage::ShouldPropagate = Damage::ShouldPropagate::No);
+#else
+    WEBCORE_EXPORT TextureMapperLayer();
+#endif
     WEBCORE_EXPORT virtual ~TextureMapperLayer();
 
 #if USE(COORDINATED_GRAPHICS)
@@ -119,9 +125,11 @@ public:
     WEBCORE_EXPORT bool descendantsOrSelfHaveRunningAnimations() const;
 
     WEBCORE_EXPORT void paint(TextureMapper&);
-    void collectDamage(TextureMapper&);
 
     void addChild(TextureMapperLayer*);
+
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
+    void collectDamage(TextureMapper&);
 
     void acceptDamageVisitor(TextureMapperLayerDamageVisitor&);
     void dismissDamageVisitor();
@@ -130,6 +138,7 @@ public:
     ALWAYS_INLINE void invalidateDamage();
     ALWAYS_INLINE void addDamage(const Damage&);
     ALWAYS_INLINE void addDamage(const FloatRect&);
+#endif
 
     FloatRect effectiveLayerRect() const;
 
@@ -173,7 +182,6 @@ private:
 
     void paintRecursive(TextureMapperPaintOptions&);
     void paintFlattened(TextureMapperPaintOptions&);
-    void collectDamageRecursive(TextureMapperPaintOptions&);
     void paintWith3DRenderingContext(TextureMapperPaintOptions&);
     void paintSelfChildrenReplicaFilterAndMask(TextureMapperPaintOptions&);
     void paintUsingOverlapRegions(TextureMapperPaintOptions&);
@@ -182,13 +190,17 @@ private:
     void paintSelfAndChildrenWithIntermediateSurface(TextureMapperPaintOptions&, const IntRect&);
     void paintSelfChildrenFilterAndMask(TextureMapperPaintOptions&);
     void paintSelf(TextureMapperPaintOptions&);
-    void collectDamageSelf(TextureMapperPaintOptions&);
     void paintSelfAndChildren(TextureMapperPaintOptions&);
     void paintSelfAndChildrenWithReplica(TextureMapperPaintOptions&);
     void paintBackdrop(TextureMapperPaintOptions&);
     void applyMask(TextureMapperPaintOptions&);
-    void recordDamage(const FloatRect&, const TransformationMatrix&, const TextureMapperPaintOptions&);
     void collect3DSceneLayers(Vector<TextureMapperLayer*>&);
+
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
+    void collectDamageRecursive(TextureMapperPaintOptions&);
+    void collectDamageSelf(TextureMapperPaintOptions&);
+    void recordDamage(const FloatRect&, const TransformationMatrix&, const TextureMapperPaintOptions&);
+#endif
 
     bool isVisible() const;
 
@@ -275,10 +287,12 @@ private:
     bool m_isBackdrop { false };
     bool m_isReplica { false };
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     Damage::ShouldPropagate m_propagateDamage;
     Damage m_damage;
 
     TextureMapperLayerDamageVisitor* m_visitor { nullptr };
+#endif
 
     struct {
         TransformationMatrix localTransform;
@@ -291,6 +305,8 @@ private:
 #endif
     } m_layerTransforms;
 };
+
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
 
 ALWAYS_INLINE void TextureMapperLayer::clearDamage()
 {
@@ -317,5 +333,7 @@ ALWAYS_INLINE void TextureMapperLayer::addDamage(const FloatRect& rect)
 
     m_damage.add(rect);
 }
+
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -416,7 +416,9 @@ void CoordinatedGraphicsLayer::setContentsOpaque(bool b)
     if (!m_needsDisplay.completeLayer) {
         m_needsDisplay.completeLayer = true;
         m_needsDisplay.rects.clear();
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
         m_nicosia.delta.damageChanged = true;
+#endif
 
         addRepaintRect({ { }, m_size });
     }
@@ -511,6 +513,7 @@ void CoordinatedGraphicsLayer::setContentsNeedsDisplay()
     addRepaintRect(contentsRect());
 }
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
 void CoordinatedGraphicsLayer::markDamageRectsUnreliable()
 {
     if (m_damagedRectsAreUnreliable)
@@ -519,6 +522,7 @@ void CoordinatedGraphicsLayer::markDamageRectsUnreliable()
     m_damagedRectsAreUnreliable = true;
     m_nicosia.delta.damageChanged = true;
 }
+#endif
 
 void CoordinatedGraphicsLayer::setContentsToPlatformLayer(PlatformLayer* platformLayer, ContentsLayerPurpose)
 {
@@ -707,7 +711,9 @@ void CoordinatedGraphicsLayer::setNeedsDisplay()
 
     m_needsDisplay.completeLayer = true;
     m_needsDisplay.rects.clear();
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     m_nicosia.delta.damageChanged = true;
+#endif
 
     notifyFlushRequired();
     addRepaintRect({ { }, m_size });
@@ -732,7 +738,9 @@ void CoordinatedGraphicsLayer::setNeedsDisplayInRect(const FloatRect& initialRec
         return;
 
     rects.append(rect);
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     m_nicosia.delta.damageChanged = true;
+#endif
 
     notifyFlushRequired();
     addRepaintRect(rect);
@@ -968,6 +976,7 @@ void CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly()
 #endif
                 if (localDelta.eventRegionChanged)
                     state.eventRegion = eventRegion();
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
                 if (localDelta.damageChanged) {
                     state.damage = Damage();
                     if (m_needsDisplay.completeLayer)
@@ -979,6 +988,7 @@ void CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly()
                     if (m_damagedRectsAreUnreliable)
                         state.damage.invalidate();
                 }
+#endif
             });
         m_nicosia.performLayerSync = !!m_nicosia.delta.value;
         m_nicosia.delta = { };

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -124,7 +124,9 @@ public:
     void setNeedsDisplay() override;
     void setNeedsDisplayInRect(const FloatRect&, ShouldClipToLayer = ClipToLayer) override;
     void setContentsNeedsDisplay() override;
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     void markDamageRectsUnreliable() override;
+#endif
     void deviceOrPageScaleFactorChanged() override;
     void flushCompositingState(const FloatRect&) override;
     void flushCompositingStateForThisLayerOnly() override;
@@ -232,7 +234,9 @@ private:
         bool completeLayer { false };
         Vector<FloatRect> rects;
     } m_needsDisplay;
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     bool m_damagedRectsAreUnreliable { false };
+#endif
 
     Timer m_animationStartedTimer;
     RunLoop::Timer m_requestPendingTileCreationTimer;

--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
@@ -60,9 +60,13 @@ public:
     virtual void willDestroyGLContext() { }
     virtual void finalize() { }
     virtual void willRenderFrame() { }
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     virtual void didRenderFrame(WebCore::Region&&) { }
 
     virtual const WebCore::Damage& addDamage(const WebCore::Damage&) { return WebCore::Damage::invalid(); };
+#else
+    virtual void didRenderFrame() { }
+#endif
 
     virtual void didCreateCompositingRunLoop(WTF::RunLoop&) { }
     virtual void willDestroyCompositingRunLoop() { }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
@@ -35,9 +35,15 @@
 namespace WebKit {
 using namespace WebCore;
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
 CoordinatedGraphicsScene::CoordinatedGraphicsScene(CoordinatedGraphicsSceneClient* client, Damage::ShouldPropagate propagateDamage)
+#else
+CoordinatedGraphicsScene::CoordinatedGraphicsScene(CoordinatedGraphicsSceneClient* client)
+#endif
     : m_client(client)
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     , m_propagateDamage(propagateDamage)
+#endif
 {
 }
 
@@ -54,11 +60,17 @@ void CoordinatedGraphicsScene::applyStateChanges(const Vector<RefPtr<Nicosia::Sc
         commitSceneState(scene);
 }
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
 void CoordinatedGraphicsScene::paintToCurrentGLContext(const TransformationMatrix& matrix, const FloatRect& clipRect, bool unifyDamagedRegions, bool flipY)
+#else
+void CoordinatedGraphicsScene::paintToCurrentGLContext(const TransformationMatrix& matrix, const FloatRect& clipRect, bool flipY)
+#endif
 {
     updateSceneState();
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     m_damage = WebCore::Damage();
+#endif
 
     TextureMapperLayer* currentRootLayer = rootLayer();
     if (!currentRootLayer)
@@ -70,6 +82,7 @@ void CoordinatedGraphicsScene::paintToCurrentGLContext(const TransformationMatri
     bool sceneHasRunningAnimations = currentRootLayer->applyAnimationsRecursively(MonotonicTime::now());
 
     FloatRoundedRect actualClipRect(clipRect);
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     if (m_propagateDamage != Damage::ShouldPropagate::No) {
         WTFBeginSignpost(this, CollectDamage);
         currentRootLayer->collectDamage(*m_textureMapper);
@@ -93,17 +106,21 @@ void CoordinatedGraphicsScene::paintToCurrentGLContext(const TransformationMatri
                 actualClipRect = static_cast<FloatRoundedRect>(damageSinceLastSurfaceUse.bounds());
         }
     }
+#endif
 
     WTFBeginSignpost(this, PaintTextureMapperLayerTree);
     m_textureMapper->beginPainting(flipY ? TextureMapper::FlipY::Yes : TextureMapper::FlipY::No);
     m_textureMapper->beginClip(TransformationMatrix(), actualClipRect);
     currentRootLayer->paint(*m_textureMapper);
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     if (m_propagateDamage == Damage::ShouldPropagate::No)
+#endif
         m_fpsCounter.updateFPSAndDisplay(*m_textureMapper, clipRect.location(), matrix);
     m_textureMapper->endClip();
     m_textureMapper->endPainting();
     WTFEndSignpost(this, PaintTextureMapperLayerTree);
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     if (m_propagateDamage != Damage::ShouldPropagate::No && m_fpsCounter.isActive()) {
         m_textureMapper->beginPainting(flipY ? TextureMapper::FlipY::Yes : TextureMapper::FlipY::No);
         m_textureMapper->beginClip(TransformationMatrix(), FloatRoundedRect(clipRect));
@@ -111,6 +128,7 @@ void CoordinatedGraphicsScene::paintToCurrentGLContext(const TransformationMatri
         m_textureMapper->endClip();
         m_textureMapper->endPainting();
     }
+#endif
 
     if (sceneHasRunningAnimations)
         updateViewport();
@@ -127,11 +145,19 @@ void CoordinatedGraphicsScene::onNewBufferAvailable()
     updateViewport();
 }
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
 static TextureMapperLayer& texmapLayer(Nicosia::CompositionLayer& compositionLayer, Damage::ShouldPropagate propagateDamage)
+#else
+static TextureMapperLayer& texmapLayer(Nicosia::CompositionLayer& compositionLayer)
+#endif
 {
     auto& compositionState = compositionLayer.compositionState();
     if (!compositionState.layer) {
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
         compositionState.layer = makeUnique<TextureMapperLayer>(propagateDamage);
+#else
+        compositionState.layer = makeUnique<TextureMapperLayer>();
+#endif
         compositionState.layer->setID(compositionLayer.id());
     }
     return *compositionState.layer;
@@ -211,7 +237,11 @@ void CoordinatedGraphicsScene::updateSceneState()
             // Handle the root layer, adding it to the TextureMapperLayer tree
             // on the first update. No such change is expected later.
             {
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
                 auto& rootLayer = texmapLayer(*state.rootLayer, m_propagateDamage);
+#else
+                auto& rootLayer = texmapLayer(*state.rootLayer);
+#endif
                 if (rootLayer.id() != m_rootLayerID) {
                     m_rootLayerID = rootLayer.id();
                     RELEASE_ASSERT(m_rootLayer->children().isEmpty());
@@ -249,7 +279,11 @@ void CoordinatedGraphicsScene::updateSceneState()
             // the incoming state changes. Layer backings are stored so that the updates
             // (possibly time-consuming) can be done outside of this scene update.
             for (auto& compositionLayer : m_nicosia.state.layers) {
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
                 auto& layer = texmapLayer(*compositionLayer, m_propagateDamage);
+#else
+                auto& layer = texmapLayer(*compositionLayer);
+#endif
                 compositionLayer->commitState(
                     [this, &layer, &layersByBacking, &replacedProxiesToInvalidate]
                     (const Nicosia::CompositionLayer::LayerState& layerState)
@@ -285,7 +319,11 @@ void CoordinatedGraphicsScene::updateSceneState()
                         if (layerState.delta.filtersChanged)
                             layer.setFilters(layerState.filters);
                         if (layerState.delta.backdropFiltersChanged)
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
                             layer.setBackdropLayer(layerState.backdropLayer ? &texmapLayer(*layerState.backdropLayer, m_propagateDamage) : nullptr);
+#else
+                            layer.setBackdropLayer(layerState.backdropLayer ? &texmapLayer(*layerState.backdropLayer) : nullptr);
+#endif
                         if (layerState.delta.backdropFiltersRectChanged)
                             layer.setBackdropFiltersRect(layerState.backdropFiltersRect);
                         if (layerState.delta.animationsChanged)
@@ -294,14 +332,26 @@ void CoordinatedGraphicsScene::updateSceneState()
                         if (layerState.delta.childrenChanged) {
                             layer.setChildren(WTF::map(layerState.children,
                                 [this](auto& child) {
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
                                     return &texmapLayer(*child, m_propagateDamage);
+#else
+                                    return &texmapLayer(*child);
+#endif
                                 }));
                         }
 
                         if (layerState.delta.maskChanged)
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
                             layer.setMaskLayer(layerState.mask ? &texmapLayer(*layerState.mask, m_propagateDamage) : nullptr);
+#else
+                            layer.setMaskLayer(layerState.mask ? &texmapLayer(*layerState.mask) : nullptr);
+#endif
                         if (layerState.delta.replicaChanged)
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
                             layer.setReplicaLayer(layerState.replica ? &texmapLayer(*layerState.replica, m_propagateDamage) : nullptr);
+#else
+                            layer.setReplicaLayer(layerState.replica ? &texmapLayer(*layerState.replica) : nullptr);
+#endif
 
                         if (layerState.delta.flagsChanged) {
                             layer.setContentsOpaque(layerState.flags.contentsOpaque);
@@ -325,7 +375,9 @@ void CoordinatedGraphicsScene::updateSceneState()
                         }
 
                         if (layerState.backingStore) {
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
                             layer.acceptDamageVisitor(*this);
+#endif
                             layersByBacking.backingStore.append({ std::ref(layer), layerState.backingStore->takePendingUpdate() });
                         } else {
                             layer.setBackingStore(nullptr);
@@ -347,11 +399,13 @@ void CoordinatedGraphicsScene::updateSceneState()
                         else
                             layer.setAnimatedBackingStoreClient(nullptr);
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
                         if (layerState.delta.damageChanged) {
                             layer.addDamage(layerState.damage);
                             if (layerState.damage.isInvalid())
                                 layer.invalidateDamage();
                         }
+#endif
                     });
             }
         });
@@ -419,8 +473,12 @@ void CoordinatedGraphicsScene::ensureRootLayer()
     if (m_rootLayer)
         return;
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     m_rootLayer = makeUnique<TextureMapperLayer>(m_propagateDamage);
     m_rootLayer->acceptDamageVisitor(*this);
+#else
+    m_rootLayer = makeUnique<TextureMapperLayer>();
+#endif
     m_rootLayer->setMasksToBounds(false);
     m_rootLayer->setDrawsContent(false);
     m_rootLayer->setAnchorPoint(FloatPoint3D(0, 0, 0));
@@ -443,7 +501,9 @@ void CoordinatedGraphicsScene::purgeGLResources()
         m_nicosia.scene = nullptr;
     }
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     m_rootLayer->dismissDamageVisitor();
+#endif
     m_rootLayer = nullptr;
     m_rootLayerID = 0;
     m_textureMapper = nullptr;
@@ -456,10 +516,12 @@ void CoordinatedGraphicsScene::detach()
     m_client = nullptr;
 }
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
 void CoordinatedGraphicsScene::recordDamage(const FloatRect& damagedRect)
 {
     m_damage.add(damagedRect);
 }
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.h
@@ -46,17 +46,31 @@ class CoordinatedGraphicsSceneClient {
 public:
     virtual ~CoordinatedGraphicsSceneClient() { }
     virtual void updateViewport() = 0;
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     virtual const WebCore::Damage& addSurfaceDamage(const WebCore::Damage&) = 0;
+#endif
 };
 
 class CoordinatedGraphicsScene : public ThreadSafeRefCounted<CoordinatedGraphicsScene>, public WebCore::TextureMapperPlatformLayerProxy::Compositor
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     , public WebCore::TextureMapperLayerDamageVisitor {
+#else
+{
+#endif
 public:
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     CoordinatedGraphicsScene(CoordinatedGraphicsSceneClient*, WebCore::Damage::ShouldPropagate);
+#else
+    CoordinatedGraphicsScene(CoordinatedGraphicsSceneClient*);
+#endif
     virtual ~CoordinatedGraphicsScene();
 
     void applyStateChanges(const Vector<RefPtr<Nicosia::Scene>>&);
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     void paintToCurrentGLContext(const WebCore::TransformationMatrix&, const WebCore::FloatRect&, bool unifyDamagedRegions, bool flipY = false);
+#else
+    void paintToCurrentGLContext(const WebCore::TransformationMatrix&, const WebCore::FloatRect&, bool flipY = false);
+#endif
     void updateSceneState();
     void detach();
 
@@ -67,8 +81,10 @@ public:
     bool isActive() const { return m_isActive; }
     void setActive(bool active) { m_isActive = active; }
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     const WebCore::Damage& lastDamage() const { return m_damage; }
     void recordDamage(const WebCore::FloatRect&) override;
+#endif
 
 private:
     void commitSceneState(const RefPtr<Nicosia::Scene>&);
@@ -94,8 +110,10 @@ private:
     CoordinatedGraphicsSceneClient* m_client;
     bool m_isActive { false };
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     WebCore::Damage::ShouldPropagate m_propagateDamage;
     WebCore::Damage m_damage;
+#endif
 
     std::unique_ptr<WebCore::TextureMapperLayer> m_rootLayer;
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -96,6 +96,7 @@ ThreadedCompositor::ThreadedCompositor(LayerTreeHost& layerTreeHost, ThreadedDis
     m_attributes.needsResize = !m_attributes.viewportSize.isEmpty();
     m_attributes.scaleFactor = scaleFactor;
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     auto& webPage = layerTreeHost.webPage();
     m_damagePropagation = ([](const WebCore::Settings& settings) {
         if (!settings.propagateDamagingInformation())
@@ -104,6 +105,7 @@ ThreadedCompositor::ThreadedCompositor(LayerTreeHost& layerTreeHost, ThreadedDis
             return DamagePropagation::Unified;
         return DamagePropagation::Region;
     })(webPage.corePage()->settings());
+#endif
 
 #if !HAVE(DISPLAY_LINK)
     m_display.displayID = displayID;
@@ -120,9 +122,13 @@ ThreadedCompositor::ThreadedCompositor(LayerTreeHost& layerTreeHost, ThreadedDis
         m_display.updateTimer->startOneShot(Seconds { 1.0 / m_display.displayUpdate.updatesPerSecond });
 #endif
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
         const auto propagateDamage = (m_damagePropagation == DamagePropagation::None)
             ? WebCore::Damage::ShouldPropagate::No : WebCore::Damage::ShouldPropagate::Yes;
         m_scene = adoptRef(new CoordinatedGraphicsScene(this, propagateDamage));
+#else
+        m_scene = adoptRef(new CoordinatedGraphicsScene(this));
+#endif
 
         // GLNativeWindowType depends on the EGL implementation: reinterpret_cast works
         // for pointers (only if they are 64-bit wide and not for other cases), and static_cast for
@@ -242,10 +248,12 @@ void ThreadedCompositor::updateViewport()
     m_compositingRunLoop->scheduleUpdate();
 }
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
 const WebCore::Damage& ThreadedCompositor::addSurfaceDamage(const WebCore::Damage& damage)
 {
     return m_surface->addDamage(damage);
 }
+#endif
 
 void ThreadedCompositor::forceRepaint()
 {
@@ -322,11 +330,16 @@ void ThreadedCompositor::renderLayerTree()
     WTFEndSignpost(this, ApplyStateChanges);
 
     WTFBeginSignpost(this, PaintToGLContext);
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     m_scene->paintToCurrentGLContext(viewportTransform, FloatRect { FloatPoint { }, viewportSize }, m_damagePropagation == DamagePropagation::Unified, m_flipY);
+#else
+    m_scene->paintToCurrentGLContext(viewportTransform, FloatRect { FloatPoint { }, viewportSize }, m_flipY);
+#endif
     WTFEndSignpost(this, PaintToGLContext);
 
     WTFEmitSignpost(this, DidRenderFrame, "compositionResponseID %i", compositionRequestID);
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     auto damageRegion = [&]() -> WebCore::Region {
         // FIXME: find a way to know if main frame scrolled since last frame to return early here.
 
@@ -354,10 +367,15 @@ void ThreadedCompositor::renderLayerTree()
 
         return region;
     }();
+#endif
 
     m_context->swapBuffers();
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     m_surface->didRenderFrame(WTFMove(damageRegion));
+#else
+    m_surface->didRenderFrame();
+#endif
 #if HAVE(DISPLAY_LINK)
     m_compositionResponseID = compositionRequestID;
     if (!m_didRenderFrameTimer.isActive())

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -101,7 +101,9 @@ private:
 
     // CoordinatedGraphicsSceneClient
     void updateViewport() override;
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     const WebCore::Damage& addSurfaceDamage(const WebCore::Damage&) override;
+#endif
 
     void renderLayerTree();
     void frameComplete();
@@ -119,7 +121,9 @@ private:
     std::unique_ptr<WebCore::GLContext> m_context;
 
     bool m_flipY { false };
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     DamagePropagation m_damagePropagation { DamagePropagation::None };
+#endif
     unsigned m_suspendedCount { 0 };
 
     std::unique_ptr<CompositingRunLoop> m_compositingRunLoop;

--- a/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
+++ b/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
@@ -112,7 +112,11 @@ void AcceleratedSurfaceLibWPE::willRenderFrame()
     wpe_renderer_backend_egl_target_frame_will_render(m_backend);
 }
 
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
 void AcceleratedSurfaceLibWPE::didRenderFrame(WebCore::Region&&)
+#else
+void AcceleratedSurfaceLibWPE::didRenderFrame()
+#endif
 {
     ASSERT(m_backend);
     wpe_renderer_backend_egl_target_frame_rendered(m_backend);

--- a/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h
+++ b/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h
@@ -49,7 +49,11 @@ public:
     void clientResize(const WebCore::IntSize&) override;
     void finalize() override;
     void willRenderFrame() override;
+#if ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     void didRenderFrame(WebCore::Region&&) override;
+#else
+    void didRenderFrame() override;
+#endif
 
 private:
     AcceleratedSurfaceLibWPE(WebPage&, Function<void()>&& frameCompleteHandler);


### PR DESCRIPTION
#### d4b5cf3cb7a907edc69689f548a9b6fa7c47a267
<pre>
[WPE] Avoid compiling damaging-related code when not needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=283483">https://bugs.webkit.org/show_bug.cgi?id=283483</a>

Reviewed by Adrian Perez de Castro.

This change makes damaging-related codepaths buildable iff the target port is GTK
or WPE with WPE_PLATFORM usage enabled.

* Source/WebCore/platform/graphics/Damage.h:
* Source/WebCore/platform/graphics/nicosia/NicosiaCompositionLayer.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::TextureMapperLayer):
(WebCore::TextureMapperLayer::addChild):
(WebCore::TextureMapperLayer::removeFromParent):
(WebCore::TextureMapperLayer::removeAllChildren):
(WebCore::TextureMapperLayer::applyAnimationsRecursively):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::setContentsOpaque):
(WebCore::CoordinatedGraphicsLayer::setNeedsDisplay):
(WebCore::CoordinatedGraphicsLayer::setNeedsDisplayInRect):
(WebCore::CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h:
* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h:
(WebKit::AcceleratedSurface::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.cpp:
(WebKit::CoordinatedGraphicsScene::CoordinatedGraphicsScene):
(WebKit::CoordinatedGraphicsScene::paintToCurrentGLContext):
(WebKit::texmapLayer):
(WebKit::CoordinatedGraphicsScene::updateSceneState):
(WebKit::CoordinatedGraphicsScene::ensureRootLayer):
(WebKit::CoordinatedGraphicsScene::purgeGLResources):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.h:
(WebKit::CoordinatedGraphicsScene::isActive const): Deleted.
(WebKit::CoordinatedGraphicsScene::setActive): Deleted.
(WebKit::CoordinatedGraphicsScene::lastDamage const): Deleted.
(WebKit::CoordinatedGraphicsScene::rootLayer): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::renderLayerTree):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp:
(WebKit::AcceleratedSurfaceLibWPE::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h:

Canonical link: <a href="https://commits.webkit.org/287064@main">https://commits.webkit.org/287064@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5207f7b3a7d282dad6c6882c637cfb45fb9f8755

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82821 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29425 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80296 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5490 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61211 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19129 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81230 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51209 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41540 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48562 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24787 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27762 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69657 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84185 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5528 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3753 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69460 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5685 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67125 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68692 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17139 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12689 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10946 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5477 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8229 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5466 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8898 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7255 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->