### PR TITLE
WebM player will report empty VideoPlaybackQualityMetrics

### DIFF
--- a/LayoutTests/media/video-playback-quality-webm-expected.txt
+++ b/LayoutTests/media/video-playback-quality-webm-expected.txt
@@ -1,0 +1,18 @@
+
+EVENT(load)
+RUN(video.src = "content/test-vp8.webm")
+EVENT(canplaythrough)
+RUN(originalQuality = video.getVideoPlaybackQuality())
+EXPECTED (originalQuality.totalVideoFrames >= '0') OK
+EXPECTED (originalQuality.droppedVideoFrames == '0') OK
+EXPECTED (originalQuality.totalFrameDelay == '0') OK
+RUN(video.play())
+EVENT(playing)
+RUN(newQuality = video.getVideoPlaybackQuality())
+EXPECTED (newQuality.creationTime > originalQuality.creationTime == 'true') OK
+EXPECTED (newQuality.totalVideoFrames >= originalQuality.totalVideoFrames == 'true') OK
+EXPECTED (newQuality.totalVideoFrames > '0') OK
+EXPECTED (newQuality.droppedVideoFrames >= originalQuality.droppedVideoFrames == 'true') OK
+EXPECTED (newQuality.droppedVideoFrames <= originalQuality.totalVideoFrames == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/video-playback-quality-webm.html
+++ b/LayoutTests/media/video-playback-quality-webm.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>getVideoPlaybackQuality with WebM</title>
+    <script src="media-file.js"></script>
+    <script src="video-test.js"></script>
+    <script>
+
+    waitFor(window, 'load').then(async event => { 
+        findMediaElement();
+
+        run('video.src = "content/test-vp8.webm"');
+        await waitFor(video, 'canplaythrough');
+
+        run(`originalQuality = video.getVideoPlaybackQuality()`);
+        testExpected('originalQuality.totalVideoFrames', 0, '>=');
+        testExpected('originalQuality.droppedVideoFrames', 0);
+        testExpected('originalQuality.totalFrameDelay', 0);
+
+        runWithKeyDown('video.play()');
+        await waitFor(video, 'playing');
+
+        run(`newQuality = video.getVideoPlaybackQuality()`);
+        testExpected('newQuality.creationTime > originalQuality.creationTime', true);
+        testExpected('newQuality.totalVideoFrames >= originalQuality.totalVideoFrames', true);
+        testExpected('newQuality.totalVideoFrames', 0, ">");
+        testExpected('newQuality.droppedVideoFrames >= originalQuality.droppedVideoFrames', true);
+        testExpected('newQuality.droppedVideoFrames <= originalQuality.totalVideoFrames', true);
+
+        endTest();
+    });
+
+    </script>
+</head>
+<body>
+    <video controls preload='auto'></video>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1157,6 +1157,7 @@ media/media-video-fullrange.html [ Skip ]
 media/media-video-videorange.html [ Skip ]
 media/media-video-fullrange-offscreen.html [ Skip ]
 media/media-video-videorange-offscreen.html [ Skip ]
+media/video-playback-quality-webm.html [ Skip ]
 
 # VP9/VP8 are not supported on WK1 and turned off by default
 media/media-source/media-source-vp8-hiddenframes.html [ Skip ]

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -198,6 +198,8 @@ private:
     bool wirelessVideoPlaybackDisabled() const final { return false; }
 #endif
 
+    std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics() final;
+
     void enqueueSample(Ref<MediaSample>&&, TrackID);
     enum class NeedsFlush: bool {
         No = 0,

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1987,6 +1987,20 @@ void MediaPlayerPrivateWebM::isInFullscreenOrPictureInPictureChanged(bool isInFu
 #endif
 }
 
+std::optional<VideoPlaybackQualityMetrics> MediaPlayerPrivateWebM::videoPlaybackQualityMetrics()
+{
+    if (!m_videoRenderer)
+        return std::nullopt;
+
+    return VideoPlaybackQualityMetrics {
+        m_videoRenderer->totalVideoFrames(),
+        m_videoRenderer->droppedVideoFrames(),
+        m_videoRenderer->corruptedVideoFrames(),
+        m_videoRenderer->totalFrameDelay().toDouble(),
+        m_videoRenderer->totalDisplayedFrames()
+    };
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(ALTERNATE_WEBM_PLAYER)


### PR DESCRIPTION
#### 8a5b62ecf40a05ba62c08ce590e3a760bb1e7906
<pre>
WebM player will report empty VideoPlaybackQualityMetrics
<a href="https://bugs.webkit.org/show_bug.cgi?id=283259">https://bugs.webkit.org/show_bug.cgi?id=283259</a>
<a href="https://rdar.apple.com/140068133">rdar://140068133</a>

Reviewed by Eric Carlson.

Hookup MediaPlayerPrivateWebM::videoPlaybackQualityMetrics().

Added test.

* LayoutTests/media/video-playback-quality-webm-expected.txt: Added.
* LayoutTests/media/video-playback-quality-webm.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::videoPlaybackQualityMetrics):

Canonical link: <a href="https://commits.webkit.org/287046@main">https://commits.webkit.org/287046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28e9ef8f1a7576306de9f3185b7a47c85b56e70d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82628 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29236 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80101 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61067 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18993 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41369 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48420 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24518 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27579 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69513 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24865 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83990 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5345 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3618 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69282 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5501 "Failed to checkout and rebase branch from PR 37079") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68537 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17125 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12537 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10721 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5293 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8046 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5285 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8717 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7070 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->