### PR TITLE
Make it possible to log style changes

### DIFF
--- a/Source/WTF/wtf/text/TextStream.h
+++ b/Source/WTF/wtf/text/TextStream.h
@@ -61,6 +61,8 @@ public:
     {
     }
 
+    bool isEmpty() const { return m_text.isEmpty(); }
+
     WTF_EXPORT_PRIVATE TextStream& operator<<(bool);
     WTF_EXPORT_PRIVATE TextStream& operator<<(char);
     WTF_EXPORT_PRIVATE TextStream& operator<<(int);

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2709,6 +2709,7 @@ platform/text/SegmentedString.cpp
 platform/text/TextBoundaries.cpp
 platform/text/TextFlags.cpp
 platform/text/TextSpacing.cpp
+platform/text/UnicodeBidi.cpp
 platform/video-codecs/BitReader.cpp
 platform/xr/openxr/OpenXRInput.cpp
 platform/xr/openxr/OpenXRInputSource.cpp

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -125,6 +125,7 @@ namespace WebCore {
     M(SQLDatabase) \
     M(Storage) \
     M(StorageAPI) \
+    M(Style) \
     M(StyleSheets) \
     M(SVG) \
     M(TextAutosizing) \

--- a/Source/WebCore/platform/text/UnicodeBidi.cpp
+++ b/Source/WebCore/platform/text/UnicodeBidi.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "UnicodeBidi.h"
+
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+TextStream& operator<<(TextStream& ts, UnicodeBidi value)
+{
+    switch (value) {
+    case UnicodeBidi::Normal: ts << "Normal"; break;
+    case UnicodeBidi::Embed: ts << "Embed"; break;
+    case UnicodeBidi::Override: ts << "Override"; break;
+    case UnicodeBidi::Isolate: ts << "Isolate"; break;
+    case UnicodeBidi::Plaintext: ts << "Plaintext"; break;
+    case UnicodeBidi::IsolateOverride: ts << "IsolateOverride"; break;
+    }
+    return ts;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/text/UnicodeBidi.h
+++ b/Source/WebCore/platform/text/UnicodeBidi.h
@@ -23,8 +23,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef UnicodeBidi_h
-#define UnicodeBidi_h
+#pragma once
+
+namespace WTF {
+class TextStream;
+}
 
 namespace WebCore {
 
@@ -47,6 +50,6 @@ inline bool isOverride(UnicodeBidi unicodeBidi)
     return unicodeBidi == UnicodeBidi::Override || unicodeBidi == UnicodeBidi::IsolateOverride;
 }
 
-}
+WTF::TextStream& operator<<(WTF::TextStream&, UnicodeBidi);
 
-#endif
+}

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -101,6 +101,7 @@
 #include <wtf/MathExtras.h>
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/TextStream.h>
 
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
 #include "ContentChangeObserver.h"
