### PR TITLE
[macOS] Add support for multi-speaker MediaStreamTrack audio playing

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -28,6 +28,7 @@
 
 #if ENABLE(MEDIA_STREAM) && USE(AVFOUNDATION)
 
+#import "AudioMediaStreamTrackRenderer.h"
 #import "AudioTrackPrivateMediaStream.h"
 #import "GraphicsContextCG.h"
 #import "LocalSampleBufferDisplayLayer.h"
@@ -1146,6 +1147,8 @@ void MediaPlayerPrivateMediaStreamAVFObjC::audioOutputDeviceChanged()
     if (!player)
         return;
     auto deviceId = player->audioOutputDeviceId();
+    if (deviceId.isEmpty())
+        deviceId = AudioMediaStreamTrackRenderer::defaultDeviceID();
     for (auto& audioTrack : m_audioTrackMap.values())
         audioTrack->setAudioOutputDevice(deviceId);
 }

--- a/Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.cpp
+++ b/Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.cpp
@@ -57,6 +57,12 @@ std::unique_ptr<AudioMediaStreamTrackRenderer> AudioMediaStreamTrackRenderer::cr
 #endif
 }
 
+String AudioMediaStreamTrackRenderer::defaultDeviceID()
+{
+    ASSERT(isMainThread());
+    return "default"_s;
+}
+
 AudioMediaStreamTrackRenderer::AudioMediaStreamTrackRenderer(Init&& init)
     : m_crashCallback(WTFMove(init.crashCallback))
 #if USE(LIBWEBRTC)

--- a/Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.h
+++ b/Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.h
@@ -27,6 +27,10 @@
 
 #if ENABLE(MEDIA_STREAM)
 
+#if USE(LIBWEBRTC)
+#include "LibWebRTCAudioModule.h"
+#endif
+
 #include <wtf/Function.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/TZoneMalloc.h>
