### PR TITLE
Compute needed quirks on object construction

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -58,6 +58,7 @@
 #include "NodeRenderStyle.h"
 #include "OrganizationStorageAccessPromptQuirk.h"
 #include "PlatformMouseEvent.h"
+#include "QuirksData.h"
 #include "RegistrableDomain.h"
 #include "ResourceLoadObserver.h"
 #include "SVGElementTypeHelpers.h"
@@ -110,14 +111,6 @@ static HashMap<RegistrableDomain, String>& updatableStorageAccessUserAgentString
     return map.get();
 }
 
-#if PLATFORM(IOS_FAMILY)
-bool Quirks::isYahooMail() const
-{
-    auto host = topDocumentURL().host();
-    return host.startsWith("mail."_s) && PublicSuffixStore::singleton().topPrivatelyControlledDomain(host).startsWith("yahoo."_s);
-}
-#endif
-
 #if USE(APPLE_INTERNAL_SDK)
 #import <WebKitAdditions/QuirksAdditions.cpp>
 #else
@@ -128,6 +121,7 @@ static inline bool shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeIn
 Quirks::Quirks(Document& document)
     : m_document(document)
 {
+    determineRelevantQuirks();
 }
 
 Quirks::~Quirks() = default;
@@ -169,23 +163,7 @@ bool Quirks::isEmbedDomain(const String& domainString) const
 bool Quirks::needsFormControlToBeMouseFocusable() const
 {
 #if PLATFORM(MAC)
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.needsFormControlToBeMouseFocusableQuirk) {
-        m_quirksData.needsFormControlToBeMouseFocusableQuirk = [&] {
-            auto host = topDocumentURL().host();
-            if (host == "ceac.state.gov"_s || host.endsWith(".ceac.state.gov"_s))
-                return true;
-
-            if (host == "weather.com"_s)
-                return true;
-
-            return false;
-        }();
-    }
-
-    return *m_quirksData.needsFormControlToBeMouseFocusableQuirk;
+    return needsQuirks() && m_quirksData.needsFormControlToBeMouseFocusableQuirk;
 #else
     return false;
 #endif // PLATFORM(MAC)
@@ -210,7 +188,7 @@ bool Quirks::needsAutoplayPlayPauseEvents() const
 // - iOS PiP
 bool Quirks::needsSeekingSupportDisabled() const
 {
-    return needsQuirks() && isNetflix();
+    return needsQuirks() && m_quirksData.needsSeekingSupportDisabledQuirk;
 }
 
 // netflix.com https://bugs.webkit.org/show_bug.cgi?id=193301
@@ -221,23 +199,14 @@ bool Quirks::needsPerDocumentAutoplayBehavior() const
     ASSERT(document.ptr() == &document->topDocument());
     return needsQuirks() && allowedAutoplayQuirks(document).contains(AutoplayQuirk::PerDocumentAutoplayBehavior);
 #else
-    if (!needsQuirks())
-        return false;
-
-    return isNetflix();
+    return needsQuirks() && m_quirksData.isNetflix;
 #endif
 }
 
 // zoom.com https://bugs.webkit.org/show_bug.cgi?id=223180
 bool Quirks::shouldAutoplayWebAudioForArbitraryUserGesture() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldAutoplayWebAudioForArbitraryUserGestureQuirk)
-        m_quirksData.shouldAutoplayWebAudioForArbitraryUserGestureQuirk = isDomain("zoom.us"_s);
-
-    return *m_quirksData.shouldAutoplayWebAudioForArbitraryUserGestureQuirk;
+    return needsQuirks() && m_quirksData.shouldAutoplayWebAudioForArbitraryUserGestureQuirk;
 }
 
 // youtube.com https://bugs.webkit.org/show_bug.cgi?id=195598
@@ -246,7 +215,7 @@ bool Quirks::hasBrokenEncryptedMediaAPISupportQuirk() const
 #if ENABLE(THUNDER)
     return false;
 #else
-    return needsQuirks() && isYouTube();
+    return needsQuirks() && m_quirksData.hasBrokenEncryptedMediaAPISupportQuirk;
 #endif
 }
 
@@ -254,7 +223,7 @@ bool Quirks::hasBrokenEncryptedMediaAPISupportQuirk() const
 bool Quirks::isTouchBarUpdateSuppressedForHiddenContentEditable() const
 {
 #if PLATFORM(MAC)
-    return needsQuirks() && isGoogleDocs();
+    return needsQuirks() && m_quirksData.isTouchBarUpdateSuppressedForHiddenContentEditableQuirk;
 #else
     return false;
 #endif
@@ -267,34 +236,10 @@ bool Quirks::isTouchBarUpdateSuppressedForHiddenContentEditable() const
 bool Quirks::isNeverRichlyEditableForTouchBar() const
 {
 #if PLATFORM(MAC)
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.isNeverRichlyEditableForTouchBarQuirk) {
-        m_quirksData.isNeverRichlyEditableForTouchBarQuirk = [&] {
-            auto url = topDocumentURL();
-            auto host = url.host();
-
-            if (host == "onedrive.live.com"_s)
-                return true;
-
-            if (isDomain("trix-editor.org"_s))
-                return true;
-
-            if (host == "www.icloud.com"_s) {
-                auto path = url.path();
-                if (path.contains("notes"_s) || url.fragmentIdentifier().contains("notes"_s))
-                    return true;
-            }
-
-            return false;
-        }();
-    }
-
-    return *m_quirksData.isNeverRichlyEditableForTouchBarQuirk;
-#endif
-
+    return needsQuirks() && m_quirksData.isNeverRichlyEditableForTouchBarQuirk;
+#else
     return false;
+#endif
 }
 
 // docs.google.com rdar://49864669
@@ -302,7 +247,7 @@ bool Quirks::isNeverRichlyEditableForTouchBar() const
 bool Quirks::shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreas() const
 {
 #if PLATFORM(IOS_FAMILY)
-    return needsQuirks() && isGoogleDocs();
+    return needsQuirks() && m_quirksData.shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasQuirk;
 #else
     return false;
 #endif
@@ -315,13 +260,7 @@ bool Quirks::shouldDispatchSyntheticMouseEventsWhenModifyingSelection() const
     if (m_document->settings().shouldDispatchSyntheticMouseEventsWhenModifyingSelection())
         return true;
 
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk)
-        m_quirksData.shouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk = isDomain("medium.com"_s) || isDomain("weebly.com"_s);
-
-    return *m_quirksData.shouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk;
+    return needsQuirks() && m_quirksData.shouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk;
 }
 
 // www.youtube.com rdar://52361019
@@ -331,13 +270,7 @@ bool Quirks::needsYouTubeMouseOutQuirk() const
     if (m_document->settings().shouldDispatchSyntheticMouseOutAfterSyntheticClick())
         return true;
 
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.needsYouTubeMouseOutQuirk)
-        m_quirksData.needsYouTubeMouseOutQuirk = m_document->url().host() == "www.youtube.com"_s;
-
-    return *m_quirksData.needsYouTubeMouseOutQuirk;
+    return needsQuirks() && m_quirksData.needsYouTubeMouseOutQuirk;
 #else
     return false;
 #endif
@@ -347,15 +280,7 @@ bool Quirks::needsYouTubeMouseOutQuirk() const
 // FIXME (rdar://138585709): Remove this quirk for safe.menlosecurity.com once investigation into text corruption on the site is completed and the issue is resolved.
 bool Quirks::shouldDisableWritingSuggestionsByDefault() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldDisableWritingSuggestionsByDefaultQuirk) {
-        auto url = topDocumentURL();
-        m_quirksData.shouldDisableWritingSuggestionsByDefaultQuirk = url.host() == "safe.menlosecurity.com"_s;
-    }
-
-    return *m_quirksData.shouldDisableWritingSuggestionsByDefaultQuirk;
+    return needsQuirks() && m_quirksData.shouldDisableWritingSuggestionsByDefaultQuirk;
 }
 
 void Quirks::updateStorageAccessUserAgentStringQuirks(HashMap<RegistrableDomain, String>&& userAgentStringQuirks)
@@ -402,110 +327,16 @@ bool Quirks::shouldDisableElementFullscreenQuirk() const
     // (Ref: rdar://121473410)
     // YouTube.com does not provide AirPlay controls in fullscreen
     // (Ref: rdar://121471373)
-    if (!m_quirksData.shouldDisableElementFullscreen) {
-        m_quirksData.shouldDisableElementFullscreen = isVimeo()
-            || isDomain("instagram.com"_s)
-            || (PAL::currentUserInterfaceIdiomIsSmallScreen() && isDomain("digitaltrends.com"_s))
-            || (PAL::currentUserInterfaceIdiomIsSmallScreen() && isDomain("as.com"_s))
-            || isEmbedDomain("x.com"_s)
-            || (PAL::currentUserInterfaceIdiomIsSmallScreen() && (isYouTube() || isYoutubeEmbedDomain()));
+    if (!m_quirksData.shouldDisableElementFullscreen && !m_document->isTopDocument()) {
+        m_quirksData.shouldDisableElementFullscreen = isEmbedDomain("x.com"_s)
+            || (PAL::currentUserInterfaceIdiomIsSmallScreen() && isYoutubeEmbedDomain());
     }
 
-    return *m_quirksData.shouldDisableElementFullscreen;
+    return m_quirksData.shouldDisableElementFullscreen;
 #else
     return false;
 #endif
 }
-
-bool Quirks::isAmazon() const
-{
-    if (!m_quirksData.isAmazon)
-        m_quirksData.isAmazon = PublicSuffixStore::singleton().topPrivatelyControlledDomain(topDocumentURL().host()).startsWith("amazon."_s);
-
-    return *m_quirksData.isAmazon;
-}
-
-bool Quirks::isCBSSports() const
-{
-    if (!m_quirksData.isCBSSports)
-        m_quirksData.isCBSSports = isDomain("cbssports.com"_s);
-
-    return *m_quirksData.isCBSSports;
-}
-
-bool Quirks::isGoogleDocs() const
-{
-    if (!m_quirksData.isGoogleDocs)
-        m_quirksData.isGoogleDocs = topDocumentURL().host() == "docs.google.com"_s;
-
-    return *m_quirksData.isGoogleDocs;
-}
-
-bool Quirks::isESPN() const
-{
-    if (!m_quirksData.isESPN)
-        m_quirksData.isESPN = isDomain("espn.com"_s);
-
-    return *m_quirksData.isESPN;
-}
-
-bool Quirks::isFacebook() const
-{
-    if (!m_quirksData.isFacebook)
-        m_quirksData.isFacebook = isDomain("facebook.com"_s);
-
-    return *m_quirksData.isFacebook;
-}
-
-bool Quirks::isSpotifyPlayer() const
-{
-    if (!m_quirksData.isSpotify)
-        m_quirksData.isSpotify = topDocumentURL().host() == "open.spotify.com"_s;
-    return *m_quirksData.isSpotify;
-}
-
-bool Quirks::isGoogleMaps() const
-{
-    if (!m_quirksData.isGoogleMaps) {
-        auto url = topDocumentURL();
-        m_quirksData.isGoogleMaps = PublicSuffixStore::singleton().topPrivatelyControlledDomain(url.host()).startsWith("google."_s) && startsWithLettersIgnoringASCIICase(url.path(), "/maps/"_s);
-    }
-
-    return *m_quirksData.isGoogleMaps;
-}
-
-bool Quirks::isNetflix() const
-{
-    if (!m_quirksData.isNetflix)
-        m_quirksData.isNetflix = isDomain("netflix.com"_s);
-
-    return *m_quirksData.isNetflix;
-}
-
-bool Quirks::isSoundCloud() const
-{
-    if (!m_quirksData.isSoundCloud)
-        m_quirksData.isSoundCloud = isDomain("soundcloud.com"_s);
-
-    return *m_quirksData.isSoundCloud;
-}
-
-bool Quirks::isVimeo() const
-{
-    if (!m_quirksData.isVimeo)
-        m_quirksData.isVimeo = isDomain("vimeo.com"_s);
-
-    return *m_quirksData.isVimeo;
-}
-
-bool Quirks::isYouTube() const
-{
-    if (!m_quirksData.isYouTube)
-        m_quirksData.isYouTube = isDomain("youtube.com"_s);
-
-    return *m_quirksData.isYouTube;
-}
-
 
 #if ENABLE(TOUCH_EVENTS)
 // rdar://49124313
@@ -527,25 +358,29 @@ bool Quirks::shouldDispatchSimulatedMouseEvents(const EventTarget* target) const
         if (!loader || loader->simulatedMouseEventsDispatchPolicy() != SimulatedMouseEventsDispatchPolicy::Allow)
             return QuirksData::ShouldDispatchSimulatedMouseEvents::No;
 
-        if (isAmazon())
+        if (m_quirksData.isAmazon)
             return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
-        if (isGoogleMaps())
+        if (m_quirksData.isGoogleMaps)
+            return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
+        if (m_quirksData.isSoundCloud)
             return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
 
-        auto url = topDocumentURL();
-        auto host = url.host();
+        const URL& topDocumentURL = this->topDocumentURL();
+        const auto registrableDomainString = RegistrableDomain(topDocumentURL).string();
 
-        if (isDomain("wix.com"_s)) {
+        if (registrableDomainString == "wix.com"_s) {
             // Disable simulated mouse dispatching for template selection.
-            return startsWithLettersIgnoringASCIICase(url.path(), "/website/templates/"_s) ? QuirksData::ShouldDispatchSimulatedMouseEvents::No : QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
+            return startsWithLettersIgnoringASCIICase(topDocumentURL.path(), "/website/templates/"_s) ? QuirksData::ShouldDispatchSimulatedMouseEvents::No : QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
         }
 
-        if (isDomain("airtable.com"_s))
+        if (registrableDomainString == "airtable.com"_s)
             return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
-        if (isDomain("flipkart.com"_s))
+        if (registrableDomainString == "flipkart.com"_s)
             return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
-        if (isSoundCloud())
-            return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
+        if (registrableDomainString == "mybinder.org"_s)
+            return QuirksData::ShouldDispatchSimulatedMouseEvents::DependingOnTargetFor_mybinder_org;
+
+        auto host = topDocumentURL.host();
         if (host == "naver.com"_s)
             return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
         if (host.endsWith(".naver.com"_s)) {
@@ -561,8 +396,7 @@ bool Quirks::shouldDispatchSimulatedMouseEvents(const EventTarget* target) const
                 return QuirksData::ShouldDispatchSimulatedMouseEvents::No;
             return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
         }
-        if (isDomain("mybinder.org"_s))
-            return QuirksData::ShouldDispatchSimulatedMouseEvents::DependingOnTargetFor_mybinder_org;
+
         return QuirksData::ShouldDispatchSimulatedMouseEvents::No;
     };
 
