### PR TITLE
[GTK][WPE] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from ArgumentsCodersGlib.h

### DIFF
--- a/Source/WebKit/Platform/IPC/glib/ArgumentCodersGlib.h
+++ b/Source/WebKit/Platform/IPC/glib/ArgumentCodersGlib.h
@@ -23,10 +23,9 @@
 #include <glib.h>
 #include <optional>
 
+#include <wtf/glib/GSpanExtras.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/CString.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK/WPE port
 
 namespace IPC {
 
@@ -40,8 +39,9 @@ template<> struct ArgumentCoder<GUniquePtr<char*>> {
         if (!length)
             return;
 
-        for (uint32_t i = 0; strv.get()[i]; i++)
-            encoder << CString(strv.get()[i]);
+        auto strvSpan = span(strv.get());
+        for (auto str : strvSpan)
+            encoder << CString(str);
     }
 
     static std::optional<GUniquePtr<char*>> decode(Decoder& decoder)
@@ -52,12 +52,13 @@ template<> struct ArgumentCoder<GUniquePtr<char*>> {
             return std::nullopt;
 
         GUniquePtr<char*>strv(g_new0(char*, *length + 1));
-        for (uint32_t i = 0; i < *length; i++) {
+        auto strvSpan = unsafeMakeSpan(strv.get(), *length);
+
+        for (auto& str : strvSpan) {
             auto strOptional = decoder.decode<CString>();
             if (UNLIKELY(!strOptional))
                 return std::nullopt;
-
-            strv.get()[i] = g_strdup(strOptional->data());
+            str = g_strdup(strOptional->data());
         }
 
         return strv;
@@ -65,5 +66,3 @@ template<> struct ArgumentCoder<GUniquePtr<char*>> {
 };
 
 } // namespace IPC
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 670688bea47f6eb8f364bcde27ce93bec0ff961f
<pre>
[GTK][WPE] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from ArgumentsCodersGlib.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=283570">https://bugs.webkit.org/show_bug.cgi?id=283570</a>

Reviewed by Adrian Perez de Castro.

Use a span to iterate the char* array instead of doing it directly.

* Source/WebKit/Platform/IPC/glib/ArgumentCodersGlib.h:

Canonical link: <a href="https://commits.webkit.org/287002@main">https://commits.webkit.org/287002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bb15aa6245c517b5ba4a4aa0d07d820ca1c5992

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77877 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29134 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5205 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60981 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18918 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66868 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41284 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48340 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27477 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69434 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24687 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83887 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5244 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3530 "Found 3 new test failures: imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.html ipc/create-media-source-with-invalid-constraints-crash.html media/media-vp8-hiddenframes.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69202 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5400 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66778 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68455 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12460 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10568 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12058 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5192 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7945 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5184 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8616 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6969 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->