### PR TITLE
AX: Compute AXAttributedStringForTextMarkerRangeAttribute off the main-thread for ranges pointing to static text objects

### DIFF
--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/attributed-string-text-styling-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/attributed-string-text-styling-expected.txt
@@ -1,0 +1,19 @@
+This test ensures that attributed string for text marker range includes text styling information.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS textPlain.attributedStringForTextMarkerRange(textPlainRange) is textPlainAttributes
+PASS textBold.attributedStringForTextMarkerRange(textBoldRange) is textBoldAttributes
+PASS textItalic.attributedStringForTextMarkerRange(textItalicRange) is textItalicAttributes
+PASS textBoldItalic.attributedStringForTextMarkerRange(textBoldItalicRange) is textBoldItalicAttributes
+PASS successfullyParsed is true
+
+TEST COMPLETE
+The
+
+Fox
+
+Jumped
+
+Over

--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/attributed-string-text-styling.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/attributed-string-text-styling.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- Copy of existing test, remove after accessibilityThreadTextApisEnabled is enabled by default. -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<p id="text-plain">The</p>
+<p id="text-bold" style="font-weight: bold">Fox</p>
+<p id="text-italic" style="font-style: italic">Jumped</p>
+<p id="text-bold-italic" style="font-style: italic; font-weight: bold;">Over</p>
+
+<script>
+    description("This test ensures that attributed string for text marker range includes text styling information.");
+    if (window.accessibilityController) {
+        var textPlain = accessibilityController.accessibleElementById("text-plain");
+        var textPlainRange = textPlain.textMarkerRangeForElement(textPlain);
+        var textPlainAttributes = "AXFont - {\n    AXFontFamily = Times;\n    AXFontName = \"Times-Roman\";\n    AXFontSize = 16;\n}, The";
+        shouldBe("textPlain.attributedStringForTextMarkerRange(textPlainRange)", "textPlainAttributes");
+
+        var textBold = accessibilityController.accessibleElementById("text-bold");
+        var textBoldRange = textBold.textMarkerRangeForElement(textBold);
+        var textBoldAttributes = "AXFont - {\n    AXFontBold = 1;\n    AXFontFamily = Times;\n    AXFontName = \"Times-Bold\";\n    AXFontSize = 16;\n}, Fox";
+        shouldBe("textBold.attributedStringForTextMarkerRange(textBoldRange)", "textBoldAttributes");
+
+        var textItalic = accessibilityController.accessibleElementById("text-italic");
+        var textItalicRange = textItalic.textMarkerRangeForElement(textItalic);
+        var textItalicAttributes = "AXFont - {\n    AXFontFamily = Times;\n    AXFontItalic = 1;\n    AXFontName = \"Times-Italic\";\n    AXFontSize = 16;\n}, Jumped";
+        shouldBe("textItalic.attributedStringForTextMarkerRange(textItalicRange)", "textItalicAttributes");
+
+        var textBoldItalic = accessibilityController.accessibleElementById("text-bold-italic");
+        var textBoldItalicRange = textBoldItalic.textMarkerRangeForElement(textBoldItalic);
+        var textBoldItalicAttributes = "AXFont - {\n    AXFontBold = 1;\n    AXFontFamily = Times;\n    AXFontItalic = 1;\n    AXFontName = \"Times-BoldItalic\";\n    AXFontSize = 16;\n}, Over";
+        shouldBe("textBoldItalic.attributedStringForTextMarkerRange(textBoldItalicRange)", "textBoldItalicAttributes");
+    }
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/dynamic-style-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/dynamic-style-expected.txt
@@ -1,0 +1,24 @@
+This test ensures we produce the right attributed string after dynamic style changes.
+
+Attributes in range {0, 29}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 24;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 1 0.647059 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0.827451 0.827451 0.827451 1 )
+AXSuperscript: 1
+AXShadow: YES
+AXUnderline: YES
+AXUnderlineColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0.4 0.2 0.6 1 )
+AXStrikethrough: YES
+AXStrikethroughColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0.4 0.2 0.6 1 )
+This is an attributed string.
+
+PASS: The attributed string matched expectations after changing styles.
+PASS: The attributed string matched expectations after removing all styles.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This is an attributed string.

