### PR TITLE
Remove some DocumentMarker.h includes

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6203,7 +6203,7 @@ void Document::textInserted(Node& text, unsigned offset, unsigned length)
 
 #if ENABLE(PLATFORM_DRIVEN_TEXT_CHECKING)
     // Freshly inserted text is expected to not inherit PlatformTextChecking markers.
-    m_markers->removeMarkers(text, { offset, offset + length }, DocumentMarker::Type::PlatformTextChecking);
+    m_markers->removeMarkers(text, { offset, offset + length }, DocumentMarkerType::PlatformTextChecking);
 #endif
 }
 

--- a/Source/WebCore/dom/DocumentMarker.h
+++ b/Source/WebCore/dom/DocumentMarker.h
@@ -51,61 +51,61 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::DocumentMark
 
 namespace WebCore {
 
+enum class DocumentMarkerType : uint32_t {
+    Spelling = 1 << 0,
+    Grammar = 1 << 1,
+    TextMatch = 1 << 2,
+    // Text has been modified by spell correction, reversion of spell correction or other type of substitution.
+    // On some platforms, this prevents the text from being autocorrected again. On post Snow Leopard Mac OS X,
+    // if a Replacement marker contains non-empty description, a reversion UI will be shown.
+    Replacement = 1 << 3,
+    // Renderer needs to add underline indicating that the text has been modified by spell
+    // correction. Text with Replacement marker doesn't necessarily has CorrectionIndicator
+    // marker. For instance, after some text has been corrected, it will have both Replacement
+    // and CorrectionIndicator. However, if user further modifies such text, we would remove
+    // CorrectionIndicator marker, but retain Replacement marker.
+    CorrectionIndicator = 1 << 4,
+    // Correction suggestion has been offered, but got rejected by user.
+    RejectedCorrection = 1 << 5,
+    // Text has been modified by autocorrection. The description of this marker is the original text before autocorrection.
+    Autocorrected = 1 << 6,
+    // On some platforms, this prevents the text from being spellchecked again.
+    SpellCheckingExemption = 1 << 7,
+    // This marker indicates user has deleted an autocorrection starting at the end of the
+    // range that bears this marker. In some platforms, if the user later inserts the same original
+    // word again at this position, it will not be autocorrected again. The description of this
+    // marker is the original word before autocorrection was applied.
+    DeletedAutocorrection = 1 << 8,
+    // This marker indicates that the range of text spanned by the marker is entered by voice dictation,
+    // and it has alternative text.
+    DictationAlternatives = 1 << 9,
+#if ENABLE(TELEPHONE_NUMBER_DETECTION)
+    TelephoneNumber = 1 << 10,
+#endif
+#if PLATFORM(IOS_FAMILY)
+    // FIXME: iOS should share the same dictation mark system with the other platforms.
+    DictationPhraseWithAlternatives = 1 << 11,
+    DictationResult = 1 << 12,
+#endif
+    // This marker indicates that the user has selected a text candidate.
+    AcceptedCandidate = 1 << 13,
+    // This marker indicates that the user has initiated a drag with this content.
+    DraggedContent = 1 << 14,
+#if ENABLE(PLATFORM_DRIVEN_TEXT_CHECKING)
+    // This marker maintains state for the platform text checker.
+    PlatformTextChecking = 1 << 15,
+#endif
+#if ENABLE(WRITING_TOOLS)
+    WritingToolsTextSuggestion = 1 << 16,
+#endif
+    TransparentContent = 1 << 17,
+};
+
 // A range of a node within a document that is "marked", such as the range of a misspelled word.
 // It optionally includes a description that could be displayed in the user interface.
 class DocumentMarker : public CanMakeWeakPtr<DocumentMarker> {
 public:
-    enum class Type : uint32_t {
-        Spelling = 1 << 0,
-        Grammar = 1 << 1,
-        TextMatch = 1 << 2,
-        // Text has been modified by spell correction, reversion of spell correction or other type of substitution. 
-        // On some platforms, this prevents the text from being autocorrected again. On post Snow Leopard Mac OS X, 
-        // if a Replacement marker contains non-empty description, a reversion UI will be shown.
-        Replacement = 1 << 3,
-        // Renderer needs to add underline indicating that the text has been modified by spell
-        // correction. Text with Replacement marker doesn't necessarily has CorrectionIndicator
-        // marker. For instance, after some text has been corrected, it will have both Replacement
-        // and CorrectionIndicator. However, if user further modifies such text, we would remove
-        // CorrectionIndicator marker, but retain Replacement marker.
-        CorrectionIndicator = 1 << 4,
-        // Correction suggestion has been offered, but got rejected by user.
-        RejectedCorrection = 1 << 5,
-        // Text has been modified by autocorrection. The description of this marker is the original text before autocorrection.
-        Autocorrected = 1 << 6,
-        // On some platforms, this prevents the text from being spellchecked again.
-        SpellCheckingExemption = 1 << 7,
-        // This marker indicates user has deleted an autocorrection starting at the end of the
-        // range that bears this marker. In some platforms, if the user later inserts the same original
-        // word again at this position, it will not be autocorrected again. The description of this
-        // marker is the original word before autocorrection was applied.
-        DeletedAutocorrection = 1 << 8,
-        // This marker indicates that the range of text spanned by the marker is entered by voice dictation,
-        // and it has alternative text.
-        DictationAlternatives = 1 << 9,
-#if ENABLE(TELEPHONE_NUMBER_DETECTION)
-        TelephoneNumber = 1 << 10,
-#endif
-#if PLATFORM(IOS_FAMILY)
-        // FIXME: iOS should share the same dictation mark system with the other platforms.
-        DictationPhraseWithAlternatives = 1 << 11,
-        DictationResult = 1 << 12,
-#endif
-        // This marker indicates that the user has selected a text candidate.
-        AcceptedCandidate = 1 << 13,
-        // This marker indicates that the user has initiated a drag with this content.
-        DraggedContent = 1 << 14,
-#if ENABLE(PLATFORM_DRIVEN_TEXT_CHECKING)
-        // This marker maintains state for the platform text checker.
-        PlatformTextChecking = 1 << 15,
-#endif
-#if ENABLE(WRITING_TOOLS)
-        WritingToolsTextSuggestion = 1 << 16,
-#endif
-        TransparentContent = 1 << 17,
-    };
-
-    static constexpr OptionSet<Type> allMarkers();
+    static constexpr OptionSet<DocumentMarkerType> allMarkers();
 
     struct DictationData {
         DictationContext context;
@@ -159,9 +159,9 @@ public:
         , TransparentContentData // TransparentContent
     >;
 
-    DocumentMarker(Type, OffsetRange, Data&& = { });
+    DocumentMarker(DocumentMarkerType, OffsetRange, Data&& = { });
 
-    Type type() const { return m_type; }
+    DocumentMarkerType type() const { return m_type; }
     unsigned startOffset() const { return m_range.start; }
     unsigned endOffset() const { return m_range.end; }
 
@@ -177,44 +177,44 @@ public:
     void shiftOffsets(int delta);
 
 private:
-    Type m_type;
+    DocumentMarkerType m_type;
     OffsetRange m_range;
     Data m_data;
 };
 
-constexpr auto DocumentMarker::allMarkers() -> OptionSet<Type>
+constexpr auto DocumentMarker::allMarkers() -> OptionSet<DocumentMarkerType>
 {
     return {
-        Type::AcceptedCandidate,
-        Type::Autocorrected,
-        Type::CorrectionIndicator,
-        Type::DeletedAutocorrection,
-        Type::DictationAlternatives,
-        Type::DraggedContent,
-        Type::Grammar,
-        Type::RejectedCorrection,
-        Type::Replacement,
-        Type::SpellCheckingExemption,
-        Type::Spelling,
-        Type::TextMatch,
+        DocumentMarkerType::AcceptedCandidate,
+        DocumentMarkerType::Autocorrected,
+        DocumentMarkerType::CorrectionIndicator,
+        DocumentMarkerType::DeletedAutocorrection,
+        DocumentMarkerType::DictationAlternatives,
+        DocumentMarkerType::DraggedContent,
+        DocumentMarkerType::Grammar,
+        DocumentMarkerType::RejectedCorrection,
+        DocumentMarkerType::Replacement,
+        DocumentMarkerType::SpellCheckingExemption,
+        DocumentMarkerType::Spelling,
+        DocumentMarkerType::TextMatch,
 #if ENABLE(TELEPHONE_NUMBER_DETECTION)
-        Type::TelephoneNumber,
+        DocumentMarkerType::TelephoneNumber,
 #endif
 #if PLATFORM(IOS_FAMILY)
-        Type::DictationPhraseWithAlternatives,
-        Type::DictationResult,
+        DocumentMarkerType::DictationPhraseWithAlternatives,
+        DocumentMarkerType::DictationResult,
 #endif
 #if ENABLE(PLATFORM_DRIVEN_TEXT_CHECKING)
-        Type::PlatformTextChecking,
+        DocumentMarkerType::PlatformTextChecking,
 #endif
 #if ENABLE(WRITING_TOOLS)
-        Type::WritingToolsTextSuggestion,
+        DocumentMarkerType::WritingToolsTextSuggestion,
 #endif
-        Type::TransparentContent,
+        DocumentMarkerType::TransparentContent,
     };
 }
 
-inline DocumentMarker::DocumentMarker(Type type, OffsetRange range, Data&& data)
+inline DocumentMarker::DocumentMarker(DocumentMarkerType type, OffsetRange range, Data&& data)
     : m_type(type)
     , m_range(range)
     , m_data(WTFMove(data))

--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -62,47 +62,47 @@ public:
 
     void detach();
 
-    WEBCORE_EXPORT void addMarker(const SimpleRange&, DocumentMarker::Type, const DocumentMarker::Data& = { });
-    void addMarker(Text&, unsigned startOffset, unsigned length, DocumentMarker::Type, DocumentMarker::Data&& = { });
+    WEBCORE_EXPORT void addMarker(const SimpleRange&, DocumentMarkerType, const DocumentMarker::Data& = { });
+    void addMarker(Text&, unsigned startOffset, unsigned length, DocumentMarkerType, DocumentMarker::Data&& = { });
     WEBCORE_EXPORT void addMarker(Node&, DocumentMarker&&);
     void addDraggedContentMarker(const SimpleRange&);
     WEBCORE_EXPORT void addTransparentContentMarker(const SimpleRange&, WTF::UUID);
 
     void copyMarkers(Node& source, OffsetRange, Node& destination);
     bool hasMarkers() const;
-    WEBCORE_EXPORT bool hasMarkers(const SimpleRange&, OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers());
+    WEBCORE_EXPORT bool hasMarkers(const SimpleRange&, OptionSet<DocumentMarkerType> = DocumentMarker::allMarkers());
 
     // When a marker partially overlaps with range, if removePartiallyOverlappingMarkers is true, we completely
     // remove the marker. If the argument is false, we will adjust the span of the marker so that it retains
     // the portion that is outside of the range.
-    WEBCORE_EXPORT void removeMarkers(const SimpleRange&, OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers(), RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
-    WEBCORE_EXPORT void removeMarkers(Node&, OffsetRange, OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers(), const Function<FilterMarkerResult(const DocumentMarker&)>& filterFunction = nullptr, RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
+    WEBCORE_EXPORT void removeMarkers(const SimpleRange&, OptionSet<DocumentMarkerType> = DocumentMarker::allMarkers(), RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
+    WEBCORE_EXPORT void removeMarkers(Node&, OffsetRange, OptionSet<DocumentMarkerType> = DocumentMarker::allMarkers(), const Function<FilterMarkerResult(const DocumentMarker&)>& filterFunction = nullptr, RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
 
-    WEBCORE_EXPORT void filterMarkers(const SimpleRange&, const Function<FilterMarkerResult(const DocumentMarker&)>& filterFunction, OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers(), RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
+    WEBCORE_EXPORT void filterMarkers(const SimpleRange&, const Function<FilterMarkerResult(const DocumentMarker&)>& filterFunction, OptionSet<DocumentMarkerType> = DocumentMarker::allMarkers(), RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
 
-    WEBCORE_EXPORT void removeMarkers(OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers());
-    WEBCORE_EXPORT void removeMarkers(OptionSet<DocumentMarker::Type>, const Function<FilterMarkerResult(const RenderedDocumentMarker&)>& filterFunction);
-    void removeMarkers(Node&, OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers());
-    void repaintMarkers(OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers());
+    WEBCORE_EXPORT void removeMarkers(OptionSet<DocumentMarkerType> = DocumentMarker::allMarkers());
+    WEBCORE_EXPORT void removeMarkers(OptionSet<DocumentMarkerType>, const Function<FilterMarkerResult(const RenderedDocumentMarker&)>& filterFunction);
+    void removeMarkers(Node&, OptionSet<DocumentMarkerType> = DocumentMarker::allMarkers());
+    void repaintMarkers(OptionSet<DocumentMarkerType> = DocumentMarker::allMarkers());
     void shiftMarkers(Node&, unsigned startOffset, int delta);
 
-    void dismissMarkers(OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers());
+    void dismissMarkers(OptionSet<DocumentMarkerType> = DocumentMarker::allMarkers());
 
-    WEBCORE_EXPORT Vector<WeakPtr<RenderedDocumentMarker>> markersFor(Node&, OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers()) const;
-    WEBCORE_EXPORT Vector<WeakPtr<RenderedDocumentMarker>> markersInRange(const SimpleRange&, OptionSet<DocumentMarker::Type>);
-    WEBCORE_EXPORT Vector<SimpleRange> rangesForMarkersInRange(const SimpleRange&, OptionSet<DocumentMarker::Type>);
-    void clearDescriptionOnMarkersIntersectingRange(const SimpleRange&, OptionSet<DocumentMarker::Type>);
+    WEBCORE_EXPORT Vector<WeakPtr<RenderedDocumentMarker>> markersFor(Node&, OptionSet<DocumentMarkerType> = DocumentMarker::allMarkers()) const;
+    WEBCORE_EXPORT Vector<WeakPtr<RenderedDocumentMarker>> markersInRange(const SimpleRange&, OptionSet<DocumentMarkerType>);
+    WEBCORE_EXPORT Vector<SimpleRange> rangesForMarkersInRange(const SimpleRange&, OptionSet<DocumentMarkerType>);
+    void clearDescriptionOnMarkersIntersectingRange(const SimpleRange&, OptionSet<DocumentMarkerType>);
 
-    WEBCORE_EXPORT void updateRectsForInvalidatedMarkersOfType(DocumentMarker::Type);
+    WEBCORE_EXPORT void updateRectsForInvalidatedMarkersOfType(DocumentMarkerType);
 
     void invalidateRectsForAllMarkers();
     void invalidateRectsForMarkersInNode(Node&);
 
-    WeakPtr<DocumentMarker> markerContainingPoint(const LayoutPoint&, DocumentMarker::Type);
-    WEBCORE_EXPORT Vector<FloatRect> renderedRectsForMarkers(DocumentMarker::Type);
+    WeakPtr<DocumentMarker> markerContainingPoint(const LayoutPoint&, DocumentMarkerType);
+    WEBCORE_EXPORT Vector<FloatRect> renderedRectsForMarkers(DocumentMarkerType);
 
     template<IterationDirection = IterationDirection::Forwards>
-    WEBCORE_EXPORT void forEach(const SimpleRange&, OptionSet<DocumentMarker::Type>, Function<bool(Node&, RenderedDocumentMarker&)>&&);
+    WEBCORE_EXPORT void forEach(const SimpleRange&, OptionSet<DocumentMarkerType>, Function<bool(Node&, RenderedDocumentMarker&)>&&);
 
     WEBCORE_EXPORT static std::tuple<float, float> markerYPositionAndHeightForFont(const FontCascade&);
 
@@ -119,10 +119,10 @@ private:
 
     using MarkerMap = UncheckedKeyHashMap<Ref<Node>, std::unique_ptr<Vector<RenderedDocumentMarker>>>;
 
-    bool possiblyHasMarkers(OptionSet<DocumentMarker::Type>) const;
-    OptionSet<DocumentMarker::Type> removeMarkersFromList(MarkerMap::iterator, OptionSet<DocumentMarker::Type>, const Function<FilterMarkerResult(const RenderedDocumentMarker&)>& filterFunction = nullptr);
+    bool possiblyHasMarkers(OptionSet<DocumentMarkerType>) const;
+    OptionSet<DocumentMarkerType> removeMarkersFromList(MarkerMap::iterator, OptionSet<DocumentMarkerType>, const Function<FilterMarkerResult(const RenderedDocumentMarker&)>& filterFunction = nullptr);
 
-    void forEachOfTypes(OptionSet<DocumentMarker::Type>, Function<bool(Node&, RenderedDocumentMarker&)>&&);
+    void forEachOfTypes(OptionSet<DocumentMarkerType>, Function<bool(Node&, RenderedDocumentMarker&)>&&);
 
     void fadeAnimationTimerFired();
     void writingToolsTextSuggestionAnimationTimerFired();
@@ -131,7 +131,7 @@ private:
 
     MarkerMap m_markers;
     // Provide a quick way to determine whether a particular marker type is absent without going through the map.
-    OptionSet<DocumentMarker::Type> m_possiblyExistingMarkerTypes;
+    OptionSet<DocumentMarkerType> m_possiblyExistingMarkerTypes;
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
 
     Timer m_fadeAnimationTimer;
@@ -140,14 +140,14 @@ private:
 
 
 template<>
-WEBCORE_EXPORT void DocumentMarkerController::forEach<DocumentMarkerController::IterationDirection::Forwards>(const SimpleRange&, OptionSet<DocumentMarker::Type>, Function<bool(Node&, RenderedDocumentMarker&)>&&);
+WEBCORE_EXPORT void DocumentMarkerController::forEach<DocumentMarkerController::IterationDirection::Forwards>(const SimpleRange&, OptionSet<DocumentMarkerType>, Function<bool(Node&, RenderedDocumentMarker&)>&&);
 
 template<>
-WEBCORE_EXPORT void DocumentMarkerController::forEach<DocumentMarkerController::IterationDirection::Backwards>(const SimpleRange&, OptionSet<DocumentMarker::Type>, Function<bool(Node&, RenderedDocumentMarker&)>&&);
+WEBCORE_EXPORT void DocumentMarkerController::forEach<DocumentMarkerController::IterationDirection::Backwards>(const SimpleRange&, OptionSet<DocumentMarkerType>, Function<bool(Node&, RenderedDocumentMarker&)>&&);
 
-WEBCORE_EXPORT void addMarker(const SimpleRange&, DocumentMarker::Type, const DocumentMarker::Data& = { });
-void addMarker(Text&, unsigned startOffset, unsigned length, DocumentMarker::Type, DocumentMarker::Data&& = { });
-void removeMarkers(const SimpleRange&, OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers(), RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
+WEBCORE_EXPORT void addMarker(const SimpleRange&, DocumentMarkerType, const DocumentMarker::Data& = { });
+void addMarker(Text&, unsigned startOffset, unsigned length, DocumentMarkerType, DocumentMarker::Data&& = { });
+void removeMarkers(const SimpleRange&, OptionSet<DocumentMarkerType> = DocumentMarker::allMarkers(), RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
 
 WEBCORE_EXPORT SimpleRange makeSimpleRange(Node&, const DocumentMarker&);
 

--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -57,23 +57,23 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(AlternativeTextController);
 
 #if USE(DICTATION_ALTERNATIVES) || USE(AUTOCORRECTION_PANEL)
 
-constexpr OptionSet<DocumentMarker::Type> markerTypesForAppliedDictationAlternative()
+constexpr OptionSet<DocumentMarkerType> markerTypesForAppliedDictationAlternative()
 {
-    return DocumentMarker::Type::SpellCheckingExemption;
+    return DocumentMarkerType::SpellCheckingExemption;
 }
 
 #endif
 
 #if USE(AUTOCORRECTION_PANEL)
 
-static inline OptionSet<DocumentMarker::Type> markerTypesForAutocorrection()
+static inline OptionSet<DocumentMarkerType> markerTypesForAutocorrection()
 {
-    return { DocumentMarker::Type::Autocorrected, DocumentMarker::Type::CorrectionIndicator, DocumentMarker::Type::Replacement, DocumentMarker::Type::SpellCheckingExemption };
+    return { DocumentMarkerType::Autocorrected, DocumentMarkerType::CorrectionIndicator, DocumentMarkerType::Replacement, DocumentMarkerType::SpellCheckingExemption };
 }
 
-static inline OptionSet<DocumentMarker::Type> markerTypesForReplacement()
+static inline OptionSet<DocumentMarkerType> markerTypesForReplacement()
 {
-    return { DocumentMarker::Type::Replacement, DocumentMarker::Type::SpellCheckingExemption };
+    return { DocumentMarkerType::Replacement, DocumentMarkerType::SpellCheckingExemption };
 }
 
 static bool markersHaveIdenticalDescription(const Vector<WeakPtr<RenderedDocumentMarker>>& markers)
@@ -170,7 +170,7 @@ bool AlternativeTextController::isSpellingMarkerAllowed(const SimpleRange& missp
     CheckedPtr controller = protectedDocument()->markersIfExists();
     if (!controller)
         return true;
-    return !controller->hasMarkers(misspellingRange, DocumentMarker::Type::SpellCheckingExemption);
+    return !controller->hasMarkers(misspellingRange, DocumentMarkerType::SpellCheckingExemption);
 }
 
 void AlternativeTextController::show(const SimpleRange& rangeToReplace, const String& replacement)
@@ -249,9 +249,9 @@ void AlternativeTextController::respondToUnappliedSpellCorrection(const VisibleS
     auto range = document->selection().selection().firstRange();
     if (!range)
         return;
-    removeMarkers(*range, OptionSet<DocumentMarker::Type> { DocumentMarker::Type::Spelling, DocumentMarker::Type::Autocorrected }, RemovePartiallyOverlappingMarker::Yes);
-    addMarker(*range, DocumentMarker::Type::Replacement);
-    addMarker(*range, DocumentMarker::Type::SpellCheckingExemption);
+    removeMarkers(*range, OptionSet<DocumentMarkerType> { DocumentMarkerType::Spelling, DocumentMarkerType::Autocorrected }, RemovePartiallyOverlappingMarker::Yes);
+    addMarker(*range, DocumentMarkerType::Replacement);
+    addMarker(*range, DocumentMarkerType::SpellCheckingExemption);
 }
 
 void AlternativeTextController::timerFired()
@@ -279,7 +279,7 @@ void AlternativeTextController::timerFired()
         auto boundingBox = rootViewRectForRange(*m_rangeWithAlternative);
         if (!boundingBox.isEmpty()) {
             if (CheckedPtr client = alternativeTextClient()) {
-                removeMarkers(*m_rangeWithAlternative, { DocumentMarker::Type::CorrectionIndicator });
+                removeMarkers(*m_rangeWithAlternative, { DocumentMarkerType::CorrectionIndicator });
                 client->showCorrectionAlternative(m_type, boundingBox, m_originalText, replacementString, { });
             }
         }
@@ -350,7 +350,7 @@ void AlternativeTextController::handleAlternativeTextUIResult(const String& resu
         if (result.length())
             applyAlternativeTextToRange(*m_rangeWithAlternative, result, m_type, markerTypesForAutocorrection());
         else if (!m_isDismissedByEditing)
-            addMarker(*m_rangeWithAlternative, DocumentMarker::Type::RejectedCorrection, m_originalText);
+            addMarker(*m_rangeWithAlternative, DocumentMarkerType::RejectedCorrection, m_originalText);
         break;
     case AlternativeTextType::Reversion:
     case AlternativeTextType::SpellingSuggestions:
@@ -442,8 +442,8 @@ void AlternativeTextController::respondToUnappliedEditing(EditCommandComposition
     auto range = command->startingSelection().firstRange();
     if (!range)
         return;
-    addMarker(*range, DocumentMarker::Type::Replacement);
-    addMarker(*range, DocumentMarker::Type::SpellCheckingExemption);
+    addMarker(*range, DocumentMarkerType::Replacement);
+    addMarker(*range, DocumentMarkerType::SpellCheckingExemption);
 }
 
 EditorClient* AlternativeTextController::editorClient()
@@ -466,14 +466,14 @@ void AlternativeTextController::recordAutocorrectionResponse(AutocorrectionRespo
 
 void AlternativeTextController::markReversed(const SimpleRange& changedRange)
 {
-    removeMarkers(changedRange, DocumentMarker::Type::Autocorrected, RemovePartiallyOverlappingMarker::Yes);
-    addMarker(changedRange, DocumentMarker::Type::SpellCheckingExemption);
+    removeMarkers(changedRange, DocumentMarkerType::Autocorrected, RemovePartiallyOverlappingMarker::Yes);
+    addMarker(changedRange, DocumentMarkerType::SpellCheckingExemption);
 }
 
 void AlternativeTextController::markCorrection(const SimpleRange& replacedRange, const String& replacedString)
 {
     for (auto markerType : markerTypesForAutocorrection()) {
-        if (markerType == DocumentMarker::Type::Replacement || markerType == DocumentMarker::Type::Autocorrected)
+        if (markerType == DocumentMarkerType::Replacement || markerType == DocumentMarkerType::Autocorrected)
             addMarker(replacedRange, markerType, replacedString);
         else
             addMarker(replacedRange, markerType);
@@ -486,7 +486,7 @@ void AlternativeTextController::recordSpellcheckerResponseForModifiedCorrection(
     if (!markers)
         return;
 
-    auto correctedOnceMarkers = markers->markersInRange(rangeOfCorrection, DocumentMarker::Type::Autocorrected);
+    auto correctedOnceMarkers = markers->markersInRange(rangeOfCorrection, DocumentMarkerType::Autocorrected);
     if (correctedOnceMarkers.isEmpty())
         return;
 
@@ -499,7 +499,7 @@ void AlternativeTextController::recordSpellcheckerResponseForModifiedCorrection(
             client->recordAutocorrectionResponse(AutocorrectionResponse::Edited, corrected, correction);
     }
 
-    removeMarkers(rangeOfCorrection, DocumentMarker::Type::Autocorrected, RemovePartiallyOverlappingMarker::Yes);
+    removeMarkers(rangeOfCorrection, DocumentMarkerType::Autocorrected, RemovePartiallyOverlappingMarker::Yes);
 }
 
 void AlternativeTextController::deletedAutocorrectionAtPosition(const Position& position, const String& originalString)
@@ -528,30 +528,30 @@ void AlternativeTextController::markPrecedingWhitespaceForDeletedAutocorrectionA
     // Mark this whitespace to indicate we have deleted an autocorrection following this
     // whitespace. So if the user types the same original word again at this position, we
     // won't autocorrect it again.
-    addMarker(*precedingCharacterRange, DocumentMarker::Type::DeletedAutocorrection, m_originalStringForLastDeletedAutocorrection);
+    addMarker(*precedingCharacterRange, DocumentMarkerType::DeletedAutocorrection, m_originalStringForLastDeletedAutocorrection);
 }
 
 bool AlternativeTextController::processMarkersOnTextToBeReplacedByResult(const TextCheckingResult& result, const SimpleRange& rangeWithAlternative, const String& stringToBeReplaced)
 {
     auto document = protectedDocument();
     auto& markers = document->markers();
-    if (markers.hasMarkers(rangeWithAlternative, DocumentMarker::Type::Replacement)) {
+    if (markers.hasMarkers(rangeWithAlternative, DocumentMarkerType::Replacement)) {
         if (result.type == TextCheckingType::Correction)
             recordSpellcheckerResponseForModifiedCorrection(rangeWithAlternative, stringToBeReplaced, result.replacement);
         return false;
     }
 
-    if (markers.hasMarkers(rangeWithAlternative, DocumentMarker::Type::RejectedCorrection))
+    if (markers.hasMarkers(rangeWithAlternative, DocumentMarkerType::RejectedCorrection))
         return false;
 
-    if (markers.hasMarkers(rangeWithAlternative, DocumentMarker::Type::AcceptedCandidate))
+    if (markers.hasMarkers(rangeWithAlternative, DocumentMarkerType::AcceptedCandidate))
         return false;
 
     auto precedingCharacterRange = makeSimpleRange(makeDeprecatedLegacyPosition(rangeWithAlternative.start).previous(), rangeWithAlternative.start);
     if (!precedingCharacterRange)
         return false;
 
-    for (auto& marker : markers.markersInRange(*precedingCharacterRange, DocumentMarker::Type::DeletedAutocorrection)) {
+    for (auto& marker : markers.markersInRange(*precedingCharacterRange, DocumentMarkerType::DeletedAutocorrection)) {
         if (marker->description() == stringToBeReplaced)
             return false;
     }
@@ -565,11 +565,11 @@ bool AlternativeTextController::shouldStartTimerFor(const WebCore::DocumentMarke
         return false;
 
     switch (marker.type()) {
-    case DocumentMarker::Type::Spelling:
-    case DocumentMarker::Type::Grammar:
-    case DocumentMarker::Type::DictationAlternatives:
+    case DocumentMarkerType::Spelling:
+    case DocumentMarkerType::Grammar:
+    case DocumentMarkerType::DictationAlternatives:
         return true;
-    case DocumentMarker::Type::Replacement:
+    case DocumentMarkerType::Replacement:
         return !marker.description().isNull();
     default:
         return false;
@@ -587,18 +587,18 @@ bool AlternativeTextController::respondToMarkerAtEndOfWord(const DocumentMarker&
         return false;
     m_originalText = currentWord;
     switch (marker.type()) {
-    case DocumentMarker::Type::Spelling:
-    case DocumentMarker::Type::Grammar:
+    case DocumentMarkerType::Spelling:
+    case DocumentMarkerType::Grammar:
         m_rangeWithAlternative = WTFMove(wordRange);
         m_details = emptyString();
-        startAlternativeTextUITimer((marker.type() == DocumentMarker::Type::Spelling) ? AlternativeTextType::SpellingSuggestions : AlternativeTextType::GrammarSuggestions);
+        startAlternativeTextUITimer((marker.type() == DocumentMarkerType::Spelling) ? AlternativeTextType::SpellingSuggestions : AlternativeTextType::GrammarSuggestions);
         break;
-    case DocumentMarker::Type::Replacement:
+    case DocumentMarkerType::Replacement:
         m_rangeWithAlternative = WTFMove(wordRange);
         m_details = marker.description();
         startAlternativeTextUITimer(AlternativeTextType::Reversion);
         break;
-    case DocumentMarker::Type::DictationAlternatives: {
+    case DocumentMarkerType::DictationAlternatives: {
         auto& markerData = std::get<DocumentMarker::DictationData>(marker.data());
         if (currentWord != markerData.originalText)
             return false;
@@ -623,10 +623,10 @@ AlternativeTextClient* AlternativeTextController::alternativeTextClient()
     return m_document->frame() && m_document->page() ? m_document->page()->alternativeTextClient() : nullptr;
 }
 
-String AlternativeTextController::markerDescriptionForAppliedAlternativeText(AlternativeTextType alternativeTextType, DocumentMarker::Type markerType)
+String AlternativeTextController::markerDescriptionForAppliedAlternativeText(AlternativeTextType alternativeTextType, DocumentMarkerType markerType)
 {
 #if USE(AUTOCORRECTION_PANEL)
-    if (alternativeTextType != AlternativeTextType::Reversion && alternativeTextType != AlternativeTextType::DictationAlternatives && (markerType == DocumentMarker::Type::Replacement || markerType == DocumentMarker::Type::Autocorrected))
+    if (alternativeTextType != AlternativeTextType::Reversion && alternativeTextType != AlternativeTextType::DictationAlternatives && (markerType == DocumentMarkerType::Replacement || markerType == DocumentMarkerType::Autocorrected))
         return m_originalText;
 #else
     UNUSED_PARAM(alternativeTextType);
@@ -635,7 +635,7 @@ String AlternativeTextController::markerDescriptionForAppliedAlternativeText(Alt
     return emptyString();
 }
 
-void AlternativeTextController::applyAlternativeTextToRange(const SimpleRange& range, const String& alternative, AlternativeTextType alternativeType, OptionSet<DocumentMarker::Type> markerTypesToAdd)
+void AlternativeTextController::applyAlternativeTextToRange(const SimpleRange& range, const String& alternative, AlternativeTextType alternativeType, OptionSet<DocumentMarkerType> markerTypesToAdd)
 {
     // After we replace the word at range rangeWithAlternative, we need to add markers to that range.
     // So before we carry out the replacement,store the start position relative to the start position
@@ -675,9 +675,9 @@ void AlternativeTextController::removeCorrectionIndicatorMarkers()
     if (!markers)
         return;
 #if HAVE(AUTOCORRECTION_ENHANCEMENTS)
-    markers->dismissMarkers(DocumentMarker::Type::CorrectionIndicator);
+    markers->dismissMarkers(DocumentMarkerType::CorrectionIndicator);
 #else
-    markers->removeMarkers(DocumentMarker::Type::CorrectionIndicator);
+    markers->removeMarkers(DocumentMarkerType::CorrectionIndicator);
 #endif
 }
 
@@ -748,7 +748,7 @@ void AlternativeTextController::applyDictationAlternative(const String& alternat
     auto selection = editor->selectedRange();
     if (!selection || !editor->shouldInsertText(alternativeString, *selection, EditorInsertAction::Pasted))
         return;
-    for (auto& marker : selection->startContainer().document().markers().markersInRange(*selection, DocumentMarker::Type::DictationAlternatives))
+    for (auto& marker : selection->startContainer().document().markers().markersInRange(*selection, DocumentMarkerType::DictationAlternatives))
         removeDictationAlternativesForMarker(*marker);
     applyAlternativeTextToRange(*selection, alternativeString, AlternativeTextType::DictationAlternatives, markerTypesForAppliedDictationAlternative());
 #else

--- a/Source/WebCore/editing/AlternativeTextController.h
+++ b/Source/WebCore/editing/AlternativeTextController.h
@@ -142,8 +142,8 @@ private:
     Position m_positionForLastDeletedAutocorrection;
 #endif
 #if USE(DICTATION_ALTERNATIVES) || USE(AUTOCORRECTION_PANEL)
-    String markerDescriptionForAppliedAlternativeText(AlternativeTextType, DocumentMarker::Type);
-    void applyAlternativeTextToRange(const SimpleRange&, const String&, AlternativeTextType, OptionSet<DocumentMarker::Type>);
+    String markerDescriptionForAppliedAlternativeText(AlternativeTextType, DocumentMarkerType);
+    void applyAlternativeTextToRange(const SimpleRange&, const String&, AlternativeTextType, OptionSet<DocumentMarkerType>);
     AlternativeTextClient* alternativeTextClient();
 #endif
     Ref<Document> protectedDocument() const { return m_document.get(); }

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -956,7 +956,7 @@ String DeleteSelectionCommand::originalStringForAutocorrectionAtBeginningOfSelec
         return String();
 
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
-    for (auto& marker : protectedDocument()->markers().markersInRange(*rangeOfFirstCharacter, DocumentMarker::Type::Autocorrected)) {
+    for (auto& marker : protectedDocument()->markers().markersInRange(*rangeOfFirstCharacter, DocumentMarkerType::Autocorrected)) {
         int startOffset = marker->startOffset();
         if (startOffset == startOfSelection.deepEquivalent().offsetInContainerNode())
             return marker->description();

--- a/Source/WebCore/editing/DictationCommand.cpp
+++ b/Source/WebCore/editing/DictationCommand.cpp
@@ -69,8 +69,8 @@ public:
         auto& markerController = document->markers();
         for (auto& alternative : m_alternatives) {
             DocumentMarker::DictationData data { alternative.context, textToBeInserted.substring(alternative.range.location, alternative.range.length) };
-            markerController.addMarker(textNode, alternative.range.location + offsetOfInsertion, alternative.range.length, DocumentMarker::Type::DictationAlternatives, WTFMove(data));
-            markerController.addMarker(textNode, alternative.range.location + offsetOfInsertion, alternative.range.length, DocumentMarker::Type::SpellCheckingExemption);
+            markerController.addMarker(textNode, alternative.range.location + offsetOfInsertion, alternative.range.length, DocumentMarkerType::DictationAlternatives, WTFMove(data));
+            markerController.addMarker(textNode, alternative.range.location + offsetOfInsertion, alternative.range.length, DocumentMarkerType::SpellCheckingExemption);
         }
     }
 

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "CompositionUnderline.h"
-#include "DocumentMarker.h"
 #include "EditAction.h"
 #include "EditingBehavior.h"
 #include "EditingStyle.h"
@@ -65,6 +64,7 @@ class SharedBuffer;
 class CustomUndoStep;
 class DataTransfer;
 class DeleteButtonController;
+class DocumentMarker;
 class EditCommand;
 class EditCommandComposition;
 class EditorClient;
@@ -97,6 +97,8 @@ struct FontAttributes;
 struct PasteboardPlainText;
 struct PasteboardURL;
 struct TextCheckingResult;
+
+enum class DocumentMarkerType : uint32_t;
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 struct PromisedAttachmentInfo;
@@ -522,8 +524,8 @@ public:
     enum class MatchStyle : bool { No, Yes };
     WEBCORE_EXPORT void replaceSelectionWithFragment(DocumentFragment&, SelectReplacement, SmartReplace, MatchStyle, EditAction = EditAction::Insert, MailBlockquoteHandling = MailBlockquoteHandling::RespectBlockquote);
     WEBCORE_EXPORT void replaceSelectionWithText(const String&, SelectReplacement, SmartReplace, EditAction = EditAction::Insert);
-    WEBCORE_EXPORT bool selectionStartHasMarkerFor(DocumentMarker::Type, int from, int length) const;
-    WEBCORE_EXPORT void selectionStartSetMarkerForTesting(DocumentMarker::Type, int from, int length, const String&);
+    WEBCORE_EXPORT bool selectionStartHasMarkerFor(DocumentMarkerType, int from, int length) const;
+    WEBCORE_EXPORT void selectionStartSetMarkerForTesting(DocumentMarkerType, int from, int length, const String&);
     void updateMarkersForWordsAffectedByEditing(bool doNotRemoveIfSelectionAtWordBoundary);
     void deletedAutocorrectionAtPosition(const Position&, const String& originalString);
     

--- a/Source/WebCore/editing/SpellChecker.cpp
+++ b/Source/WebCore/editing/SpellChecker.cpp
@@ -243,11 +243,11 @@ void SpellChecker::didCheckSucceed(TextCheckingRequestIdentifier identifier, con
 {
     TextCheckingRequestData requestData = m_processingRequest->data();
     if (requestData.identifier() == identifier) {
-        OptionSet<DocumentMarker::Type> markerTypes;
+        OptionSet<DocumentMarkerType> markerTypes;
         if (requestData.checkingTypes().contains(TextCheckingType::Spelling))
-            markerTypes.add(DocumentMarker::Type::Spelling);
+            markerTypes.add(DocumentMarkerType::Spelling);
         if (requestData.checkingTypes().contains(TextCheckingType::Grammar))
-            markerTypes.add(DocumentMarker::Type::Grammar);
+            markerTypes.add(DocumentMarkerType::Grammar);
         if (!markerTypes.isEmpty())
             removeMarkers(m_processingRequest->checkingRange(), markerTypes);
     }

--- a/Source/WebCore/editing/TextCheckingHelper.cpp
+++ b/Source/WebCore/editing/TextCheckingHelper.cpp
@@ -260,7 +260,7 @@ auto TextCheckingHelper::findMisspelledWords(Operation operation) const -> std::
         auto misspellingRange = resolveCharacterRange(m_range, CharacterRange(currentChunkOffset + misspellingLocation, misspellingLength));
 
         if (operation == Operation::MarkAll)
-            addMarker(misspellingRange, DocumentMarker::Type::Spelling);
+            addMarker(misspellingRange, DocumentMarkerType::Spelling);
 
         if (first.first.word.isNull()) {
             first = {
@@ -431,7 +431,7 @@ int TextCheckingHelper::findUngrammaticalPhrases(Operation operation, const Vect
         
         if (operation == Operation::MarkAll) {
             auto badGrammarRange = resolveCharacterRange(m_range, { badGrammarPhraseLocation - startOffset + detail->range.location, detail->range.length });
-            addMarker(badGrammarRange, DocumentMarker::Type::Grammar, detail->userDescription);
+            addMarker(badGrammarRange, DocumentMarkerType::Grammar, detail->userDescription);
         }
         
         // Remember this detail only if it's earlier than our current candidate (the details aren't in a guaranteed order)

--- a/Source/WebCore/editing/ios/DictationCommandIOS.cpp
+++ b/Source/WebCore/editing/ios/DictationCommandIOS.cpp
@@ -61,7 +61,7 @@ void DictationCommandIOS::doApply()
         if (interpretations.size() > 1) {
             auto alternatives = interpretations;
             alternatives.remove(0);
-            addMarker(*endingSelection().toNormalizedRange(), DocumentMarker::Type::DictationPhraseWithAlternatives, WTFMove(alternatives));
+            addMarker(*endingSelection().toNormalizedRange(), DocumentMarkerType::DictationPhraseWithAlternatives, WTFMove(alternatives));
         }
 
         setEndingSelection(VisibleSelection(endingSelection().visibleEnd()));
@@ -80,7 +80,7 @@ void DictationCommandIOS::doApply()
         return;
 
     auto resultRange = resolveCharacterRange(makeRangeSelectingNodeContents(*root), { endOffset - resultLength, endOffset });
-    addMarker(resultRange, DocumentMarker::Type::DictationResult, m_metadata);
+    addMarker(resultRange, DocumentMarkerType::DictationResult, m_metadata);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/editing/ios/EditorIOS.mm
+++ b/Source/WebCore/editing/ios/EditorIOS.mm
@@ -293,12 +293,12 @@ void Editor::setDictationPhrasesAsChildOfElement(const Vector<Vector<String>>& d
         if (interpretations.size() > 1) {
             auto alternatives = interpretations;
             alternatives.remove(0);
-            addMarker(*textNode, previousDictationPhraseStart, dictationPhraseLength, DocumentMarker::Type::DictationPhraseWithAlternatives, WTFMove(alternatives));
+            addMarker(*textNode, previousDictationPhraseStart, dictationPhraseLength, DocumentMarkerType::DictationPhraseWithAlternatives, WTFMove(alternatives));
         }
         previousDictationPhraseStart += dictationPhraseLength;
     }
 
-    addMarker(*textNode, 0, textNode->length(), DocumentMarker::Type::DictationResult, retainPtr(metadata));
+    addMarker(*textNode, 0, textNode->length(), DocumentMarkerType::DictationResult, retainPtr(metadata));
 
     client()->respondToChangedContents();
 }

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4207,7 +4207,7 @@ void EventHandler::invalidateDataTransfer()
 static void removeDraggedContentDocumentMarkersFromAllFramesInPage(Page& page)
 {
     page.forEachDocument([] (Document& document) {
-        document.markers().removeMarkers(DocumentMarker::Type::DraggedContent);
+        document.markers().removeMarkers(DocumentMarkerType::DraggedContent);
     });
 
     if (auto* localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame())) {

--- a/Source/WebCore/page/IntelligenceTextEffectsSupport.cpp
+++ b/Source/WebCore/page/IntelligenceTextEffectsSupport.cpp
@@ -47,7 +47,7 @@ Vector<FloatRect> writingToolsTextSuggestionRectsInRootViewCoordinates(Document&
     Vector<FloatRect> textRectsInRootViewCoordinates;
 
     auto& markers = document.markers();
-    markers.forEach(resolvedRange, { DocumentMarker::Type::WritingToolsTextSuggestion }, [&](auto& node, auto& marker) {
+    markers.forEach(resolvedRange, { DocumentMarkerType::WritingToolsTextSuggestion }, [&](auto& node, auto& marker) {
         auto data = std::get<DocumentMarker::WritingToolsTextSuggestionData>(marker.data());
 
         auto markerRange = makeSimpleRange(node, marker);
@@ -65,7 +65,7 @@ Vector<FloatRect> writingToolsTextSuggestionRectsInRootViewCoordinates(Document&
 void updateTextVisibility(Document& document, const SimpleRange& scope, const CharacterRange& range, bool visible, const WTF::UUID& identifier)
 {
     if (visible) {
-        document.markers().removeMarkers({ WebCore::DocumentMarker::Type::TransparentContent }, [identifier](auto& marker) {
+        document.markers().removeMarkers({ WebCore::DocumentMarkerType::TransparentContent }, [identifier](auto& marker) {
             auto& data = std::get<WebCore::DocumentMarker::TransparentContentData>(marker.data());
             return data.uuid == identifier ? WebCore::FilterMarkerResult::Remove : WebCore::FilterMarkerResult::Keep;
         });
@@ -106,7 +106,7 @@ void decorateWritingToolsTextReplacements(Document& document, const SimpleRange&
 
     Vector<std::tuple<SimpleRange, DocumentMarker::WritingToolsTextSuggestionData>> markersToReinsert;
 
-    markers.forEach(resolvedRange, { DocumentMarker::Type::WritingToolsTextSuggestion }, [&](auto& node, auto& marker) {
+    markers.forEach(resolvedRange, { DocumentMarkerType::WritingToolsTextSuggestion }, [&](auto& node, auto& marker) {
         auto range = makeSimpleRange(node, marker);
         auto data = std::get<DocumentMarker::WritingToolsTextSuggestionData>(marker.data());
 
@@ -115,11 +115,11 @@ void decorateWritingToolsTextReplacements(Document& document, const SimpleRange&
         return false;
     });
 
-    markers.removeMarkers(resolvedRange, { DocumentMarker::Type::WritingToolsTextSuggestion });
+    markers.removeMarkers(resolvedRange, { DocumentMarkerType::WritingToolsTextSuggestion });
 
     for (const auto& [range, oldData] : markersToReinsert) {
         auto newData = DocumentMarker::WritingToolsTextSuggestionData { oldData.originalText, oldData.suggestionID, oldData.state, DocumentMarker::WritingToolsTextSuggestionData::Decoration::Underline };
-        markers.addMarker(range, DocumentMarker::Type::WritingToolsTextSuggestion, newData);
+        markers.addMarker(range, DocumentMarkerType::WritingToolsTextSuggestion, newData);
     }
 }
 #endif

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1251,7 +1251,7 @@ void Page::unmarkAllTextMatches()
 {
     forEachDocument([] (Document& document) {
         if (CheckedPtr markers = document.markersIfExists())
-            markers->removeMarkers(DocumentMarker::Type::TextMatch);
+            markers->removeMarkers(DocumentMarkerType::TextMatch);
     });
 }
 

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -728,7 +728,7 @@ NSArray *LocalFrame::interpretationsForCurrentRoot() const
     auto* root = selection().isNone() ? document()->bodyOrFrameset() : selection().selection().rootEditableElement();
     auto rangeOfRootContents = makeRangeSelectingNodeContents(*root);
 
-    auto markersInRoot = document()->markers().markersInRange(rangeOfRootContents, DocumentMarker::Type::DictationPhraseWithAlternatives);
+    auto markersInRoot = document()->markers().markersInRange(rangeOfRootContents, DocumentMarkerType::DictationPhraseWithAlternatives);
 
     // There are no phrases with alternatives, so there is just one interpretation.
     if (markersInRoot.isEmpty())
@@ -748,7 +748,7 @@ NSArray *LocalFrame::interpretationsForCurrentRoot() const
     unsigned combinationsSoFar = 1;
 
     for (auto& node : intersectingNodes(rangeOfRootContents)) {
-        for (auto& marker : document()->markers().markersFor(node, DocumentMarker::Type::DictationPhraseWithAlternatives)) {
+        for (auto& marker : document()->markers().markersFor(node, DocumentMarkerType::DictationPhraseWithAlternatives)) {
             auto& alternatives = std::get<Vector<String>>(marker->data());
 
             auto rangeForMarker = makeSimpleRange(node, *marker);

--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -309,7 +309,7 @@ void WritingToolsController::proofreadingSessionDidReceiveSuggestions(const Writ
 
     HashSet<WTF::UUID> transparentContentMarkerIdentifiers;
 
-    document->markers().forEach(adjustedProcessedRangeBeforeReplacement, { DocumentMarker::Type::TransparentContent }, [&](auto&, auto marker) {
+    document->markers().forEach(adjustedProcessedRangeBeforeReplacement, { DocumentMarkerType::TransparentContent }, [&](auto&, auto marker) {
         auto& data = std::get<DocumentMarker::TransparentContentData>(marker.data());
         transparentContentMarkerIdentifiers.add(data.uuid);
 
@@ -347,7 +347,7 @@ void WritingToolsController::proofreadingSessionDidReceiveSuggestions(const Writ
         auto originalString = attributedTextString.substring(suggestion.originalRange.location, suggestion.originalRange.length);
 
         auto markerData = DocumentMarker::WritingToolsTextSuggestionData { originalString, suggestion.identifier, DocumentMarker::WritingToolsTextSuggestionData::State::Accepted, DocumentMarker::WritingToolsTextSuggestionData::Decoration::None };
-        addMarker(newResolvedRange, DocumentMarker::Type::WritingToolsTextSuggestion, markerData);
+        addMarker(newResolvedRange, DocumentMarkerType::WritingToolsTextSuggestion, markerData);
 
         state->replacementLocationOffset += static_cast<int>(suggestion.replacement.length()) - static_cast<int>(suggestion.originalRange.length);
     }
@@ -426,7 +426,7 @@ void WritingToolsController::proofreadingSessionDidUpdateStateForSuggestion(cons
         auto data = std::get<DocumentMarker::WritingToolsTextSuggestionData>(marker.data());
 
         auto offsetRange = OffsetRange { marker.startOffset(), marker.endOffset() };
-        document->markers().removeMarkers(node, offsetRange, { DocumentMarker::Type::WritingToolsTextSuggestion });
+        document->markers().removeMarkers(node, offsetRange, { DocumentMarkerType::WritingToolsTextSuggestion });
 
         replaceContentsOfRangeInSession(*state, rangeToReplace, data.originalText);
 
@@ -702,13 +702,13 @@ void WritingToolsController::writingToolsSessionDidReceiveAction<WritingTools::S
 
     Vector<std::tuple<Ref<Node>, DocumentMarker::WritingToolsTextSuggestionData, unsigned, unsigned>> markerData;
 
-    markers.forEach(sessionRange, { DocumentMarker::Type::WritingToolsTextSuggestion }, [&](auto& node, auto& marker) {
+    markers.forEach(sessionRange, { DocumentMarkerType::WritingToolsTextSuggestion }, [&](auto& node, auto& marker) {
         auto data = std::get<DocumentMarker::WritingToolsTextSuggestionData>(marker.data());
         markerData.append({ node, data, marker.startOffset(), marker.endOffset() });
         return false;
     });
 
-    markers.removeMarkers(sessionRange, { DocumentMarker::Type::WritingToolsTextSuggestion });
+    markers.removeMarkers(sessionRange, { DocumentMarkerType::WritingToolsTextSuggestion });
 
     for (auto& [node, oldData, startOffset, endOffset] : markerData | std::views::reverse) {
         auto rangeToReplace = SimpleRange { { node.get(), startOffset }, { node.get(), endOffset } };
@@ -721,7 +721,7 @@ void WritingToolsController::writingToolsSessionDidReceiveAction<WritingTools::S
         auto newData = DocumentMarker::WritingToolsTextSuggestionData { currentText, oldData.suggestionID, newState, oldData.decoration };
         auto newOffsetRange = OffsetRange { startOffset, endOffset + previousText.length() - currentText.length() };
 
-        markers.addMarker(node, DocumentMarker { DocumentMarker::Type::WritingToolsTextSuggestion, newOffsetRange, WTFMove(newData) });
+        markers.addMarker(node, DocumentMarker { DocumentMarkerType::WritingToolsTextSuggestion, newOffsetRange, WTFMove(newData) });
     }
 }
 
@@ -788,14 +788,14 @@ void WritingToolsController::willEndWritingToolsSession<WritingTools::Session::T
 
     // If the session as a whole is not accepted, revert all the suggestions to their original text.
 
-    markers.forEach<DocumentMarkerController::IterationDirection::Backwards>(sessionRange, { DocumentMarker::Type::WritingToolsTextSuggestion }, [&](auto& node, auto& marker) {
+    markers.forEach<DocumentMarkerController::IterationDirection::Backwards>(sessionRange, { DocumentMarkerType::WritingToolsTextSuggestion }, [&](auto& node, auto& marker) {
         auto data = std::get<DocumentMarker::WritingToolsTextSuggestionData>(marker.data());
 
         auto offsetRange = OffsetRange { marker.startOffset(), marker.endOffset() };
 
         auto rangeToReplace = makeSimpleRange(node, marker);
 
-        markers.removeMarkers(node, offsetRange, { DocumentMarker::Type::WritingToolsTextSuggestion });
+        markers.removeMarkers(node, offsetRange, { DocumentMarkerType::WritingToolsTextSuggestion });
 
         if (!accepted && data.state != DocumentMarker::WritingToolsTextSuggestionData::State::Rejected)
             replaceContentsOfRangeInSession(*state, rangeToReplace, data.originalText);
@@ -1084,7 +1084,7 @@ std::optional<std::tuple<Node&, DocumentMarker&>> WritingToolsController::findTe
     RefPtr<Node> targetNode;
     WeakPtr<DocumentMarker> targetMarker;
 
-    document->markers().forEach(outerRange, { DocumentMarker::Type::WritingToolsTextSuggestion }, [&textSuggestionID, &targetNode, &targetMarker](auto& node, auto& marker) mutable {
+    document->markers().forEach(outerRange, { DocumentMarkerType::WritingToolsTextSuggestion }, [&textSuggestionID, &targetNode, &targetMarker](auto& node, auto& marker) mutable {
         auto data = std::get<DocumentMarker::WritingToolsTextSuggestionData>(marker.data());
         if (data.suggestionID != textSuggestionID)
             return false;
@@ -1112,7 +1112,7 @@ std::optional<std::tuple<Node&, DocumentMarker&>> WritingToolsController::findTe
     RefPtr<Node> targetNode;
     WeakPtr<DocumentMarker> targetMarker;
 
-    document->markers().forEach(range, { DocumentMarker::Type::WritingToolsTextSuggestion }, [&range, &targetNode, &targetMarker](auto& node, auto& marker) mutable {
+    document->markers().forEach(range, { DocumentMarkerType::WritingToolsTextSuggestion }, [&range, &targetNode, &targetMarker](auto& node, auto& marker) mutable {
         auto data = std::get<DocumentMarker::WritingToolsTextSuggestionData>(marker.data());
 
         auto markerRange = makeSimpleRange(node, marker);

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -252,7 +252,7 @@ String HitTestResult::spellingToolTip(TextDirection& dir) const
     CheckedPtr markers = m_innerNonSharedNode->document().markersIfExists();
     if (!markers)
         return String();
-    WeakPtr marker = markers->markerContainingPoint(m_hitTestLocation.point(), DocumentMarker::Type::Grammar);
+    WeakPtr marker = markers->markerContainingPoint(m_hitTestLocation.point(), DocumentMarkerType::Grammar);
     if (!marker)
         return String();
 
@@ -271,7 +271,7 @@ String HitTestResult::replacedString() const
     CheckedPtr markers = m_innerNonSharedNode->document().markersIfExists();
     if (!markers)
         return String();
-    WeakPtr marker = markers->markerContainingPoint(m_hitTestLocation.point(), DocumentMarker::Type::Replacement);
+    WeakPtr marker = markers->markerContainingPoint(m_hitTestLocation.point(), DocumentMarkerType::Replacement);
     if (!marker)
         return String();
     
@@ -820,7 +820,7 @@ Vector<String> HitTestResult::dictationAlternatives() const
     if (!markers)
         return Vector<String>();
 
-    WeakPtr marker = markers->markerContainingPoint(pointInInnerNodeFrame(), DocumentMarker::Type::DictationAlternatives);
+    WeakPtr marker = markers->markerContainingPoint(pointInInnerNodeFrame(), DocumentMarkerType::DictationAlternatives);
     if (!marker)
         return Vector<String>();
 

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -203,24 +203,24 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
 
     auto markers = markerController->markersFor(*renderer.textNode());
 
-    auto markedTextTypeForMarkerType = [] (DocumentMarker::Type type) {
+    auto markedTextTypeForMarkerType = [] (DocumentMarkerType type) {
         switch (type) {
-        case DocumentMarker::Type::Spelling:
+        case DocumentMarkerType::Spelling:
             return MarkedText::Type::SpellingError;
-        case DocumentMarker::Type::Grammar:
+        case DocumentMarkerType::Grammar:
             return MarkedText::Type::GrammarError;
-        case DocumentMarker::Type::CorrectionIndicator:
+        case DocumentMarkerType::CorrectionIndicator:
             return MarkedText::Type::Correction;
 #if ENABLE(WRITING_TOOLS)
-        case DocumentMarker::Type::WritingToolsTextSuggestion:
+        case DocumentMarkerType::WritingToolsTextSuggestion:
             return MarkedText::Type::WritingToolsTextSuggestion;
 #endif
-        case DocumentMarker::Type::TextMatch:
+        case DocumentMarkerType::TextMatch:
             return MarkedText::Type::TextMatch;
-        case DocumentMarker::Type::DictationAlternatives:
+        case DocumentMarkerType::DictationAlternatives:
             return MarkedText::Type::DictationAlternatives;
 #if PLATFORM(IOS_FAMILY)
-        case DocumentMarker::Type::DictationPhraseWithAlternatives:
+        case DocumentMarkerType::DictationPhraseWithAlternatives:
             return MarkedText::Type::DictationPhraseWithAlternatives;
 #endif
         default:
@@ -236,30 +236,30 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
     for (auto& marker : markers) {
         // Collect either the background markers or the foreground markers, but not both
         switch (marker->type()) {
-        case DocumentMarker::Type::Grammar:
-        case DocumentMarker::Type::Spelling:
+        case DocumentMarkerType::Grammar:
+        case DocumentMarkerType::Spelling:
             break;
-        case DocumentMarker::Type::CorrectionIndicator:
+        case DocumentMarkerType::CorrectionIndicator:
 #if ENABLE(WRITING_TOOLS)
-        case DocumentMarker::Type::WritingToolsTextSuggestion:
+        case DocumentMarkerType::WritingToolsTextSuggestion:
 #endif
-        case DocumentMarker::Type::Replacement:
-        case DocumentMarker::Type::DictationAlternatives:
+        case DocumentMarkerType::Replacement:
+        case DocumentMarkerType::DictationAlternatives:
 #if PLATFORM(IOS_FAMILY)
         // FIXME: Remove the PLATFORM(IOS_FAMILY)-guard.
-        case DocumentMarker::Type::DictationPhraseWithAlternatives:
+        case DocumentMarkerType::DictationPhraseWithAlternatives:
 #endif
             if (phase != MarkedText::PaintPhase::Decoration)
                 continue;
             break;
-        case DocumentMarker::Type::TextMatch:
+        case DocumentMarkerType::TextMatch:
             if (!renderer.frame().editor().markedTextMatchesAreHighlighted())
                 continue;
             if (phase == MarkedText::PaintPhase::Decoration)
                 continue;
             break;
 #if ENABLE(TELEPHONE_NUMBER_DETECTION)
-        case DocumentMarker::Type::TelephoneNumber:
+        case DocumentMarkerType::TelephoneNumber:
             if (!renderer.frame().editor().markedTextMatchesAreHighlighted())
                 continue;
             if (phase != MarkedText::PaintPhase::Background)
@@ -283,12 +283,12 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
 
         // Marker intersects this run. Collect it.
         switch (marker->type()) {
-        case DocumentMarker::Type::Spelling:
-        case DocumentMarker::Type::CorrectionIndicator:
+        case DocumentMarkerType::Spelling:
+        case DocumentMarkerType::CorrectionIndicator:
 #if ENABLE(WRITING_TOOLS)
-        case DocumentMarker::Type::WritingToolsTextSuggestion: {
+        case DocumentMarkerType::WritingToolsTextSuggestion: {
             auto shouldPaintMarker = [&] {
-                if (marker->type() != DocumentMarker::Type::WritingToolsTextSuggestion)
+                if (marker->type() != DocumentMarkerType::WritingToolsTextSuggestion)
                     return true;
 
                 auto data = std::get<DocumentMarker::WritingToolsTextSuggestionData>(marker->data());
@@ -308,23 +308,23 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
             BFALLTHROUGH;
         }
 #endif
-        case DocumentMarker::Type::DictationAlternatives:
-        case DocumentMarker::Type::Grammar:
+        case DocumentMarkerType::DictationAlternatives:
+        case DocumentMarkerType::Grammar:
 #if PLATFORM(IOS_FAMILY)
         // FIXME: See <rdar://problem/8933352>. Also, remove the PLATFORM(IOS_FAMILY)-guard.
-        case DocumentMarker::Type::DictationPhraseWithAlternatives:
+        case DocumentMarkerType::DictationPhraseWithAlternatives:
 #endif
-        case DocumentMarker::Type::TextMatch: {
+        case DocumentMarkerType::TextMatch: {
             auto [clampedStart, clampedEnd] = selectableRange.clamp(marker->startOffset(), marker->endOffset());
 
             auto markedTextType = markedTextTypeForMarkerType(marker->type());
             markedTexts.append({ clampedStart, clampedEnd, markedTextType, marker.get() });
             break;
         }
-        case DocumentMarker::Type::Replacement:
+        case DocumentMarkerType::Replacement:
             break;
 #if ENABLE(TELEPHONE_NUMBER_DETECTION)
-        case DocumentMarker::Type::TelephoneNumber:
+        case DocumentMarkerType::TelephoneNumber:
             break;
 #endif
         default:
@@ -334,13 +334,13 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
     return markedTexts;
 }
 
-Vector<MarkedText> MarkedText::collectForDraggedAndTransparentContent(const DocumentMarker::Type type, const RenderText& renderer, const TextBoxSelectableRange& selectableRange)
+Vector<MarkedText> MarkedText::collectForDraggedAndTransparentContent(const DocumentMarkerType type, const RenderText& renderer, const TextBoxSelectableRange& selectableRange)
 {
-    auto markerTypeForDocumentMarker = [] (DocumentMarker::Type type) {
+    auto markerTypeForDocumentMarker = [] (DocumentMarkerType type) {
         switch (type) {
-        case DocumentMarker::Type::DraggedContent:
+        case DocumentMarkerType::DraggedContent:
             return MarkedText::Type::DraggedContent;
-        case DocumentMarker::Type::TransparentContent:
+        case DocumentMarkerType::TransparentContent:
             return MarkedText::Type::TransparentContent;
         default:
             return MarkedText::Type::Unmarked;

--- a/Source/WebCore/rendering/MarkedText.h
+++ b/Source/WebCore/rendering/MarkedText.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "DocumentMarker.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/Hasher.h>
 #include <wtf/Vector.h>
@@ -37,6 +36,7 @@ class RenderBoxModelObject;
 class RenderText;
 class RenderedDocumentMarker;
 struct TextBoxSelectableRange;
+enum class DocumentMarkerType : uint32_t;
 
 struct MarkedText : public CanMakeCheckedPtr<MarkedText, WTF::DefaultedOperatorEqual::Yes> {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
@@ -90,7 +90,7 @@ struct MarkedText : public CanMakeCheckedPtr<MarkedText, WTF::DefaultedOperatorE
 
     static Vector<MarkedText> collectForDocumentMarkers(const RenderText&, const TextBoxSelectableRange&, PaintPhase);
     static Vector<MarkedText> collectForHighlights(const RenderText&, const TextBoxSelectableRange&, PaintPhase);
-    static Vector<MarkedText> collectForDraggedAndTransparentContent(const DocumentMarker::Type, const RenderText& renderer, const TextBoxSelectableRange&);
+    static Vector<MarkedText> collectForDraggedAndTransparentContent(const DocumentMarkerType, const RenderText& renderer, const TextBoxSelectableRange&);
 
     unsigned startOffset { 0 };
     unsigned endOffset { 0 };

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -155,10 +155,10 @@ bool RenderReplaced::shouldDrawSelectionTint() const
 inline static bool contentContainsReplacedElement(const Vector<WeakPtr<RenderedDocumentMarker>>& markers, const Element& element)
 {
     for (auto& marker : markers) {
-        if (marker->type() == DocumentMarker::Type::DraggedContent) {
+        if (marker->type() == DocumentMarkerType::DraggedContent) {
             if (std::get<RefPtr<Node>>(marker->data()) == &element)
                 return true;
-        } else if (marker->type() == DocumentMarker::Type::TransparentContent) {
+        } else if (marker->type() == DocumentMarkerType::TransparentContent) {
             if (std::get<DocumentMarker::TransparentContentData>(marker->data()).node == &element)
                 return true;
         }
@@ -259,11 +259,11 @@ void RenderReplaced::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
         ASSERT(parentContainer);
         CheckedPtr markers = document().markersIfExists();
         if (markers) {
-            if (contentContainsReplacedElement(markers->markersFor(*parentContainer, DocumentMarker::Type::DraggedContent), *element())) {
+            if (contentContainsReplacedElement(markers->markersFor(*parentContainer, DocumentMarkerType::DraggedContent), *element())) {
                 savedGraphicsContext.save();
                 paintInfo.context().setAlpha(0.25);
             }
-            if (contentContainsReplacedElement(markers->markersFor(*parentContainer, DocumentMarker::Type::TransparentContent), *element())) {
+            if (contentContainsReplacedElement(markers->markersFor(*parentContainer, DocumentMarkerType::TransparentContent), *element())) {
                 savedGraphicsContext.save();
                 paintInfo.context().setAlpha(0.0);
             }

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1418,7 +1418,7 @@ bool RenderText::containsOnlyCSSWhitespace(unsigned from, unsigned length) const
     return containsOnlyPossiblyCollapsibleWhitespace(text().span16().subspan(from, length));
 }
 
-Vector<std::pair<unsigned, unsigned>> RenderText::contentRangesBetweenOffsetsForType(DocumentMarker::Type type, unsigned startOffset, unsigned endOffset) const
+Vector<std::pair<unsigned, unsigned>> RenderText::contentRangesBetweenOffsetsForType(DocumentMarkerType type, unsigned startOffset, unsigned endOffset) const
 {
     if (!textNode())
         return { };

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -23,7 +23,6 @@
 
 #pragma once
 
-#include "DocumentMarker.h"
 #include "RenderElement.h"
 #include "RenderTextLineBoxes.h"
 #include "Text.h"
@@ -37,6 +36,7 @@ class Font;
 class LegacyInlineTextBox;
 struct GlyphOverflow;
 struct WordTrailingSpace;
+enum class DocumentMarkerType : uint32_t;
 
 namespace Layout {
 class InlineTextBox;
@@ -187,7 +187,7 @@ public:
     
     bool containsOnlyCSSWhitespace(unsigned from, unsigned length) const;
 
-    Vector<std::pair<unsigned, unsigned>> contentRangesBetweenOffsetsForType(const DocumentMarker::Type, unsigned startOffset, unsigned endOffset) const;
+    Vector<std::pair<unsigned, unsigned>> contentRangesBetweenOffsetsForType(const DocumentMarkerType, unsigned startOffset, unsigned endOffset) const;
 
     RenderInline* inlineWrapperForDisplayContents();
     void setInlineWrapperForDisplayContents(RenderInline*);

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -317,13 +317,13 @@ void TextBoxPainter::paintForegroundAndDecorations()
 
             bool shouldPaintDraggedContent = !(m_paintInfo.paintBehavior.contains(PaintBehavior::ExcludeSelection));
             if (shouldPaintDraggedContent) {
-                auto markedTextsForDraggedContent = MarkedText::collectForDraggedAndTransparentContent(DocumentMarker::Type::DraggedContent, m_renderer, m_selectableRange);
+                auto markedTextsForDraggedContent = MarkedText::collectForDraggedAndTransparentContent(DocumentMarkerType::DraggedContent, m_renderer, m_selectableRange);
                 if (!markedTextsForDraggedContent.isEmpty()) {
                     shouldPaintSelectionForeground = false;
                     markedTexts.appendVector(WTFMove(markedTextsForDraggedContent));
                 }
             }
-            auto markedTextsForTransparentContent = MarkedText::collectForDraggedAndTransparentContent(DocumentMarker::Type::TransparentContent, m_renderer, m_selectableRange);
+            auto markedTextsForTransparentContent = MarkedText::collectForDraggedAndTransparentContent(DocumentMarkerType::TransparentContent, m_renderer, m_selectableRange);
             if (!markedTextsForTransparentContent.isEmpty())
                 markedTexts.appendVector(WTFMove(markedTextsForTransparentContent));
         }
@@ -1012,7 +1012,7 @@ void TextBoxPainter::paintPlatformDocumentMarkers()
         });
     }
 
-    auto transparentContentMarkedTexts = MarkedText::collectForDraggedAndTransparentContent(DocumentMarker::Type::TransparentContent, m_renderer, m_selectableRange);
+    auto transparentContentMarkedTexts = MarkedText::collectForDraggedAndTransparentContent(DocumentMarkerType::TransparentContent, m_renderer, m_selectableRange);
 
     // Ensure the transparent content marked texts go first in the vector, so that they take precedence over
     // the other marked texts when being subdivided so that they do not get painted.

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -488,47 +488,47 @@ void InspectorStubFrontend::sendMessageToFrontend(const String& message)
     frontendAPIDispatcher().dispatchMessageAsync(message);
 }
 
-static bool markerTypeFrom(const String& markerType, DocumentMarker::Type& result)
+static bool markerTypeFrom(const String& markerType, DocumentMarkerType& result)
 {
     if (equalLettersIgnoringASCIICase(markerType, "spelling"_s))
-        result = DocumentMarker::Type::Spelling;
+        result = DocumentMarkerType::Spelling;
     else if (equalLettersIgnoringASCIICase(markerType, "grammar"_s))
-        result = DocumentMarker::Type::Grammar;
+        result = DocumentMarkerType::Grammar;
     else if (equalLettersIgnoringASCIICase(markerType, "textmatch"_s))
-        result = DocumentMarker::Type::TextMatch;
+        result = DocumentMarkerType::TextMatch;
     else if (equalLettersIgnoringASCIICase(markerType, "replacement"_s))
-        result = DocumentMarker::Type::Replacement;
+        result = DocumentMarkerType::Replacement;
     else if (equalLettersIgnoringASCIICase(markerType, "correctionindicator"_s))
-        result = DocumentMarker::Type::CorrectionIndicator;
+        result = DocumentMarkerType::CorrectionIndicator;
     else if (equalLettersIgnoringASCIICase(markerType, "rejectedcorrection"_s))
-        result = DocumentMarker::Type::RejectedCorrection;
+        result = DocumentMarkerType::RejectedCorrection;
     else if (equalLettersIgnoringASCIICase(markerType, "autocorrected"_s))
-        result = DocumentMarker::Type::Autocorrected;
+        result = DocumentMarkerType::Autocorrected;
     else if (equalLettersIgnoringASCIICase(markerType, "spellcheckingexemption"_s))
-        result = DocumentMarker::Type::SpellCheckingExemption;
+        result = DocumentMarkerType::SpellCheckingExemption;
     else if (equalLettersIgnoringASCIICase(markerType, "deletedautocorrection"_s))
-        result = DocumentMarker::Type::DeletedAutocorrection;
+        result = DocumentMarkerType::DeletedAutocorrection;
     else if (equalLettersIgnoringASCIICase(markerType, "dictationalternatives"_s))
-        result = DocumentMarker::Type::DictationAlternatives;
+        result = DocumentMarkerType::DictationAlternatives;
 #if ENABLE(TELEPHONE_NUMBER_DETECTION)
     else if (equalLettersIgnoringASCIICase(markerType, "telephonenumber"_s))
-        result = DocumentMarker::Type::TelephoneNumber;
+        result = DocumentMarkerType::TelephoneNumber;
 #endif
 #if ENABLE(WRITING_TOOLS)
     else if (equalLettersIgnoringASCIICase(markerType, "writingtoolstextsuggestion"_s))
-        result = DocumentMarker::Type::WritingToolsTextSuggestion;
+        result = DocumentMarkerType::WritingToolsTextSuggestion;
 #endif
     else if (equalLettersIgnoringASCIICase(markerType, "transparentcontent"_s))
-        result = DocumentMarker::Type::TransparentContent;
+        result = DocumentMarkerType::TransparentContent;
     else
         return false;
 
     return true;
 }
 
-static bool markerTypesFrom(const String& markerType, OptionSet<DocumentMarker::Type>& result)
+static bool markerTypesFrom(const String& markerType, OptionSet<DocumentMarkerType>& result)
 {
-    DocumentMarker::Type singularResult;
+    DocumentMarkerType singularResult;
 
     if (markerType.isEmpty() || equalLettersIgnoringASCIICase(markerType, "all"_s))
         result = DocumentMarker::allMarkers();
@@ -2010,7 +2010,7 @@ ExceptionOr<unsigned> Internals::inspectorPaintRectCount()
 
 ExceptionOr<unsigned> Internals::markerCountForNode(Node& node, const String& markerType)
 {
-    OptionSet<DocumentMarker::Type> markerTypes;
+    OptionSet<DocumentMarkerType> markerTypes;
     if (!markerTypesFrom(markerType, markerTypes))
         return Exception { ExceptionCode::SyntaxError };
 
@@ -2022,7 +2022,7 @@ ExceptionOr<RenderedDocumentMarker*> Internals::markerAt(Node& node, const Strin
 {
     node.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
-    OptionSet<DocumentMarker::Type> markerTypes;
+    OptionSet<DocumentMarkerType> markerTypes;
     if (!markerTypesFrom(markerType, markerTypes))
         return Exception { ExceptionCode::SyntaxError };
 
@@ -2058,7 +2058,7 @@ ExceptionOr<String> Internals::markerDescriptionForNode(Node& node, const String
 
 ExceptionOr<String> Internals::dumpMarkerRects(const String& markerTypeString)
 {
-    DocumentMarker::Type markerType;
+    DocumentMarkerType markerType;
     if (!markerTypeFrom(markerTypeString, markerType))
         return Exception { ExceptionCode::SyntaxError };
 
@@ -2811,7 +2811,7 @@ void Internals::updateEditorUINowIfScheduled()
     }
 }
 
-bool Internals::hasMarkerFor(DocumentMarker::Type type, int from, int length)
+bool Internals::hasMarkerFor(DocumentMarkerType type, int from, int length)
 {
     Document* document = contextDocument();
     if (!document || !document->frame())
@@ -2824,7 +2824,7 @@ bool Internals::hasMarkerFor(DocumentMarker::Type type, int from, int length)
 
 ExceptionOr<void> Internals::setMarkerFor(const String& markerTypeString, int from, int length, const String& data)
 {
-    DocumentMarker::Type markerType;
+    DocumentMarkerType markerType;
     if (!markerTypeFrom(markerTypeString, markerType))
         return Exception { ExceptionCode::SyntaxError };
 
@@ -2840,39 +2840,39 @@ ExceptionOr<void> Internals::setMarkerFor(const String& markerTypeString, int fr
 
 bool Internals::hasSpellingMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarker::Type::Spelling, from, length);
+    return hasMarkerFor(DocumentMarkerType::Spelling, from, length);
 }
 
 bool Internals::hasGrammarMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarker::Type::Grammar, from, length);
+    return hasMarkerFor(DocumentMarkerType::Grammar, from, length);
 }
 
 bool Internals::hasAutocorrectedMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarker::Type::Autocorrected, from, length);
+    return hasMarkerFor(DocumentMarkerType::Autocorrected, from, length);
 }
 
 bool Internals::hasDictationAlternativesMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarker::Type::DictationAlternatives, from, length);
+    return hasMarkerFor(DocumentMarkerType::DictationAlternatives, from, length);
 }
 
 bool Internals::hasCorrectionIndicatorMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarker::Type::CorrectionIndicator, from, length);
+    return hasMarkerFor(DocumentMarkerType::CorrectionIndicator, from, length);
 }
 
 #if ENABLE(WRITING_TOOLS)
 bool Internals::hasWritingToolsTextSuggestionMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarker::Type::WritingToolsTextSuggestion, from, length);
+    return hasMarkerFor(DocumentMarkerType::WritingToolsTextSuggestion, from, length);
 }
 #endif
 
 bool Internals::hasTransparentContentMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarker::Type::TransparentContent, from, length);
+    return hasMarkerFor(DocumentMarkerType::TransparentContent, from, length);
 }
 
 void Internals::setContinuousSpellCheckingEnabled(bool enabled)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -31,7 +31,6 @@
 #include "CSSComputedStyleDeclaration.h"
 #include "ContextDestructionObserver.h"
 #include "Cookie.h"
-#include "DocumentMarker.h"
 #include "EpochTimeStamp.h"
 #include "EventTrackingRegions.h"
 #include "ExceptionOr.h"
@@ -145,6 +144,8 @@ class WebAnimation;
 class WebGLRenderingContext;
 class WindowProxy;
 class XMLHttpRequest;
+
+enum class DocumentMarkerType : uint32_t;
 
 #if ENABLE(ENCRYPTED_MEDIA)
 class MediaKeys;
@@ -1561,7 +1562,7 @@ private:
 
     CachedResource* resourceFromMemoryCache(const String& url);
 
-    bool hasMarkerFor(DocumentMarker::Type, int from, int length);
+    bool hasMarkerFor(DocumentMarkerType, int from, int length);
 
 #if ENABLE(MEDIA_STREAM)
     // RealtimeMediaSourceObserver API

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
@@ -164,7 +164,7 @@ void TextAnimationController::removeTransparentMarkersForTextAnimationID(const W
         return;
     }
 
-    document->markers().removeMarkers({ WebCore::DocumentMarker::Type::TransparentContent }, [&](const WebCore::DocumentMarker& marker) {
+    document->markers().removeMarkers({ WebCore::DocumentMarkerType::TransparentContent }, [&](const WebCore::DocumentMarker& marker) {
         return std::get<WebCore::DocumentMarker::TransparentContentData>(marker.data()).uuid == uuid ? WebCore::FilterMarkerResult::Remove : WebCore::FilterMarkerResult::Keep;
     });
 }

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -383,7 +383,7 @@ void WebPage::addDictationAlternative(const String& text, DictationContext conte
         return;
     }
 
-    document->markers().addMarker(matchRange, DocumentMarker::Type::DictationAlternatives, { DocumentMarker::DictationData { context, text } });
+    document->markers().addMarker(matchRange, DocumentMarkerType::DictationAlternatives, { DocumentMarker::DictationData { context, text } });
     completion(true);
 }
 
@@ -406,7 +406,7 @@ void WebPage::dictationAlternativesAtSelection(CompletionHandler<void(Vector<Dic
         return;
     }
 
-    auto markers = document->markers().markersInRange(*expandedSelectionRange, DocumentMarker::Type::DictationAlternatives);
+    auto markers = document->markers().markersInRange(*expandedSelectionRange, DocumentMarkerType::DictationAlternatives);
     auto contexts = WTF::compactMap(markers, [](auto& marker) -> std::optional<DictationContext> {
         if (std::holds_alternative<DocumentMarker::DictationData>(marker->data()))
             return std::get<DocumentMarker::DictationData>(marker->data()).context;
@@ -435,7 +435,7 @@ void WebPage::clearDictationAlternatives(Vector<DictationContext>&& contexts)
         if (!std::holds_alternative<DocumentMarker::DictationData>(marker.data()))
             return FilterMarkerResult::Keep;
         return setOfContextsToRemove.contains(std::get<WebCore::DocumentMarker::DictationData>(marker.data()).context) ? FilterMarkerResult::Remove : FilterMarkerResult::Keep;
-    }, DocumentMarker::Type::DictationAlternatives);
+    }, DocumentMarkerType::DictationAlternatives);
 }
 
 void WebPage::accessibilityTransferRemoteToken(RetainPtr<NSData> remoteToken)

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -556,7 +556,7 @@ Vector<FloatRect> FindController::rectsForTextMatchesInRect(IntRect clipRect)
         if (!document)
             continue;
 
-        for (FloatRect rect : document->markers().renderedRectsForMarkers(DocumentMarker::Type::TextMatch)) {
+        for (FloatRect rect : document->markers().renderedRectsForMarkers(DocumentMarkerType::TextMatch)) {
             if (!localFrame->isMainFrame())
                 rect = mainFrameView->windowToContents(localFrame->view()->contentsToWindow(enclosingIntRect(rect)));
 

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -151,10 +151,10 @@ void WebFoundTextRangeController::decorateTextRangeWithStyle(const WebFoundTextR
     if (auto simpleRange = simpleRangeFromFoundTextRange(range)) {
         switch (style) {
         case FindDecorationStyle::Normal:
-            simpleRange->start.document().markers().removeMarkers(*simpleRange, WebCore::DocumentMarker::Type::TextMatch);
+            simpleRange->start.document().markers().removeMarkers(*simpleRange, WebCore::DocumentMarkerType::TextMatch);
             break;
         case FindDecorationStyle::Found:
-            simpleRange->start.document().markers().addMarker(*simpleRange, WebCore::DocumentMarker::Type::TextMatch);
+            simpleRange->start.document().markers().addMarker(*simpleRange, WebCore::DocumentMarkerType::TextMatch);
             break;
         case FindDecorationStyle::Highlighted: {
             m_highlightedRange = range;
@@ -477,7 +477,7 @@ Vector<WebCore::FloatRect> WebFoundTextRangeController::rectsForTextMatchesInRec
         if (!document)
             continue;
 
-        for (auto rect : document->markers().renderedRectsForMarkers(WebCore::DocumentMarker::Type::TextMatch)) {
+        for (auto rect : document->markers().renderedRectsForMarkers(WebCore::DocumentMarkerType::TextMatch)) {
             if (!localFrame->isMainFrame())
                 rect = mainFrameView->windowToContents(localFrame->view()->contentsToWindow(enclosingIntRect(rect)));
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5913,7 +5913,7 @@ void WebPage::unmarkAllMisspellings()
         if (!localFrame)
             continue;
         if (RefPtr document = localFrame->document())
-            document->markers().removeMarkers(DocumentMarker::Type::Spelling);
+            document->markers().removeMarkers(DocumentMarkerType::Spelling);
     }
 }
 
@@ -5924,7 +5924,7 @@ void WebPage::unmarkAllBadGrammar()
         if (!localFrame)
             continue;
         if (RefPtr document = localFrame->document())
-            document->markers().removeMarkers(DocumentMarker::Type::Grammar);
+            document->markers().removeMarkers(DocumentMarkerType::Grammar);
     }
 }
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -228,7 +228,7 @@ static void adjustCandidateAutocorrectionInFrame(const String& correction, Local
     if (correctedRange.collapsed())
         return;
 
-    addMarker(correctedRange, WebCore::DocumentMarker::Type::CorrectionIndicator);
+    addMarker(correctedRange, WebCore::DocumentMarkerType::CorrectionIndicator);
 #else
     UNUSED_PARAM(frame);
 #endif
@@ -403,7 +403,7 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
 
 #if USE(DICTATION_ALTERNATIVES)
     if (selectedRange) {
-        auto markers = frame.document()->markers().markersInRange(*selectedRange, DocumentMarker::Type::DictationAlternatives);
+        auto markers = frame.document()->markers().markersInRange(*selectedRange, DocumentMarkerType::DictationAlternatives);
         postLayoutData.dictationContextsForSelection = WTF::map(markers, [] (auto& marker) {
             return std::get<DocumentMarker::DictationData>(marker->data()).context;
         });
@@ -420,7 +420,7 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
                 auto& style = editableRoot->renderer()->style();
                 postLayoutData.caretColor = CaretBase::computeCaretColor(style, editableRoot.get());
                 postLayoutData.hasCaretColorAuto = style.hasAutoCaretColor();
-                postLayoutData.hasGrammarDocumentMarkers = editableRoot->document().markers().hasMarkers(makeRangeSelectingNodeContents(*editableRoot), DocumentMarker::Type::Grammar);
+                postLayoutData.hasGrammarDocumentMarkers = editableRoot->document().markers().hasMarkers(makeRangeSelectingNodeContents(*editableRoot), DocumentMarkerType::Grammar);
             }
         }
 
@@ -2058,7 +2058,7 @@ void WebPage::extendSelectionForReplacement(CompletionHandler<void()>&& completi
     if (!container)
         return;
 
-    auto markerRanges = document->markers().markersFor(*container, { DocumentMarker::Type::DictationAlternatives, DocumentMarker::Type::CorrectionIndicator }).map([&](auto& marker) {
+    auto markerRanges = document->markers().markersFor(*container, { DocumentMarkerType::DictationAlternatives, DocumentMarkerType::CorrectionIndicator }).map([&](auto& marker) {
         return makeSimpleRange(*container, *marker);
     });
 
@@ -5435,7 +5435,7 @@ void WebPage::requestDocumentEditingContext(DocumentEditingContextRequest&& requ
 
     if (request.options.contains(DocumentEditingContextRequest::Options::AutocorrectedRanges)) {
         if (auto contextRange = makeSimpleRange(contextBeforeStart, contextAfterEnd)) {
-            auto ranges = frame->document()->markers().rangesForMarkersInRange(*contextRange, DocumentMarker::Type::CorrectionIndicator);
+            auto ranges = frame->document()->markers().rangesForMarkersInRange(*contextRange, DocumentMarkerType::CorrectionIndicator);
             context.autocorrectedRanges = ranges.map([&] (auto& range) {
                 auto characterRangeInContext = characterRange(*contextRange, range);
                 return DocumentEditingContext::Range { characterRangeInContext.location, characterRangeInContext.length };

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebVisiblePosition.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebVisiblePosition.mm
@@ -413,7 +413,7 @@ static inline SelectionDirection toSelectionDirection(WebTextAdjustmentDirection
 
     unsigned offset = position.deepEquivalent().deprecatedEditingOffset();
     auto& document = node->document();
-    for (auto& marker : document.markers().markersFor(*node, DocumentMarker::Type::DictationPhraseWithAlternatives)) {
+    for (auto& marker : document.markers().markersFor(*node, DocumentMarkerType::DictationPhraseWithAlternatives)) {
         if (marker->startOffset() <= offset && marker->endOffset() >= offset) {
             *alternatives = createNSArray(std::get<Vector<String>>(marker->data())).autorelease();
             return kit(makeSimpleRange(*node, *marker));
@@ -431,7 +431,7 @@ static inline SelectionDirection toSelectionDirection(WebTextAdjustmentDirection
 
     unsigned offset = position.deepEquivalent().deprecatedEditingOffset();
     auto& document = node->document();
-    for (auto& marker : document.markers().markersFor(*node, DocumentMarker::Type::Spelling)) {
+    for (auto& marker : document.markers().markersFor(*node, DocumentMarkerType::Spelling)) {
         if (marker->startOffset() <= offset && marker->endOffset() >= offset)
             return kit(makeSimpleRange(*node, *marker));
     }

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -491,7 +491,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         if (!frame)
             continue;
         if (auto* document = frame->document())
-            document->markers().removeMarkers(WebCore::DocumentMarker::Type::Grammar);
+            document->markers().removeMarkers(WebCore::DocumentMarkerType::Grammar);
     }
 }
 
@@ -504,7 +504,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         if (!frame)
             continue;
         if (auto* document = frame->document())
-            document->markers().removeMarkers(WebCore::DocumentMarker::Type::Spelling);
+            document->markers().removeMarkers(WebCore::DocumentMarkerType::Spelling);
     }
 #endif
 }
@@ -1712,7 +1712,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
     for (WebCore::Node* node = root; node; node = WebCore::NodeTraversal::next(*node)) {
         auto markers = document->markers().markersFor(*node);
         for (auto& marker : markers) {
-            if (marker->type() != WebCore::DocumentMarker::Type::DictationResult)
+            if (marker->type() != WebCore::DocumentMarkerType::DictationResult)
                 continue;
 
             id metadata = std::get<RetainPtr<id>>(marker->data()).get();
@@ -1753,7 +1753,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
     if (!range)
         return nil;
 
-    auto markers = core(self)->document()->markers().markersInRange(makeSimpleRange(*core(range)), WebCore::DocumentMarker::Type::DictationResult);
+    auto markers = core(self)->document()->markers().markersInRange(makeSimpleRange(*core(range)), WebCore::DocumentMarkerType::DictationResult);
 
     // UIKit should only ever give us a DOMRange for a phrase with alternatives, which should not be part of more than one result.
     ASSERT(markers.size() <= 1);

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -4638,8 +4638,8 @@ static RefPtr<WebCore::KeyboardEvent> currentKeyboardEvent(WebCore::LocalFrame* 
 
 #if PLATFORM(IOS_FAMILY)
         if (auto* document = coreFrame->document()) {
-            document->markers().removeMarkers(WebCore::DocumentMarker::Type::DictationPhraseWithAlternatives);
-            document->markers().removeMarkers(WebCore::DocumentMarker::Type::DictationResult);
+            document->markers().removeMarkers(WebCore::DocumentMarkerType::DictationPhraseWithAlternatives);
+            document->markers().removeMarkers(WebCore::DocumentMarkerType::DictationResult);
         }
 #endif
 
@@ -7123,7 +7123,7 @@ static CGImageRef selectionImage(WebCore::LocalFrame* frame, bool forceBlackText
     auto* document = coreFrame->document();
     if (!document)
         return;
-    document->markers().removeMarkers(WebCore::DocumentMarker::Type::TextMatch);
+    document->markers().removeMarkers(WebCore::DocumentMarkerType::TextMatch);
 }
 
 - (NSArray *)rectsForTextMatches
@@ -7135,7 +7135,7 @@ static CGImageRef selectionImage(WebCore::LocalFrame* frame, bool forceBlackText
     if (!document)
         return @[];
 
-    return createNSArray(document->markers().renderedRectsForMarkers(WebCore::DocumentMarker::Type::TextMatch)).autorelease();
+    return createNSArray(document->markers().renderedRectsForMarkers(WebCore::DocumentMarkerType::TextMatch)).autorelease();
 }
 
 - (BOOL)_findString:(NSString *)string options:(WebFindOptions)options

--- a/Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp
@@ -102,7 +102,7 @@ TEST(MarkedText, SubdivideSimple)
 
 TEST(MarkedText, SubdivideSpellingAndGrammarSimple)
 {
-    RenderedDocumentMarker grammarErrorMarker { DocumentMarker { DocumentMarker::Type::Grammar, { 7, 8 } } };
+    RenderedDocumentMarker grammarErrorMarker { DocumentMarker { DocumentMarkerType::Grammar, { 7, 8 } } };
     Vector<MarkedText> expectedMarkedTexts {
         MarkedText { grammarErrorMarker.startOffset(), grammarErrorMarker.endOffset(), MarkedText::Type::GrammarError, &grammarErrorMarker },
         MarkedText { 22, 32, MarkedText::Type::SpellingError },


### PR DESCRIPTION
#### f1208f657429e7dcd264261405accd8c5d648fa5
<pre>
Remove some DocumentMarker.h includes
<a href="https://bugs.webkit.org/show_bug.cgi?id=283629">https://bugs.webkit.org/show_bug.cgi?id=283629</a>
<a href="https://rdar.apple.com/140476862">rdar://140476862</a>

Reviewed by Timothy Hatcher.

DocumentMarker.h ends up pulling in Node.h, which in turn pulls in JSC headers via EventTarget.h.

Remove DocumentMarker.h includes by making it possible to forward-declare DocumentMarker::Type.

In most compilation units, other files pull in EventTarget.h so this probably isn&apos;t yet a build
time improvement.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::textInserted):
* Source/WebCore/dom/DocumentMarker.h:
(WebCore::DocumentMarker::DocumentMarker):
(WebCore::DocumentMarker::type const):
(WebCore::DocumentMarker::allMarkers):
* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::possiblyHasMarkers const):
(WebCore::DocumentMarkerController::addMarker):
(WebCore::DocumentMarkerController::addDraggedContentMarker):
(WebCore::DocumentMarkerController::addTransparentContentMarker):
(WebCore::DocumentMarkerController::removeMarkers):
(WebCore::DocumentMarkerController::filterMarkers):
(WebCore::DocumentMarkerController::updateRectsForInvalidatedMarkersOfType):
(WebCore::DocumentMarkerController::renderedRectsForMarkers):
(WebCore::shouldInsertAsSeparateMarker):
(WebCore::canMergeMarkers):
(WebCore::DocumentMarkerController::markerContainingPoint):
(WebCore::DocumentMarkerController::markersFor const):
(WebCore::DocumentMarkerController::forEach&lt;DocumentMarkerController::IterationDirection::Forwards&gt;):
(WebCore::DocumentMarkerController::forEach&lt;DocumentMarkerController::IterationDirection::Backwards&gt;):
(WebCore::DocumentMarkerController::forEachOfTypes):
(WebCore::DocumentMarkerController::markersInRange):
(WebCore::DocumentMarkerController::rangesForMarkersInRange):
(WebCore::DocumentMarkerController::removeMarkersFromList):
(WebCore::DocumentMarkerController::repaintMarkers):
(WebCore::DocumentMarkerController::dismissMarkers):
(WebCore::DocumentMarkerController::writingToolsTextSuggestionAnimationTimerFired):
(WebCore::DocumentMarkerController::hasMarkers):
(WebCore::DocumentMarkerController::clearDescriptionOnMarkersIntersectingRange):
(WebCore::addMarker):
(WebCore::removeMarkers):
* Source/WebCore/dom/DocumentMarkerController.h:
(WebCore::addMarker):
* Source/WebCore/editing/AlternativeTextController.cpp:
(WebCore::markerTypesForAppliedDictationAlternative):
(WebCore::markerTypesForAutocorrection):
(WebCore::markerTypesForReplacement):
(WebCore::AlternativeTextController::isSpellingMarkerAllowed const):
(WebCore::AlternativeTextController::respondToUnappliedSpellCorrection):
(WebCore::AlternativeTextController::timerFired):
(WebCore::AlternativeTextController::handleAlternativeTextUIResult):
(WebCore::AlternativeTextController::respondToUnappliedEditing):
(WebCore::AlternativeTextController::markReversed):
(WebCore::AlternativeTextController::markCorrection):
(WebCore::AlternativeTextController::recordSpellcheckerResponseForModifiedCorrection):
(WebCore::AlternativeTextController::markPrecedingWhitespaceForDeletedAutocorrectionAfterCommand):
(WebCore::AlternativeTextController::processMarkersOnTextToBeReplacedByResult):
(WebCore::AlternativeTextController::shouldStartTimerFor const):
(WebCore::AlternativeTextController::respondToMarkerAtEndOfWord):
(WebCore::AlternativeTextController::markerDescriptionForAppliedAlternativeText):
(WebCore::AlternativeTextController::applyAlternativeTextToRange):
(WebCore::AlternativeTextController::removeCorrectionIndicatorMarkers):
(WebCore::AlternativeTextController::applyDictationAlternative):
* Source/WebCore/editing/AlternativeTextController.h:
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::DeleteSelectionCommand::originalStringForAutocorrectionAtBeginningOfSelection):
* Source/WebCore/editing/DictationCommand.cpp:
* Source/WebCore/editing/Editor.cpp:
(WebCore::didApplyAutocorrection):
(WebCore::adjustMarkerTypesToRemoveForWordsAffectedByEditing):
(WebCore::Editor::ignoreSpelling):
(WebCore::Editor::learnSpelling):
(WebCore::Editor::advanceToNextMisspelling):
(WebCore::Editor::clearMisspellingsAndBadGrammar):
(WebCore::Editor::markMisspellingsAfterTypingToWord):
(WebCore::Editor::markAndReplaceFor):
(WebCore::Editor::changeBackToReplacedString):
(WebCore::Editor::updateMarkersForWordsAffectedByEditing):
(WebCore::Editor::countMatchesForText):
(WebCore::Editor::setMarkedTextMatchesAreHighlighted):
(WebCore::Editor::scanSelectionForTelephoneNumbers):
(WebCore::Editor::editorUIUpdateTimerFired):
(WebCore::Editor::selectionStartHasMarkerFor const):
(WebCore::Editor::selectionStartSetMarkerForTesting):
(WebCore::Editor::handleAcceptedCandidate):
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/SpellChecker.cpp:
(WebCore::SpellChecker::didCheckSucceed):
* Source/WebCore/editing/TextCheckingHelper.cpp:
(WebCore::TextCheckingHelper::findMisspelledWords const):
(WebCore::TextCheckingHelper::findUngrammaticalPhrases const):
* Source/WebCore/editing/ios/DictationCommandIOS.cpp:
(WebCore::DictationCommandIOS::doApply):
* Source/WebCore/editing/ios/EditorIOS.mm:
(WebCore::Editor::setDictationPhrasesAsChildOfElement):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::removeDraggedContentDocumentMarkersFromAllFramesInPage):
* Source/WebCore/page/IntelligenceTextEffectsSupport.cpp:
(WebCore::IntelligenceTextEffectsSupport::writingToolsTextSuggestionRectsInRootViewCoordinates):
(WebCore::IntelligenceTextEffectsSupport::updateTextVisibility):
(WebCore::IntelligenceTextEffectsSupport::decorateWritingToolsTextReplacements):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::unmarkAllTextMatches):
* Source/WebCore/page/ios/FrameIOS.mm:
(WebCore::LocalFrame::interpretationsForCurrentRoot const):
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::proofreadingSessionDidReceiveSuggestions):
(WebCore::WritingToolsController::proofreadingSessionDidUpdateStateForSuggestion):
(WebCore::WritingToolsController::writingToolsSessionDidReceiveAction&lt;WritingTools::Session::Type::Proofreading&gt;):
(WebCore::WritingToolsController::willEndWritingToolsSession&lt;WritingTools::Session::Type::Proofreading&gt;):
(WebCore::WritingToolsController::findTextSuggestionMarkerByID const):
(WebCore::WritingToolsController::findTextSuggestionMarkerContainingRange const):
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::spellingToolTip const):
(WebCore::HitTestResult::replacedString const):
(WebCore::HitTestResult::dictationAlternatives const):
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForDocumentMarkers):
(WebCore::MarkedText::collectForDraggedAndTransparentContent):
* Source/WebCore/rendering/MarkedText.h:
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::contentContainsReplacedElement):
(WebCore::RenderReplaced::paint):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::contentRangesBetweenOffsetsForType const):
* Source/WebCore/rendering/RenderText.h:
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter::paintForegroundAndDecorations):
(WebCore::TextBoxPainter::paintPlatformDocumentMarkers):
* Source/WebCore/testing/Internals.cpp:
(WebCore::markerTypeFrom):
(WebCore::markerTypesFrom):
(WebCore::Internals::markerCountForNode):
(WebCore::Internals::dumpMarkerRects):
(WebCore::Internals::hasMarkerFor):
(WebCore::Internals::setMarkerFor):
(WebCore::Internals::hasSpellingMarker):
(WebCore::Internals::hasGrammarMarker):
(WebCore::Internals::hasAutocorrectedMarker):
(WebCore::Internals::hasDictationAlternativesMarker):
(WebCore::Internals::hasCorrectionIndicatorMarker):
(WebCore::Internals::hasWritingToolsTextSuggestionMarker):
(WebCore::Internals::hasTransparentContentMarker):
* Source/WebCore/testing/Internals.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm:
(WebKit::TextAnimationController::removeTransparentMarkersForTextAnimationID):
* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm:
(WebKit::relevantMarkerTypes):
(WebKit::TextCheckingControllerProxy::replaceRelativeToSelection):
(WebKit::TextCheckingControllerProxy::removeAnnotationRelativeToSelection):
(WebKit::TextCheckingControllerProxy::annotatedSubstringBetweenPositions):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::addDictationAlternative):
(WebKit::WebPage::dictationAlternativesAtSelection):
(WebKit::WebPage::clearDictationAlternatives):
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::rectsForTextMatchesInRect):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::decorateTextRangeWithStyle):
(WebKit::WebFoundTextRangeController::rectsForTextMatchesInRect):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::unmarkAllMisspellings):
(WebKit::WebPage::unmarkAllBadGrammar):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::adjustCandidateAutocorrectionInFrame):
(WebKit::WebPage::getPlatformEditorState const):
(WebKit::WebPage::extendSelectionForReplacement):
(WebKit::WebPage::requestDocumentEditingContext):
* Source/WebKitLegacy/ios/WebCoreSupport/WebVisiblePosition.mm:
(-[WebVisiblePosition enclosingRangeWithDictationPhraseAlternatives:]):
(-[WebVisiblePosition enclosingRangeWithCorrectionIndicator]):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _unmarkAllBadGrammar]):
(-[WebFrame _unmarkAllMisspellings]):
(-[WebFrame getDictationResultRanges:andMetadatas:]):
(-[WebFrame dictationResultMetadataForRange:]):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView resignFirstResponder]):
(-[WebHTMLView unmarkAllTextMatches]):
(-[WebHTMLView rectsForTextMatches]):
* Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp:
(TestWebKitAPI::TEST(MarkedText, SubdivideSpellingAndGrammarSimple)):

Canonical link: <a href="https://commits.webkit.org/287042@main">https://commits.webkit.org/287042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60f706694453888dfa3bcf8bc996735f87979e48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56993 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82608 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29217 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80081 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61049 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18976 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67233 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41351 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48405 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24483 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-008.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27561 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69498 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24829 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83970 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5327 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3598 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69267 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68522 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17121 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12525 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10686 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5275 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8028 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5267 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8699 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7052 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->