### PR TITLE
REGRESSION (280616@main?): [macOS Debug wk2] ASSERTION FAILED: m_wrapper in *WebCore::JSEventListener::ensureJSFunction(ScriptExecutionContext

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1880,9 +1880,6 @@ imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/b
 # webkit.org/b/282063 REGRESSION (285464@main?) : [ macOS iOS wk2 ] media/remote-control-comman d-is-user-gesture.html is a constant timeout.
 media/remote-control-command-is-user-gesture.html [ Timeout ]
 
-# webkit.org/b/281793 REGRESSION (280616@main?): [macOS Debug wk2] ASSERTION FAILED: m_wrapper in *WebCore::JSEventListener:: ensureJSFunction(ScriptExec utionContext
-[ Debug ] imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-204-205-download-then-same-document.html [ Skip ]
-
 # webkit.org/b/281984 Undo test changes expecting SameSite=Lax cookies by default
 [ Sequoia+ Debug ] imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]
 [ Sequoia+ Debug ] imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window.html [ Failure ]

--- a/Source/WebCore/bindings/js/JSAbortSignalCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAbortSignalCustom.cpp
@@ -48,9 +48,15 @@ bool JSAbortSignalOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> ha
                 *reason = "Has Timeout And Abort Event Listener"_s;
             return true;
         }
-        if (!abortSignal.sourceSignals().isEmptyIgnoringNullReferences()) {
+        if (abortSignal.isDependent()) {
+            if (!abortSignal.sourceSignals().isEmptyIgnoringNullReferences()) {
+                if (UNLIKELY(reason))
+                    *reason = "Has Source Signals And Abort Event Listener"_s;
+                return true;
+            }
+        } else {
             if (UNLIKELY(reason))
-                *reason = "Has Source Signals And Abort Event Listener"_s;
+                *reason = "Has Abort Event Listener"_s;
             return true;
         }
     }

--- a/Source/WebCore/dom/AbortSignal.h
+++ b/Source/WebCore/dom/AbortSignal.h
@@ -77,13 +77,14 @@ public:
     const AbortSignalSet& sourceSignals() const { return m_sourceSignals; }
     AbortSignalSet& sourceSignals() { return m_sourceSignals; }
 
+    bool isDependent() const { return m_isDependent; }
+
 private:
     enum class Aborted : bool { No, Yes };
     explicit AbortSignal(ScriptExecutionContext*, Aborted = Aborted::No, JSC::JSValue reason = JSC::jsUndefined());
 
     void setHasActiveTimeoutTimer(bool hasActiveTimeoutTimer) { m_hasActiveTimeoutTimer = hasActiveTimeoutTimer; }
 
-    bool isDependent() const { return m_isDependent; }
     void markAsDependent() { m_isDependent = true; }
     void addSourceSignal(AbortSignal&);
     void addDependentSignal(AbortSignal&);

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -765,8 +765,8 @@ void Navigation::abortOngoingNavigation(NavigateEvent& event)
             errorInformation.sourceURL = scriptExecutionContext()->url().string();
     }
 
-    if (event.signal())
-        event.signal()->signalAbort(domException);
+    if (RefPtr signal = event.signal())
+        signal->signalAbort(domException);
 
     m_ongoingNavigateEvent = nullptr;
 


### PR DESCRIPTION
#### dd0e9528e748f64e636e40b00421e9d758118851
<pre>
REGRESSION (280616@main?): [macOS Debug wk2] ASSERTION FAILED: m_wrapper in *WebCore::JSEventListener::ensureJSFunction(ScriptExecutionContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=281793">https://bugs.webkit.org/show_bug.cgi?id=281793</a>
<a href="https://rdar.apple.com/138219837">rdar://138219837</a>

Reviewed by Ryosuke Niwa.

The test was crashing because the AbortSignal&apos;s JS wrapper was destroyed
by the time the navigation gets aborted and we attempt to dispatch an
`abort` event on the AbortSignal object.

The AbortSignal object has an `abort` event listener so one would expect
the JS wrapper to be kept alive. However, the logic in
JSAbortSignalOwner::isReachableFromOpaqueRoots() required both having
an `abort` event listener and having source signals. Source signals only
apply to &quot;dependent&quot; signals so it shouldn&apos;t apply here. Tweak this
function to address the lifetime issue.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/bindings/js/JSAbortSignalCustom.cpp:
(WebCore::JSAbortSignalOwner::isReachableFromOpaqueRoots):
* Source/WebCore/dom/AbortSignal.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::abortOngoingNavigation):

Canonical link: <a href="https://commits.webkit.org/286987@main">https://commits.webkit.org/286987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2939ab4f2b899c33a39169344858a3d7e3c501eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82462 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29071 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79930 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5141 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60944 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18886 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50918 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66767 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41246 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/48307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24286 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27414 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24640 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83823 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5182 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69166 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66751 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68414 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12424 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/10527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12050 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5129 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5120 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8554 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6906 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->