### PR TITLE
Add NumberOrPercentageResolvedToNumber CSS/Style type

### DIFF
--- a/Source/WebCore/css/CSSGradientValue.cpp
+++ b/Source/WebCore/css/CSSGradientValue.cpp
@@ -107,6 +107,10 @@ template<RawNumeric CSSType> struct StyleImageIsUncacheable<PrimitiveNumeric<CSS
     constexpr bool operator()(const auto& value) { return styleImageIsUncacheableOnVariantLike(value); }
 };
 
+template<auto R> struct StyleImageIsUncacheable<NumberOrPercentageResolvedToNumber<R>> {
+    constexpr bool operator()(const auto& value) { return styleImageIsUncacheableOnVariantLike(value); }
+};
+
 template<CSSValueID C> struct StyleImageIsUncacheable<Constant<C>> {
     constexpr bool operator()(const auto&) { return false; }
 };

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percentage.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percentage.cpp
@@ -43,13 +43,6 @@ RefPtr<CSSPrimitiveValue> consumePercentage(CSSParserTokenRange& range, const CS
     return CSSPrimitiveValueResolver<CSS::Percentage<CSS::Nonnegative>>::consumeAndResolve(range, context, { }, { }, { });
 }
 
-RefPtr<CSSPrimitiveValue> consumePercentageOrNumber(CSSParserTokenRange& range, const CSSParserContext& context, ValueRange valueRange)
-{
-    if (valueRange == ValueRange::All)
-        return CSSPrimitiveValueResolver<CSS::Percentage<CSS::All>, CSS::Number<CSS::All>>::consumeAndResolve(range, context, { }, { }, { });
-    return CSSPrimitiveValueResolver<CSS::Percentage<CSS::Nonnegative>, CSS::Number<CSS::Nonnegative>>::consumeAndResolve(range, context, { }, { }, { });
-}
-
 template<auto R> static RefPtr<CSSPrimitiveValue> consumePercentageDividedBy100OrNumber(CSSParserTokenRange& range, const CSSParserContext& context)
 {
     using NumberConsumer = ConsumerDefinition<CSS::Number<R>>;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percentage.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percentage.h
@@ -43,9 +43,6 @@ namespace CSSPropertyParserHelpers {
 // MARK: - Percent
 RefPtr<CSSPrimitiveValue> consumePercentage(CSSParserTokenRange&, const CSSParserContext&, ValueRange = ValueRange::All);
 
-// MARK: - Percent or Number
-RefPtr<CSSPrimitiveValue> consumePercentageOrNumber(CSSParserTokenRange&, const CSSParserContext&, ValueRange = ValueRange::All);
-
 // FIXME: Users of this function are likely getting incorrect results when used with calc() producing a percent, as it is not getting divided by 100.
 RefPtr<CSSPrimitiveValue> consumePercentageDividedBy100OrNumber(CSSParserTokenRange&, const CSSParserContext&, ValueRange = ValueRange::All);
 

--- a/Source/WebCore/css/values/images/CSSGradient.h
+++ b/Source/WebCore/css/values/images/CSSGradient.h
@@ -36,7 +36,7 @@ namespace CSS {
 
 // MARK: - Common Types
 
-using DeprecatedGradientPosition = SpaceSeparatedArray<PercentageOrNumber, 2>;
+using DeprecatedGradientPosition = SpaceSeparatedArray<NumberOrPercentage<>, 2>;
 
 using Horizontal     = std::variant<Left, Right>;
 using Vertical       = std::variant<Top, Bottom>;
@@ -99,7 +99,7 @@ using GradientLinearColorStopPosition = std::optional<LengthPercentage<>>;
 using GradientLinearColorStop = GradientColorStop<GradientLinearColorStopPosition>;
 using GradientLinearColorStopList = GradientColorStopList<GradientLinearColorStop>;
 
-using GradientDeprecatedColorStopPosition = PercentageOrNumber;
+using GradientDeprecatedColorStopPosition = NumberOrPercentageResolvedToNumber<>;
 using GradientDeprecatedColorStop = GradientColorStop<GradientDeprecatedColorStopPosition>;
 using GradientDeprecatedColorStopList = GradientColorStopList<GradientDeprecatedColorStop>;
 

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueVisitation.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueVisitation.h
@@ -45,5 +45,12 @@ template<RawNumeric RawType> struct CSSValueChildrenVisitor<PrimitiveNumeric<Raw
     }
 };
 
+template<auto R> struct CSSValueChildrenVisitor<NumberOrPercentageResolvedToNumber<R>> {
+    IterationStatus operator()(const Function<IterationStatus(CSSValue&)>& func, const NumberOrPercentageResolvedToNumber<R>& value)
+    {
+        return visitCSSValueChildren(func, value.value);
+    }
+};
+
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+ComputedStyleDependencies.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+ComputedStyleDependencies.h
@@ -67,6 +67,13 @@ template<RawNumeric RawType> struct ComputedStyleDependenciesCollector<Primitive
     }
 };
 
+// NumberOrPercentageResolvedToNumber trivially forwards to its inner variant.
+template<auto R> struct ComputedStyleDependenciesCollector<NumberOrPercentageResolvedToNumber<R>> {
+    void operator()(ComputedStyleDependencies& dependencies, const NumberOrPercentageResolvedToNumber<R>& value)
+    {
+        collectComputedStyleDependencies(dependencies, value.value);
+    }
+};
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h
@@ -48,6 +48,22 @@ template<RawNumeric RawType> struct Serialize<PrimitiveNumeric<RawType>> {
     }
 };
 
