### PR TITLE
[GStreamer][WebRTC] Fallback to constrained-baseline when H.264 is negotiated for outgoing video source

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
@@ -84,14 +84,14 @@ RefPtr<GStreamerVideoRTPPacketizer> GStreamerVideoRTPPacketizer::create(RefPtr<U
         g_object_set(payloader.get(), "config-interval", -1, nullptr);
 
         auto profileValue = gstStructureGetString(codecParameters, "profile"_s);
-        auto profile = profileValue ? profileValue : "baseline"_s;
+        auto profile = profileValue ? profileValue : "constrained-baseline"_s;
 
         AVCParameters parameters;
         if (profile == "baseline"_s)
             parameters.profileIDC = 66;
         else if (profile == "constrained-baseline"_s) {
             parameters.profileIDC = 66;
-            parameters.constraintsFlags |= 0x40 << 6;
+            parameters.constraintsFlags |= 1 << 6;
         } else if (profile == "main"_s)
             parameters.profileIDC = 77;
 


### PR DESCRIPTION
#### 6a6659e8614fdfd6342981b340789b07c14df914
<pre>
[GStreamer][WebRTC] Fallback to constrained-baseline when H.264 is negotiated for outgoing video source
<a href="https://bugs.webkit.org/show_bug.cgi?id=283557">https://bugs.webkit.org/show_bug.cgi?id=283557</a>

Reviewed by Xabier Rodriguez-Calvar.

According to RFC 7742, endpoints MUST support Constrained Baseline Profile Level 1.2 and SHOULD
support H.264 Constrained High Profile Level 1.3. So if no profile is specified, use
constrained-baseline.

The AVC constraint flags were also wrongly set for this profile, so fix that as well, by setting the
second most significant bit to 1, corresponding to the constraint_set1_flag.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp:
(WebCore::GStreamerVideoRTPPacketizer::create):

Canonical link: <a href="https://commits.webkit.org/287056@main">https://commits.webkit.org/287056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ad104bde1a3739d204afb2c5e08973358dbb64d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82335 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28979 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79820 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65892 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5036 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60877 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18839 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41162 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48217 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24181 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27312 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69333 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83707 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3436 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69102 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5240 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66657 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68353 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17134 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12377 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10462 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5030 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7820 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5041 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8479 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6808 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->