### PR TITLE
LibWebRTCAudioModule does not need to nullify its log timer

### DIFF
--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.h
@@ -54,7 +54,6 @@ public:
     ~LibWebRTCAudioModule();
 
     static constexpr unsigned PollSamplesCount = 1;
-    void stop() { Terminate(); }
 
 #if PLATFORM(COCOA)
     void startIncomingAudioRendering() { m_isRenderingIncomingAudio = true; }
@@ -87,7 +86,7 @@ private:
 
     int32_t ActiveAudioLayer(AudioLayer*) const final { return shouldNotBeCalled(-1); }
     int32_t Init() final { return 0; }
-    int32_t Terminate() final;
+    int32_t Terminate() final { return 0; }
     bool Initialized() const final { return true; }
     int16_t PlayoutDevices() final { return 0; }
     int16_t RecordingDevices() final { return 0; }
@@ -157,7 +156,7 @@ private:
     bool m_isPlaying { false };
     webrtc::AudioTransport* m_audioTransport { nullptr };
     MonotonicTime m_pollingTime;
-    std::unique_ptr<Timer> m_logTimer;
+    Timer m_logTimer;
     int m_timeSpent { 0 };
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
@@ -80,8 +80,6 @@ LibWebRTCProvider::LibWebRTCProvider()
 
 LibWebRTCProvider::~LibWebRTCProvider()
 {
-    if (RefPtr audioModule = std::exchange(m_audioModule, { }))
-        audioModule->stop();
 }
 
 #if !PLATFORM(COCOA)


### PR DESCRIPTION
#### 11d3279e047968cb88bbe02d15fc95675aec64fe
<pre>
LibWebRTCAudioModule does not need to nullify its log timer
<a href="https://rdar.apple.com/140405398">rdar://140405398</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=283547">https://bugs.webkit.org/show_bug.cgi?id=283547</a>

Reviewed by Jean-Yves Avenard.

LibWebRTCAudioModule is now sure to be destroyed in main thread as it is noted as DestructionThread::Main.
We can thus change its log timer to be a Timer instead of a unique_ptr&lt;Timer&gt;.
And we can remove the code that makes sure to destroy the Timer in main thread.

* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp:
(WebCore::LibWebRTCAudioModule::LibWebRTCAudioModule):
(WebCore::LibWebRTCAudioModule::~LibWebRTCAudioModule):
(WebCore::LibWebRTCAudioModule::StartPlayout):
(WebCore::LibWebRTCAudioModule::StopPlayout):
(WebCore::LibWebRTCAudioModule::pollAudioData):
(WebCore::LibWebRTCAudioModule::Terminate): Deleted.
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.h:
(WebCore::LibWebRTCAudioModule::stop): Deleted.
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp:
(WebCore::LibWebRTCProvider::~LibWebRTCProvider):

Canonical link: <a href="https://commits.webkit.org/286948@main">https://commits.webkit.org/286948@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81f88d36037d9449c20e71710cb783067b60a838

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77679 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/56712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82306 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/28957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79796 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5012 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/28957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41140 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/48213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24153 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27288 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/69328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83683 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/5059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69089 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/5216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68341 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17072 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/10449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5006 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/5019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/8457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->