### PR TITLE
Reduce use of `NotRefCounted` in *.messages.in files

### DIFF
--- a/Source/WebKit/GPUProcess/RemoteSharedResourceCache.messages.in
+++ b/Source/WebKit/GPUProcess/RemoteSharedResourceCache.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
-messages -> RemoteSharedResourceCache NotRefCounted {
+messages -> RemoteSharedResourceCache {
     void ReleaseSerializedImageBuffer(WebCore::RenderingResourceIdentifier imageBuffer)
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(WEB_AUDIO)
 
 [EnabledBy=WebAudioEnabled]
-messages -> RemoteAudioDestinationManager NotRefCounted {
+messages -> RemoteAudioDestinationManager {
     CreateAudioDestination(WebKit::RemoteAudioDestinationIdentifier identifier, String inputDeviceId, uint32_t numberOfInputChannels, uint32_t numberOfOutputChannels, float sampleRate, float hardwareSampleRate, IPC::Semaphore renderSemaphore, WebCore::SharedMemory::Handle frameCount)
     DeleteAudioDestination(WebKit::RemoteAudioDestinationIdentifier identifier)
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in
@@ -26,7 +26,7 @@
 #if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
 
 [EnabledBy=MediaPlaybackEnabled]
-messages -> RemoteAudioSessionProxy NotRefCounted {
+messages -> RemoteAudioSessionProxy {
     SetCategory(enum:uint8_t WebCore::AudioSessionCategory type, enum:uint8_t WebCore::AudioSessionMode mode, enum:uint8_t WebCore::RouteSharingPolicy policy)
     SetPreferredBufferSize(uint64_t preferredBufferSize)
     TryToSetActive(bool active) -> (bool suceeded) Synchronous

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.messages.in
@@ -26,7 +26,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(ENCRYPTED_MEDIA)
 
 [EnabledBy=EncryptedMediaAPIEnabled]
-messages -> RemoteCDMFactoryProxy NotRefCounted {
+messages -> RemoteCDMFactoryProxy {
     CreateCDM(String keySystem) -> (std::optional<WebKit::RemoteCDMIdentifier> identifier, struct WebKit::RemoteCDMConfiguration configuration) Synchronous
     SupportsKeySystem(String keySystem) -> (bool result) Synchronous
     RemoveInstance(WebKit::RemoteCDMInstanceIdentifier identifier)

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.messages.in
@@ -26,7 +26,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(ENCRYPTED_MEDIA)
 
 [EnabledBy=EncryptedMediaAPIEnabled]
-messages -> RemoteCDMInstanceProxy NotRefCounted {
+messages -> RemoteCDMInstanceProxy {
     CreateSession(uint64_t logIdentifier) -> (std::optional<WebKit::RemoteCDMInstanceSessionIdentifier> identifier) Synchronous
     InitializeWithConfiguration(struct WebCore::CDMKeySystemConfiguration configuration, enum:bool WebCore::CDMInstance::AllowDistinctiveIdentifiers distinctiveIdentifiersAllowed, enum:bool WebCore::CDMInstance::AllowPersistentState persistentStateAllowed) -> (enum:bool WebCore::CDMInstance::SuccessValue success)
     SetServerCertificate(Ref<WebCore::SharedBuffer> certificate) -> (enum:bool WebCore::CDMInstance::SuccessValue success)

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.messages.in
@@ -26,7 +26,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(ENCRYPTED_MEDIA)
 
 [EnabledBy=EncryptedMediaAPIEnabled]
-messages -> RemoteCDMProxy NotRefCounted {
+messages -> RemoteCDMProxy {
     GetSupportedConfiguration(struct WebCore::CDMKeySystemConfiguration candidateConfiguration, enum:bool WebCore::CDMPrivate::LocalStorageAccess access) -> (std::optional<WebCore::CDMKeySystemConfiguration> accumulatedConfiguration)
     CreateInstance() -> (std::optional<WebKit::RemoteCDMInstanceIdentifier> identifier, struct WebKit::RemoteCDMInstanceConfiguration configuration) Synchronous
     LoadAndInitialize()

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(LEGACY_ENCRYPTED_MEDIA)
 
 [EnabledBy=LegacyEncryptedMediaAPIEnabled]
-messages -> RemoteLegacyCDMFactoryProxy NotRefCounted {
+messages -> RemoteLegacyCDMFactoryProxy {
     CreateCDM(String keySystem, std::optional<WebCore::MediaPlayerIdentifier> playerId) -> (std::optional<WebKit::RemoteLegacyCDMIdentifier> identifier) Synchronous
     SupportsKeySystem(String keySystem, std::optional<String> mimeType) -> (bool result) Synchronous
     RemoveSession(WebKit::RemoteLegacyCDMSessionIdentifier identifier) -> ()

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.messages.in
@@ -23,7 +23,7 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
 
-messages -> RemoteMediaPlayerManagerProxy NotRefCounted {
+messages -> RemoteMediaPlayerManagerProxy {
     CreateMediaPlayer(WebCore::MediaPlayerIdentifier identifier, WebCore::MediaPlayerClientIdentifier clientIdentifier, enum:uint8_t WebCore::MediaPlayerMediaEngineIdentifier remoteEngineIdentifier, struct WebKit::RemoteMediaPlayerProxyConfiguration proxyConfiguration)
     DeleteMediaPlayer(WebCore::MediaPlayerIdentifier identifier)
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.messages.in
@@ -25,7 +25,7 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
 
-messages -> RemoteMediaResourceManager NotRefCounted {
+messages -> RemoteMediaResourceManager {
     ResponseReceived(WebKit::RemoteMediaResourceIdentifier identifier, WebCore::ResourceResponse response, bool didPassAccessControlCheck) -> (enum:bool WebCore::ShouldContinuePolicyCheck shouldContinue)
     RedirectReceived(WebKit::RemoteMediaResourceIdentifier identifier, WebCore::ResourceRequest request, WebCore::ResourceResponse response) -> (WebCore::ResourceRequest returnRequest)
     DataSent(WebKit::RemoteMediaResourceIdentifier identifier, uint64_t bytesSent, uint64_t totalBytesToBeSent)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in
@@ -26,7 +26,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)
 
 [EnabledBy=MediaSourceEnabled || ManagedMediaSourceEnabled]
-messages -> RemoteMediaSourceProxy NotRefCounted {
+messages -> RemoteMediaSourceProxy {
     AddSourceBuffer(WebCore::ContentType contentType) -> (enum:uint8_t WebCore::MediaSourcePrivateAddStatus status, std::optional<WebKit::RemoteSourceBufferIdentifier> remoteSourceBufferIdentifier) Synchronous
     DurationChanged(MediaTime duration)
     BufferedChanged(WebCore::PlatformTimeRanges buffered)

--- a/Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.messages.in
@@ -25,7 +25,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
-messages -> RemoteRemoteCommandListenerProxy NotRefCounted {
+messages -> RemoteRemoteCommandListenerProxy {
     UpdateSupportedCommands(Vector<WebCore::PlatformMediaSessionRemoteControlCommandType> commands, bool supportsSeeking)
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
@@ -26,7 +26,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)
 
 [EnabledBy=MediaSourceEnabled || ManagedMediaSourceEnabled]
-messages -> RemoteSourceBufferProxy NotRefCounted {
+messages -> RemoteSourceBufferProxy {
     SetActive(bool active)
     CanSwitchToType(WebCore::ContentType contentType) -> (bool canSwitch) Synchronous
     SetMode(WebCore::SourceBufferAppendMode appendMode)

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.messages.in
@@ -22,7 +22,7 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
-messages -> RemoteVideoFrameObjectHeap NotRefCounted {
+messages -> RemoteVideoFrameObjectHeap {
 #if PLATFORM(COCOA)
     GetVideoFrameBuffer(WebKit::RemoteVideoFrameReadReference read, bool canSendIOSurface) AllowedWhenWaitingForSyncReply
     PixelBuffer(WebKit::RemoteVideoFrameReadReference read) -> (RetainPtr<CVPixelBufferRef> result) Synchronous

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in
@@ -24,7 +24,7 @@
 #if USE(LIBWEBRTC) && PLATFORM(COCOA) && ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebCodecsVideoEnabled || PeerConnectionEnabled]
-messages -> LibWebRTCCodecsProxy NotRefCounted {
+messages -> LibWebRTCCodecsProxy {
     CreateDecoder(WebKit::VideoDecoderIdentifier id, enum:uint8_t WebCore::VideoCodecType codecType, String codecString, bool useRemoteFrames, bool enableAdditionalLogging) -> (bool success);
     ReleaseDecoder(WebKit::VideoDecoderIdentifier id)
     FlushDecoder(WebKit::VideoDecoderIdentifier id) -> ()

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.messages.in
@@ -23,7 +23,7 @@
 
 #if PLATFORM(COCOA) && ENABLE(GPU_PROCESS) && ENABLE(MEDIA_STREAM)
 
-messages -> RemoteSampleBufferDisplayLayer NotRefCounted {
+messages -> RemoteSampleBufferDisplayLayer {
 #if !RELEASE_LOG_DISABLED
     SetLogIdentifier(String logIdentifier)
 #endif

--- a/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.messages.in
+++ b/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(MODEL_PROCESS)
 
 [EnabledBy=ModelElementEnabled && ModelProcessEnabled]
-messages -> ModelProcessModelPlayerManagerProxy NotRefCounted {
+messages -> ModelProcessModelPlayerManagerProxy {
     CreateModelPlayer(WebCore::ModelPlayerIdentifier identifier)
     DeleteModelPlayer(WebCore::ModelPlayerIdentifier identifier)
 }

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> NetworkSocketChannel NotRefCounted {
+messages -> NetworkSocketChannel {
     SendString(std::span<const uint8_t> message) -> ()
     SendData(std::span<const uint8_t> data) -> ()
     Close(int32_t code, String reason)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> ServiceWorkerDownloadTask NotRefCounted {
+messages -> ServiceWorkerDownloadTask {
     DidFail(WebCore::ResourceError error)
     DidReceiveData(IPC::SharedBufferReference data, uint64_t encodedDataLength)
     DidReceiveFormData(IPC::FormDataReference data)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> ServiceWorkerFetchTask NotRefCounted {
+messages -> ServiceWorkerFetchTask {
     DidNotHandle()
     DidFail(WebCore::ResourceError error)
     DidReceiveRedirectResponse(WebCore::ResourceResponse response)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> WebSWServerToContextConnection NotRefCounted {
+messages -> WebSWServerToContextConnection {
     # When possible, these messages can be implemented directly by WebCore::SWServerToContextConnection
 
     ScriptContextFailedToStart(std::optional<WebCore::ServiceWorkerJobDataIdentifier> jobDataIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, String message)

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> WebSharedWorkerServerConnection NotRefCounted {
+messages -> WebSharedWorkerServerConnection {
     RequestSharedWorker(struct WebCore::SharedWorkerKey sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::TransferredMessagePort port, struct WebCore::WorkerOptions workerOptions)
     SharedWorkerObjectIsGoingAway(struct WebCore::SharedWorkerKey sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier)
     SuspendForBackForwardCache(struct WebCore::SharedWorkerKey sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier)

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> WebSharedWorkerServerToContextConnection NotRefCounted {
+messages -> WebSharedWorkerServerToContextConnection {
     PostErrorToWorkerObject(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, String errorMessage, int lineNumber, int columnNumber, String sourceURL, bool isErrorEvent)
     SharedWorkerTerminated(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier)
 }

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.messages.in
@@ -22,7 +22,7 @@
 
 #if USE(LIBWEBRTC)
 
-messages -> NetworkRTCMonitor NotRefCounted {
+messages -> NetworkRTCMonitor {
     void StartUpdatingIfNeeded()
     void StopUpdating()
 }

--- a/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(WEB_RTC)
 
-messages -> RTCDataChannelRemoteManagerProxy NotRefCounted {
+messages -> RTCDataChannelRemoteManagerProxy {
     // To source
     SendData(struct WebCore::RTCDataChannelIdentifier source, bool isRaw, std::span<const uint8_t> text);
     Close(struct WebCore::RTCDataChannelIdentifier source);

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 [EnabledBy=WebTransportEnabled]
-messages -> NetworkTransportSession NotRefCounted {
+messages -> NetworkTransportSession {
     SendDatagram(std::span<const uint8_t> datagram) -> ()
     CreateOutgoingUnidirectionalStream() -> (std::optional<WebKit::WebTransportStreamIdentifier> identifier)
     CreateBidirectionalStream() -> (std::optional<WebKit::WebTransportStreamIdentifier> identifier)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithIfReceiver.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithIfReceiver.messages.in
@@ -24,7 +24,7 @@
 // top-level #if, avoiding generic #include for ApplePayPaymentAuthorizationResult.
 
 #if ENABLE(APPLE_PAY)
-messages -> TestWithIfReceiver NotRefCounted {
+messages -> TestWithIfReceiver {
     CompletePaymentSession(struct WebCore::ApplePayPaymentAuthorizationResult result)
 }
 #endif

--- a/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.messages.in
+++ b/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> RemoteObjectRegistry NotRefCounted {
+messages -> RemoteObjectRegistry {
     InvokeMethod(WebKit::RemoteObjectInvocation invocation)
     CallReplyBlock(uint64_t replyID, WebKit::UserData blockInvocation);
     ReleaseUnusedReplyBlock(uint64_t replyID);

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.messages.in
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.messages.in
@@ -25,7 +25,7 @@
 #if ENABLE(APPLE_PAY)
 
 [EnabledBy=ApplePayEnabled]
-messages -> WebPaymentCoordinatorProxy NotRefCounted {
+messages -> WebPaymentCoordinatorProxy {
 
     CanMakePayments() -> (bool result) Synchronous
     CanMakePaymentsWithActiveCard(String merchantIdentifier, String domainName) -> (bool canMakePayments)

--- a/Source/WebKit/Shared/Authentication/AuthenticationManager.messages.in
+++ b/Source/WebKit/Shared/Authentication/AuthenticationManager.messages.in
@@ -20,6 +20,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> AuthenticationManager NotRefCounted {
+messages -> AuthenticationManager {
     void CompleteAuthenticationChallenge(WebKit::AuthenticationChallengeIdentifier challengeID, enum:uint8_t WebKit::AuthenticationChallengeDisposition disposition, WebCore::Credential credential);
 }

--- a/Source/WebKit/Shared/IPCConnectionTester.messages.in
+++ b/Source/WebKit/Shared/IPCConnectionTester.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(IPC_TESTING_API)
 
-messages -> IPCConnectionTester NotRefCounted {
+messages -> IPCConnectionTester {
     AsyncMessage(uint32_t value)
     SyncMessage(uint32_t value) -> (uint32_t sameValue) Synchronous
 }

--- a/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.messages.in
+++ b/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(ROUTING_ARBITRATION)
 [EnabledBy=MediaPlaybackEnabled]
-messages -> AudioSessionRoutingArbitratorProxy NotRefCounted {
+messages -> AudioSessionRoutingArbitratorProxy {
     BeginRoutingArbitrationWithCategory(enum:uint8_t WebCore::AudioSessionCategory category) -> (enum:uint8_t WebCore::AudioSessionRoutingArbitrationError error, enum:bool WebCore::AudioSessionRoutingArbitrationClient::DefaultRouteChanged defaultRouteChanged)
     EndRoutingArbitration();
 }

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.messages.in
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.messages.in
@@ -25,7 +25,7 @@
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
 
 [EnabledBy=MediaSessionCoordinatorEnabled]
-messages -> RemoteMediaSessionCoordinatorProxy NotRefCounted {
+messages -> RemoteMediaSessionCoordinatorProxy {
 
     Join() -> (std::optional<WebCore::ExceptionData> error)
 

--- a/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> LegacyCustomProtocolManagerProxy NotRefCounted {
+messages -> LegacyCustomProtocolManagerProxy {
     StartLoading(WebKit::LegacyCustomProtocolID customProtocolID, WebCore::ResourceRequest request)
     StopLoading(WebKit::LegacyCustomProtocolID customProtocolID)
 }

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.messages.in
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(MEDIA_STREAM)
 
 [EnabledBy=SpeechRecognitionEnabled]
-messages -> SpeechRecognitionRemoteRealtimeMediaSourceManager NotRefCounted {
+messages -> SpeechRecognitionRemoteRealtimeMediaSourceManager {
     RemoteAudioSamplesAvailable(WebCore::RealtimeMediaSourceIdentifier identifier, MediaTime time, uint64_t numberOfFrames)
     RemoteCaptureFailed(WebCore::RealtimeMediaSourceIdentifier identifier)
     RemoteSourceStopped(WebCore::RealtimeMediaSourceIdentifier identifier)

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.messages.in
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.messages.in
@@ -24,7 +24,7 @@
  */
  
  [EnabledBy=SpeechRecognitionEnabled]
- messages -> SpeechRecognitionServer NotRefCounted {
+ messages -> SpeechRecognitionServer {
     Start(WebCore::SpeechRecognitionConnectionClientIdentifier identifier, String lang, bool continuous, bool interimResults, uint64_t maxAlternatives, struct WebCore::ClientOrigin origin, WebCore::FrameIdentifier frameIdentifier)
     Stop(WebCore::SpeechRecognitionConnectionClientIdentifier identifier)
     Abort(WebCore::SpeechRecognitionConnectionClientIdentifier identifier)

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.messages.in
@@ -25,7 +25,7 @@
 #if ENABLE(WEB_AUTHN)
 
 [EnabledBy=WebAuthenticationEnabled]
-messages -> WebAuthenticatorCoordinatorProxy NotRefCounted {
+messages -> WebAuthenticatorCoordinatorProxy {
 
     MakeCredential(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, struct WebCore::PublicKeyCredentialCreationOptions options, enum:uint8_t WebCore::MediationRequirement mediation) -> (struct WebCore::AuthenticatorResponseData data, enum:uint8_t WebCore::AuthenticatorAttachment attachment, struct WebCore::ExceptionData exception)
     GetAssertion(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, struct WebCore::PublicKeyCredentialRequestOptions options, enum:uint8_t WebCore::MediationRequirement mediation, std::optional<WebCore::SecurityOriginData> parentOrigin) -> (struct WebCore::AuthenticatorResponseData data, enum:uint8_t WebCore::AuthenticatorAttachment attachment, struct WebCore::ExceptionData exception)

--- a/Source/WebKit/UIProcess/WebLockRegistryProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebLockRegistryProxy.messages.in
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 [EnabledBy=WebLocksAPIEnabled]
-messages -> WebLockRegistryProxy NotRefCounted {
+messages -> WebLockRegistryProxy {
     RequestLock(struct WebCore::ClientOrigin clientOrigin, WebCore::WebLockIdentifier identifier, WebCore::ScriptExecutionContextIdentifier clientID, String name, enum:bool WebCore::WebLockMode mode, bool steal, bool ifAvailable)
     ReleaseLock(struct WebCore::ClientOrigin clientOrigin, WebCore::WebLockIdentifier identifier, WebCore::ScriptExecutionContextIdentifier clientID, String name)
     AbortLockRequest(struct WebCore::ClientOrigin clientOrigin, WebCore::WebLockIdentifier identifier, WebCore::ScriptExecutionContextIdentifier clientID, String name) -> (bool wasAborted)

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in
@@ -26,7 +26,7 @@
 #if ENABLE(WEBXR)
 
 [EnabledBy=WebXREnabled]
-messages -> PlatformXRSystem NotRefCounted {
+messages -> PlatformXRSystem {
     EnumerateImmersiveXRDevices() -> (Vector<WebKit::XRDeviceInfo> devicesInfos)
     RequestPermissionOnSessionFeatures(WebCore::SecurityOriginData origin, PlatformXR::SessionMode mode, Vector<PlatformXR::SessionFeature> granted, Vector<PlatformXR::SessionFeature> consentRequired, Vector<PlatformXR::SessionFeature> consentOptional, Vector<PlatformXR::SessionFeature> requiredFeaturesRequested, Vector<PlatformXR::SessionFeature> optionalFeaturesRequested) -> (std::optional<Vector<PlatformXR::SessionFeature>> userGranted)
     InitializeTrackingAndRendering()

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.messages.in
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
 
-messages -> RemoteGraphicsContextGLProxy NotRefCounted {
+messages -> RemoteGraphicsContextGLProxy {
     void WasCreated(IPC::Semaphore streamWakeUpSemaphore, IPC::Semaphore streamClientWaitSemaphore, std::optional<WebKit::RemoteGraphicsContextGLInitializationState> initializationState) CanDispatchOutOfOrder
     void WasLost()
     void addDebugMessage(GCGLenum type, GCGLenum id, GCGLenum severity, String message) CanDispatchOutOfOrder

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.messages.in
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
-messages -> RemoteImageBufferProxy NotRefCounted  {
+messages -> RemoteImageBufferProxy  {
     DidCreateBackend(std::optional<WebKit::ImageBufferBackendHandle> handle) CanDispatchOutOfOrder
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.messages.in
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
-messages -> RemoteGPUProxy NotRefCounted {
+messages -> RemoteGPUProxy {
     void WasCreated(bool didSucceed, IPC::Semaphore streamWakeUpSemaphore, IPC::Semaphore streamClientWaitSemaphore) CanDispatchOutOfOrder
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in
@@ -23,7 +23,7 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
 
-messages -> MediaPlayerPrivateRemote NotRefCounted {
+messages -> MediaPlayerPrivateRemote {
     NetworkStateChanged(struct WebKit::RemoteMediaPlayerState state)
     ReadyStateChanged(struct WebKit::RemoteMediaPlayerState state, enum:uint8_t WebCore::MediaPlayerReadyState readyStat)
     FirstVideoFrameAvailable()

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in
@@ -25,7 +25,7 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)
 
-messages -> MediaSourcePrivateRemoteMessageReceiver NotRefCounted {
+messages -> MediaSourcePrivateRemoteMessageReceiver {
     ProxyWaitForTarget(struct WebCore::SeekTarget target) -> (Expected<MediaTime, WebCore::PlatformMediaError> seekedTime);
     ProxySeekToTime(MediaTime time) -> (Expected<void, WebCore::PlatformMediaError> result);
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.messages.in
@@ -25,7 +25,7 @@
 
 #if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
 
-messages -> RemoteAudioSession NotRefCounted {
+messages -> RemoteAudioSession {
     ConfigurationChanged(struct WebKit::RemoteAudioSessionConfiguration configuration)
     BeginInterruptionRemote()
     EndInterruptionRemote(WebCore::AudioSession::MayResume flags)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.messages.in
@@ -25,7 +25,7 @@
 
 #if PLATFORM(COCOA) && ENABLE(GPU_PROCESS)
 
-messages -> RemoteAudioSourceProviderManager NotRefCounted {
+messages -> RemoteAudioSourceProviderManager {
     AudioStorageChanged(WebCore::MediaPlayerIdentifier id, struct WebKit::ConsumerSharedCARingBufferHandle storageHandle, WebCore::CAAudioStreamDescription description)
     AudioSamplesAvailable(WebCore::MediaPlayerIdentifier id, uint64_t startFrame, uint64_t numberOfFrames)
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.messages.in
@@ -23,7 +23,7 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(ENCRYPTED_MEDIA)
 
-messages -> RemoteCDMInstance NotRefCounted {
+messages -> RemoteCDMInstance {
     UnrequestedInitializationDataReceived(String type, Ref<WebCore::SharedBuffer> initData)
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.messages.in
@@ -23,7 +23,7 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(ENCRYPTED_MEDIA)
 
-messages -> RemoteCDMInstanceSession NotRefCounted {
+messages -> RemoteCDMInstanceSession {
     UpdateKeyStatuses(WebCore::CDMInstanceSession::KeyStatusVector keyStatuses)
     SendMessage(enum:uint8_t WebCore::CDMMessageType type, RefPtr<WebCore::SharedBuffer> message)
     SessionIdChanged(String sessionId)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.messages.in
@@ -27,7 +27,7 @@
 
 #if ENABLE(GPU_PROCESS) && HAVE(AVASSETREADER)
 
-messages -> RemoteImageDecoderAVFManager NotRefCounted {
+messages -> RemoteImageDecoderAVFManager {
     EncodedDataStatusChanged(WebCore::ImageDecoderIdentifier identifier, size_t frameCount, WebCore::IntSize size, bool hasTrack)
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.messages.in
@@ -23,7 +23,7 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(LEGACY_ENCRYPTED_MEDIA)
 
-messages -> RemoteLegacyCDMSession NotRefCounted {
+messages -> RemoteLegacyCDMSession {
     SendMessage(RefPtr<WebCore::SharedBuffer> message, String destinationURL)
     SendError(WebCore::LegacyCDMSessionClient::MediaKeyErrorCode errorCode, uint32_t systemCode)
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.messages.in
@@ -25,7 +25,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
-messages -> RemoteRemoteCommandListener NotRefCounted {
+messages -> RemoteRemoteCommandListener {
     DidReceiveRemoteControlCommand(enum:uint8_t WebCore::PlatformMediaSessionRemoteControlCommandType command, struct WebCore::PlatformMediaSession::RemoteCommandArgument argument)
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver.messages.in
@@ -25,7 +25,7 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)
 
-messages -> SourceBufferPrivateRemoteMessageReceiver NotRefCounted {
+messages -> SourceBufferPrivateRemoteMessageReceiver {
     SourceBufferPrivateDidReceiveInitializationSegment(struct WebKit::InitializationSegmentInfo segmentConfiguration) -> (Expected<void, WebCore::PlatformMediaError> result)
     TakeOwnershipOfMemory(WebCore::SharedMemory::Handle remoteData)
     SourceBufferPrivateHighestPresentationTimestampChanged(MediaTime timestamp)

--- a/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.messages.in
@@ -23,7 +23,7 @@
 
 #if ENABLE(GPU_PROCESS) && PLATFORM(IOS_FAMILY)
 
-messages -> RemoteMediaSessionHelper NotRefCounted {
+messages -> RemoteMediaSessionHelper {
     ApplicationWillEnterForeground(enum:bool WebKit::RemoteMediaSessionHelper::SuspendedUnderLock suspendedUnderLock)
     ApplicationDidEnterBackground(enum:bool WebKit::RemoteMediaSessionHelper::SuspendedUnderLock suspendedUnderLock)
     ApplicationWillBecomeInactive()

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.messages.in
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.messages.in
@@ -22,7 +22,7 @@
 
 #if USE(LIBWEBRTC) && PLATFORM(COCOA) && ENABLE(GPU_PROCESS)
 
-messages -> LibWebRTCCodecs NotRefCounted {
+messages -> LibWebRTCCodecs {
     FailedDecoding(WebKit::VideoDecoderIdentifier identifier)
     CompletedDecoding(WebKit::VideoDecoderIdentifier identifier, int64_t timeStamp, int64_t timeStampNs, struct WebKit::RemoteVideoFrameProxyProperties frame)
     CompletedDecodingCV(WebKit::VideoDecoderIdentifier identifier, int64_t timeStamp, int64_t timeStampNs, RetainPtr<CVPixelBufferRef> pixelBuffer)

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.messages.in
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.messages.in
@@ -23,7 +23,7 @@
 
 #if PLATFORM(COCOA) && ENABLE(GPU_PROCESS) && ENABLE(MEDIA_STREAM)
 
-messages -> SampleBufferDisplayLayer NotRefCounted {
+messages -> SampleBufferDisplayLayer {
     SetDidFail(bool value)
 }
 

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
 
-messages -> WebInspectorUIExtensionController NotRefCounted {
+messages -> WebInspectorUIExtensionController {
     RegisterExtension(String extensionID, String extensionBundleIdentifier, String displayName) -> (Expected<void, Inspector::ExtensionError> result)
     UnregisterExtension(String extensionID) -> (Expected<void, Inspector::ExtensionError> result)
 

--- a/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.messages.in
+++ b/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.messages.in
@@ -25,7 +25,7 @@
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
 
-messages -> RemoteMediaSessionCoordinator NotRefCounted {
+messages -> RemoteMediaSessionCoordinator {
 
     SeekSessionToTime(double time) -> (bool result)
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.messages.in
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.messages.in
@@ -20,6 +20,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> WebFileSystemStorageConnection NotRefCounted {
+messages -> WebFileSystemStorageConnection {
     InvalidateAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier identifier)
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.messages.in
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.messages.in
@@ -23,6 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
  
- messages -> WebSpeechRecognitionConnection NotRefCounted {
+ messages -> WebSpeechRecognitionConnection {
     DidReceiveUpdate(WebCore::SpeechRecognitionUpdate update)
  }

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(PLATFORM_DRIVEN_TEXT_CHECKING)
 
-messages -> TextCheckingControllerProxy NotRefCounted {
+messages -> TextCheckingControllerProxy {
     ReplaceRelativeToSelection(struct WebCore::AttributedString annotatedString, int64_t selectionOffset, uint64_t length, uint64_t relativeReplacementLocation, uint64_t relativeReplacementLength)
 
     RemoveAnnotationRelativeToSelection(String annotationName, int64_t selectionOffset, uint64_t length)

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> DrawingArea NotRefCounted {
+messages -> DrawingArea {
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
     UpdateGeometry(WebCore::IntSize size) -> ()
     SetDeviceScaleFactor(float deviceScaleFactor)

--- a/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> ViewGestureGeometryCollector NotRefCounted {
+messages -> ViewGestureGeometryCollector {
 #if PLATFORM(COCOA)
     CollectGeometryForSmartMagnificationGesture(WebCore::FloatPoint origin)
 #endif

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> WebProcess : AuxiliaryProcess NotRefCounted WantsAsyncDispatchMessage {
+messages -> WebProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
     InitializeWebProcess(struct WebKit::WebProcessCreationParameters processCreationParameters) -> (WebCore::ProcessIdentity processIdentity)
     SetWebsiteDataStoreParameters(struct WebKit::WebProcessDataStoreParameters parameters)
 

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.messages.in
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> StorageAreaMap NotRefCounted {
+messages -> StorageAreaMap {
     DispatchStorageEvent(std::optional<WebKit::StorageAreaImplIdentifier> storageAreaImplID, String key, String oldValue, String newValue, String urlString, uint64_t messageIdentifier)
     ClearCache(uint64_t messageIdentifier)
 }

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.messages.in
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.messages.in
@@ -25,7 +25,7 @@
 
 #if ENABLE(WEBXR)
 
-messages -> PlatformXRSystemProxy NotRefCounted {
+messages -> PlatformXRSystemProxy {
     SessionDidEnd(WebKit::XRDeviceIdentifier deviceIdentifier)
     SessionDidUpdateVisibilityState(WebKit::XRDeviceIdentifier deviceIdentifier, PlatformXR::VisibilityState visibilityState)
 }


### PR DESCRIPTION
#### 31f23dad62ddb0e6397c8df81bbf4f2bb233b4ea
<pre>
Reduce use of `NotRefCounted` in *.messages.in files
<a href="https://bugs.webkit.org/show_bug.cgi?id=283519">https://bugs.webkit.org/show_bug.cgi?id=283519</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/GPUProcess/RemoteSharedResourceCache.messages.in:
* Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.messages.in:
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteCDMProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.messages.in:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.messages.in:
* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.messages.in:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in:
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.messages.in:
* Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.messages.in:
* Source/WebKit/NetworkProcess/NetworkSocketChannel.messages.in:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.messages.in:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.messages.in:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.messages.in:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.messages.in:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.messages.in:
* Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.in:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithIfReceiver.messages.in:
* Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.messages.in:
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.messages.in:
* Source/WebKit/Shared/Authentication/AuthenticationManager.messages.in:
* Source/WebKit/Shared/IPCConnectionTester.messages.in:
* Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.messages.in:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.messages.in:
* Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.messages.in:
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.messages.in:
* Source/WebKit/UIProcess/SpeechRecognitionServer.messages.in:
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.messages.in:
* Source/WebKit/UIProcess/WebLockRegistryProxy.messages.in:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in:
* Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in:
* Source/WebKit/UIProcess/ios/SmartMagnificationController.messages.in:
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.messages.in:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver.messages.in:
* Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.messages.in:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.messages.in:
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.messages.in:
* Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.messages.in:
* Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.messages.in:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.messages.in:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.messages.in:
* Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in:
* Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.messages.in:
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.messages.in:
* Source/WebKit/WebProcess/WebProcess.messages.in:
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.messages.in:
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.messages.in:
* Source/WebKit/WebProcess/glib/SystemSettingsManager.messages.in:
* Source/WebKit/WebProcess/glib/UserMediaCaptureManager.messages.in:

Canonical link: <a href="https://commits.webkit.org/287015@main">https://commits.webkit.org/287015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/130d4b3cbd036529f76929ab72cde5b7d8545277

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77952 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82600 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29209 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61040 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18969 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41342 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/77461 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48398 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27552 "Built successfully") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69491 "Build is in progress. Recent messages:OS: Sonoma (14.6), Xcode: 15.4; Running apply-patch; Checked out pull request; 1 api test failed or timed out; re-run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83962 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5319 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3593 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69262 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66875 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68517 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12517 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10672 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12064 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5267 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8020 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5259 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8691 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7044 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->