### PR TITLE
Non-unified build fixes

### DIFF
--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "URLPattern.h"
 
+#include "ScriptExecutionContext.h"
 #include "URLPatternCanonical.h"
 #include "URLPatternInit.h"
 #include "URLPatternOptions.h"

--- a/Source/WebCore/Modules/url-pattern/URLPattern.h
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.h
@@ -35,6 +35,7 @@
 
 namespace WebCore {
 
+class ScriptExecutionContext;
 struct URLPatternInit;
 struct URLPatternOptions;
 struct URLPatternResult;

--- a/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
@@ -27,6 +27,9 @@
 #include "URLPatternComponent.h"
 
 #include "URLPatternCanonical.h"
+#include "URLPatternParser.h"
+#include <JavaScriptCore/RegExp.h>
+#include <JavaScriptCore/YarrFlags.h>
 
 namespace WebCore {
 namespace URLPatternUtilities {
@@ -39,7 +42,7 @@ URLPatternComponent::URLPatternComponent(String&& patternString, JSC::Strong<JSC
 {
 }
 
-ExceptionOr<URLPatternComponent> URLPatternComponent::compile(Ref<VM> vm, StringView input, EncodingCallbackType type, const URLPatternUtilities::URLPatternStringOptions& options)
+ExceptionOr<URLPatternComponent> URLPatternComponent::compile(Ref<JSC::VM> vm, StringView input, EncodingCallbackType type, const URLPatternUtilities::URLPatternStringOptions& options)
 {
     auto maybePartList = URLPatternUtilities::URLPatternParser::parse(input, options, type);
     if (maybePartList.hasException())
@@ -48,11 +51,11 @@ ExceptionOr<URLPatternComponent> URLPatternComponent::compile(Ref<VM> vm, String
 
     auto [regularExpressionString, nameList] = generateRegexAndNameList(partList, options);
 
-    OptionSet<Yarr::Flags> flags = { Yarr::Flags::UnicodeSets };
+    OptionSet<JSC::Yarr::Flags> flags = { JSC::Yarr::Flags::UnicodeSets };
     if (options.ignoreCase)
-        flags.add(Yarr::Flags::IgnoreCase);
+        flags.add(JSC::Yarr::Flags::IgnoreCase);
 
-    RegExp* regularExpression = RegExp::create(vm, regularExpressionString, flags);
+    JSC::RegExp* regularExpression = JSC::RegExp::create(vm, regularExpressionString, flags);
     if (!regularExpression)
         return Exception { ExceptionCode::TypeError, "Unable to create RegExp object regular expression from provided URLPattern string."_s };
 

--- a/Source/WebCore/Modules/url-pattern/URLPatternComponent.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternComponent.h
@@ -25,9 +25,18 @@
 
 #pragma once
 
+#include <JavaScriptCore/Strong.h>
+#include <JavaScriptCore/StrongInlines.h>
+
+namespace JSC {
+class RegExp;
+class VM;
+}
+
 namespace WebCore {
 
 enum class EncodingCallbackType : uint8_t;
+template<typename> class ExceptionOr;
 
 namespace URLPatternUtilities {
 struct URLPatternStringOptions;

--- a/Source/WebCore/Modules/url-pattern/URLPatternParser.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternParser.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "URLPatternParser.h"
 
+#include "URLPatternCanonical.h"
 #include "URLPatternTokenizer.h"
 #include <wtf/text/MakeString.h>
 

--- a/Source/WebCore/Modules/url-pattern/URLPatternParser.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternParser.h
@@ -25,11 +25,14 @@
 
 #pragma once
 
+#include "URLPatternTokenizer.h"
+#include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 enum class EncodingCallbackType : uint8_t;
+template<typename> class ExceptionOr;
 
 namespace URLPatternUtilities {
 


### PR DESCRIPTION
#### 22656abea6f1fdcfa26a3db7779588772324a9f9
<pre>
Non-unified build fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=283604">https://bugs.webkit.org/show_bug.cgi?id=283604</a>

Unreviewed.

* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
* Source/WebCore/Modules/url-pattern/URLPattern.h:
* Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp:
(WebCore::URLPatternUtilities::URLPatternComponent::compile):
* Source/WebCore/Modules/url-pattern/URLPatternComponent.h:
* Source/WebCore/Modules/url-pattern/URLPatternParser.cpp:
* Source/WebCore/Modules/url-pattern/URLPatternParser.h:

Canonical link: <a href="https://commits.webkit.org/287007@main">https://commits.webkit.org/287007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9a40cceb386a3951aa7559faf4a558260f289a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82584 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29193 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5264 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/61029 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18956 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81004 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41331 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48385 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24437 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27536 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69478 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24781 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83946 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5303 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/69247 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5459 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/66853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68502 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12504 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10638 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12062 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5251 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8004 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5243 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8675 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7028 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->