@@ -527,8 +528,19 @@ void RenderElement::setStyle(RenderStyle&& style, StyleDifference minimalStyleDi
 
     StyleDifference diff = StyleDifference::Equal;
     OptionSet<StyleDifferenceContextSensitiveProperty> contextSensitiveProperties;
-    if (m_hasInitializedStyle)
+    if (m_hasInitializedStyle) {
         diff = m_style.diff(style, contextSensitiveProperties);
+
+#if !LOG_DISABLED
+        if (LogStyle.state == WTFLogChannelState::On) {
+            TextStream diffStream(TextStream::LineMode::MultipleLine, TextStream::Formatting::NumberRespectingIntegers);
+            diffStream.increaseIndent(2);
+            m_style.dumpDifferences(diffStream, style);
+            if (!diffStream.isEmpty())
+                LOG_WITH_STREAM(Style, stream << *this << " style diff " << diff << " (context sensitive changes " << contextSensitiveProperties << "):\n" << diffStream.release());
+        }
+#endif
+    }
 
     diff = std::max(diff, minimalStyleDifference);
 

--- a/Source/WebCore/rendering/style/CounterDirectives.h
+++ b/Source/WebCore/rendering/style/CounterDirectives.h
@@ -35,6 +35,8 @@ struct CounterDirectives {
 
 struct CounterDirectiveMap {
     UncheckedKeyHashMap<AtomString, CounterDirectives> map;
+
+    friend bool operator==(const CounterDirectiveMap&, const CounterDirectiveMap&) = default;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -33,6 +33,10 @@
 #include <wtf/OptionSet.h>
 #include <wtf/Vector.h>
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 class AnimationList;
@@ -1813,6 +1817,10 @@ public:
     bool diffRequiresLayerRepaint(const RenderStyle&, bool isComposited) const;
     void conservativelyCollectChangedAnimatableProperties(const RenderStyle&, CSSPropertiesBitSet&) const;
 
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const RenderStyle&) const;
+#endif
+
     constexpr bool isDisplayInlineType() const;
     constexpr bool isOriginalDisplayInlineType() const;
     constexpr bool isDisplayFlexibleOrGridBox() const;
@@ -2275,6 +2283,10 @@ private:
         bool hasPseudoStyle(PseudoId) const;
         void setHasPseudoStyles(PseudoIdSet);
 
+#if !LOG_DISABLED
+        void dumpDifferences(TextStream&, const NonInheritedFlags&) const;
+#endif
+
         unsigned effectiveDisplay : 5; // DisplayType
         unsigned originalDisplay : 5; // DisplayType
         unsigned overflowX : 3; // Overflow
@@ -2305,6 +2317,10 @@ private:
 
     struct InheritedFlags {
         friend bool operator==(const InheritedFlags&, const InheritedFlags&) = default;
+
+#if !LOG_DISABLED
+        void dumpDifferences(TextStream&, const InheritedFlags&) const;
+#endif
 
         // Writing Mode = 8 bits (can be packed into 6 if needed)
         WritingMode writingMode;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -32,6 +32,31 @@
 
 namespace WebCore {
 
+
+bool alwaysPageBreak(BreakBetween between)
+{
+    return between >= BreakBetween::Page;
+}
+
+CSSBoxType transformBoxToCSSBoxType(TransformBox transformBox)
+{
+    switch (transformBox) {
+    case TransformBox::StrokeBox:
+        return CSSBoxType::StrokeBox;
+    case TransformBox::ContentBox:
+        return CSSBoxType::ContentBox;
+    case TransformBox::BorderBox:
+        return CSSBoxType::BorderBox;
+    case TransformBox::FillBox:
+        return CSSBoxType::FillBox;
+    case TransformBox::ViewBox:
+        return CSSBoxType::ViewBox;
+    default:
+        ASSERT_NOT_REACHED();
+        return CSSBoxType::BorderBox;
+    }
+}
+
 TextStream& operator<<(TextStream& ts, AnimationFillMode fillMode)
 {
     switch (fillMode) {
@@ -1407,18 +1432,10 @@ TextStream& operator<<(TextStream& ts, MathStyle mathStyle)
 TextStream& operator<<(TextStream& ts, ContainIntrinsicSizeType containIntrinsicSizeType)
 {
     switch (containIntrinsicSizeType) {
-    case ContainIntrinsicSizeType::None:
-        ts << "none";
-        break;
-    case ContainIntrinsicSizeType::Length:
-        ts << "length";
-        break;
-    case ContainIntrinsicSizeType::AutoAndLength:
-        ts << "autoandlength";
-        break;
-    case ContainIntrinsicSizeType::AutoAndNone:
-        ts << "autoandnone";
-        break;
+    case ContainIntrinsicSizeType::None: ts << "none"; break;
+    case ContainIntrinsicSizeType::Length: ts << "length"; break;
+    case ContainIntrinsicSizeType::AutoAndLength: ts << "autoandlength"; break;
+    case ContainIntrinsicSizeType::AutoAndNone: ts << "autoandnone"; break;
     }
     return ts;
 }
@@ -1436,28 +1453,17 @@ TextStream& operator<<(TextStream& ts, OverflowContinue overflowContinue)
     return ts;
 }
 
-bool alwaysPageBreak(BreakBetween between)
+TextStream& operator<<(TextStream& ts, StyleDifferenceContextSensitiveProperty property)
 {
-    return between >= BreakBetween::Page;
-}
-
-CSSBoxType transformBoxToCSSBoxType(TransformBox transformBox)
-{
-    switch (transformBox) {
-    case TransformBox::StrokeBox:
-        return CSSBoxType::StrokeBox;
-    case TransformBox::ContentBox:
-        return CSSBoxType::ContentBox;
-    case TransformBox::BorderBox:
-        return CSSBoxType::BorderBox;
-    case TransformBox::FillBox:
-        return CSSBoxType::FillBox;
-    case TransformBox::ViewBox:
-        return CSSBoxType::ViewBox;
-    default:
-        ASSERT_NOT_REACHED();
-        return CSSBoxType::BorderBox;
+    switch (property) {
+    case StyleDifferenceContextSensitiveProperty::Transform: ts << "transform"; break;
+    case StyleDifferenceContextSensitiveProperty::Opacity: ts << "opacity"; break;
+    case StyleDifferenceContextSensitiveProperty::Filter: ts << "filter"; break;
+    case StyleDifferenceContextSensitiveProperty::ClipRect: ts << "clipRect"; break;
+    case StyleDifferenceContextSensitiveProperty::ClipPath: ts << "clipPath"; break;
+    case StyleDifferenceContextSensitiveProperty::WillChange: ts << "willChange"; break;
     }
+    return ts;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -1299,6 +1299,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, ScrollSnapStop);
 WTF::TextStream& operator<<(WTF::TextStream&, ScrollSnapStrictness);
 WTF::TextStream& operator<<(WTF::TextStream&, SpeakAs);
 WTF::TextStream& operator<<(WTF::TextStream&, StyleDifference);
+WTF::TextStream& operator<<(WTF::TextStream&, StyleDifferenceContextSensitiveProperty);
 WTF::TextStream& operator<<(WTF::TextStream&, TableLayoutType);
 WTF::TextStream& operator<<(WTF::TextStream&, TextAlignMode);
 WTF::TextStream& operator<<(WTF::TextStream&, TextAlignLast);

--- a/Source/WebCore/rendering/style/RenderStyleDifference.h
+++ b/Source/WebCore/rendering/style/RenderStyleDifference.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if !LOG_DISABLED
+
+#include <wtf/PointerComparison.h>
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+#define LOG_IF_DIFFERENT(name) \
+    do { logIfDifferent(ts, ASCIILiteral::fromLiteralUnsafe(#name), name, other.name); } while (0)
+
+#define LOG_IF_DIFFERENT_WITH_CAST(type, name) \
+    do { logIfDifferent(ts, ASCIILiteral::fromLiteralUnsafe(#name), static_cast<type>(name), static_cast<type>(other.name)); } while (0)
+
+#define LOG_RAW_OPTIONSET_IF_DIFFERENT(type, name) \
+    do { logIfDifferent(ts, ASCIILiteral::fromLiteralUnsafe(#name), OptionSet<type>::fromRaw(name), OptionSet<type>::fromRaw(other.name)); } while (0)
+
+
+template<class T>
+struct is_pointer_wrapper : std::false_type { };
+
+template<class T>
+struct is_pointer_wrapper<RefPtr<T>> : std::true_type { };
+
+template<class T>
+struct is_pointer_wrapper<Ref<T>> : std::true_type { };
+
+template<class T>
+struct is_pointer_wrapper<std::unique_ptr<T>> : std::true_type { };
+
+template<typename T>
+struct ValueOrUnstreamableMessage {
+    explicit ValueOrUnstreamableMessage(const T& value)
+        : value(value)
+    { }
+    const T& value;
+};
+
+template<typename T>
+TextStream& operator<<(TextStream& ts, ValueOrUnstreamableMessage<T> item)
+{
+    if constexpr (WTF::supports_text_stream_insertion<T>::value) {
+        if constexpr (is_pointer_wrapper<T>::value)
+            ts << ValueOrNull(item.value.get());
+        else
+            ts << item.value;
+    } else
+        ts << "(unstreamable)";
+    return ts;
+}
+
+
+template<typename T>
+void logIfDifferent(TextStream& ts, ASCIILiteral name, const T& item1, const T& item2)
+{
+    bool differ = false;
+    if constexpr (is_pointer_wrapper<T>::value)
+        differ = !arePointingToEqualData(item1, item2);
+    else
+        differ = item1 != item2;
+
+    if (differ)
+        ts << name << " differs: " << ValueOrUnstreamableMessage(item1) << ", " << ValueOrUnstreamableMessage(item2) << '\n';
+}
+
+} // namespace WebCore
+
+#endif // !LOG_DISABLED

--- a/Source/WebCore/rendering/style/SVGRenderStyle.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.cpp
@@ -34,6 +34,7 @@
 #include "NodeRenderStyle.h"
 #include "SVGElement.h"
 #include <wtf/NeverDestroyed.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 
@@ -352,5 +353,44 @@ void SVGRenderStyle::conservativelyCollectChangedAnimatableProperties(const SVGR
     if (m_nonInheritedFlags != other.m_nonInheritedFlags)
         conservativelyCollectChangedAnimatablePropertiesViaNonInheritedFlags(m_nonInheritedFlags, other.m_nonInheritedFlags);
 }
+
+#if !LOG_DISABLED
+
+void SVGRenderStyle::InheritedFlags::dumpDifferences(TextStream& ts, const SVGRenderStyle::InheritedFlags& other) const
+{
+    LOG_IF_DIFFERENT_WITH_CAST(ShapeRendering, shapeRendering);
+    LOG_IF_DIFFERENT_WITH_CAST(WindRule, clipRule);
+    LOG_IF_DIFFERENT_WITH_CAST(WindRule, fillRule);
+    LOG_IF_DIFFERENT_WITH_CAST(TextAnchor, textAnchor);
+    LOG_IF_DIFFERENT_WITH_CAST(ColorInterpolation, colorInterpolation);
+    LOG_IF_DIFFERENT_WITH_CAST(ColorInterpolation, colorInterpolationFilters);
+    LOG_IF_DIFFERENT_WITH_CAST(GlyphOrientation, glyphOrientationHorizontal);
+    LOG_IF_DIFFERENT_WITH_CAST(GlyphOrientation, glyphOrientationVertical);
+}
+
+void SVGRenderStyle::NonInheritedFlags::dumpDifferences(TextStream& ts, const SVGRenderStyle::NonInheritedFlags& other) const
+{
+    LOG_IF_DIFFERENT_WITH_CAST(AlignmentBaseline, flagBits.alignmentBaseline);
+    LOG_IF_DIFFERENT_WITH_CAST(DominantBaseline, flagBits.dominantBaseline);
+    LOG_IF_DIFFERENT_WITH_CAST(BaselineShift, flagBits.baselineShift);
+    LOG_IF_DIFFERENT_WITH_CAST(VectorEffect, flagBits.vectorEffect);
+    LOG_IF_DIFFERENT_WITH_CAST(BufferedRendering, flagBits.bufferedRendering);
+    LOG_IF_DIFFERENT_WITH_CAST(MaskType, flagBits.maskType);
+}
+
+void SVGRenderStyle::dumpDifferences(TextStream& ts, const SVGRenderStyle& other) const
+{
+    m_inheritedFlags.dumpDifferences(ts, other.m_inheritedFlags);
+    m_nonInheritedFlags.dumpDifferences(ts, other.m_nonInheritedFlags);
+
+    m_fillData->dumpDifferences(ts, other.m_fillData);
+    m_strokeData->dumpDifferences(ts, other.m_strokeData);
+    m_inheritedResourceData->dumpDifferences(ts, other.m_inheritedResourceData);
+
+    m_stopData->dumpDifferences(ts, other.m_stopData);
+    m_miscData->dumpDifferences(ts, other.m_miscData);
+    m_layoutData->dumpDifferences(ts, other.m_layoutData);
+}
+#endif
 
 }

--- a/Source/WebCore/rendering/style/SVGRenderStyle.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.h
@@ -29,6 +29,10 @@
 #include "StyleRareInheritedData.h"
 #include "WindRule.h"
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SVGRenderStyle);
@@ -48,6 +52,10 @@ public:
     bool changeRequiresLayout(const SVGRenderStyle& other) const;
 
     bool operator==(const SVGRenderStyle&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const SVGRenderStyle&) const;
+#endif
 
     // Initial values for all the properties
     static AlignmentBaseline initialAlignmentBaseline() { return AlignmentBaseline::Baseline; }
@@ -195,6 +203,10 @@ private:
     struct InheritedFlags {
         friend bool operator==(const InheritedFlags&, const InheritedFlags&) = default;
 
+#if !LOG_DISABLED
+        void dumpDifferences(TextStream&, const InheritedFlags&) const;
+#endif
+
         unsigned shapeRendering : 2; // ShapeRendering
         unsigned clipRule : 1; // WindRule
         unsigned fillRule : 1; // WindRule
@@ -208,6 +220,10 @@ private:
     struct NonInheritedFlags {
         // 32 bit non-inherited, don't add to the struct, or the operator will break.
         bool operator==(const NonInheritedFlags& other) const { return flags == other.flags; }
+
+#if !LOG_DISABLED
+        void dumpDifferences(TextStream&, const NonInheritedFlags&) const;
+#endif
 
         union {
             struct {

--- a/Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "SVGRenderStyleDefs.h"
 
+#include "RenderStyleDifference.h"
 #include "RenderStyleInlines.h"
 #include "SVGRenderStyle.h"
 #include <wtf/PointerComparison.h>
@@ -65,6 +66,19 @@ Ref<StyleFillData> StyleFillData::copy() const
 {
     return adoptRef(*new StyleFillData(*this));
 }
+
+#if !LOG_DISABLED
+void StyleFillData::dumpDifferences(TextStream& ts, const StyleFillData& other) const
+{
+    LOG_IF_DIFFERENT(opacity);
+    LOG_IF_DIFFERENT(paintColor);
+    LOG_IF_DIFFERENT(visitedLinkPaintColor);
+    LOG_IF_DIFFERENT(paintUri);
+    LOG_IF_DIFFERENT(visitedLinkPaintUri);
+    LOG_IF_DIFFERENT(paintType);
+    LOG_IF_DIFFERENT(visitedLinkPaintType);
+}
+#endif
 
 bool StyleFillData::operator==(const StyleFillData& other) const
 {
@@ -125,6 +139,23 @@ bool StyleStrokeData::operator==(const StyleStrokeData& other) const
         && visitedLinkPaintType == other.visitedLinkPaintType;
 }
 
+#if !LOG_DISABLED
+void StyleStrokeData::dumpDifferences(TextStream& ts, const StyleStrokeData& other) const
+{
+    LOG_IF_DIFFERENT(opacity);
+    LOG_IF_DIFFERENT(paintColor);
+    LOG_IF_DIFFERENT(visitedLinkPaintColor);
+    LOG_IF_DIFFERENT(paintUri);
+    LOG_IF_DIFFERENT(visitedLinkPaintUri);
+
+    LOG_IF_DIFFERENT(dashOffset);
+    LOG_IF_DIFFERENT(dashArray);
+
+    LOG_IF_DIFFERENT(paintType);
+    LOG_IF_DIFFERENT(visitedLinkPaintType);
+}
+#endif
+
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleStopData);
 
 StyleStopData::StyleStopData()
@@ -150,6 +181,14 @@ bool StyleStopData::operator==(const StyleStopData& other) const
     return opacity == other.opacity
         && color == other.color;
 }
+
+#if !LOG_DISABLED
+void StyleStopData::dumpDifferences(TextStream& ts, const StyleStopData& other) const
+{
+    LOG_IF_DIFFERENT(opacity);
+    LOG_IF_DIFFERENT(color);
+}
+#endif
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleMiscData);
 
@@ -183,6 +222,16 @@ bool StyleMiscData::operator==(const StyleMiscData& other) const
         && baselineShiftValue == other.baselineShiftValue;
 }
 
+#if !LOG_DISABLED
+void StyleMiscData::dumpDifferences(TextStream& ts, const StyleMiscData& other) const
+{
+    LOG_IF_DIFFERENT(floodOpacity);
+    LOG_IF_DIFFERENT(floodColor);
+    LOG_IF_DIFFERENT(lightingColor);
+    LOG_IF_DIFFERENT(baselineShiftValue);
+}
+#endif
+
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleShadowSVGData);
 
 StyleShadowSVGData::StyleShadowSVGData()
@@ -204,6 +253,13 @@ bool StyleShadowSVGData::operator==(const StyleShadowSVGData& other) const
 {
     return arePointingToEqualData(shadow, other.shadow);
 }
+
+#if !LOG_DISABLED
+void StyleShadowSVGData::dumpDifferences(TextStream& ts, const StyleShadowSVGData& other) const
+{
+    LOG_IF_DIFFERENT(shadow);
+}
+#endif
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleInheritedResourceData);
 
@@ -233,6 +289,15 @@ bool StyleInheritedResourceData::operator==(const StyleInheritedResourceData& ot
         && markerMid == other.markerMid
         && markerEnd == other.markerEnd;
 }
+
+#if !LOG_DISABLED
+void StyleInheritedResourceData::dumpDifferences(TextStream& ts, const StyleInheritedResourceData& other) const
+{
+    LOG_IF_DIFFERENT(markerStart);
+    LOG_IF_DIFFERENT(markerMid);
+    LOG_IF_DIFFERENT(markerEnd);
+}
+#endif
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleLayoutData);
 
@@ -278,6 +343,19 @@ bool StyleLayoutData::operator==(const StyleLayoutData& other) const
         && d == other.d;
 }
 
+#if !LOG_DISABLED
+void StyleLayoutData::dumpDifferences(TextStream& ts, const StyleLayoutData& other) const
+{
+    LOG_IF_DIFFERENT(cx);
+    LOG_IF_DIFFERENT(cy);
+    LOG_IF_DIFFERENT(r);
+    LOG_IF_DIFFERENT(rx);
+    LOG_IF_DIFFERENT(ry);
+    LOG_IF_DIFFERENT(x);
+    LOG_IF_DIFFERENT(y);
+    LOG_IF_DIFFERENT(d);
+}
+#endif
 
 TextStream& operator<<(TextStream& ts, AlignmentBaseline value)
 {

--- a/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
@@ -151,6 +151,10 @@ public:
 
     bool operator==(const StyleFillData&) const;
 
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleFillData&) const;
+#endif
+
     float opacity;
     StyleColor paintColor;
     StyleColor visitedLinkPaintColor;
@@ -172,6 +176,10 @@ public:
     Ref<StyleStrokeData> copy() const;
 
     bool operator==(const StyleStrokeData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleStrokeData&) const;
+#endif
 
     float opacity;
 
@@ -201,6 +209,10 @@ public:
 
     bool operator==(const StyleStopData&) const;
 
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleStopData&) const;
+#endif
+
     float opacity;
     StyleColor color;
 
@@ -218,6 +230,10 @@ public:
     Ref<StyleMiscData> copy() const;
 
     bool operator==(const StyleMiscData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleMiscData&) const;
+#endif
 
     float floodOpacity;
     StyleColor floodColor;
@@ -239,6 +255,10 @@ public:
 
     bool operator==(const StyleShadowSVGData&) const;
 
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleShadowSVGData&) const;
+#endif
+
     std::unique_ptr<ShadowData> shadow;
 
 private:
@@ -255,6 +275,10 @@ public:
     Ref<StyleInheritedResourceData> copy() const;
 
     bool operator==(const StyleInheritedResourceData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleInheritedResourceData&) const;
+#endif
 
     String markerStart;
     String markerMid;
@@ -274,6 +298,10 @@ public:
     Ref<StyleLayoutData> copy() const;
 
     bool operator==(const StyleLayoutData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleLayoutData&) const;
+#endif
 
     Length cx;
     Length cy;

--- a/Source/WebCore/rendering/style/StyleBackgroundData.cpp
+++ b/Source/WebCore/rendering/style/StyleBackgroundData.cpp
@@ -24,6 +24,7 @@
 
 #include "BorderData.h"
 #include "RenderStyleConstants.h"
+#include "RenderStyleDifference.h"
 #include "RenderStyleInlines.h"
 
 namespace WebCore {
@@ -76,6 +77,15 @@ void StyleBackgroundData::dump(TextStream& ts, DumpStyleValues behavior) const
     if (behavior == DumpStyleValues::All || outline != OutlineValue())
         ts.dumpProperty("outline", outline);
 }
+
+#if !LOG_DISABLED
+void StyleBackgroundData::dumpDifferences(TextStream& ts, const StyleBackgroundData& other) const
+{
+    LOG_IF_DIFFERENT(background);
+    LOG_IF_DIFFERENT(color);
+    LOG_IF_DIFFERENT(outline);
+}
+#endif
 
 TextStream& operator<<(TextStream& ts, const StyleBackgroundData& backgroundData)
 {

--- a/Source/WebCore/rendering/style/StyleBackgroundData.h
+++ b/Source/WebCore/rendering/style/StyleBackgroundData.h
@@ -31,6 +31,10 @@
 #include <wtf/RefCounted.h>
 #include <wtf/Ref.h>
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleBackgroundData);
@@ -41,6 +45,10 @@ public:
     Ref<StyleBackgroundData> copy() const;
 
     bool operator==(const StyleBackgroundData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleBackgroundData&) const;
+#endif
 
     bool isEquivalentForPainting(const StyleBackgroundData&, bool currentColorDiffers) const;
 

--- a/Source/WebCore/rendering/style/StyleBoxData.cpp
+++ b/Source/WebCore/rendering/style/StyleBoxData.cpp
@@ -23,6 +23,7 @@
 #include "StyleBoxData.h"
 
 #include "RenderStyleConstants.h"
+#include "RenderStyleDifference.h"
 #include "RenderStyleInlines.h"
 
 namespace WebCore {
@@ -93,5 +94,31 @@ bool StyleBoxData::operator==(const StyleBoxData& o) const
         && m_boxDecorationBreak == o.m_boxDecorationBreak
         && m_verticalAlign == o.m_verticalAlign;
 }
+
+#if !LOG_DISABLED
+void StyleBoxData::dumpDifferences(TextStream& ts, const StyleBoxData& other) const
+{
+    LOG_IF_DIFFERENT(m_width);
+    LOG_IF_DIFFERENT(m_height);
+
+    LOG_IF_DIFFERENT(m_minWidth);
+    LOG_IF_DIFFERENT(m_maxWidth);
+
+    LOG_IF_DIFFERENT(m_minHeight);
+    LOG_IF_DIFFERENT(m_maxHeight);
+
+    LOG_IF_DIFFERENT(m_verticalAlignLength);
+
+    LOG_IF_DIFFERENT(m_specifiedZIndex);
+    LOG_IF_DIFFERENT(m_usedZIndex);
+
+    LOG_IF_DIFFERENT_WITH_CAST(bool, m_hasAutoSpecifiedZIndex);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, m_hasAutoUsedZIndex);
+
+    LOG_IF_DIFFERENT_WITH_CAST(BoxSizing, m_boxSizing);
+    LOG_IF_DIFFERENT_WITH_CAST(BoxDecorationBreak, m_boxDecorationBreak);
+    LOG_IF_DIFFERENT_WITH_CAST(VerticalAlign, m_verticalAlign);
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleBoxData.h
+++ b/Source/WebCore/rendering/style/StyleBoxData.h
@@ -29,6 +29,10 @@
 #include <wtf/RefCounted.h>
 #include <wtf/Ref.h>
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleBoxData);
@@ -39,6 +43,10 @@ public:
     Ref<StyleBoxData> copy() const;
 
     bool operator==(const StyleBoxData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleBoxData&) const;
+#endif
 
     const Length& width() const { return m_width; }
     const Length& height() const { return m_height; }

--- a/Source/WebCore/rendering/style/StyleCustomPropertyData.cpp
+++ b/Source/WebCore/rendering/style/StyleCustomPropertyData.cpp
@@ -171,4 +171,12 @@ AtomString StyleCustomPropertyData::findKeyAtIndex(unsigned index) const
     return key;
 }
 
+#if !LOG_DISABLED
+void StyleCustomPropertyData::dumpDifferences(TextStream& ts, const StyleCustomPropertyData& other) const
+{
+    if (*this != other)
+        ts << "custom properies differ\n";
+}
+#endif // !LOG_DISABLED
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleCustomPropertyData.h
+++ b/Source/WebCore/rendering/style/StyleCustomPropertyData.h
@@ -41,6 +41,10 @@ public:
 
     bool operator==(const StyleCustomPropertyData&) const;
 
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleCustomPropertyData&) const;
+#endif
+
     const CSSCustomPropertyValue* get(const AtomString&) const;
     void set(const AtomString&, Ref<const CSSCustomPropertyValue>&&);
 

--- a/Source/WebCore/rendering/style/StyleDeprecatedFlexibleBoxData.cpp
+++ b/Source/WebCore/rendering/style/StyleDeprecatedFlexibleBoxData.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "StyleDeprecatedFlexibleBoxData.h"
 
+#include "RenderStyleDifference.h"
 #include "RenderStyleInlines.h"
 
 namespace WebCore {
@@ -62,5 +63,19 @@ bool StyleDeprecatedFlexibleBoxData::operator==(const StyleDeprecatedFlexibleBox
         && ordinalGroup == other.ordinalGroup && align == other.align
         && pack == other.pack && orient == other.orient && lines == other.lines;
 }
+
+#if !LOG_DISABLED
+void StyleDeprecatedFlexibleBoxData::dumpDifferences(TextStream& ts, const StyleDeprecatedFlexibleBoxData& other) const
+{
+    LOG_IF_DIFFERENT(flex);
+    LOG_IF_DIFFERENT(flexGroup);
+    LOG_IF_DIFFERENT(ordinalGroup);
+
+    LOG_IF_DIFFERENT_WITH_CAST(BoxAlignment, align);
+    LOG_IF_DIFFERENT_WITH_CAST(BoxPack, pack);
+    LOG_IF_DIFFERENT_WITH_CAST(BoxOrient, orient);
+    LOG_IF_DIFFERENT_WITH_CAST(BoxLines, lines);
+}
+#endif // !LOG_DISABLED
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleDeprecatedFlexibleBoxData.h
+++ b/Source/WebCore/rendering/style/StyleDeprecatedFlexibleBoxData.h
@@ -27,6 +27,10 @@
 #include <wtf/RefCounted.h>
 #include <wtf/Ref.h>
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleDeprecatedFlexibleBoxData);
@@ -37,6 +41,10 @@ public:
     Ref<StyleDeprecatedFlexibleBoxData> copy() const;
 
     bool operator==(const StyleDeprecatedFlexibleBoxData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleDeprecatedFlexibleBoxData&) const;
+#endif
 
     float flex;
     unsigned flexGroup;

--- a/Source/WebCore/rendering/style/StyleFilterData.cpp
+++ b/Source/WebCore/rendering/style/StyleFilterData.cpp
@@ -26,13 +26,13 @@
 #include "config.h"
 #include "StyleFilterData.h"
 
+#include "RenderStyleDifference.h"
+
 namespace WebCore {
 
-StyleFilterData::StyleFilterData()
-{
-}
+StyleFilterData::StyleFilterData() = default;
 
-inline StyleFilterData::StyleFilterData(const StyleFilterData& other)
+StyleFilterData::StyleFilterData(const StyleFilterData& other)
     : RefCounted<StyleFilterData>()
     , operations(other.operations)
 {
@@ -47,5 +47,12 @@ bool StyleFilterData::operator==(const StyleFilterData& other) const
 {
     return operations == other.operations;
 }
+
+#if !LOG_DISABLED
+void StyleFilterData::dumpDifferences(TextStream& ts, const StyleFilterData& other) const
+{
+    LOG_IF_DIFFERENT(operations);
+}
+#endif // !LOG_DISABLED
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleFilterData.h
+++ b/Source/WebCore/rendering/style/StyleFilterData.h
@@ -29,6 +29,10 @@
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 class StyleFilterData : public RefCounted<StyleFilterData> {
@@ -37,6 +41,10 @@ public:
     Ref<StyleFilterData> copy() const;
 
     bool operator==(const StyleFilterData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleFilterData&) const;
+#endif
 
     FilterOperations operations;
 

--- a/Source/WebCore/rendering/style/StyleFlexibleBoxData.cpp
+++ b/Source/WebCore/rendering/style/StyleFlexibleBoxData.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "StyleFlexibleBoxData.h"
 
+#include "RenderStyleDifference.h"
 #include "RenderStyleInlines.h"
 
 namespace WebCore {
@@ -61,5 +62,17 @@ bool StyleFlexibleBoxData::operator==(const StyleFlexibleBoxData& other) const
     return flexGrow == other.flexGrow && flexShrink == other.flexShrink && flexBasis == other.flexBasis
         && flexDirection == other.flexDirection && flexWrap == other.flexWrap;
 }
+
+#if !LOG_DISABLED
+void StyleFlexibleBoxData::dumpDifferences(TextStream& ts, const StyleFlexibleBoxData& other) const
+{
+    LOG_IF_DIFFERENT(flexGrow);
+    LOG_IF_DIFFERENT(flexShrink);
+    LOG_IF_DIFFERENT(flexBasis);
+
+    LOG_IF_DIFFERENT_WITH_CAST(FlexDirection, flexDirection);
+    LOG_IF_DIFFERENT_WITH_CAST(FlexWrap, flexWrap);
+}
+#endif // !LOG_DISABLED
 
 }

--- a/Source/WebCore/rendering/style/StyleFlexibleBoxData.h
+++ b/Source/WebCore/rendering/style/StyleFlexibleBoxData.h
@@ -29,6 +29,10 @@
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleFlexibleBoxData);
@@ -39,6 +43,10 @@ public:
     Ref<StyleFlexibleBoxData> copy() const;
 
     bool operator==(const StyleFlexibleBoxData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleFlexibleBoxData&) const;
+#endif
 
     float flexGrow;
     float flexShrink;

--- a/Source/WebCore/rendering/style/StyleGridData.cpp
+++ b/Source/WebCore/rendering/style/StyleGridData.cpp
@@ -27,6 +27,7 @@
 #include "StyleGridData.h"
 
 #include "RenderStyleInlines.h"
+#include "RenderStyleDifference.h"
 
 namespace WebCore {
 
@@ -99,6 +100,23 @@ inline StyleGridData::StyleGridData(const StyleGridData& o)
     , m_masonryRows(o.m_masonryRows)
     , m_masonryColumns(o.m_masonryColumns)
 {
+}
+
+bool StyleGridData::operator==(const StyleGridData& o) const
+{
+    return m_columns == o.m_columns
+        && m_rows == o.m_rows
+        && implicitNamedGridColumnLines == o.implicitNamedGridColumnLines
+        && implicitNamedGridRowLines == o.implicitNamedGridRowLines
+        && gridAutoFlow == o.gridAutoFlow
+        && gridAutoRows == o.gridAutoRows
+        && gridAutoColumns == o.gridAutoColumns
+        && namedGridArea == o.namedGridArea
+        && namedGridAreaRowCount == o.namedGridAreaRowCount
+        && namedGridAreaColumnCount == o.namedGridAreaColumnCount
+        && m_masonryRows == o.m_masonryRows
+        && m_masonryColumns == o.m_masonryColumns
+        && masonryAutoFlow == o.masonryAutoFlow;
 }
 
 void StyleGridData::setRows(const GridTrackList& list)
@@ -233,5 +251,41 @@ Ref<StyleGridData> StyleGridData::copy() const
 {
     return adoptRef(*new StyleGridData(*this));
 }
+
+#if !LOG_DISABLED
+void StyleGridData::dumpDifferences(TextStream& ts, const StyleGridData& other) const
+{
+    LOG_IF_DIFFERENT(m_columns);
+    LOG_IF_DIFFERENT(m_rows);
+
+    LOG_IF_DIFFERENT(m_gridColumnTrackSizes);
+    LOG_IF_DIFFERENT(m_gridRowTrackSizes);
+
+    LOG_IF_DIFFERENT(m_namedGridColumnLines);
+    LOG_IF_DIFFERENT(m_namedGridColumnLines);
+
+    // m_orderedNamedGridColumnLines and m_orderedNamedGridRowLines are not part of the diff.
+
+    LOG_IF_DIFFERENT(m_autoRepeatNamedGridColumnLines);
+    LOG_IF_DIFFERENT(m_autoRepeatNamedGridRowLines);
+
+    // m_autoRepeatOrderedNamedGridColumnLines and m_autoRepeatOrderedNamedGridRowLines are not part of the diff.
+
+    LOG_IF_DIFFERENT(m_gridAutoRepeatColumns);
+    LOG_IF_DIFFERENT(m_gridAutoRepeatRows);
+
+    LOG_IF_DIFFERENT(m_autoRepeatColumnsInsertionPoint);
+    LOG_IF_DIFFERENT(m_autoRepeatRowsInsertionPoint);
+
+    LOG_IF_DIFFERENT(m_autoRepeatColumnsType);
+    LOG_IF_DIFFERENT(m_autoRepeatRowsType);
+
+    LOG_IF_DIFFERENT(m_subgridRows);
+    LOG_IF_DIFFERENT(m_subgridColumns);
+
+    LOG_IF_DIFFERENT(m_masonryRows);
+    LOG_IF_DIFFERENT(m_masonryRows);
+}
+#endif // !LOG_DISABLED
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleGridData.h
+++ b/Source/WebCore/rendering/style/StyleGridData.h
@@ -97,10 +97,11 @@ public:
     static Ref<StyleGridData> create() { return adoptRef(*new StyleGridData); }
     Ref<StyleGridData> copy() const;
 
-    bool operator==(const StyleGridData& o) const
-    {
-        return m_columns == o.m_columns && m_rows == o.m_rows && implicitNamedGridColumnLines == o.implicitNamedGridColumnLines && implicitNamedGridRowLines == o.implicitNamedGridRowLines && gridAutoFlow == o.gridAutoFlow && gridAutoRows == o.gridAutoRows && gridAutoColumns == o.gridAutoColumns && namedGridArea == o.namedGridArea && namedGridAreaRowCount == o.namedGridAreaRowCount && namedGridAreaColumnCount == o.namedGridAreaColumnCount && m_masonryRows == o.m_masonryRows && m_masonryColumns == o.m_masonryColumns && masonryAutoFlow == o.masonryAutoFlow;
-    }
+    bool operator==(const StyleGridData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleGridData&) const;
+#endif
 
     void setRows(const GridTrackList&);
     void setColumns(const GridTrackList&);

--- a/Source/WebCore/rendering/style/StyleGridItemData.cpp
+++ b/Source/WebCore/rendering/style/StyleGridItemData.cpp
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "StyleGridItemData.h"
 
+#include "RenderStyleDifference.h"
 #include "RenderStyleInlines.h"
 
 namespace WebCore {
@@ -58,5 +59,15 @@ Ref<StyleGridItemData> StyleGridItemData::copy() const
 {
     return adoptRef(*new StyleGridItemData(*this));
 }
+
+#if !LOG_DISABLED
+void StyleGridItemData::dumpDifferences(TextStream& ts, const StyleGridItemData& other) const
+{
+    LOG_IF_DIFFERENT(gridColumnStart);
+    LOG_IF_DIFFERENT(gridColumnEnd);
+    LOG_IF_DIFFERENT(gridRowStart);
+    LOG_IF_DIFFERENT(gridRowEnd);
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleGridItemData.h
+++ b/Source/WebCore/rendering/style/StyleGridItemData.h
@@ -49,6 +49,10 @@ public:
             && gridRowStart == o.gridRowStart && gridRowEnd == o.gridRowEnd;
     }
 
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleGridItemData&) const;
+#endif
+
     GridPosition gridColumnStart;
     GridPosition gridColumnEnd;
     GridPosition gridRowStart;

--- a/Source/WebCore/rendering/style/StyleInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleInheritedData.cpp
@@ -22,7 +22,7 @@
 #include "config.h"
 #include "StyleInheritedData.h"
 
-#include "RenderStyleInlines.h"
+#include "RenderStyleDifference.h"
 
 namespace WebCore {
 
@@ -89,5 +89,22 @@ void StyleInheritedData::fastPathInheritFrom(const StyleInheritedData& inheritPa
     color = inheritParent.color;
     visitedLinkColor = inheritParent.visitedLinkColor;
 }
+
+#if !LOG_DISABLED
+void StyleInheritedData::dumpDifferences(TextStream& ts, const StyleInheritedData& other) const
+{
+    LOG_IF_DIFFERENT(horizontalBorderSpacing);
+    LOG_IF_DIFFERENT(verticalBorderSpacing);
+    LOG_IF_DIFFERENT(lineHeight);
+
+#if ENABLE(TEXT_AUTOSIZING)
+    LOG_IF_DIFFERENT(specifiedLineHeight);
+#endif
+
+    LOG_IF_DIFFERENT(fontCascade);
+    LOG_IF_DIFFERENT(color);
+    LOG_IF_DIFFERENT(visitedLinkColor);
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleInheritedData.h
@@ -28,6 +28,10 @@
 #include "Length.h"
 #include "StyleColor.h"
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleInheritedData);
@@ -38,6 +42,10 @@ public:
     Ref<StyleInheritedData> copy() const;
 
     bool operator==(const StyleInheritedData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleInheritedData&) const;
+#endif
 
     bool fastPathInheritedEqual(const StyleInheritedData&) const;
     bool nonFastPathInheritedEqual(const StyleInheritedData&) const;

--- a/Source/WebCore/rendering/style/StyleMarqueeData.cpp
+++ b/Source/WebCore/rendering/style/StyleMarqueeData.cpp
@@ -23,6 +23,7 @@
 #include "StyleMarqueeData.h"
 
 #include "RenderStyleConstants.h"
+#include "RenderStyleDifference.h"
 #include "RenderStyleInlines.h"
 
 namespace WebCore {
@@ -61,5 +62,15 @@ bool StyleMarqueeData::operator==(const StyleMarqueeData& o) const
     return increment == o.increment && speed == o.speed && direction == o.direction &&
            behavior == o.behavior && loops == o.loops;
 }
+
+#if !LOG_DISABLED
+void StyleMarqueeData::dumpDifferences(TextStream& ts, const StyleMarqueeData& other) const
+{
+    LOG_IF_DIFFERENT(increment);
+    LOG_IF_DIFFERENT(speed);
+    LOG_IF_DIFFERENT_WITH_CAST(MarqueeBehavior, behavior);
+    LOG_IF_DIFFERENT_WITH_CAST(MarqueeDirection, direction);
+}
+#endif // !LOG_DISABLED
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleMarqueeData.h
+++ b/Source/WebCore/rendering/style/StyleMarqueeData.h
@@ -27,6 +27,10 @@
 #include "Length.h"
 #include <wtf/RefCounted.h>
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 struct StyleMarqueeData : RefCounted<StyleMarqueeData> {
@@ -34,6 +38,10 @@ struct StyleMarqueeData : RefCounted<StyleMarqueeData> {
     Ref<StyleMarqueeData> copy() const;
 
     bool operator==(const StyleMarqueeData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleMarqueeData&) const;
+#endif
 
     Length increment;
     int speed;

--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp
@@ -29,6 +29,7 @@
 #include "AnimationList.h"
 #include "ContentData.h"
 #include "FillLayer.h"
+#include "RenderStyleDifference.h"
 #include "RenderStyleInlines.h"
 #include "ShadowData.h"
 #include "StyleDeprecatedFlexibleBoxData.h"
@@ -180,5 +181,63 @@ bool StyleMiscNonInheritedData::hasFilters() const
 {
     return !filter->operations.isEmpty();
 }
+
+#if !LOG_DISABLED
+void StyleMiscNonInheritedData::dumpDifferences(TextStream& ts, const StyleMiscNonInheritedData& other) const
+{
+    LOG_IF_DIFFERENT(opacity);
+
+    deprecatedFlexibleBox->dumpDifferences(ts, other.deprecatedFlexibleBox);
+    flexibleBox->dumpDifferences(ts, other.flexibleBox);
+    multiCol->dumpDifferences(ts, other.multiCol);
+
+    filter->dumpDifferences(ts, other.filter);
+    transform->dumpDifferences(ts, other.transform);
+
+    LOG_IF_DIFFERENT(mask);
+
+    visitedLinkColor->dumpDifferences(ts, other.visitedLinkColor);
+
+    LOG_IF_DIFFERENT(animations);
+    LOG_IF_DIFFERENT(transitions);
+
+    LOG_IF_DIFFERENT(content);
+    LOG_IF_DIFFERENT(boxShadow);
+
+    LOG_IF_DIFFERENT(altText);
+    LOG_IF_DIFFERENT(aspectRatioWidth);
+    LOG_IF_DIFFERENT(aspectRatioHeight);
+
+    LOG_IF_DIFFERENT(alignContent);
+    LOG_IF_DIFFERENT(justifyContent);
+    LOG_IF_DIFFERENT(alignItems);
+    LOG_IF_DIFFERENT(alignSelf);
+    LOG_IF_DIFFERENT(justifyItems);
+    LOG_IF_DIFFERENT(justifySelf);
+    LOG_IF_DIFFERENT(objectPosition);
+    LOG_IF_DIFFERENT(order);
+
+    LOG_IF_DIFFERENT_WITH_CAST(bool, hasAttrContent);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, hasDisplayAffectedByAnimations);
+
+#if ENABLE(DARK_MODE_CSS)
+    LOG_IF_DIFFERENT_WITH_CAST(bool, hasExplicitlySetColorScheme);
+#endif
+
+    LOG_IF_DIFFERENT_WITH_CAST(bool, hasExplicitlySetDirection);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, hasExplicitlySetWritingMode);
+
+    LOG_IF_DIFFERENT_WITH_CAST(TableLayoutType, tableLayout);
+    LOG_IF_DIFFERENT_WITH_CAST(AspectRatioType, aspectRatioType);
+    LOG_IF_DIFFERENT_WITH_CAST(StyleAppearance, appearance);
+    LOG_IF_DIFFERENT_WITH_CAST(StyleAppearance, usedAppearance);
+
+    LOG_IF_DIFFERENT_WITH_CAST(bool, textOverflow);
+
+    LOG_IF_DIFFERENT_WITH_CAST(UserDrag, objectFit);
+    LOG_IF_DIFFERENT_WITH_CAST(ObjectFit, textOverflow);
+    LOG_IF_DIFFERENT_WITH_CAST(Resize, resize);
+}
+#endif // !LOG_DISABLED
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
@@ -34,6 +34,10 @@
 #include <wtf/RefPtr.h>
 #include <wtf/text/WTFString.h>
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 class AnimationList;
@@ -58,6 +62,10 @@ public:
     ~StyleMiscNonInheritedData();
 
     bool operator==(const StyleMiscNonInheritedData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleMiscNonInheritedData&) const;
+#endif
 
     bool hasOpacity() const { return opacity < 1; }
     bool hasZeroOpacity() const { return !opacity; }
@@ -100,8 +108,8 @@ public:
     unsigned hasExplicitlySetWritingMode : 1 { false };
     unsigned tableLayout : 1; // TableLayoutType
     unsigned aspectRatioType : 2; // AspectRatioType
-    unsigned appearance : appearanceBitWidth; // EAppearance
-    unsigned usedAppearance : appearanceBitWidth; // EAppearance
+    unsigned appearance : appearanceBitWidth; // StyleAppearance
+    unsigned usedAppearance : appearanceBitWidth; // StyleAppearance
     unsigned textOverflow : 1; // Whether or not lines that spill out should be truncated with "..."
     unsigned userDrag : 2; // UserDrag
     unsigned objectFit : 3; // ObjectFit

--- a/Source/WebCore/rendering/style/StyleMultiColData.cpp
+++ b/Source/WebCore/rendering/style/StyleMultiColData.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "StyleMultiColData.h"
 
+#include "RenderStyleDifference.h"
 #include "RenderStyleInlines.h"
 
 namespace WebCore {
@@ -67,5 +68,23 @@ bool StyleMultiColData::operator==(const StyleMultiColData& other) const
         && fill == other.fill && columnSpan == other.columnSpan
         && axis == other.axis && progression == other.progression;
 }
+
+#if !LOG_DISABLED
+void StyleMultiColData::dumpDifferences(TextStream& ts, const StyleMultiColData& other) const
+{
+    LOG_IF_DIFFERENT(width);
+    LOG_IF_DIFFERENT(count);
+    LOG_IF_DIFFERENT(rule);
+    LOG_IF_DIFFERENT(visitedLinkColumnRuleColor);
+
+    LOG_IF_DIFFERENT(autoWidth);
+    LOG_IF_DIFFERENT(autoCount);
+
+    LOG_IF_DIFFERENT_WITH_CAST(ColumnFill, fill);
+    LOG_IF_DIFFERENT_WITH_CAST(ColumnSpan, columnSpan);
+    LOG_IF_DIFFERENT_WITH_CAST(ColumnAxis, axis);
+    LOG_IF_DIFFERENT_WITH_CAST(ColumnProgression, progression);
+}
+#endif // !LOG_DISABLED
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleMultiColData.h
+++ b/Source/WebCore/rendering/style/StyleMultiColData.h
@@ -29,6 +29,10 @@
 #include "RenderStyleConstants.h"
 #include <wtf/RefCounted.h>
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 // CSS3 Multi Column Layout
@@ -41,6 +45,10 @@ public:
     Ref<StyleMultiColData> copy() const;
     
     bool operator==(const StyleMultiColData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleMultiColData&) const;
+#endif
 
     unsigned short ruleWidth() const
     {

--- a/Source/WebCore/rendering/style/StyleNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleNonInheritedData.cpp
@@ -76,4 +76,16 @@ bool StyleNonInheritedData::operator==(const StyleNonInheritedData& other) const
         && rareData == other.rareData;
 }
 
+#if !LOG_DISABLED
+void StyleNonInheritedData::dumpDifferences(TextStream& ts, const StyleNonInheritedData& other) const
+{
+    boxData->dumpDifferences(ts, *other.boxData);
+    backgroundData->dumpDifferences(ts, *other.backgroundData);
+    surroundData->dumpDifferences(ts, *other.surroundData);
+
+    miscData->dumpDifferences(ts, *other.miscData);
+    rareData->dumpDifferences(ts, *other.rareData);
+}
+#endif
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleNonInheritedData.h
@@ -29,6 +29,10 @@
 #include <wtf/DataRef.h>
 #include <wtf/RefCounted.h>
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 class StyleBoxData;
@@ -45,6 +49,10 @@ public:
     Ref<StyleNonInheritedData> copy() const;
 
     bool operator==(const StyleNonInheritedData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleNonInheritedData&) const;
+#endif
 
     DataRef<StyleBoxData> boxData;
     DataRef<StyleBackgroundData> backgroundData;

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -25,7 +25,7 @@
 #include "CursorList.h"
 #include "QuotesData.h"
 #include "RenderStyleConstants.h"
-#include "RenderStyleInlines.h"
+#include "RenderStyleDifference.h"
 #include "ShadowData.h"
 #include "StyleFilterData.h"
 #include "StyleImage.h"
@@ -382,5 +382,148 @@ bool StyleRareInheritedData::hasColorFilters() const
 {
     return !appleColorFilter->operations.isEmpty();
 }
+
+#if !LOG_DISABLED
+void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInheritedData& other) const
+{
+    customProperties->dumpDifferences(ts, other.customProperties);
+
+    LOG_IF_DIFFERENT(textStrokeWidth);
+
+    LOG_IF_DIFFERENT(listStyleImage);
+    LOG_IF_DIFFERENT(textStrokeColor);
+    LOG_IF_DIFFERENT(textFillColor);
+    LOG_IF_DIFFERENT(textEmphasisColor);
+
+    LOG_IF_DIFFERENT(visitedLinkTextStrokeColor);
+    LOG_IF_DIFFERENT(visitedLinkTextFillColor);
+    LOG_IF_DIFFERENT(visitedLinkTextEmphasisColor);
+
+    LOG_IF_DIFFERENT(caretColor);
+    LOG_IF_DIFFERENT(visitedLinkCaretColor);
+
+    LOG_IF_DIFFERENT(textShadow);
+
+    LOG_IF_DIFFERENT(cursorData);
+
+    LOG_IF_DIFFERENT(indent);
+    LOG_IF_DIFFERENT(usedZoom);
+
+    LOG_IF_DIFFERENT(textUnderlineOffset);
+
+    LOG_IF_DIFFERENT(textBoxEdge);
+    LOG_IF_DIFFERENT(lineFitEdge);
+
+    LOG_IF_DIFFERENT(wordSpacing);
+    LOG_IF_DIFFERENT(miterLimit);
+
+    LOG_IF_DIFFERENT(widows);
+    LOG_IF_DIFFERENT(orphans);
+    LOG_IF_DIFFERENT(hasAutoWidows);
+    LOG_IF_DIFFERENT(hasAutoOrphans);
+
+    LOG_IF_DIFFERENT_WITH_CAST(TextSecurity, textSecurity);
+    LOG_IF_DIFFERENT_WITH_CAST(UserModify, userModify);
+
+    LOG_IF_DIFFERENT_WITH_CAST(WordBreak, wordBreak);
+    LOG_IF_DIFFERENT_WITH_CAST(OverflowWrap, overflowWrap);
+    LOG_IF_DIFFERENT_WITH_CAST(NBSPMode, nbspMode);
+    LOG_IF_DIFFERENT_WITH_CAST(LineBreak, lineBreak);
+    LOG_IF_DIFFERENT_WITH_CAST(UserSelect, userSelect);
+    LOG_IF_DIFFERENT_WITH_CAST(ColorSpace, colorSpace);
+
+    LOG_RAW_OPTIONSET_IF_DIFFERENT(SpeakAs, speakAs);
+
+    LOG_IF_DIFFERENT_WITH_CAST(Hyphens, hyphens);
+    LOG_IF_DIFFERENT_WITH_CAST(TextCombine, textCombine);
+    LOG_IF_DIFFERENT_WITH_CAST(TextEmphasisFill, textEmphasisFill);
+    LOG_IF_DIFFERENT_WITH_CAST(TextEmphasisMark, textEmphasisMark);
+    LOG_IF_DIFFERENT_WITH_CAST(TextEmphasisPosition, textEmphasisPosition);
+    LOG_IF_DIFFERENT_WITH_CAST(TextIndentLine, textIndentLine);
+    LOG_IF_DIFFERENT_WITH_CAST(TextIndentType, textIndentType);
+    LOG_IF_DIFFERENT_WITH_CAST(TextUnderlinePosition, textUnderlinePosition);
+
+    LOG_RAW_OPTIONSET_IF_DIFFERENT(LineBoxContain, lineBoxContain);
+
+    LOG_IF_DIFFERENT_WITH_CAST(ImageOrientation, imageOrientation);
+    LOG_IF_DIFFERENT_WITH_CAST(ImageRendering, imageRendering);
+    LOG_IF_DIFFERENT_WITH_CAST(LineSnap, lineSnap);
+    LOG_IF_DIFFERENT_WITH_CAST(LineAlign, lineAlign);
+
+#if ENABLE(OVERFLOW_SCROLLING_TOUCH)
+    LOG_IF_DIFFERENT_WITH_CAST(bool, useTouchOverflowScrolling);
+#endif
+
+    LOG_IF_DIFFERENT_WITH_CAST(TextAlignLast, textAlignLast);
+    LOG_IF_DIFFERENT_WITH_CAST(TextJustify, textJustify);
+    LOG_IF_DIFFERENT_WITH_CAST(TextDecorationSkipInk, textDecorationSkipInk);
+
+    LOG_IF_DIFFERENT_WITH_CAST(RubyPosition, rubyPosition);
+    LOG_IF_DIFFERENT_WITH_CAST(RubyAlign, rubyAlign);
+    LOG_IF_DIFFERENT_WITH_CAST(RubyOverhang, rubyOverhang);
+
+    LOG_IF_DIFFERENT_WITH_CAST(TextZoom, textZoom);
+
+#if PLATFORM(IOS_FAMILY)
+    LOG_IF_DIFFERENT_WITH_CAST(bool, touchCalloutEnabled);
+#endif
+
+    LOG_RAW_OPTIONSET_IF_DIFFERENT(HangingPunctuation, hangingPunctuation);
+
+    LOG_IF_DIFFERENT_WITH_CAST(PaintOrder, paintOrder);
+    LOG_IF_DIFFERENT_WITH_CAST(LineCap, capStyle);
+    LOG_IF_DIFFERENT_WITH_CAST(LineJoin, joinStyle);
+
+    LOG_IF_DIFFERENT_WITH_CAST(bool, hasSetStrokeWidth);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, hasSetStrokeColor);
+
+    LOG_IF_DIFFERENT_WITH_CAST(MathStyle, mathStyle);
+
+    LOG_IF_DIFFERENT_WITH_CAST(bool, hasAutoCaretColor);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, hasVisitedLinkAutoCaretColor);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, hasAutoAccentColor);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, effectiveInert);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, isInSubtreeWithBlendMode);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, isInVisibilityAdjustmentSubtree);
+
+    LOG_IF_DIFFERENT_WITH_CAST(ContentVisibility, usedContentVisibility);
+
+
+    LOG_IF_DIFFERENT(usedTouchActions);
+    LOG_IF_DIFFERENT(eventListenerRegionTypes);
+
+    LOG_IF_DIFFERENT(strokeWidth);
+    LOG_IF_DIFFERENT(strokeColor);
+    LOG_IF_DIFFERENT(visitedLinkStrokeColor);
+
+    LOG_IF_DIFFERENT(hyphenationString);
+    LOG_IF_DIFFERENT(hyphenationLimitBefore);
+    LOG_IF_DIFFERENT(hyphenationLimitAfter);
+    LOG_IF_DIFFERENT(hyphenationLimitLines);
+
+#if ENABLE(DARK_MODE_CSS)
+    LOG_IF_DIFFERENT(colorScheme);
+#endif
+
+    LOG_IF_DIFFERENT(textEmphasisCustomMark);
+    LOG_IF_DIFFERENT(quotes);
+
+    appleColorFilter->dumpDifferences(ts, other.appleColorFilter);
+
+    LOG_IF_DIFFERENT(lineGrid);
+    LOG_IF_DIFFERENT(tabSize);
+
+#if ENABLE(TEXT_AUTOSIZING)
+    LOG_IF_DIFFERENT(textSizeAdjust);
+#endif
+#if ENABLE(TOUCH_EVENTS)
+    LOG_IF_DIFFERENT(tapHighlightColor);
+#endif
+
+    LOG_IF_DIFFERENT(listStyleType);
+    LOG_IF_DIFFERENT(scrollbarColor);
+    LOG_IF_DIFFERENT(blockEllipsis);
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -48,6 +48,10 @@
 #include "StyleColorScheme.h"
 #endif
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 class CursorList;
@@ -67,7 +71,11 @@ public:
     Ref<StyleRareInheritedData> copy() const;
     ~StyleRareInheritedData();
 