--- a/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/dynamic-style.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/attributed-string/dynamic-style.html
@@ -1,0 +1,83 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- New test added as part of the accessibilityThreadTextApisEnabled work. Move to LayoutTests/accessibility/mac/ after this feature is enabled by default. -->
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+.style {
+    color: orange;
+    background-color: lightgrey;
+    font-size: 24px;
+    text-shadow: 1px 1px 2px red, 0 0 1em blue, 0 0 0.2em blue;
+    text-decoration-line: underline line-through;
+    text-decoration-color: rebeccapurple;
+    vertical-align: super;
+}
+</style>
+</head>
+<body>
+
+<div id="container" class="style" role="group" aria-label="text-container">This is an attributed string.</div>
+
+<script>
+var output = "This test ensures we produce the right attributed string after dynamic style changes.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var container = document.getElementById("container");
+    var text = accessibilityController.accessibleElementById("container").childAtIndex(0);
+    var markerRange = text.textMarkerRangeForElement(text);
+    output += `${text.attributedStringForTextMarkerRange(markerRange)}\n\n`;
+
+    container.style.color = "red";
+    container.style.backgroundColor = "blue";
+    container.style.textDecorationColor = "yellow";
+    container.style.verticalAlign = "sub";
+    container.style.fontSize = "32px";
+    container.style.fontFamily = "Arial";
+    var expected = `Attributes in range {0, 29}:
+AXFont: {
+    AXFontFamily = Arial;
+    AXFontName = ArialMT;
+    AXFontSize = 32;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 1 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 1 1 )
+AXSuperscript: -1
+AXShadow: YES
+AXUnderline: YES
+AXUnderlineColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 1 1 0 1 )
+AXStrikethrough: YES
+AXStrikethroughColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 1 1 0 1 )
+This is an attributed string.`;
+    var actual;
+    setTimeout(async function() {
+        await waitFor(() => expected === text.attributedStringForTextMarkerRange(markerRange));
+        output += `PASS: The attributed string matched expectations after changing styles.\n`;
+
+        // Now remove all styles.
+        container.removeAttribute("class");
+        container.removeAttribute("style");
+        expected = `Attributes in range {0, 29}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+This is an attributed string.`;
+        await waitFor(() => expected === text.attributedStringForTextMarkerRange(markerRange));
+        output += `PASS: The attributed string matched expectations after removing all styles.`;
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -137,6 +137,7 @@ Modules/speech/cocoa/WebSpeechRecognizerTaskMock.mm
 Modules/system-preview/ARKitBadgeSystemImage.mm
 Modules/webdatabase/cocoa/DatabaseManagerCocoa.mm
 Modules/webxr/WebXROpaqueFramebufferCocoa.cpp
+accessibility/cocoa/AXCoreObjectCocoa.mm
 accessibility/cocoa/AXTextMarkerCocoa.mm
 accessibility/cocoa/AccessibilityObjectCocoa.mm
 accessibility/ios/AXObjectCacheIOS.mm

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -30,6 +30,8 @@
 #include "AXCoreObject.h"
 
 #include "LocalFrameView.h"
+#include "RenderObject.h"
+#include "TextDecorationPainter.h"
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -895,6 +897,38 @@ AXCoreObject* AXCoreObject::parentObjectUnignored() const
     return Accessibility::findAncestor<AXCoreObject>(*this, false, [&] (const AXCoreObject& object) {
         return !object.isIgnored();
     });
+}
+
+// LineDecorationStyle implementations.
+
+LineDecorationStyle::LineDecorationStyle(RenderObject& renderer)
+{
+    const auto& style = renderer.style();
+    auto decor = style.textDecorationsInEffect();
+    if (decor & TextDecorationLine::Underline || decor & TextDecorationLine::LineThrough) {
+        auto decorationStyles = TextDecorationPainter::stylesForRenderer(renderer, decor);
+        if (decor & TextDecorationLine::Underline) {
+            hasUnderline = true;
+            underlineColor = decorationStyles.underline.color;
+        }
+
+        if (decor & TextDecorationLine::LineThrough) {
+            hasLinethrough = true;
+            linethroughColor = decorationStyles.linethrough.color;
+        }
+    }
+}
+
+String LineDecorationStyle::debugDescription() const
+{
+    return makeString(
+        "{"_s,
+        "hasUnderline: "_s, hasUnderline,
+        ", underlineColor: "_s, underlineColor.debugDescription(),
+        ", hasLinethrough: "_s, hasLinethrough,
+        ", linethroughColor: "_s, linethroughColor.debugDescription(),
+        "}"_s
+    );
 }
 
 namespace Accessibility {

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -657,6 +657,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXPropertyName property)
     case AXPropertyName::AutoCompleteValue:
         stream << "AutoCompleteValue";
         break;
+    case AXPropertyName::BackgroundColor:
+        stream << "BackgroundColor";
+        break;
     case AXPropertyName::BlockquoteLevel:
         stream << "BlockquoteLevel";
         break;
@@ -752,6 +755,14 @@ TextStream& operator<<(WTF::TextStream& stream, AXPropertyName property)
     case AXPropertyName::ExtendedDescription:
         stream << "ExtendedDescription";
         break;
+#if PLATFORM(COCOA)
+    case AXPropertyName::Font:
+        stream << "Font";
+        break;
+#endif // PLATFORM(COCOA)
+    case AXPropertyName::TextColor:
+        stream << "TextColor";
+        break;
     case AXPropertyName::HasApplePDFAnnotationAttribute:
         stream << "HasApplePDFAnnotationAttribute";
         break;
@@ -770,11 +781,23 @@ TextStream& operator<<(WTF::TextStream& stream, AXPropertyName property)
     case AXPropertyName::HasItalicFont:
         stream << "HasItalicFont";
         break;
+    case AXPropertyName::HasLinethrough:
+        stream << "HasLinethrough";
+        break;
     case AXPropertyName::HasPlainText:
         stream << "HasPlainText";
         break;
     case AXPropertyName::HasRemoteFrameChild:
         stream << "HasRemoteFrameChild";
+        break;
+    case AXPropertyName::IsSubscript:
+        stream << "IsSubscript";
+        break;
+    case AXPropertyName::IsSuperscript:
+        stream << "IsSuperscript";
+        break;
+    case AXPropertyName::HasTextShadow:
+        stream << "HasTextShadow";
         break;
     case AXPropertyName::HasUnderline:
         stream << "HasUnderline";
@@ -964,6 +987,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXPropertyName property)
         break;
     case AXPropertyName::Language:
         stream << "Language";
