### PR TITLE
[Navigation] Implement url censoring

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-dynamic-url-censored-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-dynamic-url-censored-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL The url of a document is censored by a no-referrer policy dynamically assert_equals: expected (object) null but got (string) "http://localhost:8800/common/blank.html"
+PASS The url of a document is censored by a no-referrer policy dynamically
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-from-meta-url-censored-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-from-meta-url-censored-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL The url of a document with no-referrer referrer meta tag is censored in NavigationHistoryEntry assert_equals: expected (object) null but got (string) "http://localhost:8800/navigation-api/navigation-history-entry/resources/no-referrer-meta.html"
+PASS The url of a document with no-referrer referrer meta tag is censored in NavigationHistoryEntry
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-url-censored-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-url-censored-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL The url of a document with no-referrer referrer policy is censored in NavigationHistoryEntry assert_equals: expected (object) null but got (string) "http://localhost:8800/navigation-api/navigation-history-entry/resources/no-referrer.html"
+PASS The url of a document with no-referrer referrer policy is censored in NavigationHistoryEntry
 

--- a/Source/WebCore/page/NavigationHistoryEntry.cpp
+++ b/Source/WebCore/page/NavigationHistoryEntry.cpp
@@ -40,19 +40,20 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(NavigationHistoryEntry);
 
-NavigationHistoryEntry::NavigationHistoryEntry(ScriptExecutionContext* context, Ref<HistoryItem>&& historyItem, String urlString, WTF::UUID key, RefPtr<SerializedScriptValue>&& state, WTF::UUID id)
+NavigationHistoryEntry::NavigationHistoryEntry(ScriptExecutionContext* context, const DocumentState& originalDocumentState, Ref<HistoryItem>&& historyItem, String urlString, WTF::UUID key, RefPtr<SerializedScriptValue>&& state, WTF::UUID id)
     : ActiveDOMObject(context)
     , m_urlString(urlString)
     , m_key(key)
     , m_id(id)
     , m_state(state)
     , m_associatedHistoryItem(WTFMove(historyItem))
+    , m_originalDocumentState(originalDocumentState)
 {
 }
 
 Ref<NavigationHistoryEntry> NavigationHistoryEntry::create(ScriptExecutionContext* context, Ref<HistoryItem>&& historyItem)
 {
-    Ref entry = adoptRef(*new NavigationHistoryEntry(context, WTFMove(historyItem), historyItem->urlString(), historyItem->uuidIdentifier()));
+    Ref entry = adoptRef(*new NavigationHistoryEntry(context, DocumentState::fromContext(context), WTFMove(historyItem), historyItem->urlString(), historyItem->uuidIdentifier()));
     entry->suspendIfNeeded();
     return entry;
 }
@@ -63,7 +64,7 @@ Ref<NavigationHistoryEntry> NavigationHistoryEntry::create(ScriptExecutionContex
     RefPtr state = historyItem->navigationAPIStateObject();
     if (!state)
         state = other.m_state;
-    Ref entry = adoptRef(*new NavigationHistoryEntry(context, WTFMove(historyItem), other.m_urlString, other.m_key, WTFMove(state), other.m_id));
+    Ref entry = adoptRef(*new NavigationHistoryEntry(context, DocumentState::fromContext(other.scriptExecutionContext()), WTFMove(historyItem), other.m_urlString, other.m_key, WTFMove(state), other.m_id));
     entry->suspendIfNeeded();
     return entry;
 }
@@ -82,6 +83,9 @@ const String& NavigationHistoryEntry::url() const
 {
     RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
     if (!document || !document->isFullyActive())
+        return nullString();
+    // https://html.spec.whatwg.org/#dom-navigationhistoryentry-url (Step 4)
+    if (document->identifier() != m_originalDocumentState.identifier && (m_originalDocumentState.referrerPolicy == ReferrerPolicy::NoReferrer || m_originalDocumentState.referrerPolicy == ReferrerPolicy::Origin))
         return nullString();
     return m_urlString;
 }
@@ -140,6 +144,13 @@ void NavigationHistoryEntry::setState(RefPtr<SerializedScriptValue>&& state)
 {
     m_state = state;
     m_associatedHistoryItem->setNavigationAPIStateObject(WTFMove(state));
+}
+
+auto NavigationHistoryEntry::DocumentState::fromContext(ScriptExecutionContext* context) -> DocumentState
+{
+    if (!context)
+        return { };
+    return { context->identifier(), context->referrerPolicy() };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -30,6 +30,7 @@
 #include "EventHandler.h"
 #include "EventTarget.h"
 #include "HistoryItem.h"
+#include "ReferrerPolicy.h"
 #include <wtf/RefCounted.h>
 
 namespace JSC {
@@ -61,7 +62,14 @@ public:
     HistoryItem& associatedHistoryItem() const { return m_associatedHistoryItem; }
 
 private:
-    NavigationHistoryEntry(ScriptExecutionContext*, Ref<HistoryItem>&&, String urlString, WTF::UUID key, RefPtr<SerializedScriptValue>&& state = { }, WTF::UUID = WTF::UUID::createVersion4());
+    struct DocumentState {
+        static DocumentState fromContext(ScriptExecutionContext*);
+
+        std::optional<ScriptExecutionContextIdentifier> identifier;
+        ReferrerPolicy referrerPolicy { ReferrerPolicy::Default };
+    };
+
+    NavigationHistoryEntry(ScriptExecutionContext*, const DocumentState&, Ref<HistoryItem>&&, String urlString, WTF::UUID key, RefPtr<SerializedScriptValue>&& state = { }, WTF::UUID = WTF::UUID::createVersion4());
 
     enum EventTargetInterfaceType eventTargetInterface() const final;
     ScriptExecutionContext* scriptExecutionContext() const final;
@@ -73,6 +81,7 @@ private:
     const WTF::UUID m_id;
     RefPtr<SerializedScriptValue> m_state;
     Ref<HistoryItem> m_associatedHistoryItem;
+    DocumentState m_originalDocumentState;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 46e5b937e6d19befd442ac5e6962a69a7eb746f9
<pre>
[Navigation] Implement url censoring
<a href="https://bugs.webkit.org/show_bug.cgi?id=282236">https://bugs.webkit.org/show_bug.cgi?id=282236</a>
<a href="https://rdar.apple.com/139279002">rdar://139279002</a>

Reviewed by Rob Buis.

Implement NavigationHistoryEntry.url censoring as per:
- <a href="https://html.spec.whatwg.org/#dom-navigationhistoryentry-url">https://html.spec.whatwg.org/#dom-navigationhistoryentry-url</a> (Step 4)

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-dynamic-url-censored-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-from-meta-url-censored-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-url-censored-expected.txt:
* Source/WebCore/page/NavigationHistoryEntry.cpp:
(WebCore::NavigationHistoryEntry::NavigationHistoryEntry):
(WebCore::NavigationHistoryEntry::create):
(WebCore::NavigationHistoryEntry::url const):
(WebCore::NavigationHistoryEntry::DocumentState::fromContext):
* Source/WebCore/page/NavigationHistoryEntry.h:

Canonical link: <a href="https://commits.webkit.org/287017@main">https://commits.webkit.org/287017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6987667659a0745d5bef68089ac5fdb06a9aa301

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82598 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29207 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80071 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5278 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61038 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18966 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51033 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41340 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48396 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24470 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27550 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69489 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83960 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5317 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3590 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69257 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5473 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66876 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68512 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12515 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10674 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12066 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5265 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8018 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5257 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8689 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->