+template<auto R> struct Serialize<NumberOrPercentageResolvedToNumber<R>> {
+    void operator()(StringBuilder& builder, const NumberOrPercentageResolvedToNumber<R>& value)
+    {
+        WTF::switchOn(value.value,
+            [&](const Number<R>& number) {
+                serializationForCSS(builder, number);
+            },
+            [&](const Percentage<R>& percentage) {
+                if (auto raw = percentage.raw())
+                    serializationForCSS(builder, NumberRaw<R> { raw->value / 100.0 });
+                else
+                    serializationForCSS(builder, percentage);
+            }
+        );
+    }
+};
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/style/values/images/StyleGradient.h
+++ b/Source/WebCore/style/values/images/StyleGradient.h
@@ -40,7 +40,7 @@ namespace Style {
 
 // MARK: - Common Types
 
-using DeprecatedGradientPosition = SpaceSeparatedArray<PercentageOrNumber, 2>;
+using DeprecatedGradientPosition = SpaceSeparatedArray<NumberOrPercentage<>, 2>;
 
 using Horizontal     = CSS::Horizontal;
 using Vertical       = CSS::Vertical;
@@ -84,7 +84,7 @@ using GradientLinearColorStopPosition = std::optional<LengthPercentage<>>;
 using GradientLinearColorStop = GradientColorStop<GradientLinearColorStopPosition>;
 using GradientLinearColorStopList = GradientColorStopList<GradientLinearColorStop>;
 
-using GradientDeprecatedColorStopPosition = Number<>;
+using GradientDeprecatedColorStopPosition = NumberOrPercentageResolvedToNumber<>;
 using GradientDeprecatedColorStop = GradientColorStop<GradientDeprecatedColorStopPosition>;
 using GradientDeprecatedColorStopList = GradientColorStopList<GradientDeprecatedColorStop>;
 

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h
@@ -113,5 +113,17 @@ template<auto R> struct Blending<LengthPercentage<R>> {
     }
 };
 
+// `NumberOrPercentageResolvedToNumber<R>` forwards to `Number<R>`.
+template<auto R> struct Blending<NumberOrPercentageResolvedToNumber<R>> {
+    auto canBlend(const NumberOrPercentageResolvedToNumber<R>& a, const NumberOrPercentageResolvedToNumber<R>& b) -> bool
+    {
+        return Style::canBlend(a.value, b.value);
+    }
+    auto blend(const NumberOrPercentageResolvedToNumber<R>& a, const NumberOrPercentageResolvedToNumber<R>& b, const BlendingContext& context) -> NumberOrPercentageResolvedToNumber<R>
+    {
+        return Style::blend(a.value, b.value, context);
+    }
+};
+
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
@@ -555,7 +555,29 @@ template<CSS::Range R = CSS::All> struct LengthPercentage {
 // MARK: Additional Common Type and Groupings
 
 // NOTE: This is spelled with an explicit "Or" to distinguish it from types like AnglePercentage/LengthPercentage that have behavior distinctions beyond just being a union of the two types (specifically, calc() has specific behaviors for those types).
-using PercentageOrNumber = std::variant<Percentage<>, Number<>>;
+template<CSS::Range R = CSS::All> using NumberOrPercentage = std::variant<Number<R>, Percentage<R>>;
+
+template<CSS::Range R = CSS::All> struct NumberOrPercentageResolvedToNumber {
+    Number<R> value { 0 };
+
+    constexpr NumberOrPercentageResolvedToNumber(typename Number<R>::ValueType value)
+        : value { value }
+    {
+    }
+
+    constexpr NumberOrPercentageResolvedToNumber(Number<R> number)
+        : value { number }
+    {
+    }
+
+    constexpr NumberOrPercentageResolvedToNumber(Percentage<R> percentage)
+        : value { percentage.value / 100.0 }
+    {
+    }
+
+    constexpr bool operator==(const NumberOrPercentageResolvedToNumber<R>&) const = default;
+    constexpr bool operator==(typename Number<R>::ValueType other) const { return value.value == other; };
+};
 
 // Standard Numbers
 using NumberAll = Number<CSS::All>;


### PR DESCRIPTION
#### 47bc6653d9ad8c1604e5130803416c48ffc7ee82
<pre>
Add NumberOrPercentageResolvedToNumber CSS/Style type
<a href="https://bugs.webkit.org/show_bug.cgi?id=283589">https://bugs.webkit.org/show_bug.cgi?id=283589</a>

Reviewed by Darin Adler.

A relatively common idiom is a [ &lt;number&gt; | &lt;percentage&gt; ] that always resolves
to a &lt;number&gt;. This implements a type for that in the new CSS/Style value types.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Percentage.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Percentage.h:
* Source/WebCore/css/values/images/CSSGradient.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueVisitation.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+ComputedStyleDependencies.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h:
* Source/WebCore/style/values/images/StyleGradient.cpp:
* Source/WebCore/style/values/images/StyleGradient.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h:

Canonical link: <a href="https://commits.webkit.org/287105@main">https://commits.webkit.org/287105@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79772c98f7963be12f8684b3c04f8f4b369924f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78075 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82731 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29336 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5403 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61144 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19064 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67706 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41457 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48489 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24646 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27676 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69584 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24999 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84092 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5442 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3677 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69367 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5598 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68621 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17158 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12615 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10832 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5390 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8143 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5380 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8812 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7168 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->