@@ -38,7 +42,6 @@ class MediaTime;
 namespace WebCore {
 
 class AudioStreamDescription;
-class LibWebRTCAudioModule;
 class PlatformAudioData;
 
 class WEBCORE_EXPORT AudioMediaStreamTrackRenderer : public LoggerHelper {
@@ -56,6 +59,8 @@ public:
     };
     static std::unique_ptr<AudioMediaStreamTrackRenderer> create(Init&&);
     virtual ~AudioMediaStreamTrackRenderer() = default;
+
+    static String defaultDeviceID();
 
     virtual void start(CompletionHandler<void()>&&) = 0;
     virtual void stop() = 0;

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.h
@@ -77,6 +77,7 @@ private:
     RefPtr<AudioSampleDataSource> m_registeredDataSource; // Used in main thread.
     bool m_shouldRecreateDataSource { false };
     WebCore::AudioMediaStreamTrackRendererUnit::ResetObserver m_resetObserver;
+    String m_deviceID;
 };
 
 }

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp
@@ -50,9 +50,11 @@ namespace WebCore {
 class LocalAudioMediaStreamTrackRendererInternalUnit final : public AudioMediaStreamTrackRendererInternalUnit, public RefCounted<LocalAudioMediaStreamTrackRendererInternalUnit>  {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(LocalAudioMediaStreamTrackRendererInternalUnit);
 public:
-    static Ref<AudioMediaStreamTrackRendererInternalUnit> create(Client& client)
+    static Ref<AudioMediaStreamTrackRendererInternalUnit> create(const String& deviceID, Client& client)
     {
-        return adoptRef(*new LocalAudioMediaStreamTrackRendererInternalUnit(client));
+        auto unit = adoptRef(*new LocalAudioMediaStreamTrackRendererInternalUnit(client));
+        unit->setAudioOutputDevice(deviceID);
+        return unit;
     }
 
     void ref() const final { RefCounted::ref(); }
@@ -66,8 +68,7 @@ private:
     void start() final;
     void stop() final;
     void retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&&) final;
-    void setAudioOutputDevice(const String&) final;
-    const String& audioOutputDeviceID() const final { return m_audioOutputDeviceID; }
+    void setAudioOutputDevice(const String&);
 
     OSStatus render(AudioUnitRenderActionFlags*, const AudioTimeStamp*, UInt32 sampleCount, AudioBufferList*);
     static OSStatus renderingCallback(void*, AudioUnitRenderActionFlags*, const AudioTimeStamp*, UInt32 inBusNumber, UInt32 sampleCount, AudioBufferList*);
@@ -98,6 +99,9 @@ void LocalAudioMediaStreamTrackRendererInternalUnit::retrieveFormatDescription(C
 void LocalAudioMediaStreamTrackRendererInternalUnit::setAudioOutputDevice(const String& deviceID)
 {
 #if PLATFORM(MAC)
+    if (deviceID == AudioMediaStreamTrackRenderer::defaultDeviceID())
+        return;
+
     auto device = CoreAudioCaptureDeviceManager::singleton().coreAudioDeviceWithUID(deviceID);
 
     if (!device && !deviceID.isEmpty()) {
@@ -306,9 +310,9 @@ void AudioMediaStreamTrackRendererInternalUnit::setCreateFunction(CreateFunction
     createInternalUnit = function;
 }
 
-Ref<AudioMediaStreamTrackRendererInternalUnit> AudioMediaStreamTrackRendererInternalUnit::create(Client& client)
+Ref<AudioMediaStreamTrackRendererInternalUnit> AudioMediaStreamTrackRendererInternalUnit::create(const String& deviceID, Client& client)
 {
-    return createInternalUnit(client);
+    return createInternalUnit(deviceID, client);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h
@@ -50,15 +50,14 @@ public:
         virtual OSStatus render(size_t sampleCount, AudioBufferList&, uint64_t sampleTime, double hostTime, AudioUnitRenderActionFlags&) = 0;
         virtual void reset() = 0;
     };
-    WEBCORE_EXPORT static Ref<AudioMediaStreamTrackRendererInternalUnit> create(Client&);
+    WEBCORE_EXPORT static Ref<AudioMediaStreamTrackRendererInternalUnit> create(const String&, Client&);
 
-    using CreateFunction = Ref<AudioMediaStreamTrackRendererInternalUnit>(*)(AudioMediaStreamTrackRendererInternalUnit::Client&);
+    using CreateFunction = Ref<AudioMediaStreamTrackRendererInternalUnit>(*)(const String&, AudioMediaStreamTrackRendererInternalUnit::Client&);
     WEBCORE_EXPORT static void setCreateFunction(CreateFunction);
     virtual void start() = 0;
     virtual void stop() = 0;
+    virtual void close() { };
     virtual void retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&&) = 0;
-    virtual void setAudioOutputDevice(const String&) = 0;
-    virtual const String& audioOutputDeviceID() const = 0;
 };
 
 }

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
@@ -35,31 +35,97 @@ namespace WebCore {
 
 AudioMediaStreamTrackRendererUnit& AudioMediaStreamTrackRendererUnit::singleton()
 {
-    static NeverDestroyed<Ref<AudioMediaStreamTrackRendererUnit>> registry { adoptRef(*new AudioMediaStreamTrackRendererUnit()) };
-    return registry.get().get();
+    static LazyNeverDestroyed<std::unique_ptr<AudioMediaStreamTrackRendererUnit>> sharedUnit;
+    auto& unit = sharedUnit.get();
+    if (!unit)
+        unit = std::unique_ptr<AudioMediaStreamTrackRendererUnit>(new AudioMediaStreamTrackRendererUnit);
+    return *unit;
 }
 
 AudioMediaStreamTrackRendererUnit::AudioMediaStreamTrackRendererUnit()
-    : m_internalUnit(AudioMediaStreamTrackRendererInternalUnit::create(*this))
+    : m_deleteUnitsTimer([] { AudioMediaStreamTrackRendererUnit::singleton().deleteUnitsIfPossible(); })
 {
 }
 
-AudioMediaStreamTrackRendererUnit::~AudioMediaStreamTrackRendererUnit()
+AudioMediaStreamTrackRendererUnit::~AudioMediaStreamTrackRendererUnit() = default;
+
+void AudioMediaStreamTrackRendererUnit::deleteUnitsIfPossible()
+{
+    assertIsMainThread();
+
+    m_units.removeIf([] (auto& keyValue) {
+        if (keyValue.value->isDefault() || keyValue.value->hasSources())
+            return false;
+
+        Ref unit = keyValue.value;
+        unit->close();
+        return true;
+    });
+}
+
+void AudioMediaStreamTrackRendererUnit::addSource(const String& deviceID, Ref<AudioSampleDataSource>&& source)
+{
+    assertIsMainThread();
+
+    Ref unit = m_units.ensure(deviceID, [&deviceID] { return Unit::create(deviceID); }).iterator->value;
+    unit->addSource(WTFMove(source));
+}
+
+void AudioMediaStreamTrackRendererUnit::removeSource(const String& deviceID, AudioSampleDataSource& source)
+{
+    assertIsMainThread();
+
+    auto iterator = m_units.find(deviceID);
+    if (iterator == m_units.end())
+        return;
+
+    static constexpr Seconds deleteUnitDelay = 10_s;
+
+    Ref unit = iterator->value;
+    if (unit->removeSource(source) && !unit->isDefault())
+        m_deleteUnitsTimer.startOneShot(deleteUnitDelay);
+}
+
+void AudioMediaStreamTrackRendererUnit::addResetObserver(const String& deviceID, ResetObserver& observer)
+{
+    assertIsMainThread();
+
+    Ref unit = m_units.ensure(deviceID, [&deviceID] { return Unit::create(deviceID); }).iterator->value;
+    unit->addResetObserver(observer);
+}
+
+void AudioMediaStreamTrackRendererUnit::retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&& callback)
+{
+    assertIsMainThread();
+
+    auto defaultDeviceID = AudioMediaStreamTrackRenderer::defaultDeviceID();
+    Ref unit = m_units.ensure(defaultDeviceID, [&defaultDeviceID] { return Unit::create(defaultDeviceID); }).iterator->value;
+    unit->retrieveFormatDescription(WTFMove(callback));
+}
+
+AudioMediaStreamTrackRendererUnit::Unit::Unit(const String& deviceID)
+    : m_internalUnit(AudioMediaStreamTrackRendererInternalUnit::create(deviceID, *this))
+    , m_isDefaultUnit(deviceID == AudioMediaStreamTrackRenderer::defaultDeviceID())
+{
+}
+
+AudioMediaStreamTrackRendererUnit::Unit::~Unit()
 {
     stop();
 }
 
-void AudioMediaStreamTrackRendererUnit::setAudioOutputDevice(const String& deviceID)
+void AudioMediaStreamTrackRendererUnit::Unit::close()
 {
-    protectedInternalUnit()->setAudioOutputDevice(deviceID);
+    assertIsMainThread();
+    m_internalUnit->close();
 }
 
-void AudioMediaStreamTrackRendererUnit::addSource(Ref<AudioSampleDataSource>&& source)
+void AudioMediaStreamTrackRendererUnit::Unit::addSource(Ref<AudioSampleDataSource>&& source)
 {
 #if !RELEASE_LOG_DISABLED
     source->logger().logAlways(LogWebRTC, "AudioMediaStreamTrackRendererUnit::addSource ", source->logIdentifier());
 #endif
-    ASSERT(isMainThread());
+    assertIsMainThread();
 
     ASSERT(!m_sources.contains(source.get()));
     bool shouldStart = m_sources.isEmpty();
@@ -75,12 +141,12 @@ void AudioMediaStreamTrackRendererUnit::addSource(Ref<AudioSampleDataSource>&& s
         start();
 }
 
-void AudioMediaStreamTrackRendererUnit::removeSource(AudioSampleDataSource& source)
+bool AudioMediaStreamTrackRendererUnit::Unit::removeSource(AudioSampleDataSource& source)
 {
 #if !RELEASE_LOG_DISABLED
     source.logger().logAlways(LogWebRTC, "AudioMediaStreamTrackRendererUnit::removeSource ", source.logIdentifier());
 #endif
-    ASSERT(isMainThread());
+    assertIsMainThread();
 
     bool shouldStop = !m_sources.isEmpty();
     m_sources.remove(source);
@@ -94,25 +160,38 @@ void AudioMediaStreamTrackRendererUnit::removeSource(AudioSampleDataSource& sour
 
     if (shouldStop)
         stop();
+    return shouldStop;
 }
 
-void AudioMediaStreamTrackRendererUnit::start()
+void AudioMediaStreamTrackRendererUnit::Unit::addResetObserver(ResetObserver& observer)
 {
+    assertIsMainThread();
+    m_resetObservers.add(observer);
+}
+
+void AudioMediaStreamTrackRendererUnit::Unit::retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&& callback)
+{
+    assertIsMainThread();
+    m_internalUnit->retrieveFormatDescription(WTFMove(callback));
+}
+
+void AudioMediaStreamTrackRendererUnit::Unit::start()
+{
+    assertIsMainThread();
     RELEASE_LOG(WebRTC, "AudioMediaStreamTrackRendererUnit::start");
-    ASSERT(isMainThread());
 
-    protectedInternalUnit()->start();
+    m_internalUnit->start();
 }
 
-void AudioMediaStreamTrackRendererUnit::stop()
+void AudioMediaStreamTrackRendererUnit::Unit::stop()
 {
+    assertIsMainThread();
     RELEASE_LOG(WebRTC, "AudioMediaStreamTrackRendererUnit::stop");
-    ASSERT(isMainThread());
 
-    protectedInternalUnit()->stop();
+    m_internalUnit->stop();
 }
 
-void AudioMediaStreamTrackRendererUnit::reset()
+void AudioMediaStreamTrackRendererUnit::Unit::reset()
 {
     RELEASE_LOG(WebRTC, "AudioMediaStreamTrackRendererUnit::reset");
     if (!isMainThread()) {
@@ -123,18 +202,13 @@ void AudioMediaStreamTrackRendererUnit::reset()
         return;
     }
 
+    assertIsMainThread();
     m_resetObservers.forEach([](auto& observer) {
         observer();
     });
 }
 
-void AudioMediaStreamTrackRendererUnit::retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&& callback)
-{
-    ASSERT(isMainThread());
-    protectedInternalUnit()->retrieveFormatDescription(WTFMove(callback));
-}
-
-void AudioMediaStreamTrackRendererUnit::updateRenderSourcesIfNecessary()
+void AudioMediaStreamTrackRendererUnit::Unit::updateRenderSourcesIfNecessary()
 {
     if (!m_pendingRenderSourcesLock.tryLock())
         return;
@@ -148,7 +222,7 @@ void AudioMediaStreamTrackRendererUnit::updateRenderSourcesIfNecessary()
     m_hasPendingRenderSources = false;
 }
 
-OSStatus AudioMediaStreamTrackRendererUnit::render(size_t sampleCount, AudioBufferList& ioData, uint64_t sampleTime, double hostTime, AudioUnitRenderActionFlags& actionFlags)
+OSStatus AudioMediaStreamTrackRendererUnit::Unit::render(size_t sampleCount, AudioBufferList& ioData, uint64_t sampleTime, double hostTime, AudioUnitRenderActionFlags& actionFlags)
 {
     // For performance reasons, we forbid heap allocations while doing rendering on the audio thread.
     ForbidMallocUseForCurrentThreadScope forbidMallocUse;

--- a/Source/WebCore/platform/mediastream/cocoa/BaseAudioMediaStreamTrackRendererUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/BaseAudioMediaStreamTrackRendererUnit.h
@@ -38,13 +38,11 @@ class BaseAudioMediaStreamTrackRendererUnit {
 public:
     virtual ~BaseAudioMediaStreamTrackRendererUnit() = default;
 
-    virtual void addSource(Ref<AudioSampleDataSource>&&) = 0;
-    virtual void removeSource(AudioSampleDataSource&) = 0;
-
-    virtual void setAudioOutputDevice(const String&) = 0;
+    virtual void addSource(const String&, Ref<AudioSampleDataSource>&&) = 0;
+    virtual void removeSource(const String&, AudioSampleDataSource&) = 0;
 
     using ResetObserver = Observer<void()>;
-    virtual void addResetObserver(ResetObserver&) = 0;
+    virtual void addResetObserver(const String&, ResetObserver&) = 0;
 };
 
 }

--- a/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h
@@ -31,6 +31,7 @@
 #include "CAAudioStreamDescription.h"
 #include "LibWebRTCAudioModule.h"
 #include <wtf/Forward.h>
+#include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/TZoneMalloc.h>
@@ -64,16 +65,19 @@ public:
     void deref() { m_audioModule.get()->deref(); };
 
 private:
-    void start();
-    void stop();
+    struct Mixer;
+    void start(Mixer&);
+    void stop(Mixer&);
     void postTask(Function<void()>&&);
     void renderAudioChunk(uint64_t currentAudioSampleCount);
 
     // BaseAudioMediaStreamTrackRendererUnit
-    void setAudioOutputDevice(const String&) final;
-    void addResetObserver(ResetObserver&) final;
-    void addSource(Ref<AudioSampleDataSource>&&) final;
-    void removeSource(AudioSampleDataSource&) final;
+    void addResetObserver(const String&, ResetObserver&) final;
+    void addSource(const String&, Ref<AudioSampleDataSource>&&) final;
+    void removeSource(const String&, AudioSampleDataSource&) final;
+
+    std::pair<bool, Vector<Ref<AudioSampleDataSource>>> addSourceToMixer(const String&, Ref<AudioSampleDataSource>&&);
+    std::pair<bool, Vector<Ref<AudioSampleDataSource>>> removeSourceFromMixer(const String&, AudioSampleDataSource&);
 
 #if !RELEASE_LOG_DISABLED
     // LoggerHelper.
@@ -86,17 +90,26 @@ private:
     const ThreadSafeWeakPtr<LibWebRTCAudioModule> m_audioModule;
     const Ref<WTF::WorkQueue> m_queue;
 
-    // Main thread variables.
-    HashSet<Ref<AudioSampleDataSource>> m_sources;
-    RefPtr<AudioSampleDataSource> m_registeredMixedSource;
+    struct Mixer {
+        HashSet<Ref<AudioSampleDataSource>> sources;
+        RefPtr<AudioSampleDataSource> registeredMixedSource;
+        String deviceID;
+    };
+
+    struct RenderMixer {
+        Vector<Ref<AudioSampleDataSource>> inputSources;
+        RefPtr<AudioSampleDataSource> mixedSource;
+        size_t writeCount { 0 };
+    };
+
+    HashMap<String, Mixer> m_mixers WTF_GUARDED_BY_CAPABILITY(mainThread);
 
     // Background thread variables.
-    Vector<Ref<AudioSampleDataSource>> m_renderSources;
-    RefPtr<AudioSampleDataSource> m_mixedSource;
-    std::optional<CAAudioStreamDescription> m_outputStreamDescription;
-    std::unique_ptr<WebAudioBufferList> m_audioBufferList;
+    HashMap<String, RenderMixer> m_renderMixers WTF_GUARDED_BY_CAPABILITY(m_queue.get());
+
+    std::optional<CAAudioStreamDescription> m_outputStreamDescription WTF_GUARDED_BY_CAPABILITY(m_queue.get());
+    std::unique_ptr<WebAudioBufferList> m_audioBufferList WTF_GUARDED_BY_CAPABILITY(m_queue.get());
     size_t m_sampleCount { 0 };
-    size_t m_writeCount { 0 };
 
 #if !RELEASE_LOG_DISABLED
     RefPtr<const Logger> m_logger;

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp
@@ -141,7 +141,7 @@ void LibWebRTCAudioModule::pollFromSource()
         char data[LibWebRTCAudioFormat::sampleByteSize * channels * LibWebRTCAudioFormat::chunkSampleCount];
         m_audioTransport->PullRenderData(LibWebRTCAudioFormat::sampleByteSize * 8, LibWebRTCAudioFormat::sampleRate, channels, LibWebRTCAudioFormat::chunkSampleCount, data, &elapsedTime, &ntpTime);
 #if PLATFORM(COCOA)
-        if (m_isRenderingIncomingAudio)
+        if (m_isRenderingIncomingAudioCounter)
             m_incomingAudioMediaStreamTrackRendererUnit->newAudioChunkPushed(m_currentAudioSampleCount);
         m_currentAudioSampleCount += LibWebRTCAudioFormat::chunkSampleCount;
 #endif

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.h
@@ -56,8 +56,9 @@ public:
     static constexpr unsigned PollSamplesCount = 1;
 
 #if PLATFORM(COCOA)
-    void startIncomingAudioRendering() { m_isRenderingIncomingAudio = true; }
-    void stopIncomingAudioRendering() { m_isRenderingIncomingAudio = false; }
+    void startIncomingAudioRendering() { ++m_isRenderingIncomingAudioCounter; }
+    void stopIncomingAudioRendering() { --m_isRenderingIncomingAudioCounter; }
+
     BaseAudioMediaStreamTrackRendererUnit& incomingAudioMediaStreamTrackRendererUnit();
     uint64_t currentAudioSampleCount() const { return m_currentAudioSampleCount; }
 #endif
@@ -161,7 +162,7 @@ private:
 
 #if PLATFORM(COCOA)
     uint64_t m_currentAudioSampleCount { 0 };
-    bool m_isRenderingIncomingAudio { false };
+    std::atomic<uint64_t> m_isRenderingIncomingAudioCounter { 0 };
     std::unique_ptr<IncomingAudioMediaStreamTrackRendererUnit> m_incomingAudioMediaStreamTrackRendererUnit;
 #endif
 };

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
@@ -64,11 +64,10 @@ public:
 
 private:
     // Messages
