### PR TITLE
Web Inspector crashes due to using erroneous `PseudoElementIdentifier`

### DIFF
--- a/LayoutTests/inspector/css/getMatchedStylesForNodeBackdropPseudoId.html
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeBackdropPseudoId.html
@@ -54,7 +54,7 @@ function test()
         description: "A non-dialog should have no `::backdrop` rules.",
         selector: "#test-div",
         async domNodeStylesHandler(styles) {
-            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.Marker), undefined, "Expected no rules entry for selector `*::backdrop`.");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.Backdrop), undefined, "Expected no rules entry for selector `*::backdrop`.");
         }
     });
 

--- a/LayoutTests/inspector/css/getMatchedStylesForNodeViewTransitionPseudoElements-expected.txt
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeViewTransitionPseudoElements-expected.txt
@@ -1,0 +1,24 @@
+Tests for the CSS.getMatchedStyleForNode command and the view transition pseudo-elements.
+
+changed
+
+== Running test suite: CSS.getMatchedStyleForNode.ViewTransitionPseudoElements
+-- Running test case: CSS.getMatchedStyleForNode.ViewTransitionPseudoElements.Root
+PASS: Expected no rules entry for selector `*::view-transition` before starting the view transition.
+PASS: Expected no rules entry for selector `*::view-transition-group()` before starting the view transition.
+PASS: Expected no rules entry for selector `*::view-transition-image-pair()` before starting the view transition.
+PASS: Expected no rules entry for selector `*::view-transition-old()` before starting the view transition.
+PASS: Expected no rules entry for selector `*::view-transition-new()` before starting the view transition.
+PASS: Expected entry for selector `*::view-transition` after starting the view transition.
+PASS: Expected entry for selector `*::view-transition-group()` after starting the view transition.
+PASS: Expected entry for selector `*::view-transition-image-pair()` after starting the view transition.
+PASS: Expected entry for selector `*::view-transition-old()` after starting the view transition.
+PASS: Expected entry for selector `*::view-transition-new()` after starting the view transition.
+
+-- Running test case: CSS.getMatchedStyleForNode.ViewTransitionPseudoElements.Div
+PASS: Expected no rules entry for selector `*::view-transition` on non-root element.
+PASS: Expected no rules entry for selector `*::view-transition-group()` on non-root element.
+PASS: Expected no rules entry for selector `*::view-transition-image-pair()` on non-root element.
+PASS: Expected no rules entry for selector `*::view-transition-old()` on non-root element.
+PASS: Expected no rules entry for selector `*::view-transition-new()` on non-root element.
+

