### PR TITLE
Update Style numeric types to use double everywhere except Length

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -888,6 +888,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/CSSValueList.h
     css/CSSVariableData.h
     css/CSSVariableReferenceValue.h
+    css/ComputedStyleDependencies.h
     css/Counter.h
     css/DeprecatedCSSOMCounter.h
     css/DeprecatedCSSOMPrimitiveValue.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1159,6 +1159,7 @@ css/values/images/CSSGradient.cpp
 css/values/motion/CSSRayFunction.cpp
 css/values/primitives/CSSNone.cpp
 css/values/primitives/CSSPosition.cpp
+css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.cpp
 css/values/primitives/CSSPrimitiveNumericTypes+ComputedStyleDependencies.cpp
 css/values/primitives/CSSPrimitiveNumericTypes+Serialization.cpp
 css/values/primitives/CSSPrimitiveNumericTypes+SymbolReplacement.cpp

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+AngleDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+AngleDefinitions.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "CSSPrimitiveNumericTypes+Canonicalization.h"
 #include "CSSPropertyParserConsumer+MetaConsumerDefinitions.h"
 
 namespace WebCore {
@@ -47,7 +48,7 @@ struct AngleValidator {
     template<auto R> static bool isValid(CSS::AngleRaw<R> raw, CSSPropertyParserOptions)
     {
         return isValidDimensionValue(raw, [&] {
-            auto canonicalValue = CSS::canonicalizeAngle(raw.value, raw.type);
+            auto canonicalValue = CSS::canonicalize(raw);
             return canonicalValue >= raw.range.min && canonicalValue <= raw.range.max;
         });
     }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+FrequencyDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+FrequencyDefinitions.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "CSSPrimitiveNumericTypes+Canonicalization.h"
 #include "CSSPropertyParserConsumer+MetaConsumerDefinitions.h"
 
 namespace WebCore {
@@ -45,7 +46,7 @@ struct FrequencyValidator {
     template<auto R> static bool isValid(CSS::FrequencyRaw<R> raw, CSSPropertyParserOptions)
     {
         return isValidDimensionValue(raw, [&] {
-            auto canonicalValue = CSS::canonicalizeFrequency(raw.value, raw.type);
+            auto canonicalValue = CSS::canonicalize(raw);
             return canonicalValue >= raw.range.min && canonicalValue <= raw.range.max;
         });
     }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ResolutionDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ResolutionDefinitions.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "CSSPrimitiveNumericTypes+Canonicalization.h"
 #include "CSSPropertyParserConsumer+MetaConsumerDefinitions.h"
 
 namespace WebCore {
@@ -47,7 +48,7 @@ struct ResolutionValidator {
     template<auto R> static bool isValid(CSS::ResolutionRaw<R> raw, CSSPropertyParserOptions)
     {
         return isValidDimensionValue(raw, [&] {
-            auto canonicalValue = CSS::canonicalizeResolution(raw.value, raw.type);
+            auto canonicalValue = CSS::canonicalize(raw);
             return canonicalValue >= raw.range.min && canonicalValue <= raw.range.max;
         });
     }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+TimeDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+TimeDefinitions.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "CSSPrimitiveNumericTypes+Canonicalization.h"
 #include "CSSPropertyParserConsumer+MetaConsumerDefinitions.h"
 
 namespace WebCore {
@@ -45,7 +46,7 @@ struct TimeValidator {
     template<auto R> static bool isValid(CSS::TimeRaw<R> raw, CSSPropertyParserOptions)
     {
         return isValidDimensionValue(raw, [&] {
-            auto canonicalValue = CSS::canonicalizeTime(raw.value, raw.type);
+            auto canonicalValue = CSS::canonicalize(raw);
             return canonicalValue >= raw.range.min && canonicalValue <= raw.range.max;
         });
     }

--- a/Source/WebCore/css/values/CSSValueTypes.h
+++ b/Source/WebCore/css/values/CSSValueTypes.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "CSSValueKeywords.h"
+#include "ComputedStyleDependencies.h"
 #include "RectEdges.h"
 #include <optional>
 #include <tuple>
@@ -37,7 +38,6 @@
 namespace WebCore {
 
 class CSSValue;
-struct ComputedStyleDependencies;
 
 namespace CSS {
 
@@ -523,6 +523,13 @@ template<typename CSSType> struct ComputedStyleDependenciesCollector;
 template<typename CSSType> void collectComputedStyleDependencies(ComputedStyleDependencies& dependencies, const CSSType& value)
 {
     ComputedStyleDependenciesCollector<CSSType>{}(dependencies, value);
+}
+
+template<typename CSSType> ComputedStyleDependencies collectComputedStyleDependencies(const CSSType& value)
+{
+    ComputedStyleDependencies dependencies;
+    collectComputedStyleDependencies(dependencies, value);
+    return dependencies;
 }
 
 template<typename CSSType> auto collectComputedStyleDependenciesOnTupleLike(ComputedStyleDependencies& dependencies, const CSSType& value)

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
@@ -49,7 +49,7 @@ inline constexpr auto All = Range { -Range::infinity, Range::infinity };
 inline constexpr auto Nonnegative = Range { 0, Range::infinity };
 
 // Clamps a floating point value to within `range`.
-template<Range range, std::floating_point T> constexpr float clampToRange(T value)
+template<Range range, std::floating_point T> constexpr T clampToRange(T value)
 {
     return std::clamp<T>(value, range.min, range.max);
 }

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.cpp
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSPrimitiveNumericTypes+Canonicalization.h"
+
+#include "CSSPrimitiveValue.h"
+#include "CSSToLengthConversionData.h"
+#include "FloatConversion.h"
+
+namespace WebCore {
+namespace CSS {
+
+// MARK: Angle
+
+double canonicalizeAngle(double value, CSSUnitType type)
+{
+    return CSSPrimitiveValue::computeAngle<CSSPrimitiveValue::AngleUnit::Degrees>(type, value);
+}
+
+// MARK: Length
+
+double canonicalizeLengthNoConversionDataRequired(double value, CSSUnitType type)
+{
+    return CSSPrimitiveValue::computeNonCalcLengthDouble({ }, type, value);
+}
+
+double canonicalizeLength(double value, CSSUnitType type, const CSSToLengthConversionData& conversionData)
+{
+    return CSSPrimitiveValue::computeNonCalcLengthDouble(conversionData, type, value);
+}
+
+float clampLengthToAllowedLimits(double value)
+{
+    return clampTo<float>(narrowPrecisionToFloat(value), minValueForCssLength, maxValueForCssLength);
+}
+
+float canonicalizeAndClampLengthNoConversionDataRequired(double value, CSSUnitType type)
+{
+    return clampLengthToAllowedLimits(canonicalizeLengthNoConversionDataRequired(value, type));
+}
+
+float canonicalizeAndClampLength(double value, CSSUnitType type, const CSSToLengthConversionData& conversionData)
+{
+    return clampLengthToAllowedLimits(canonicalizeLength(value, type, conversionData));
+}
+
+// MARK: Time
+
+double canonicalizeTime(double value, CSSUnitType type)
+{
+    return CSSPrimitiveValue::computeTime<CSSPrimitiveValue::TimeUnit::Seconds>(type, value);
+}
+
+// MARK: Frequency
+
+double canonicalizeFrequency(double value, CSSUnitType type)
+{
+    return CSSPrimitiveValue::computeFrequency<CSSPrimitiveValue::FrequencyUnit::Hz>(type, value);
+}
+
+// MARK: Resolution
+
+double canonicalizeResolution(double value, CSSUnitType type)
+{
+    return CSSPrimitiveValue::computeResolution<CSSPrimitiveValue::ResolutionUnit::Dppx>(type, value);
+}
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveNumericTypes.h"
+
+namespace WebCore {
+namespace CSS {
+
+// MARK: Angle
+
+double canonicalizeAngle(double value, CSSUnitType);
+
+template<auto R> double canonicalize(AngleRaw<R> raw)
+{
+    return canonicalizeAngle(raw.value, raw.type);
+}
+
+// MARK: Length
+
+double canonicalizeLengthNoConversionDataRequired(double, CSSUnitType);
+double canonicalizeLength(double, CSSUnitType, const CSSToLengthConversionData&);
+float clampLengthToAllowedLimits(double);
+float canonicalizeAndClampLengthNoConversionDataRequired(double, CSSUnitType);
+float canonicalizeAndClampLength(double, CSSUnitType, const CSSToLengthConversionData&);
+
+// MARK: Time
+
+double canonicalizeTime(double, CSSUnitType);
+
+template<auto R> double canonicalize(TimeRaw<R> raw)
+{
+    return canonicalizeTime(raw.value, raw.type);
+}
+
+// MARK: Frequency
+
+double canonicalizeFrequency(double, CSSUnitType);
+
+template<auto R> double canonicalize(FrequencyRaw<R> raw)
+{
+    return canonicalizeFrequency(raw.value, raw.type);
+}
+
+// MARK: Resolution
+
+double canonicalizeResolution(double, CSSUnitType);
+
+template<auto R> double canonicalize(ResolutionRaw<R> raw)
+{
+    return canonicalizeResolution(raw.value, raw.type);
+}
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.cpp
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.cpp
@@ -25,67 +25,10 @@
 #include "config.h"
 #include "CSSPrimitiveNumericTypes.h"
 
-#include "CSSPrimitiveValue.h"
-#include "CSSToLengthConversionData.h"
-#include "FloatConversion.h"
-
 namespace WebCore {
 namespace CSS {
 
-// MARK: Angle
-
-double canonicalizeAngle(double value, CSSUnitType type)
-{
-    return CSSPrimitiveValue::computeAngle<CSSPrimitiveValue::AngleUnit::Degrees>(type, value);
-}
-
-// MARK: Length
-
-double canonicalizeLengthNoConversionDataRequired(double value, CSSUnitType type)
-{
-    return CSSPrimitiveValue::computeNonCalcLengthDouble({ }, type, value);
-}
-
-double canonicalizeLength(double value, CSSUnitType type, const CSSToLengthConversionData& conversionData)
-{
-    return CSSPrimitiveValue::computeNonCalcLengthDouble(conversionData, type, value);
-}
-
-static float clampLengthToAllowedLimits(double value)
-{
-    return clampTo<float>(narrowPrecisionToFloat(value), minValueForCssLength, maxValueForCssLength);
-}
-
-float canonicalizeAndClampLengthNoConversionDataRequired(double value, CSSUnitType type)
-{
-    return clampLengthToAllowedLimits(canonicalizeLengthNoConversionDataRequired(value, type));
-}
-
-float canonicalizeAndClampLength(double value, CSSUnitType type, const CSSToLengthConversionData& conversionData)
-{
-    return clampLengthToAllowedLimits(canonicalizeLength(value, type, conversionData));
-}
-
-// MARK: Time
-
-double canonicalizeTime(double value, CSSUnitType type)
-{
-    return CSSPrimitiveValue::computeTime<CSSPrimitiveValue::TimeUnit::Seconds>(type, value);
-}
-
-// MARK: Frequency
-
-double canonicalizeFrequency(double value, CSSUnitType type)
-{
-    return CSSPrimitiveValue::computeFrequency<CSSPrimitiveValue::FrequencyUnit::Hz>(type, value);
-}
-
-// MARK: Resolution
-
-double canonicalizeResolution(double value, CSSUnitType type)
-{
-    return CSSPrimitiveValue::computeResolution<CSSPrimitiveValue::ResolutionUnit::Dppx>(type, value);
-}
+// isSupportedUnitForCategory will go here.
 
 // MARK: Unit Validation
 

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h
@@ -121,8 +121,6 @@ template<Range R = All> struct AngleRaw {
     constexpr bool operator==(const AngleRaw<R>&) const = default;
 };
 
-double canonicalizeAngle(double value, CSSUnitType);
-
 template<Range R = All> struct LengthRaw {
     using ValueType = double;
     static constexpr auto range = R;
@@ -132,11 +130,6 @@ template<Range R = All> struct LengthRaw {
 
     constexpr bool operator==(const LengthRaw<R>&) const = default;
 };
-
-double canonicalizeLengthNoConversionDataRequired(double, CSSUnitType);
-double canonicalizeLength(double, CSSUnitType, const CSSToLengthConversionData&);
-float canonicalizeAndClampLengthNoConversionDataRequired(double, CSSUnitType);
-float canonicalizeAndClampLength(double, CSSUnitType, const CSSToLengthConversionData&);
 
 template<Range R = All> struct TimeRaw {
     using ValueType = double;
@@ -148,8 +141,6 @@ template<Range R = All> struct TimeRaw {
     constexpr bool operator==(const TimeRaw<R>&) const = default;
 };
 
-double canonicalizeTime(double, CSSUnitType);
-
 template<Range R = All> struct FrequencyRaw {
     using ValueType = double;
     static constexpr auto range = R;
@@ -159,8 +150,6 @@ template<Range R = All> struct FrequencyRaw {
 
     constexpr bool operator==(const FrequencyRaw<R>&) const = default;
 };
-
-double canonicalizeFrequency(double, CSSUnitType);
 
 template<Range R = Nonnegative> struct ResolutionRaw {
     using ValueType = double;
@@ -172,8 +161,6 @@ template<Range R = Nonnegative> struct ResolutionRaw {
 
     constexpr bool operator==(const ResolutionRaw<R>&) const = default;
 };
-
-double canonicalizeResolution(double, CSSUnitType);
 
 template<Range R = All> struct FlexRaw {
     using ValueType = double;

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
@@ -26,7 +26,6 @@
 #include "CSSUnevaluatedCalc.h"
 
 #include "CSSCalcSymbolTable.h"
-#include "FloatConversion.h"
 #include "StyleBuilderState.h"
 #include <wtf/text/StringBuilder.h>
 
@@ -58,36 +57,36 @@ Ref<CSSCalcValue> unevaluatedCalcSimplify(const Ref<CSSCalcValue>& calc, const C
     return calc->copySimplified(conversionData, symbolTable);
 }
 
-float unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const Style::BuilderState& state, Calculation::Category category)
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const Style::BuilderState& state, Calculation::Category category)
 {
     return unevaluatedCalcEvaluate(calc, state.cssToLengthConversionData(), { }, category);
 }
 
-float unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const Style::BuilderState& state, const CSSCalcSymbolTable& symbolTable, Calculation::Category category)
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const Style::BuilderState& state, const CSSCalcSymbolTable& symbolTable, Calculation::Category category)
 {
     return unevaluatedCalcEvaluate(calc, state.cssToLengthConversionData(), symbolTable, category);
 }
 
-float unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const CSSToLengthConversionData& conversionData, Calculation::Category category)
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const CSSToLengthConversionData& conversionData, Calculation::Category category)
 {
     return unevaluatedCalcEvaluate(calc, conversionData, { }, category);
 }
 
-float unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable, Calculation::Category category)
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>& calc, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable, Calculation::Category category)
 {
     ASSERT_UNUSED(category, calc->category() == category);
-    return narrowPrecisionToFloat(calc->doubleValue(conversionData, symbolTable));
+    return calc->doubleValue(conversionData, symbolTable);
 }
 
-float unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>& calc, Calculation::Category category)
+double unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>& calc, Calculation::Category category)
 {
     return unevaluatedCalcEvaluateNoConversionDataRequired(calc, { }, category);
 }
 
-float unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>& calc, const CSSCalcSymbolTable& symbolTable, Calculation::Category category)
+double unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>& calc, const CSSCalcSymbolTable& symbolTable, Calculation::Category category)
 {
     ASSERT_UNUSED(category, calc->category() == category);
-    return narrowPrecisionToFloat(calc->doubleValueNoConversionDataRequired(symbolTable));
+    return calc->doubleValueNoConversionDataRequired(symbolTable);
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
@@ -59,12 +59,12 @@ void unevaluatedCalcCollectComputedStyleDependencies(ComputedStyleDependencies&,
 
 Ref<CSSCalcValue> unevaluatedCalcSimplify(const Ref<CSSCalcValue>&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&);
 
-float unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const Style::BuilderState&, Calculation::Category);
-float unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const Style::BuilderState&, const CSSCalcSymbolTable&, Calculation::Category);
-float unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const CSSToLengthConversionData&, Calculation::Category);
-float unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&, Calculation::Category);
-float unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>&, Calculation::Category);
-float unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>&, const CSSCalcSymbolTable&, Calculation::Category);
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const Style::BuilderState&, Calculation::Category);
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const Style::BuilderState&, const CSSCalcSymbolTable&, Calculation::Category);
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const CSSToLengthConversionData&, Calculation::Category);
+double unevaluatedCalcEvaluate(const Ref<CSSCalcValue>&, const CSSToLengthConversionData&, const CSSCalcSymbolTable&, Calculation::Category);
+double unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>&, Calculation::Category);
+double unevaluatedCalcEvaluateNoConversionDataRequired(const Ref<CSSCalcValue>&, const CSSCalcSymbolTable&, Calculation::Category);
 
 // `UnevaluatedCalc` annotates a `CSSCalcValue` with the raw value type that it
 // will be evaluated to, allowing the processing of calc in generic code.

--- a/Source/WebCore/rendering/shapes/LayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/LayoutShape.cpp
@@ -95,8 +95,8 @@ static inline FloatSize physicalSizeToLogical(const FloatSize& size, WritingMode
 Ref<const LayoutShape> LayoutShape::createShape(const Style::BasicShape& basicShape, const LayoutPoint& borderBoxOffset, const LayoutSize& logicalBoxSize, WritingMode writingMode, float margin)
 {
     bool horizontalWritingMode = writingMode.isHorizontal();
-    auto boxWidth = horizontalWritingMode ? logicalBoxSize.width() : logicalBoxSize.height();
-    auto boxHeight = horizontalWritingMode ? logicalBoxSize.height() : logicalBoxSize.width();
+    float boxWidth = horizontalWritingMode ? logicalBoxSize.width() : logicalBoxSize.height();
+    float boxHeight = horizontalWritingMode ? logicalBoxSize.height() : logicalBoxSize.width();
 
     auto shape = WTF::switchOn(basicShape,
         [&](const Style::CircleFunction& circle) -> Ref<LayoutShape> {

--- a/Source/WebCore/style/values/images/StyleGradient.cpp
+++ b/Source/WebCore/style/values/images/StyleGradient.cpp
@@ -1192,8 +1192,8 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
     auto firstPoint = computeEndPoint(radial.parameters.gradientBox.first, size);
     auto secondPoint = computeEndPoint(radial.parameters.gradientBox.second, size);
 
-    auto firstRadius = radial.parameters.gradientBox.firstRadius.value;
-    auto secondRadius = radial.parameters.gradientBox.secondRadius.value;
+    auto firstRadius = narrowPrecisionToFloat(radial.parameters.gradientBox.firstRadius.value);
+    auto secondRadius = narrowPrecisionToFloat(radial.parameters.gradientBox.secondRadius.value);
     auto aspectRatio = 1.0f;
 
     WebCore::Gradient::RadialData data { firstPoint, secondPoint, firstRadius, secondRadius, aspectRatio };

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "AnimationUtilities.h"
+#include "StylePrimitiveNumericTypes+Calculation.h"
 #include "StylePrimitiveNumericTypes.h"
 
 namespace WebCore {
@@ -53,10 +54,6 @@ template<StyleNumeric StylePrimitive> struct Blending<StylePrimitive> {
         // that concept, and the `WebCore::Length` code path did clamping in the same fashion.
         // https://drafts.csswg.org/css-values/#combining-range
 
-        // FIXME: This does not preserve the `quirk` bit for `Style::Length` values, matching
-        // the behavior of the `WebCore::Length` code path. It is not clear if it ever makes
-        // sense to preserve it during interpolation.
-
         return StylePrimitive { CSS::clampToRange<StylePrimitive::range>(WebCore::blend(from.value, to.value, context)) };
     }
 };
@@ -71,7 +68,7 @@ template<auto R> struct Blending<LengthPercentage<R>> {
 
     auto blend(const LengthPercentage<R>& from, const LengthPercentage<R>& to, const BlendingContext& context) -> LengthPercentage<R>
     {
-        // Interpolation of percentage-dimension value combinations (e.g. <length-percentage>, <frequency-percentage>,
+        // Interpolation of dimension-percentage value combinations (e.g. <length-percentage>, <frequency-percentage>,
         // <angle-percentage>, <time-percentage> or equivalent notations) is defined as:
         //
         //  - equivalent to interpolation of <length> if both VA and VB are pure <length> values
@@ -84,16 +81,21 @@ template<auto R> struct Blending<LengthPercentage<R>> {
             if (context.compositeOperation != CompositeOperation::Replace)
                 return Calculation::add(copyCalculation(from), copyCalculation(to));
 
-            if (!to.value.isCalculationValue() && !from.value.isPercentage() && (context.progress == 1 || from.value.isZero())) {
-                if (to.value.isLength())
-                    return WebCore::Style::blend(Length<R> { 0 }, to.value.asLength(), context);
-                return WebCore::Style::blend(Percentage<R> { 0 }, to.value.asPercentage(), context);
+            // 0% to 0px -> calc(0px + 0%) to calc(0px + 0%) -> 0px
+            // 0px to 0% -> calc(0px + 0%) to calc(0px + 0%) -> 0px
+            if (from.isZero() && to.isZero())
+                return Length<R> { 0 };
+
+            if (!to.isCalculationValue() && !from.isPercentage() && (context.progress == 1 || from.isZero())) {
+                if (to.isLength())
+                    return WebCore::Style::blend(Length<R> { 0 }, to.asLength(), context);
+                return WebCore::Style::blend(Percentage<R> { 0 }, to.asPercentage(), context);
             }
 
-            if (!from.value.isCalculationValue() && !to.value.isPercentage() && (!context.progress || to.value.isZero())) {
-                if (from.value.isLength())
-                    return WebCore::Style::blend(from.value.asLength(), Length<R> { 0 }, context);
-                return WebCore::Style::blend(from.value.asPercentage(), Percentage<R> { 0 }, context);
+            if (!from.isCalculationValue() && !to.isPercentage() && (!context.progress || to.isZero())) {
+                if (from.isLength())
+                    return WebCore::Style::blend(from.asLength(), Length<R> { 0 }, context);
+                return WebCore::Style::blend(from.asPercentage(), Percentage<R> { 0 }, context);
             }
 
             return Calculation::blend(copyCalculation(from), copyCalculation(to), context.progress);
@@ -105,9 +107,9 @@ template<auto R> struct Blending<LengthPercentage<R>> {
         if (context.progress == 1 && context.isReplace())
             return to;
 
-        if (to.value.isLength())
-            return WebCore::Style::blend(from.value.asLength(), to.value.asLength(), context);
-        return WebCore::Style::blend(from.value.asPercentage(), to.value.asPercentage(), context);
+        if (to.isLength())
+            return WebCore::Style::blend(from.asLength(), to.asLength(), context);
+        return WebCore::Style::blend(from.asPercentage(), to.asPercentage(), context);
     }
 };
 

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CalculationValue.h"
+#include "StylePrimitiveNumericTypes.h"
+#include <wtf/Forward.h>
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Conversion to `Calculation::Child`.
+
+inline Calculation::Child copyCalculation(Ref<CalculationValue> value)
+{
+    return value->copyRoot();
+}
+
+template<auto R> Calculation::Child copyCalculation(const Number<R>& value)
+{
+    return Calculation::number(value.value);
+}
+
+template<auto R> Calculation::Child copyCalculation(const Percentage<R>& value)
+{
+    return Calculation::percentage(value.value);
+}
+
+template<StyleNumericPrimitive Dimension> Calculation::Child copyCalculation(const Dimension& value)
+{
+    return Calculation::dimension(value.value);
+}
+
+template<StyleDimensionPercentage DimensionPercentage> Calculation::Child copyCalculation(const DimensionPercentage& value)
+{
+    return WTF::switchOn(value, [](const auto& value) { return copyCalculation(value); });
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -24,12 +24,130 @@
 
 #pragma once
 
+#include "CSSPrimitiveNumericTypes+Canonicalization.h"
+#include "CSSPrimitiveNumericTypes+ComputedStyleDependencies.h"
 #include "CSSToLengthConversionData.h"
 #include "StyleBuilderState.h"
 #include "StylePrimitiveNumericTypes.h"
 
 namespace WebCore {
 namespace Style {
+
+template<auto R> constexpr Number<R> canonicalizeNoConversionDataRequired(const CSS::NumberRaw<R>& raw)
+{
+    return { raw.value };
+}
+
+template<auto R> constexpr Number<R> canonicalize(const CSS::NumberRaw<R>& raw, const CSSToLengthConversionData&)
+{
+    return canonicalizeNoConversionDataRequired(raw);
+}
+
+template<auto R> constexpr Percentage<R> canonicalizeNoConversionDataRequired(const CSS::PercentageRaw<R>& raw)
+{
+    return { raw.value };
+}
+
+template<auto R> constexpr Percentage<R> canonicalize(const CSS::PercentageRaw<R>& raw, const CSSToLengthConversionData&)
+{
+    return canonicalizeNoConversionDataRequired(raw);
+}
+
+template<auto R> Angle<R> canonicalizeNoConversionDataRequired(const CSS::AngleRaw<R>& raw)
+{
+    return { CSS::canonicalizeAngle(raw.value, raw.type) };
+}
+
+template<auto R> Angle<R> canonicalize(const CSS::AngleRaw<R>& raw, const CSSToLengthConversionData&)
+{
+    return canonicalizeNoConversionDataRequired(raw);
+}
+
+template<auto R> Length<R> canonicalizeNoConversionDataRequired(const CSS::LengthRaw<R>& raw)
+{
+    ASSERT(!requiresConversionData(raw));
+
+    return { CSS::canonicalizeAndClampLengthNoConversionDataRequired(raw.value, raw.type) };
+}
+
+template<auto R> Length<R> canonicalize(const CSS::LengthRaw<R>& raw, const CSSToLengthConversionData& conversionData)
+{
+    ASSERT(CSS::collectComputedStyleDependencies(raw).canResolveDependenciesWithConversionData(conversionData));
+
+    return { CSS::canonicalizeAndClampLength(raw.value, raw.type, conversionData) };
+}
+
+template<auto R> Time<R> canonicalizeNoConversionDataRequired(const CSS::TimeRaw<R>& raw)
+{
+    return { CSS::canonicalizeTime(raw.value, raw.type) };
+}
+
+template<auto R> Time<R> canonicalize(const CSS::TimeRaw<R>& raw, const CSSToLengthConversionData&)
+{
+    return canonicalizeNoConversionDataRequired(raw);
+}
+
+template<auto R> Frequency<R> canonicalizeNoConversionDataRequired(const CSS::FrequencyRaw<R>& raw)
+{
+    return { CSS::canonicalizeFrequency(raw.value, raw.type) };
+}
+
+template<auto R> Frequency<R> canonicalize(const CSS::FrequencyRaw<R>& raw, const CSSToLengthConversionData&)
+{
+    return canonicalizeNoConversionDataRequired(raw);
+}
+
+template<auto R> Resolution<R> canonicalizeNoConversionDataRequired(const CSS::ResolutionRaw<R>& raw)
+{
+    return { CSS::canonicalizeResolution(raw.value, raw.type) };
+}
+
+template<auto R> Resolution<R> canonicalize(const CSS::ResolutionRaw<R>& raw, const CSSToLengthConversionData&)
+{
+    return canonicalizeNoConversionDataRequired(raw);
+}
+
+template<auto R> constexpr Flex<R> canonicalizeNoConversionDataRequired(const CSS::FlexRaw<R>& raw)
+{
+    return { raw.value };
+}
+
+template<auto R> constexpr Flex<R> canonicalize(const CSS::FlexRaw<R>& raw, const CSSToLengthConversionData&)
+{
+    return canonicalizeNoConversionDataRequired(raw);
+}
+
+template<auto R> AnglePercentage<R> canonicalizeNoConversionDataRequired(const CSS::AnglePercentageRaw<R>& raw)
+{
+    if (raw.type == CSSUnitType::CSS_PERCENTAGE)
+        return { canonicalizeNoConversionDataRequired(CSS::PercentageRaw<R> { raw.value }) };
+    return { canonicalizeNoConversionDataRequired(CSS::AngleRaw<R> { raw.type, raw.value }) };
+}
+
+template<auto R> AnglePercentage<R> canonicalize(const CSS::AnglePercentageRaw<R>& raw, const CSSToLengthConversionData&)
+{
+    return canonicalizeNoConversionDataRequired(raw);
+}
+
+template<auto R> LengthPercentage<R> canonicalizeNoConversionDataRequired(const CSS::LengthPercentageRaw<R>& raw)
+{
+    if (raw.type == CSSUnitType::CSS_PERCENTAGE)
+        return canonicalizeNoConversionDataRequired(CSS::PercentageRaw<R> { raw.value });
+
+    // NOTE: This uses the non-clamping version length canonicalization to match the behavior of CSSPrimitiveValue::convertToLength().
+    return Length<R> { narrowPrecisionToFloat(CSS::canonicalizeLengthNoConversionDataRequired(raw.value, raw.type)) };
+}
+
+template<auto R> LengthPercentage<R> canonicalize(const CSS::LengthPercentageRaw<R>& raw, const CSSToLengthConversionData& conversionData)
+{
+    ASSERT(CSS::collectComputedStyleDependencies(raw).canResolveDependenciesWithConversionData(conversionData));
+
+    if (raw.type == CSSUnitType::CSS_PERCENTAGE)
+        return canonicalize(CSS::PercentageRaw<R> { raw.value }, conversionData);
+
+    // NOTE: This uses the non-clamping version length canonicalization to match the behavior of CSSPrimitiveValue::convertToLength().
+    return Length<R> { narrowPrecisionToFloat(CSS::canonicalizeLength(raw.value, raw.type, conversionData)) };
+}
 
 // MARK: - Conversion Data specialization
 
@@ -61,11 +179,19 @@ Ref<CSSCalcValue> makeCalc(const CalculationValue&, const RenderStyle&);
 // Out of line to avoid inclusion of RenderStyleInlines.h
 float adjustForZoom(float, const RenderStyle&);
 
+// Length requires a specialized implementation due to zoom adjustment.
+template<auto R> struct ToCSS<Length<R>> {
+    auto operator()(const Length<R>& value, const RenderStyle& style) -> CSS::Length<R>
+    {
+        return CSS::LengthRaw<R> { value.unit, adjustForZoom(value.value, style) };
+    }
+};
+
 // AnglePercentage / LengthPercentage require specialized implementations due to additional `calc` field.
 template<auto R> struct ToCSS<AnglePercentage<R>> {
     auto operator()(const AnglePercentage<R>& value, const RenderStyle& style) -> CSS::AnglePercentage<R>
     {
-        return value.value.switchOn(
+        return WTF::switchOn(value,
             [&](Angle<R> angle) -> CSS::AnglePercentage<R> {
                 return CSS::AnglePercentageRaw<R> { angle.unit, angle.value };
             },
@@ -82,7 +208,7 @@ template<auto R> struct ToCSS<AnglePercentage<R>> {
 template<auto R> struct ToCSS<LengthPercentage<R>> {
     auto operator()(const LengthPercentage<R>& value, const RenderStyle& style) -> CSS::LengthPercentage<R>
     {
-        return value.value.switchOn(
+        return WTF::switchOn(value,
             [&](Length<R> length) -> CSS::LengthPercentage<R> {
                 return CSS::LengthPercentageRaw<R> { length.unit, adjustForZoom(length.value, style) };
             },
@@ -123,12 +249,12 @@ template<auto R> struct ToStyle<CSS::AnglePercentage<R>> {
     {
         Ref calc = value.protectedCalc();
 
-        ASSERT(calc->tree().category == Calculation::Category::AnglePercentage);
+        ASSERT(calc->tree().category == From::category);
 
         if (!calc->tree().type.percentHint)
-            return { Style::Angle<R> { narrowPrecisionToFloat(calc->doubleValue(conversionData, symbolTable)) } };
+            return { Style::Angle<R> { calc->doubleValue(conversionData, symbolTable) } };
         if (std::holds_alternative<CSSCalc::Percentage>(calc->tree().root))
-            return { Style::Percentage<R> { narrowPrecisionToFloat(calc->doubleValue(conversionData, symbolTable)) } };
+            return { Style::Percentage<R> { calc->doubleValue(conversionData, symbolTable) } };
         return { calc->createCalculationValue(conversionData, symbolTable) };
     }
     auto operator()(const From& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) -> To
@@ -157,12 +283,12 @@ template<auto R> struct ToStyle<CSS::AnglePercentage<R>> {
     {
         Ref calc = value.protectedCalc();
 
-        ASSERT(calc->tree().category == Calculation::Category::AnglePercentage);
+        ASSERT(calc->tree().category == From::category);
 
         if (!calc->tree().type.percentHint)
-            return { Style::Angle<R> { narrowPrecisionToFloat(calc->doubleValueNoConversionDataRequired(symbolTable)) } };
+            return { Style::Angle<R> { calc->doubleValueNoConversionDataRequired(symbolTable) } };
         if (std::holds_alternative<CSSCalc::Percentage>(calc->tree().root))
-            return { Style::Percentage<R> { narrowPrecisionToFloat(calc->doubleValueNoConversionDataRequired(symbolTable)) } };
+            return { Style::Percentage<R> { calc->doubleValueNoConversionDataRequired(symbolTable) } };
         return { calc->createCalculationValueNoConversionDataRequired(symbolTable) };
     }
     auto operator()(const From& value, NoConversionDataRequiredToken token, const CSSCalcSymbolTable& symbolTable) -> To
@@ -182,12 +308,12 @@ template<auto R> struct ToStyle<CSS::LengthPercentage<R>> {
     {
         Ref calc = value.protectedCalc();
 
-        ASSERT(calc->tree().category == Calculation::Category::LengthPercentage);
+        ASSERT(calc->tree().category == From::category);
 
         if (!calc->tree().type.percentHint)
-            return { Style::Length<R> { narrowPrecisionToFloat(calc->doubleValue(conversionData, symbolTable)) } };
+            return { Style::Length<R> { CSS::clampLengthToAllowedLimits(calc->doubleValue(conversionData, symbolTable)) } };
         if (std::holds_alternative<CSSCalc::Percentage>(calc->tree().root))
-            return { Style::Percentage<R> { narrowPrecisionToFloat(calc->doubleValue(conversionData, symbolTable)) } };
+            return { Style::Percentage<R> { calc->doubleValue(conversionData, symbolTable) } };
         return { calc->createCalculationValue(conversionData, symbolTable) };
     }
     auto operator()(const From& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) -> To
@@ -214,15 +340,59 @@ template<auto R> struct ToStyle<CSS::LengthPercentage<R>> {
     }
     auto operator()(const typename From::Calc& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable) -> To
     {
-            Ref calc = value.protectedCalc();
+        Ref calc = value.protectedCalc();
 
-        ASSERT(calc->tree().category == Calculation::Category::LengthPercentage);
+        ASSERT(calc->tree().category == From::category);
 
         if (!calc->tree().type.percentHint)
-            return { Style::Length<R> { narrowPrecisionToFloat(calc->doubleValueNoConversionDataRequired(symbolTable)) } };
+            return { Style::Length<R> { CSS::clampLengthToAllowedLimits(calc->doubleValueNoConversionDataRequired(symbolTable)) } };
         if (std::holds_alternative<CSSCalc::Percentage>(calc->tree().root))
-            return { Style::Percentage<R> { narrowPrecisionToFloat(calc->doubleValueNoConversionDataRequired(symbolTable)) } };
+            return { Style::Percentage<R> { calc->doubleValueNoConversionDataRequired(symbolTable) } };
         return { calc->createCalculationValueNoConversionDataRequired(symbolTable) };
+    }
+    auto operator()(const From& value, NoConversionDataRequiredToken token, const CSSCalcSymbolTable& symbolTable) -> To
+    {
+        return WTF::switchOn(value, [&](const auto& value) { return (*this)(value, token, symbolTable); });
+    }
+};
+
+template<auto R> struct ToStyle<CSS::Length<R>> {
+    using From = CSS::Length<R>;
+    using To = Length<R>;
+
+    auto operator()(const typename From::Raw& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable&) -> To
+    {
+        return { canonicalize(value, conversionData) };
+    }
+    auto operator()(const typename From::Calc& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) -> To
+    {
+        return { CSS::clampLengthToAllowedLimits(CSS::unevaluatedCalcEvaluate(value.protectedCalc(), conversionData, symbolTable, From::category)) };
+    }
+    auto operator()(const From& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) -> To
+    {
+        return WTF::switchOn(value, [&](const auto& value) { return (*this)(value, conversionData, symbolTable); });
+    }
+
+    auto operator()(const typename From::Raw& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
+    {
+        return (*this)(value, conversionData<typename From::Raw>(state), symbolTable);
+    }
+    auto operator()(const typename From::Calc& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
+    {
+        return (*this)(value, conversionData<typename From::Raw>(state), symbolTable);
+    }
+    auto operator()(const From& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
+    {
+        return (*this)(value, conversionData<typename From::Raw>(state), symbolTable);
+    }
+
+    auto operator()(const typename From::Raw& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable&) -> To
+    {
+        return { canonicalizeNoConversionDataRequired(value) };
+    }
+    auto operator()(const typename From::Calc& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable) -> To
+    {
+        return { CSS::clampLengthToAllowedLimits(CSS::unevaluatedCalcEvaluateNoConversionDataRequired(value.protectedCalc(), symbolTable, From::category)) };
     }
     auto operator()(const From& value, NoConversionDataRequiredToken token, const CSSCalcSymbolTable& symbolTable) -> To
     {
@@ -241,7 +411,7 @@ template<CSS::RawNumeric RawType> struct ToStyle<CSS::PrimitiveNumeric<RawType>>
     }
     auto operator()(const typename From::Calc& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) -> To
     {
-        return { CSS::unevaluatedCalcEvaluate(value.protectedCalc(), conversionData, symbolTable, RawType::category) };
+        return { CSS::unevaluatedCalcEvaluate(value.protectedCalc(), conversionData, symbolTable, From::category) };
     }
     auto operator()(const From& value, const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) -> To
     {
@@ -250,15 +420,15 @@ template<CSS::RawNumeric RawType> struct ToStyle<CSS::PrimitiveNumeric<RawType>>
 
     auto operator()(const typename From::Raw& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
     {
-        return (*this)(value, conversionData<RawType>(state), symbolTable);
+        return (*this)(value, conversionData<typename From::Raw>(state), symbolTable);
     }
     auto operator()(const typename From::Calc& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
     {
-        return (*this)(value, conversionData<RawType>(state), symbolTable);
+        return (*this)(value, conversionData<typename From::Raw>(state), symbolTable);
     }
-    auto operator()(const CSS::PrimitiveNumeric<RawType>& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
+    auto operator()(const From& value, const BuilderState& state, const CSSCalcSymbolTable& symbolTable) -> To
     {
-        return (*this)(value, conversionData<RawType>(state), symbolTable);
+        return (*this)(value, conversionData<typename From::Raw>(state), symbolTable);
     }
 
     auto operator()(const typename From::Raw& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable&) -> To
@@ -267,7 +437,7 @@ template<CSS::RawNumeric RawType> struct ToStyle<CSS::PrimitiveNumeric<RawType>>
     }
     auto operator()(const typename From::Calc& value, NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable) -> To
     {
-        return { CSS::unevaluatedCalcEvaluateNoConversionDataRequired(value.protectedCalc(), symbolTable, RawType::category) };
+        return { CSS::unevaluatedCalcEvaluateNoConversionDataRequired(value.protectedCalc(), symbolTable, From::category) };
     }
     auto operator()(const From& value, NoConversionDataRequiredToken token, const CSSCalcSymbolTable& symbolTable) -> To
     {

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "StyleShapeFunction.h"
 
+#include "FloatConversion.h"
 #include "FloatRect.h"
 #include "GeometryUtilities.h"
 #include "Path.h"
@@ -239,7 +240,7 @@ private:
         return ArcToSegment {
             .rx = radius.width(),
             .ry = radius.height(),
-            .angle = arcCommand.rotation.value,
+            .angle = narrowPrecisionToFloat(arcCommand.rotation.value),
             .largeArc = std::holds_alternative<Large>(arcCommand.arcSize),
             .sweep = std::holds_alternative<Cw>(arcCommand.arcSweep),
             .targetPoint = evaluate(arcCommand.toBy, m_boxSize)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3055,26 +3055,24 @@ class WebCore::SVGPathByteStream {
 
 header: <WebCore/StylePrimitiveNumericTypes.h>
 [CustomHeader, Nested] struct WebCore::Style::Angle<WebCore::CSS::Nonnegative> {
-    float value;
+    double value;
 };
 [CustomHeader, Nested] struct WebCore::Style::Angle<WebCore::CSS::All> {
-    float value;
+    double value;
 };
 
 [CustomHeader, Nested] struct WebCore::Style::Length<WebCore::CSS::Nonnegative> {
     float value;
-    bool quirk;
 };
 [CustomHeader, Nested] struct WebCore::Style::Length<WebCore::CSS::All> {
     float value;
-    bool quirk;
 };
 
 [CustomHeader, Nested] struct WebCore::Style::Percentage<WebCore::CSS::Nonnegative> {
-    float value;
+    double value;
 };
 [CustomHeader, Nested] struct WebCore::Style::Percentage<WebCore::CSS::All> {
-    float value;
+    double value;
 };
 
 [CustomHeader, Nested] struct WebCore::Style::LengthPercentage<WebCore::CSS::All> {


### PR DESCRIPTION
#### 0f32a7fa58d1fb4afe1652fe4ecd0f99fe8c84c8
<pre>
Update Style numeric types to use double everywhere except Length
<a href="https://bugs.webkit.org/show_bug.cgi?id=283572">https://bugs.webkit.org/show_bug.cgi?id=283572</a>

Reviewed by Darin Adler.

In preparation for moving transform to the new CSS/Style value types system,
update Style numeric types to use double everywhere except Length, which is
the most common expectation.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
    - Add new files.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+AngleDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+FrequencyDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ResolutionDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+TimeDefinitions.h:
    - Call new canonicalization functions.

* Source/WebCore/css/values/CSSValueTypes.h:
    - Add non-accumulating collectComputedStyleDependencies() function that just
      returns the final result.

* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h:
    - Fix clamp to maintain the same input and output types. Previously, it was always
      returning float.

* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.cpp: Added.
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.h: Added.
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.cpp:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h:
    - Move all raw canonicalization functions to a shared set of files. Currently these mostly
      delegate to CSSPrimitiveValue, but eventually that relationship will be flipped.

* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp:
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h:
    - Remove any eager precision narrowing done here. Let callers narrow only if needed.

* Source/WebCore/rendering/shapes/LayoutShape.cpp:
    - Add explicit `float` type to make overload resolution happy.

* Source/WebCore/style/values/images/StyleGradient.cpp:
    - Add explicit precision narrowing for radii.

* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h:
    - Use functions on LengthPercentage&lt;&gt; rather than using the internal representation directly.

* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h: Added.
    - Move overloaded Calculation copying to its own file.

* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
    - Move typed canonicalization here from StylePrimitiveNumericTypes.h
    - Add specialization of conversion operators for Length to handle zoom adjustments correctly,
      previously this was only happening for LengthPercentage which was the only kind of Length
      being exercised.

* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h:
    - Add overloads for evaluation to double.

* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h:
    - Use double value types for all the primitives except Length.
    - Remove quirk bit from Length. This is only needed for margin values, and they
      will be handled separately.
    - Merge AnglePercentageValue and LengthPercentageValue into generic `PrimitiveDimensionPercentage`
      type that works for both.

* Source/WebCore/style/values/shapes/StyleShapeFunction.cpp:
    - Add explicit precision narrowing.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
    - Update primitive value types to double where needed.

Canonical link: <a href="https://commits.webkit.org/287032@main">https://commits.webkit.org/287032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a9d51f95312a4a22e87e52921707b3e3433f76e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77911 "12 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82559 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29168 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80032 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5239 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61009 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18936 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50996 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41312 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24379 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27511 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69456 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24731 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83921 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5278 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3599 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69227 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5434 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66817 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68483 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17117 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12483 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10602 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5226 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7979 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5218 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8650 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->