@@ -600,14 +434,14 @@ bool Quirks::shouldDispatchedSimulatedMouseEventsAssumeDefaultPrevented(EventTar
     if (!needsQuirks() || !shouldDispatchSimulatedMouseEvents(target))
         return false;
 
-    if (!isAmazon() || !isSoundCloud())
+    if (!m_quirksData.shouldDispatchedSimulatedMouseEventsAssumeDefaultPreventedQuirk)
         return false;
 
     RefPtr element = dynamicDowncast<Element>(target);
     if (!element)
         return false;
 
-    if (isAmazon()) {
+    if (m_quirksData.isAmazon) {
         // When panning on an Amazon product image, we're either touching on the #magnifierLens element
         // or its previous sibling.
         if (element->getIdAttribute() == "magnifierLens"_s)
@@ -616,7 +450,7 @@ bool Quirks::shouldDispatchedSimulatedMouseEventsAssumeDefaultPrevented(EventTar
             return sibling->getIdAttribute() == "magnifierLens"_s;
     }
 
-    if (isSoundCloud())
+    if (m_quirksData.isSoundCloud)
         return element->hasClassName("sceneLayer"_s);
 
     return false;
@@ -629,9 +463,6 @@ bool Quirks::shouldPreventDispatchOfTouchEvent(const AtomString& touchEventType,
         return false;
 
     if (!m_quirksData.shouldPreventDispatchOfTouchEventQuirk)
-        m_quirksData.shouldPreventDispatchOfTouchEventQuirk = topDocumentURL().host() == "sites.google.com"_s;
-
-    if (!m_quirksData.shouldPreventDispatchOfTouchEventQuirk.value())
         return false;
 
     if (RefPtr element = dynamicDowncast<Element>(target); element && touchEventType == eventNames().touchendEvent)
@@ -647,43 +478,17 @@ bool Quirks::shouldPreventDispatchOfTouchEvent(const AtomString& touchEventType,
 // maps.google.com https://bugs.webkit.org/show_bug.cgi?id=214945
 bool Quirks::shouldAvoidResizingWhenInputViewBoundsChange() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldAvoidResizingWhenInputViewBoundsChangeQuirk) {
-        m_quirksData.shouldAvoidResizingWhenInputViewBoundsChangeQuirk = [&] {
-            auto url = topDocumentURL();
-            auto host = url.host();
-
-            if (isDomain("live.com"_s))
-                return true;
-
-            if (isGoogleMaps())
-                return true;
-
-            if (host.endsWith(".sharepoint.com"_s))
-                return true;
-
-            return false;
-        }();
-    }
-
-    return *m_quirksData.shouldAvoidResizingWhenInputViewBoundsChangeQuirk;
+    return needsQuirks() && m_quirksData.shouldAvoidResizingWhenInputViewBoundsChangeQuirk;
 }
 
 // mailchimp.com rdar://47868965
 bool Quirks::shouldDisablePointerEventsQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldDisablePointerEventsQuirk)
-        m_quirksData.shouldDisablePointerEventsQuirk = isDomain("mailchimp.com"_s);
-
-    return *m_quirksData.shouldDisablePointerEventsQuirk;
-#endif
+    return needsQuirks() && m_quirksData.shouldDisablePointerEventsQuirk;
+#else
     return false;
+#endif
 }
 
 // docs.google.com https://bugs.webkit.org/show_bug.cgi?id=199587
@@ -693,7 +498,7 @@ bool Quirks::needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommand() const
     if (m_document->settings().needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk())
         return true;
 
-    return needsQuirks() && isGoogleDocs();
+    return needsQuirks() && m_quirksData.isGoogleDocs;
 #else
     return false;
 #endif
@@ -704,13 +509,7 @@ bool Quirks::needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommand() const
 bool Quirks::needsGMailOverflowScrollQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.needsGMailOverflowScrollQuirk)
-        m_quirksData.needsGMailOverflowScrollQuirk = m_document->url().host() == "mail.google.com"_s;
-
-    return *m_quirksData.needsGMailOverflowScrollQuirk;
+    return needsQuirks() && m_quirksData.needsGMailOverflowScrollQuirk;
 #else
     return false;
 #endif
@@ -720,13 +519,7 @@ bool Quirks::needsGMailOverflowScrollQuirk() const
 bool Quirks::needsIPadSkypeOverflowScrollQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.needsIPadSkypeOverflowScrollQuirk)
-        m_quirksData.needsIPadSkypeOverflowScrollQuirk = m_document->url().host() == "web.skype.com"_s;
-
-    return *m_quirksData.needsIPadSkypeOverflowScrollQuirk;
+    return needsQuirks() && m_quirksData.needsIPadSkypeOverflowScrollQuirk;
 #else
     return false;
 #endif
@@ -737,13 +530,7 @@ bool Quirks::needsIPadSkypeOverflowScrollQuirk() const
 bool Quirks::needsYouTubeOverflowScrollQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.needsYouTubeOverflowScrollQuirk)
-        m_quirksData.needsYouTubeOverflowScrollQuirk = m_document->url().host() == "www.youtube.com"_s;
-
-    return *m_quirksData.needsYouTubeOverflowScrollQuirk;
+    return needsQuirks() && m_quirksData.needsYouTubeOverflowScrollQuirk;
 #else
     return false;
 #endif
@@ -753,13 +540,7 @@ bool Quirks::needsYouTubeOverflowScrollQuirk() const
 bool Quirks::needsPrimeVideoUserSelectNoneQuirk() const
 {
 #if PLATFORM(MAC)
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.needsPrimeVideoUserSelectNoneQuirk)
-        m_quirksData.needsPrimeVideoUserSelectNoneQuirk = isAmazon();
-
-    return *m_quirksData.needsPrimeVideoUserSelectNoneQuirk;
+    return needsQuirks() && m_quirksData.needsPrimeVideoUserSelectNoneQuirk;
 #else
     return false;
 #endif
@@ -769,26 +550,20 @@ bool Quirks::needsPrimeVideoUserSelectNoneQuirk() const
 // NOTE: Also remove `BuilderConverter::convertScrollbarWidth` and related code when removing this quirk.
 bool Quirks::needsScrollbarWidthThinDisabledQuirk() const
 {
-    return needsQuirks() && isYouTube();
+    return needsQuirks() && m_quirksData.needsScrollbarWidthThinDisabledQuirk;
 }
 
 // spotify.com rdar://138918575
 bool Quirks::needsBodyScrollbarWidthNoneDisabledQuirk() const
 {
-    return needsQuirks() && isSpotifyPlayer();
+    return needsQuirks() && m_quirksData.needsBodyScrollbarWidthNoneDisabledQuirk;
 }
 
 // gizmodo.com rdar://102227302
 bool Quirks::needsFullscreenDisplayNoneQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.needsFullscreenDisplayNoneQuirk)
-        m_quirksData.needsFullscreenDisplayNoneQuirk = isDomain("gizmodo.com"_s);
-
-    return *m_quirksData.needsFullscreenDisplayNoneQuirk;
+    return needsQuirks() && m_quirksData.needsFullscreenDisplayNoneQuirk;
 #else
     return false;
 #endif
@@ -798,13 +573,7 @@ bool Quirks::needsFullscreenDisplayNoneQuirk() const
 bool Quirks::needsFullscreenObjectFitQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.needsFullscreenObjectFitQuirk)
-        m_quirksData.needsFullscreenObjectFitQuirk = isDomain("cnn.com"_s);
-
-    return *m_quirksData.needsFullscreenObjectFitQuirk;
+    return needsQuirks() && m_quirksData.needsFullscreenObjectFitQuirk;
 #else
     return false;
 #endif
@@ -814,7 +583,8 @@ bool Quirks::needsFullscreenObjectFitQuirk() const
 bool Quirks::needsWeChatScrollingQuirk() const
 {
 #if PLATFORM(IOS) || PLATFORM(VISION)
-    return needsQuirks() && !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NoWeChatScrollingQuirk) && WTF::IOSApplication::isWechat();
+    static bool shouldUseWeChatScrollingQuirk = !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NoWeChatScrollingQuirk) && WTF::IOSApplication::isWechat();
+    return needsQuirks() && shouldUseWeChatScrollingQuirk;
 #else
     return false;
 #endif
@@ -824,7 +594,7 @@ bool Quirks::needsWeChatScrollingQuirk() const
 bool Quirks::needsGoogleMapsScrollingQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    return needsQuirks() && isGoogleMaps();
+    return needsQuirks() && m_quirksData.needsGoogleMapsScrollingQuirk;
 #else
     return false;
 #endif
@@ -855,7 +625,7 @@ bool Quirks::shouldSilenceResizeObservers() const
     if (!page || !page->isTakingSnapshotsForApplicationSuspension())
         return false;
 
-    return isYouTube();
+    return m_quirksData.shouldSilenceResizeObservers;
 #else
     return false;
 #endif
@@ -867,6 +637,9 @@ bool Quirks::shouldSilenceWindowResizeEvents() const
     if (!needsQuirks())
         return false;
 
+    if (!m_quirksData.shouldSilenceWindowResizeEvents)
+        return false;
+
     // We silence window resize events during the 'homing out' snapshot sequence when on nytimes.com
     // to address <rdar://problem/59763843>, and on x.com (twitter) to address <rdar://problem/58804852> &
     // <rdar://problem/61731801>.
@@ -874,10 +647,7 @@ bool Quirks::shouldSilenceWindowResizeEvents() const
     if (!page || !page->isTakingSnapshotsForApplicationSuspension())
         return false;
 
-    if (!m_quirksData.shouldSilenceWindowResizeEvents)
-        m_quirksData.shouldSilenceWindowResizeEvents = isDomain("nytimes.com"_s) || isDomain("x.com"_s) || isDomain("zillow.com"_s) || isDomain("365scores.com"_s);
-
-    return *m_quirksData.shouldSilenceWindowResizeEvents;
+    return true;
 #else
     return false;
 #endif
@@ -889,16 +659,16 @@ bool Quirks::shouldSilenceMediaQueryListChangeEvents() const
     if (!needsQuirks())
         return false;
 
+    if (!m_quirksData.shouldSilenceMediaQueryListChangeEvents)
+        return false;
+
     // We silence MediaQueryList's change events during the 'homing out' snapshot sequence when on x.com (twitter)
     // to address <rdar://problem/58804852> & <rdar://problem/61731801>.
     auto* page = m_document->page();
     if (!page || !page->isTakingSnapshotsForApplicationSuspension())
         return false;
 
-    if (!m_quirksData.shouldSilenceMediaQueryListChangeEvents)
-        m_quirksData.shouldSilenceMediaQueryListChangeEvents = isDomain("x.com"_s);
-
-    return *m_quirksData.shouldSilenceMediaQueryListChangeEvents;
+    return true;
 #else
     return false;
 #endif
@@ -907,60 +677,30 @@ bool Quirks::shouldSilenceMediaQueryListChangeEvents() const
 // zillow.com rdar://53103732
 bool Quirks::shouldAvoidScrollingWhenFocusedContentIsVisible() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldAvoidScrollingWhenFocusedContentIsVisibleQuirk)
-        m_quirksData.shouldAvoidScrollingWhenFocusedContentIsVisibleQuirk = m_document->url().host() == "www.zillow.com"_s;
-
-    return *m_quirksData.shouldAvoidScrollingWhenFocusedContentIsVisibleQuirk;
+    return needsQuirks() && m_quirksData.shouldAvoidScrollingWhenFocusedContentIsVisibleQuirk;
 }
 
 // att.com rdar://55185021
 bool Quirks::shouldUseLegacySelectPopoverDismissalBehaviorInDataActivation() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk)
-        m_quirksData.shouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk = isDomain("att.com"_s);
-
-    return *m_quirksData.shouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk;
-
+    return needsQuirks() && m_quirksData.shouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk;
 }
 
 // ralphlauren.com rdar://55629493
 bool Quirks::shouldIgnoreAriaForFastPathContentObservationCheck() const
 {
 #if PLATFORM(IOS_FAMILY)
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldIgnoreAriaForFastPathContentObservationCheckQuirk)
-        m_quirksData.shouldIgnoreAriaForFastPathContentObservationCheckQuirk = m_document->url().host() == "www.ralphlauren.com"_s;
-
-    return *m_quirksData.shouldIgnoreAriaForFastPathContentObservationCheckQuirk;
-#endif
+    return needsQuirks() && m_quirksData.shouldIgnoreAriaForFastPathContentObservationCheckQuirk;
+#else
     return false;
-}
-
-static bool isWikipediaDomain(const URL& url)
-{
-    static NeverDestroyed wikipediaDomain = RegistrableDomain { URL { "https://wikipedia.org"_s } };
-    return wikipediaDomain->matches(url);
+#endif
 }
 
 // wikipedia.org https://webkit.org/b/247636
 bool Quirks::shouldIgnoreViewportArgumentsToAvoidExcessiveZoom() const
 {
-    if (!needsQuirks())
-        return false;
-
 #if ENABLE(META_VIEWPORT)
-    if (!m_quirksData.shouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk)
-        m_quirksData.shouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk = isWikipediaDomain(m_document->url());
-
-    return *m_quirksData.shouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk;
+    return needsQuirks() && m_quirksData.shouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk;
 #endif
     return false;
 }
@@ -994,7 +734,7 @@ bool Quirks::shouldOpenAsAboutBlank(const String& stringToOpen) const
 bool Quirks::needsPreloadAutoQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    return needsQuirks() && isVimeo();
