### PR TITLE
Various ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr cleanups

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		5311BD531EA71CAD00525281 /* Signals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5311BD511EA71CAD00525281 /* Signals.cpp */; };
 		5311BD5C1EA822F900525281 /* ThreadMessage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5311BD5B1EA822F900525281 /* ThreadMessage.cpp */; };
 		53534F2A1EC0E10E00141B2F /* MachExceptions.defs in Sources */ = {isa = PBXBuildFile; fileRef = 53534F291EC0E10E00141B2F /* MachExceptions.defs */; settings = {ATTRIBUTES = (Client, Server, ); }; };
+		5363861F2CFE391C0034E883 /* AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 5363861E2CFE391C0034E883 /* AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53CAC0632C6FBD8200B1A77C /* ScopedPrintStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 53CAC0622C6FBD8200B1A77C /* ScopedPrintStream.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53F202252CAB267000A33D14 /* TaggedPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 53F202242CAB267000A33D14 /* TaggedPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53FC70D023FB950C005B1990 /* OSLogPrintStream.mm in Sources */ = {isa = PBXBuildFile; fileRef = 53FC70CF23FB950C005B1990 /* OSLogPrintStream.mm */; };
@@ -1277,6 +1278,7 @@
 		5311BD5B1EA822F900525281 /* ThreadMessage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ThreadMessage.cpp; sourceTree = "<group>"; };
 		5338EBA423AB04D100382662 /* EnumClassOperatorOverloads.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EnumClassOperatorOverloads.h; sourceTree = "<group>"; };
 		53534F291EC0E10E00141B2F /* MachExceptions.defs */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.mig; path = MachExceptions.defs; sourceTree = "<group>"; };
+		5363861E2CFE391C0034E883 /* AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h; sourceTree = "<group>"; };
 		539EB0621D55284200C82EF7 /* LEBDecoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LEBDecoder.h; sourceTree = "<group>"; };
 		53CAC0622C6FBD8200B1A77C /* ScopedPrintStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScopedPrintStream.h; sourceTree = "<group>"; };
 		53EC253C1E95AD30000831B9 /* PriorityQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PriorityQueue.h; sourceTree = "<group>"; };
@@ -2130,6 +2132,7 @@
 				A8A4731B151A825B004123FF /* text */,
 				A8A47339151A825B004123FF /* threads */,
 				A8A47348151A825B004123FF /* unicode */,
+				5363861E2CFE391C0034E883 /* AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h */,
 				E3B8E6012961EA7600A8AEE3 /* AccessibleAddress.h */,
 				CDCC9BC422382FCE00FFB51C /* AggregateLogger.h */,
 				CD6D9FCD1EEF3AD4008B0671 /* Algorithms.h */,
@@ -3201,6 +3204,7 @@
 				FE6997E129D241630078B9C6 /* AbortWithReasonSPI.h in Headers */,
 				144EB7462CBC94B100926E1B /* AbstractRefCounted.h in Headers */,
 				1404B3E52CBC954D00A7471C /* AbstractRefCountedAndCanMakeWeakPtr.h in Headers */,
+				5363861F2CFE391C0034E883 /* AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h in Headers */,
 				E3B8E6032961EA7600A8AEE3 /* AccessibleAddress.h in Headers */,
 				E383AAC92B6C730B00058E60 /* AdaptiveStringSearcher.h in Headers */,
 				DD3DC8FA27A4BF8E007E5B61 /* AggregateLogger.h in Headers */,

--- a/Source/WTF/wtf/AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h
+++ b/Source/WTF/wtf/AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/AbstractRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+
+namespace WTF {
+
+class AbstractThreadSafeRefCountedAndCanMakeWeakPtr : public AbstractRefCounted {
+public:
+    virtual ThreadSafeWeakPtrControlBlock& controlBlock() const = 0;
+
+private:
+    template<typename> friend class ThreadSafeWeakHashSet;
+    virtual size_t weakRefCount() const = 0;
+};
+
+}
+
+using WTF::AbstractThreadSafeRefCountedAndCanMakeWeakPtr;
+
+// Convinience macro that implements AbstractThreadSafeRefCountedAndCanMakeWeakPtr for you.
+#define WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL \
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); } \
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); } \
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::controlBlock(); } \
+    size_t weakRefCount() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::weakRefCount(); } \
+    using __Unused_type_for_semicolon = int
+

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(WTF_PUBLIC_HEADERS
     AbstractRefCounted.h
     AbstractRefCountedAndCanMakeWeakPtr.h
+    AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h
     ASCIICType.h
     AccessibleAddress.h
     AggregateLogger.h

--- a/Source/WTF/wtf/ThreadSafeWeakHashSet.h
+++ b/Source/WTF/wtf/ThreadSafeWeakHashSet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <wtf/Algorithms.h>
-#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Vector.h>
 
@@ -92,55 +92,71 @@ public:
 
     const_iterator end() const { return { { } }; }
 
-    template<typename U, std::enable_if_t<std::is_convertible_v<U*, T*>>* = nullptr>
-    void add(const U& value)
+    template<typename U>
+    void add(const U& value) requires (std::is_convertible_v<U*, T*>)
     {
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!value.controlBlock().objectHasStartedDeletion());
         Locker locker { m_lock };
         ControlBlockRefPtr retainedControlBlock { &value.controlBlock() };
-        if (!retainedControlBlock)
-            return;
+        ASSERT(retainedControlBlock);
         amortizedCleanupIfNeeded();
-        m_map.add(static_cast<const T*>(&value), WTFMove(retainedControlBlock));
+        m_set.add(std::make_pair(WTFMove(retainedControlBlock), &value));
     }
 
