### PR TITLE
Further reduce use of NotRefCounted in *.messages.in files

### DIFF
--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.messages.in
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.messages.in
@@ -23,7 +23,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
-messages -> RemoteBarcodeDetector NotRefCounted Stream {
+messages -> RemoteBarcodeDetector Stream {
     [EnabledBy=ShapeDetection] void Detect(WebCore::RenderingResourceIdentifier renderingResourceIdentifier) -> (Vector<WebCore::ShapeDetection::DetectedBarcode> detectedBarcodes)
 }
 

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.messages.in
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.messages.in
@@ -23,7 +23,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
-messages -> RemoteFaceDetector NotRefCounted Stream {
+messages -> RemoteFaceDetector Stream {
     [EnabledBy=ShapeDetection] void Detect(WebCore::RenderingResourceIdentifier renderingResourceIdentifier) -> (Vector<WebCore::ShapeDetection::DetectedFace> detectedFaces)
 }
 

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.messages.in
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.messages.in
@@ -23,7 +23,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
-messages -> RemoteTextDetector NotRefCounted Stream {
+messages -> RemoteTextDetector Stream {
     [EnabledBy=ShapeDetection] void Detect(WebCore::RenderingResourceIdentifier renderingResourceIdentifier) -> (Vector<WebCore::ShapeDetection::DetectedText> detectedText)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
-messages -> RemoteDisplayListRecorder NotRefCounted Stream {
+messages -> RemoteDisplayListRecorder Stream {
     Save() StreamBatched
     Restore() StreamBatched
     Translate(float x, float y) StreamBatched

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -25,7 +25,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
 
 [EnabledBy=WebGLEnabled && UseGPUProcessForWebGLEnabled]
-messages -> RemoteGraphicsContextGL NotRefCounted Stream {
+messages -> RemoteGraphicsContextGL Stream {
     void Reshape(int32_t width, int32_t height)
 #if PLATFORM(COCOA)
     void PrepareForDisplay(IPC::Semaphore finishedFence) -> (MachSendRight displayBuffer) Synchronous NotStreamEncodable NotStreamEncodableReply

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
@@ -23,7 +23,7 @@
 #if ENABLE(GPU_PROCESS)
 
 // FIXME: Will be renamed to RemoteImageBufferBackend.
-messages -> RemoteImageBuffer NotRefCounted Stream {
+messages -> RemoteImageBuffer Stream {
     GetPixelBuffer(struct WebCore::PixelBufferFormat outputFormat, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize) -> () Synchronous
     GetPixelBufferWithNewMemory(WebCore::SharedMemory::Handle handle, struct WebCore::PixelBufferFormat outputFormat, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize) -> () Synchronous NotStreamEncodable
     PutPixelBuffer(Ref<WebCore::PixelBuffer> pixelBuffer, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize, WebCore::IntPoint destPoint, enum:uint8_t WebCore::AlphaPremultiplication destFormat)

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
-messages -> RemoteImageBufferSet NotRefCounted Stream {
+messages -> RemoteImageBufferSet Stream {
     UpdateConfiguration(WebCore::FloatSize logicalSize, WebCore::RenderingMode renderingMode, float resolutionScale, WebCore::DestinationColorSpace colorSpace, enum:uint8_t WebCore::ImageBufferPixelFormat pixelFormat)
     EndPrepareForDisplay(WebKit::RenderingUpdateID renderingUpdateID)
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
-messages -> RemoteRenderingBackend NotRefCounted Stream {
+messages -> RemoteRenderingBackend Stream {
     CreateImageBuffer(WebCore::FloatSize logicalSize, WebCore::RenderingMode renderingMode, WebCore::RenderingPurpose renderingPurpose, float resolutionScale, WebCore::DestinationColorSpace colorSpace, enum:uint8_t WebCore::ImageBufferPixelFormat pixelFormat, WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
     ReleaseImageBuffer(WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
     GetImageBufferResourceLimitsForTesting() -> (struct WebCore::ImageBufferResourceLimits limits) Async

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteAdapter NotRefCounted Stream {
+messages -> RemoteAdapter Stream {
     void Destruct()
     void RequestDevice(WebKit::WebGPU::DeviceDescriptor deviceDescriptor, WebKit::WebGPUIdentifier identifier, WebKit::WebGPUIdentifier queueIdentifier) -> (WebKit::WebGPU::SupportedFeatures supportedFeatures, WebKit::WebGPU::SupportedLimits supportedLimits) Synchronous
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteBindGroup NotRefCounted Stream {
+messages -> RemoteBindGroup Stream {
     void Destruct()
     void SetLabel(String label)
     void UpdateExternalTextures(WebKit::WebGPUIdentifier externalTextureIdentifier) -> (bool success) Synchronous

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteBindGroupLayout NotRefCounted Stream {
+messages -> RemoteBindGroupLayout Stream {
     void Destruct()
     void SetLabel(String label)
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteBuffer NotRefCounted Stream {
+messages -> RemoteBuffer Stream {
     void GetMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size) -> (std::optional<Vector<uint8_t>> data) Synchronous
     void MapAsync(WebCore::WebGPU::MapModeFlags mapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size) -> (bool success)
     void Copy(std::optional<WebCore::SharedMemory::Handle> data, size_t offset) -> (bool success) NotStreamEncodable

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteCommandBuffer NotRefCounted Stream {
+messages -> RemoteCommandBuffer Stream {
     void Destruct()
     void SetLabel(String label)
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteCommandEncoder NotRefCounted Stream {
+messages -> RemoteCommandEncoder Stream {
     void BeginRenderPass(WebKit::WebGPU::RenderPassDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void BeginComputePass(std::optional<WebKit::WebGPU::ComputePassDescriptor> descriptor, WebKit::WebGPUIdentifier identifier)
     void CopyBufferToBuffer(WebKit::WebGPUIdentifier source, WebCore::WebGPU::Size64 sourceOffset, WebKit::WebGPUIdentifier destination, WebCore::WebGPU::Size64 destinationOffset, WebCore::WebGPU::Size64 size)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteCompositorIntegration NotRefCounted Stream {
+messages -> RemoteCompositorIntegration Stream {
 #if PLATFORM(COCOA)
     void RecreateRenderBuffers(int width, int height, WebCore::DestinationColorSpace destinationColorSpace, enum:uint8_t WebCore::AlphaPremultiplication alphaMode, WebCore::WebGPU::TextureFormat textureFormat, WebKit::WebGPUIdentifier deviceIdentifier) -> (Vector<MachSendRight> renderBuffers) Synchronous NotStreamEncodableReply
 #endif

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteComputePassEncoder NotRefCounted Stream {
+messages -> RemoteComputePassEncoder Stream {
     void Destruct()
     void SetPipeline(WebKit::WebGPUIdentifier identifier)
     void Dispatch(WebCore::WebGPU::Size32 workgroupCountX, WebCore::WebGPU::Size32 workgroupCountY, WebCore::WebGPU::Size32 workgroupCountZ)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteComputePipeline NotRefCounted Stream {
+messages -> RemoteComputePipeline Stream {
     void Destruct()
     void GetBindGroupLayout(uint32_t index, WebKit::WebGPUIdentifier identifier)
     void SetLabel(String label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteDevice NotRefCounted Stream {
+messages -> RemoteDevice Stream {
     void Destroy()
     void Destruct()
     void CreateXRBinding(WebKit::WebGPUIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteExternalTexture NotRefCounted Stream {
+messages -> RemoteExternalTexture Stream {
     void Destruct()
     void SetLabel(String label)
     void Destroy()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteGPU NotRefCounted Stream {
+messages -> RemoteGPU Stream {
     void RequestAdapter(WebKit::WebGPU::RequestAdapterOptions options, WebKit::WebGPUIdentifier identifier) -> (std::optional<WebKit::RemoteGPURequestAdapterResponse> response) Synchronous
     void CreatePresentationContext(WebKit::WebGPU::PresentationContextDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void CreateCompositorIntegration(WebKit::WebGPUIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemotePipelineLayout NotRefCounted Stream {
+messages -> RemotePipelineLayout Stream {
     void Destruct()
     void SetLabel(String label)
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemotePresentationContext NotRefCounted Stream {
+messages -> RemotePresentationContext Stream {
     void Configure(WebKit::WebGPU::CanvasConfiguration configuration)
     void Unconfigure()
     void GetCurrentTexture(WebKit::WebGPUIdentifier identifier, uint32_t frameIndex)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteQuerySet NotRefCounted Stream {
+messages -> RemoteQuerySet Stream {
     void Destroy()
     void Destruct()
     void SetLabel(String label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteQueue NotRefCounted Stream {
+messages -> RemoteQueue Stream {
     void Destruct()
     void Submit(Vector<WebKit::WebGPUIdentifier> commandBuffers)
     void OnSubmittedWorkDone() -> ()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteRenderBundle NotRefCounted Stream {
+messages -> RemoteRenderBundle Stream {
     void Destruct()
     void SetLabel(String label)
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteRenderBundleEncoder NotRefCounted Stream {
+messages -> RemoteRenderBundleEncoder Stream {
     void Destruct()
     void SetPipeline(WebKit::WebGPUIdentifier identifier)
     void SetIndexBuffer(WebKit::WebGPUIdentifier identifier, WebCore::WebGPU::IndexFormat indexFormat, std::optional<WebCore::WebGPU::Size64> offset, std::optional<WebCore::WebGPU::Size64> size)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteRenderPassEncoder NotRefCounted Stream {
+messages -> RemoteRenderPassEncoder Stream {
     void Destruct()
     void SetPipeline(WebKit::WebGPUIdentifier identifier)
     void SetIndexBuffer(WebKit::WebGPUIdentifier identifier, WebCore::WebGPU::IndexFormat indexFormat, std::optional<WebCore::WebGPU::Size64> offset, std::optional<WebCore::WebGPU::Size64> size)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteRenderPipeline NotRefCounted Stream {
+messages -> RemoteRenderPipeline Stream {
     void Destruct()
     void GetBindGroupLayout(uint32_t index, WebKit::WebGPUIdentifier identifier);
     void SetLabel(String label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteSampler NotRefCounted Stream {
+messages -> RemoteSampler Stream {
     void Destruct()
     void SetLabel(String label)
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteShaderModule NotRefCounted Stream {
+messages -> RemoteShaderModule Stream {
     void CompilationInfo() -> (Vector<WebKit::WebGPU::CompilationMessage> messages)
     void SetLabel(String label)
     void Destruct()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteTexture NotRefCounted Stream {
+messages -> RemoteTexture Stream {
     void CreateView(std::optional<WebKit::WebGPU::TextureViewDescriptor> descriptor, WebKit::WebGPUIdentifier identifier)
     void Destroy()
     void Undestroy()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebGPUEnabled]
-messages -> RemoteTextureView NotRefCounted Stream {
+messages -> RemoteTextureView Stream {
     void Destruct()
     void SetLabel(String label)
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebXRWebGPUBindingsEnabled]
-messages -> RemoteXRBinding NotRefCounted Stream {
+messages -> RemoteXRBinding Stream {
 void Destruct()
 void CreateProjectionLayer(WebCore::WebGPU::TextureFormat colorFormat, std::optional<WebCore::WebGPU::TextureFormat> depthStencilFormat, WebCore::WebGPU::TextureUsageFlags textureUsage, double scaleFactor, WebKit::WebGPUIdentifier identifier)
 void GetViewSubImage(WebKit::WebGPUIdentifier projectionLayerIdentifier, WebKit::WebGPUIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebXRWebGPUBindingsEnabled]
-messages -> RemoteXRProjectionLayer NotRefCounted Stream {
+messages -> RemoteXRProjectionLayer Stream {
 #if PLATFORM(COCOA)
 void StartFrame(size_t frameIndex, MachSendRight colorBuffer, MachSendRight depthBuffer, MachSendRight completionSyncEvent, size_t textureIndex) NotStreamEncodable
 #endif

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebXRWebGPUBindingsEnabled]
-messages -> RemoteXRSubImage NotRefCounted Stream {
+messages -> RemoteXRSubImage Stream {
 void Destruct()
 void GetColorTexture(WebKit::WebGPUIdentifier identifier)
 void GetDepthTexture(WebKit::WebGPUIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 [EnabledBy=WebXRWebGPUBindingsEnabled]
-messages -> RemoteXRView NotRefCounted Stream {
+messages -> RemoteXRView Stream {
 void Destruct()
 }
 

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1434,9 +1434,10 @@ def generate_message_handler(receiver):
         result.append('void %s::didReceiveStreamMessage(IPC::StreamServerConnection& connection, IPC::Decoder& decoder)\n' % (receiver.name))
         result.append('{\n')
         result += generate_enabled_by_for_receiver(receiver, receiver.messages)
-        assert(receiver.has_attribute(NOT_REFCOUNTED_RECEIVER_ATTRIBUTE))
         assert(not receiver.has_attribute(WANTS_DISPATCH_MESSAGE_ATTRIBUTE))
         assert(not receiver.has_attribute(WANTS_ASYNC_DISPATCH_MESSAGE_ATTRIBUTE))
+        if not receiver.has_attribute(NOT_REFCOUNTED_RECEIVER_ATTRIBUTE):
+            result.append('    Ref protectedThis { *this };\n')
         result += async_message_statements
         result += sync_message_statements
         if (receiver.superclass):
@@ -1453,7 +1454,7 @@ def generate_message_handler(receiver):
         result.append('{\n')
         enable_by_statement = generate_enabled_by_for_receiver(receiver, async_messages)
         result += enable_by_statement
-        if not (receiver.has_attribute(NOT_REFCOUNTED_RECEIVER_ATTRIBUTE) or receiver.has_attribute(STREAM_ATTRIBUTE)):
+        if not receiver.has_attribute(NOT_REFCOUNTED_RECEIVER_ATTRIBUTE):
             result.append('    Ref protectedThis { *this };\n')
         result += async_message_statements
         if receiver.has_attribute(WANTS_DISPATCH_MESSAGE_ATTRIBUTE) or receiver.has_attribute(WANTS_ASYNC_DISPATCH_MESSAGE_ATTRIBUTE):

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStream.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStream.messages.in
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # Tests Stream receiver attribute.
-messages -> TestWithStream NotRefCounted Stream {
+messages -> TestWithStream Stream {
     void SendString(String url)
     void SendStringAsync(String url) -> (int64_t returnValue)
     void SendStringSync(String url) -> (int64_t returnValue) Synchronous

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatched.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatched.messages.in
@@ -21,6 +21,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # Tests StreamBatched message attribute.
-messages -> TestWithStreamBatched NotRefCounted Stream {
+messages -> TestWithStreamBatched Stream {
     void SendString(String url) StreamBatched
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp
@@ -39,6 +39,7 @@ namespace WebKit {
 
 void TestWithStreamBatched::didReceiveStreamMessage(IPC::StreamServerConnection& connection, IPC::Decoder& decoder)
 {
+    Ref protectedThis { *this };
     if (decoder.messageName() == Messages::TestWithStreamBatched::SendString::name())
         return IPC::handleMessage<Messages::TestWithStreamBatched::SendString>(connection, decoder, this, &TestWithStreamBatched::sendString);
     RELEASE_LOG_ERROR(IPC, "Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
@@ -42,6 +42,7 @@ namespace WebKit {
 
 void TestWithStream::didReceiveStreamMessage(IPC::StreamServerConnection& connection, IPC::Decoder& decoder)
 {
+    Ref protectedThis { *this };
     if (decoder.messageName() == Messages::TestWithStream::SendString::name())
         return IPC::handleMessage<Messages::TestWithStream::SendString>(connection, decoder, this, &TestWithStream::sendString);
     if (decoder.messageName() == Messages::TestWithStream::SendStringAsync::name())

--- a/Source/WebKit/Shared/IPCStreamTester.messages.in
+++ b/Source/WebKit/Shared/IPCStreamTester.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(IPC_TESTING_API)
 
-messages -> IPCStreamTester NotRefCounted Stream {
+messages -> IPCStreamTester Stream {
     SyncMessage(uint32_t value) -> (uint32_t sameValue) Synchronous
     SyncMessageNotStreamEncodableReply(uint32_t value) -> (uint32_t sameValue) Synchronous NotStreamEncodableReply
     SyncMessageNotStreamEncodableBoth(uint32_t value) -> (uint32_t sameValue) Synchronous NotStreamEncodable NotStreamEncodableReply

--- a/Source/WebKit/Shared/LogStream.messages.in
+++ b/Source/WebKit/Shared/LogStream.messages.in
@@ -22,7 +22,7 @@
  */
 
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-messages -> LogStream NotRefCounted Stream {
+messages -> LogStream Stream {
     LogOnBehalfOfWebContent(std::span<const uint8_t> logChannel, std::span<const uint8_t> logCategory, std::span<const uint8_t> logString, uint8_t logType)
 }
 #endif


### PR DESCRIPTION
#### 33fc758d84d6053a099d371170534f193dcbd6f4
<pre>
Further reduce use of NotRefCounted in *.messages.in files
<a href="https://bugs.webkit.org/show_bug.cgi?id=283614">https://bugs.webkit.org/show_bug.cgi?id=283614</a>

Reviewed by Geoffrey Garen.

Further reduce use of NotRefCounted in *.messages.in files for extra safety.

* Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.messages.in:
* Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.messages.in:
* Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.messages.in:
* Source/WebKit/Scripts/webkit/messages.py:
(generate_message_handler):
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::jsValueForArguments):
(IPC::messageArgumentDescriptions):
* Source/WebKit/Scripts/webkit/tests/MessageNames.cpp:
* Source/WebKit/Scripts/webkit/tests/MessageNames.h:
* Source/WebKit/Scripts/webkit/tests/TestWithStream.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBatched.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp:
(WebKit::TestWithStreamBatched::didReceiveStreamMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp:
(WebKit::TestWithStream::didReceiveStreamMessage):
* Source/WebKit/Shared/IPCStreamTester.messages.in:
* Source/WebKit/Shared/LogStream.messages.in:

Canonical link: <a href="https://commits.webkit.org/287016@main">https://commits.webkit.org/287016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebb5b30f641c3bfe735c72e4461525e6a5afa8e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82573 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29182 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61018 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18945 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51010 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66967 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41320 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/77434 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48373 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27525 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69467 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83935 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5292 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3585 "Found 2 new test failures: ipc/create-media-source-with-invalid-constraints-crash.html webrtc/vp8-then-h264.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69236 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5448 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68492 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12493 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10619 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12065 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5240 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/7993 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5232 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8664 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7017 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->