-    bool operator==(const StyleRareInheritedData& o) const;
+    bool operator==(const StyleRareInheritedData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleRareInheritedData&) const;
+#endif
 
     bool hasColorFilters() const;
 
@@ -120,7 +128,7 @@ public:
     unsigned colorSpace : 1; // ColorSpace
     unsigned speakAs : 4 { 0 }; // OptionSet<SpeakAs>
     unsigned hyphens : 2; // Hyphens
-    unsigned textCombine : 1; // text-combine-upright
+    unsigned textCombine : 1; // TextCombine
     unsigned textEmphasisFill : 1; // TextEmphasisFill
     unsigned textEmphasisMark : 3; // TextEmphasisMark
     unsigned textEmphasisPosition : 4; // TextEmphasisPosition
@@ -148,7 +156,7 @@ public:
     unsigned touchCalloutEnabled : 1;
 #endif
 
-    unsigned hangingPunctuation : 4;
+    unsigned hangingPunctuation : 4; // OptionSet<HangingPunctuation>
 
     unsigned paintOrder : 3; // PaintOrder
     unsigned capStyle : 2; // LineCap
@@ -156,7 +164,7 @@ public:
     unsigned hasSetStrokeWidth : 1;
     unsigned hasSetStrokeColor : 1;
 
-    unsigned mathStyle : 1;
+    unsigned mathStyle : 1; // MathStyle
 
     unsigned hasAutoCaretColor : 1;
     unsigned hasVisitedLinkAutoCaretColor : 1;

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -253,7 +253,7 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && clip == o.clip
         && scrollMargin == o.scrollMargin
         && scrollPadding == o.scrollPadding