-    template<typename U, std::enable_if_t<std::is_convertible_v<U*, T*>>* = nullptr>
-    bool remove(const U& value)
+    template<typename U>
+    bool remove(const U& value) requires (std::is_convertible_v<U*, T*>)
     {
         Locker locker { m_lock };
         amortizedCleanupIfNeeded();
-        auto it = m_map.find(static_cast<const T*>(&value));
-        if (it == m_map.end())
+        // If there are no weak refs then it can't be in our table. In that case
+        // there's no point in potentially allocating a ControlBlock.
+        if (!value.weakRefCount())
             return false;
-        bool wasDeleted = it->value && it->value->objectHasStartedDeletion();
-        bool result = m_map.remove(it);
-        return !wasDeleted && result;
+
+        auto it = m_set.find(std::make_pair(&value.controlBlock(), &value));
+        if (it == m_set.end())
+            return false;
+        bool wasDeleted = it->first->objectHasStartedDeletion();
+        bool result = m_set.remove(it);
+        ASSERT_UNUSED(result, result);
+        return !wasDeleted;
     }
 
     void clear()
     {
         Locker locker { m_lock };
-        m_map.clear();
+        m_set.clear();
         cleanupHappened();
     }
 
-    template<typename U, std::enable_if_t<std::is_convertible_v<U*, T*>>* = nullptr>
-    bool contains(const U& value) const
+    template<typename U>
+    bool contains(const U& value) const requires (std::is_convertible_v<U*, T*>)
     {
         Locker locker { m_lock };
         amortizedCleanupIfNeeded();
-        auto it = m_map.find(static_cast<const T*>(&value));
-        if (it == m_map.end())
+        // If there are no weak refs then it can't be in our table. In that case
+        // there's no point in potentially allocating a ControlBlock.
+        if (!value.weakRefCount())
             return false;
-        return it->value && !it->value->objectHasStartedDeletion();
+
+        auto it = m_set.find(std::make_pair(&value.controlBlock(), &value));
+        if (it == m_set.end())
+            return false;
+
+        bool wasDeleted = it->first->objectHasStartedDeletion();
+        if (wasDeleted)
+            m_set.remove(it);
+        return !wasDeleted;
     }
 
     bool isEmptyIgnoringNullReferences() const
     {
         Locker locker { m_lock };
         amortizedCleanupIfNeeded();
-        for (auto& controlBlock : m_map.values()) {
-            if (!controlBlock->objectHasStartedDeletion())
+        // FIXME: This seems like it should remove any stale entries it finds along the way. Although, it might require a
+        // HashSet::removeNoRehash function. https://bugs.webkit.org/show_bug.cgi?id=283928
+        for (auto& pair : m_set) {
+            if (!pair.first->objectHasStartedDeletion())
                 return false;
         }
         return true;
@@ -152,14 +168,14 @@ public:
         {
             Locker locker { m_lock };
             bool hasNullReferences = false;
-            strongReferences = compactMap(m_map, [&hasNullReferences](auto& pair) -> RefPtr<T> {
-                if (RefPtr strongReference = pair.value->template makeStrongReferenceIfPossible<T>(pair.key))
+            strongReferences = compactMap(m_set, [&hasNullReferences](auto& pair) -> RefPtr<T> {
+                if (RefPtr strongReference = pair.first->template makeStrongReferenceIfPossible<T>(pair.second))
                     return strongReference;
                 hasNullReferences = true;
                 return nullptr;
             });
             if (hasNullReferences)
-                m_map.removeIf([](auto& pair) { return pair.value->objectHasStartedDeletion(); });
+                m_set.removeIf([](auto& pair) { return pair.first->objectHasStartedDeletion(); });
             cleanupHappened();
         }
         return strongReferences;
@@ -169,9 +185,10 @@ public:
     {
         Vector<ThreadSafeWeakPtr<T>> weakReferences;
         {
+            // FIXME: It seems like this should prune known dead entries as it goes. https://bugs.webkit.org/show_bug.cgi?id=283928
             Locker locker { m_lock };
-            weakReferences = WTF::map(m_map, [](auto& pair) {
-                return ThreadSafeWeakPtr { *pair.value, *pair.key };
+            weakReferences = WTF::map(m_set, [](auto& pair) {
+                return ThreadSafeWeakPtr<T> { *pair.first, *pair.second };
             });
         }
         return weakReferences;
@@ -187,21 +204,21 @@ public:
     unsigned sizeIncludingEmptyEntriesForTesting()
     {
         Locker locker { m_lock };
-        return m_map.size();
+        return m_set.size();
     }
 
 private:
     ALWAYS_INLINE void cleanupHappened() const WTF_REQUIRES_LOCK(m_lock)
     {
         m_operationCountSinceLastCleanup = 0;
-        m_maxOperationCountWithoutCleanup = std::min(std::numeric_limits<unsigned>::max() / 2, m_map.size()) * 2;
+        m_maxOperationCountWithoutCleanup = std::min(std::numeric_limits<unsigned>::max() / 2, m_set.size()) * 2;
     }
 
     ALWAYS_INLINE void moveFrom(ThreadSafeWeakHashSet&& other)
     {
         Locker locker { m_lock };
         Locker otherLocker { other.m_lock };
-        m_map = std::exchange(other.m_map, { });
+        m_set = std::exchange(other.m_set, { });
         m_operationCountSinceLastCleanup = std::exchange(other.m_operationCountSinceLastCleanup, 0);
         m_maxOperationCountWithoutCleanup = std::exchange(other.m_maxOperationCountWithoutCleanup, 0);
     }
@@ -209,14 +226,15 @@ private:
     ALWAYS_INLINE void amortizedCleanupIfNeeded() const WTF_REQUIRES_LOCK(m_lock)
     {
         if (++m_operationCountSinceLastCleanup > m_maxOperationCountWithoutCleanup) {
-            m_map.removeIf([] (auto& pair) {
-                return pair.value->objectHasStartedDeletion();
+            m_set.removeIf([] (auto& pair) {
+                ASSERT(pair.first->weakRefCount());
+                return pair.first->objectHasStartedDeletion();
             });
             cleanupHappened();
         }
     }
 
-    mutable UncheckedKeyHashMap<const T*, ControlBlockRefPtr> m_map WTF_GUARDED_BY_LOCK(m_lock);
+    mutable HashSet<std::pair<ControlBlockRefPtr, const T*>> m_set WTF_GUARDED_BY_LOCK(m_lock);
     mutable unsigned m_operationCountSinceLastCleanup WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     mutable unsigned m_maxOperationCountWithoutCleanup WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     mutable Lock m_lock;

--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -43,11 +43,8 @@ public:
     ThreadSafeWeakPtrControlBlock* weakRef()
     {
         Locker locker { m_lock };
-        if (m_object) {
-            ++m_weakReferenceCount;
-            return this;
-        }
-        return nullptr;
+        ++m_weakReferenceCount;
+        return this;
     }
 
     void weakDeref()
@@ -61,24 +58,6 @@ public:
         }
         if (shouldDeleteControlBlock)
             delete this;
-    }
-
-    size_t weakReferenceCount() const
-    {
-        Locker locker { m_lock };
-        return m_weakReferenceCount;
-    }
-
-    size_t refCount() const
-    {
-        Locker locker { m_lock };
-        return m_strongReferenceCount;
-    }
-
-    bool hasOneRef() const
-    {
-        Locker locker { m_lock };
-        return m_strongReferenceCount == 1;
     }
 
     void strongRef() const
@@ -122,29 +101,64 @@ public:
         }
     }
 
-    template<typename T>
-    RefPtr<T> makeStrongReferenceIfPossible(const T* objectOfCorrectType) const
+    template<typename U>
+    RefPtr<U> makeStrongReferenceIfPossible(const U* maybeInteriorPointer) const
     {
         Locker locker { m_lock };
+        // N.B. We don't just return m_object here since a ThreadSafeWeakPtr could be calling with a pointer to
+        // some interior pointer when there is multiple inheritance.
+        // Consider:
+        // struct Cat : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Cat>;
+        // struct Dog { virtual ThreadSafeWeakPtrControlBlock& controlBlock() const = 0; };
+        // struct CatDog : public Cat, public Dog {
+        //     ThreadSafeWeakPtrControlBlock& controlBlock() const { return Cat::controlBlock(); }
+        // };
+        //
+        // If we have a ThreadSafeWeakPtr<Dog> from a CatDog then we want to return maybeInteriorPointer's Dog*
+        // and not m_object's CatDog* pointer.
         if (m_object) {
             // Calling the RefPtr constructor would call strongRef() and deadlock.
             ++m_strongReferenceCount;
-            return adoptRef(const_cast<T*>(objectOfCorrectType));
+            return adoptRef(const_cast<U*>(maybeInteriorPointer));
         }
         return nullptr;
     }
 
+    // These should really only be used for debugging and shouldn't be used to guard any checks in production,
+    // unless you really know what you're doing. This is because they're prone to time of check time of use bugs.
+    // Consider:
+    // if (!objectHasStartedDeletion())
+    //     strongRef();
+    // Between objectHasStartedDeletion() and strongRef() another thread holding the sole remaining reference
+    // to the underlying object could release it's reference and start deletion.
     bool objectHasStartedDeletion() const
     {
         Locker locker { m_lock };
         return !m_object;
     }
+    size_t weakRefCount() const
+    {
+        Locker locker { m_lock };
+        return m_weakReferenceCount;
+    }
+
+    size_t refCount() const
+    {
+        Locker locker { m_lock };
+        return m_strongReferenceCount;
+    }
+
+    bool hasOneRef() const
+    {
+        Locker locker { m_lock };
+        return m_strongReferenceCount == 1;
+    }
 
 private:
     template<typename, DestructionThread> friend class ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr;
-    template<typename T>
-    explicit ThreadSafeWeakPtrControlBlock(T* object)
-        : m_object(object)
+    template<typename T, DestructionThread thread>
+    explicit ThreadSafeWeakPtrControlBlock(const ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<T, thread>* object)
+        : m_object(const_cast<T*>(static_cast<const T*>(object)))
     { }
 
     void setStrongReferenceCountDuringInitialization(size_t count) WTF_IGNORES_THREAD_SAFETY_ANALYSIS { m_strongReferenceCount = count; }
@@ -258,7 +272,7 @@ protected:
         if (LIKELY(!isStrongOnly(bits)))
             return *std::bit_cast<ThreadSafeWeakPtrControlBlock*>(bits);
 
-        auto* controlBlock = new ThreadSafeWeakPtrControlBlock(const_cast<T*>(static_cast<const T*>(this)));
+        auto* controlBlock = new ThreadSafeWeakPtrControlBlock(this);
 
         bool didSetControlBlock = m_bits.transaction([&](uintptr_t& bits) {
             if (!isStrongOnly(bits))
@@ -280,6 +294,10 @@ protected:
         delete controlBlock;
         return *std::bit_cast<ThreadSafeWeakPtrControlBlock*>(m_bits.loadRelaxed());
     }
+
+    // Ideally this would have been private but AbstractRefCounted subclasses need to be able to access this function
+    // to provide its result to ThreadSafeWeakHashSet.
+    size_t weakRefCount() const { return !isStrongOnly(m_bits.loadRelaxed()) ? controlBlock().weakRefCount() : 0; }
 
 private:
     static bool isStrongOnly(uintptr_t bits) { return bits & strongOnlyFlag; }
@@ -411,7 +429,8 @@ public:
     TagType tag() const { return m_objectOfCorrectType.tag(); }
 
 private:
-    template<typename U, std::enable_if_t<std::is_convertible_v<U*, T*>>* = nullptr>
+    template<typename U>
+    requires (std::is_convertible_v<U*, T*>)
     ThreadSafeWeakPtrControlBlock* controlBlock(const U& classOrChildClass)
     {
         return &classOrChildClass.controlBlock();
@@ -422,9 +441,9 @@ private:
     template<typename> friend class ThreadSafeWeakOrStrongPtr;
 
     TaggedPtr<T, TaggingTraits> m_objectOfCorrectType;
-    // FIXME: Either remove ThreadSafeWeakPtrControlBlock::m_object as redundant information,
-    // or use CompactRefPtrTuple to reduce sizeof(ThreadSafeWeakPtr) by storing just an offset
+    // FIXME: Use CompactRefPtrTuple to reduce sizeof(ThreadSafeWeakPtr) by storing just an offset
     // from ThreadSafeWeakPtrControlBlock::m_object and don't support structs larger than 65535.
+    // https://bugs.webkit.org/show_bug.cgi?id=283929
     ControlBlockRefPtr m_controlBlock;
 };
 

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
@@ -57,9 +57,7 @@ private:
         void requestFrame() { m_shouldEmitFrame = true; }
         std::optional<double> frameRequestRate() const { return m_frameRequestRate; }
 
-        void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Source, WTF::DestructionThread::MainRunLoop>::ref(); }
-        void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Source, WTF::DestructionThread::MainRunLoop>::deref(); }
-        ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Source, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
+        WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
     private:
         Source(HTMLCanvasElement&, std::optional<double>&&);

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.h
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.h
@@ -57,9 +57,7 @@ private:
     public:
         static Ref<Source> create(ScriptExecutionContextIdentifier identifier) { return adoptRef(*new Source(identifier)); }
 
-        void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Source, WTF::DestructionThread::MainRunLoop>::ref(); }
-        void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Source, WTF::DestructionThread::MainRunLoop>::deref(); }
-        ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Source, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
+        WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
         void writeVideoFrame(VideoFrame&, VideoFrameTimeMetadata);
 

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSource.h
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSource.h
@@ -43,9 +43,7 @@ public:
     static Ref<MediaStreamAudioSource> create(float sampleRate) { return adoptRef(*new MediaStreamAudioSource { sampleRate }); }
 
     ~MediaStreamAudioSource();
-    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaStreamAudioSource, WTF::DestructionThread::MainRunLoop>::ref(); }
-    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaStreamAudioSource, WTF::DestructionThread::MainRunLoop>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaStreamAudioSource, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
     const RealtimeMediaSourceCapabilities& capabilities() final;
     const RealtimeMediaSourceSettings& settings() final;

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -163,7 +163,7 @@ private:
 std::unique_ptr<SerializedImageBuffer> ImageBuffer::sinkIntoSerializedImageBuffer()
 {
     ASSERT(hasOneRef());
-    ASSERT(!controlBlock().weakReferenceCount());
+    ASSERT(!controlBlock().weakRefCount());
     return makeUnique<DefaultSerializedImageBuffer>(this);
 }
 

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.h
@@ -63,9 +63,7 @@ public:
     void setAudioModule(RefPtr<LibWebRTCAudioModule>&&);
     LibWebRTCAudioModule* audioModule() { return m_audioModule.get(); }
 
-    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingAudioSource, WTF::DestructionThread::MainRunLoop>::ref(); }
-    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingAudioSource, WTF::DestructionThread::MainRunLoop>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingAudioSource, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
     ~RealtimeIncomingAudioSource();
 protected:
     RealtimeIncomingAudioSource(rtc::scoped_refptr<webrtc::AudioTrackInterface>&&, String&&);

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h
@@ -61,9 +61,7 @@ class RealtimeIncomingVideoSource
 public:
     static Ref<RealtimeIncomingVideoSource> create(rtc::scoped_refptr<webrtc::VideoTrackInterface>&&, String&&);
     ~RealtimeIncomingVideoSource();