+        break;
+    case AXPropertyName::LinethroughColor:
+        stream << "LinethroughColor";
         break;
     case AXPropertyName::LiveRegionAtomic:
         stream << "LiveRegionAtomic";
@@ -1173,6 +1199,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXPropertyName property)
         break;
     case AXPropertyName::URL:
         stream << "URL";
+        break;
+    case AXPropertyName::UnderlineColor:
+        stream << "UnderlineColor";
         break;
     case AXPropertyName::ValueAutofillButtonType:
         stream << "ValueAutofillButtonType";

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -364,7 +364,8 @@ public:
     void onPopoverToggle(const HTMLElement&);
     void onScrollbarFrameRectChange(const Scrollbar&);
     void onSelectedChanged(Element&);
-    void onStyleChange(Element&, Style::Change, const RenderStyle* newStyle, const RenderStyle* oldStyle);
+    void onStyleChange(Element&, Style::Change, const RenderStyle* oldStyle, const RenderStyle* newStyle);
+    void onStyleChange(RenderText&, StyleDifference, const RenderStyle* oldStyle, const RenderStyle& newStyle);
     void onTextSecurityChanged(HTMLInputElement&);
     void onTitleChange(Document&);
     void onValidityChange(Element&);

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -290,7 +290,10 @@ public:
 #if ENABLE(AX_THREAD_TEXT_APIS)
     // Traverses from m_start to m_end, collecting all text along the way.
     String toString() const;
-#endif
+#if PLATFORM(COCOA)
+    RetainPtr<NSAttributedString> toAttributedString() const;
+#endif // PLATFORM(COCOA)
+#endif // ENABLE(AX_THREAD_TEXT_APIS)
 
     String debugDescription() const;
 private:

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -406,6 +406,16 @@ public:
     RetainPtr<NSArray> contentForRange(const SimpleRange&, SpellCheck = SpellCheck::No) const;
     RetainPtr<NSAttributedString> attributedStringForRange(const SimpleRange&, SpellCheck) const;
     RetainPtr<NSAttributedString> attributedStringForTextMarkerRange(AXTextMarkerRange&&, SpellCheck = SpellCheck::No) const override;
+    // The following functions are PLATFORM(COCOA) because these are currently only used to power a
+    // Cocoa API (attributed strings).
+    AttributedStringStyle stylesForAttributedString() const final;
+    RetainPtr<CTFontRef> font() const;
+    Color textColor() const;
+    Color backgroundColor() const;
+    bool isSubscript() const;
+    bool isSuperscript() const;
+    bool hasTextShadow() const;
+    LineDecorationStyle lineDecorationStyle() const;
 #endif
     virtual String ariaLabeledByAttribute() const { return String(); }
     virtual String ariaDescribedByAttribute() const { return String(); }
@@ -1020,6 +1030,13 @@ public:
 private:
     Ref<const AccessibilityObject> m_parent;
 }; // class AXChildIterator