-        && counterDirectives.map == o.counterDirectives.map
+        && counterDirectives == o.counterDirectives
         && arePointingToEqualData(willChange, o.willChange)
         && arePointingToEqualData(boxReflect, o.boxReflect)
         && maskBorder == o.maskBorder
@@ -354,5 +354,143 @@ bool StyleRareNonInheritedData::hasBackdropFilters() const
 {
     return !backdropFilter->operations.isEmpty();
 }
+
+#if !LOG_DISABLED
+void StyleRareNonInheritedData::dumpDifferences(TextStream& ts, const StyleRareNonInheritedData& other) const
+{
+    marquee->dumpDifferences(ts, other.marquee);
+    backdropFilter->dumpDifferences(ts, other.backdropFilter);
+    grid->dumpDifferences(ts, other.grid);
+    gridItem->dumpDifferences(ts, other.gridItem);
+
+    LOG_IF_DIFFERENT(containIntrinsicWidth);
+    LOG_IF_DIFFERENT(containIntrinsicHeight);
+
+    LOG_IF_DIFFERENT(perspectiveOriginX);
+    LOG_IF_DIFFERENT(perspectiveOriginY);
+
+    LOG_IF_DIFFERENT(lineClamp);
+    LOG_IF_DIFFERENT(maxLines);
+    LOG_IF_DIFFERENT(overflowContinue);
+
+    LOG_IF_DIFFERENT(initialLetter);
+
+    LOG_IF_DIFFERENT(clip);
+    LOG_IF_DIFFERENT(scrollMargin);
+    LOG_IF_DIFFERENT(scrollPadding);
+
+    LOG_IF_DIFFERENT(counterDirectives);
+
+    LOG_IF_DIFFERENT(willChange);
+    LOG_IF_DIFFERENT(boxReflect);
+
+    LOG_IF_DIFFERENT(maskBorder);
+    LOG_IF_DIFFERENT(pageSize);
+
+    LOG_IF_DIFFERENT(shapeOutside);
+
+    LOG_IF_DIFFERENT(shapeMargin);
+    LOG_IF_DIFFERENT(shapeImageThreshold);
+    LOG_IF_DIFFERENT(perspective);
+
+    LOG_IF_DIFFERENT(clipPath);
+
+    LOG_IF_DIFFERENT(textDecorationColor);
+
+    customProperties->dumpDifferences(ts, other.customProperties);
+    LOG_IF_DIFFERENT(customPaintWatchedProperties);
+
+    LOG_IF_DIFFERENT(rotate);
+    LOG_IF_DIFFERENT(scale);
+    LOG_IF_DIFFERENT(translate);
+    LOG_IF_DIFFERENT(offsetPath);
+
+    LOG_IF_DIFFERENT(containerNames);
+
+    LOG_IF_DIFFERENT(viewTransitionClasses);
+    LOG_IF_DIFFERENT(viewTransitionName);
+
+    LOG_IF_DIFFERENT(columnGap);
+    LOG_IF_DIFFERENT(rowGap);
+
+    LOG_IF_DIFFERENT(offsetDistance);
+    LOG_IF_DIFFERENT(offsetPosition);
+    LOG_IF_DIFFERENT(offsetAnchor);
+    LOG_IF_DIFFERENT(offsetRotate);
+
+    LOG_IF_DIFFERENT(textDecorationThickness);
+
+    LOG_IF_DIFFERENT(touchActions);
+    LOG_IF_DIFFERENT(marginTrim);
+    LOG_IF_DIFFERENT(contain);
+
+    LOG_IF_DIFFERENT(scrollSnapType);
+    LOG_IF_DIFFERENT(scrollSnapAlign);
+    LOG_IF_DIFFERENT(scrollSnapStop);
+
+    LOG_IF_DIFFERENT(scrollTimelines);
+    LOG_IF_DIFFERENT(scrollTimelineAxes);
+    LOG_IF_DIFFERENT(scrollTimelineNames);
+
+    LOG_IF_DIFFERENT(viewTimelines);
+    LOG_IF_DIFFERENT(viewTimelineAxes);
+    LOG_IF_DIFFERENT(viewTimelineInsets);
+    LOG_IF_DIFFERENT(viewTimelineNames);
+
+    LOG_IF_DIFFERENT(timelineScope);
+
+    LOG_IF_DIFFERENT(scrollbarGutter);
+    LOG_IF_DIFFERENT(scrollbarWidth);
+
+    LOG_IF_DIFFERENT(zoom);
+    LOG_IF_DIFFERENT(pseudoElementNameArgument);
+
+    LOG_IF_DIFFERENT(anchorNames);
+    LOG_IF_DIFFERENT(positionAnchor);
+
+    LOG_IF_DIFFERENT(blockStepSize);
+
+    LOG_IF_DIFFERENT_WITH_CAST(BlockStepInsert, blockStepInsert);
+
+    LOG_IF_DIFFERENT_WITH_CAST(OverscrollBehavior, overscrollBehaviorX);
+    LOG_IF_DIFFERENT_WITH_CAST(BlockStepInsert, overscrollBehaviorY);
+
+    LOG_IF_DIFFERENT_WITH_CAST(PageSizeType, pageSizeType);
+
+    LOG_IF_DIFFERENT_WITH_CAST(TransformStyle3D, transformStyle3D);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, transformStyleForcedToFlat);
+    LOG_IF_DIFFERENT_WITH_CAST(BackfaceVisibility, backfaceVisibility);
+
+    LOG_IF_DIFFERENT_WITH_CAST(ScrollBehavior, useSmoothScrolling);
+    LOG_IF_DIFFERENT_WITH_CAST(TextDecorationStyle, textDecorationStyle);
+    LOG_IF_DIFFERENT_WITH_CAST(TextGroupAlign, textGroupAlign);
+
+    LOG_IF_DIFFERENT_WITH_CAST(ContentVisibility, contentVisibility);
+    LOG_IF_DIFFERENT_WITH_CAST(BlendMode, effectiveBlendMode);
+
+    LOG_IF_DIFFERENT_WITH_CAST(Isolation, isolation);
+
+#if ENABLE(APPLE_PAY)
+    LOG_IF_DIFFERENT_WITH_CAST(ApplePayButtonStyle, applePayButtonStyle);
+    LOG_IF_DIFFERENT_WITH_CAST(ApplePayButtonType, applePayButtonType);
+#endif
+
+    LOG_IF_DIFFERENT_WITH_CAST(BreakBetween, breakBefore);
+    LOG_IF_DIFFERENT_WITH_CAST(BreakBetween, breakAfter);
+    LOG_IF_DIFFERENT_WITH_CAST(BreakInside, breakInside);
+
+    LOG_IF_DIFFERENT_WITH_CAST(InputSecurity, inputSecurity);
+
+    LOG_IF_DIFFERENT_WITH_CAST(ContainIntrinsicSizeType, containIntrinsicWidthType);
+    LOG_IF_DIFFERENT_WITH_CAST(ContainIntrinsicSizeType, containIntrinsicHeightType);
+
+    LOG_IF_DIFFERENT_WITH_CAST(ContainerType, containerType);
+    LOG_IF_DIFFERENT_WITH_CAST(TextBoxTrim, textBoxTrim);
+    LOG_IF_DIFFERENT_WITH_CAST(OverflowAnchor, overflowAnchor);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, hasClip);
+    LOG_IF_DIFFERENT_WITH_CAST(Style::PositionTryOrder, positionTryOrder);
+    LOG_IF_DIFFERENT(fieldSizing);
+}
+#endif // !LOG_DISABLED
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -60,6 +60,10 @@
 #include <wtf/OptionSet.h>
 #include <wtf/Vector.h>
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 class AnimationList;
@@ -101,6 +105,10 @@ public:
     ~StyleRareNonInheritedData();
     
     bool operator==(const StyleRareNonInheritedData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleRareNonInheritedData&) const;
