### PR TITLE
Clean up ViewTransition.h includes

### DIFF
--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -590,27 +590,4 @@ ALWAYS_INLINE bool matchesActiveViewTransitionPseudoClass(const Element& element
     return !!element.document().activeViewTransition();
 }
 
-ALWAYS_INLINE bool matchesActiveViewTransitionTypePseudoClass(const Element& element, const FixedVector<AtomString>& types)
-{
-    // This pseudo class only matches the root element.
-    if (&element != element.document().documentElement())
-        return false;
-
-    if (const auto* viewTransition = element.document().activeViewTransition()) {
-        const auto& activeTypes = viewTransition->types();
-
-        for (const auto& type : types) {
-            // https://github.com/w3c/csswg-drafts/issues/9534#issuecomment-1802364085
-            // RESOLVED: type can accept any idents, except 'none' or '-ua-' prefixes
-            if (type.convertToASCIILowercase() == "none"_s || type.convertToASCIILowercase().startsWith("-ua-"_s))
-                continue;
-
-            if (activeTypes.hasType(type))
-                return true;
-        }
-    }
-
-    return false;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -52,6 +52,7 @@
 #include "StyleResolver.h"
 #include "StyleScope.h"
 #include "Styleable.h"
+#include "ViewTransitionTypeSet.h"
 #include "WebAnimation.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
@@ -920,6 +921,11 @@ ExceptionOr<void> ViewTransition::updatePseudoElementSizes()
         document->styleScope().didChangeStyleSheetContents();
 
     return { };
+}
+
+void ViewTransition::setTypes(Ref<ViewTransitionTypeSet>&& newTypes)
+{
+    m_types = WTFMove(newTypes);
 }
 
 RenderViewTransitionCapture* ViewTransition::viewTransitionNewPseudoForCapturedElement(RenderLayerModelObject& renderer)

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -30,16 +30,18 @@
 #include "Element.h"
 #include "ExceptionOr.h"
 #include "ImageBuffer.h"
-#include "JSValueInWrappedObject.h"
 #include "MutableStyleProperties.h"
 #include "Styleable.h"
-#include "ViewTransitionTypeSet.h"
 #include "ViewTransitionUpdateCallback.h"
 #include "VisibilityChangeClient.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/Ref.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/AtomString.h>
+
+namespace JSC {
+class JSValue;
+}
 
 namespace WebCore {
 
@@ -48,6 +50,7 @@ class DeferredPromise;
 class RenderLayerModelObject;
 class RenderViewTransitionCapture;
 class RenderLayerModelObject;
+class ViewTransitionTypeSet;
 
 enum class ViewTransitionPhase : uint8_t {
     PendingCapture,
@@ -190,11 +193,12 @@ public:
     bool documentElementIsCaptured() const;
 
     const ViewTransitionTypeSet& types() const { return m_types; }
-    void setTypes(Ref<ViewTransitionTypeSet>&& newTypes) { m_types = WTFMove(newTypes); }
+    void setTypes(Ref<ViewTransitionTypeSet>&&);
 
     RenderViewTransitionCapture* viewTransitionNewPseudoForCapturedElement(RenderLayerModelObject&);
 
     static constexpr Seconds defaultTimeout = 4_s;
+
 private:
     ViewTransition(Document&, RefPtr<ViewTransitionUpdateCallback>&&, Vector<AtomString>&&);
     ViewTransition(Document&, Vector<AtomString>&&);


### PR DESCRIPTION
#### 5fda7954d50a1a6b8061cdc863524bd1e955eaf0
<pre>
Clean up ViewTransition.h includes
<a href="https://bugs.webkit.org/show_bug.cgi?id=283630">https://bugs.webkit.org/show_bug.cgi?id=283630</a>
<a href="https://rdar.apple.com/140477111">rdar://140477111</a>

Reviewed by Tim Nguyen.

ViewTransition.h pulls in JSC stuff via #include &quot;JSValueInWrappedObject.h&quot;, so fix that.

* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::matchesActiveViewTransitionTypePseudoClass):
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesActiveViewTransitionTypePseudoClass): Deleted.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::setTypes):
* Source/WebCore/dom/ViewTransition.h:
(WebCore::ViewTransition::setTypes): Deleted.

Canonical link: <a href="https://commits.webkit.org/287043@main">https://commits.webkit.org/287043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ab881d48003efa5dcda57c3abbc88b43d6593b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56994 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82609 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29218 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80082 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61048 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18978 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Passed layout tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51043 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67242 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41350 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48406 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24485 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27562 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24831 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83971 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5328 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3600 "Found 2 new test failures: ipc/create-media-source-with-invalid-constraints-crash.html webrtc/vp8-then-h264.html (failure)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69266 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 29 flakes 280 failures; Uploaded test results; Running layout-tests-repeat-failures; 4 flakes 94 failures; Running analyze-layout-tests-results") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5484 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68521 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17122 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12526 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10689 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5276 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8029 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5268 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8700 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7053 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->