+
+#if PLATFORM(COCOA)
+// Helpers to extract information from RenderStyle needed for accessibility purposes.
+RetainPtr<CTFontRef> fontFrom(const RenderStyle&);
+Color textColorFrom(const RenderStyle&);
+Color backgroundColorFrom(const RenderStyle&);
+#endif // PLATFORM(COCOA)
 
 } // namespace WebCore
 

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "AXCoreObject.h"
+
+#import "ColorCocoa.h"
+#import "WebAccessibilityObjectWrapperBase.h"
+
+#if PLATFORM(IOS_FAMILY)
+#import <wtf/SoftLinking.h>
+
+SOFT_LINK_PRIVATE_FRAMEWORK(AXRuntime);
+
+SOFT_LINK_CONSTANT(AXRuntime, UIAccessibilityTokenFontName, NSString *);
+#define AccessibilityTokenFontName getUIAccessibilityTokenFontName()
+SOFT_LINK_CONSTANT(AXRuntime, UIAccessibilityTokenFontFamily, NSString *);
+#define AccessibilityTokenFontFamily getUIAccessibilityTokenFontFamily()
+SOFT_LINK_CONSTANT(AXRuntime, UIAccessibilityTokenFontSize, NSString *);
+#define AccessibilityTokenFontSize getUIAccessibilityTokenFontSize()
+SOFT_LINK_CONSTANT(AXRuntime, UIAccessibilityTokenBold, NSString *);
+#define AccessibilityTokenBold getUIAccessibilityTokenBold()
+SOFT_LINK_CONSTANT(AXRuntime, UIAccessibilityTokenItalic, NSString *);
+#define AccessibilityTokenItalic getUIAccessibilityTokenItalic()
+SOFT_LINK_CONSTANT(AXRuntime, UIAccessibilityTokenAttachment, NSString *);
+#define AccessibilityTokenAttachment getUIAccessibilityTokenAttachment()
+
+#endif // PLATFORM(IOS_FAMILY)
+
+#if PLATFORM(COCOA)
+
+namespace WebCore {
+
+// When modifying attributed strings, the range can come from a source which may provide faulty information (e.g. the spell checker).
+// To protect against such cases, the range should be validated before adding or removing attributes.
+bool attributedStringContainsRange(NSAttributedString *attributedString, const NSRange& range)
+{
+    return NSMaxRange(range) <= attributedString.length;
+}
+
+void attributedStringSetFont(NSMutableAttributedString *attributedString, CTFontRef font, const NSRange& range)
+{
+    if (!attributedStringContainsRange(attributedString, range) || !font)
+        return;
+
+    auto fontAttributes = adoptNS([[NSMutableDictionary alloc] init]);
+    auto familyName = adoptCF(CTFontCopyFamilyName(font));
+    NSNumber *size = [NSNumber numberWithFloat:CTFontGetSize(font)];
+
+#if PLATFORM(IOS_FAMILY)
+    auto fullName = adoptCF(CTFontCopyFullName(font));
+    if (fullName)
+        [fontAttributes setValue:bridge_cast(fullName.get()) forKey:AccessibilityTokenFontName];
+    if (familyName)
+        [fontAttributes setValue:bridge_cast(familyName.get()) forKey:AccessibilityTokenFontFamily];
+    if ([size boolValue])
+        [fontAttributes setValue:size forKey:AccessibilityTokenFontSize];
+    auto traits = CTFontGetSymbolicTraits(font);
+    if (traits & kCTFontTraitBold)
+        [fontAttributes setValue:@YES forKey:AccessibilityTokenBold];
+    if (traits & kCTFontTraitItalic)
+        [fontAttributes setValue:@YES forKey:AccessibilityTokenItalic];
+
+    [attributedString addAttributes:fontAttributes.get() range:range];
+#endif // PLATFORM(IOS_FAMILY)
+
+#if PLATFORM(MAC)
+    [fontAttributes setValue:size forKey:NSAccessibilityFontSizeKey];
+
+    if (familyName)
+        [fontAttributes setValue:bridge_cast(familyName.get()) forKey:NSAccessibilityFontFamilyKey];
+    auto postScriptName = adoptCF(CTFontCopyPostScriptName(font));
+    if (postScriptName)
+        [fontAttributes setValue:bridge_cast(postScriptName.get()) forKey:NSAccessibilityFontNameKey];
+    auto traits = CTFontGetSymbolicTraits(font);
+    if (traits & kCTFontTraitBold)
+        [fontAttributes setValue:@YES forKey:@"AXFontBold"];
+    if (traits & kCTFontTraitItalic)
+        [fontAttributes setValue:@YES forKey:@"AXFontItalic"];
+
+    [attributedString addAttribute:NSAccessibilityFontTextAttribute value:fontAttributes.get() range:range];
+#endif // PLATFORM(MAC)
+}
+
+#if PLATFORM(MAC)
+void attributedStringSetColor(NSMutableAttributedString *attrString, NSString *attribute, NSColor *color, const NSRange& range)
+{
+    if (color) {
+        // Use the CGColor instead of the passed NSColor because that's what the AX system framework expects. Using the NSColor causes that the AX client gets nil instead of a valid NSAttributedString.
+        [attrString addAttribute:attribute value:(__bridge id)color.CGColor range:range];
+    }
+}
+#endif // PLATFORM(MAC)
+
+static void attributedStringSetStyle(NSMutableAttributedString *attributedString, AttributedStringStyle&& style, const NSRange& range)
+{
+    attributedStringSetFont(attributedString, style.font.get(), range);
+
+#if PLATFORM(MAC)
+    attributedStringSetColor(attributedString, NSAccessibilityForegroundColorTextAttribute, cocoaColor(style.textColor).get(), range);
+    attributedStringSetColor(attributedString, NSAccessibilityBackgroundColorTextAttribute, cocoaColor(style.backgroundColor).get(), range);
+
+    // Set subscript / superscript.
+    if (style.isSubscript)
+        attributedStringSetNumber(attributedString, NSAccessibilitySuperscriptTextAttribute, @(-1), range);
+    else if (style.isSuperscript)
+        attributedStringSetNumber(attributedString, NSAccessibilitySuperscriptTextAttribute, @(1), range);
+
+    // Set text shadow.
+    if (style.hasTextShadow)
+        attributedStringSetNumber(attributedString, NSAccessibilityShadowTextAttribute, @YES, range);
+
+    // Set underline and strikethrough.
+    if (style.hasUnderline()) {
+        attributedStringSetNumber(attributedString, NSAccessibilityUnderlineTextAttribute, @YES, range);
+        attributedStringSetColor(attributedString, NSAccessibilityUnderlineColorTextAttribute, cocoaColor(style.underlineColor()).get(), range);
+    }
+
+    if (style.hasLinethrough()) {
+        attributedStringSetNumber(attributedString, NSAccessibilityStrikethroughTextAttribute, @YES, range);
+        attributedStringSetColor(attributedString, NSAccessibilityStrikethroughColorTextAttribute, cocoaColor(style.linethroughColor()).get(), range);
+    }
+#endif // PLATFORM(MAC)
+
+    // FIXME: Implement this.
+//    // Indicate background highlighting.
+//    for (Node* node = renderer->node(); node; node = node->parentNode()) {
+//        if (node->hasTagName(HTMLNames::markTag))
+//            attributedStringSetNumber(attributedString, @"AXHighlight", @YES, range);
+//        if (auto* element = dynamicDowncast<Element>(*node)) {
+//            auto& roleValue = element->attributeWithoutSynchronization(HTMLNames::roleAttr);
+//            if (equalLettersIgnoringASCIICase(roleValue, "insertion"_s))
+//                attributedStringSetNumber(attributedString, @"AXIsSuggestedInsertion", @YES, range);
+//            else if (equalLettersIgnoringASCIICase(roleValue, "deletion"_s))
+//                attributedStringSetNumber(attributedString, @"AXIsSuggestedDeletion", @YES, range);
+//            else if (equalLettersIgnoringASCIICase(roleValue, "suggestion"_s))
+//                attributedStringSetNumber(attributedString, @"AXIsSuggestion", @YES, range);
+//            else if (equalLettersIgnoringASCIICase(roleValue, "mark"_s))
+//                attributedStringSetNumber(attributedString, @"AXHighlight", @YES, range);
+//        }
+//    }
+}
+
+// This is intended to replace the static attributedStringCreate() methods once we have ported all functionality.
+RetainPtr<NSAttributedString> AXCoreObject::createAttributedString(String&& text) const
+{
+    if (text.isEmpty())
+        return nil;
+
+    auto result = adoptNS([[NSMutableAttributedString alloc] initWithString:WTFMove(text)]);
+    NSRange range = NSMakeRange(0, [result length]);
+    attributedStringSetStyle(result.get(), stylesForAttributedString(), range);
+
+    // FIXME: Implement the rest of these.
+//    attributedStringSetHeadingLevel(result.get(), renderer.get(), range);
+//    attributedStringSetBlockquoteLevel(result.get(), renderer.get(), range);
+//    attributedStringSetExpandedText(result.get(), renderer.get(), range);
+//    attributedStringSetElement(result.get(), NSAccessibilityLinkTextAttribute, AccessibilityObject::anchorElementForNode(node), range);
+//    attributedStringSetCompositionAttributes(result.get(), node, textRange);
+//    // Do spelling last because it tends to break up the range.
+//    if (spellCheck == AXCoreObject::SpellCheck::Yes) {
+//        if (AXObjectCache::shouldSpellCheck())
+//            attributedStringSetSpelling(result.get(), node, text, range);
+//        else
+//            attributedStringSetNeedsSpellCheck(result.get(), node);
+//    }
+//
+    return result;
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -190,7 +190,9 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
     setProperty(AXPropertyName::HasBoldFont, object.hasBoldFont());
     setProperty(AXPropertyName::HasItalicFont, object.hasItalicFont());
     setProperty(AXPropertyName::HasPlainText, object.hasPlainText());
+#if !ENABLE(AX_THREAD_TEXT_APIS)
     setProperty(AXPropertyName::HasUnderline, object.hasUnderline());
+#endif
     setProperty(AXPropertyName::IsKeyboardFocusable, object.isKeyboardFocusable());
     setProperty(AXPropertyName::BrailleRoleDescription, object.brailleRoleDescription().isolatedCopy());
     setProperty(AXPropertyName::BrailleLabel, object.brailleLabel().isolatedCopy());
@@ -613,6 +615,7 @@ void AXIsolatedObject::setProperty(AXPropertyName propertyName, AXPropertyValueV
         },
 #if ENABLE(AX_THREAD_TEXT_APIS)
         [](AXTextRuns& runs) { return !runs.size(); },
+        [](RetainPtr<CTFontRef>& typedValue) { return !typedValue; },
 #endif
         [] (WallTime& time) { return !time; },
         [] (DateComponentsType& typedValue) { return typedValue == DateComponentsType::Invalid; },

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -503,6 +503,7 @@ private:
     unsigned textLength() const final;
 #if PLATFORM(COCOA)
     RetainPtr<NSAttributedString> attributedStringForTextMarkerRange(AXTextMarkerRange&&, SpellCheck) const final;
+    AttributedStringStyle stylesForAttributedString() const final;
 #endif
     AXObjectCache* axObjectCache() const final;
     Element* actionElement() const final;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -572,7 +572,7 @@ void AXIsolatedTree::updatePropertiesForSelfAndDescendants(AccessibilityObject& 
     });
 }
 