+#endif
 
     LengthPoint perspectiveOrigin() const { return { perspectiveOriginX, perspectiveOriginY }; }
 
@@ -223,16 +231,16 @@ public:
 
     unsigned contentVisibility : 2; // ContentVisibility
 
-    unsigned effectiveBlendMode: 5; // EBlendMode
+    unsigned effectiveBlendMode: 5; // BlendMode
     unsigned isolation : 1; // Isolation
 
 #if ENABLE(APPLE_PAY)
-    unsigned applePayButtonStyle : 2;
-    unsigned applePayButtonType : 4;
+    unsigned applePayButtonStyle : 2; // ApplePayButtonStyle
+    unsigned applePayButtonType : 4; // ApplePayButtonType
 #endif
 
     unsigned breakBefore : 4; // BreakBetween
-    unsigned breakAfter : 4;
+    unsigned breakAfter : 4; // BreakBetween
     unsigned breakInside : 3; // BreakInside
 
     unsigned inputSecurity : 1; // InputSecurity

--- a/Source/WebCore/rendering/style/StyleSurroundData.cpp
+++ b/Source/WebCore/rendering/style/StyleSurroundData.cpp
@@ -22,6 +22,8 @@
 #include "config.h"
 #include "StyleSurroundData.h"
 
+#include "RenderStyleDifference.h"
+
 namespace WebCore {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleSurroundData);