-    void createUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier, CompletionHandler<void(std::optional<WebCore::CAAudioStreamDescription>, size_t)>&& callback);
+    void createUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier, const String&, CompletionHandler<void(std::optional<WebCore::CAAudioStreamDescription>, size_t)>&& callback);
     void deleteUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier);
     void startUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier, ConsumerSharedCARingBuffer::Handle&&, IPC::Semaphore&&);
     void stopUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier);
-    void setAudioOutputDevice(AudioMediaStreamTrackRendererInternalUnitIdentifier, const String&);
 
     HashMap<AudioMediaStreamTrackRendererInternalUnitIdentifier, Ref<class RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit>> m_units;
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in
@@ -24,13 +24,11 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_STREAM) && PLATFORM(COCOA)
 
 messages -> RemoteAudioMediaStreamTrackRendererInternalUnitManager NotRefCounted {
-    CreateUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier) -> (std::optional<WebCore::CAAudioStreamDescription> description, size_t frameChunkSize)
+    CreateUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, String deviceID) -> (std::optional<WebCore::CAAudioStreamDescription> description, size_t frameChunkSize)
     DeleteUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
 
     StartUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, struct WebKit::ConsumerSharedCARingBufferHandle storageHandle, IPC::Semaphore renderSemaphore)
     StopUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