-    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingVideoSource, WTF::DestructionThread::MainRunLoop>::ref(); }
-    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingVideoSource, WTF::DestructionThread::MainRunLoop>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingVideoSource, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
     void enableFrameRatedMonitoring();
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -47,7 +47,7 @@
 #include "RealtimeMediaSourceFactory.h"
 #include "RealtimeMediaSourceIdentifier.h"
 #include "VideoFrameTimeMetadata.h"
-#include <wtf/AbstractRefCounted.h>
+#include <wtf/AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
@@ -113,7 +113,7 @@ public:
     virtual void hasStartedProducingData() { }
 };
 
-class WEBCORE_EXPORT RealtimeMediaSource : public AbstractRefCounted
+class WEBCORE_EXPORT RealtimeMediaSource : public AbstractThreadSafeRefCountedAndCanMakeWeakPtr
 #if !RELEASE_LOG_DISABLED
     , public LoggerHelper
 #endif
@@ -226,7 +226,6 @@ public:
 
     virtual const RealtimeMediaSourceCapabilities& capabilities() = 0;
     virtual const RealtimeMediaSourceSettings& settings() = 0;
-    virtual ThreadSafeWeakPtrControlBlock& controlBlock() const = 0;
 
     using TakePhotoNativePromise = NativePromise<std::pair<Vector<uint8_t>, String>, String>;
     virtual Ref<TakePhotoNativePromise> takePhoto(PhotoSettings&&);