--- a/LayoutTests/inspector/css/getMatchedStylesForNodeViewTransitionPseudoElements.html
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeViewTransitionPseudoElements.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function startViewTransition()
+{
+    document.startViewTransition(() => {
+        document.querySelector("#change").textContent = "changed";
+    });
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("CSS.getMatchedStyleForNode.ViewTransitionPseudoElements");
+
+    function addTestCase({name, description, selector, domNodeStylesHandler})
+    {
+        suite.addTestCase({
+            name,
+            description,
+            async test() {
+                let documentNode = await WI.domManager.requestDocument();
+                let nodeId = await documentNode.querySelector(selector);
+                let domNode = WI.domManager.nodeForId(nodeId);
+                InspectorTest.assert(domNode, `Should find DOM Node for selector '${selector}'.`);
+
+                let domNodeStyles = WI.cssManager.stylesForNode(domNode);
+                InspectorTest.assert(domNodeStyles, `Should find CSS Styles for DOM Node.`);
+                await domNodeStyles.refreshIfNeeded();
+
+                await domNodeStylesHandler(domNodeStyles);
+            },
+        });
+    }
+
+    addTestCase({
+        name: "CSS.getMatchedStyleForNode.ViewTransitionPseudoElements.Root",
+        description: "A dialog should have both the User Agent and authored `::backdrop` rules.",
+        selector: "html",
+        async domNodeStylesHandler(styles) {
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransition), undefined, "Expected no rules entry for selector `*::view-transition` before starting the view transition.");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransitionGroup), undefined, "Expected no rules entry for selector `*::view-transition-group()` before starting the view transition.");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransitionImagePair), undefined, "Expected no rules entry for selector `*::view-transition-image-pair()` before starting the view transition.");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransitionOld), undefined, "Expected no rules entry for selector `*::view-transition-old()` before starting the view transition.");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransitionNew), undefined, "Expected no rules entry for selector `*::view-transition-new()` before starting the view transition.");
+
+            await InspectorTest.evaluateInPage(`startViewTransition()`);
+            await styles.refresh();
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransition).matchedRules.length, 2, "Expected entry for selector `*::view-transition` after starting the view transition.");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransitionGroup).matchedRules.length, 9, "Expected entry for selector `*::view-transition-group()` after starting the view transition.");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransitionImagePair).matchedRules.length, 6, "Expected entry for selector `*::view-transition-image-pair()` after starting the view transition.");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransitionOld).matchedRules.length, 6, "Expected entry for selector `*::view-transition-old()` after starting the view transition.");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransitionNew).matchedRules.length, 6, "Expected entry for selector `*::view-transition-new()` after starting the view transition.");
+        }
+    });
+
+    addTestCase({
+        name: "CSS.getMatchedStyleForNode.ViewTransitionPseudoElements.Div",
+        description: "A non-dialog should have no `::backdrop` rules.",
+        selector: "#test-div",
+        async domNodeStylesHandler(styles) {
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransition), undefined, "Expected no rules entry for selector `*::view-transition` on non-root element.");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransitionGroup), undefined, "Expected no rules entry for selector `*::view-transition-group()` on non-root element.");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransitionImagePair), undefined, "Expected no rules entry for selector `*::view-transition-image-pair()` on non-root element.");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransitionOld), undefined, "Expected no rules entry for selector `*::view-transition-old()` on non-root element.");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransitionNew), undefined, "Expected no rules entry for selector `*::view-transition-new()` on non-root element.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<style>
+    ::view-transition {
+        background-color: red;
+    }
+
+    ::view-transition-group(*) {
+        color: orange;
+    }
+
+    ::view-transition-group(root) {
+        background-color: red;
+    }
+
+    ::view-transition-group(other-name) {
+        background-color: red;
+    }
+
+    ::view-transition-group(other-name-2) {
+        background-color: red;
+    }
+
+    ::view-transition-group(non-existant-name) {
+        color: blue;
+    }
+
+    ::view-transition-image-pair(root) {
+        background-color: red;
+    }
+
+    ::view-transition-image-pair(other-name) {
+        background-color: red;
+    }
+
+    ::view-transition-image-pair(other-name-2) {
+        background-color: red;
+    }
+
+    ::view-transition-image-pair(non-existant-name) {
+        color: blue;
+    }
+
+    ::view-transition-old(root) {
+        background-color: red;
+        animation-play-state: paused;
+        animation-duration: 30s;
+    }
+
+    ::view-transition-old(other-name) {
+        background-color: red;
+    }
+
+    ::view-transition-old(other-name-2) {
+        background-color: red;
+    }
+
+    ::view-transition-old(non-existant-name) {
+        color: blue;
+    }
+
+    ::view-transition-new(root) {
+        background-color: red;
+    }
+
+    ::view-transition-new(other-name) {
+        background-color: red;
+    }
+
+    ::view-transition-new(other-name-2) {
+        background-color: red;
+    }
+
+    ::view-transition-new(non-existant-name) {
+        color: blue;
+    }
+</style>
+</head>
+<body onload="runTest()">
+    <p>Tests for the CSS.getMatchedStyleForNode command and the view transition pseudo-elements.</p>
+    <div id="other-name" style="view-transition-name: other-name;"></div>
+    <div id="other-name-2" style="view-transition-name: other-name-2;"></div>
+    <div id="change"></div>
+    <div id="test-div"></div>
+</body>
+</html>

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -175,8 +175,9 @@ private:
 
     RefPtr<Inspector::Protocol::CSS::CSSRule> buildObjectForRule(const StyleRule*, Style::Resolver&, Element&);
     RefPtr<Inspector::Protocol::CSS::CSSRule> buildObjectForRule(CSSStyleRule*);
