### PR TITLE
Build fix: Add missing #include <wtf/TZoneMallocInlines.h>s.

### DIFF
--- a/Source/WebCore/Modules/airplay/WebKitPlaybackTargetAvailabilityEvent.cpp
+++ b/Source/WebCore/Modules/airplay/WebKitPlaybackTargetAvailabilityEvent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,10 +26,10 @@
 #include "config.h"
 #include "WebKitPlaybackTargetAvailabilityEvent.h"
 
+#if ENABLE(WIRELESS_PLAYBACK_TARGET_AVAILABILITY_API)
+
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
-
-#if ENABLE(WIRELESS_PLAYBACK_TARGET_AVAILABILITY_API)
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,6 +33,7 @@
 #include "EventNames.h"
 #include "PermissionsPolicy.h"
 #include "PlatformMediaSessionManager.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/notifications/NotificationEvent.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationEvent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,9 +26,9 @@
 #include "config.h"
 #include "NotificationEvent.h"
 
-#include <wtf/TZoneMallocInlines.h>
-
 #if ENABLE(NOTIFICATION_EVENT)
+
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,6 +41,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/TypedArrayInlines.h>
 #include <wtf/CheckedArithmetic.h>
+#include <wtf/TZoneMallocInlines.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/WebCore/Modules/webxr/WebXRViewerPose.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRViewerPose.cpp
@@ -25,9 +25,10 @@
 
 #include "config.h"
 #include "WebXRViewerPose.h"
-#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(WEBXR)
+
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/webxr/XRGPUBinding.cpp
+++ b/Source/WebCore/Modules/webxr/XRGPUBinding.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "XRGPUBinding.h"
 
+#if ENABLE(WEBXR_LAYERS)
+
 #include "GPUDevice.h"
 #include "WebGPUXRBinding.h"
 #include "WebGPUXREye.h"
@@ -36,8 +38,7 @@
 #include "XRGPUProjectionLayerInit.h"
 #include "XRGPUSubImage.h"
 #include "XRProjectionLayer.h"
-
-#if ENABLE(WEBXR_LAYERS)
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/webxr/XRGPUSubImage.cpp
+++ b/Source/WebCore/Modules/webxr/XRGPUSubImage.cpp
@@ -31,6 +31,7 @@
 #include "GPUTextureDescriptor.h"
 #include "GPUTextureFormat.h"
 #include "WebXRViewport.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/webxr/XRProjectionLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XRProjectionLayer.cpp
@@ -26,9 +26,10 @@
 #include "config.h"
 #include "XRProjectionLayer.h"
 
-#include "PlatformXR.h"
-
 #if ENABLE(WEBXR_LAYERS)
+
+#include "PlatformXR.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
@@ -121,4 +122,4 @@ WebCore::WebGPU::XRProjectionLayer& XRProjectionLayer::backing()
 
 } // namespace WebCore
 
-#endif
+#endif // ENABLE(WEBXR_LAYERS)

--- a/Source/WebCore/Modules/webxr/XRSessionEvent.cpp
+++ b/Source/WebCore/Modules/webxr/XRSessionEvent.cpp
@@ -28,8 +28,8 @@
 
 #if ENABLE(WEBXR)
 
-#include <wtf/TZoneMallocInlines.h>
 #include "WebXRSession.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
@@ -28,6 +28,8 @@
 
 #if ENABLE(WEBXR_LAYERS)
 
+#include <wtf/TZoneMallocInlines.h>
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(XRWebGLBinding);

--- a/Source/WebCore/Modules/webxr/XRWebGLSubImage.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLSubImage.cpp
@@ -28,6 +28,8 @@
 
 #if ENABLE(WEBXR_LAYERS)
 
+#include <wtf/TZoneMallocInlines.h>
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(XRWebGLSubImage);

--- a/Source/WebCore/dom/EventTargetConcrete.cpp
+++ b/Source/WebCore/dom/EventTargetConcrete.cpp
@@ -27,6 +27,7 @@
 #include "EventTargetConcrete.h"
 
 #include "ContextDestructionObserverInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/PageRevealEvent.cpp
+++ b/Source/WebCore/dom/PageRevealEvent.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "PageRevealEvent.h"
+
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/PageSwapEvent.cpp
+++ b/Source/WebCore/dom/PageSwapEvent.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "PageSwapEvent.h"
+
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,6 +38,7 @@
 #include "TableFormattingContext.h"
 #include "TableFormattingState.h"
 #include "TableWrapperBlockFormattingQuirks.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 namespace Layout {

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -39,6 +39,7 @@
 #include "RenderLayoutState.h"
 #include "RenderTreeBuilder.h"
 #include "RenderView.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 


### PR DESCRIPTION
#### a62c70aec31f382d50b8a39164c2c561d53eecf1
<pre>
Build fix: Add missing #include &lt;wtf/TZoneMallocInlines.h&gt;s.
<a href="https://bugs.webkit.org/show_bug.cgi?id=283586">https://bugs.webkit.org/show_bug.cgi?id=283586</a>
<a href="https://rdar.apple.com/140429797">rdar://140429797</a>

Reviewed by Abrar Rahman Protyasha and Mike Wyrzykowski.

Also clean up some #include in some files for style and faster building.

* Source/WebCore/Modules/airplay/WebKitPlaybackTargetAvailabilityEvent.cpp:
* Source/WebCore/Modules/audiosession/DOMAudioSession.cpp:
* Source/WebCore/Modules/notifications/NotificationEvent.cpp:
* Source/WebCore/Modules/webaudio/AudioBuffer.cpp:
* Source/WebCore/Modules/webxr/WebXRViewerPose.cpp:
* Source/WebCore/Modules/webxr/XRGPUBinding.cpp:
* Source/WebCore/Modules/webxr/XRGPUSubImage.cpp:
* Source/WebCore/Modules/webxr/XRProjectionLayer.cpp:
* Source/WebCore/Modules/webxr/XRSessionEvent.cpp:
* Source/WebCore/Modules/webxr/XRWebGLBinding.cpp:
* Source/WebCore/Modules/webxr/XRWebGLSubImage.cpp:
* Source/WebCore/dom/EventTargetConcrete.cpp:
* Source/WebCore/dom/PageRevealEvent.cpp:
* Source/WebCore/dom/PageSwapEvent.cpp:
* Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.cpp:
* Source/WebCore/rendering/RenderGrid.cpp:

Canonical link: <a href="https://commits.webkit.org/286977@main">https://commits.webkit.org/286977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90ac2622d5ef4210d25174ee7a6e7751475a66c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82473 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/29082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5152 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/60945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/29082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80893 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/50924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/66749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41248 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/48276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/24274 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27425 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/69395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/24625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83835 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/5192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/69167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/5348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66744 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/68416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/10521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12042 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/5140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/5132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/8564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/6917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->