-void AXIsolatedTree::updateNodeProperties(AXCoreObject& axObject, const AXPropertyNameSet& properties)
+void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const AXPropertyNameSet& properties)
 {
     AXTRACE("AXIsolatedTree::updateNodeProperties"_s);
     AXLOG(makeString("Updating properties for objectID "_s, axObject.objectID().loggingString(), ": "_s));
@@ -626,7 +626,7 @@ void AXIsolatedTree::updateNodeProperties(AXCoreObject& axObject, const AXProper
             propertyMap.set(AXPropertyName::Cells, axIDs(axObject.cells()));
             break;
         case AXPropertyName::CellSlots:
-            propertyMap.set(AXPropertyName::CellSlots, dynamicDowncast<AccessibilityObject>(axObject)->cellSlots());
+            propertyMap.set(AXPropertyName::CellSlots, axObject.cellSlots());
             break;
         case AXPropertyName::ColumnIndex:
             propertyMap.set(AXPropertyName::ColumnIndex, axObject.columnIndex());
@@ -766,10 +766,40 @@ void AXIsolatedTree::updateNodeProperties(AXCoreObject& axObject, const AXProper
             break;
         }
 #if ENABLE(AX_THREAD_TEXT_APIS)
-        case AXPropertyName::TextRuns:
-            propertyMap.set(AXPropertyName::TextRuns, dynamicDowncast<AccessibilityObject>(axObject)->textRuns());
+        case AXPropertyName::BackgroundColor:
+            propertyMap.set(AXPropertyName::BackgroundColor, axObject.backgroundColor());
             break;
-#endif
+        case AXPropertyName::Font:
+            propertyMap.set(AXPropertyName::Font, axObject.font());
+            break;
+        case AXPropertyName::HasLinethrough:
+            propertyMap.set(AXPropertyName::HasLinethrough, axObject.lineDecorationStyle().hasLinethrough);
+            break;
+        case AXPropertyName::HasTextShadow:
+            propertyMap.set(AXPropertyName::HasTextShadow, axObject.hasTextShadow());
+            break;
+        case AXPropertyName::HasUnderline:
+            propertyMap.set(AXPropertyName::HasUnderline, axObject.lineDecorationStyle().hasUnderline);
+            break;
+        case AXPropertyName::IsSubscript:
+            propertyMap.set(AXPropertyName::IsSubscript, axObject.isSubscript());
+            break;
+        case AXPropertyName::IsSuperscript:
+            propertyMap.set(AXPropertyName::IsSuperscript, axObject.isSuperscript());
+            break;
+        case AXPropertyName::LinethroughColor:
+            propertyMap.set(AXPropertyName::LinethroughColor, axObject.lineDecorationStyle().linethroughColor);
+            break;
+        case AXPropertyName::TextColor:
+            propertyMap.set(AXPropertyName::TextColor, axObject.textColor());
+            break;
+        case AXPropertyName::TextRuns:
+            propertyMap.set(AXPropertyName::TextRuns, axObject.textRuns());
+            break;
+        case AXPropertyName::UnderlineColor:
+            propertyMap.set(AXPropertyName::UnderlineColor, axObject.lineDecorationStyle().underlineColor);
+            break;
+#endif // ENABLE(AX_THREAD_TEXT_APIS)
         case AXPropertyName::Title:
             propertyMap.set(AXPropertyName::Title, axObject.title().isolatedCopy());
             break;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -93,6 +93,7 @@ enum class AXPropertyName : uint16_t {
     ActionVerb,
     AncestorFlags,
     AutoCompleteValue,
+    BackgroundColor,
     BlockquoteLevel,
     BrailleLabel,
     BrailleRoleDescription,
@@ -126,14 +127,22 @@ enum class AXPropertyName : uint16_t {
     EmbeddedImageDescription,
     ExpandedTextValue,
     ExtendedDescription,
+#if PLATFORM(COCOA)
+    Font,
+#endif
+    TextColor,
     HasApplePDFAnnotationAttribute,
     HasBoldFont,
     HasBodyTag,
     HasClickHandler,
     HasHighlighting,
     HasItalicFont,
+    HasLinethrough,
     HasPlainText,
     HasRemoteFrameChild,
+    IsSubscript,
+    IsSuperscript,
+    HasTextShadow,
     HasUnderline,
     HeaderContainer,
     HeadingLevel,
@@ -197,6 +206,7 @@ enum class AXPropertyName : uint16_t {
     IsWidget,
     KeyShortcuts,
     Language,
+    LinethroughColor,
     LiveRegionAtomic,
     LiveRegionRelevant,
     LiveRegionStatus,
@@ -268,6 +278,7 @@ enum class AXPropertyName : uint16_t {
     Title,
     TitleAttributeValue,
     URL,
+    UnderlineColor,
     ValueAutofillButtonType,
     ValueDescription,
     ValueForRange,
@@ -286,6 +297,7 @@ using AXPropertyValueVariant = std::variant<std::nullptr_t, Markable<AXID>, Stri
     , RetainPtr<id>
 #endif
 #if ENABLE(AX_THREAD_TEXT_APIS)
+    , RetainPtr<CTFontRef>
     , AXTextRuns
 #endif
 >;
@@ -362,8 +374,8 @@ public:
     enum class ResolveNodeChanges : bool { No, Yes };
     void updateChildren(AccessibilityObject&, ResolveNodeChanges = ResolveNodeChanges::Yes);
     void updateChildrenForObjects(const ListHashSet<Ref<AccessibilityObject>>&);
-    void updateNodeProperty(AXCoreObject& object, AXPropertyName property) { updateNodeProperties(object, { property }); }
-    void updateNodeProperties(AXCoreObject&, const AXPropertyNameSet&);
+    void updateNodeProperty(AccessibilityObject& object, AXPropertyName property) { updateNodeProperties(object, { property }); }
+    void updateNodeProperties(AccessibilityObject&, const AXPropertyNameSet&);
     void updateNodeProperties(AccessibilityObject* axObject, const AXPropertyNameSet& properties)
     {
         if (axObject)

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -38,6 +38,31 @@ void AXIsolatedObject::initializePlatformProperties(const Ref<const Accessibilit
 {
     setProperty(AXPropertyName::HasApplePDFAnnotationAttribute, object->hasApplePDFAnnotationAttribute());
     setProperty(AXPropertyName::SpeechHint, object->speechHintAttributeValue().isolatedCopy());
+#if ENABLE(AX_THREAD_TEXT_APIS)
+    if (object->isStaticText()) {
+        auto style = object->stylesForAttributedString();
+        setProperty(AXPropertyName::BackgroundColor, WTFMove(style.backgroundColor));
+        setProperty(AXPropertyName::Font, style.font);
+        setProperty(AXPropertyName::HasLinethrough, style.hasLinethrough());
+        setProperty(AXPropertyName::HasTextShadow, style.hasTextShadow);
+        setProperty(AXPropertyName::HasUnderline, style.hasUnderline());
+        setProperty(AXPropertyName::IsSubscript, style.isSubscript);
+        setProperty(AXPropertyName::IsSuperscript, style.isSuperscript);
+        setProperty(AXPropertyName::LinethroughColor, style.linethroughColor());
+        // FIXME: We're going to end up caching a lot of the same TextColor properties over and over.
+        //  1. Should we implement some kind of Color interning?
+        //  2. Or maybe have a "main" text color mechanism, where when we create the isolated tree, we try to compute the
+        //     "main" text color by walking n-number of RenderTexts. Then AXIsolatedObject::setProperty, if the Color is
+        //     equivalent to the "main" one, we consider the color to be "isDefaultValue", thus not caching it.
+        //       - Probably want to do this for both TextColor and BackgroundColor.
+        //       - Maybe set this as an OpportunisticTask to re-compute the main colors, and if it has changed, walk all
+        //         objects and uncache properties for those with the new "main" color? Not sure if this is worth it...
+        //       - Only trigger the walk if font-color changes?
+        // Resolve this FIXME before shipping AX_THREAD_TEXT_APIS.
+        setProperty(AXPropertyName::TextColor, WTFMove(style.textColor));
+        setProperty(AXPropertyName::UnderlineColor, style.underlineColor());
+    }
+#endif // ENABLE(AX_THREAD_TEXT_APIS)
 
     RetainPtr<NSAttributedString> attributedText;
     // FIXME: Don't eagerly cache textarea/contenteditable values longer than 12500 characters as rangeForCharacterRange is very expensive.
@@ -79,6 +104,24 @@ void AXIsolatedObject::initializePlatformProperties(const Ref<const Accessibilit
         m_platformWidget = object->platformWidget();
         m_remoteParent = object->remoteParentObject();
     }
+}
+
+AttributedStringStyle AXIsolatedObject::stylesForAttributedString() const
+{
+    return {
+        propertyValue<RetainPtr<CTFontRef>>(AXPropertyName::Font),
+        colorAttributeValue(AXPropertyName::TextColor),
+        colorAttributeValue(AXPropertyName::BackgroundColor),
+        boolAttributeValue(AXPropertyName::IsSubscript),
+        boolAttributeValue(AXPropertyName::IsSuperscript),
+        boolAttributeValue(AXPropertyName::HasTextShadow),
+        LineDecorationStyle(
+            boolAttributeValue(AXPropertyName::HasUnderline),
+            colorAttributeValue(AXPropertyName::UnderlineColor),
+            boolAttributeValue(AXPropertyName::HasLinethrough),
+            colorAttributeValue(AXPropertyName::LinethroughColor)
+        )
+    };
 }
 
 RemoteAXObjectRef AXIsolatedObject::remoteParentObject() const

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "AccessibilityObject.h"
 
+#import "AXObjectCache.h"
 #import "AXRemoteFrame.h"
 #import "AccessibilityLabel.h"
 #import "AccessibilityList.h"
@@ -562,14 +563,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 // NSAttributedString support.
-
-static void attributedStringSetColor(NSMutableAttributedString *attrString, NSString *attribute, NSColor *color, const NSRange& range)
-{
-    if (color) {
-        // Use the CGColor instead of the passed NSColor because that's what the AX system framework expects. Using the NSColor causes that the AX client gets nil instead of a valid NSAttributedString.
-        [attrString addAttribute:attribute value:(__bridge id)color.CGColor range:range];
-    }
-}
 
 static void attributedStringSetStyle(NSMutableAttributedString *attrString, RenderObject* renderer, const NSRange& range)
 {

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
@@ -50,6 +50,9 @@ class VisiblePosition;
 // functions are implemented in AccessibilityObjectCocoa.mm. Additional helper
 // functions are implemented in AccessibilityObjectMac or IOS .mm respectively.
 bool attributedStringContainsRange(NSAttributedString *, const NSRange&);
+#if PLATFORM(MAC)
+void attributedStringSetColor(NSMutableAttributedString *attrString, NSString *attribute, NSColor *, const NSRange&);
+#endif // PLATFORM(MAC)
 void attributedStringSetNumber(NSMutableAttributedString *, NSString *, NSNumber *, const NSRange&);
 void attributedStringSetFont(NSMutableAttributedString *, CTFontRef, const NSRange&);
 void attributedStringSetSpelling(NSMutableAttributedString *, Node&, StringView, const NSRange&);

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -3608,8 +3608,17 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         });
     }
 
-    if ([attribute isEqualToString:AXAttributedStringForTextMarkerRangeAttribute])
+    if ([attribute isEqualToString:AXAttributedStringForTextMarkerRangeAttribute]) {
+        if (!textMarkerRange)
+            return nil;
+#if ENABLE(AX_THREAD_TEXT_APIS)
+        // FIXME: Expand this beyond static text (i.e. ranges that span multiple objects).
+        if (AXObjectCache::useAXThreadTextApis() && backingObject->isStaticText())
+            return AXTextMarkerRange { textMarkerRange }.toAttributedString().autorelease();
+#endif // ENABLE(AX_THREAD_TEXT_APIS)
+
         return attributedStringForTextMarkerRange(*backingObject, textMarkerRange, AXCoreObject::SpellCheck::Yes);
+    }
 
     if ([attribute isEqualToString:AXAttributedStringForTextMarkerRangeWithOptionsAttribute]) {
         if (textMarkerRange)

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -442,6 +442,9 @@ void RenderText::styleDidChange(StyleDifference diff, const RenderStyle* oldStyl
     auto needsLayoutBoxStyleUpdate = layoutBox() && (diff >= StyleDifference::Repaint || (&style() != &firstLineStyle()));
     if (needsLayoutBoxStyleUpdate)
         LayoutIntegration::LineLayout::updateStyle(*this);
+
+    if (CheckedPtr cache = document().existingAXObjectCache())
+        cache->onStyleChange(*this, diff, oldStyle, newStyle);
 }
 
 void RenderText::removeAndDestroyLegacyTextBoxes()

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1118,7 +1118,7 @@ void TreeResolver::resolveComposedTree()
             if (element.hasCustomStyleResolveCallbacks())
                 element.didRecalcStyle(elementUpdate.change);
             if (CheckedPtr cache = m_document->existingAXObjectCache())
-                cache->onStyleChange(element, elementUpdate.change, elementUpdate.style.get(), style);
+                cache->onStyleChange(element, elementUpdate.change, style, elementUpdate.style.get());
 
             style = elementUpdate.style.get();
             change = elementUpdate.change;


### PR DESCRIPTION
#### cc3d1eef8dbf47a550477853ab61012aa91192e9
<pre>
AX: Compute AXAttributedStringForTextMarkerRangeAttribute off the main-thread for ranges pointing to static text objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=283607">https://bugs.webkit.org/show_bug.cgi?id=283607</a>
<a href="https://rdar.apple.com/problem/140447302">rdar://problem/140447302</a>

Reviewed by Chris Fleizach.

This commit implements off-main-thread support for AXAttributedStringForTextMarkerRangeAttribute for text marker ranges
that point within a single static text object. Supporting ranges that span multiple objects, and ranges that are confined
to one object that is not static text, will be implemented in future patches. These both should be much easier with this
base laid down, as fundamentally they will need to simply move from static text to static text, using the code written
in this commit to build a combined attributed string.

Beyond setting style attributes on attributed strings, there are several other categories of attributes that this commit
leaves for a future patch, e.g. heading level, blockquote level, expanded text, and a few more.

Several new isolated tree properties were added to support this functionality. Once this work is complete and ships, several
existing stale cache bugs will be fixed (we do not currently update cached attributed strings when style changes).

With this commit, we now pass attributed-string/attributed-string-text-styling.html with AX_THREAD_TEXT_APIS_ENABLED.
A new test is also created to ensure that dynamic style changes are reflected in an object&apos;s computed attributed string:
ax-thread-text-apis/attributed-string/dynamic-style.html

* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/attributed-string-text-styling-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/attributed-string-text-styling.html: Added.
* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/dynamic-style-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/attributed-string/dynamic-style.html: Added.
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::LineDecorationStyle::LineDecorationStyle):
(WebCore::LineDecorationStyle::debugDescription const):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::LineDecorationStyle::LineDecorationStyle):
(WebCore::AttributedStringStyle::hasUnderline const):
(WebCore::AttributedStringStyle::underlineColor const):
(WebCore::AttributedStringStyle::hasLinethrough const):
(WebCore::AttributedStringStyle::linethroughColor const):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onStyleChange):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::characterRangeForLine const):
(WebCore::AXTextMarker::lineNumberForIndex const):
* Source/WebCore/accessibility/AXTextMarker.h:
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm: Added.
(WebCore::attributedStringContainsRange):
(WebCore::attributedStringSetFont):
(WebCore::attributedStringSetColor):
(WebCore::attributedStringSetStyle):
(WebCore::AXCoreObject::createAttributedString const):
* Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm:
(WebCore::AXTextMarkerRange::toAttributedString const):
* Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm:
(WebCore::fontFrom):
(WebCore::textColorFrom):
(WebCore::backgroundColorFrom):
(WebCore::AccessibilityObject::font const):
(WebCore::AccessibilityObject::textColor const):
(WebCore::AccessibilityObject::backgroundColor const):
(WebCore::AccessibilityObject::isSubscript const):
(WebCore::AccessibilityObject::isSuperscript const):
(WebCore::AccessibilityObject::hasTextShadow const):
(WebCore::AccessibilityObject::lineDecorationStyle const):
(WebCore::AccessibilityObject::stylesForAttributedString const):
(WebCore::attributedStringContainsRange): Deleted.
(WebCore::attributedStringSetFont): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
(WebCore::AXIsolatedObject::setProperty):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::updateNodeProperty):
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::initializePlatformProperties):
(WebCore::AXIsolatedObject::stylesForAttributedString const):
(WebCore::AXIsolatedObject::textMarkerRange const):
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::attributedStringSetColor): Deleted.
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::styleDidChange):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveComposedTree):

Canonical link: <a href="https://commits.webkit.org/287243@main">https://commits.webkit.org/287243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18f06cdb4766a34498f30675b0a0043d8bf04420

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77904 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82552 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29161 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5232 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60999 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18934 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66909 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41302 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24366 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27504 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69451 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24719 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83914 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5271 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3550 "Found 2 new test failures: ipc/create-media-source-with-invalid-constraints-crash.html webrtc/vp8-then-h264.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69220 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5427 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68476 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17252 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12473 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10593 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5219 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7972 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5211 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8643 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6996 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->