### PR TITLE
Support partitioned cookies in Clear-Site-Data: Cookies

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3350,6 +3350,7 @@ webkit.org/b/3652 http/tests/misc/prefetch-purpose.html [ Skip ]
 http/tests/cookies/only-accept-first-party-cookies.html [ Skip ]
 # Enable on appropriate platforms: rdar://140222322
 http/tests/cookies/accept-partitioned-first-and-third-party-cookies.https.html [ Skip ]
+http/tests/clear-site-data/set-and-clear-cookies.https.html [ Skip ]
 
 # Disabled WPT tests
 webkit.org/b/185939 imported/w3c/web-platform-tests/css/WOFF2 [ Skip ]

--- a/LayoutTests/http/tests/clear-site-data/resources/clear-site-data-cookies.py
+++ b/LayoutTests/http/tests/clear-site-data/resources/clear-site-data-cookies.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.stdout.write(
+    'Clear-Site-Data: "cookies"\r\n'
+    'Content-Type: text/html\r\n\r\n'
+)
+
+print('FOO')

--- a/LayoutTests/http/tests/clear-site-data/set-and-clear-cookies.https-expected.txt
+++ b/LayoutTests/http/tests/clear-site-data/set-and-clear-cookies.https-expected.txt
@@ -1,0 +1,48 @@
+CONSOLE MESSAGE: First party cookies before clear-site-data: test_first_party_cookie=1
+CONSOLE MESSAGE: First party cookies after clear-site-data:
+CONSOLE MESSAGE: First party cookies before clear-site-data: test_first_party_cookie=1
+CONSOLE MESSAGE: First party cookies after third-party clear-site-data: test_first_party_cookie=1
+Tests that first and third-party partitioned cookies are accepted.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+
+
+--------
+Frame: '<!--frame2-->'
+--------
+Cookies are: test_cookie = 1
+
+--------
+Frame: '<!--frame3-->'
+--------
+Cookies are: test_cookie = 1
+
+--------
+Frame: '<!--frame4-->'
+--------
+Cookies are: test_cookie = 1
+
+--------
+Frame: '<!--frame5-->'
+--------
+FOO
+
+--------
+Frame: '<!--frame6-->'
+--------
+Cookies are:
+
+--------
+Frame: '<!--frame7-->'
+--------
+

