### PR TITLE
[WebGPU Swift] Disallow use of protectedFromAPI in Swift

### DIFF
--- a/Source/WebGPU/WebGPU/APIConversions.h
+++ b/Source/WebGPU/WebGPU/APIConversions.h
@@ -204,142 +204,144 @@ inline String fromAPI(const char* string)
     return String::fromUTF8(string);
 }
 
-inline Ref<Adapter> protectedFromAPI(WGPUAdapter adapter)
+#define WGPU_PROTECTED_API_UNAVAILABLE NS_SWIFT_UNAVAILABLE("use fromAPI, reference couting is implicit")
+
+inline Ref<Adapter> protectedFromAPI(WGPUAdapter adapter) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<Adapter&>(*adapter);
 }
 
-inline Ref<BindGroup> protectedFromAPI(WGPUBindGroup bindGroup)
+inline Ref<BindGroup> protectedFromAPI(WGPUBindGroup bindGroup) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<BindGroup&>(*bindGroup);
 }
 
-inline Ref<BindGroupLayout> protectedFromAPI(WGPUBindGroupLayout bindGroupLayout)
+inline Ref<BindGroupLayout> protectedFromAPI(WGPUBindGroupLayout bindGroupLayout) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<BindGroupLayout&>(*bindGroupLayout);
 }
 
-inline Ref<Buffer> protectedFromAPI(WGPUBuffer buffer)
+inline Ref<Buffer> protectedFromAPI(WGPUBuffer buffer) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<Buffer&>(*buffer);
 }
 
-inline Ref<CommandBuffer> protectedFromAPI(WGPUCommandBuffer commandBuffer)
+inline Ref<CommandBuffer> protectedFromAPI(WGPUCommandBuffer commandBuffer) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<CommandBuffer&>(*commandBuffer);
 }
 
-inline Ref<CommandEncoder> protectedFromAPI(WGPUCommandEncoder commandEncoder)
+inline Ref<CommandEncoder> protectedFromAPI(WGPUCommandEncoder commandEncoder) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<CommandEncoder&>(*commandEncoder);
 }
 
-inline Ref<ComputePassEncoder> protectedFromAPI(WGPUComputePassEncoder computePassEncoder)
+inline Ref<ComputePassEncoder> protectedFromAPI(WGPUComputePassEncoder computePassEncoder) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<ComputePassEncoder&>(*computePassEncoder);
 }
 
-inline Ref<ComputePipeline> protectedFromAPI(WGPUComputePipeline computePipeline)
+inline Ref<ComputePipeline> protectedFromAPI(WGPUComputePipeline computePipeline) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<ComputePipeline&>(*computePipeline);
 }
 
-inline Ref<Device> protectedFromAPI(WGPUDevice device)
+inline Ref<Device> protectedFromAPI(WGPUDevice device) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<Device&>(*device);
 }
 
-inline Ref<ExternalTexture> protectedFromAPI(WGPUExternalTexture texture)
+inline Ref<ExternalTexture> protectedFromAPI(WGPUExternalTexture texture) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<ExternalTexture&>(*texture);
 }
 
-inline Ref<Instance> protectedFromAPI(WGPUInstance instance)
+inline Ref<Instance> protectedFromAPI(WGPUInstance instance) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<Instance&>(*instance);
 }
 
-inline Ref<PipelineLayout> protectedFromAPI(WGPUPipelineLayout pipelineLayout)
+inline Ref<PipelineLayout> protectedFromAPI(WGPUPipelineLayout pipelineLayout) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<PipelineLayout&>(*pipelineLayout);
 }
 
-inline Ref<QuerySet> protectedFromAPI(WGPUQuerySet querySet)
+inline Ref<QuerySet> protectedFromAPI(WGPUQuerySet querySet) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<QuerySet&>(*querySet);
 }
 
-inline Ref<Queue> protectedFromAPI(WGPUQueue queue)
+inline Ref<Queue> protectedFromAPI(WGPUQueue queue) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<Queue&>(*queue);
 }
 
-inline Ref<RenderBundle> protectedFromAPI(WGPURenderBundle renderBundle)
+inline Ref<RenderBundle> protectedFromAPI(WGPURenderBundle renderBundle) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<RenderBundle&>(*renderBundle);
 }
 
-inline Ref<RenderBundleEncoder> protectedFromAPI(WGPURenderBundleEncoder renderBundleEncoder)
+inline Ref<RenderBundleEncoder> protectedFromAPI(WGPURenderBundleEncoder renderBundleEncoder) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<RenderBundleEncoder&>(*renderBundleEncoder);
 }
 
