### PR TITLE
Compile a pathname component in URLPattern::create

### DIFF
--- a/LayoutTests/fast/urlpattern/urlpattern-component-expected.txt
+++ b/LayoutTests/fast/urlpattern/urlpattern-component-expected.txt
@@ -664,7 +664,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/*. Was /foo/(.*).
+PASS urlPatternComponent is "/foo/*"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -702,7 +702,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/*. Was /foo/(.*).
+PASS urlPatternComponent is "/foo/*"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -740,7 +740,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/*. Was /foo/(.*).
+PASS urlPatternComponent is "/foo/*"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -778,7 +778,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/*. Was /foo/(.*).
+PASS urlPatternComponent is "/foo/*"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1177,7 +1177,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/*?. Was /foo/(.*)?.
+PASS urlPatternComponent is "/foo/*?"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1215,7 +1215,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/*?. Was /foo/(.*)?.
+PASS urlPatternComponent is "/foo/*?"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1253,7 +1253,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/*?. Was /foo/(.*)?.
+PASS urlPatternComponent is "/foo/*?"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1291,7 +1291,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/*?. Was /foo/(.*)?.
+PASS urlPatternComponent is "/foo/*?"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1329,7 +1329,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/*?. Was /foo/(.*)?.
+PASS urlPatternComponent is "/foo/*?"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1367,7 +1367,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/*?. Was /foo/(.*)?.
+PASS urlPatternComponent is "/foo/*?"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1405,7 +1405,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/*+. Was /foo/(.*)+.
+PASS urlPatternComponent is "/foo/*+"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1443,7 +1443,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/*+. Was /foo/(.*)+.
+PASS urlPatternComponent is "/foo/*+"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1481,7 +1481,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/*+. Was /foo/(.*)+.
+PASS urlPatternComponent is "/foo/*+"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1519,7 +1519,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/*+. Was /foo/(.*)+.
+PASS urlPatternComponent is "/foo/*+"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1557,7 +1557,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/*+. Was /foo/(.*)+.
+PASS urlPatternComponent is "/foo/*+"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1595,7 +1595,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/*+. Was /foo/(.*)+.
+PASS urlPatternComponent is "/foo/*+"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1633,7 +1633,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/**. Was /foo/(.*)*.
+PASS urlPatternComponent is "/foo/**"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1671,7 +1671,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/**. Was /foo/(.*)*.
+PASS urlPatternComponent is "/foo/**"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1709,7 +1709,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/**. Was /foo/(.*)*.
+PASS urlPatternComponent is "/foo/**"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1747,7 +1747,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/**. Was /foo/(.*)*.
+PASS urlPatternComponent is "/foo/**"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1785,7 +1785,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/**. Was /foo/(.*)*.
+PASS urlPatternComponent is "/foo/**"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1823,7 +1823,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/**. Was /foo/(.*)*.
+PASS urlPatternComponent is "/foo/**"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1861,7 +1861,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/bar. Was /foo{/bar}.
+PASS urlPatternComponent is "/foo/bar"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1880,7 +1880,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/bar. Was /foo{/bar}.
+PASS urlPatternComponent is "/foo/bar"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1899,7 +1899,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/bar. Was /foo{/bar}.
+PASS urlPatternComponent is "/foo/bar"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -1918,7 +1918,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo/bar. Was /foo{/bar}.
+PASS urlPatternComponent is "/foo/bar"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -2198,26 +2198,7 @@ PASS var pattern = new URLPattern(...errorEntry.pattern) threw exception TypeErr
 Testing: {"pattern":[{"hostname":"(cafÃ©)"}],"expected_obj":"error"}
 PASS var pattern = new URLPattern(...errorEntry.pattern) threw exception TypeError: Current codepoint is not ascii.
 Testing: {"pattern":[{"pathname":"(cafÃ©)"}],"expected_obj":"error"}
-Component: protocol
-PASS urlPatternComponent is "*"
-Component: username
-PASS urlPatternComponent is "*"
-Component: password
-PASS urlPatternComponent is "*"
-Component: hostname
-PASS urlPatternComponent is "*"
-Component: port
-PASS urlPatternComponent is "*"
-Component: password
-PASS urlPatternComponent is "*"
-Component: pathname
-PASS urlPatternComponent is "(cafÃ©)"
-Component: search
-WARN: shouldBeEqualToString() expects string arguments
-WARN: shouldBe() expects function or string arguments
-FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
-Component: hash
-PASS urlPatternComponent is "*"
+PASS var pattern = new URLPattern(...errorEntry.pattern) threw exception TypeError: Current codepoint is not ascii.
 Testing: {"pattern":[{"search":"(cafÃ©)"}],"expected_obj":"error"}
 PASS var pattern = new URLPattern(...errorEntry.pattern) threw exception TypeError: Current codepoint is not ascii.
 Testing: {"pattern":[{"hash":"(cafÃ©)"}],"expected_obj":"error"}
@@ -3036,7 +3017,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /caf%C3%A9. Was /cafÃ©.
+FAIL urlPatternComponent should be /caf%C3%A9. Was /caf%C3%83%C2%A9.
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -3112,7 +3093,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /bar. Was /foo/../bar.
+PASS urlPatternComponent is "/bar"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -3169,7 +3150,7 @@ PASS urlPatternComponent is ""
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /bar. Was {/bar}.
+PASS urlPatternComponent is "/bar"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -3188,7 +3169,7 @@ PASS urlPatternComponent is ""
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /bar. Was \/bar.
+PASS urlPatternComponent is "/bar"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -3422,26 +3403,7 @@ PASS urlPatternComponent is "*"
 Component: hash
 PASS urlPatternComponent is "*"
 Testing: {"pattern":[{"pathname":"/(\\m)"}],"expected_obj":"error"}
-Component: protocol
-PASS urlPatternComponent is "*"
-Component: username
-PASS urlPatternComponent is "*"
-Component: password
-PASS urlPatternComponent is "*"
-Component: hostname
-PASS urlPatternComponent is "*"
-Component: port
-PASS urlPatternComponent is "*"
-Component: password
-PASS urlPatternComponent is "*"
-Component: pathname
-PASS urlPatternComponent is "/(\\m)"
-Component: search
-WARN: shouldBeEqualToString() expects string arguments
-WARN: shouldBe() expects function or string arguments
-FAIL urlPatternComponent should be undefined (of type undefined). Was * (of type string).
-Component: hash
-PASS urlPatternComponent is "*"
+PASS var pattern = new URLPattern(...errorEntry.pattern) threw exception TypeError: Unable to create RegExp object regular expression from provided URLPattern string..
 Testing: {"pattern":[{"pathname":"/foo!"}],"inputs":[{"pathname":"/foo!"}],"expected_match":{"pathname":{"input":"/foo!","groups":{}}}}
 Component: protocol
 PASS urlPatternComponent is "*"
@@ -3494,7 +3456,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be /foo%7B. Was /foo\{.
+PASS urlPatternComponent is "/foo%7B"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -3532,7 +3494,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-PASS urlPatternComponent is "var x = 1;"
+FAIL urlPatternComponent should be var x = 1;. Was var%20x%20=%201;.
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -3551,7 +3513,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be var%20x%20=%201;. Was var x = 1;.
+PASS urlPatternComponent is "var%20x%20=%201;"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -3570,7 +3532,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-PASS urlPatternComponent is "var x = 1;"
+FAIL urlPatternComponent should be var x = 1;. Was var%20x%20=%201;.
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -3589,7 +3551,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-PASS urlPatternComponent is "var x = 1;"
+FAIL urlPatternComponent should be var x = 1;. Was var%20x%20=%201;.
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -3608,7 +3570,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be var%20x%20=%201;. Was var x = 1;.
+PASS urlPatternComponent is "var%20x%20=%201;"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash
@@ -3627,7 +3589,7 @@ PASS urlPatternComponent is "*"
 Component: password
 PASS urlPatternComponent is "*"
 Component: pathname
-FAIL urlPatternComponent should be var%20x%20=%201;. Was var x = 1;.
+PASS urlPatternComponent is "var%20x%20=%201;"
 Component: search
 PASS urlPatternComponent is "*"
 Component: hash

--- a/LayoutTests/fast/urlpattern/urlpattern-component.html
+++ b/LayoutTests/fast/urlpattern/urlpattern-component.html
@@ -2885,7 +2885,7 @@ function executeURLPatternConstructor(jsonArray) {
     debug("Testing: " + JSON.stringify(entry));
 
     errorEntry = entry;
-    if (errorEntry.expected_obj === 'error' && !entry.pattern[0]['pathname']) {
+    if (errorEntry.expected_obj === 'error') {
       shouldThrow("var pattern = new URLPattern(...errorEntry.pattern)");
       return;
     }

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
@@ -34,13 +34,13 @@ FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
@@ -61,46 +61,46 @@ FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] 
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
@@ -119,14 +119,14 @@ PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
 PASS Pattern: [{"username":"(café)"}] Inputs: undefined
 PASS Pattern: [{"password":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
-FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"search":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
 FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
 FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
 FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
@@ -165,15 +165,15 @@ FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is 
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: compiled pattern property 'pathname' expected "/caf%C3%A9" but got "/café"
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "/foo/../bar"
+FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "{/bar}"
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "\\/bar"
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
 FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
@@ -186,17 +186,17 @@ FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not
 FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
 FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: compiled pattern property 'pathname' expected "/foo%7B" but got "/foo\\{"
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
@@ -287,7 +287,7 @@ FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] a
     [native code]
 }" ("TypeError")
 FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Not implemented.
-FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -322,27 +322,27 @@ FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
 FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "(foo)?*" but got "(foo)?(.*)"
+FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got "{:foo}{(.*)}"
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{*bar}" but got "{:foo}{(.*)bar}"
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{bar*}" but got "{:foo}{bar(.*)}"
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo:bar(.*)" but got "{:foo}:bar(.*)"
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo?*" but got "{:foo}?(.*)"
+FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo.bar}" but got "{:foo\\.bar}"
+FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo\\bar"
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got ":foo{}(.*)"
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}bar"
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}?bar"
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "*(.*)?" but got "*{}**?"
+FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "*/{*}" but got "*\\/*"
+FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
@@ -351,7 +351,7 @@ FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operatio
 FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] assert_equals: compiled pattern property 'pathname' expected "{/:foo}bar" but got "/:foo\\bar"
+FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
 FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
@@ -34,13 +34,13 @@ FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
@@ -61,46 +61,46 @@ FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] 
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
@@ -119,14 +119,14 @@ PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
 PASS Pattern: [{"username":"(café)"}] Inputs: undefined
 PASS Pattern: [{"password":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
-FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"search":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
 FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
 FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
 FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
@@ -165,15 +165,15 @@ FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is 
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: compiled pattern property 'pathname' expected "/caf%C3%A9" but got "/café"
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "/foo/../bar"
+FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "{/bar}"
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "\\/bar"
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
 FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
@@ -186,17 +186,17 @@ FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not
 FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
 FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: compiled pattern property 'pathname' expected "/foo%7B" but got "/foo\\{"
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
@@ -287,7 +287,7 @@ FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] a
     [native code]
 }" ("TypeError")
 FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Not implemented.
-FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -322,27 +322,27 @@ FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
 FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "(foo)?*" but got "(foo)?(.*)"
+FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got "{:foo}{(.*)}"
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{*bar}" but got "{:foo}{(.*)bar}"
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{bar*}" but got "{:foo}{bar(.*)}"
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo:bar(.*)" but got "{:foo}:bar(.*)"
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo?*" but got "{:foo}?(.*)"
+FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo.bar}" but got "{:foo\\.bar}"
+FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo\\bar"
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got ":foo{}(.*)"
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}bar"
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}?bar"
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "*(.*)?" but got "*{}**?"
+FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "*/{*}" but got "*\\/*"
+FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
@@ -351,7 +351,7 @@ FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operatio
 FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] assert_equals: compiled pattern property 'pathname' expected "{/:foo}bar" but got "/:foo\\bar"
+FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
 FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
@@ -34,13 +34,13 @@ FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
@@ -61,46 +61,46 @@ FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] 
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
@@ -119,14 +119,14 @@ PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
 PASS Pattern: [{"username":"(café)"}] Inputs: undefined
 PASS Pattern: [{"password":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
-FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"search":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
 FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
 FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
 FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
@@ -165,15 +165,15 @@ FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is 
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: compiled pattern property 'pathname' expected "/caf%C3%A9" but got "/café"
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "/foo/../bar"
+FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "{/bar}"
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "\\/bar"
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
 FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
@@ -186,17 +186,17 @@ FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not
 FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
 FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: compiled pattern property 'pathname' expected "/foo%7B" but got "/foo\\{"
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
@@ -287,7 +287,7 @@ FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] a
     [native code]
 }" ("TypeError")
 FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Not implemented.
-FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -322,27 +322,27 @@ FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
 FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "(foo)?*" but got "(foo)?(.*)"
+FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got "{:foo}{(.*)}"
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{*bar}" but got "{:foo}{(.*)bar}"
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{bar*}" but got "{:foo}{bar(.*)}"
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo:bar(.*)" but got "{:foo}:bar(.*)"
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo?*" but got "{:foo}?(.*)"
+FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo.bar}" but got "{:foo\\.bar}"
+FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo\\bar"
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got ":foo{}(.*)"
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}bar"
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}?bar"
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "*(.*)?" but got "*{}**?"
+FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "*/{*}" but got "*\\/*"
+FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
@@ -351,7 +351,7 @@ FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operatio
 FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] assert_equals: compiled pattern property 'pathname' expected "{/:foo}bar" but got "/:foo\\bar"
+FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
 FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
@@ -34,13 +34,13 @@ FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
@@ -61,46 +61,46 @@ FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] 
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
@@ -119,14 +119,14 @@ PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
 PASS Pattern: [{"username":"(café)"}] Inputs: undefined
 PASS Pattern: [{"password":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
-FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"search":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
 FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
 FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
 FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
@@ -165,15 +165,15 @@ FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is 
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: compiled pattern property 'pathname' expected "/caf%C3%A9" but got "/café"
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "/foo/../bar"
+FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "{/bar}"
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "\\/bar"
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
 FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
@@ -186,17 +186,17 @@ FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not
 FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
 FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: compiled pattern property 'pathname' expected "/foo%7B" but got "/foo\\{"
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
@@ -287,7 +287,7 @@ FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] a
     [native code]
 }" ("TypeError")
 FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Not implemented.
-FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -322,27 +322,27 @@ FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
 FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "(foo)?*" but got "(foo)?(.*)"
+FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got "{:foo}{(.*)}"
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{*bar}" but got "{:foo}{(.*)bar}"
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{bar*}" but got "{:foo}{bar(.*)}"
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo:bar(.*)" but got "{:foo}:bar(.*)"
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo?*" but got "{:foo}?(.*)"
+FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo.bar}" but got "{:foo\\.bar}"
+FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo\\bar"
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got ":foo{}(.*)"
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}bar"
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}?bar"
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "*(.*)?" but got "*{}**?"
+FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "*/{*}" but got "*\\/*"
+FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
@@ -351,7 +351,7 @@ FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operatio
 FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] assert_equals: compiled pattern property 'pathname' expected "{/:foo}bar" but got "/:foo\\bar"
+FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
 FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
@@ -34,13 +34,13 @@ FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
@@ -61,46 +61,46 @@ FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] 
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
@@ -119,14 +119,14 @@ PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
 PASS Pattern: [{"username":"(café)"}] Inputs: undefined
 PASS Pattern: [{"password":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
-FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"search":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
 FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
 FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
 FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
@@ -165,15 +165,15 @@ FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is 
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: compiled pattern property 'pathname' expected "/caf%C3%A9" but got "/café"
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "/foo/../bar"
+FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "{/bar}"
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "\\/bar"
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
 FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
@@ -186,17 +186,17 @@ FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not
 FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
 FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: compiled pattern property 'pathname' expected "/foo%7B" but got "/foo\\{"
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
@@ -287,7 +287,7 @@ FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] a
     [native code]
 }" ("TypeError")
 FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Not implemented.
-FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -322,27 +322,27 @@ FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
 FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "(foo)?*" but got "(foo)?(.*)"
+FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got "{:foo}{(.*)}"
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{*bar}" but got "{:foo}{(.*)bar}"
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{bar*}" but got "{:foo}{bar(.*)}"
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo:bar(.*)" but got "{:foo}:bar(.*)"
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo?*" but got "{:foo}?(.*)"
+FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo.bar}" but got "{:foo\\.bar}"
+FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo\\bar"
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got ":foo{}(.*)"
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}bar"
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}?bar"
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "*(.*)?" but got "*{}**?"
+FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "*/{*}" but got "*\\/*"
+FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
@@ -351,7 +351,7 @@ FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operatio
 FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] assert_equals: compiled pattern property 'pathname' expected "{/:foo}bar" but got "/:foo\\bar"
+FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
 FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
@@ -34,13 +34,13 @@ FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
@@ -61,46 +61,46 @@ FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] 
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
@@ -119,14 +119,14 @@ PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
 PASS Pattern: [{"username":"(café)"}] Inputs: undefined
 PASS Pattern: [{"password":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
-FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"search":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
 FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
 FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
 FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
@@ -165,15 +165,15 @@ FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is 
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: compiled pattern property 'pathname' expected "/caf%C3%A9" but got "/café"
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "/foo/../bar"
+FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "{/bar}"
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "\\/bar"
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
 FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
@@ -186,17 +186,17 @@ FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not
 FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
 FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: compiled pattern property 'pathname' expected "/foo%7B" but got "/foo\\{"
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
@@ -287,7 +287,7 @@ FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] a
     [native code]
 }" ("TypeError")
 FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Not implemented.
-FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -322,27 +322,27 @@ FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
 FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "(foo)?*" but got "(foo)?(.*)"
+FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got "{:foo}{(.*)}"
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{*bar}" but got "{:foo}{(.*)bar}"
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{bar*}" but got "{:foo}{bar(.*)}"
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo:bar(.*)" but got "{:foo}:bar(.*)"
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo?*" but got "{:foo}?(.*)"
+FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo.bar}" but got "{:foo\\.bar}"
+FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo\\bar"
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got ":foo{}(.*)"
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}bar"
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}?bar"
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "*(.*)?" but got "*{}**?"
+FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "*/{*}" but got "*\\/*"
+FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
@@ -351,7 +351,7 @@ FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operatio
 FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] assert_equals: compiled pattern property 'pathname' expected "{/:foo}bar" but got "/:foo\\bar"
+FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
 FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
@@ -34,13 +34,13 @@ FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
@@ -61,46 +61,46 @@ FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] 
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
@@ -119,14 +119,14 @@ PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
 PASS Pattern: [{"username":"(café)"}] Inputs: undefined
 PASS Pattern: [{"password":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
-FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"search":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
 FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
 FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
 FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
@@ -165,15 +165,15 @@ FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is 
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: compiled pattern property 'pathname' expected "/caf%C3%A9" but got "/café"
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "/foo/../bar"
+FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "{/bar}"
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "\\/bar"
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
 FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
@@ -186,17 +186,17 @@ FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not
 FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
 FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: compiled pattern property 'pathname' expected "/foo%7B" but got "/foo\\{"
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
@@ -287,7 +287,7 @@ FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] a
     [native code]
 }" ("TypeError")
 FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Not implemented.
-FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -322,27 +322,27 @@ FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
 FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "(foo)?*" but got "(foo)?(.*)"
+FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got "{:foo}{(.*)}"
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{*bar}" but got "{:foo}{(.*)bar}"
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{bar*}" but got "{:foo}{bar(.*)}"
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo:bar(.*)" but got "{:foo}:bar(.*)"
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo?*" but got "{:foo}?(.*)"
+FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo.bar}" but got "{:foo\\.bar}"
+FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo\\bar"
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got ":foo{}(.*)"
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}bar"
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}?bar"
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "*(.*)?" but got "*{}**?"
+FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "*/{*}" but got "*\\/*"
+FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
@@ -351,7 +351,7 @@ FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operatio
 FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] assert_equals: compiled pattern property 'pathname' expected "{/:foo}bar" but got "/:foo\\bar"
+FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
 FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
@@ -34,13 +34,13 @@ FAIL Pattern: [{"pathname":"/foo/([^\\/]+?)"}] Inputs: [{"pathname":"/foo/bar"}]
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/index.html"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/bar/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*" but got "/foo/(.*)"
+FAIL Pattern: [{"pathname":"/foo/(.*)"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar(.*)"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
@@ -61,46 +61,46 @@ FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/bar/baz"}] 
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/:bar*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*?" but got "/foo/(.*)?"
+FAIL Pattern: [{"pathname":"/foo/(.*)?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*?"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/*+" but got "/foo/(.*)+"
+FAIL Pattern: [{"pathname":"/foo/(.*)+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/*+"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/**" but got "/foo/(.*)*"
+FAIL Pattern: [{"pathname":"/foo/(.*)*"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/**"}] Inputs: [{"pathname":"/fo"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
-FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "/foo{/bar}"
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/foo{/bar}"}] Inputs: [{"pathname":"/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo/bar/baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo{/bar}?"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
@@ -119,14 +119,14 @@ PASS Pattern: [{"protocol":"(café)"}] Inputs: undefined
 PASS Pattern: [{"username":"(café)"}] Inputs: undefined
 PASS Pattern: [{"password":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
-FAIL Pattern: [{"pathname":"(café)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"search":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
 FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
 FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
 FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
 FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
 FAIL Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}] The operation is not supported.
@@ -165,15 +165,15 @@ FAIL Pattern: [{"port":"(.*)"}] Inputs: [{"port":"invalid80"}] The operation is 
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/./bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/baz"}] Inputs: [{"pathname":"/foo/bar/../baz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%C3%A9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] assert_equals: compiled pattern property 'pathname' expected "/caf%C3%A9" but got "/café"
+FAIL Pattern: [{"pathname":"/café"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/caf%c3%a9"}] Inputs: [{"pathname":"/café"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "/foo/../bar"
+FAIL Pattern: [{"pathname":"/foo/../bar"}] Inputs: [{"pathname":"/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"./foo/bar","baseURL":"https://example.com"}] Inputs: [{"pathname":"foo/bar","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "./foo/bar"
 FAIL Pattern: [{"pathname":"","baseURL":"https://example.com"}] Inputs: [{"pathname":"/","baseURL":"https://example.com"}] assert_equals: compiled pattern property 'pathname' expected "/" but got ""
-FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "{/bar}"
-FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/bar" but got "\\/bar"
+FAIL Pattern: [{"pathname":"{/bar}","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"\\/bar","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./bar","baseURL":"https://example.com/foo/"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"b","baseURL":"https://example.com/foo/"}] Inputs: [{"pathname":"./b","baseURL":"https://example.com/foo/"}] assert_equals: compiled pattern property 'pathname' expected "/foo/b" but got "b"
 FAIL Pattern: [{"pathname":"foo/bar"}] Inputs: ["https://example.com/foo/bar"] The operation is not supported.
 FAIL Pattern: [{"pathname":"foo/bar","baseURL":"https://example.com"}] Inputs: ["https://example.com/foo/bar"] assert_equals: compiled pattern property 'pathname' expected "/foo/bar" but got "foo/bar"
@@ -186,17 +186,17 @@ FAIL Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}] The operation is not
 FAIL Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}] The operation is not supported.
 FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] The operation is not supported.
 FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] The operation is not supported.
-FAIL Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] assert_equals: compiled pattern property 'pathname' expected "/foo%7B" but got "/foo\\{"
+FAIL Pattern: [{"pathname":"/foo\\{"}] Inputs: [{"pathname":"/foo{"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo\\("}] Inputs: [{"pathname":"/foo("}] The operation is not supported.
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
-FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
-FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
-FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var%20x%20=%201;" but got "var x = 1;"
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"baseURL":"javascript:var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
+FAIL Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"] assert_throws_js: test() result function "_ => pattern.test(...entry.inputs)" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
     [native code]
@@ -287,7 +287,7 @@ FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] a
     [native code]
 }" ("TypeError")
 FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] Not implemented.
-FAIL Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
 FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
@@ -322,27 +322,27 @@ FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.
 FAIL Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "(foo)?*" but got "(foo)?(.*)"
+FAIL Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}(barbaz)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got "{:foo}{(.*)}"
-FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{*bar}" but got "{:foo}{(.*)bar}"
-FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo{bar*}" but got "{:foo}{bar(.*)}"
-FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo:bar(.*)" but got "{:foo}:bar(.*)"
-FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] assert_equals: compiled pattern property 'pathname' expected ":foo?*" but got "{:foo}?(.*)"
+FAIL Pattern: [{"pathname":"{:foo}{(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{(.*)bar}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}{bar(.*)}"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}:bar(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"{:foo}?(.*)"}] Inputs: [{"pathname":"foobarbaz"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo\\bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo.bar}" but got "{:foo\\.bar}"
+FAIL Pattern: [{"pathname":"{:foo\\.bar}"}] Inputs: [{"pathname":"foo.bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo(foo)bar}"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"{:foo}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo\\bar"
-FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}(.*)" but got ":foo{}(.*)"
-FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}bar"
-FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "{:foo}bar" but got ":foo{}?bar"
-FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] assert_equals: compiled pattern property 'pathname' expected "*(.*)?" but got "*{}**?"
+FAIL Pattern: [{"pathname":":foo\\bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}(.*)"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":":foo{}?bar"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
+FAIL Pattern: [{"pathname":"*{}**?"}] Inputs: [{"pathname":"foobar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo(baz)(.*)"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo(baz)bar"}] Inputs: [{"pathname":"bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] assert_equals: compiled pattern property 'pathname' expected "*/{*}" but got "*\\/*"
+FAIL Pattern: [{"pathname":"*\\/*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*/{*}"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"*//*"}] Inputs: [{"pathname":"foo/bar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/:foo."}] Inputs: [{"pathname":"/bar."}] The operation is not supported.
@@ -351,7 +351,7 @@ FAIL Pattern: [{"pathname":"./foo"}] Inputs: [{"pathname":"./foo"}] The operatio
 FAIL Pattern: [{"pathname":"../foo"}] Inputs: [{"pathname":"../foo"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo./"}] Inputs: [{"pathname":"bar./"}] The operation is not supported.
 FAIL Pattern: [{"pathname":":foo../"}] Inputs: [{"pathname":"bar../"}] The operation is not supported.
-FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] assert_equals: compiled pattern property 'pathname' expected "{/:foo}bar" but got "/:foo\\bar"
+FAIL Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}] The operation is not supported.
 FAIL Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
 FAIL Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}] The operation is not supported.
 FAIL Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Not implemented.