--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
@@ -44,21 +44,6 @@ RealtimeVideoCaptureSource::RealtimeVideoCaptureSource(const CaptureDevice& devi
 
 RealtimeVideoCaptureSource::~RealtimeVideoCaptureSource() = default;
 
-void RealtimeVideoCaptureSource::ref() const
-{
-    ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeVideoCaptureSource, WTF::DestructionThread::MainRunLoop>::ref();
-}
-
-void RealtimeVideoCaptureSource::deref() const
-{
-    ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeVideoCaptureSource, WTF::DestructionThread::MainRunLoop>::deref();
-}
-
-ThreadSafeWeakPtrControlBlock& RealtimeVideoCaptureSource::controlBlock() const
-{
-    return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeVideoCaptureSource, WTF::DestructionThread::MainRunLoop>::controlBlock();
-}
-
 const Vector<VideoPreset>& RealtimeVideoCaptureSource::presets()
 {
     if (m_presets.isEmpty())

--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h
@@ -51,9 +51,7 @@ public:
 
     void ensureIntrinsicSizeMaintainsAspectRatio();
 
-    void ref() const final;
-    void deref() const final;
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final;
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
 protected:
     RealtimeVideoCaptureSource(const CaptureDevice&, MediaDeviceHashSalts&&, std::optional<PageIdentifier>);

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
@@ -133,9 +133,7 @@ public:
 
     Seconds elapsedTime();
 
-    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<DisplayCaptureSourceCocoa, WTF::DestructionThread::MainRunLoop>::ref(); }
-    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<DisplayCaptureSourceCocoa, WTF::DestructionThread::MainRunLoop>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<DisplayCaptureSourceCocoa, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
     virtual ~DisplayCaptureSourceCocoa();
 
 private:

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.h
@@ -43,9 +43,7 @@ public:
 
     std::pair<GstClockTime, GstClockTime> queryCaptureLatency() const final;
 
-    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerAudioCaptureSource>::ref(); }
-    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerAudioCaptureSource>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerAudioCaptureSource>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
     virtual ~GStreamerAudioCaptureSource();
 
     // GStreamerCapturerObserver

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
@@ -28,9 +28,7 @@ namespace WebCore {
 
 class RealtimeIncomingSourceGStreamer : public RealtimeMediaSource, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer> {
 public:
-    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>::ref(); }
-    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
     GstElement* bin() const { return m_bin.get(); }
     bool setBin(const GRefPtr<GstElement>&);

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -62,9 +62,7 @@ public:
 
     void handleNewCurrentMicrophoneDevice(const CaptureDevice&);
 
-    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CoreAudioCaptureSource, WTF::DestructionThread::MainRunLoop>::ref(); }
-    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CoreAudioCaptureSource, WTF::DestructionThread::MainRunLoop>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CoreAudioCaptureSource, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
     virtual ~CoreAudioCaptureSource();
 
 protected:

--- a/Source/WebCore/platform/mock/MockRealtimeAudioSource.h
+++ b/Source/WebCore/platform/mock/MockRealtimeAudioSource.h
@@ -49,9 +49,7 @@ public:
 
     WEBCORE_EXPORT void setChannelCount(unsigned);
 
-    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MockRealtimeAudioSource, WTF::DestructionThread::MainRunLoop>::ref(); }
-    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MockRealtimeAudioSource, WTF::DestructionThread::MainRunLoop>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MockRealtimeAudioSource, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
 protected:
     MockRealtimeAudioSource(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&, std::optional<PageIdentifier>);

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -366,10 +366,6 @@ class Device : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Device> {
 public:
     virtual ~Device() = default;
 
-    void ref() const { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Device>::ref(); }
-    void deref() const { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Device>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Device>::controlBlock(); }
-
     using FeatureList = Vector<SessionFeature>;
     bool supports(SessionMode mode) const { return m_supportedFeaturesMap.contains(mode); }
     void setSupportedFeatures(SessionMode mode, const FeatureList& features) { m_supportedFeaturesMap.set(mode, features); }

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h
@@ -50,9 +50,7 @@ class SpeechRecognitionRemoteRealtimeMediaSource : public WebCore::RealtimeMedia
 public:
     static Ref<WebCore::RealtimeMediaSource> create(SpeechRecognitionRemoteRealtimeMediaSourceManager&, const WebCore::CaptureDevice&, WebCore::PageIdentifier);
     ~SpeechRecognitionRemoteRealtimeMediaSource();
-    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SpeechRecognitionRemoteRealtimeMediaSource, WTF::DestructionThread::MainRunLoop>::ref(); }
-    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SpeechRecognitionRemoteRealtimeMediaSource, WTF::DestructionThread::MainRunLoop>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SpeechRecognitionRemoteRealtimeMediaSource, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
     WebCore::RealtimeMediaSourceIdentifier identifier() const { return m_identifier; }
 

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
@@ -39,7 +39,7 @@
 #include <WebCore/AudioSession.h>
 #include <WebCore/PlatformMediaSession.h>
 #include <WebCore/SharedMemory.h>
