### PR TITLE
REGRESSION(286103@main): [Debug] `fast/canvas/webgl/canvas-webgl-page-cache.html` is a flaky crash

### DIFF
--- a/LayoutTests/fast/canvas/webgl/canvas-test.html
+++ b/LayoutTests/fast/canvas/webgl/canvas-test.html
@@ -26,165 +26,159 @@ var canvas = document.getElementById("canvas");
 var canvas2d = document.getElementById("canvas2d");
 var ctx2d = canvas2d.getContext("2d");
 var gl = create3DContext(canvas);
-if (!gl) {
-  testFailed("context does not exist");
-} else {
-  testPassed("context exists");
 
-  debug("");
-  debug("Checking canvas and WebGL interaction");
+// Check get a 4 value gl parameter as a csv string.
+function getValue4v(name) {
+  var v = gl.getParameter(name);
+  var result = '' +
+      v[0] + ',' +
+      v[1] + ',' +
+      v[2] + ',' +
+      v[3];
+  return result;
+}
 
-  // Check that a canvas with no width or height is 300x150 pixels
-  shouldBe('canvas.width', '300');
-  shouldBe('canvas.height', '150');
+function getViewport() {
+  return getValue4v(gl.VIEWPORT);
+}
 
-  // Check get a 4 value gl parameter as a csv string.
-  function getValue4v(name) {
-    var v = gl.getParameter(name);
-    var result = '' +
-        v[0] + ',' +
-        v[1] + ',' +
-        v[2] + ',' +
-        v[3];
-    return result;
+function getClearColor() {
+  return getValue4v(gl.COLOR_CLEAR_VALUE);
+}
+
+function isAboutEqual(a, b) {
+  return Math.abs(a - b) < 0.01;
+}
+
+function isAboutEqualInt(a, b) {
+  return Math.abs(a - b) < 3;
+}
+
+function checkCanvasContentIs(r3d,g3d,b3d,a3d) {
+  var r2d;
+  var g2d;
+  var b2d;
+  var a2d;
+
+  function checkPixel(x, y, r3d,g3d,b3d,a3d) {
+    var offset = (y * 40 + x) * 4;
+    r2d = imgData.data[offset];
+    g2d = imgData.data[offset + 1];
+    b2d = imgData.data[offset + 2];
+    a2d = imgData.data[offset + 3];
+    //debug('' + x + ', ' + y + "(" + offset + ") = " + r2d + ", " + g2d + ", " + b2d + ", " + a2d);
+    return isAboutEqualInt(r2d, r3d) &&
+            isAboutEqualInt(g2d, g3d) &&
+            isAboutEqualInt(b2d, b3d) &&
+            isAboutEqualInt(a2d, a3d);
   }
 
-  function getViewport() {
-    return getValue4v(gl.VIEWPORT);
+  function checkPixels(r3d,g3d,b3d,a3d) {
+    return checkPixel(0, 0, r3d, g3d, b3d, a3d) &&
+            checkPixel(0, 39, r3d, g3d, b3d, a3d) &&
+            checkPixel(39, 0, r3d, g3d, b3d, a3d) &&
+            checkPixel(39, 39, r3d, g3d, b3d, a3d) &&
+            checkPixel(0, 0, r3d, g3d, b3d, a3d);
+  };
+
+  // Set to just take the color from the 3d canvas
+  ctx2d.globalCompositeOperation = 'copy';
+
+  // fill 2d canvas with orange
+  ctx2d.fillStyle = "rgb(255,192,128)";
+  ctx2d.fillRect (0, 0, 40, 40);
+
+  // get the image data
+  var imgData = ctx2d.getImageData(0, 0, 40, 40);
+
+  // check it got cleared.
+  if (!checkPixels(255, 192, 128, 255)) {
+    testFailed("unable to fill 2d context.");
+    return;
   }
 
-  function getClearColor() {
-    return getValue4v(gl.COLOR_CLEAR_VALUE);
+  // draw 3d canvas on top.
+  ctx2d.drawImage(canvas, 0,0, 40, 40);
+
+  // get the image data
+  var imgData = ctx2d.getImageData(0, 0, 40, 40);
+
+  // Check it's the expected color.
+  if (!checkPixels(r3d, g3d, b3d, a3d)) {
+    testFailed("pixels are " + r2d + "," + g2d + "," + b2d + "," + a2d +
+              " expected " + r3d + "," + g3d + "," + b3d + "," + a3d);
+  } else {
+    testPassed("pixels are " + r3d + "," + g3d + "," + b3d + "," + a3d);
   }
+}
 
-  function isAboutEqual(a, b) {
-    return Math.abs(a - b) < 0.01;
-  }
+async function runTest() {
+  if (!gl) {
+    testFailed("context does not exist");
+  } else {
+    testPassed("context exists");
 
-  function isAboutEqualInt(a, b) {
-    return Math.abs(a - b) < 3;
-  }
+    debug("");
+    debug("Checking canvas and WebGL interaction");
 
-  function checkCanvasContentIs(r3d,g3d,b3d,a3d) {
-    var r2d;
-    var g2d;
-    var b2d;
-    var a2d;
+    // Check that a canvas with no width or height is 300x150 pixels
+    shouldBe('canvas.width', '300');
+    shouldBe('canvas.height', '150');
+    checkCanvasContentIs(0, 0, 0, 0);
+    shouldBe('getViewport()', '"0,0,300,150"');
 
-    function checkPixel(x, y, r3d,g3d,b3d,a3d) {
-      var offset = (y * 40 + x) * 4;
-      r2d = imgData.data[offset];
-      g2d = imgData.data[offset + 1];
-      b2d = imgData.data[offset + 2];
-      a2d = imgData.data[offset + 3];
-      //debug('' + x + ', ' + y + "(" + offset + ") = " + r2d + ", " + g2d + ", " + b2d + ", " + a2d);
-      return isAboutEqualInt(r2d, r3d) &&
-             isAboutEqualInt(g2d, g3d) &&
-             isAboutEqualInt(b2d, b3d) &&
-             isAboutEqualInt(a2d, a3d);
-    }
-
-    function checkPixels(r3d,g3d,b3d,a3d) {
-      return checkPixel(0, 0, r3d, g3d, b3d, a3d) &&
-             checkPixel(0, 39, r3d, g3d, b3d, a3d) &&
-             checkPixel(39, 0, r3d, g3d, b3d, a3d) &&
-             checkPixel(39, 39, r3d, g3d, b3d, a3d) &&
-             checkPixel(0, 0, r3d, g3d, b3d, a3d);
-    };
-
-    // Set to just take the color from the 3d canvas
-    ctx2d.globalCompositeOperation = 'copy';
-
-    // fill 2d canvas with orange
-    ctx2d.fillStyle = "rgb(255,192,128)";
-    ctx2d.fillRect (0, 0, 40, 40);
-
-    // get the image data
-    var imgData = ctx2d.getImageData(0, 0, 40, 40);
-
-    // check it got cleared.
-    if (!checkPixels(255, 192, 128, 255)) {
-      testFailed("unable to fill 2d context.");
-      return;
-    }
-
-    // draw 3d canvas on top.
-    ctx2d.drawImage(canvas, 0,0, 40, 40);
-
-    // get the image data
-    var imgData = ctx2d.getImageData(0, 0, 40, 40);
-
-    // Check it's the expected color.
-    if (!checkPixels(r3d, g3d, b3d, a3d)) {
-     testFailed("pixels are " + r2d + "," + g2d + "," + b2d + "," + a2d +
-                " expected " + r3d + "," + g3d + "," + b3d + "," + a3d);
-    } else {
-      testPassed("pixels are " + r3d + "," + g3d + "," + b3d + "," + a3d);
-    }
-  }
-
-  checkCanvasContentIs(0, 0, 0, 0);
-  shouldBe('getViewport()', '"0,0,300,150"');
-
-  // Change the display size of the canvas and check
-  // the viewport size does not change.
-  debug("");
-  debug("change display size of canvas and see that viewport does not change");
-  canvas.style.width = "100px";
-  canvas.style.height = "25px";
-  var intervalId;
-  intervalId = window.setInterval(async function() {
+    // Change the display size of the canvas and check
+    // the viewport size does not change.
+    debug("");
+    debug("change display size of canvas and see that viewport does not change");
+    canvas.style.width = "100px";
+    canvas.style.height = "25px";
     await testRunner?.displayAndTrackRepaints();
-    if (canvas.clientWidth == 100 &&
-        canvas.clientHeight == 25) {
-      window.clearInterval(intervalId);
-      shouldBe('getViewport()', '"0,0,300,150"');
-      shouldBe('canvas.width', '300');
-      shouldBe('canvas.height', '150');
+    var intervalId;
+    intervalId = window.setInterval(async function() {
+      if (canvas.clientWidth == 100 &&
+          canvas.clientHeight == 25) {
+        window.clearInterval(intervalId);
+        shouldBe('getViewport()', '"0,0,300,150"');
+        shouldBe('canvas.width', '300');
+        shouldBe('canvas.height', '150');
 
-      // Change the actual size of the canvas
-      // Check that the viewport does not change.
-      // Check that the clear color does not change.
-      // Check that the color mask does not change.
-      debug("");
-      debug("change the actual size of the canvas and see that the viewport does not change");
-      gl.clearColor(0.25, 0.5, 0.75, 1);
-      gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-      checkCanvasContentIs(64, 128, 192, 255);
-      gl.colorMask(0,0,0,0);
-      canvas.width = 400;
-      canvas.height = 10;
+        // Change the actual size of the canvas
+        // Check that the viewport does not change.
+        // Check that the clear color does not change.
+        // Check that the color mask does not change.
+        debug("");
+        debug("change the actual size of the canvas and see that the viewport does not change");
+        gl.clearColor(0.25, 0.5, 0.75, 1);
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+        checkCanvasContentIs(64, 128, 192, 255);
+        gl.colorMask(0,0,0,0);
+        canvas.width = 400;
+        canvas.height = 10;
 
-      var v = gl.getParameter(gl.COLOR_CLEAR_VALUE);
-      assertMsg(isAboutEqual(v[0], 0.25) &&
-                isAboutEqual(v[1], 0.5) &&
-                isAboutEqual(v[2], 0.75) &&
-                isAboutEqual(v[3], 1),
-                "gl.clearColor should not change after canvas resize");
-      v = gl.getParameter(gl.COLOR_WRITEMASK);
-      assertMsg(isAboutEqual(v[0], 0) &&
-                isAboutEqual(v[1], 0) &&
-                isAboutEqual(v[2], 0) &&
-                isAboutEqual(v[3], 0),
-                "gl.colorMask should not change after canvas resize");
-      shouldBe('getViewport()', '"0,0,300,150"');
-      checkCanvasContentIs(0, 0, 0, 0);
+        var v = gl.getParameter(gl.COLOR_CLEAR_VALUE);
+        assertMsg(isAboutEqual(v[0], 0.25) &&
+                  isAboutEqual(v[1], 0.5) &&
+                  isAboutEqual(v[2], 0.75) &&
+                  isAboutEqual(v[3], 1),
+                  "gl.clearColor should not change after canvas resize");
+        v = gl.getParameter(gl.COLOR_WRITEMASK);
+        assertMsg(isAboutEqual(v[0], 0) &&
+                  isAboutEqual(v[1], 0) &&
+                  isAboutEqual(v[2], 0) &&
+                  isAboutEqual(v[3], 0),
+                  "gl.colorMask should not change after canvas resize");
+        shouldBe('getViewport()', '"0,0,300,150"');
+        checkCanvasContentIs(0, 0, 0, 0);
 
-      debug("");
-      var epilogue = document.createElement("script");
-      epilogue.onload = finish;
-      epilogue.src = "../../../resources/js-test-post.js";
-      document.body.appendChild(epilogue);
-    }
-   }, 1000/30);
-}
-
-function finish() {
-  if (window.nonKhronosFrameworkNotifyDone) {
-    window.nonKhronosFrameworkNotifyDone();
+        debug("");
+        finishTest();
+      }
+    }, 1000/300);
   }
 }
 
+runTest();
 </script>
 </body>
 </html>


### PR DESCRIPTION
#### 5ea352280424fe1276451efb0a27c03e7c70a57e
<pre>
REGRESSION(286103@main): [Debug] `fast/canvas/webgl/canvas-webgl-page-cache.html` is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=283554">https://bugs.webkit.org/show_bug.cgi?id=283554</a>

Reviewed by Anne van Kesteren.

`fast/canvas/webgl/canvas-webgl-page-cache.html` is wrongly accused.
The actual culprit is `fast/canvas/webgl/canvas-test.html` but it
crashes after reporting a failure and confusing the test runner.

Results history [1] proves this by showing that the pattern of
`canvas-webgl-page-cache.html` crashes absolutely matches the pattern of
`canvas-test.html` failures.

286103@main made `testRunner.displayAndTrackRepaints()` asynchronous. In
`canvas-test.html`, it&apos;s being called from `setInterval()`&apos;s callback
before `clearInterval()`. That can lead to a situation where the
callback is triggered again while the first execution is waiting for
`displayAndTrackRepaints()` to be resolved.

Results of failing test runs [2] prove that by showing logs reported by
the callback multiple times.

This patch fixes the test by moving `displayAndTrackRepaints()` out of
the callback. This requires wrapping the test logic into an `async`
function.

Also, similarly to 157930@main, finishing the test was simplified by
calling `finishTest()` from `webgl-test.js`. This should speed it up.

1. <a href="https://results.webkit.org/?suite=layout-tests&amp">https://results.webkit.org/?suite=layout-tests&amp</a>;suite=layout-tests&amp;test=fast%2Fcanvas%2Fwebgl%2Fcanvas-test.html&amp;test=fast%2Fcanvas%2Fwebgl%2Fcanvas-webgl-page-cache.html&amp;style=debug&amp;limit=5000
2. <a href="https://build.webkit.org/results/GTK-Linux-64-bit-Debug-Tests/287141@main%20(14983)/fast/canvas/webgl/canvas-test-actual.txt">https://build.webkit.org/results/GTK-Linux-64-bit-Debug-Tests/287141@main%20(14983)/fast/canvas/webgl/canvas-test-actual.txt</a>

* LayoutTests/fast/canvas/webgl/canvas-test.html:

Canonical link: <a href="https://commits.webkit.org/287155@main">https://commits.webkit.org/287155@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc33e7c7b7b22e815db18e423f459736f9b98e77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83194 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29798 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61513 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19428 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41824 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48870 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25342 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28135 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69970 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84560 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5898 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4044 "Found 2 new test failures: fast/selectors/selection-window-inactive-stroke-color.html imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69738 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6059 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68992 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17195 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13013 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11445 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5845 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5833 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9267 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7620 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->