### PR TITLE
[WK1] CRASH in TimerBase::setNextFireTime()

### DIFF
--- a/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.h
+++ b/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.h
@@ -29,18 +29,18 @@
 
 #if PLATFORM(COCOA)
 
-#include <wtf/WeakPtr.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 
-class RemoteCommandListenerCocoa : public RemoteCommandListener, public CanMakeWeakPtr<RemoteCommandListenerCocoa>, public RefCounted<RemoteCommandListenerCocoa> {
+class RemoteCommandListenerCocoa : public RemoteCommandListener, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteCommandListenerCocoa> {
 public:
     static Ref<RemoteCommandListenerCocoa> create(RemoteCommandListenerClient&);
     RemoteCommandListenerCocoa(RemoteCommandListenerClient&);
     virtual ~RemoteCommandListenerCocoa();
 
-    void ref() const final { return RefCounted<RemoteCommandListenerCocoa>::ref(); }
-    void deref() const { return RefCounted<RemoteCommandListenerCocoa>::deref(); }
+    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteCommandListenerCocoa>::ref(); }
+    void deref() const { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteCommandListenerCocoa>::deref(); }
 
 private:
     void updateSupportedCommands() final;


### PR DESCRIPTION
#### f277ad5b589daf5b4020cd0266d38a49f3d8375c
<pre>
[WK1] CRASH in TimerBase::setNextFireTime()
<a href="https://bugs.webkit.org/show_bug.cgi?id=283587">https://bugs.webkit.org/show_bug.cgi?id=283587</a>
<a href="https://rdar.apple.com/140290399">rdar://140290399</a>

Reviewed by Eric Carlson.

RemoteCommandListenerCocoa is called into by MediaRemote on the main thread,
rather than the Web thread, which on WK1 will result in a RELEASE_ASSERT when
a timer is restarted. Ensure the RemoteCommandListener callback is moved to
the WebThread on WK1 via ensureMainThread().

* Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.h:
(WebCore::RemoteCommandListenerCocoa::deref const):
* Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm:
(WebCore::RemoteCommandListenerCocoa::RemoteCommandListenerCocoa):

Canonical link: <a href="https://commits.webkit.org/286988@main">https://commits.webkit.org/286988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e6407d4d12cacc23ca8bf593db6cc3ee219adae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82470 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29079 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60943 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18889 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66746 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41245 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48310 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24271 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27422 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69393 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83832 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3493 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69165 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68413 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17097 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12426 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10517 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5137 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5129 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8562 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6914 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->