-#include <wtf/AbstractRefCounted.h>
+#include <wtf/AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
@@ -127,11 +127,9 @@ public:
     void createGPU(WebGPUIdentifier, RenderingBackendIdentifier, IPC::StreamServerConnection::Handle&&);
     void releaseGPU(WebGPUIdentifier);
 
-    class Client : public AbstractRefCounted {
+    class Client : public AbstractThreadSafeRefCountedAndCanMakeWeakPtr {
     public:
         virtual ~Client() = default;
-
-        virtual ThreadSafeWeakPtrControlBlock& controlBlock() const = 0;
 
         virtual void gpuProcessConnectionDidClose(GPUProcessConnection&) { }
     };

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.h
@@ -50,9 +50,7 @@ public:
 
     void update(WCUpdateInfo&&, CompletionHandler<void(std::optional<WebKit::UpdateInfo>)>&&);
 
-    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteWCLayerTreeHostProxy>::ref(); }
-    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteWCLayerTreeHostProxy>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteWCLayerTreeHostProxy>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
 private:
     WCLayerTreeHostIdentifier wcLayerTreeHostIdentifier() const { return m_wcLayerTreeHostIdentifier; };

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
@@ -59,9 +59,7 @@ public:
     RemoteAudioDestinationProxy(AudioIOCallback&, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate);
     ~RemoteAudioDestinationProxy();
 
-    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioDestinationProxy>::ref(); }
-    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioDestinationProxy>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioDestinationProxy>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
 private:
     void startRendering(CompletionHandler<void(bool)>&&) override;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h
@@ -54,9 +54,7 @@ public:
     static Ref<RemoteAudioHardwareListener> create(WebCore::AudioHardwareListener::Client&);
     ~RemoteAudioHardwareListener();
 
-    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioHardwareListener>::ref(); }
-    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioHardwareListener>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioHardwareListener>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
 private:
     explicit RemoteAudioHardwareListener(WebCore::AudioHardwareListener::Client&);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -53,9 +53,7 @@ public:
     static Ref<RemoteAudioSession> create();
     ~RemoteAudioSession();
 
-    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioSession>::ref(); }
-    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioSession>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioSession>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
 private:
     RemoteAudioSession();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
@@ -56,9 +56,7 @@ public:
     void setUseGPUProcess(bool);
     GPUProcessConnection& ensureGPUProcessConnection();
 
-    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteImageDecoderAVFManager>::ref(); }
-    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteImageDecoderAVFManager>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteImageDecoderAVFManager>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
 private:
     RemoteImageDecoderAVFManager();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
@@ -67,9 +67,7 @@ public:
 
     RemoteMediaPlayerMIMETypeCache& typeCache(WebCore::MediaPlayerEnums::MediaEngineIdentifier);
 
-    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteMediaPlayerManager>::ref(); }
-    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteMediaPlayerManager>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteMediaPlayerManager>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
     void initialize(const WebProcessCreationParameters&);
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h
@@ -53,9 +53,7 @@ public:
     explicit RemoteRemoteCommandListener(WebCore::RemoteCommandListenerClient&);
     ~RemoteRemoteCommandListener();
 
-    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteRemoteCommandListener>::ref(); }
-    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteRemoteCommandListener>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteRemoteCommandListener>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
 private:
     // IPC::MessageReceiver

--- a/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h
+++ b/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h
@@ -53,9 +53,7 @@ public:
     using SupportsAirPlayVideo = WebCore::MediaSessionHelperClient::SupportsAirPlayVideo;
     using SuspendedUnderLock = WebCore::MediaSessionHelperClient::SuspendedUnderLock;
 
-    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCore::MediaSessionHelper>::ref(); }
-    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCore::MediaSessionHelper>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCore::MediaSessionHelper>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
 private:
     // IPC::MessageReceiver

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -191,6 +191,7 @@ public:
     void ref() const final { return IPC::WorkQueueMessageReceiver::ref(); }
     void deref() const final { return IPC::WorkQueueMessageReceiver::deref(); }
     ThreadSafeWeakPtrControlBlock& controlBlock() const final { return IPC::WorkQueueMessageReceiver::controlBlock(); }