-    Ref<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>> buildArrayForMatchedRuleList(const Vector<RefPtr<const StyleRule>>&, Style::Resolver&, Element&, PseudoId);
     RefPtr<Inspector::Protocol::CSS::CSSStyle> buildObjectForAttributesStyle(StyledElement&);
+
+    void collectRulesForRuleMatchArray(JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>&, const Vector<RefPtr<const StyleRule>>&, Style::Resolver&, Element&, PseudoId);
 
     void nodeHasLayoutFlagsChange(Node&);
     void nodesWithPendingLayoutFlagsChangeDispatchTimerFired();


### PR DESCRIPTION
#### db7cd77dcbfe2ab67cc70b82b780afbeecc3e84b
<pre>
Web Inspector crashes due to using erroneous `PseudoElementIdentifier`
<a href="https://bugs.webkit.org/show_bug.cgi?id=283574">https://bugs.webkit.org/show_bug.cgi?id=283574</a>
<a href="https://rdar.apple.com/140243623">rdar://140243623</a>

Reviewed by NOBODY (OOPS!).

Use a correct PseudoElementIdentifier when getting styles for named view transition pseudo elements.

* LayoutTests/inspector/css/getMatchedStylesForNodeBackdropPseudoId.html:
* LayoutTests/inspector/css/getMatchedStylesForNodeViewTransitionPseudoElements-expected.txt: Added.
* LayoutTests/inspector/css/getMatchedStylesForNodeViewTransitionPseudoElements.html: Added.
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::getMatchedStylesForNode):
(WebCore::InspectorCSSAgent::collectRulesForRuleMatchArray):
(WebCore::InspectorCSSAgent::buildArrayForMatchedRuleList): Deleted.
* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db7cd77dcbfe2ab67cc70b82b780afbeecc3e84b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77844 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82492 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29101 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79965 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60958 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18902 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80912 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50940 "Found 60 new test failures: accessibility/ios-simulator/aria-details-toggle-summary.html accessibility/ios-simulator/has-touch-event-listener-with-shadow.html accessibility/ios-simulator/strong-password-field.html accessibility/visible-character-range-vertical-rl.html animations/animation-composite-order-notimeline.html compositing/backing/backing-store-attachment-animated-transform-inside-fixed.html compositing/backing/no-backing-for-perspective.html compositing/blend-mode/tiled-to-non-tiled-with-blend-mode.html compositing/masks/clip-path-on-tiled-toggle.html compositing/masks/reference-clip-path-on-composited-image.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66817 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41261 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48295 "Found 60 new test failures: imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any.html imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any.worker.html imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_X25519.https.any.html imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_X25519.https.any.worker.html imported/w3c/web-platform-tests/clipboard-apis/clipboard-item.https.html imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.html imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.serviceworker.html imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.sharedworker.html imported/w3c/web-platform-tests/compression/compression-bad-chunks.tentative.any.worker.html imported/w3c/web-platform-tests/compression/compression-output-length.tentative.any.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24429 "21 flakes 1 failures") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27444 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69410 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24656 "Exiting early after 10 failures. 18 tests run. 1 flakes") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83854 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5211 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69181 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5367 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66755 "Exiting early after 10 failures. 15 tests run. 1 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68430 "Found 1 new API test failure: /TestWebKit:WebKit.GetInjectedBundleInitializationUserDataCallback (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12439 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10533 "13 flakes 2 failures") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5159 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7912 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5151 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8583 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->