### PR TITLE
Use a WeakRef + Ref in lambda to avoid dropping element and crashing

### DIFF
--- a/Source/WebCore/dom/ToggleEventTask.cpp
+++ b/Source/WebCore/dom/ToggleEventTask.cpp
@@ -41,22 +41,14 @@ void ToggleEventTask::queue(ToggleState oldState, ToggleState newState)
     if (m_data)
         oldState = m_data->oldState;
 
-    RefPtr element = m_element.get();
-    if (!element)
-        return;
-
     m_data = { oldState, newState };
-    element->queueTaskKeepingThisNodeAlive(TaskSource::DOMManipulation, [this, newState] {
+    m_element->queueTaskKeepingThisNodeAlive(TaskSource::DOMManipulation, [this, element = Ref { m_element.get() }, newState] {
         if (!m_data || m_data->newState != newState)
             return;
 
         auto stringForState = [](ToggleState state) {
             return state == ToggleState::Closed ? "closed"_s : "open"_s;
         };
-
-        RefPtr element = m_element.get();
-        if (!element)
-            return;
 
         auto data = *std::exchange(m_data, std::nullopt);
         element->dispatchEvent(ToggleEvent::create(eventNames().toggleEvent, { EventInit { }, stringForState(data.oldState), stringForState(data.newState) }, Event::IsCancelable::No));

--- a/Source/WebCore/dom/ToggleEventTask.h
+++ b/Source/WebCore/dom/ToggleEventTask.h
@@ -49,7 +49,7 @@ private:
     ToggleEventTask(Element& element)
         : m_element(element) { }
 
-    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_element;
+    WeakRef<Element, WeakPtrImplWithEventTargetData> m_element;
     std::optional<ToggleEventData> m_data;
 };
 


### PR DESCRIPTION
#### 19b6d6ff094fd9b2360b1c948269854481e54e32
<pre>
Use a WeakRef + Ref in lambda to avoid dropping element and crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=283537">https://bugs.webkit.org/show_bug.cgi?id=283537</a>

Reviewed by NOBODY (OOPS!).

The prior implementation used a `WeakPtr` when being passed a ref, which
was a little pointless, as we can instead use a `WeakRef`. However there
were still crashes when getting `m_element` in the lambda expression so
instead this now creates a held Ref as part of the capture clause to
ensure the pointer isn&apos;t dropped.

It should be kept alive during this execution (because the expression is
passed to queueTaskKeepingThisNodeAlive), so there is no need to use a
RefPtr/WeakPtr here.

* Source/WebCore/dom/ToggleEventTask.cpp:
(WebCore::ToggleEventTask::queue):
* Source/WebCore/dom/ToggleEventTask.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19b6d6ff094fd9b2360b1c948269854481e54e32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77720 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30645 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82358 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28994 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5054 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60893 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18845 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80786 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50856 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41183 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48227 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24190 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27330 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83726 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3442 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69117 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66666 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68366 "Found 1 new API test failure: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12373 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10464 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5047 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5056 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8494 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6824 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->