### PR TITLE
REGRESSION(286884@main?): [macOS Debug] imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.html is consistent crash(flaky in EWS)

### DIFF
--- a/Source/WebCore/dom/ToggleEventTask.cpp
+++ b/Source/WebCore/dom/ToggleEventTask.cpp
@@ -46,19 +46,15 @@ void ToggleEventTask::queue(ToggleState oldState, ToggleState newState)
         return;
 
     m_data = { oldState, newState };
-    element->queueTaskKeepingThisNodeAlive(TaskSource::DOMManipulation, [this, newState] {
-        if (!m_data || m_data->newState != newState)
+    element->queueTaskKeepingThisNodeAlive(TaskSource::DOMManipulation, [task = Ref { *this }, element, newState] {
+        if (!task->m_data || task->m_data->newState != newState)
             return;
 
         auto stringForState = [](ToggleState state) {
             return state == ToggleState::Closed ? "closed"_s : "open"_s;
         };
 
-        RefPtr element = m_element.get();
-        if (!element)
-            return;
-
-        auto data = *std::exchange(m_data, std::nullopt);
+        auto data = *std::exchange(task->m_data, std::nullopt);
         element->dispatchEvent(ToggleEvent::create(eventNames().toggleEvent, { EventInit { }, stringForState(data.oldState), stringForState(data.newState) }, Event::IsCancelable::No));
     });
 }


### PR DESCRIPTION
#### edf1353f6c6a2cb57eb9f595ba8c32ef721572b5
<pre>
REGRESSION(286884@main?): [macOS Debug] imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.html is consistent crash(flaky in EWS)
<a href="https://rdar.apple.com/140385278">rdar://140385278</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=283537">https://bugs.webkit.org/show_bug.cgi?id=283537</a>

Reviewed by Tim Nguyen and Ryosuke Niwa.

* Source/WebCore/dom/ToggleEventTask.cpp:
(WebCore::ToggleEventTask::queue): Capture more smart pointers to make
object lifetime more obvious. We no longer are taking advantage of the
&quot;keeping this node alive&quot; behavior, but we&apos;re also not accessing anything
that&apos;s not through a smart pointer.

Canonical link: <a href="https://commits.webkit.org/287005@main">https://commits.webkit.org/287005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b36c13fc6862ef95f24d0be66347bcddf65da76a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77839 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82487 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29096 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79960 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5166 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60957 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18901 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66842 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41260 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48291 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24311 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27439 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83849 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3506 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69179 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5362 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66762 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68428 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12437 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10546 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12060 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5154 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7907 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5146 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8578 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6931 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->