@@ -62,5 +64,20 @@ bool StyleSurroundData::operator==(const StyleSurroundData& o) const
         && hasExplicitlySetBorderTopLeftRadius == o.hasExplicitlySetBorderTopLeftRadius
         && hasExplicitlySetBorderTopRightRadius == o.hasExplicitlySetBorderTopRightRadius;
 }
+
+#if !LOG_DISABLED
+void StyleSurroundData::dumpDifferences(TextStream& ts, const StyleSurroundData& other) const
+{
+    LOG_IF_DIFFERENT(hasExplicitlySetBorderBottomLeftRadius);
+    LOG_IF_DIFFERENT(hasExplicitlySetBorderBottomRightRadius);
+    LOG_IF_DIFFERENT(hasExplicitlySetBorderTopLeftRadius);
+    LOG_IF_DIFFERENT(hasExplicitlySetBorderTopRightRadius);
+
+    LOG_IF_DIFFERENT(offset);
+    LOG_IF_DIFFERENT(margin);
+    LOG_IF_DIFFERENT(padding);
+    LOG_IF_DIFFERENT(border);
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleSurroundData.h
+++ b/Source/WebCore/rendering/style/StyleSurroundData.h
@@ -29,6 +29,10 @@
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleSurroundData);
@@ -39,6 +43,10 @@ public:
     Ref<StyleSurroundData> copy() const;
     
     bool operator==(const StyleSurroundData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleSurroundData&) const;
