### PR TITLE
Support flashing Yocto images to external sd card

### DIFF
--- a/Tools/yocto/deploy_image_scripts/wic-to-sdcard.sh
+++ b/Tools/yocto/deploy_image_scripts/wic-to-sdcard.sh
@@ -44,8 +44,14 @@ else
     cat "${WICIMAGE}" | xz -dc | dd bs=4k status=progress of="${DEVICESDCARD}"
 fi
 
+if [[ $DEVICESDCARD =~ /dev/sd. ]]; then
+    export P2="2"
+else
+    export P2="p2"
+fi
+
 if which growpart &>/dev/null; then
-    SECONDPART="${DEVICESDCARD}p2"
+    SECONDPART="${DEVICESDCARD}${P2}"
     if test -w "${SECONDPART}"; then
         sudo growpart "${DEVICESDCARD}" 2
         sudo resize2fs "${SECONDPART}"


### PR DESCRIPTION
#### 2e4cd21d0de30eb4e38f16269508b3271197311b
<pre>
Support flashing Yocto images to external sd card
<a href="https://bugs.webkit.org/show_bug.cgi?id=283573">https://bugs.webkit.org/show_bug.cgi?id=283573</a>

Reviewed by Carlos Alberto Lopez Perez.

If you use an external SD card reader, the device path looks like /dev/sde.
The second partition is numbered /dev/sde2, not /dev/sdep2. Update the deployment script
to handle this case.

* Tools/yocto/deploy_image_scripts/wic-to-sdcard.sh:

Canonical link: <a href="https://commits.webkit.org/287094@main">https://commits.webkit.org/287094@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90ed41fa5ec90f06777f1780d9965c9167dc924b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82426 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29053 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5109 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60928 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18875 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50896 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66715 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41224 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48257 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24235 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27385 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69376 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83784 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5154 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3478 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-invalid-behavior.tentative.html ipc/create-connection-and-send-async.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69140 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5317 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66711 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68389 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17154 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12416 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10493 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5102 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5102 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8537 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6879 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->