### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in SharedBuffer

### DIFF
--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -52,8 +52,6 @@ typedef struct _GBytes GBytes;
 #include "GStreamerCommon.h"
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 #if USE(FOUNDATION)
 OBJC_CLASS NSArray;
 OBJC_CLASS NSData;
@@ -278,7 +276,7 @@ private:
 
     // Combines all the segments into a Vector and returns that vector after clearing the FragmentedSharedBuffer.
     WEBCORE_EXPORT Vector<uint8_t> takeData();
-    const DataSegmentVectorEntry* getSegmentForPosition(size_t position) const;
+    std::span<const DataSegmentVectorEntry> segmentForPosition(size_t position) const;
 
 #if ASSERT_ENABLED
     bool internallyConsistent() const;
@@ -428,5 +426,3 @@ RefPtr<SharedBuffer> utf8Buffer(const String&);
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SharedBuffer)
     static bool isType(const WebCore::FragmentedSharedBuffer& buffer) { return buffer.isContiguous(); }
 SPECIALIZE_TYPE_TRAITS_END()
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 599662b88bdf1a53bd61b0837f5140b1a5ded4e7
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in SharedBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=283617">https://bugs.webkit.org/show_bug.cgi?id=283617</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::FragmentedSharedBuffer::getSomeData const):
(WebCore::FragmentedSharedBuffer::getContiguousData const):
(WebCore::FragmentedSharedBuffer::getSegmentForPosition const):
(WebCore::FragmentedSharedBuffer::startsWith const):
(WebCore::FragmentedSharedBuffer::read const):
(WebCore::FragmentedSharedBuffer::copyTo const):
(WebCore::FragmentedSharedBuffer::operator== const):
* Source/WebCore/platform/SharedBuffer.h:

Canonical link: <a href="https://commits.webkit.org/287018@main">https://commits.webkit.org/287018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4c42710034ac68fec08e1b0960078714eda7d7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77953 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82601 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29210 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5281 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61044 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18972 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67202 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41346 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24471 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27553 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69492 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83963 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5320 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3592 "Found 2 new test failures: ipc/create-media-source-with-invalid-constraints-crash.html webrtc/vp8-then-h264.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69258 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5476 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68513 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12519 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10676 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12067 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5268 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8021 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5260 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8692 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7045 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->