### PR TITLE
[CoreIPC] [Fuzz Blocker] TRAP in WebKit::WebSWServerToContextConnection::didReceiveFetchTaskMessage

### DIFF
--- a/LayoutTests/http/tests/ipc/ipc-fetch-task-message-crash-expected.txt
+++ b/LayoutTests/http/tests/ipc/ipc-fetch-task-message-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/http/tests/ipc/ipc-fetch-task-message-crash.html
+++ b/LayoutTests/http/tests/ipc/ipc-fetch-task-message-crash.html
@@ -1,0 +1,112 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if WebKit does not crash.</p>
+
+<script>
+  if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+  }
+
+  navigator.serviceWorker.register("empty.js").then(() => {
+    window.setTimeout(async () => {
+      if (!window.IPC)
+        return window.testRunner?.notifyDone();
+      const { CoreIPC } = await import('./coreipc.js');
+      await CoreIPC.Networking.ServiceWorkerFetchTask.DidFinish(0, {
+        metrics: {
+          redirectStart: {
+            secondsSinceEpochSeconds: 69
+          },
+          fetchStart: {
+            secondsSinceEpochSeconds: 103
+          },
+          domainLookupStart: {
+            secondsSinceEpochSeconds: 66
+          },
+          domainLookupEnd: {
+            secondsSinceEpochSeconds: 20
+          },
+          connectStart: {
+            secondsSinceEpochSeconds: 106
+          },
+          secureConnectionStart: {
+            secondsSinceEpochSeconds: 347892350986
+          },
+          connectEnd: {
+            secondsSinceEpochSeconds: 90194313277
+          },
+          requestStart: {
+            secondsSinceEpochSeconds: 112
+          },
+          responseStart: {
+            secondsSinceEpochSeconds: 99
+          },
+          responseEnd: {
+            secondsSinceEpochSeconds: 64
+          },
+          workerStart: {
+            secondsSinceEpochSeconds: 26
+          },
+          protocol: '',
+          redirectCount: 384,
+          isComplete: false,
+          isCellular: false,
+          isExpensive: false,
+          isConstrained: false,
+          isMultipath: false,
+          reusedConnection: false,
+          doesFailTAOCheck: true,
+          crossOriginRedirect: false,
+          privacyStance: 3,
+          responseBodyBytesReceived: 820,
+          responseBodyDecodedSize: 981,
+          additionalNetworkLoadMetricsForWebInspector: {
+            optionalValue: {
+              priority: 2,
+              remoteAddress: '',
+              connectionIdentifier: '',
+              tlsProtocol: '',
+              tlsCipher: '',
+              requestHeaders: {
+                commonHeaders: [{
+                  key: 20,
+                  value: ''
+                }, {
+                  key: 70,
+                  value: ''
+                }, {
+                  key: 92,
+                  value: ''
+                }, {
+                  key: 62,
+                  value: ''
+                }, {
+                  key: 34,
+                  value: ''
+                }, {
+                  key: 33,
+                  value: ''
+                }, {
+                  key: 35,
+                  value: ''
+                }, {
+                  key: 40,
+                  value: ''
+                }, {
+                  key: 68,
+                  value: ''
+                }],
+                uncommonHeaders: []
+              },
+              requestHeaderBytesSent: 298,
+              responseHeaderBytesReceived: 411,
+              requestBodyBytesSent: 828,
+              isProxyConnection: false
+            }
+          }
+        }
+      });
+      window.testRunner?.notifyDone();
+    }, 5);
+  })
+</script>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1061,6 +1061,7 @@ http/tests/referrer-policy-img/no-referrer-when-downgrade/ [ Skip ]
 http/tests/referrer-policy-img/unsafe-url/cross-origin-http-http.html [ Skip ]
 http/tests/referrer-policy-img/unsafe-url/cross-origin-http.https.html [ Skip ]
 http/tests/referrer-policy-img/unsafe-url/cross-origin-http-UpgradeMixedContent.https.html [ Skip ]
+http/tests/ipc/ipc-fetch-task-message-crash.html [ Skip ]
 
 # Cross origin HTTPS loads require certificate validation, which are not supported for WK1 ping loads.
 http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-ping-in-iframe.https.html [ Failure ]

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -352,6 +352,8 @@ void WebSWServerToContextConnection::startFetch(ServiceWorkerFetchTask& task)
 
 void WebSWServerToContextConnection::didReceiveFetchTaskMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
+    MESSAGE_CHECK(ObjectIdentifier<FetchIdentifierType>::isValidIdentifier(decoder.destinationID()));
+
     RefPtr fetch = m_ongoingFetches.get(ObjectIdentifier<FetchIdentifierType>(decoder.destinationID())).get();
     if (!fetch)
         return;

--- a/Tools/Scripts/webkitpy/layout_tests/servers/aliases.json
+++ b/Tools/Scripts/webkitpy/layout_tests/servers/aliases.json
@@ -1,4 +1,5 @@
 [
+    ["/ipc/coreipc.js", "ipc/coreipc.js"],
     ["/js-test-resources", "resources"],
     ["/media-resources", "media"],
     ["/modern-media-controls", "../Source/WebCore/Modules/modern-media-controls"],


### PR DESCRIPTION
#### 009ef3ee3033bc99b063fabd654cf72fcfd959eb
<pre>
[CoreIPC] [Fuzz Blocker] TRAP in WebKit::WebSWServerToContextConnection::didReceiveFetchTaskMessage
<a href="https://bugs.webkit.org/show_bug.cgi?id=283577">https://bugs.webkit.org/show_bug.cgi?id=283577</a>
<a href="https://rdar.apple.com/139805005">rdar://139805005</a>

Reviewed by Ryosuke Niwa.

Added a check to ensure that the destinationID extracted from the decoder corresponds to a valid identifier for a fetch task.

* LayoutTests/http/tests/ipc/empty.js: Added.
* LayoutTests/http/tests/ipc/ipc-fetch-task-message-crash-expected.txt: Added.
* LayoutTests/http/tests/ipc/ipc-fetch-task-message-crash.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::didReceiveFetchTaskMessage):
* Tools/Scripts/webkitpy/layout_tests/servers/aliases.json:

Canonical link: <a href="https://commits.webkit.org/287709@main">https://commits.webkit.org/287709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18475803fb31e7a6e89925568a592a391d172d9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85079 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31540 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82669 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7870 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62935 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20740 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/53042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73339 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43240 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/80015 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50342 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27497 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29999 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71488 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86513 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7784 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71227 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69176 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70468 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14477 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13422 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12476 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7746 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7585 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11104 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9390 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->