-inline Ref<RenderPassEncoder> protectedFromAPI(WGPURenderPassEncoder renderPassEncoder)
+inline Ref<RenderPassEncoder> protectedFromAPI(WGPURenderPassEncoder renderPassEncoder) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<RenderPassEncoder&>(*renderPassEncoder);
 }
 
-inline Ref<RenderPipeline> protectedFromAPI(WGPURenderPipeline renderPipeline)
+inline Ref<RenderPipeline> protectedFromAPI(WGPURenderPipeline renderPipeline) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<RenderPipeline&>(*renderPipeline);
 }
 
-inline Ref<Sampler> protectedFromAPI(WGPUSampler sampler)
+inline Ref<Sampler> protectedFromAPI(WGPUSampler sampler) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<Sampler&>(*sampler);
 }
 
-inline Ref<ShaderModule> protectedFromAPI(WGPUShaderModule shaderModule)
+inline Ref<ShaderModule> protectedFromAPI(WGPUShaderModule shaderModule) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<ShaderModule&>(*shaderModule);
 }
 
-inline Ref<PresentationContext> protectedFromAPI(WGPUSurface surface)
+inline Ref<PresentationContext> protectedFromAPI(WGPUSurface surface) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<PresentationContext&>(*surface);
 }
 
-inline Ref<PresentationContext> protectedFromAPI(WGPUSwapChain swapChain)
+inline Ref<PresentationContext> protectedFromAPI(WGPUSwapChain swapChain) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<PresentationContext&>(*swapChain);
 }
 
-inline Ref<Texture> protectedFromAPI(WGPUTexture texture)
+inline Ref<Texture> protectedFromAPI(WGPUTexture texture) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<Texture&>(*texture);
 }
 
-inline Ref<TextureView> protectedFromAPI(WGPUTextureView textureView)
+inline Ref<TextureView> protectedFromAPI(WGPUTextureView textureView) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<TextureView&>(*textureView);
 }
 
-inline Ref<XRBinding> protectedFromAPI(WGPUXRBinding binding)
+inline Ref<XRBinding> protectedFromAPI(WGPUXRBinding binding) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<XRBinding&>(*binding);
 }
 
-inline Ref<XRSubImage> protectedFromAPI(WGPUXRSubImage subImage)
+inline Ref<XRSubImage> protectedFromAPI(WGPUXRSubImage subImage) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<XRSubImage&>(*subImage);
 }
 
-inline Ref<XRProjectionLayer> protectedFromAPI(WGPUXRProjectionLayer layer)
+inline Ref<XRProjectionLayer> protectedFromAPI(WGPUXRProjectionLayer layer) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<XRProjectionLayer&>(*layer);
 }
 
-inline Ref<XRView> protectedFromAPI(WGPUXRView view)
+inline Ref<XRView> protectedFromAPI(WGPUXRView view) WGPU_PROTECTED_API_UNAVAILABLE
 {
     return static_cast<XRView&>(*view);
 }
@@ -364,5 +366,7 @@ inline T* releaseToAPI(RefPtr<T>&& pointer)
         return pointer.leakRef();
     return nullptr;
 }
+
+#undef WGPU_PROTECTED_API_UNAVAILABLE
 
 } // namespace WebGPU


### PR DESCRIPTION
#### de6e76b5c3db3a558ea1a2766efed2fcf5a45c9b
<pre>
[WebGPU Swift] Disallow use of protectedFromAPI in Swift
<a href="https://rdar.apple.com/140452896">rdar://140452896</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=283612">https://bugs.webkit.org/show_bug.cgi?id=283612</a>

Reviewed by NOBODY (OOPS!).

Swift code needs to use WebGPU::fromAPI for static_casting between the
API and internal types, because Swift doesn&apos;t have subtype knowledge of
C++ objects. But it should never use WebGPU::protectedFromAPI, which
returns a ref. In Swift, the class instances returned by fromAPI are
implicitly refcounted by the caller.

* Source/WebGPU/WebGPU/APIConversions.h:
(WebGPU::protectedFromAPI): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de6e76b5c3db3a558ea1a2766efed2fcf5a45c9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82547 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29156 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60996 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18929 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41299 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48351 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27499 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69445 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83909 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5266 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3546 "Found 2 new test failures: ipc/create-media-source-with-invalid-constraints-crash.html webrtc/vp8-then-h264.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69217 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5422 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68473 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12472 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10590 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5214 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5206 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8638 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6991 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->