+    return needsQuirks() && m_quirksData.needsPreloadAutoQuirk;
 #else
     return false;
 #endif
@@ -1008,28 +748,29 @@ bool Quirks::shouldBypassBackForwardCache() const
     if (!needsQuirks())
         return false;
 
+    if (!m_quirksData.maybeBypassBackForwardCache)
+        return false;
+
     RefPtr document = m_document.get();
-    auto topURL = topDocumentURL();
-    RegistrableDomain registrableDomain { topURL };
 
     // Vimeo.com used to bypass the back/forward cache by serving "Cache-Control: no-store" over HTTPS.
     // We started caching such content in r250437 but the vimeo.com content unfortunately is not currently compatible
     // because it changes the opacity of its body to 0 when navigating away and fails to restore the original opacity
     // when coming back from the back/forward cache (e.g. in 'pageshow' event handler). See <rdar://problem/56996057>.
-    if (topURL.protocolIs("https"_s) && isVimeo()) {
+    if (m_quirksData.isVimeo && topDocumentURL().protocolIs("https"_s)) {
         if (auto* documentLoader = document->frame() ? document->frame()->loader().documentLoader() : nullptr)
             return documentLoader->response().cacheControlContainsNoStore();
     }
 
     // Spinner issue from image search for bing.com.
-    if (registrableDomain == "bing.com"_s) {
+    if (m_quirksData.isBing) {
         static MainThreadNeverDestroyed<const AtomString> imageSearchDialogID("sb_sbidialog"_s);
         if (RefPtr element = document->getElementById(imageSearchDialogID.get()))
             return element->renderer();
     }
 
     // Login issue on bankofamerica.com (rdar://104938789).
-    if (registrableDomain == "bankofamerica.com"_s) {
+    if (m_quirksData.isBankOfAmerica) {
         if (RefPtr window = document->domWindow()) {
             if (window->hasEventListeners(eventNames().unloadEvent)) {
                 static MainThreadNeverDestroyed<const AtomString> signInId("signIn"_s);
@@ -1040,16 +781,18 @@ bool Quirks::shouldBypassBackForwardCache() const
         }
     }
 
-    // Google Docs used to bypass the back/forward cache by serving "Cache-Control: no-store" over HTTPS.
-    // We started caching such content in r250437 but the Google Docs index page unfortunately is not currently compatible
-    // because it puts an overlay (with class "docs-homescreen-freeze-el-full") over the page when navigating away and fails
-    // to remove it when coming back from the back/forward cache (e.g. in 'pageshow' event handler). See <rdar://problem/57670064>.
-    // Note that this does not check for docs.google.com host because of hosted G Suite apps.
-    static MainThreadNeverDestroyed<const AtomString> googleDocsOverlayDivClass("docs-homescreen-freeze-el-full"_s);
-    auto* firstChildInBody = document->body() ? document->body()->firstChild() : nullptr;
-    if (RefPtr div = dynamicDowncast<HTMLDivElement>(firstChildInBody)) {
-        if (div->hasClassName(googleDocsOverlayDivClass))
-            return true;
+    if (m_quirksData.isGoogleProperty) {
+        // Google Docs used to bypass the back/forward cache by serving "Cache-Control: no-store" over HTTPS.
+        // We started caching such content in r250437 but the Google Docs index page unfortunately is not currently compatible
+        // because it puts an overlay (with class "docs-homescreen-freeze-el-full") over the page when navigating away and fails
+        // to remove it when coming back from the back/forward cache (e.g. in 'pageshow' event handler). See <rdar://problem/57670064>.
+        // Note that this does not check for docs.google.com host because of hosted G Suite apps.
+        static MainThreadNeverDestroyed<const AtomString> googleDocsOverlayDivClass("docs-homescreen-freeze-el-full"_s);
+        auto* firstChildInBody = document->body() ? document->body()->firstChild() : nullptr;
+        if (RefPtr div = dynamicDowncast<HTMLDivElement>(firstChildInBody)) {
+            if (div->hasClassName(googleDocsOverlayDivClass))
+                return true;
+        }
     }
 
     return false;
@@ -1059,16 +802,9 @@ bool Quirks::shouldBypassBackForwardCache() const
 // sfusd.edu: rdar://116292738
 bool Quirks::shouldBypassAsyncScriptDeferring() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldBypassAsyncScriptDeferring) {
-        auto domain = RegistrableDomain { topDocumentURL() };
-        // Deferring 'mapbox-gl.js' script on bungalow.com causes the script to get in a bad state (rdar://problem/61658940).
-        // Deferring the google maps script on sfusd.edu may get the page in a bad state (rdar://116292738).
-        m_quirksData.shouldBypassAsyncScriptDeferring = domain == "bungalow.com"_s || domain == "sfusd.edu"_s;
-    }
-    return *m_quirksData.shouldBypassAsyncScriptDeferring;
+    // Deferring 'mapbox-gl.js' script on bungalow.com causes the script to get in a bad state (rdar://problem/61658940).
+    // Deferring the google maps script on sfusd.edu may get the page in a bad state (rdar://116292738).
+    return needsQuirks() && m_quirksData.shouldBypassAsyncScriptDeferring;
 }
 
 // smoothscroll JS library rdar://52712513
@@ -1112,69 +848,35 @@ bool Quirks::shouldMakeEventListenerPassive(const EventTarget& eventTarget, cons
 // baidu.com rdar://56421276
 bool Quirks::shouldEnableLegacyGetUserMediaQuirk() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldEnableLegacyGetUserMediaQuirk) {
-        auto host = m_document->securityOrigin().host();
-        m_quirksData.shouldEnableLegacyGetUserMediaQuirk = host == "www.baidu.com"_s || host == "www.warbyparker.com"_s;
-    }
-
-    return *m_quirksData.shouldEnableLegacyGetUserMediaQuirk;
+    return needsQuirks() && m_quirksData.shouldEnableLegacyGetUserMediaQuirk;
 }
 
 // zoom.us rdar://118185086
 bool Quirks::shouldDisableImageCaptureQuirk() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldDisableImageCaptureQuirk)
-        m_quirksData.shouldDisableImageCaptureQuirk = isDomain("zoom.us"_s);
-
-    return *m_quirksData.shouldDisableImageCaptureQuirk;
+    return needsQuirks() && m_quirksData.shouldDisableImageCaptureQuirk;
 }
 #endif
 
 // hulu.com rdar://55041979
 bool Quirks::needsCanPlayAfterSeekedQuirk() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.needsCanPlayAfterSeekedQuirk) {
-        auto domain = m_document->securityOrigin().domain();
-        m_quirksData.needsCanPlayAfterSeekedQuirk = domain == "hulu.com"_s || domain.endsWith(".hulu.com"_s);
-    }
-
-    return *m_quirksData.needsCanPlayAfterSeekedQuirk;
+    return needsQuirks() && m_quirksData.needsCanPlayAfterSeekedQuirk;
 }
 
 // wikipedia.org rdar://54856323
 bool Quirks::shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraints() const
 {
-    if (!needsQuirks())
-        return false;
-
     // FIXME: We should consider replacing this with a heuristic to determine whether
     // or not the edges of the page mostly lack content after shrinking to fit.
-    if (!m_quirksData.shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk)
-        m_quirksData.shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk = isWikipediaDomain(m_document->url());
-
-    return *m_quirksData.shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk;
+    return needsQuirks() && m_quirksData.shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk;
 }
 
 // mail.yahoo.com rdar://63511613
 bool Quirks::shouldAvoidPastingImagesAsWebContent() const
 {
 #if PLATFORM(IOS_FAMILY)
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldAvoidPastingImagesAsWebContent)
-        m_quirksData.shouldAvoidPastingImagesAsWebContent = isYahooMail();
-
-    return *m_quirksData.shouldAvoidPastingImagesAsWebContent;
+    return needsQuirks() && m_quirksData.shouldAvoidPastingImagesAsWebContent;
 #else
     return false;
 #endif
@@ -1394,64 +1096,45 @@ Quirks::StorageAccessResult Quirks::triggerOptionalStorageAccessQuirk(Element& e
 // youtube.com rdar://66242343
 bool Quirks::needsVP9FullRangeFlagQuirk() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.needsVP9FullRangeFlagQuirk)
-        m_quirksData.needsVP9FullRangeFlagQuirk = m_document->url().host() == "www.youtube.com"_s;
-
-    return *m_quirksData.needsVP9FullRangeFlagQuirk;
+    return needsQuirks() && m_quirksData.needsVP9FullRangeFlagQuirk;
 }
 
+// facebook.com: rdar://67273166
+// forbes.com:
+// reddit.com: rdar://80550715
+// twitter.com: rdar://73369869
 bool Quirks::requiresUserGestureToPauseInPictureInPicture() const
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     // Facebook, X (twitter), and Reddit will naively pause a <video> element that has scrolled out of the viewport,
     // regardless of whether that element is currently in PiP mode.
     // We should remove the quirk once <rdar://problem/67273166>, <rdar://problem/73369869>, and <rdar://problem/80645747> have been fixed.
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.requiresUserGestureToPauseInPictureInPictureQuirk) {
-        auto domain = RegistrableDomain(topDocumentURL()).string();
-        m_quirksData.requiresUserGestureToPauseInPictureInPictureQuirk = isFacebook() || isDomain("x.com"_s) || isDomain("reddit.com"_s) || isDomain("forbes.com"_s);
-    }
-
-    return *m_quirksData.requiresUserGestureToPauseInPictureInPictureQuirk;
+    return needsQuirks() && m_quirksData.requiresUserGestureToPauseInPictureInPictureQuirk;
 #else
     return false;
 #endif
 }
 
+// bbc.co.uk: rdar://126494734
 bool Quirks::returnNullPictureInPictureElementDuringFullscreenChange() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.returnNullPictureInPictureElementDuringFullscreenChangeQuirk)
-        m_quirksData.returnNullPictureInPictureElementDuringFullscreenChangeQuirk = isDomain("bbc.co.uk"_s);
-
-    return *m_quirksData.returnNullPictureInPictureElementDuringFullscreenChangeQuirk;
+    return needsQuirks() && m_quirksData.returnNullPictureInPictureElementDuringFullscreenChangeQuirk;
 }
 
+// twitter.com: rdar://73369869
 bool Quirks::requiresUserGestureToLoadInPictureInPicture() const
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     // X (Twitter) will remove the "src" attribute of a <video> element that has scrolled out of the viewport and
     // load the <video> element with an empty "src" regardless of whether that element is currently in PiP mode.
     // We should remove the quirk once <rdar://problem/73369869> has been fixed.
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.requiresUserGestureToLoadInPictureInPictureQuirk)
-        m_quirksData.requiresUserGestureToLoadInPictureInPictureQuirk = isDomain("x.com"_s);
-
-    return *m_quirksData.requiresUserGestureToLoadInPictureInPictureQuirk;
+    return needsQuirks() && m_quirksData.requiresUserGestureToLoadInPictureInPictureQuirk;
 #else
     return false;
 #endif
 }
 
+// vimeo.com: rdar://problem/70788878
 bool Quirks::blocksReturnToFullscreenFromPictureInPictureQuirk() const
 {
 #if ENABLE(FULLSCREEN_API) && ENABLE(VIDEO_PRESENTATION_MODE)
@@ -1459,23 +1142,26 @@ bool Quirks::blocksReturnToFullscreenFromPictureInPictureQuirk() const
     // returns to fullscreen from picture-in-picture. This quirk disables the "return to fullscreen
     // from picture-in-picture" feature for those sites. We should remove the quirk once
     // rdar://problem/73167931 has been fixed.
-    return needsQuirks() && isVimeo();
+    return needsQuirks() && m_quirksData.blocksReturnToFullscreenFromPictureInPictureQuirk;
 #else
     return false;
 #endif
 }
 
+// vimeo.com: rdar://107592139
 bool Quirks::blocksEnteringStandardFullscreenFromPictureInPictureQuirk() const
 {
 #if ENABLE(FULLSCREEN_API) && ENABLE(VIDEO_PRESENTATION_MODE)
     // Vimeo enters fullscreen when starting playback from the inline play button while already in PIP.
     // This behavior is revealing a bug in the fullscreen handling. See rdar://107592139.
-    return needsQuirks() && isVimeo();
+    return needsQuirks() && m_quirksData.blocksEnteringStandardFullscreenFromPictureInPictureQuirk;
 #else
     return false;
 #endif
 }
 
+// espn.com: rdar://problem/73227900
+// vimeo.com: rdar://problem/73227900
 bool Quirks::shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk() const
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
@@ -1483,24 +1169,19 @@ bool Quirks::shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFull
     // from fullscreen for the sites which cannot handle the event properly in that case.
     // We should remove once the quirks have been fixed.
     // <rdar://90393832> vimeo.com
-    return needsQuirks() && (isESPN() || isVimeo());
+    return needsQuirks() && m_quirksData.shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk;
 #else
     return false;
 #endif
 }
 
+// bbc.com: rdar://108304377
 bool Quirks::shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk() const
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     // This quirk delay the "webkitstartfullscreen" and "fullscreenchange" event when a video exits picture-in-picture
     // to fullscreen.
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk)
-        m_quirksData.shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk = isDomain("bbc.com"_s);
-
-    return *m_quirksData.shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk;
+    return needsQuirks() && m_quirksData.shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk;
 #else
     return false;
 #endif
@@ -1514,9 +1195,10 @@ bool Quirks::shouldAllowNavigationToCustomProtocolWithoutUserGesture(StringView 
 }
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
+// espn.com: rdar://problem/95651814
 bool Quirks::allowLayeredFullscreenVideos() const
 {
-    return needsQuirks() && isESPN();
+    return needsQuirks() && m_quirksData.allowLayeredFullscreenVideos;
 }
 #endif
 
@@ -1525,13 +1207,7 @@ bool Quirks::allowLayeredFullscreenVideos() const
 // FIXME (rdar://124579556): Remove once 'x.com' adjusts video handling for visionOS.
 bool Quirks::shouldDisableFullscreenVideoAspectRatioAdaptiveSizing() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldDisableFullscreenVideoAspectRatioAdaptiveSizingQuirk)