+#endif
 
     // Here instead of in BorderData to pack up against the refcount.
     bool hasExplicitlySetBorderBottomLeftRadius : 1;

--- a/Source/WebCore/rendering/style/StyleTransformData.cpp
+++ b/Source/WebCore/rendering/style/StyleTransformData.cpp
@@ -23,6 +23,7 @@
 #include "StyleTransformData.h"
 
 #include "RenderStyleInlines.h"
+#include "RenderStyleDifference.h"
 
 namespace WebCore {
 
@@ -56,5 +57,16 @@ bool StyleTransformData::operator==(const StyleTransformData& other) const
 {
     return x == other.x && y == other.y && z == other.z && transformBox == other.transformBox && operations == other.operations;
 }
+
+#if !LOG_DISABLED
+void StyleTransformData::dumpDifferences(TextStream& ts, const StyleTransformData& other) const
+{
+    LOG_IF_DIFFERENT(operations);
+    LOG_IF_DIFFERENT(x);
+    LOG_IF_DIFFERENT(y);
+    LOG_IF_DIFFERENT(z);
+    LOG_IF_DIFFERENT(transformBox);
+}
+#endif // !LOG_DISABLED
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleTransformData.h
+++ b/Source/WebCore/rendering/style/StyleTransformData.h
@@ -40,7 +40,11 @@ public:
     Ref<StyleTransformData> copy() const;
 
     bool operator==(const StyleTransformData&) const;
-    
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleTransformData&) const;
+#endif
+
     bool hasTransform() const { return operations.size(); }
 
     LengthPoint originXY() const { return { x, y }; }