--- a/Source/JavaScriptCore/runtime/RegExpObject.h
+++ b/Source/JavaScriptCore/runtime/RegExpObject.h
@@ -101,7 +101,7 @@ public:
 
     bool test(JSGlobalObject* globalObject, JSString* string) { return !!match(globalObject, string); }
     bool testInline(JSGlobalObject* globalObject, JSString* string) { return !!matchInline(globalObject, string); }
-    JSValue exec(JSGlobalObject*, JSString*);
+    JS_EXPORT_PRIVATE JSValue exec(JSGlobalObject*, JSString*);
     JSValue execInline(JSGlobalObject*, JSString*);
     MatchResult match(JSGlobalObject*, JSString*);
     JSValue matchGlobal(JSGlobalObject*, JSString*);

--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -304,8 +304,12 @@ ExceptionOr<void> URLPattern::compileAllComponents(ScriptExecutionContext& conte
 
     URLPatternUtilities::URLPatternStringOptions compileOptions { .ignoreCase = options.ignoreCase };
 
-    // FIXME: Implement https://urlpattern.spec.whatwg.org/#protocol-component-matches-a-special-scheme
-    m_pathname = processedInit.pathname;
+    auto maybePathnameComponent = m_protocolComponent.matchSpecialSchemeProtocol(context)
+    ? URLPatternUtilities::URLPatternComponent::compile(vm, processedInit.pathname, EncodingCallbackType::Path, URLPatternUtilities::URLPatternStringOptions  { "/"_s, "/"_s, options.ignoreCase })
+    : URLPatternUtilities::URLPatternComponent::compile(vm, processedInit.pathname, EncodingCallbackType::OpaquePath, compileOptions);
+    if (maybePathnameComponent.hasException())
+        return maybePathnameComponent.releaseException();
+    m_pathnameComponent = maybePathnameComponent.releaseReturnValue();
 
     auto maybeSearchComponent = URLPatternUtilities::URLPatternComponent::compile(vm, processedInit.search, EncodingCallbackType::Search, compileOptions);
     if (maybeSearchComponent.hasException())

--- a/Source/WebCore/Modules/url-pattern/URLPattern.h
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.h
@@ -63,7 +63,7 @@ public:
     const String& password() const { return m_passwordComponent.patternString(); }
     const String& hostname() const { return m_hostnameComponent.patternString(); }
     const String& port() const { return m_portComponent.patternString(); }
-    const String& pathname() const { return m_pathname; }
+    const String& pathname() const { return m_pathnameComponent.patternString(); }
     const String& search() const { return m_searchComponent.patternString(); }
     const String& hash() const { return m_hashComponent.patternString(); }
 
@@ -77,8 +77,7 @@ private:
     URLPatternUtilities::URLPatternComponent m_usernameComponent;
     URLPatternUtilities::URLPatternComponent m_passwordComponent;
     URLPatternUtilities::URLPatternComponent m_hostnameComponent;
-    // FIXME: Implement tracking pathname with URLPatternComponent
-    String m_pathname;
+    URLPatternUtilities::URLPatternComponent m_pathnameComponent;
     URLPatternUtilities::URLPatternComponent m_portComponent;
     URLPatternUtilities::URLPatternComponent m_searchComponent;
     URLPatternUtilities::URLPatternComponent m_hashComponent;

--- a/Source/WebCore/Modules/url-pattern/URLPatternComponent.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternComponent.h
@@ -45,6 +45,7 @@ class URLPatternComponent {
 public:
     static ExceptionOr<URLPatternComponent> compile(Ref<JSC::VM>, StringView, EncodingCallbackType, const URLPatternStringOptions&);
     const String& patternString() const { return m_patternString; }
+    bool matchSpecialSchemeProtocol(ScriptExecutionContext&) const;
     URLPatternComponent() = default;
 
 private:

--- a/Source/WebCore/Modules/url-pattern/URLPatternParser.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternParser.cpp
@@ -462,7 +462,7 @@ String generatePatternString(const Vector<Part>& partList, const URLPatternStrin
 
         if (!needsGrouping && part.prefix.isEmpty() && previousPart && previousPart->type == PartType::FixedText) {
             if (options.prefixCodepoint.length() == 1
-                && options.prefixCodepoint.startsWith(*StringView(nextPart->value).codePoints().codePointAt(nextPart->value.length() - 1)))
+                && options.prefixCodepoint.startsWith(*StringView(previousPart->value).codePoints().codePointAt(previousPart->value.length() - 1)))
                 needsGrouping = true;
         }
 


### PR DESCRIPTION
#### 1af3a5bba50a5114c2b53aa2ece25992d35c6c5d
<pre>
Compile a pathname component in URLPattern::create
<a href="https://bugs.webkit.org/show_bug.cgi?id=283616">https://bugs.webkit.org/show_bug.cgi?id=283616</a>
<a href="https://rdar.apple.com/140454352">rdar://140454352</a>

Reviewed by Chris Dumez and Sihui Liu.

Currently, pathname exists as a String and not a URLPatternComponent. This updates pathname to be stored as a URLPatternComponent like the rest of the URLPattern components (eg: protocol, hostname, etc).

* LayoutTests/fast/urlpattern/urlpattern-component-expected.txt:
* LayoutTests/fast/urlpattern/urlpattern-component.html:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt:
* Source/JavaScriptCore/runtime/RegExpObject.h:
* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
(WebCore::URLPattern::compileAllComponents):
* Source/WebCore/Modules/url-pattern/URLPattern.h:
* Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp:
(WebCore::canonicalizeOpaquePathname):
(WebCore::canonicalizePathname):
* Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp:
(WebCore::URLPatternUtilities::URLPatternComponent::compile):
(WebCore::URLPatternUtilities::URLPatternComponent::matchSpecialSchemeProtocol const):
* Source/WebCore/Modules/url-pattern/URLPatternComponent.h:
* Source/WebCore/Modules/url-pattern/URLPatternParser.cpp:
(WebCore::URLPatternUtilities::generatePatternString):

Canonical link: <a href="https://commits.webkit.org/287342@main">https://commits.webkit.org/287342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb17bd9d5e7599409cfbb53409fa30330a5f72d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79147 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83778 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30345 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61927 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19840 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42232 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49329 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26253 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28718 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/72265 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70446 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85168 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/78359 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6457 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4471 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70171 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6620 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69419 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13470 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12277 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/100684 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12233 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6411 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12216 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21967 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/struct-new_default-small-members.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6358 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9818 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8150 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->