-
-    SetAudioOutputDevice(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, String deviceId)
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -51,9 +51,9 @@ namespace WebKit {
 class AudioMediaStreamTrackRendererInternalUnitManagerProxy final : public WebCore::AudioMediaStreamTrackRendererInternalUnit, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AudioMediaStreamTrackRendererInternalUnitManagerProxy>, public Identified<AudioMediaStreamTrackRendererInternalUnitIdentifier> {
     WTF_MAKE_TZONE_ALLOCATED(AudioMediaStreamTrackRendererInternalUnitManagerProxy);
 public:
-    static Ref<AudioMediaStreamTrackRendererInternalUnitManagerProxy> create(Client& client)
+    static Ref<AudioMediaStreamTrackRendererInternalUnitManagerProxy> create(const String& deviceID, Client& client)
     {
-        return adoptRef(*new AudioMediaStreamTrackRendererInternalUnitManagerProxy(client));
+        return adoptRef(*new AudioMediaStreamTrackRendererInternalUnitManagerProxy(deviceID, client));
     }
 
     ~AudioMediaStreamTrackRendererInternalUnitManagerProxy();
@@ -65,14 +65,14 @@ public:
     void reset(IsClosed);
 
 private:
-    explicit AudioMediaStreamTrackRendererInternalUnitManagerProxy(Client&);
+    explicit AudioMediaStreamTrackRendererInternalUnitManagerProxy(const String&, Client&);
 
     // AudioMediaStreamTrackRendererUnit::InternalUnit API.
     void start() final;
     void stop() final;
+    void close() { stopThread(); }
+
     void retrieveFormatDescription(CompletionHandler<void(std::optional<WebCore::CAAudioStreamDescription>)>&&) final;
-    void setAudioOutputDevice(const String&) final;
-    const String& audioOutputDeviceID() const final { return m_deviceId; }
 
     void initialize(const WebCore::CAAudioStreamDescription&, size_t frameChunkSize);
     void storageChanged(WebCore::SharedMemory*, const WebCore::CAAudioStreamDescription&, size_t);
@@ -81,11 +81,11 @@ private:
     void startThread();
     void createRemoteUnit();
 
+    String m_deviceID;
     ThreadSafeWeakPtr<Client> m_client;
 
     Deque<CompletionHandler<void(std::optional<WebCore::CAAudioStreamDescription>)>> m_descriptionCallbacks;
 
-    String m_deviceId;
     bool m_isPlaying { false };
 
     std::optional<WebCore::CAAudioStreamDescription> m_description;
@@ -113,9 +113,9 @@ void AudioMediaStreamTrackRendererInternalUnitManager::remove(AudioMediaStreamTr
     m_proxies.remove(proxy.identifier());
 }
 
-Ref<WebCore::AudioMediaStreamTrackRendererInternalUnit> createRemoteAudioMediaStreamTrackRendererInternalUnitProxy(WebCore::AudioMediaStreamTrackRendererInternalUnit::Client& client)
+Ref<WebCore::AudioMediaStreamTrackRendererInternalUnit> createRemoteAudioMediaStreamTrackRendererInternalUnitProxy(const String& deviceID, WebCore::AudioMediaStreamTrackRendererInternalUnit::Client& client)
 {
-    return AudioMediaStreamTrackRendererInternalUnitManagerProxy::create(client);
+    return AudioMediaStreamTrackRendererInternalUnitManagerProxy::create(deviceID, client);
 }
 
 void AudioMediaStreamTrackRendererInternalUnitManager::reset(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
@@ -136,8 +136,9 @@ void AudioMediaStreamTrackRendererInternalUnitManager::restartAllUnits()
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioMediaStreamTrackRendererInternalUnitManagerProxy);
 
-AudioMediaStreamTrackRendererInternalUnitManagerProxy::AudioMediaStreamTrackRendererInternalUnitManagerProxy(Client& client)
-    : m_client(client)
+AudioMediaStreamTrackRendererInternalUnitManagerProxy::AudioMediaStreamTrackRendererInternalUnitManagerProxy(const String& deviceID, Client& client)
+    : m_deviceID(deviceID)
+    , m_client(client)
 {
     WebProcess::singleton().audioMediaStreamTrackRendererInternalUnitManager().add(*this);
     createRemoteUnit();
@@ -154,7 +155,7 @@ AudioMediaStreamTrackRendererInternalUnitManagerProxy::~AudioMediaStreamTrackRen
 
 void AudioMediaStreamTrackRendererInternalUnitManagerProxy::createRemoteUnit()
 {
-    WebProcess::singleton().ensureGPUProcessConnection().connection().sendWithAsyncReply(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::CreateUnit { identifier() }, [weakThis = ThreadSafeWeakPtr { *this }](auto&& description, auto frameChunkSize) {
+    WebProcess::singleton().ensureGPUProcessConnection().connection().sendWithAsyncReply(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::CreateUnit { identifier(), m_deviceID }, [weakThis = ThreadSafeWeakPtr { *this }](auto&& description, auto frameChunkSize) {
         if (RefPtr protectedThis = weakThis.get(); protectedThis && description && frameChunkSize)
             protectedThis->initialize(*description, frameChunkSize);
     }, 0);
@@ -186,8 +187,6 @@ void AudioMediaStreamTrackRendererInternalUnitManagerProxy::start()
     if (m_didClose) {
         m_didClose = false;
         createRemoteUnit();
-        if (!m_deviceId.isEmpty())
-            setAudioOutputDevice(m_deviceId);
         m_isPlaying = true;
         return;
     }
@@ -213,12 +212,6 @@ void AudioMediaStreamTrackRendererInternalUnitManagerProxy::stop()
 {
     m_isPlaying = false;
     WebProcess::singleton().ensureGPUProcessConnection().connection().send(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::StopUnit { identifier() }, 0);
-}
-
-void AudioMediaStreamTrackRendererInternalUnitManagerProxy::setAudioOutputDevice(const String& deviceId)
-{
-    m_deviceId = deviceId;
-    WebProcess::singleton().ensureGPUProcessConnection().connection().send(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::SetAudioOutputDevice { identifier(), deviceId }, 0);
 }
 
 void AudioMediaStreamTrackRendererInternalUnitManagerProxy::retrieveFormatDescription(CompletionHandler<void(std::optional<WebCore::CAAudioStreamDescription>)>&& callback)

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.h
@@ -60,7 +60,7 @@ private:
     HashMap<AudioMediaStreamTrackRendererInternalUnitIdentifier, ThreadSafeWeakPtr<AudioMediaStreamTrackRendererInternalUnitManagerProxy>> m_proxies;
 };
 
-Ref<WebCore::AudioMediaStreamTrackRendererInternalUnit> createRemoteAudioMediaStreamTrackRendererInternalUnitProxy(WebCore::AudioMediaStreamTrackRendererInternalUnit::Client&);
+Ref<WebCore::AudioMediaStreamTrackRendererInternalUnit> createRemoteAudioMediaStreamTrackRendererInternalUnitProxy(const String&, WebCore::AudioMediaStreamTrackRendererInternalUnit::Client&);
 
 }
 


### PR DESCRIPTION
#### 6a2161611cb0a04bded789c994bee25aad099943
<pre>
[macOS] Add support for multi-speaker MediaStreamTrack audio playing
<a href="https://rdar.apple.com/139969268">rdar://139969268</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=283174">https://bugs.webkit.org/show_bug.cgi?id=283174</a>

Reviewed by Eric Carlson.

Within WebProcess, we update AudioMediaStreamTrackRendererUnit and IncomingAudioMediaStreamTrackRendererUnit to support sources going to different speakers.
For each one of these classes, we register/unregister sources with their speaker device ID.
We then mix the sources that are using the same device ID.
We then send those per-speaker-device streams to the GPUProcess.

These streams are then rendered using LocalAudioMediaStreamTrackRendererInternalUnit, except if the ID is &apos;default&apos;.
In that case, this stream will be rendered through VPIO if VPIO is running or via LocalAudioMediaStreamTrackRendererInternalUnit otherwise.

We no longer allow an audio rendering unit to change of device dynamically.
Instead, when this happens, the source will unregister itself from AudioMediaStreamTrackRendererUnit or IncomingAudioMediaStreamTrackRendererUnit,
and reregister itself with the new speaker device ID.

We add some threading assertions as a small improvement to the code.

Manually tested.

Relanding with a fix for m_outputDescription check.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::audioOutputDeviceChanged):
* Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.cpp:
(WebCore::AudioMediaStreamTrackRenderer::defaultDeviceID):
* Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.h:
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.cpp:
(WebCore::m_deviceID):
(WebCore::AudioMediaStreamTrackRendererCocoa::stop):
(WebCore::AudioMediaStreamTrackRendererCocoa::setAudioOutputDevice):
(WebCore::AudioMediaStreamTrackRendererCocoa::setRegisteredDataSource):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.h:
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp:
(WebCore::LocalAudioMediaStreamTrackRendererInternalUnit::setAudioOutputDevice):
(WebCore::AudioMediaStreamTrackRendererInternalUnit::create):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h:
(WebCore::AudioMediaStreamTrackRendererInternalUnit::close):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp:
(WebCore::AudioMediaStreamTrackRendererUnit::singleton):
(WebCore::AudioMediaStreamTrackRendererUnit::AudioMediaStreamTrackRendererUnit):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::Unit):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::~Unit):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::close):
(WebCore::AudioMediaStreamTrackRendererUnit::deleteUnitsIfPossible):
(WebCore::AudioMediaStreamTrackRendererUnit::addSource):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::addSource):
(WebCore::AudioMediaStreamTrackRendererUnit::removeSource):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::removeSource):
(WebCore::AudioMediaStreamTrackRendererUnit::addResetObserver):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::addResetObserver):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::retrieveFormatDescription):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::start):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::stop):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::reset):
(WebCore::AudioMediaStreamTrackRendererUnit::retrieveFormatDescription):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::updateRenderSourcesIfNecessary):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::render):
(WebCore::AudioMediaStreamTrackRendererUnit::~AudioMediaStreamTrackRendererUnit): Deleted.
(WebCore::AudioMediaStreamTrackRendererUnit::setAudioOutputDevice): Deleted.
(WebCore::AudioMediaStreamTrackRendererUnit::start): Deleted.
(WebCore::AudioMediaStreamTrackRendererUnit::stop): Deleted.
(WebCore::AudioMediaStreamTrackRendererUnit::reset): Deleted.
(WebCore::AudioMediaStreamTrackRendererUnit::updateRenderSourcesIfNecessary): Deleted.
(WebCore::AudioMediaStreamTrackRendererUnit::render): Deleted.
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h:
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::create):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::hasSources const):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::isDefault const):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::WTF_GUARDED_BY_LOCK):
(WebCore::AudioMediaStreamTrackRendererUnit::protectedInternalUnit): Deleted.
(WebCore::AudioMediaStreamTrackRendererUnit::WTF_GUARDED_BY_LOCK): Deleted.
* Source/WebCore/platform/mediastream/cocoa/BaseAudioMediaStreamTrackRendererUnit.h:
* Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp:
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::addResetObserver):
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::addSourceToMixer):
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::addSource):
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::removeSourceFromMixer):
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::removeSource):
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::start):
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::stop):
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::renderAudioChunk):
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::setAudioOutputDevice): Deleted.
* Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h:
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp:
(WebCore::LibWebRTCAudioModule::pollFromSource):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.h:
(WebCore::LibWebRTCAudioModule::startIncomingAudioRendering):
(WebCore::LibWebRTCAudioModule::stopIncomingAudioRendering):
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::create):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::createUnit):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::setShouldRegisterAsSpeakerSamplesProducer):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::updateShouldRegisterAsSpeakerSamplesProducer):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::setAudioOutputDevice): Deleted.
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::setAudioOutputDevice): Deleted.
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in:
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::createRemoteAudioMediaStreamTrackRendererInternalUnitProxy):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManagerProxy::AudioMediaStreamTrackRendererInternalUnitManagerProxy):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManagerProxy::createRemoteUnit):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManagerProxy::start):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManagerProxy::setAudioOutputDevice): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.h:

Canonical link: <a href="https://commits.webkit.org/286952@main">https://commits.webkit.org/286952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/290276c66d1056a32992eee077b22fe67af006db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77681 "11 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56714 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82308 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28959 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79798 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5014 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60865 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18832 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66655 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41144 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/48212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24159 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27290 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69327 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83685 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5061 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69090 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66632 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68342 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17075 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12354 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10453 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5008 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/5021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/8459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6786 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->