--- a/LayoutTests/http/tests/clear-site-data/set-and-clear-cookies.https.html
+++ b/LayoutTests/http/tests/clear-site-data/set-and-clear-cookies.https.html
@@ -1,0 +1,108 @@
+<html><!-- webkit-test-runner [ OptInPartitionedCookiesEnabled=true CFNetworkNetworkLoaderEnabled=false ] -->
+<head>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="/cookies/resources/resources/resetCookies.js"></script>
+    <script>
+        description("Tests that first and third-party partitioned cookies are accepted.");
+        jsTestIsAsync = true;
+
+        const iframeUrls = {
+            echoCookies : "https://localhost:8443/cookies/resources/echo-cookies.py",
+            resetCookies : "https://localhost:8443/cookies/resources/reset-cookies.html"
+        };
+
+        function injectThirdPartyIframe(url) {
+            let iframeElement = document.createElement("iframe");
+            iframeElement.src = url;
+            iframeElement.onload = runNextTestOrFinish;
+            document.body.appendChild(iframeElement);
+        }
+
+        function runNextTestOrFinish() {
+            if (!window.testRunner) {
+                testFailed("No testRunner.");
+                finishJSTest();
+            }
+
+            switch (document.location.hash) {
+                case "":
+                    internals.setTrackingPreventionEnabled(true);
+                    testRunner.setStatisticsIsRunningTest(true);
+                    testRunner.setOnlyAcceptFirstPartyCookies(false);
+                    testRunner.dumpChildFramesAsText();
+                    document.location.hash = "1";
+                    testRunner.setStatisticsShouldBlockThirdPartyCookies(true, () => {
+                        testRunner.setStatisticsHasHadUserInteraction("https://127.0.0.1:8443", true, () => {
+                            // Should see one cookie.
+                            injectThirdPartyIframe(iframeUrls.resetCookies);
+                        });
+                    }, true);
+                    document.cookie = "test_first_party_cookie=1";
+                    // Should output one cookie in the console message
+                    console.log(`First party cookies before clear-site-data: ${document.cookie}`);
+                    break;
+                case "#1":
+                    document.location.hash = "2";
+                    // Should see one cookie in Frame 2.
+                    injectThirdPartyIframe(`https://localhost:8443/cookies/resources/set-cookie-and-redirect-back.py?isPartitioned=True&redirectBackTo=${iframeUrls.echoCookies}`);
+                    break;
+                case "#2":
+                    document.location.hash = "3";
+                    fetch(`/clear-site-data/resources/clear-site-data-cookies.py`).then((r) => {
+                        setTimeout(runNextTestOrFinish, 100);
+                    });
+                    break;
+                case "#3":
+                    document.location.hash = "4";
+                    // Should not output any cookies in the console message
+                    console.log(`First party cookies after clear-site-data: ${document.cookie}`);
+                    testRunner.setStatisticsShouldBlockThirdPartyCookies(false, () => {
+                        // Should see one cookie in Frame 3.
+                        injectThirdPartyIframe(iframeUrls.echoCookies);
+                    }, true);
+                    break;
+                case "#4":
+                    document.location.hash = "5";
+
+                    document.cookie = "test_first_party_cookie=1";
+                    // Should output one cookie in the console message
+                    console.log(`First party cookies before clear-site-data: ${document.cookie}`);
+
+                    // Should see one cookie in Frame 4.
+                    injectThirdPartyIframe(`https://localhost:8443/cookies/resources/set-cookie-and-redirect-back.py?isPartitioned=True&redirectBackTo=${iframeUrls.echoCookies}`);
+                    break;
+                case "#5":
+                    document.location.hash = "6";
+                    // Should see Foo in Frame 5.
+                    injectThirdPartyIframe(`https://localhost:8443/clear-site-data/resources/clear-site-data-cookies.py`);
+                    break;
+                case "#6":
+                    document.location.hash = "7";
+
+                    // Should output one cookie in the console message
+                    console.log(`First party cookies after third-party clear-site-data: ${document.cookie}`);
+
+                    // Should not have cookies in Frame 6.
+                    injectThirdPartyIframe(iframeUrls.echoCookies);
+                    break;
+                case "#7":
+                    document.location.hash = "8";
+                    injectThirdPartyIframe(iframeUrls.resetCookies);
+                    break;
+                case "#8":
+                    internals.setTrackingPreventionEnabled(false);
+                    testRunner.setStatisticsIsRunningTest(false);
+                    finishJSTest();
+                    break;
+                default:
+                    internals.setTrackingPreventionEnabled(false);
+                    testRunner.setStatisticsIsRunningTest(false);
+                    testFailed("Unknown location hash value.");
+                    finishJSTest();
+            }
+        }
+    </script>
+</head>
+<body onload="runNextTestOrFinish()">
+</body>
+</html>


### PR DESCRIPTION
#### 78e86d4b6b77da06ba4eac1a2e4c6ac59300dcda
<pre>
Support partitioned cookies in Clear-Site-Data: Cookies
<a href="https://bugs.webkit.org/show_bug.cgi?id=283552">https://bugs.webkit.org/show_bug.cgi?id=283552</a>
<a href="https://rdar.apple.com/140403030">rdar://140403030</a>

Reviewed by Sihui Liu.

This is another step toward supporting opt-in partitioned cookies. When a
top-level site requests deleting cookies using the Clear-Site-Data header, we
should delete only the site&apos;s cookies. When a cross-site subframe requests
deleting cookies using the header, then we should delete only the cookies in
the partition.

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/clear-site-data/set-and-clear-cookies.https-expected.txt: Added.
* LayoutTests/http/tests/clear-site-data/set-and-clear-cookies.https.html: Added.
* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::NetworkStorageSession::cookiePartitionIdentifier):
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::deleteCookies):

Canonical link: <a href="https://commits.webkit.org/287547@main">https://commits.webkit.org/287547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb915d16ab0c5eb74ad0528657dc413c3515ce64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84334 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30811 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81918 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62381 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20219 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42688 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49778 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26829 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29259 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70905 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85760 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7040 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4933 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-pause-networkState.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70640 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7214 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68520 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69881 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13885 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12804 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12381 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6999 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12577 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6859 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10370 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8666 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->