### PR TITLE
Minor assorted dynamicDowncast<> cleanup

### DIFF
--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -105,7 +105,7 @@ void CookieStore::MainThreadBridge::ensureOnMainThread(Function<void(ScriptExecu
         return;
     ASSERT(context->isContextThread());
 
-    if (RefPtr document = dynamicDowncast<Document>(*context)) {
+    if (is<Document>(*context)) {
         task(*context);
         return;
     }

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -925,7 +925,8 @@ ExceptionOr<Ref<SourceBuffer>> MediaSource::addSourceBuffer(const String& type)
     // 2. If type contains a MIME type that is not supported ..., then throw a
     // NotSupportedError exception and abort these steps.
     Vector<ContentType> mediaContentTypesRequiringHardwareSupport;
-    if (RefPtr document = dynamicDowncast<Document>(context))
+    RefPtr document = dynamicDowncast<Document>(*context);
+    if (document)
         mediaContentTypesRequiringHardwareSupport.appendVector(document->settings().mediaContentTypesRequiringHardwareSupport());
 
     if (!isTypeSupported(*context, type, WTFMove(mediaContentTypesRequiringHardwareSupport)))
@@ -938,7 +939,6 @@ ExceptionOr<Ref<SourceBuffer>> MediaSource::addSourceBuffer(const String& type)
 
     // 5. Create a new SourceBuffer object and associated resources.
     ContentType contentType(type);
-    RefPtr document = dynamicDowncast<Document>(context);
     if (document && document->quirks().needsVP9FullRangeFlagQuirk())
         contentType = addVP9FullRangeVideoFlagToContentType(contentType);
 
@@ -1214,7 +1214,7 @@ bool MediaSource::isTypeSupported(ScriptExecutionContext& context, const String&
     parameters.isMediaSource = true;
     parameters.contentTypesRequiringHardwareSupport = WTFMove(contentTypesRequiringHardwareSupport);
 
-    if (RefPtr document = dynamicDowncast<Document>(context)) {
+    if (document) {
         if (!contentTypeMeetsContainerAndCodecTypeRequirements(contentType, document->settings().allowedMediaContainerTypes(), document->settings().allowedMediaCodecTypes()))
             return false;
 
@@ -1447,8 +1447,7 @@ ExceptionOr<Ref<SourceBufferPrivate>> MediaSource::createSourceBufferPrivate(con
 {
     ContentType type { incomingType };
 
-    RefPtr context = scriptExecutionContext();
-    RefPtr document = dynamicDowncast<Document>(context);
+    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
     if (document && document->quirks().needsVP9FullRangeFlagQuirk())
         type = addVP9FullRangeVideoFlagToContentType(incomingType);
 

--- a/Source/WebCore/Modules/reporting/ReportingObserver.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.cpp
@@ -62,10 +62,10 @@ Ref<ReportingObserver> ReportingObserver::create(ScriptExecutionContext& scriptE
 
 static WeakPtr<ReportingScope> reportingScopeForContext(ScriptExecutionContext& scriptExecutionContext)
 {
-    if (RefPtr document = dynamicDowncast<Document>(&scriptExecutionContext))
+    if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext))
         return document->reportingScope();
 
-    if (RefPtr workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(&scriptExecutionContext))
+    if (RefPtr workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext))
         return workerGlobalScope->reportingScope();
 
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/Modules/speech/LocalDOMWindowSpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/LocalDOMWindowSpeechSynthesis.cpp
@@ -63,7 +63,7 @@ LocalDOMWindowSpeechSynthesis* LocalDOMWindowSpeechSynthesis::from(DOMWindow* wi
     if (!supplement) {
         auto newSupplement = makeUnique<LocalDOMWindowSpeechSynthesis>(window);
         supplement = newSupplement.get();
-        provideTo(dynamicDowncast<LocalDOMWindow>(window), supplementName(), WTFMove(newSupplement));
+        provideTo(localWindow.get(), supplementName(), WTFMove(newSupplement));
     }
     return supplement;
 }

--- a/Source/WebCore/Modules/storage/StorageManager.cpp
+++ b/Source/WebCore/Modules/storage/StorageManager.cpp
@@ -76,14 +76,14 @@ static ExceptionOr<ConnectionInfo> connectionInfo(NavigatorBase* navigator)
     RefPtr origin = context->securityOrigin();
     ASSERT(origin);
 
-    if (RefPtr document = dynamicDowncast<Document>(context)) {
+    if (RefPtr document = dynamicDowncast<Document>(*context)) {
         if (RefPtr connection = document->storageConnection())
             return ConnectionInfo { *connection, { document->topOrigin().data(), origin->data() } };
 
         return Exception { ExceptionCode::InvalidStateError, "Connection is invalid"_s };
     }
 
-    if (RefPtr globalScope = dynamicDowncast<WorkerGlobalScope>(context))
+    if (RefPtr globalScope = dynamicDowncast<WorkerGlobalScope>(*context))
         return ConnectionInfo { globalScope->storageConnection(), { globalScope->topOrigin().data(), origin->data() } };
 
     return Exception { ExceptionCode::NotSupportedError };


### PR DESCRIPTION
#### f8d07e7b15f270f03ce887be147e511276476628
<pre>
Minor assorted dynamicDowncast&lt;&gt; cleanup
<a href="https://bugs.webkit.org/show_bug.cgi?id=283566">https://bugs.webkit.org/show_bug.cgi?id=283566</a>

Reviewed by Chris Dumez.

* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::MainThreadBridge::ensureOnMainThread):

The downcast was not used, use is&lt;&gt; instead.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::addSourceBuffer):
(WebCore::MediaSource::isTypeSupported):
(WebCore::MediaSource::createSourceBufferPrivate):

Removed redundant downcasting.

* Source/WebCore/Modules/reporting/ReportingObserver.cpp:
(WebCore::reportingScopeForContext):

dynamicDowncast&lt;&gt; can take a reference.

* Source/WebCore/Modules/speech/LocalDOMWindowSpeechSynthesis.cpp:
(WebCore::LocalDOMWindowSpeechSynthesis::from):

Removed redundant downcasting.

* Source/WebCore/Modules/storage/StorageManager.cpp:
(WebCore::connectionInfo):

Removed redundant null checks.

Canonical link: <a href="https://commits.webkit.org/286979@main">https://commits.webkit.org/286979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e243b4571058e441333987e9f5e21e03f00ddfc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82383 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29008 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79851 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60908 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18856 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80800 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41203 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48234 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24208 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27344 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69350 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83758 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5113 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3451 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69133 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68382 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17092 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12390 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10477 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5061 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5068 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8506 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6838 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->