### PR TITLE
Add a check for `textUnderlineOffset` in the `changeRequiresRepaintIfText` function

### DIFF
--- a/LayoutTests/fast/css/text-underline-offset-repaint-expected.txt
+++ b/LayoutTests/fast/css/text-underline-offset-repaint-expected.txt
@@ -1,0 +1,6 @@
+Text
+
+(repaint rects
+  (rect 8 20 784 20)
+)
+

--- a/LayoutTests/fast/css/text-underline-offset-repaint.html
+++ b/LayoutTests/fast/css/text-underline-offset-repaint.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <style>
+        #text {
+            font: 20px/1 Ahem;
+            text-decoration: underline;
+        }
+    </style>
+    <script>
+        function repaintTest() {
+            if (!window.testRunner) {
+                alert('This test requires testRunner to run!');
+                return;
+            }
+
+            if (!window.internals) {
+                alert('This test requires window.interals to run!');
+                return;
+            }
+
+            window.internals.startTrackingRepaints();
+            window.testRunner.dumpAsText(false);
+
+            const target = document.getElementById('text');
+            target.style.textUnderlineOffset = "-5px";
+
+            const repaintRects = window.internals.repaintRectsAsText();
+            window.internals.stopTrackingRepaints();
+
+            const pre = document.getElementById('repaintRects');
+            pre.innerHTML = repaintRects;
+        }
+    </script>
+</head>
+
+<body onload="repaintTest()">
+    <p id="text">Text</p>
+    <pre id="repaintRects"></pre>
+</body>
+
+</html>

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1351,7 +1351,8 @@ bool RenderStyle::changeRequiresRepaintIfText(const RenderStyle& other, OptionSe
             || m_rareInheritedData->textEmphasisColor != other.m_rareInheritedData->textEmphasisColor
             || m_rareInheritedData->textEmphasisFill != other.m_rareInheritedData->textEmphasisFill
             || m_rareInheritedData->strokeColor != other.m_rareInheritedData->strokeColor
-            || m_rareInheritedData->caretColor != other.m_rareInheritedData->caretColor)
+            || m_rareInheritedData->caretColor != other.m_rareInheritedData->caretColor
+            || m_rareInheritedData->textUnderlineOffset != other.m_rareInheritedData->textUnderlineOffset)
             return true;
     }
 


### PR DESCRIPTION
#### 958c0c8b47a0721f1f54f3f94911bad3eaacf5d0
<pre>
Add a check for `textUnderlineOffset` in the `changeRequiresRepaintIfText` function

<a href="https://bugs.webkit.org/show_bug.cgi?id=283621">https://bugs.webkit.org/show_bug.cgi?id=283621</a>

Reviewed by Alan Baradlay.

Currently, changing the `text-underline-offset` value does not trigger a repaint if the ink overflow state remains unchanged. With this update, a repaint will be triggered regardless of whether the ink overflow state changes.

* LayoutTests/fast/css/text-underline-offset-repaint-expected.txt: Added.
* LayoutTests/fast/css/text-underline-offset-repaint.html: Added.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::changeRequiresRepaintIfText const):

Canonical link: <a href="https://commits.webkit.org/287048@main">https://commits.webkit.org/287048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e5539b9d4ab70d44932529955232e2c63ed593e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82760 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29365 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80234 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61167 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19085 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67810 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41481 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48513 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24690 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27705 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69608 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25044 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84122 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5471 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3696 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69388 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5628 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68643 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17127 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12643 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10864 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5420 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/8172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5409 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8841 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7197 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->