-        m_quirksData.shouldDisableFullscreenVideoAspectRatioAdaptiveSizingQuirk = isDomain("x.com"_s);
-
-    return *m_quirksData.shouldDisableFullscreenVideoAspectRatioAdaptiveSizingQuirk;
+    return needsQuirks() && m_quirksData.shouldDisableFullscreenVideoAspectRatioAdaptiveSizingQuirk;
 }
 #endif
 
@@ -1547,52 +1223,28 @@ bool Quirks::shouldEnableFontLoadingAPIQuirk() const
     if (!needsQuirks() || m_document->settings().downloadableBinaryFontTrustedTypes() == DownloadableBinaryFontTrustedTypes::Any)
         return false;
 
-    if (!m_quirksData.shouldEnableFontLoadingAPIQuirk)
-        m_quirksData.shouldEnableFontLoadingAPIQuirk = m_document->url().host() == "play.hbomax.com"_s;
-
-    return *m_quirksData.shouldEnableFontLoadingAPIQuirk;
+    return m_quirksData.shouldEnableFontLoadingAPIQuirk;
 }
 
 // hulu.com rdar://100199996
 bool Quirks::needsVideoShouldMaintainAspectRatioQuirk() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.needsVideoShouldMaintainAspectRatioQuirk)
-        m_quirksData.needsVideoShouldMaintainAspectRatioQuirk = isDomain("hulu.com"_s);
-
-    return *m_quirksData.needsVideoShouldMaintainAspectRatioQuirk;
+    return needsQuirks() && m_quirksData.needsVideoShouldMaintainAspectRatioQuirk;
 }
 
+// Marcus: <rdar://101086391>.
+// Pandora: <rdar://100243111>.
+// Soundcloud: <rdar://102913500>.
 bool Quirks::shouldExposeShowModalDialog() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldExposeShowModalDialog) {
-        // Marcus: <rdar://101086391>.
-        // Pandora: <rdar://100243111>.
-        // Soundcloud: <rdar://102913500>.
-        m_quirksData.shouldExposeShowModalDialog = isDomain("pandora.com"_s) || isDomain("marcus.com"_s) || isSoundCloud();
-    }
-
-    return *m_quirksData.shouldExposeShowModalDialog;
+    return needsQuirks() && m_quirksData.shouldExposeShowModalDialog;
 }
 
 // marcus.com rdar://102959860
 bool Quirks::shouldNavigatorPluginsBeEmpty() const
 {
 #if PLATFORM(IOS_FAMILY)
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldNavigatorPluginsBeEmpty) {
-        // Marcus login issue: <rdar://103011164>.
-        m_quirksData.shouldNavigatorPluginsBeEmpty = isDomain("marcus.com"_s);
-    }
-
-    return *m_quirksData.shouldNavigatorPluginsBeEmpty;
+    return needsQuirks() && m_quirksData.shouldNavigatorPluginsBeEmpty;
 #else
     return false;
 #endif
@@ -1601,43 +1253,19 @@ bool Quirks::shouldNavigatorPluginsBeEmpty() const
 // Fix for the UNIQLO app (rdar://104519846).
 bool Quirks::shouldDisableLazyIframeLoadingQuirk() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldDisableLazyIframeLoadingQuirk) {
-#if PLATFORM(IOS_FAMILY)
-        m_quirksData.shouldDisableLazyIframeLoadingQuirk = !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NoUNIQLOLazyIframeLoadingQuirk) && WTF::IOSApplication::isUNIQLOApp();
-#else
-        m_quirksData.shouldDisableLazyIframeLoadingQuirk = false;
-#endif
-    }
-
-    return *m_quirksData.shouldDisableLazyIframeLoadingQuirk;
+    return needsQuirks() && m_quirksData.shouldDisableLazyIframeLoadingQuirk;
 }
 
 // Breaks express checkout on victoriassecret.com (rdar://104818312).
 bool Quirks::shouldDisableFetchMetadata() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldDisableFetchMetadata)
-        m_quirksData.shouldDisableFetchMetadata = isDomain("victoriassecret.com"_s);
-
-    return *m_quirksData.shouldDisableFetchMetadata;
+    return needsQuirks() && m_quirksData.shouldDisableFetchMetadata;
 }
 
 // Push state file path restrictions break Mimeo Photo Plugin (rdar://112445672).
 bool Quirks::shouldDisablePushStateFilePathRestrictions() const
 {
-    if (!needsQuirks())
-        return false;
-
-#if PLATFORM(MAC)
-    return WTF::MacApplication::isMimeoPhotoProject();
-#else
-    return false;
-#endif
+    return needsQuirks() && m_quirksData.shouldDisablePushStateFilePathRestrictions;
 }
 
 // ungap/@custom-elements polyfill (rdar://problem/111008826).
@@ -1695,7 +1323,7 @@ String Quirks::advancedPrivacyProtectionSubstituteDataURLForScriptWithFeatures(c
 bool Quirks::needsResettingTransitionCancelsRunningTransitionQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    return needsQuirks() && !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ResettingTransitionCancelsRunningTransitionQuirk) && WTF::IOSApplication::isDOFUSTouch();
+    return needsQuirks() && m_quirksData.needsResettingTransitionCancelsRunningTransitionQuirk;
 #else
     return false;
 #endif
@@ -1704,13 +1332,7 @@ bool Quirks::needsResettingTransitionCancelsRunningTransitionQuirk() const
 // Microsoft office online generates data URLs with incorrect padding on Safari only (rdar://114573089).
 bool Quirks::shouldDisableDataURLPaddingValidation() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldDisableDataURLPaddingValidation)
-        m_quirksData.shouldDisableDataURLPaddingValidation = m_document->url().host().endsWith("officeapps.live.com"_s) || m_document->url().host().endsWith("onedrive.live.com"_s);
-
-    return *m_quirksData.shouldDisableDataURLPaddingValidation;
+    return needsQuirks() && m_quirksData.shouldDisableDataURLPaddingValidation;
 }
 
 bool Quirks::needsDisableDOMPasteAccessQuirk() const
@@ -1737,27 +1359,17 @@ bool Quirks::needsDisableDOMPasteAccessQuirk() const
     return *m_quirksData.needsDisableDOMPasteAccessQuirk;
 }
 
+// rdar://133423460
 bool Quirks::shouldPreventOrientationMediaQueryFromEvaluatingToLandscape() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk)
-        m_quirksData.shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk = shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeInternal(topDocumentURL());
-
-    return *m_quirksData.shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk;
+    return needsQuirks() && m_quirksData.shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk;
 }
 
+// rdar://133423460
 bool Quirks::shouldFlipScreenDimensions() const
 {
 #if ENABLE(FLIP_SCREEN_DIMENSIONS_QUIRKS)
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldFlipScreenDimensionsQuirk)
-        m_quirksData.shouldFlipScreenDimensionsQuirk = shouldFlipScreenDimensionsInternal(topDocumentURL());
-
-    return *m_quirksData.shouldFlipScreenDimensionsQuirk;
+    return needsQuirks() && m_quirksData.shouldFlipScreenDimensionsQuirk;
 #else
     return false;
 #endif
@@ -1766,13 +1378,7 @@ bool Quirks::shouldFlipScreenDimensions() const
 // FIXME: Remove this when rdar://137625935 is resolved.
 bool Quirks::shouldAllowDownloadsInSpiteOfCSP() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldAllowDownloadsInSpiteOfCSPQuirk)
-        m_quirksData.shouldAllowDownloadsInSpiteOfCSPQuirk = isDomain("apple.com"_s);
-
-    return *m_quirksData.shouldAllowDownloadsInSpiteOfCSPQuirk;
+    return needsQuirks() && m_quirksData.shouldAllowDownloadsInSpiteOfCSPQuirk;
 }
 
 // This section is dedicated to UA override for iPad. iPads (but iPad Mini) are sending a desktop user agent
@@ -1849,16 +1455,11 @@ bool Quirks::needsDesktopUserAgent(const URL& url)
     return needsDesktopUserAgentInternal(url);
 }
 
+// premierleague.com: rdar://123721211
 bool Quirks::shouldIgnorePlaysInlineRequirementQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldIgnorePlaysInlineRequirementQuirk)
-        m_quirksData.shouldIgnorePlaysInlineRequirementQuirk = isDomain("premierleague.com"_s);
-
-    return *m_quirksData.shouldIgnorePlaysInlineRequirementQuirk;
+    return needsQuirks() && m_quirksData.shouldIgnorePlaysInlineRequirementQuirk;
 #else
     return false;
 #endif
@@ -1884,24 +1485,17 @@ bool Quirks::shouldUseEphemeralPartitionedStorageForDOMCookies(const URL& url) c
 bool Quirks::needsGetElementsByNameQuirk() const
 {
 #if PLATFORM(IOS)
-    return needsQuirks() && !PAL::currentUserInterfaceIdiomIsSmallScreen() && !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NoGetElementsByNameQuirk);
+    return needsQuirks() && m_quirksData.needsGetElementsByNameQuirk;
 #else
     return false;
 #endif
 }
 
+// tripadvisor.com: rdar://112851939
 // FIXME: Remove this quirk when <rdar://127247321> is complete
 bool Quirks::needsRelaxedCorsMixedContentCheckQuirk() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.needsRelaxedCorsMixedContentCheckQuirk) {
-        auto host = m_document->url().host();
-        m_quirksData.needsRelaxedCorsMixedContentCheckQuirk = host == "tripadvisor.com"_s || host.endsWith(".tripadvisor.com"_s);
-    }
-
-    return *m_quirksData.needsRelaxedCorsMixedContentCheckQuirk;
+    return needsQuirks() && m_quirksData.needsRelaxedCorsMixedContentCheckQuirk;
 }
 
 // rdar://127398734
@@ -1914,16 +1508,10 @@ bool Quirks::needsLaxSameSiteCookieQuirk(const URL& requestURL) const
     return url.protocolIs("https"_s) && url.host() == "login.microsoftonline.com"_s && requestURL.protocolIs("https"_s) && requestURL.host() == "www.bing.com"_s;
 }
 #if ENABLE(TEXT_AUTOSIZING)
-// rdar://127246368
+// news.ycombinator.com: rdar://127246368
 bool Quirks::shouldIgnoreTextAutoSizing() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldIgnoreTextAutoSizingQuirk)
-        m_quirksData.shouldIgnoreTextAutoSizingQuirk = topDocumentURL().host() == "news.ycombinator.com"_s;
-
-    return *m_quirksData.shouldIgnoreTextAutoSizingQuirk;
+    return needsQuirks() && m_quirksData.shouldIgnoreTextAutoSizingQuirk;
 }
 #endif
 
@@ -1939,18 +1527,19 @@ std::optional<TargetedElementSelectors> Quirks::defaultVisibilityAdjustmentSelec
 
 String Quirks::scriptToEvaluateBeforeRunningScriptFromURL(const URL& scriptURL)
 {
+#if PLATFORM(IOS_FAMILY)
     if (!needsQuirks())
         return { };
 
-#if PLATFORM(IOS_FAMILY)
-    auto topDomain = RegistrableDomain(topDocumentURL()).string();
+    if (!m_quirksData.needsScriptToEvaluateBeforeRunningScriptFromURLQuirk)
+        return { };
 
     // player.anyclip.com rdar://138789765
-    if (UNLIKELY(topDomain == "thesaurus.com"_s && scriptURL.lastPathComponent().endsWith("lre.js"_s)) && scriptURL.host() == "player.anyclip.com"_s)
+    if (UNLIKELY(m_quirksData.isThesaurus && scriptURL.lastPathComponent().endsWith("lre.js"_s)) && scriptURL.host() == "player.anyclip.com"_s)
         return "(function() { let userAgent = navigator.userAgent; Object.defineProperty(navigator, 'userAgent', { get: () => { return userAgent + ' Chrome/130.0.0.0 Android/15.0'; }, configurable: true }); })();"_s;
 
 #if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
-    if (UNLIKELY(topDomain == "webex.com"_s && scriptURL.lastPathComponent().startsWith("pushdownload."_s)))
+    if (UNLIKELY(m_quirksData.isWebEx && scriptURL.lastPathComponent().startsWith("pushdownload."_s)))
         return "Object.defineProperty(window, 'Touch', { get: () => undefined });"_s;
 #endif
 #else
@@ -1960,16 +1549,11 @@ String Quirks::scriptToEvaluateBeforeRunningScriptFromURL(const URL& scriptURL)
     return { };
 }
 
+// disneyplus: rdar://137613110
 bool Quirks::shouldHideCoarsePointerCharacteristics() const
 {
 #if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldHideCoarsePointerCharacteristicsQuirk)
-        m_quirksData.shouldHideCoarsePointerCharacteristicsQuirk = isDomain("disneyplus.com"_s);
-
-    return *m_quirksData.shouldHideCoarsePointerCharacteristicsQuirk;
+    return needsQuirks() && m_quirksData.shouldHideCoarsePointerCharacteristicsQuirk;
 #else
     return false;
 #endif
@@ -1979,15 +1563,7 @@ bool Quirks::shouldHideCoarsePointerCharacteristics() const
 bool Quirks::implicitMuteWhenVolumeSetToZero() const
 {
 #if HAVE(MEDIA_VOLUME_PER_ELEMENT)
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.implicitMuteWhenVolumeSetToZero) {
-        auto domain = RegistrableDomain(topDocumentURL()).string();
-        m_quirksData.implicitMuteWhenVolumeSetToZero = domain == "hulu.com"_s || domain.endsWith(".hulu.com"_s);
-    }
-
-    return *m_quirksData.implicitMuteWhenVolumeSetToZero;
+    return needsQuirks() && m_quirksData.implicitMuteWhenVolumeSetToZero;
 #else
     return false;
 #endif
@@ -2000,45 +1576,28 @@ bool Quirks::shouldOmitTouchEventDOMAttributesForDesktopWebsite(const URL& reque
     return requestURL.host() == "secure.chase.com"_s;
 }
 
+// soylent.*; rdar://113314067
 bool Quirks::shouldDispatchPointerOutAfterHandlingSyntheticClick() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.shouldDispatchPointerOutAfterHandlingSyntheticClick) {
-        // Remove once rdar://139397190 is fixed.
-        m_quirksData.shouldDispatchPointerOutAfterHandlingSyntheticClick = domainStartsWith("soylent."_s);
-    }
-
-    return *m_quirksData.shouldDispatchPointerOutAfterHandlingSyntheticClick;
+    return needsQuirks() && m_quirksData.shouldDispatchPointerOutAfterHandlingSyntheticClick;
 }
 
 #endif // ENABLE(TOUCH_EVENTS)
 