--- a/Source/WebCore/rendering/style/StyleVisitedLinkColorData.cpp
+++ b/Source/WebCore/rendering/style/StyleVisitedLinkColorData.cpp
@@ -27,6 +27,7 @@
 #include "StyleVisitedLinkColorData.h"
 
 #include "RenderStyleInlines.h"
+#include "RenderStyleDifference.h"
 
 namespace WebCore {
 
@@ -72,5 +73,18 @@ bool StyleVisitedLinkColorData::operator==(const StyleVisitedLinkColorData& o) c
         && textDecoration == o.textDecoration
         && outline == o.outline;
 }
+
+#if !LOG_DISABLED
+void StyleVisitedLinkColorData::dumpDifferences(TextStream& ts, const StyleVisitedLinkColorData& other) const
+{
+    LOG_IF_DIFFERENT(background);
+    LOG_IF_DIFFERENT(borderLeft);
+    LOG_IF_DIFFERENT(borderRight);
+    LOG_IF_DIFFERENT(borderTop);
+    LOG_IF_DIFFERENT(borderBottom);
+    LOG_IF_DIFFERENT(textDecoration);
+    LOG_IF_DIFFERENT(outline);
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleVisitedLinkColorData.h
+++ b/Source/WebCore/rendering/style/StyleVisitedLinkColorData.h
@@ -39,6 +39,10 @@ public:
 
     bool operator==(const StyleVisitedLinkColorData&) const;
 
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleVisitedLinkColorData&) const;
+#endif
+
     StyleColor background;
     StyleColor borderLeft;
     StyleColor borderRight;


### PR DESCRIPTION
#### 9988108f8b32a9057590e3cacb90b1118a7cd026
<pre>
Make it possible to log style changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=283592">https://bugs.webkit.org/show_bug.cgi?id=283592</a>
<a href="https://rdar.apple.com/140439950">rdar://140439950</a>

Reviewed by Alan Baradlay.

Add a `Style` log channel. When enabled, `RenderElement::setStyle()` logs the difference between
the old and new styles.

This requires adding a `dumpDifferences()` member function to each of the StyleFoo classes.
These use macros from RenderStyleDifference.h to dump values that are different, making use of
some template magic to handle pointer types, and types which don&apos;t yet support `operator&lt;&lt;(TextStream&amp;...)`.

Dumping is complete for all parts of style, including SVGRenderStyle.

* Source/WTF/wtf/text/TextStream.h:
(WTF::TextStream::isEmpty const):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/Logging.h:
* Source/WebCore/platform/text/UnicodeBidi.cpp: Added.
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/text/UnicodeBidi.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::setStyle):
* Source/WebCore/rendering/style/CounterDirectives.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::rareDataChangeRequiresLayout):
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):
(WebCore::RenderStyle::NonInheritedFlags::dumpDifferences const):
(WebCore::RenderStyle::InheritedFlags::dumpDifferences const):
(WebCore::RenderStyle::dumpDifferences const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::alwaysPageBreak):
(WebCore::transformBoxToCSSBoxType):
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleDifference.h: Added.
(WebCore::ValueOrUnstreamableMessage::ValueOrUnstreamableMessage):
(WebCore::operator&lt;&lt;):
(WebCore::logIfDifferent):
* Source/WebCore/rendering/style/SVGRenderStyle.cpp:
(WebCore::SVGRenderStyle::InheritedFlags::dumpDifferences const):
(WebCore::SVGRenderStyle::NonInheritedFlags::dumpDifferences const):
(WebCore::SVGRenderStyle::dumpDifferences const):
* Source/WebCore/rendering/style/SVGRenderStyle.h:
* Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp:
(WebCore::StyleFillData::dumpDifferences const):
(WebCore::StyleStrokeData::dumpDifferences const):
(WebCore::StyleStopData::dumpDifferences const):
(WebCore::StyleMiscData::dumpDifferences const):
(WebCore::StyleShadowSVGData::dumpDifferences const):
(WebCore::StyleInheritedResourceData::dumpDifferences const):
(WebCore::StyleLayoutData::dumpDifferences const):
* Source/WebCore/rendering/style/SVGRenderStyleDefs.h:
* Source/WebCore/rendering/style/StyleBackgroundData.cpp:
(WebCore::StyleBackgroundData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleBackgroundData.h:
* Source/WebCore/rendering/style/StyleBoxData.cpp:
(WebCore::StyleBoxData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleBoxData.h:
* Source/WebCore/rendering/style/StyleCustomPropertyData.cpp:
(WebCore::StyleCustomPropertyData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleCustomPropertyData.h:
* Source/WebCore/rendering/style/StyleDeprecatedFlexibleBoxData.cpp:
(WebCore::StyleDeprecatedFlexibleBoxData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleDeprecatedFlexibleBoxData.h:
* Source/WebCore/rendering/style/StyleFilterData.cpp:
(WebCore::StyleFilterData::StyleFilterData):
(WebCore::StyleFilterData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleFilterData.h:
* Source/WebCore/rendering/style/StyleFlexibleBoxData.cpp:
(WebCore::StyleFlexibleBoxData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleFlexibleBoxData.h:
* Source/WebCore/rendering/style/StyleGridData.cpp:
(WebCore::StyleGridData::operator== const):
(WebCore::StyleGridData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleGridData.h:
(WebCore::StyleGridData::operator== const): Deleted.
* Source/WebCore/rendering/style/StyleGridItemData.cpp:
(WebCore::StyleGridItemData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleGridItemData.h:
* Source/WebCore/rendering/style/StyleInheritedData.cpp:
(WebCore::StyleInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleInheritedData.h:
* Source/WebCore/rendering/style/StyleMarqueeData.cpp:
(WebCore::StyleMarqueeData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleMarqueeData.h:
* Source/WebCore/rendering/style/StyleMiscNonInheritedData.cpp:
(WebCore::StyleMiscNonInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleMiscNonInheritedData.h:
* Source/WebCore/rendering/style/StyleMultiColData.cpp:
(WebCore::StyleMultiColData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleMultiColData.h:
* Source/WebCore/rendering/style/StyleNonInheritedData.cpp:
(WebCore::StyleNonInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleNonInheritedData.h:
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::operator== const):
(WebCore::StyleRareNonInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/rendering/style/StyleSurroundData.cpp:
(WebCore::StyleSurroundData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleSurroundData.h:
* Source/WebCore/rendering/style/StyleTransformData.cpp:
(WebCore::StyleTransformData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleTransformData.h:
* Source/WebCore/rendering/style/StyleVisitedLinkColorData.cpp:
(WebCore::StyleVisitedLinkColorData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleVisitedLinkColorData.h:

Canonical link: <a href="https://commits.webkit.org/287012@main">https://commits.webkit.org/287012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1a688f71db45e0412e51fc105e1504afaa676da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56954 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82569 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29178 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5249 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61014 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18947 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41317 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48371 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24397 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27521 "Hash a1a688f7 for PR 37047 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71065 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69465 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83931 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77156 "Found 1 new JSC stress test failure: stress/get-by-val-hoist-above-structure.js.ftl-eager-no-cjit-b3o1 (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5288 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3563 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69233 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5444 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66828 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68489 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17110 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12489 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10615 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/99469 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5236 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7989 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21720 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5228 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8660 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7013 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->