### PR TITLE
AX: REGRESSION(286869@main): AXPropertyName::IsExpanded becomes stale for details and summary elements, causing accessibility/mac/details-summary.html to fail in ITM

### DIFF
--- a/LayoutTests/accessibility/mac/details-summary-expected.txt
+++ b/LayoutTests/accessibility/mac/details-summary-expected.txt
@@ -6,12 +6,12 @@ PASS: summary1.role === 'AXRole: AXDisclosureTriangle'
 PASS: summary1.subrole === 'AXSubrole: AXSummary'
 PASS: summary1.title === 'AXTitle: Some open info'
 PASS: details1.isAttributeSettable('AXExpanded') === true
-Received AXExpandedChanged notification
+Got AXExpandedChanged notification for details1
 PASS: details1.isExpanded === false
 PASS: summary1.isExpanded === false
 PASS: details1.isExpanded === false
 PASS: summary1.isExpanded === false
-Received AXExpandedChanged notification
+Got AXExpandedChanged notification for details1
 PASS: details1.isExpanded === true
 PASS: summary1.isExpanded === true
 PASS: details1.isExpanded === true

--- a/LayoutTests/accessibility/mac/details-summary.html
+++ b/LayoutTests/accessibility/mac/details-summary.html
@@ -30,9 +30,10 @@
         window.jsTestIsAsync = true;
 
         var body = accessibilityController.rootElement.childAtIndex(0);
-        body.addNotificationListener(function(notification) {
-            if (notification == "AXExpandedChanged")
-                output += `Received ${notification} notification\n`;
+        accessibilityController.addNotificationListener(function(element, notification) {
+            if (notification != "AXExpandedChanged")
+                return;
+            output += `Got AXExpandedChanged notification for ${element.domIdentifier}\n`;
         });
 
         var details1 = accessibilityController.accessibleElementById("details1");
@@ -100,6 +101,7 @@
             output += expect("details3.isExpanded", "true");
 
             debug(output);
+            accessibilityController.removeNotificationListener();
             document.getElementById("content").style.visibility = "hidden";
             finishJSTest();
         }, 0);

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -78,6 +78,7 @@
 #include "HTMLAreaElement.h"
 #include "HTMLButtonElement.h"
 #include "HTMLCanvasElement.h"
+#include "HTMLDetailsElement.h"
 #include "HTMLDialogElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLInputElement.h"
@@ -89,6 +90,7 @@
 #include "HTMLOptionElement.h"
 #include "HTMLProgressElement.h"
 #include "HTMLSelectElement.h"
+#include "HTMLSummaryElement.h"
 #include "HTMLTableElement.h"
 #include "HTMLTablePartElement.h"
 #include "HTMLTableRowElement.h"
@@ -1311,6 +1313,17 @@ void AXObjectCache::onEventListenerRemoved(Node& node, const AtomString& eventTy
     UNUSED_PARAM(node);
     UNUSED_PARAM(eventType);
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+}
+
+void AXObjectCache::onExpandedChanged(HTMLDetailsElement& detailsElement)
+{
+    postNotification(get(detailsElement), AXExpandedChanged);
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    if (!AXIsolatedTree::treeForPageID(m_pageID))
+        return;
+    for (auto& summary : descendantsOfType<HTMLSummaryElement>(detailsElement))
+        updateIsolatedTree(get(summary), AXExpandedChanged);
+#endif
 }
 
 void AXObjectCache::updateLoadingProgress(double newProgressValue)

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -64,6 +64,7 @@ class AccessibilityTable;
 class AccessibilityTableCell;
 class Document;
 class HTMLAreaElement;
+class HTMLDetailsElement;
 class HTMLTableElement;
 class HTMLTextFormControlElement;
 class Node;
@@ -344,6 +345,7 @@ public:
     void childrenChanged(AccessibilityObject*);
     void onEventListenerAdded(Node&, const AtomString& eventType);
     void onEventListenerRemoved(Node&, const AtomString& eventType);
+    void onExpandedChanged(HTMLDetailsElement&);
     void onFocusChange(Element* oldElement, Element* newElement);
     void onInertOrVisibilityChange(RenderElement&);
     void onPopoverToggle(const HTMLElement&);

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -214,9 +214,8 @@ void HTMLDetailsElement::toggleOpen()
 {
     setBooleanAttribute(openAttr, !hasAttribute(openAttr));
 
-    // We need to post to the document because toggling this element will delete it.
-    if (AXObjectCache* cache = document().existingAXObjectCache())
-        cache->postNotification(nullptr, &document(), AXObjectCache::AXExpandedChanged);
+    if (CheckedPtr cache = document().existingAXObjectCache())
+        cache->onExpandedChanged(*this);
 }
 
 }


### PR DESCRIPTION
#### 9da9cefb7d6d75043aef967725b987292d3863f2
<pre>
AX: REGRESSION(286869@main): AXPropertyName::IsExpanded becomes stale for details and summary elements, causing accessibility/mac/details-summary.html to fail in ITM
<a href="https://bugs.webkit.org/show_bug.cgi?id=283578">https://bugs.webkit.org/show_bug.cgi?id=283578</a>
<a href="https://rdar.apple.com/140428627">rdar://140428627</a>

Reviewed by Chris Fleizach.

Prior to <a href="https://commits.webkit.org/286869@main">https://commits.webkit.org/286869@main</a>, we used to get away with not updating this property because every time
the details were expanded, we would throw away the entire details, summary, and other descendant objects and create new
ones (because the DOM implementation destroyed and recreated the DOM elements each time). After
<a href="https://commits.webkit.org/286869@main">https://commits.webkit.org/286869@main</a>, the DOM implementation no longer destroys and recreates brand new DOM elements,
instead managing the visibility via CSS content-visibility. This a good change, since we now do significantly less work,
but need to make sure this property stays up-to-date. This commit does that.

* LayoutTests/accessibility/mac/details-summary-expected.txt:
* LayoutTests/accessibility/mac/details-summary.html:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onExpandedChanged):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::HTMLDetailsElement::toggleOpen):

Canonical link: <a href="https://commits.webkit.org/287009@main">https://commits.webkit.org/287009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad083bdb537d0c284003ebc2d5af4392dad1ac98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82554 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29163 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5234 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61002 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18935 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66907 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41305 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48359 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24365 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27506 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69453 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24718 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83916 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5273 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3549 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.html ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69222 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68478 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17108 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12476 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10592 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5221 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7974 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5213 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8645 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->