+// max.com: rdar://138424489
 bool Quirks::needsZeroMaxTouchPointsQuirk() const
 {
 #if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.needsZeroMaxTouchPointsQuirk)
-        m_quirksData.needsZeroMaxTouchPointsQuirk = isDomain("max.com"_s);
-
-    return *m_quirksData.needsZeroMaxTouchPointsQuirk;
+    return needsQuirks() && m_quirksData.needsZeroMaxTouchPointsQuirk;
 #else
     return false;
 #endif
 }
 
+// imdb.com: rdar://137991466
 bool Quirks::needsChromeMediaControlsPseudoElement() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.needsChromeMediaControlsPseudoElementQuirk)
-        m_quirksData.needsChromeMediaControlsPseudoElementQuirk = isDomain("imdb.com"_s);
-
-    return *m_quirksData.needsChromeMediaControlsPseudoElementQuirk;
+    return needsQuirks() && m_quirksData.needsChromeMediaControlsPseudoElementQuirk;
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -2049,10 +1608,13 @@ bool Quirks::shouldSynthesizeTouchEventsAfterNonSyntheticClick(const Element& ta
     if (!needsQuirks())
         return false;
 
-    if (isCBSSports())
+    if (!m_quirksData.shouldSynthesizeTouchEventsAfterNonSyntheticClickQuirk)
+        return false;
+
+    if (m_quirksData.isCBSSports)
         return target.nodeName() == "AVIA-BUTTON"_s;
 
-    if (isGoogleDocs()) {
+    if (m_quirksData.isGoogleDocs) {
         unsigned numberOfAncestorsToCheck = 3;
         for (Ref ancestor : lineageOfType<HTMLElement>(target)) {
             if (ancestor->hasClassName("docs-ml-promotion-action-container"_s))
@@ -2071,15 +1633,13 @@ static AccessibilityRole accessibilityRole(const Element& element)
     return AccessibilityObject::ariaRoleToWebCoreRole(element.attributeWithoutSynchronization(HTMLNames::roleAttr));
 }
 
+// walmart.com: rdar://123734840
 bool Quirks::shouldIgnoreContentObservationForClick(const Node& targetNode) const
 {
     if (!needsQuirks())
         return false;
 
     if (!m_quirksData.mayNeedToIgnoreContentObservation)
-        m_quirksData.mayNeedToIgnoreContentObservation = isDomain("walmart.com"_s);
-
-    if (!m_quirksData.mayNeedToIgnoreContentObservation.value())
         return false;
 
     RefPtr target = dynamicDowncast<Element>(targetNode);
@@ -2095,15 +1655,10 @@ bool Quirks::shouldIgnoreContentObservationForClick(const Node& targetNode) cons
 
 #endif // PLATFORM(IOS_FAMILY)
 
+// outlook.live.com: rdar://136624720
 bool Quirks::needsMozillaFileTypeForDataTransfer() const
 {
-    if (!needsQuirks())
-        return false;
-
-    if (!m_quirksData.needsMozillaFileTypeForDataTransferQuirk)
-        m_quirksData.needsMozillaFileTypeForDataTransferQuirk = topDocumentURL().host() == "outlook.live.com"_s;
-
-    return *m_quirksData.needsMozillaFileTypeForDataTransferQuirk;
+    return needsQuirks() && m_quirksData.needsMozillaFileTypeForDataTransferQuirk;
 }
 
 // bing.com rdar://126573838
@@ -2112,12 +1667,7 @@ bool Quirks::needsBingGestureEventQuirk(EventTarget* target) const
     if (!needsQuirks())
         return false;
 
-    if (!m_quirksData.needsBingGestureEventQuirk) {
-        auto url = topDocumentURL();
-        m_quirksData.needsBingGestureEventQuirk = url.host() == "www.bing.com"_s && startsWithLettersIgnoringASCIICase(url.path(), "/maps"_s);
-    }
-
-    if (!m_quirksData.needsBingGestureEventQuirk.value())
+    if (!m_quirksData.needsBingGestureEventQuirk)
         return false;
 
     if (RefPtr element = dynamicDowncast<Element>(target)) {
@@ -2135,11 +1685,12 @@ bool Quirks::shouldAvoidStartingSelectionOnMouseDown(const Node& target) const
     if (!needsQuirks())
         return false;
 
-    if (isSpotifyPlayer()) {
-        if (CheckedPtr style = target.renderStyle()) {
-            if (style->usedTouchActions().contains(TouchAction::None) && style->cursor() == CursorType::Pointer)
-                return true;
-        }
+    if (!m_quirksData.shouldAvoidStartingSelectionOnMouseDown)
+        return false;
+
+    if (CheckedPtr style = target.renderStyle()) {
+        if (style->usedTouchActions().contains(TouchAction::None) && style->cursor() == CursorType::Pointer)
+            return true;
     }
 #else
     UNUSED_PARAM(target);
@@ -2185,7 +1736,7 @@ bool Quirks::needsFacebookStoriesCreationFormQuirk(const Element& element, const
     if (!needsQuirks())
         return false;
 
-    if (!isFacebook())
+    if (!m_quirksData.isFacebook)
         return false;
 
     if (!topDocumentURL().path().startsWith("/stories/create"_s)) {
@@ -2241,6 +1792,996 @@ URL Quirks::topDocumentURL() const
 void Quirks::setTopDocumentURLForTesting(URL&& url)
 {
     m_topDocumentURLForTesting = WTFMove(url);
+    determineRelevantQuirks();
+}
+
+// FIXME(rdar://141554467): The set of static functions below will be generated from a JSON file in a future patch. For now, we just move the logic
+// for deciding if a particular quirk is needed to domain-specific functionss below:
+#if PLATFORM(IOS) || PLATFORM(VISION)
+static void handle365ScoresQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "365scores.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // 365scores.com rdar://116491386
+    quirksData.shouldSilenceWindowResizeEvents = true;
+}
+
+static void handleNYTimesQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "nytimes.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // nytimes.com: rdar://problem/5976384
+    quirksData.shouldSilenceWindowResizeEvents = true;
+}
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+static void handleASQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "as.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // as.com: rdar://121014613
+    quirksData.shouldDisableElementFullscreen = PAL::currentUserInterfaceIdiomIsSmallScreen();
+}
+
+static void handleATTQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "att.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // att.com rdar://55185021
+    quirksData.shouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk = true;
+}
+
+static void handleCBSSportsQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "cbssports.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    quirksData.isCBSSports = true;
+    // Remove this once rdar://139478801 is resolved.
+    quirksData.shouldSynthesizeTouchEventsAfterNonSyntheticClickQuirk = true;
+}
+
+static void handleCNNQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "cnn.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // cnn.com rdar://119640248
+    quirksData.needsFullscreenObjectFitQuirk = true;
+}
+
+static void handleDigitalTrendsQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "digitaltrends.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // digitaltrends.com rdar://121014613
+    quirksData.shouldDisableElementFullscreen = PAL::currentUserInterfaceIdiomIsSmallScreen();
+}
+
+static void handleGizmodoQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "gizmodo.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // gizmodo.com rdar://102227302
+    quirksData.needsFullscreenDisplayNoneQuirk = true;
+}
+
+static void handleInstagramQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "instagram.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // instagram.com rdar://121014613
+    quirksData.shouldDisableElementFullscreen = true;
+}
+
+static void handleMailChimpQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "mailchimp.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // mailchimp.com rdar://47868965
+    quirksData.shouldDisablePointerEventsQuirk = true;
+}
+
+static void handleRalphLaurenQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "ralphlauren.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // ralphlauren.com rdar://55629493
+    quirksData.shouldIgnoreAriaForFastPathContentObservationCheckQuirk = true;
+}
+
+static void handleSkypeQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    UNUSED_PARAM(quirksDomainString);
+    UNUSED_PARAM(documentURL);
+    auto topDocumentHost = quirksURL.host();
+    if (topDocumentHost != "web.skype.com"_s)
+        return;
+
+    // web.skype.com webkit.org/b/275941
+    quirksData.needsIPadSkypeOverflowScrollQuirk = true;
+}
+
+static void handleWalmartQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "walmart.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // walmart.com: rdar://123734840
+    quirksData.mayNeedToIgnoreContentObservation = true;
+}
+
+static void handleYahooQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    UNUSED_PARAM(documentURL);
+    UNUSED_PARAM(quirksDomainString);
+
+    auto topDocumentHost = quirksURL.host();
+    if (topDocumentHost.startsWith("mail."_s)) {
+        // mail.yahoo.com rdar://63511613
+        quirksData.shouldAvoidPastingImagesAsWebContent = true;
+    }
+}
+
+static void handleScriptToEvaluateBeforeRunningScriptFromURLQuirk(QuirksData& quirksData, const URL& quirksURL, const String& topDomain, const URL& documentURL)
+{
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+
+    if (topDomain == "thesaurus.com"_s) {
+        quirksData.isThesaurus = true;
+        quirksData.needsScriptToEvaluateBeforeRunningScriptFromURLQuirk = true;
+    }
+
+#if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
+    if (topDomain == "webex.com"_s) {
+        quirksData.isWebEx = true;
+        quirksData.needsScriptToEvaluateBeforeRunningScriptFromURLQuirk = true;
+    }
+#endif
+}
+#endif
+
+#if PLATFORM(MAC)
+static void handleCEACStateGovQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    UNUSED_PARAM(documentURL);
+    UNUSED_PARAM(quirksDomainString);
+    auto topDocumentHost = quirksURL.host();
+    if (topDocumentHost == "ceac.state.gov"_s || topDocumentHost.endsWith(".ceac.state.gov"_s)) {
+        // ceac.state.gov https://bugs.webkit.org/show_bug.cgi?id=193478
+        quirksData.needsFormControlToBeMouseFocusableQuirk = true;
+    }
+}
+
+static void handleICloudQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "icloud.com"_s)
+        return;
+
+    UNUSED_PARAM(documentURL);
+    // icloud.com rdar://26013388
+    quirksData.isNeverRichlyEditableForTouchBarQuirk = quirksURL.path().contains("notes"_s) || quirksURL.fragmentIdentifier().contains("notes"_s);
+}
+
+static void handleTrixEditorQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "trix-editor.org"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // trix-editor.org rdar://28242210
+    quirksData.isNeverRichlyEditableForTouchBarQuirk = true;
+}
+
+static void handleWeatherQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "weather.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // weather.com rdar://139689157
+    quirksData.needsFormControlToBeMouseFocusableQuirk = true;
+}
+#endif
+
+#if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
+static void handleDisneyPlusQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "disneyplus.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // disneyplus rdar://137613110
+    quirksData.shouldHideCoarsePointerCharacteristicsQuirk = true;
+}
+
+static void handleMaxQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "max.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // max.com: rdar://138424489
+    quirksData.needsZeroMaxTouchPointsQuirk = true;
+}
+#endif
+
+#if ENABLE(MEDIA_STREAM)
+static void handleBaiduQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    UNUSED_PARAM(quirksDomainString);
+    UNUSED_PARAM(documentURL);
+    auto topDocumentHost = quirksURL.host();
+    if (topDocumentHost != "www.baidu.com"_s)
+        return;
+
+    // baidu.com rdar://56421276
+    quirksData.shouldEnableLegacyGetUserMediaQuirk = true;
+}
+
+static void handleWarbyParkerQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "warbyparker.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // warbyparker.com rdar://72839707
+    quirksData.shouldEnableLegacyGetUserMediaQuirk = true;
+}
+#endif
+
+#if ENABLE(TEXT_AUTOSIZING)
+static void handleYCombinatorQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    UNUSED_PARAM(quirksDomainString);
+    UNUSED_PARAM(documentURL);
+    auto topDocumentHost = quirksURL.host();
+    if (topDocumentHost != "news.ycombinator.com"_s)
+        return;
+
+    // news.ycombinator.com: rdar://127246368
+    quirksData.shouldIgnoreTextAutoSizingQuirk = true;
+}
+#endif
+
+#if ENABLE(TOUCH_EVENTS)
+static void handleSoylentQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(quirksDomainString);
+    UNUSED_PARAM(documentURL);
+
+    // soylent.*: rdar://113314067
+    quirksData.shouldDispatchPointerOutAfterHandlingSyntheticClick = true;
+}
+#endif
+
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+static void handleFacebookQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "facebook.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    quirksData.isFacebook = true;
+    // facebook.com rdar://67273166
+    quirksData.requiresUserGestureToPauseInPictureInPictureQuirk = true;
+}
+
+static void handleForbesQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "forbes.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // forbes.com rdar://67273166
+    quirksData.requiresUserGestureToPauseInPictureInPictureQuirk = true;
+}
+
+static void handleRedditQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "reddit.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // reddit.com: rdar://80550715
+    quirksData.requiresUserGestureToPauseInPictureInPictureQuirk = true;
+}
+#endif
+
+static void handleAmazonQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    UNUSED_PARAM(quirksDomainString);
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    quirksData.isAmazon = true;
+    // amazon.com rdar://49124529
+    quirksData.shouldDispatchedSimulatedMouseEventsAssumeDefaultPreventedQuirk = true;
+#if PLATFORM(MAC)
+    // amazon.com rdar://128962002
+    quirksData.needsPrimeVideoUserSelectNoneQuirk = true;
+#endif
+}
+
+static void handleAppleQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "apple.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // FIXME: Remove this when rdar://137625935 is resolved.
+    quirksData.shouldAllowDownloadsInSpiteOfCSPQuirk = true;
+}
+
+static void handleBBCQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+
+    if (quirksDomainString == "bbc.co.uk"_s) {
+        // bbc.co.uk rdar://126494734
+        quirksData.returnNullPictureInPictureElementDuringFullscreenChangeQuirk = true;
+    }
+
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    if (quirksDomainString == "bbc.com"_s) {
+        // bbc.com rdar://108304377
+        quirksData.shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk = true;
+    }
+#endif
+}
+
+static void handleBankOfAmericaQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "bankofamerica.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    quirksData.isBankOfAmerica = true;
+    // Login issue on bankofamerica.com (rdar://104938789).
+    quirksData.maybeBypassBackForwardCache = true;
+}
+
+static void handleBingQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "bing.com"_s)
+        return;
+
+    UNUSED_PARAM(documentURL);
+    quirksData.isBing = true;
+    // bing.com rdar://133223599
+    quirksData.maybeBypassBackForwardCache = true;
+    // bing.com rdar://126573838
+    auto topDocumentHost = quirksURL.host();
+    quirksData.needsBingGestureEventQuirk = topDocumentHost == "www.bing.com"_s && startsWithLettersIgnoringASCIICase(quirksURL.path(), "/maps"_s);
+}
+
+static void handleBungalowQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "bungalow.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // bungalow.com rdar://61658940
+    quirksData.shouldBypassAsyncScriptDeferring = true;
+}
+
+static void handleESPNQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "espn.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    quirksData.isESPN = true;
+#if PLATFORM(IOS) || PLATFORM(VISION)
+    // espn.com rdar://problem/95651814
+    quirksData.allowLayeredFullscreenVideos = true;
+#endif
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    // espn.com rdar://problem/73227900
+    quirksData.shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk = true;
+#endif
+}
+
+static void handleGoogleQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    UNUSED_PARAM(quirksDomainString);
+    UNUSED_PARAM(documentURL);
+    quirksData.isGoogleProperty = true;
+    auto topDocumentHost = quirksURL.host();
+    if (startsWithLettersIgnoringASCIICase(quirksURL.path(), "/maps/"_s)) {
+        quirksData.isGoogleMaps = true;
+#if PLATFORM(IOS_FAMILY)
+        // maps.google.com rdar://67358928
+        quirksData.needsGoogleMapsScrollingQuirk = true;
+#endif
+        // maps.google.com https://bugs.webkit.org/show_bug.cgi?id=214945
+        quirksData.shouldAvoidResizingWhenInputViewBoundsChangeQuirk = true;
+    }
+    quirksData.isGoogleDocs = topDocumentHost == "docs.google.com"_s;
+#if PLATFORM(IOS_FAMILY)
+    if (quirksData.isGoogleDocs) {
+        // docs.google.com rdar://49864669
+        quirksData.shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasQuirk = true;
+        // docs.google.com https://bugs.webkit.org/show_bug.cgi?id=199587
+        quirksData.needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk = startsWithLettersIgnoringASCIICase(quirksURL.path(), "/spreadsheets/"_s);
+    } else if (topDocumentHost == "mail.google.com"_s) {
+        // mail.google.com rdar://49403416
+        quirksData.needsGMailOverflowScrollQuirk =true;
+    }
+#endif
+    // docs.google.com rdar://59893415
+    quirksData.maybeBypassBackForwardCache = true;
+#if ENABLE(TOUCH_EVENTS)
+    // sites.google.com rdar://58653069
+    quirksData.shouldPreventDispatchOfTouchEventQuirk = topDocumentHost == "sites.google.com"_s;
+#endif
+#if PLATFORM(MAC)
+    // docs.google.com https://bugs.webkit.org/show_bug.cgi?id=161984
+    quirksData.isTouchBarUpdateSuppressedForHiddenContentEditableQuirk = quirksData.isGoogleDocs;
+#endif
+}
+
+static void handleHBOMaxQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "hbomax.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    auto topDocumentHost = quirksURL.host();
+    if (topDocumentHost != "play.hbomax.com"_s)
+        return;
+
+    // play.hbomax.com https://bugs.webkit.org/show_bug.cgi?id=244737
+    quirksData.shouldEnableFontLoadingAPIQuirk = true;
+}
+
+static void handleHuluQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "hulu.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // hulu.com rdar://100199996
+    quirksData.needsVideoShouldMaintainAspectRatioQuirk = true;
+    // hulu.com rdar://126096361
+    quirksData.implicitMuteWhenVolumeSetToZero = true;
+}
+
+static void handleIMDBQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "imdb.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // imdb.com: rdar://137991466
+    quirksData.needsChromeMediaControlsPseudoElementQuirk = true;
+}
+
+static void handleLiveQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "live.com"_s)
+        return;
+
+    UNUSED_PARAM(documentURL);
+    auto topDocumentHost = quirksURL.host();
+    // outlook.live.com: rdar://136624720
+    quirksData.needsMozillaFileTypeForDataTransferQuirk = topDocumentHost == "outlook.live.com"_s;
+    // live.com rdar://52116170
+    quirksData.shouldAvoidResizingWhenInputViewBoundsChangeQuirk = true;
+    // Microsoft office online generates data URLs with incorrect padding on Safari only (rdar://114573089).
+    quirksData.shouldDisableDataURLPaddingValidation = topDocumentHost.endsWith("officeapps.live.com"_s) || topDocumentHost.endsWith("onedrive.live.com"_s);
+#if PLATFORM(MAC)
+    // onedrive.live.com rdar://26013388
+    quirksData.isNeverRichlyEditableForTouchBarQuirk = topDocumentHost == "onedrive.live.com"_s;
+#endif
+}
+
+static void handleMarcusQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "marcus.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // Marcus: <rdar://101086391>.
+    quirksData.shouldExposeShowModalDialog = true;
+#if PLATFORM(IOS_FAMILY)
+    // marcus.com rdar://102959860
+    quirksData.shouldNavigatorPluginsBeEmpty = true;
+#endif
+}
+
+static void handleMediumQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "medium.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // medium.com rdar://50457837
+    quirksData.shouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk = true;
+}
+
+static void handleMenloSecurityQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    UNUSED_PARAM(quirksDomainString);
+    UNUSED_PARAM(documentURL);
+    auto topDocumentHost = quirksURL.host();
+    if (topDocumentHost != "safe.menlosecurity.com"_s)
+        return;
+
+    // safe.menlosecurity.com rdar://135114489
+    quirksData.shouldDisableWritingSuggestionsByDefaultQuirk = true;
+}
+
+static void handleNetflixQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "netflix.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    quirksData.isNetflix = true;
+    // netflix.com https://bugs.webkit.org/show_bug.cgi?id=173030
+    quirksData.needsSeekingSupportDisabledQuirk = true;
+}
+
+static void handlePandoraQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "pandora.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // Pandora: <rdar://100243111>.
+    quirksData.shouldExposeShowModalDialog = true;
+}
+
+static void handlePremierLeagueQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "premierleague.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // premierleague.com: rdar://123721211
+    quirksData.shouldIgnorePlaysInlineRequirementQuirk = true;
+}
+
+static void handleSFUSDQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "sfusd.edu"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // sfusd.edu: rdar://116292738
+    quirksData.shouldBypassAsyncScriptDeferring = true;
+}
+
+static void handleSharePointQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "sharepoint.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // sharepoint.com rdar://52116170
+    quirksData.shouldAvoidResizingWhenInputViewBoundsChangeQuirk = true;
+}
+
+static void handleSoundCloudQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "soundcloud.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    quirksData.isSoundCloud = true;
+    // soundcloud.com rdar://52915981
+    quirksData.shouldDispatchedSimulatedMouseEventsAssumeDefaultPreventedQuirk = true;
+    // Soundcloud: rdar://102913500
+    quirksData.shouldExposeShowModalDialog = true;
+}
+
+static void handleSpotifyQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    UNUSED_PARAM(quirksDomainString);
+    UNUSED_PARAM(documentURL);
+    auto topDocumentHost = quirksURL.host();
+    if (topDocumentHost != "open.spotify.com"_s)
+        return;
+
+    // spotify.com rdar://138918575
+    quirksData.needsBodyScrollbarWidthNoneDisabledQuirk = true;
+#if PLATFORM(MAC)
+    quirksData.shouldAvoidStartingSelectionOnMouseDown = true;
+#endif
+}
+
+static void handleTripAdvisorQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "tripadvisor.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // tripadvisor.com: rdar://112851939
+    quirksData.needsRelaxedCorsMixedContentCheckQuirk = true;
+}
+
+static void handleVictoriasSecretQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "victoriassecret.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // Breaks express checkout on victoriassecret.com (rdar://104818312).
+    quirksData.shouldDisableFetchMetadata = true;
+}
+
+static void handleVimeoQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "vimeo.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    quirksData.isVimeo = true;
+    // vimeo.com rdar://56996057
+    quirksData.maybeBypassBackForwardCache = true;
+#if PLATFORM(IOS_FAMILY)
+    // vimeo.com rdar://55759025
+    quirksData.needsPreloadAutoQuirk = true;
+    // Vimeo.com has incorrect layout on iOS on certain videos with wider
+    // aspect ratios than the device's screen in landscape mode.
+    // (Ref: rdar://116531089)
+    quirksData.shouldDisableElementFullscreen = true;
+#endif
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    // vimeo.com: rdar://problem/73227900
+    quirksData.shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk = true;
+#endif
+#if ENABLE(FULLSCREEN_API) && ENABLE(VIDEO_PRESENTATION_MODE)
+    // vimeo.com: rdar://107592139
+    quirksData.blocksEnteringStandardFullscreenFromPictureInPictureQuirk = true;
+    // vimeo.com: rdar://problem/70788878
+    quirksData.blocksReturnToFullscreenFromPictureInPictureQuirk = true;
+#endif
+}
+
+static void handleWeeblyQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "weebly.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // weebly.com rdar://48003980
+    quirksData.shouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk = true;
+}
+
+static void handleWikipediaQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "wikipedia.org"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // wikipedia.org rdar://54856323
+    quirksData.shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk = true;
+#if ENABLE(META_VIEWPORT)
+    // wikipedia.org https://webkit.org/b/247636
+    quirksData.shouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk = true;
+#endif
+}
+
+static void handleTwitterXQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "x.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksData);
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+#if PLATFORM(VISION)
+    // x.com: rdar://132850672
+    quirksData.shouldDisableFullscreenVideoAspectRatioAdaptiveSizingQuirk = true;
+#endif
+#if PLATFORM(IOS) || PLATFORM(VISION)
+    // Twitter.com video embeds have controls that are too tiny and
+    // show page behind fullscreen.
+    // (Ref: rdar://121473410)
+    quirksData.shouldSilenceMediaQueryListChangeEvents = true;
+    // twitter.com: rdar://problem/58804852 and rdar://problem/61731801
+    quirksData.shouldSilenceWindowResizeEvents = true;
+#endif
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    // twitter.com: rdar://73369869
+    quirksData.requiresUserGestureToLoadInPictureInPictureQuirk = true;
+    // twitter.com: rdar://73369869
+    quirksData.requiresUserGestureToPauseInPictureInPictureQuirk = true;
+#endif
+}
+
+static void handleYouTubeQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "youtube.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    quirksData.isYouTube = true;
+    // youtube.com https://bugs.webkit.org/show_bug.cgi?id=195598
+    quirksData.hasBrokenEncryptedMediaAPISupportQuirk = true;
+    // youtube.com rdar://135886305
+    quirksData.needsScrollbarWidthThinDisabledQuirk = true;
+    // youtube.com rdar://66242343
+    quirksData.needsVP9FullRangeFlagQuirk = true;
+#if PLATFORM(IOS_FAMILY)
+    // YouTube.com does not provide AirPlay controls in fullscreen
+    // (Ref: rdar://121471373)
+    quirksData.shouldDisableElementFullscreen = PAL::currentUserInterfaceIdiomIsSmallScreen();
+    auto topDocumentHost = quirksURL.host();
+    if (topDocumentHost == "www.youtube.com"_s) {
+        // www.youtube.com rdar://52361019
+        quirksData.needsYouTubeMouseOutQuirk = true;
+        // youtube.com rdar://49582231
+        quirksData.needsYouTubeOverflowScrollQuirk = true;
+    }
+#endif
+#if PLATFORM(IOS) || PLATFORM(VISION)
+    // youtube.com: rdar://110097836
+    quirksData.shouldSilenceResizeObservers = true;
+#endif
+}
+
+static void handleZillowQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "zillow.com"_s)
+        return;
+
+    UNUSED_PARAM(documentURL);
+    // zillow.com rdar://53103732
+    auto topDocumentHost = quirksURL.host();
+    quirksData.shouldAvoidScrollingWhenFocusedContentIsVisibleQuirk = topDocumentHost == "www.zillow.com"_s;
+#if PLATFORM(IOS) || PLATFORM(VISION)
+    // rdar://110097836
+    quirksData.shouldSilenceResizeObservers = true;
+#endif
+}
+
+static void handleZoomQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "zoom.us"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    quirksData.isZoom = true;
+    // zoom.com https://bugs.webkit.org/show_bug.cgi?id=223180
+    quirksData.shouldAutoplayWebAudioForArbitraryUserGestureQuirk = true;
+#if ENABLE(MEDIA_STREAM)
+    // zoom.us rdar://118185086
+    quirksData.shouldDisableImageCaptureQuirk = true;
+#endif
+}
+
+void Quirks::determineRelevantQuirks()
+{
+    RELEASE_ASSERT(m_document);
+    m_quirksData = { };
+
+#if PLATFORM(IOS_FAMILY)
+    static const bool shouldDisableLazyIframeLoadingQuirk = !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NoUNIQLOLazyIframeLoadingQuirk) && WTF::IOSApplication::isUNIQLOApp();
+    static const bool needsResettingTransitionCancelsRunningTransitionQuirk = !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ResettingTransitionCancelsRunningTransitionQuirk) && WTF::IOSApplication::isDOFUSTouch();
+
+    m_quirksData.shouldDisableLazyIframeLoadingQuirk = shouldDisableLazyIframeLoadingQuirk;
+    // DOFUS Touch app (rdar://112679186)
+    m_quirksData.needsResettingTransitionCancelsRunningTransitionQuirk = needsResettingTransitionCancelsRunningTransitionQuirk;
+#endif
+
+#if PLATFORM(IOS)
+    // This quirk has intentionally limited exposure to increase the odds of being able to remove it
+    // again within a reasonable timeframe as the impacted apps are being updated. <rdar://122548304>
+    static const bool needsGetElementsByNameQuirk = !PAL::currentUserInterfaceIdiomIsSmallScreen() && !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NoGetElementsByNameQuirk);
+    m_quirksData.needsGetElementsByNameQuirk = needsGetElementsByNameQuirk;
+#endif
+
+#if PLATFORM(MAC)
+    // Push state file path restrictions break Mimeo Photo Plugin (rdar://112445672).
+    m_quirksData.shouldDisablePushStateFilePathRestrictions = WTF::MacApplication::isMimeoPhotoProject();
+#endif
+
+    auto quirksURL = topDocumentURL();
+    if (quirksURL.isEmpty())
+        return;
+
+    auto quirksDomainString = RegistrableDomain(quirksURL).string();
+    auto quirkDomainWithoutPSL = PublicSuffixStore::singleton().domainWithoutPublicSuffix(quirksDomainString);
+
+    using QuirkHandler = void (*)(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL);
+    using DispatchMap = HashMap<String, QuirkHandler>;
+    static NeverDestroyed<DispatchMap> dispatchMap = DispatchMap({
+#if PLATFORM(IOS) || PLATFORM(VISION)
+        { "365scores"_s, &handle365ScoresQuirks },
+#endif
+        { "amazon"_s, &handleAmazonQuirks },
+        { "apple"_s, &handleAppleQuirks },
+#if PLATFORM(IOS_FAMILY)
+        { "as"_s, &handleASQuirks },
+        { "att"_s, &handleATTQuirks },
+#endif
+        { "bbc"_s, &handleBBCQuirks },
+#if ENABLE(MEDIA_STREAM)
+        { "baidu"_s, &handleBaiduQuirks },
+#endif
+        { "bankofamerica"_s, &handleBankOfAmericaQuirks },
+        { "bing"_s, &handleBingQuirks },
+        { "bungalow"_s, &handleBungalowQuirks },
+#if PLATFORM(IOS_FAMILY)
+        { "cbssports"_s, &handleCBSSportsQuirks },
+        { "cnn"_s, &handleCNNQuirks },
+        { "digitaltrends"_s, &handleDigitalTrendsQuirks },
+#endif
+#if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
+        { "disneyplus"_s, &handleDisneyPlusQuirks },
+#endif
+        { "espn"_s, &handleESPNQuirks },
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+        { "facebook"_s, &handleFacebookQuirks },
+        { "forbes"_s, &handleForbesQuirks },
+#endif
+#if PLATFORM(IOS_FAMILY)
+        { "gizmodo"_s, &handleGizmodoQuirks },
+#endif
+        { "google"_s, &handleGoogleQuirks },
+        { "hbomax"_s, &handleHBOMaxQuirks },
+        { "hulu"_s, &handleHuluQuirks },
+#if PLATFORM(MAC)
+        { "icloud"_s, &handleICloudQuirks },
+#endif
+        { "imdb"_s, &handleIMDBQuirks },
+#if PLATFORM(IOS_FAMILY)
+        { "instagram"_s, &handleInstagramQuirks },
+#endif
+        { "live"_s, &handleLiveQuirks },
+#if PLATFORM(IOS_FAMILY)
+        { "mailchimp"_s, &handleMailChimpQuirks },
+#endif
+        { "marcus"_s, &handleMarcusQuirks },
+#if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
+        { "max"_s, &handleMaxQuirks },
+#endif
+        { "medium"_s, &handleMediumQuirks },
+        { "menlosecurity"_s, &handleMenloSecurityQuirks },
+        { "netflix"_s, &handleNetflixQuirks },
+#if PLATFORM(IOS) || PLATFORM(VISION)
+        { "nytimes"_s, &handleNYTimesQuirks },
+#endif
+        { "pandora"_s, &handlePandoraQuirks },
+        { "premierleague"_s, &handlePremierLeagueQuirks },
+#if PLATFORM(IOS_FAMILY)
+        { "ralphlauren"_s, &handleRalphLaurenQuirks },
+#endif
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+        { "reddit"_s, & handleRedditQuirks },
+#endif
+        { "sfusd"_s, &handleSFUSDQuirks },
+        { "sharepoint"_s, &handleSharePointQuirks },
+#if PLATFORM(IOS_FAMILY)
+        { "skype"_s, &handleSkypeQuirks },
+#endif
+        { "soundcloud"_s, &handleSoundCloudQuirks },
+#if ENABLE(TOUCH_EVENTS)
+        { "soylent"_s, &handleSoylentQuirks },
+#endif
+        { "spotify"_s, &handleSpotifyQuirks },
+#if PLATFORM(MAC)
+        { "state"_s, &handleCEACStateGovQuirks },
+#endif
+#if PLATFORM(IOS_FAMILY)
+        { "thesaurus"_s, &handleScriptToEvaluateBeforeRunningScriptFromURLQuirk },
+#endif
+        { "tripadvisor"_s, &handleTripAdvisorQuirks },
+#if PLATFORM(MAC)
+        { "trix-editor"_s, &handleTrixEditorQuirks },
+#endif
+        { "victoriassecret"_s, &handleVictoriasSecretQuirks },
+        { "vimeo"_s, &handleVimeoQuirks },
+#if PLATFORM(IOS_FAMILY)
+        { "walmart"_s, &handleWalmartQuirks },
+#endif
+        { "wikipedia"_s, &handleWikipediaQuirks },
+#if ENABLE(MEDIA_STREAM)
+        { "warbyparker"_s, &handleWarbyParkerQuirks },
+#endif
+#if PLATFORM(MAC)
+        { "weather"_s, &handleWeatherQuirks },
+#endif
+#if PLATFORM(IOS_FAMILY) && ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
+        { "webex"_s, &handleScriptToEvaluateBeforeRunningScriptFromURLQuirk },
+#endif
+        { "weebly"_s, &handleWeeblyQuirks },
+        { "x"_s, &handleTwitterXQuirks },
+#if PLATFORM(IOS_FAMILY)
+        { "yahoo"_s, &handleYahooQuirks },
+#endif
+#if ENABLE(TEXT_AUTOSIZING)
+        { "ycombinator"_s, &handleYCombinatorQuirks },
+#endif
+        { "youtube"_s, &handleYouTubeQuirks },
+        { "zillow"_s, &handleZillowQuirks },
+        { "zoom"_s, &handleZoomQuirks },
+    });
+
+    auto findResult = dispatchMap->find(quirkDomainWithoutPSL);
+    if (findResult != dispatchMap->end())
+        (findResult->value)(m_quirksData, quirksURL, quirksDomainString, m_document->url());
+
+    // Note: `needsDisableDOMPasteAccessQuirk` needs a live document to assess
+    // Note: `shouldDisableElementFullscreen` needs a live document for embedded sites
+
+    // FIXME: The below quirks should be handled more efficiently in a
+#if ENABLE(FLIP_SCREEN_DIMENSIONS_QUIRKS)
+    // rdar://133423460
+    m_quirksData.shouldFlipScreenDimensionsQuirk = shouldFlipScreenDimensionsInternal(quirksURL);
+#endif
+
+    // rdar://133423460
+    m_quirksData.shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk = shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeInternal(quirksURL);
 }
 
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -243,20 +243,14 @@ private:
     bool domainStartsWith(const String&) const;
     bool isEmbedDomain(const String&) const;
     bool isYoutubeEmbedDomain() const;
