### PR TITLE
Fix Bugzilla bug tree page in dark mode

### DIFF
--- a/Websites/bugs.webkit.org/skins/custom/global.css
+++ b/Websites/bugs.webkit.org/skins/custom/global.css
@@ -222,7 +222,7 @@ dialog {
     color: var(--text-color);
 }
 
-a {
+a, .summ a, .summ_deep a {
     color: var(--link-color);
     text-decoration: none;
 }
@@ -2634,6 +2634,63 @@ table.file_table {
 .attachment-collapse-toggles {
     line-height: 3rem;
 }
+
+/** Tree & Graph pages **/
+ul.tree li a.b {
+    padding-left: 0;
+    margin-right: 0;
+    text-decoration: none;
+    font-size: 0;
+}
+
+ul.tree li a.b::before {
+    content: "\25B6";
+    font-size: var(--font-size-large);
+    display: inline-block;
+    width: 2rem;
+    height: 2.5rem;
+}
+
+ul.tree li a.b_open {
+    background: none;
+    cursor: pointer;
+}
+
+ul.tree li a.b_open::before {
+    content: "\25BC";
+}
+
+ul.tree li:has(ul) a.b:link {
+    color: var(--link-color);
+}
+
+ul.tree li:not(:has(ul)) a.b {
+    color: var(--text-color-light);
+}
+
+ul.tree li {
+    padding: 0.3rem 0.5rem;
+    text-indent: 0;
+    list-style-type: none;
+    background: none;
+}
+
+.tree_link {
+    margin-left: 0.3rem;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.tree_link svg {
+    display: block;
+    width: var(--font-size-medium);
+    height: auto;
+}
+
+ul.tree .bz_closed a:link {
+    color: var(--visited-color);
+}
+
 
 @media only screen and (max-width: 800px) {
     #bugzilla-body .navigation {

--- a/Websites/bugs.webkit.org/template/en/custom/bug/dependency-tree.html.tmpl
+++ b/Websites/bugs.webkit.org/template/en/custom/bug/dependency-tree.html.tmpl
@@ -1,0 +1,260 @@
+[%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  #
+  # This Source Code Form is "Incompatible With Secondary Licenses", as
+  # defined by the Mozilla Public License, v. 2.0.
+  #%]
+
+[% filtered_desc = blocked_tree.$bugid.short_desc FILTER html %]
+[% PROCESS global/header.html.tmpl
+   title           = "Dependency tree for $terms.Bug $bugid"
+   header          = "Dependency tree for 
+                      <a href=\"show_bug.cgi?id=$bugid\">$terms.Bug $bugid</a>"
+   javascript_urls = ["js/expanding-tree.js"]
+   style_urls      = ['skins/standard/bug.css']
+   subheader       = filtered_desc
+   doc_section     = "using/understanding.html"
+%]
+
+[% PROCESS depthControlToolbar %]
+  
+[% INCLUDE tree_section ids=dependson_ids type=1 %]
+ 
+[% INCLUDE tree_section ids=blocked_ids type=2 %] 
+
+[% PROCESS depthControlToolbar %]
+
+[% PROCESS global/footer.html.tmpl %]
+
+[%###########################################################################%]
+[%# Tree-drawing blocks                                                     #%]
+[%###########################################################################%]
+
+[% BLOCK tree_section %]
+  [%# INTERFACE
+    #   - ids: a list of bug IDs to be displayed as children
+    #   - type: the type of tree. 1 = depends on, 2 = blockeds
+    # GLOBALS
+    #   - seen: Maintains a global hash of bugs that have been displayed
+    #%]
+  [% global.seen = {} %]
+  [%# Display the tree of bugs that this bug depends on. %]
+  <h3>
+    <a href="show_bug.cgi?id=[% bugid %]">[% terms.Bug %] [%+ bugid %]</a> 
+    [% IF type == 1 %]
+        [% tree_name = "dependson_tree" %]
+        [% IF ids.size %]
+            depends on 
+        [% ELSE %]
+            does not depend on any [% 'open ' IF hide_resolved %][% terms.bugs %].
+        [% END %]
+    [% ELSIF type == 2 %]
+        [% tree_name = "blocked_tree" %]
+        [% IF ids.size %] 
+            blocks 
+        [% ELSE %]
+            does not block any [% 'open ' IF hide_resolved %][% terms.bugs %].
+        [% END %]
+    [% END %]
+    [% IF ids.size %]
+        [%+ (ids.size == 1) ? "one" : ids.size %]
+        [%+ IF hide_resolved %]open[% END %]
+        [%+ (ids.size == 1) ? terms.bug : terms.bugs %]:
+    [% END %] 
+  </h3>
+  [% IF ids.size %]
+    [%# 27 chars is the length of buglist.cgi?tweak=&bug_id=" %]
+    [% use_post = (ids.join(",").length > constants.CGI_URI_LIMIT - 27 ) ? 1 : 0 %]
+    [% IF use_post %]
+      <form action="buglist.cgi" method="post">
+      <input type="hidden" name="bug_id" value="[% ids.join(",") %]">
+    [% END %]
+
+    [% IF maxdepth -%]Up to [% maxdepth %] level[% "s" IF maxdepth > 1 %] deep | [% END -%]
+    [% IF use_post %]
+      <button>view as [% terms.bug %] list</button>
+      [% IF user.in_group('editbugs') && ids.size > 1 %]
+        | <button type="submit" name="tweak" value="1">change several</button>
+      [% END %]
+      </form>
+    [% ELSE %]
+      <a href="buglist.cgi?bug_id=[% ids.join(",") %]">view as [% terms.bug %] list</a>
+      [% IF user.in_group('editbugs') && ids.size > 1 %]
+        | <a href="buglist.cgi?bug_id=[% ids.join(",") %]&amp;tweak=1">change several</a>
+      [% END %]
+    [% END %]
+
+    <ul class="tree">
+      [% INCLUDE display_tree tree=$tree_name %]
+    </ul>
+  [% END %]
+[% END %]
+
+
+[% BLOCK display_tree %]
+  [%# INTERFACE
+    #   - bugid: the ID of the bug being displayed
+    #   - tree: a hash of bug objects and of bug dependencies
+    #%]
+  [% bug = tree.$bugid %]
+  <li>
+    [%- INCLUDE bullet bugid=bugid tree=tree -%]
+    <span class="summ[% "_deep" IF tree.dependencies.$bugid.size %]" 
+          id="[% bugid FILTER html %]" 
+          [% IF global.seen.$bugid %]
+            onMouseover="duplicatedover('[% bugid FILTER html %]')"
+            onMouseout="duplicatedout('[% bugid FILTER html %]')"
+          [% END %]>
+      [%- INCLUDE buglink bug=bug bugid=bugid %]
+    </span>
+    [% IF global.seen.$bugid %]
+      <b><a title="Already displayed above; click to locate"
+            onclick="duplicated('[% bugid FILTER html %]')"
+            href="#b[% bugid %]">(*)</a></b>
+    [% ELSIF tree.dependencies.$bugid.size %]
+      <ul>
+        [% FOREACH depid = tree.dependencies.$bugid %]
+          [% INCLUDE display_tree bugid=depid %]
+        [% END %]
+      </ul>
+    [% END %]
+  </li>
+  [% global.seen.$bugid = 1 %]
+[% END %]
+
+[% BLOCK bullet %]
+  [% IF tree.dependencies.$bugid.size && ! global.seen.$bugid %]
+    [% extra_class = " b_open" %]
+    [% extra_args = 'onclick="return doToggle(this, event)"' %] 
+  [% END %]
+  <a id="b[% bugid %]" 
+     class="b [%+ extra_class FILTER none %]"
+     title="Click to expand or contract this portion of the tree. Hold down the Ctrl key while clicking to expand or contract all subtrees."
+     [% extra_args FILTER none %]>&nbsp;&nbsp;</a>
+[% END %]
+
+[% BLOCK buglink %]
+  [% isclosed = !bug.isopened %]
+  [% FILTER closed(isclosed) -%]
+    <a title="[% INCLUDE buginfo bug=bug %]"
+       href="show_bug.cgi?id=[% bugid %]">
+      <b>[%- bugid %]:</b>
+      <span class="summ_text">[%+ bug.short_desc FILTER html %]</span>
+      <span class="summ_info">[[% INCLUDE buginfo %]]</span>
+    </a>
+    <a href="showdependencytree.cgi?id=[% bugid FILTER uri %]"
+       class="tree_link button" title="See dependency tree for [% terms.bug %]  [%+ bugid FILTER html %]">
+       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="currentColor" d="M3.06159045,6.96835546 L4.12604358,5.60116796 L4.38971545,5.76718358 C6.33307483,7.01718358 8.98932483,10.0933555 8.98932483,12.3296836 L8.98932483,17.554293 C8.98932483,18.4039023 9.4092467,18.8628867 10.1709655,18.8628867 C10.9229186,18.8628867 11.3428405,18.4039023 11.3428405,17.554293 L11.3428405,12.3296836 C11.3428405,10.0933555 13.9893248,7.01718358 15.9522155,5.76718358 L16.1572936,5.63046483 L17.1143248,6.93905858 C17.6123717,7.63241796 18.3057311,7.40780858 18.5791686,6.56796483 L19.9365905,2.38827733 C20.1611998,1.71444921 19.7705748,1.16757421 19.0576842,1.16757421 L14.6533873,1.18710546 C13.7744811,1.17733983 13.3643248,1.78280858 13.8526061,2.45663671 L14.7608092,3.69687108 L14.7119811,3.72616796 C12.9053405,4.91757421 10.6983092,7.40780858 10.1904967,9.03866796 L10.1514342,9.03866796 C9.62409045,7.39804296 7.42682483,4.91757421 5.6201842,3.72616796 L5.59088733,3.70663671 L6.46002795,2.58358983 C6.96784045,1.92929296 6.58698108,1.31405858 5.70807483,1.28476171 L1.30377795,1.13827733 C0.590887327,1.10898046 0.180731077,1.63632421 0.385809202,2.31015233 L1.60651233,6.53866796 C1.85065295,7.38827733 2.5342467,7.63241796 3.06159045,6.96835546 Z" transform="rotate(-180 10.166 10)"/></svg>
+    </a>
+  [% END %]
+[% END %]
+
+[% BLOCK buginfo %]
+  [% display_value("bug_status", bug.bug_status) FILTER html -%]
+  [%- IF bug.resolution %] [%+ display_value("resolution", bug.resolution) FILTER html %][% END %];
+  [%-%] assigned to [% bug.assigned_to.login FILTER email FILTER html %]
+  [% IF Param("usetargetmilestone") AND bug.target_milestone %]
+    [%-%]; target: [% bug.target_milestone FILTER html %]
+  [% END %]
+[% END %]
+
+[%###########################################################################%]
+[%# Block for depth control toolbar                                         #%]
+[%###########################################################################%]
+
+[% BLOCK depthControlToolbar %]
+ <table class="dependency_tree_controls">
+   <tr>
+   [%# Hide/show resolved button
+       Swaps text depending on the state of hide_resolved %]
+   <td>
+   <form method="get" action="showdependencytree.cgi">
+     <input name="id" type="hidden" value="[% bugid %]">
+     [% IF maxdepth %]
+       <input name="maxdepth" type="hidden" value="[% maxdepth %]">
+     [% END %]
+     <input type="hidden" name="hide_resolved" value="[% hide_resolved ? 0 : 1 %]">
+     <input type="submit" id="toggle_visibility"
+            value="[% IF hide_resolved %]Show[% ELSE %]Hide[% END %] Resolved">
+   </form>
+   </td>
+
+   <td>
+     Max Depth:
+   </td>
+
+   <td>
+     &nbsp;
+   </td>
+
+   <td>
+   <form method="get" action="showdependencytree.cgi">
+     [%# set to one form %]
+     <input type="submit" id="change_maxdepth" value="1"
+       [% "disabled" IF realdepth < 2 || maxdepth == 1 %]>
+     <input name="id" type="hidden" value="[% bugid %]">
+     <input name="maxdepth" type="hidden" value="1">
+     <input name="hide_resolved" type="hidden" value="[% hide_resolved %]">
+   </form>
+   </td>
+
+   <td>
+   <form method="get" action="showdependencytree.cgi">
+     [%# Minus one form
+         Allow subtracting only when realdepth and maxdepth > 1 %]
+     <input name="id" type="hidden" value="[% bugid %]">
+     <input name="maxdepth" type="hidden" value="[%
+         maxdepth == 1 ? 1
+                       : ( maxdepth ? maxdepth - 1 : realdepth - 1 )
+     %]">
+     <input name="hide_resolved" type="hidden" value="[% hide_resolved %]">
+     <input type="submit" id="decrease_depth" value="&lt;"
+       [% "disabled" IF realdepth < 2 || ( maxdepth && maxdepth < 2 ) %]>
+   </form>
+   </td>
+
+   <td>
+   <form method="get" action="showdependencytree.cgi">
+     [%# Limit entry form: the button cannot do anything when total depth
+         is less than two, so disable it %]
+     <input name="maxdepth" size="4" maxlength="4" value="[%
+         maxdepth > 0 && maxdepth <= realdepth ? maxdepth : ""
+     %]">
+     <input name="id" type="hidden" value="[% bugid %]">
+     <input name="hide_resolved" type="hidden" value="[% hide_resolved %]">
+     <noscript>
+       <input type="submit" id="change_depth" value="Change"
+              [% "disabled" IF realdepth < 2 %]>
+     </noscript>
+   </form>
+   </td>
+
+   <td>
+   <form method="get" action="showdependencytree.cgi">
+     [%# plus one form
+         Disable button if total depth < 2, or if depth set to unlimited %]
+     <input name="id" type="hidden" value="[% bugid %]">
+     [% IF maxdepth %]
+       <input name="maxdepth" type="hidden" value="[% maxdepth + 1 %]">
+     [% END %]
+     <input name="hide_resolved" type="hidden" value="[% hide_resolved %]">
+     <input type="submit" id="increase_depth" value="&gt;"
+        [% "disabled" IF realdepth < 2 || !maxdepth || maxdepth >= realdepth %]>
+   </form>
+   </td>
+
+   <td>
+   <form method="get" action="showdependencytree.cgi">
+     [%# Unlimited button %]
+     <input name="id" type="hidden" value="[% bugid %]">
+     <input name="hide_resolved" type="hidden" value="[% hide_resolved %]">
+     <input type="submit" id="remove_limit"
+       value="Unlimited"
+       [% "disabled" IF maxdepth == 0 || maxdepth == realdepth %]>
+   </form>
+   </td>
+ </tr>
+</table>
+
+[% END %]


### PR DESCRIPTION
#### 189c5d7f08afa336132128cc2156e05e3ca01531
<pre>
Fix Bugzilla bug tree page in dark mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=283580">https://bugs.webkit.org/show_bug.cgi?id=283580</a>

Reviewed by Tim Nguyen.

Updates styles for dark mode and adds SVG artwork for
an improved UI.

Canonical link: <a href="https://commits.webkit.org/286981@main">https://commits.webkit.org/286981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e880680e7d50b9d04398d9fe4f5e6b4fdf0303ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82458 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/29068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5138 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60939 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/29068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80871 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/50914 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66741 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/41241 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/48302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27411 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69384 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24615 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83812 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5179 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/69161 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66734 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68408 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12425 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/10512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12044 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5126 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/5117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/8551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6903 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->