+    size_t weakRefCount() const final { return IPC::WorkQueueMessageReceiver::weakRefCount(); }
 
     WorkQueue& workQueue() const { return m_queue; }
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
@@ -65,6 +65,7 @@ public:
     RefPtr<WebCore::NativeImage> getNativeImage(const WebCore::VideoFrame&);
 
     ThreadSafeWeakPtrControlBlock& controlBlock() const final { return IPC::WorkQueueMessageReceiver::controlBlock(); }
+    size_t weakRefCount() const final { return IPC::WorkQueueMessageReceiver::weakRefCount(); }
 
     void ref() const final { IPC::WorkQueueMessageReceiver::ref(); }
     void deref() const final { IPC::WorkQueueMessageReceiver::deref(); }

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
@@ -52,9 +52,7 @@ public:
 
     WebCore::LayerHostingContextID hostingContextID() const final { return m_hostingContextID.value_or(0); }
 
-    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCore::SampleBufferDisplayLayer, WTF::DestructionThread::MainRunLoop>::ref(); }
-    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCore::SampleBufferDisplayLayer, WTF::DestructionThread::MainRunLoop>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCore::SampleBufferDisplayLayer, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
 private:
     SampleBufferDisplayLayer(SampleBufferDisplayLayerManager&, WebCore::SampleBufferDisplayLayerClient&);

--- a/Source/WebKit/WebProcess/Model/ModelProcessConnection.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessConnection.h
@@ -29,7 +29,7 @@
 
 #include "Connection.h"
 #include "MessageReceiverMap.h"
-#include <wtf/AbstractRefCounted.h>
+#include <wtf/AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RefCounted.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
@@ -68,11 +68,9 @@ public:
 
     void configureLoggingChannel(const String&, WTFLogChannelState, WTFLogLevel);
 
-    class Client : public AbstractRefCounted {
+    class Client : public AbstractThreadSafeRefCountedAndCanMakeWeakPtr {
     public:
         virtual ~Client() = default;
-
-        virtual ThreadSafeWeakPtrControlBlock& controlBlock() const = 0;
 
         virtual void modelProcessConnectionDidClose(ModelProcessConnection&) { }
     };

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.h
@@ -56,9 +56,7 @@ public:
 
     void didReceivePlayerMessage(IPC::Connection&, IPC::Decoder&);
 
-    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ModelProcessModelPlayerManager>::ref(); }
-    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ModelProcessModelPlayerManager>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ModelProcessModelPlayerManager>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
 private:
     ModelProcessModelPlayerManager();

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
@@ -59,9 +59,7 @@ public:
     void configurationChanged(String&& persistentID, WebCore::RealtimeMediaSourceSettings&&, WebCore::RealtimeMediaSourceCapabilities&&);
 
 #if ENABLE(GPU_PROCESS)
-    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteRealtimeMediaSource, WTF::DestructionThread::MainRunLoop>::ref(); }
-    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteRealtimeMediaSource, WTF::DestructionThread::MainRunLoop>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteRealtimeMediaSource, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 #endif
 
 protected:

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -2925,16 +2925,13 @@ public:
 
     ~ObjectAddingAndRemovingItself()
     {
-        EXPECT_FALSE(m_set.contains(*this));
         auto sizeBefore = m_set.sizeIncludingEmptyEntriesForTesting();
-        EXPECT_FALSE(m_set.remove(*this));
+        EXPECT_FALSE(m_set.contains(*this));
         auto sizeAfter = m_set.sizeIncludingEmptyEntriesForTesting();
-        static size_t i { 0 };
-        if (++i == 8) {
-            // Amortized cleanup gets this one during the contains call.
-            EXPECT_EQ(sizeBefore, sizeAfter);
-        } else
-            EXPECT_EQ(sizeBefore, sizeAfter + 1);
+        EXPECT_FALSE(m_set.remove(*this));
+        auto sizeAfterRemove = m_set.sizeIncludingEmptyEntriesForTesting();
+        EXPECT_EQ(sizeBefore, sizeAfter + 1);
+        EXPECT_EQ(sizeAfter, sizeAfterRemove);
         EXPECT_FALSE(m_set.contains(*this));
     }
 
@@ -2969,6 +2966,37 @@ TEST(WTF_ThreadSafeWeakPtr, ThreadSafeWeakHashSetRemoveOnDestruction)
     setSize = 0;
     set.forEach([&](auto& object) { ++setSize; });
     EXPECT_EQ(setSize, 0u);