-    bool isYahooMail() const;
-    bool isSpotifyPlayer() const;
 
-    bool isAmazon() const;
-    bool isCBSSports() const;
-    bool isESPN() const;
-    bool isFacebook() const;
-    bool isGoogleMaps() const;
-    bool isGoogleDocs() const;
-    bool isNetflix() const;
-    bool isSoundCloud() const;
-    bool isVimeo() const;
-    bool isYouTube() const;
-    bool isZoom() const;
+    void determineRelevantQuirks();
+
+    static bool domainNeedsAvoidResizingWhenInputViewBoundsChangeQuirk(const URL&, QuirksData&);
+    static bool domainNeedsScrollbarWidthThinDisabledQuirk(const URL&, QuirksData&);
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    static bool domainShouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk(const URL&, QuirksData&);
+#endif
 
     RefPtr<Document> protectedDocument() const;
 

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -28,98 +28,126 @@
 namespace WebCore {
 
 struct WEBCORE_EXPORT QuirksData {
-    std::optional<bool> isAmazon;
-    std::optional<bool> isCBSSports;
-    std::optional<bool> isESPN;
-    std::optional<bool> isFacebook;
-    std::optional<bool> isGoogleDocs;
-    std::optional<bool> isGoogleMaps;
-    std::optional<bool> isNetflix;
-    std::optional<bool> isSoundCloud;
-    std::optional<bool> isSpotify;
-    std::optional<bool> isVimeo;
-    std::optional<bool> isYouTube;
-    std::optional<bool> isZoom;
+    bool isAmazon { false };
+    bool isBankOfAmerica { false };
+    bool isBing { false };
+    bool isCBSSports { false };
+    bool isESPN { false };
+    bool isFacebook { false };
+    bool isGoogleDocs { false };
+    bool isGoogleProperty { false };
+    bool isGoogleMaps { false };
+    bool isNetflix { false };
+    bool isSoundCloud { false };
+    bool isSpotify { false };
+    bool isThesaurus { false };
+    bool isVimeo { false };
+    bool isWebEx { false };
+    bool isYouTube { false };
+    bool isZoom { false };
 
-    std::optional<bool> implicitMuteWhenVolumeSetToZero;
-    std::optional<bool> needsBingGestureEventQuirk;
-    std::optional<bool> needsCanPlayAfterSeekedQuirk;
-    std::optional<bool> needsChromeMediaControlsPseudoElementQuirk;
+    bool hasBrokenEncryptedMediaAPISupportQuirk { false };
+    bool implicitMuteWhenVolumeSetToZero { false };
+    bool maybeBypassBackForwardCache { false };
+    bool needsBingGestureEventQuirk { false };
+    bool needsBodyScrollbarWidthNoneDisabledQuirk { false };
+    bool needsCanPlayAfterSeekedQuirk { false };
+    bool needsChromeMediaControlsPseudoElementQuirk { false };
+    bool needsMozillaFileTypeForDataTransferQuirk { false };
+    bool needsRelaxedCorsMixedContentCheckQuirk { false };
+    bool needsResettingTransitionCancelsRunningTransitionQuirk { false };
+    bool needsScrollbarWidthThinDisabledQuirk { false };
+    bool needsSeekingSupportDisabledQuirk { false };
+    bool needsVP9FullRangeFlagQuirk { false };
+    bool needsVideoShouldMaintainAspectRatioQuirk { false };
+    bool returnNullPictureInPictureElementDuringFullscreenChangeQuirk { false };
+    bool shouldAllowDownloadsInSpiteOfCSPQuirk { false };
+    bool shouldAutoplayWebAudioForArbitraryUserGestureQuirk { false };
+    bool shouldAvoidResizingWhenInputViewBoundsChangeQuirk { false };
+    bool shouldAvoidScrollingWhenFocusedContentIsVisibleQuirk { false };
+    bool shouldBypassAsyncScriptDeferring { false };
+    bool shouldDisableDataURLPaddingValidation { false };
+    bool shouldDisableElementFullscreen { false };
+    bool shouldDisableFetchMetadata { false };
+    bool shouldDisableLazyIframeLoadingQuirk { false };
+    bool shouldDisablePushStateFilePathRestrictions { false };
+    bool shouldDisableWritingSuggestionsByDefaultQuirk { false };
+    bool shouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk { false };
+    bool shouldDispatchedSimulatedMouseEventsAssumeDefaultPreventedQuirk { false };
+    bool shouldEnableFontLoadingAPIQuirk { false };
+    bool shouldExposeShowModalDialog { false };
+    bool shouldIgnorePlaysInlineRequirementQuirk { false };
+    bool shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk { false };
+    bool shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk { false };
+    bool shouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk { false };
+
+    // Requires check at moment of use
     std::optional<bool> needsDisableDOMPasteAccessQuirk;
-    std::optional<bool> needsMozillaFileTypeForDataTransferQuirk;
-    std::optional<bool> needsRelaxedCorsMixedContentCheckQuirk;
-    std::optional<bool> needsVP9FullRangeFlagQuirk;
-    std::optional<bool> needsVideoShouldMaintainAspectRatioQuirk;
-    std::optional<bool> returnNullPictureInPictureElementDuringFullscreenChangeQuirk;
-    std::optional<bool> shouldAllowDownloadsInSpiteOfCSPQuirk;
-    std::optional<bool> shouldAutoplayWebAudioForArbitraryUserGestureQuirk;
-    std::optional<bool> shouldAvoidResizingWhenInputViewBoundsChangeQuirk;
-    std::optional<bool> shouldAvoidScrollingWhenFocusedContentIsVisibleQuirk;
-    std::optional<bool> shouldBypassAsyncScriptDeferring;
-    std::optional<bool> shouldDisableDataURLPaddingValidation;
-    std::optional<bool> shouldDisableElementFullscreen;
-    std::optional<bool> shouldDisableFetchMetadata;
-    std::optional<bool> shouldDisableLazyIframeLoadingQuirk;
-    std::optional<bool> shouldDisableWritingSuggestionsByDefaultQuirk;
-    std::optional<bool> shouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk;
-    std::optional<bool> shouldEnableFontLoadingAPIQuirk;
-    std::optional<bool> shouldExposeShowModalDialog;
-    std::optional<bool> shouldIgnorePlaysInlineRequirementQuirk;
-    std::optional<bool> shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk;
-    std::optional<bool> shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk;
-    std::optional<bool> shouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk;
 
 #if PLATFORM(IOS_FAMILY)
-    std::optional<bool> mayNeedToIgnoreContentObservation;
-    std::optional<bool> needsFullscreenDisplayNoneQuirk;
-    std::optional<bool> needsFullscreenObjectFitQuirk;
-    std::optional<bool> needsGMailOverflowScrollQuirk;
-    std::optional<bool> needsIPadSkypeOverflowScrollQuirk;
-    std::optional<bool> needsYouTubeMouseOutQuirk;
-    std::optional<bool> needsYouTubeOverflowScrollQuirk;
-    std::optional<bool> shouldAvoidPastingImagesAsWebContent;
-    std::optional<bool> shouldDisablePointerEventsQuirk;
-    std::optional<bool> shouldEnableApplicationCacheQuirk;
-    std::optional<bool> shouldIgnoreAriaForFastPathContentObservationCheckQuirk;
-    std::optional<bool> shouldNavigatorPluginsBeEmpty;
+    bool mayNeedToIgnoreContentObservation { false };
+    bool needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk { false };
+    bool needsFullscreenDisplayNoneQuirk { false };
+    bool needsFullscreenObjectFitQuirk { false };
+    bool needsGMailOverflowScrollQuirk { false };
+    bool needsGoogleMapsScrollingQuirk { false };
+    bool needsIPadSkypeOverflowScrollQuirk { false };
+    bool needsPreloadAutoQuirk { false };
+    bool needsScriptToEvaluateBeforeRunningScriptFromURLQuirk { false };
+    bool needsYouTubeMouseOutQuirk { false };
+    bool needsYouTubeOverflowScrollQuirk { false };
+    bool shouldAvoidPastingImagesAsWebContent { false };
+    bool shouldDisablePointerEventsQuirk { false };
+    bool shouldEnableApplicationCacheQuirk { false };
+    bool shouldIgnoreAriaForFastPathContentObservationCheckQuirk { false };
+    bool shouldNavigatorPluginsBeEmpty { false };
+    bool shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasQuirk { false };
+    bool shouldSynthesizeTouchEventsAfterNonSyntheticClickQuirk { false };
+#endif
+
+#if PLATFORM(IOS)
+    bool needsGetElementsByNameQuirk { false };
 #endif
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
-    std::optional<bool> allowLayeredFullscreenVideos;
-    std::optional<bool> shouldSilenceMediaQueryListChangeEvents;
-    std::optional<bool> shouldSilenceWindowResizeEvents;
+    bool allowLayeredFullscreenVideos { false };
+    bool shouldSilenceMediaQueryListChangeEvents { false };
+    bool shouldSilenceResizeObservers { false };
+    bool shouldSilenceWindowResizeEvents { false };
 #endif
 
 #if PLATFORM(VISION)
-    std::optional<bool> shouldDisableFullscreenVideoAspectRatioAdaptiveSizingQuirk;
+    bool shouldDisableFullscreenVideoAspectRatioAdaptiveSizingQuirk { false };
 #endif
 
 #if PLATFORM(MAC)
-    std::optional<bool> isNeverRichlyEditableForTouchBarQuirk;
-    std::optional<bool> needsFormControlToBeMouseFocusableQuirk;
-    std::optional<bool> needsPrimeVideoUserSelectNoneQuirk;
+    bool isNeverRichlyEditableForTouchBarQuirk { false };
+    bool isTouchBarUpdateSuppressedForHiddenContentEditableQuirk { false };
+    bool needsFormControlToBeMouseFocusableQuirk { false };
+    bool needsPrimeVideoUserSelectNoneQuirk { false };
+    bool shouldAvoidStartingSelectionOnMouseDown { false };
 #endif
 
 #if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
-    std::optional<bool> needsZeroMaxTouchPointsQuirk;
-    std::optional<bool> shouldHideCoarsePointerCharacteristicsQuirk;
+    bool needsZeroMaxTouchPointsQuirk { false };
+    bool shouldHideCoarsePointerCharacteristicsQuirk { false };
 #endif
 
 #if ENABLE(FLIP_SCREEN_DIMENSIONS_QUIRKS)
-    std::optional<bool> shouldFlipScreenDimensionsQuirk;
+    bool shouldFlipScreenDimensionsQuirk { false };
 #endif
 
 #if ENABLE(MEDIA_STREAM)
-    std::optional<bool> shouldDisableImageCaptureQuirk;
-    std::optional<bool> shouldEnableLegacyGetUserMediaQuirk;
+    bool shouldDisableImageCaptureQuirk { false };
+    bool shouldEnableLegacyGetUserMediaQuirk { false };
 #endif
 
 #if ENABLE(META_VIEWPORT)
-    std::optional<bool> shouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk;
+    bool shouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk { false };
 #endif
 
 #if ENABLE(TEXT_AUTOSIZING)
-    std::optional<bool> shouldIgnoreTextAutoSizingQuirk;
+    bool shouldIgnoreTextAutoSizingQuirk { false };
 #endif
 
 #if ENABLE(TOUCH_EVENTS)
@@ -130,14 +158,20 @@ struct WEBCORE_EXPORT QuirksData {
         Yes,
     };
     ShouldDispatchSimulatedMouseEvents shouldDispatchSimulatedMouseEventsQuirk { ShouldDispatchSimulatedMouseEvents::Unknown };
-    std::optional<bool> shouldDispatchPointerOutAfterHandlingSyntheticClick;
-    std::optional<bool> shouldPreventDispatchOfTouchEventQuirk;
+    bool shouldDispatchPointerOutAfterHandlingSyntheticClick { false };
+    bool shouldPreventDispatchOfTouchEventQuirk { false };
+#endif
+
+#if ENABLE(FULLSCREEN_API) && ENABLE(VIDEO_PRESENTATION_MODE)
+    bool blocksEnteringStandardFullscreenFromPictureInPictureQuirk { false };
+    bool blocksReturnToFullscreenFromPictureInPictureQuirk { false };
 #endif
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    std::optional<bool> requiresUserGestureToLoadInPictureInPictureQuirk;
-    std::optional<bool> requiresUserGestureToPauseInPictureInPictureQuirk;
-    std::optional<bool> shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk;
+    bool requiresUserGestureToLoadInPictureInPictureQuirk { false };
+    bool requiresUserGestureToPauseInPictureInPictureQuirk { false };
+    bool shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk { false };
+    bool shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk { false };
 #endif
 };
 


### PR DESCRIPTION
#### f6403030bdeda40f5b4d6c4bd3f34be3e3196016
<pre>
Compute needed quirks on object construction
<a href="https://bugs.webkit.org/show_bug.cgi?id=283522">https://bugs.webkit.org/show_bug.cgi?id=283522</a>
<a href="https://rdar.apple.com/140429884">rdar://140429884</a>

Reviewed by Sammy Gill.

Currently, Quirks are assessed at runtime when relevant code checks if a quirk is needed, often multiple
times during a load or render. We should decide this information at object construction time instead.

This is in preparation for making these decisions in the UIProcess and notifying the WebProcess of the
result.

This change also computes a key value based on the domain of the Top Document URL, removing the public
suffix from the domain, and uses this to quickly determine if any quirk might be applicable. If not,
it does no further action.

If a quirk might be applicable, it does a more careful check of the domain and stores the result so that
future checks of the quirk do not need to do further work.

The large number of local static functions implementing the detailed checks for each quirk will be
replaced in a future change by Function objects created by a future parser for quirks. However, that
work is part of a future patch.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::Quirks):
(WebCore::Quirks::isDomain const):
(WebCore::Quirks::needsFormControlToBeMouseFocusable const):
(WebCore::Quirks::needsSeekingSupportDisabled const):
(WebCore::Quirks::needsPerDocumentAutoplayBehavior const):
(WebCore::Quirks::shouldAutoplayWebAudioForArbitraryUserGesture const):
(WebCore::Quirks::hasBrokenEncryptedMediaAPISupportQuirk const):
(WebCore::Quirks::isTouchBarUpdateSuppressedForHiddenContentEditable const):
(WebCore::Quirks::isNeverRichlyEditableForTouchBar const):
(WebCore::Quirks::shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreas const):
(WebCore::Quirks::shouldDispatchSyntheticMouseEventsWhenModifyingSelection const):
(WebCore::Quirks::needsYouTubeMouseOutQuirk const):
(WebCore::Quirks::shouldDisableWritingSuggestionsByDefault const):
(WebCore::Quirks::shouldDisableElementFullscreenQuirk const):
(WebCore::Quirks::shouldDispatchSimulatedMouseEvents const):
(WebCore::Quirks::shouldDispatchedSimulatedMouseEventsAssumeDefaultPrevented const):
(WebCore::Quirks::shouldPreventDispatchOfTouchEvent const):
(WebCore::Quirks::domainNeedsAvoidResizingWhenInputViewBoundsChangeQuirk):
(WebCore::Quirks::shouldAvoidResizingWhenInputViewBoundsChange const):
(WebCore::Quirks::shouldDisablePointerEventsQuirk const):
(WebCore::urlNeedsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk):
(WebCore::Quirks::needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommand const):
(WebCore::domainNeedsGMailOverflowScrollQuirk):
(WebCore::Quirks::needsGMailOverflowScrollQuirk const):
(WebCore::Quirks::needsIPadSkypeOverflowScrollQuirk const):
(WebCore::domainNeedsYouTubeOverflowScrollQuirk):
(WebCore::Quirks::needsYouTubeOverflowScrollQuirk const):
(WebCore::Quirks::needsPrimeVideoUserSelectNoneQuirk const):
(WebCore::Quirks::needsScrollbarWidthThinDisabledQuirk const):
(WebCore::Quirks::needsBodyScrollbarWidthNoneDisabledQuirk const):
(WebCore::domainNeedsFullscreenDisplayNoneQuirk):
(WebCore::Quirks::needsFullscreenDisplayNoneQuirk const):
(WebCore::Quirks::needsFullscreenObjectFitQuirk const):
(WebCore::Quirks::needsGoogleMapsScrollingQuirk const):
(WebCore::Quirks::shouldSilenceResizeObservers const):
(WebCore::Quirks::shouldSilenceWindowResizeEvents const):
(WebCore::Quirks::shouldAvoidScrollingWhenFocusedContentIsVisible const):
(WebCore::Quirks::shouldUseLegacySelectPopoverDismissalBehaviorInDataActivation const):
(WebCore::Quirks::shouldIgnoreAriaForFastPathContentObservationCheck const):
(WebCore::Quirks::shouldIgnoreViewportArgumentsToAvoidExcessiveZoom const):
(WebCore::Quirks::needsPreloadAutoQuirk const):
(WebCore::Quirks::shouldBypassBackForwardCache const):
(WebCore::Quirks::shouldBypassAsyncScriptDeferring const):
(WebCore::Quirks::shouldEnableLegacyGetUserMediaQuirk const):
(WebCore::Quirks::shouldDisableImageCaptureQuirk const):
(WebCore::Quirks::needsCanPlayAfterSeekedQuirk const):
(WebCore::Quirks::shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraints const):
(WebCore::Quirks::shouldAvoidPastingImagesAsWebContent const):
(WebCore::Quirks::needsVP9FullRangeFlagQuirk const):
(WebCore::domainRequiresUserGestureToPauseInPictureInPicture):
(WebCore::Quirks::requiresUserGestureToPauseInPictureInPicture const):
(WebCore::Quirks::returnNullPictureInPictureElementDuringFullscreenChange const):
(WebCore::Quirks::blocksReturnToFullscreenFromPictureInPictureQuirk const):
(WebCore::Quirks::blocksEnteringStandardFullscreenFromPictureInPictureQuirk const):
(WebCore::Quirks::shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk const):
(WebCore::Quirks::shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk const):
(WebCore::Quirks::allowLayeredFullscreenVideos const):
(WebCore::Quirks::shouldDisableFullscreenVideoAspectRatioAdaptiveSizing const):
(WebCore::Quirks::shouldEnableFontLoadingAPIQuirk const):
(WebCore::Quirks::needsVideoShouldMaintainAspectRatioQuirk const):
(WebCore::Quirks::shouldExposeShowModalDialog const):
(WebCore::Quirks::shouldNavigatorPluginsBeEmpty const):
(WebCore::Quirks::shouldDisableFetchMetadata const):
(WebCore::Quirks::shouldStarBePermissionsPolicyDefaultValue const):
(WebCore::Quirks::shouldDisableDataURLPaddingValidation const):
(WebCore::Quirks::shouldPreventOrientationMediaQueryFromEvaluatingToLandscape const):
(WebCore::Quirks::shouldFlipScreenDimensions const):
(WebCore::Quirks::shouldIgnorePlaysInlineRequirementQuirk const):
(WebCore::Quirks::needsRelaxedCorsMixedContentCheckQuirk const):
(WebCore::Quirks::shouldIgnoreTextAutoSizing const):
(WebCore::Quirks::shouldHideCoarsePointerCharacteristics const):
(WebCore::Quirks::implicitMuteWhenVolumeSetToZero const):
(WebCore::Quirks::shouldDispatchPointerOutAfterHandlingSyntheticClick const):
(WebCore::Quirks::needsZeroMaxTouchPointsQuirk const):
(WebCore::Quirks::needsChromeMediaControlsPseudoElement const):
(WebCore::Quirks::shouldSynthesizeTouchEventsAfterNonSyntheticClick const):
(WebCore::Quirks::shouldIgnoreContentObservationForClick const):
(WebCore::Quirks::needsMozillaFileTypeForDataTransfer const):
(WebCore::Quirks::needsBingGestureEventQuirk const):
(WebCore::Quirks::determineRelevantQuirks):
(WebCore::Quirks::isAmazon const): Deleted.
(WebCore::Quirks::isESPN const): Deleted.
(WebCore::Quirks::isGoogleMaps const): Deleted.
(WebCore::Quirks::isNetflix const): Deleted.
(WebCore::Quirks::isSoundCloud const): Deleted.
(WebCore::Quirks::isVimeo const): Deleted.
(WebCore::Quirks::isYouTube const): Deleted.
(WebCore::isWikipediaDomain): Deleted.
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/287966@main">https://commits.webkit.org/287966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d597fae47c80291c558e63e389896d95584f60ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35489 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/86073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/32535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83651 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8885 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/86073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/32535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84610 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/74208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/86073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28381 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30988 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87509 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8774 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8955 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71194 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15259 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/14174 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12629 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8734 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8572 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/12094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/10379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->