### PR TITLE
[scroll-animations] Anonymous timelines should not share timeline object

### DIFF
--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -129,11 +129,15 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
                 CheckedRef timelinesController = document->ensureTimelinesController();
                 timelinesController->setTimelineForName(name, target, *this);
             }, [&] (Ref<ScrollTimeline> anonymousTimeline) {
-                if (RefPtr viewTimeline = dynamicDowncast<ViewTimeline>(anonymousTimeline))
-                    viewTimeline->setSubject(target.ptr());
-                else
-                    anonymousTimeline->setSource(target.ptr());
-                setTimeline(RefPtr { anonymousTimeline.ptr() });
+                if (RefPtr viewTimeline = dynamicDowncast<ViewTimeline>(anonymousTimeline)) {
+                    Ref timelineCopy = ViewTimeline::create(*viewTimeline);
+                    timelineCopy->setSubject(target.ptr());
+                    setTimeline(RefPtr { timelineCopy.ptr() });
+                } else {
+                    Ref timelineCopy = ScrollTimeline::create(anonymousTimeline);
+                    timelineCopy->setSource(target.ptr());
+                    setTimeline(RefPtr { timelineCopy.ptr() });
+                }
             }
         );
     }

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -38,6 +38,11 @@
 
 namespace WebCore {
 
+Ref<ScrollTimeline> ScrollTimeline::create(Ref<ScrollTimeline> timeline)
+{
+    return adoptRef(*new ScrollTimeline(timeline->scroller(), timeline->axis()));
+}
+
 Ref<ScrollTimeline> ScrollTimeline::create(ScrollTimelineOptions&& options)
 {
     return adoptRef(*new ScrollTimeline(WTFMove(options)));

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -45,6 +45,7 @@ struct TimelineRange;
 
 class ScrollTimeline : public AnimationTimeline {
 public:
+    static Ref<ScrollTimeline> create(Ref<ScrollTimeline>);
     static Ref<ScrollTimeline> create(ScrollTimelineOptions&& = { });
     static Ref<ScrollTimeline> create(const AtomString&, ScrollAxis);
     static Ref<ScrollTimeline> createFromCSSValue(const CSSScrollValue&);
@@ -74,6 +75,9 @@ public:
     void clearTimelineScopeDeclaredElement() { m_timelineScopeElement = nullptr; }
 
 protected:
+    enum class Scroller : uint8_t { Nearest, Root, Self };
+    Scroller scroller() const { return m_scroller; }
+
     explicit ScrollTimeline(const AtomString&, ScrollAxis);
 
     struct Data {
@@ -85,8 +89,6 @@ protected:
     virtual Data computeTimelineData(const TimelineRange&) const;
 
 private:
-    enum class Scroller : uint8_t { Nearest, Root, Self };
-
     explicit ScrollTimeline(ScrollTimelineOptions&& = { });
     explicit ScrollTimeline(Scroller, ScrollAxis);
 

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -48,6 +48,12 @@
 
 namespace WebCore {
 
+Ref<ViewTimeline> ViewTimeline::create(Ref<ViewTimeline> timeline)
+{
+    auto insetCopy = timeline->insets();
+    return adoptRef(*new ViewTimeline(nullAtom(), timeline->axis(), WTFMove(insetCopy)));
+}
+
 Ref<ViewTimeline> ViewTimeline::create(ViewTimelineOptions&& options)
 {
     return adoptRef(*new ViewTimeline(WTFMove(options)));

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -50,6 +50,7 @@ struct ViewTimelineInsets {
 
 class ViewTimeline final : public ScrollTimeline {
 public:
+    static Ref<ViewTimeline> create(Ref<ViewTimeline>);
     static Ref<ViewTimeline> create(ViewTimelineOptions&& = { });
     static Ref<ViewTimeline> create(const AtomString&, ScrollAxis, ViewTimelineInsets&&);
     static Ref<ViewTimeline> createFromCSSValue(const Style::BuilderState&, const CSSViewValue&);


### PR DESCRIPTION
#### 64c224d7ca73a9f841cc56f8a6f3c627ab2e2b4f
<pre>
[scroll-animations] Anonymous timelines should not share timeline object
<a href="https://bugs.webkit.org/show_bug.cgi?id=283594">https://bugs.webkit.org/show_bug.cgi?id=283594</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

When style sharing an anonymous timeline animation, we create only one timeline.
This would cause us to try and set the subject/source multiple times on the same
timeline. Instead, create a timeline per animation.

* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncPropertiesWithBackingAnimation):
* Source/WebCore/animation/ScrollTimeline.h:
(WebCore::ScrollTimeline::scroller const):
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::create):
* Source/WebCore/animation/ViewTimeline.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64c224d7ca73a9f841cc56f8a6f3c627ab2e2b4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77889 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82537 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29146 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5217 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60994 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18928 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66889 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41297 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48345 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24349 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27489 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69439 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24703 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83899 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5256 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3538 "Found 2 new test failures: imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment.html ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69212 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68467 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12465 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10580 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5204 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7957 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5196 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8628 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->