+}
+
+class ObjectRemovingItself : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ObjectRemovingItself> {
+public:
+    static Ref<ObjectRemovingItself> create(ThreadSafeWeakHashSet<ObjectRemovingItself>& set)
+    {
+        return adoptRef(*new ObjectRemovingItself(set));
+    }
+
+    ~ObjectRemovingItself()
+    {
+        EXPECT_FALSE(m_set.contains(*this));
+        EXPECT_FALSE(m_set.remove(*this));
+    }
+
+private:
+    ObjectRemovingItself(ThreadSafeWeakHashSet<ObjectRemovingItself>& set)
+        : m_set(set)
+    {
+    }
+
+    ThreadSafeWeakHashSet<ObjectRemovingItself>& m_set;
+};
+
+// Test removing an object that was never inserted during its destructor is ok.
+TEST(WTF_ThreadSafeWeakPtr, ThreadSafeWeakHashSetRemoveNonExistantOnDestruction)
+{
+    ThreadSafeWeakHashSet<ObjectRemovingItself> set;
+    {
+        Ref<ObjectRemovingItself> object = ObjectRemovingItself::create(set);
+    }
 }
 
 class ObjectAddingItselfOnly : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ObjectAddingAndRemovingItself> {
@@ -3037,6 +3065,7 @@ TEST(WTF_ThreadSafeWeakPtr, MultipleInheritance)
         virtual void ref() const = 0;
         virtual void deref() const = 0;
         virtual ThreadSafeWeakPtrControlBlock& controlBlock() const = 0;
+        virtual size_t weakRefCount() const = 0;
 
         bool dog { true };
     };
@@ -3047,6 +3076,7 @@ TEST(WTF_ThreadSafeWeakPtr, MultipleInheritance)
         void ref() const final { Cat::ref(); }
         void deref() const final { Cat::deref(); }
         ThreadSafeWeakPtrControlBlock& controlBlock() const final { return Cat::controlBlock(); }
+        size_t weakRefCount() const final { return Cat::weakRefCount(); }
 
         void meow() final { meowed = true; }
         void woof() final { barked = true; }


### PR DESCRIPTION
#### cb9e03866203faa7c3a986f3bbd561661cca913f
<pre>
Various ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr cleanups
<a href="https://bugs.webkit.org/show_bug.cgi?id=283588">https://bugs.webkit.org/show_bug.cgi?id=283588</a>
<a href="https://rdar.apple.com/140325747">rdar://140325747</a>

Reviewed by Alex Christensen.

This patch clears up some parts of how ThreadSafeRefCountedAndCanMakeWeakPtr work.
In particular, now that we no longer permit creating a WeakRef during the destructor
of an object we don&apos;t need to use a HashMap in ThreadSafeWeakHashSet and can just use
a std::pair, which simplifies the logic. I also added an optimization to not check the
set if there&apos;s no weakRefCount when removing/contains checking. This also prevents
allocating a ControlBlock for an object that can&apos;t be in the table anyway.

I was originally thinking we could just remove this second pointer but due to
multiple inheritance it&apos;s actually necessary. I added some comments to clarify this.

I also added some logic to remove an entry if it&apos;s stale when calling
`ThreadSafeWeakHashSet::contains()` as well as some other places we could
opportunistically clear dead entries.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h: Added.
* Source/WTF/wtf/ThreadSafeWeakHashSet.h:
* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::ThreadSafeWeakPtrControlBlock::weakRef):
(WTF::ThreadSafeWeakPtrControlBlock::makeStrongReferenceIfPossible const):
(WTF::ThreadSafeWeakPtrControlBlock::weakRefCount const):
(WTF::ThreadSafeWeakPtrControlBlock::refCount const):
(WTF::ThreadSafeWeakPtrControlBlock::hasOneRef const):
(WTF::ThreadSafeWeakPtrControlBlock::ThreadSafeWeakPtrControlBlock):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::controlBlock const):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::weakRefCount const):
(WTF::ThreadSafeWeakPtrControlBlock::weakReferenceCount const): Deleted.
* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.h:
* Source/WebCore/Modules/webaudio/MediaStreamAudioSource.h:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::sinkIntoSerializedImageBuffer):
* Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.h:
* Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp:
(WebCore::RealtimeVideoCaptureSource::ref const): Deleted.
(WebCore::RealtimeVideoCaptureSource::deref const): Deleted.
(WebCore::RealtimeVideoCaptureSource::controlBlock const): Deleted.
* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h:
(): Deleted.
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:
* Source/WebCore/platform/mock/MockRealtimeAudioSource.h:
* Source/WebCore/platform/xr/PlatformXR.h:
(PlatformXR::Device::ref const): Deleted.
(PlatformXR::Device::deref const): Deleted.
(PlatformXR::Device::controlBlock const): Deleted.
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h:
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.h:
* Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h:
(): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h:
* Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h:
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h:
* Source/WebKit/WebProcess/Model/ModelProcessConnection.h:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.h:
(): Deleted.
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h:
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
(TestWebKitAPI::ObjectAddingAndRemovingItself::~ObjectAddingAndRemovingItself):
(TestWebKitAPI::ObjectRemovingItself::create):
(TestWebKitAPI::ObjectRemovingItself::~ObjectRemovingItself):
(TestWebKitAPI::ObjectRemovingItself::ObjectRemovingItself):
(TestWebKitAPI::TEST(WTF_ThreadSafeWeakPtr, ThreadSafeWeakHashSetRemoveNonExistantOnDestruction)):
(TestWebKitAPI::TEST(WTF_ThreadSafeWeakPtr, MultipleInheritance)):

Canonical link: <a href="https://commits.webkit.org/287313@main">https://commits.webkit.org/287313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66accc562e628fdf6d9c2e5a9f2c80330bc099e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32463 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30299 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81219 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6392 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61899 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19814 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72084 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42203 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49290 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26193 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28664 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/72210 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85112 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/78303 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6409 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70138 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6572 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67955 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69387 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/17300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13432 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12224 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/100626 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6361 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12181 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21960 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6317 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9772 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8109 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->