### PR TITLE
[WTF] Add new class to test matching the URL with pattern.

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -882,6 +882,8 @@
 		E4A0AD3D1A96253C00536DF6 /* WorkQueueCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4A0AD3C1A96253C00536DF6 /* WorkQueueCocoa.cpp */; };
 		EB2C86D9267B275D0052CB9A /* CPUTimePOSIX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB2C86D8267B275C0052CB9A /* CPUTimePOSIX.cpp */; };
 		EB61EDC72409CCC1001EFE36 /* SystemTracingCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB61EDC62409CCC0001EFE36 /* SystemTracingCocoa.cpp */; };
+		EB7CE0EB2CEFB4A700BECB13 /* URLMatch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB7CE0EA2CEFB4A700BECB13 /* URLMatch.cpp */; };
+		EB7CE0ED2CEFB4B400BECB13 /* URLMatch.h in Headers */ = {isa = PBXBuildFile; fileRef = EB7CE0EC2CEFB4B400BECB13 /* URLMatch.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FA0C387B2BEAD56B00583842 /* SmallMap.h in Headers */ = {isa = PBXBuildFile; fileRef = FA0C387A2BEAD56B00583842 /* SmallMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE032AD22463E43B0012D7C7 /* WTFConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE032AD02463E43B0012D7C7 /* WTFConfig.cpp */; };
 		FE03831C2ABC04F700A576A2 /* TZoneMallocInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FE03831A2ABC04F700A576A2 /* TZoneMallocInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1891,6 +1893,8 @@
 		E4D2AE4D268A4C7F00DFEA02 /* SystemMalloc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SystemMalloc.h; sourceTree = "<group>"; };
 		EB2C86D8267B275C0052CB9A /* CPUTimePOSIX.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CPUTimePOSIX.cpp; sourceTree = "<group>"; };
 		EB61EDC62409CCC0001EFE36 /* SystemTracingCocoa.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SystemTracingCocoa.cpp; sourceTree = "<group>"; };
+		EB7CE0EA2CEFB4A700BECB13 /* URLMatch.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = URLMatch.cpp; sourceTree = "<group>"; };
+		EB7CE0EC2CEFB4B400BECB13 /* URLMatch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = URLMatch.h; sourceTree = "<group>"; };
 		EB95E1EF161A72410089A2F5 /* ByteOrder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ByteOrder.h; sourceTree = "<group>"; };
 		EF7D6CD59D8642A8A0DA86AD /* StackTrace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StackTrace.h; sourceTree = "<group>"; };
 		F6D67D3226F90142006E0349 /* Int128.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Int128.h; sourceTree = "<group>"; };
@@ -2570,6 +2574,8 @@
 				5CC0EE772162A01000A1A842 /* URLHash.h */,
 				5FAD3AE121B9636600BEE178 /* URLHelpers.cpp */,
 				5FAD3AE021B9636600BEE178 /* URLHelpers.h */,
+				EB7CE0EA2CEFB4A700BECB13 /* URLMatch.cpp */,
+				EB7CE0EC2CEFB4B400BECB13 /* URLMatch.h */,
 				5CC0EE7321629F1900A1A842 /* URLParser.cpp */,
 				5CC0EE7221629F1900A1A842 /* URLParser.h */,
 				7AFEC6B01EB22B5900DADE36 /* UUID.cpp */,
@@ -3677,6 +3683,7 @@
 				DD3DC90327A4BF8E007E5B61 /* URL.h in Headers */,
 				DD3DC8ED27A4BF8E007E5B61 /* URLHash.h in Headers */,
 				DD3DC99A27A4BF8E007E5B61 /* URLHelpers.h in Headers */,
+				EB7CE0ED2CEFB4B400BECB13 /* URLMatch.h in Headers */,
 				DD3DC8BD27A4BF8E007E5B61 /* URLParser.h in Headers */,
 				DDF307D227C086DF006A526F /* UTextProvider.h in Headers */,
 				DDF307E227C086DF006A526F /* UTextProviderLatin1.h in Headers */,
@@ -4245,6 +4252,7 @@
 				5C1F0595216437B30039302C /* URLCF.cpp in Sources */,
 				5CC0EE892162BC2200A1A842 /* URLCocoa.mm in Sources */,
 				5FAD3AE221B9636600BEE178 /* URLHelpers.cpp in Sources */,
+				EB7CE0EB2CEFB4A700BECB13 /* URLMatch.cpp in Sources */,
 				5CC0EE7521629F1900A1A842 /* URLParser.cpp in Sources */,
 				1C181C8F1D307AB800F5FA16 /* UTextProvider.cpp in Sources */,
 				1C181C911D307AB800F5FA16 /* UTextProviderLatin1.cpp in Sources */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -338,6 +338,7 @@ set(WTF_PUBLIC_HEADERS
     URL.h
     URLHelpers.h
     URLHash.h
+    URLMatch.h
     URLParser.h
     UUID.h
     UnalignedAccess.h
@@ -574,6 +575,7 @@ set(WTF_SOURCES
     TimingScope.cpp
     URL.cpp
     URLHelpers.cpp
+    URLMatch.cpp
     URLParser.cpp
     UUID.cpp
     UniqueArray.cpp

--- a/Source/WTF/wtf/OptionSet.h
+++ b/Source/WTF/wtf/OptionSet.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <bit>
 #include <initializer_list>
 #include <iterator>
 #include <optional>
@@ -143,9 +144,19 @@ public:
             remove(optionSet);
     }
 
+    constexpr void clear()
+    {
+        m_storage = 0;
+    }
+
     constexpr bool hasExactlyOneBitSet() const
     {
         return m_storage && !(m_storage & (m_storage - 1));
+    }
+
+    constexpr size_t size() const
+    {
+        return std::popcount(m_storage);
     }
 
     constexpr std::optional<E> toSingleValue() const
@@ -181,7 +192,7 @@ public:
         return fromRaw(lhs.m_storage ^ rhs.m_storage);
     }
 
-    static OptionSet all() { return fromRaw(-1); }
+    constexpr static OptionSet all() { return fromRaw(-1); }
 
 private:
     enum InitializationTag { FromRawValue };

--- a/Source/WTF/wtf/URLMatch.cpp
+++ b/Source/WTF/wtf/URLMatch.cpp
@@ -1,0 +1,409 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/URLMatch.h>
+
+#include <wtf/ASCIICType.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringBuilder.h>
+
+namespace WTF {
+namespace URLMatch {
+
+static StringView trim(const StringView& str)
+{
+    return str.trim(isASCIIWhitespace<LChar>);
+}
+
+Expected<Vector<Rule>, Parser::Error> Parser::parse(StringView source)
+{
+    Vector<Rule> rules;
+    size_t lineNo = 1;
+
+    while (!source.isEmpty()) {
+        auto pos = source.find('\n');
+        auto line = (pos == notFound) ? source : source.substring(0, pos);
+        source = source.substring(pos + 1);
+
+        auto result = parseLine(line);
+        if (result.has_value())
+            rules.append(result.value());
+        else {
+            auto errorCode = result.error();
+            if (!canIgnoreError(errorCode))
+                return makeUnexpected(Error { errorCode, lineNo });
+        }
+        lineNo++;
+    }
+
+    return rules;
+}
+
+Expected<Rule, Parser::Error::Code>
+Parser::parseLine(StringView line)
+{
+    prepareOptionDetailsMap();
+
+    // Strip all leading and trailing whitespaces.
+    auto part = trim(line);
+    if (part.isEmpty() || part.startsWith('!'))
+        return makeUnexpected(Parser::Error::Code::Ignored);
+
+    // Suppose it is a CSS rule if a CSS-selector separator character ('#') is
+    // present, followed by '#' or '@'.
+    for (auto pos = part.find('#'); pos != notFound; pos = part.find('#', pos + 1)) {
+        if (pos + 2 >= part.length())
+            break;
+        if (auto nextChar = part[pos + 1]; nextChar == '#' || nextChar == '@')
+            return makeUnexpected(Parser::Error::Code::NotSupported);
+    }
+
+    Rule rule;
+
+    // Check whether it's an allowlist rule.
+    if (part.startsWith('@')) {
+        if (part.length() < 2 || part[1] != '@')
+            return makeUnexpected(Parser::Error::Code::InvalidRule);
+
+        part = part.substring(2);
+        if (part.isEmpty())
+            return makeUnexpected(Parser::Error::Code::InvalidRule);
+
+        rule.isException = true;
+    }
+
+    auto optionPos = part.reverseFind('$');
+    // If the URL pattern is a regular expression, |options_start| might be
+    // pointing to a character inside the pattern. This can happen for those rules
+    // which don't have options at all, e.g., "/.*substring$/". All such rules end
+    // with '/', therefore the following code can detect them to work around.
+    if (optionPos != notFound && part[part.length() - 1] == '/')
+        optionPos = notFound;
+
+    if (optionPos != notFound) {
+        auto errorCode = parseOptions(part.substring(optionPos + 1), rule);
+        if (errorCode != Error::Code::NoError && errorCode != Error::Code::NotSupported)
+            return makeUnexpected(errorCode);
+
+        part = part.substring(0, optionPos);
+        if (part.isEmpty())
+            return makeUnexpected(Parser::Error::Code::InvalidRule);
+    }
+
+    // Check for a left anchor.
+    if (part.startsWith('|')) {
+        if (part.length() >= 2 && part[1] == '|') {
+            part = part.substring(2);
+            if (part.isEmpty())
+                return makeUnexpected(Parser::Error::Code::InvalidRule);
+
+            rule.anchorLeft = Anchor::Subdomain;
+        } else {
+            part = part.substring(1);
+            if (part.isEmpty())
+                return makeUnexpected(Parser::Error::Code::InvalidRule);
+
+            rule.anchorLeft = Anchor::Boundary;
+        }
+    }
+
+    // Check for a right anchor.
+    if (part.endsWith('|')) {
+        part = part.substring(0, part.length() - 1);
+        if (part.isEmpty())
+            return makeUnexpected(Parser::Error::Code::InvalidRule);
+
+        rule.anchorRight = Anchor::Boundary;
+    }
+
+    rule.pattern = part.toString();
+
+    return rule;
+}
+
+Parser::Error::Code
+Parser::parseOptions(StringView part, Rule& rule)
+{
+    using Type = OptionDetails::Type;
+
+    if (part.isEmpty())
+        return Error::Code::NoError;
+
+    bool hasSeenElementOrActivationType = false;
+
+    for (auto piece : part.split(',')) {
+        piece = trim(piece);
+        if (piece.isEmpty())
+            return Error::Code::InvalidOption;
+
+        TriState state = TriState::Yes;
+        if (piece.startsWith('~')) {
+            state = TriState::No;
+            piece = piece.substring(1);
+        }
+
+        auto nameEnd = piece.find('=');
+        String optionName = piece.substring(0, nameEnd).toString();
+
+        const auto optionDetails = m_optionDetailsMap.get(optionName);
+        if (!optionDetails)
+            return Error::Code::InvalidOption;
+
+        if (state == TriState::No && !optionDetails->isTriState())
+            return Error::Code::NotTriStateOption;
+
+        if (optionDetails->requiresValue() && nameEnd == notFound)
+            return Error::Code::NoOptionValueProvided;
+
+        if (optionDetails->isAllowlistOnly() && !rule.isException)
+            return Error::Code::AllowlistOnlyOption;
+
+        if (optionDetails->isDeprecated() || optionDetails->isNotSupported())
+            return Error::Code::NotSupported;
+
+        switch (optionDetails->type) {
+        case Type::ElementType:
+            ASSERT(optionDetails->elementType);
+            // The sign of the first element type option encountered determines
+            // whether the unspecified element types will be included (if the first
+            // option is negated) or excluded (otherwise).
+            if (state == TriState::Yes) {
+                if (!hasSeenElementOrActivationType)
+                    rule.elementTypes.clear();
+                rule.elementTypes.add(optionDetails->elementType);
+            } else
+                rule.elementTypes.remove(optionDetails->elementType);
+            hasSeenElementOrActivationType = true;
+            break;
+
+        case Type::ActivationType:
+            if (!hasSeenElementOrActivationType) {
+                rule.elementTypes.clear();
+                rule.activationTypes.clear();
+                hasSeenElementOrActivationType = true;
+            }
+
+            ASSERT(optionDetails->activationType);
+            rule.activationTypes |= optionDetails->activationType.value();
+            break;
+
+        case Type::ThirdParty:
+            rule.isThirdParty = state;
+            break;
+
+        case Type::MatchCase:
+            rule.matchCase = true;
+            break;
+
+        case Type::Domain:
+            for (auto domain : piece.substring(nameEnd + 1).split('|'))
+                rule.domains.append(trim(domain).toString().foldCase());
+            break;
+
+        default:
+            return Error::Code::NotSupported;
+        }
+    }
+    return Error::Code::NoError;
+}
+
+using Type = OptionDetails::Type;
+using Flag = OptionDetails::Flag;
+
+constexpr static struct {
+    const char* name;
+    ElementType type;
+} const kElementTypes[] = {
+    { "other", ElementType::Other },
+    { "script", ElementType::Script },
+    { "image", ElementType::Image },
+    { "stylesheet", ElementType::Stylesheet },
+    { "object", ElementType::Object },
+    { "xmlhttprequest", ElementType::XMLHTTPRequest },
+    { "subdocument", ElementType::Subdocument },
+    { "ping", ElementType::Ping },
+    { "media", ElementType::Media },
+    { "font", ElementType::Font },
+    { "websocket", ElementType::WebSocket },
+    { "webrtc", ElementType::WebRTC },
+};
+
+// A mapping from deprecated element type names to active element types.
+constexpr static struct {
+    const char* name;
+    ElementType type;
+} const kDeprecatedElementTypes[] = {
+    { "background",  ElementType::Image },
+    { "xbl",  ElementType::Other },
+    { "dtd",  ElementType::Other },
+};
+
+// A list of items mapping activation type options to their names.
+constexpr static struct {
+    const char* name;
+    ActivationType type;
+} const kActivationTypes[] = {
+    { "document", ActivationType::Document },
+    { "elemhide", ActivationType::ElemHide },
+    { "generichide", ActivationType::GenericHide },
+    { "genericblock", ActivationType::GenericBlock },
+};
+
+constexpr static struct {
+    const char* name;
+    Type type;
+    OptionSet<Flag> flags;
+} const kOtherOptions[] = {
+    // Tristate options.
+    { "third-party", Type::ThirdParty, Flag::TriState },
+    { "collapse", Type::Collapse, { Flag::TriState, Flag::IsNotSupported } },
+    // Flag options.
+    { "match-case", Type::MatchCase, { } },
+    { "donottrack", Type::DoNotTrack, Flag::IsNotSupported },
+    { "popup", Type::Popup, Flag::IsDeprecated },
+    // Value options.
+    { "sitekey", Type::SiteKey, { Flag::RequiresValue, Flag::IsNotSupported } },
+    { "domain", Type::Domain, Flag::RequiresValue },
+};
+
+void Parser::prepareOptionDetailsMap()
+{
+    if (!m_optionDetailsMap.isEmpty())
+        return;
+
+    for (const auto& option : kElementTypes)
+        m_optionDetailsMap.add(String::fromLatin1(option.name), makeUnique<OptionDetails>(option.type, OptionSet<Flag>()));
+
+    for (const auto& option : kDeprecatedElementTypes)
+        m_optionDetailsMap.add(String::fromLatin1(option.name), makeUnique<OptionDetails>(option.type, Flag::IsDeprecated));
+
+    for (const auto& option : kActivationTypes)
+        m_optionDetailsMap.add(String::fromLatin1(option.name), makeUnique<OptionDetails>(option.type));
+
+    for (const auto& option : kOtherOptions)
+        m_optionDetailsMap.add(String::fromLatin1(option.name), makeUnique<OptionDetails>(option.type, option.flags));
+}
+
+bool Parser::canIgnoreError(Parser::Error::Code errorCode)
+{
+    switch (errorCode) {
+    case Error::Code::NoError:
+    case Error::Code::Ignored:
+    case Error::Code::NotSupported:
+        return true;
+    default:
+        break;
+    }
+    return false;
+}
+
+String Rule::toString() const
+{
+    StringBuilder builder;
+
+    if (isException)
+        builder.append("@@"_s);
+
+    if (anchorLeft == Anchor::Subdomain)
+        builder.append("||"_s);
+    else if (anchorLeft == Anchor::Boundary)
+        builder.append('|');
+
+    builder.append(pattern);
+
+    if (anchorRight == Anchor::Boundary)
+        builder.append('|');
+
+    Vector<String> options;
+
+    if (elementTypes != defaultElementTypes()) {
+        auto count = elementTypes.size();
+        bool showNegated = count >= (static_cast<size_t>(ElementType::Count) - count);
+        for (const auto& option : kElementTypes) {
+            bool isSet = elementTypes.contains(option.type);
+            auto name = String::fromLatin1(option.name);
+            if (showNegated) {
+                if (!isSet)
+                    options.append(makeString("~"_s, name));
+            } else {
+                if (isSet)
+                    options.append(name);
+            }
+        }
+    }
+
+    if (activationTypes) {
+        auto count = activationTypes.size();
+        bool showNegated = count >= (static_cast<size_t>(ActivationType::Count) - count);
+        for (const auto& option : kActivationTypes) {
+            bool isSet = activationTypes.contains(option.type);
+            auto name = String::fromLatin1(option.name);
+            if (showNegated) {
+                if (!isSet)
+                    options.append(makeString("~"_s, name));
+            } else {
+                if (isSet)
+                    options.append(name);
+            }
+        }
+    }
+
+    if (isThirdParty != TriState::DontCare)
+        options.append(isThirdParty == TriState::No ? "~third-party"_s : "third-party"_s);
+
+    if (matchCase)
+        options.append("match-case"_s);
+
+    if (!domains.isEmpty()) {
+        StringBuilder domainBuilder;
+        domainBuilder.append("domain"_s);
+
+        char separator = '=';
+        for (const auto& domain : domains) {
+            domainBuilder.append(separator);
+            domainBuilder.append(domain);
+            if (separator == '=')
+                separator = '|';
+        }
+
+        options.append(domainBuilder.toString());
+    }
+
+    if (!options.isEmpty()) {
+        builder.append('$');
+        builder.append(options[0]);
+
+        for (size_t i = 1; i < options.size(); ++i) {
+            builder.append(',');
+            builder.append(options[i]);
+        }
+    }
+
+    return builder.toString();
+}
+
+} // namespace URLMatch
+} // namespace WTF

--- a/Source/WTF/wtf/URLMatch.h
+++ b/Source/WTF/wtf/URLMatch.h
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <optional>
+#include <wtf/HashMap.h>
+#include <wtf/OptionSet.h>
+#include <wtf/URL.h>
+#include <wtf/Vector.h>
+#include <wtf/text/StringHash.h>
+#include <wtf/text/WTFString.h>
+
+namespace WTF {
+namespace URLMatch {
+
+// The types of subresource requests that a URL rule should be applied to.
+enum class ElementType : uint16_t {
+    Other = 1 << 0,
+    Script = 1 << 1,
+    Image = 1 << 2,
+    Stylesheet = 1 << 3,
+    Object = 1 << 4,
+    XMLHTTPRequest = 1 << 5,
+    Subdocument = 1 << 6,
+    Ping = 1 << 7,
+    Media = 1 << 8,
+    Font = 1 << 9,
+    WebSocket = 1 << 10,
+    WebRTC = 1 << 11,
+
+    Count = 12,
+    All = (1 << Count) - 1,
+    None = 0,
+};
+
+// The options controlling whether or not to activate filtering for subresources
+// of documents that match the URL pattern of the rule.
+// Note: Values are used as flags in a bitmask.
+enum class ActivationType : uint8_t {
+    // Disable all rules on the page.
+    Document = 1 << 0,
+    // Disable CSS rules on the page.
+    ElemHide = 1 << 1,
+    // Disable generic CSS rules on the page.
+    GenericHide = 1 << 2,
+    // Disable generic URL rules on the page.
+    GenericBlock = 1 << 3,
+
+    Count = 4,
+    All = (1 << Count) - 1,
+    None = 0,
+};
+
+enum class Anchor : uint8_t {
+    None,
+    Boundary,
+    Subdomain,
+};
+
+enum class TriState : uint8_t {
+    DontCare,
+    Yes,
+    No,
+};
+
+struct Rule final {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
+    String pattern;
+
+    // The list of domains to be included/excluded from the filter's affected set.
+    // If a particular string in the list starts with '~' then the respective
+    // domain is excluded, otherwise included. The list should be ordered by
+    // |CanonicalizeDomainList|.
+    Vector<String> domains;
+
+    // A bitmask that reflects what ElementType's to block/allow and what
+    // kinds of ActivationType's to associate this rule with.
+    OptionSet<ElementType> elementTypes { defaultElementTypes() };
+    OptionSet<ActivationType> activationTypes;
+
+    // This is an allowlist rule (aka rule-level exception).
+    bool isException { false };
+    // An anchor used at the beginning of the URL pattern.
+    Anchor anchorLeft { Anchor::None };
+    // The same for the end of the pattern. Never equals to ANCHOR_TYPE_SUBDOMAIN.
+    Anchor anchorRight { Anchor::None };
+    // Apply the filter only to addresses with matching case.
+    bool matchCase { false };
+    // Restriction to first-party/third-party requests.
+    TriState isThirdParty { TriState::DontCare };
+
+    bool isValid() const { return !pattern.isEmpty(); }
+    String toString() const;
+
+    constexpr static OptionSet<ElementType> defaultElementTypes()
+    {
+        return OptionSet<ElementType>::fromRaw(static_cast<uint16_t>(ElementType::All));
+    }
+};
+
+// Meta-information about an option represented by a certain keyword.
+struct OptionDetails final {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
+    enum class Type : uint8_t {
+        Undefined,
+        ElementType,
+        ActivationType,
+        ThirdParty,
+        Domain,
+        SiteKey,
+        MatchCase,
+        Collapse,
+        DoNotTrack,
+        Popup,
+    };
+
+    enum class Flag : uint8_t {
+        // The option requires a value, e.g. 'domain=example.org'.
+        RequiresValue = 1 << 0,
+        // The option allows invertion, e.g. 'image' and '~image'.
+        TriState = 1 << 1,
+        // The option can be used with allowlist rules only.
+        AllowlistOnly = 1 << 2,
+        // The option is not supposed to be used any more.
+        IsDeprecated = 1 << 3,
+        // The option is not supported yet.
+        IsNotSupported = 1 << 4,
+    };
+
+    // Creates an option that defines a filter for the specified |elementType|.
+    // In addition to the provided |flags|, FLAG_IS_TRISTATE will always be set
+    // by default.
+    OptionDetails(ElementType elementType, OptionSet<Flag> flags)
+        : type(Type::ElementType)
+        , flags(Flag::TriState | flags)
+        , elementType(elementType)
+    {
+    }
+
+    // Creates an ActivationType option.
+    explicit OptionDetails(ActivationType activationType)
+        : type(Type::ActivationType)
+        , flags(Flag::AllowlistOnly)
+        , activationType(activationType)
+    {
+    }
+
+    // Creates a generic option.
+    OptionDetails(Type type, OptionSet<Flag> flags)
+        : type(type)
+        , flags(flags)
+    {
+        ASSERT(type != Type::ElementType && type != Type::ActivationType);
+    }
+
+    bool isTriState() const { return flags.contains(Flag::TriState); }
+    bool requiresValue() const { return flags.contains(Flag::RequiresValue); }
+    bool isAllowlistOnly() const { return flags.contains(Flag::AllowlistOnly); }
+    bool isDeprecated() const { return flags.contains(Flag::IsDeprecated); }
+    bool isNotSupported() const { return flags.contains(Flag::IsNotSupported); }
+
+    Type type { Type::Undefined };
+    OptionSet<Flag> flags;
+    std::optional<ElementType> elementType;
+    std::optional<ActivationType> activationType;
+};
+
+class Parser final {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    Parser() = default;
+    ~Parser() = default;
+
+    struct Error final {
+        enum class Code : uint8_t {
+            NoError,
+            Ignored,
+            NotSupported,
+            InvalidRule,
+            InvalidOption,
+            NotTriStateOption,
+            NoOptionValueProvided,
+            AllowlistOnlyOption,
+        };
+
+        Code code { Code::NoError };
+        size_t line { 0 };
+    };
+
+    Expected<Vector<Rule>, Error> parse(StringView source);
+    Expected<Rule, Error::Code> parseLine(StringView line);
+    Error::Code parseOptions(StringView part, Rule&);
+
+private:
+    void prepareOptionDetailsMap();
+
+    static bool canIgnoreError(Error::Code);
+
+    HashMap<String, std::unique_ptr<OptionDetails>> m_optionDetailsMap;
+};
+
+} // namespace URLMatch
+} // namespace WTF
+
+namespace URLMatch = WTF::URLMatch;

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1268,6 +1268,7 @@
 		E5AA42F2259128AE00410A3D /* UserInterfaceIdiomUpdate.mm in Sources */ = {isa = PBXBuildFile; fileRef = E5AA42F1259128AE00410A3D /* UserInterfaceIdiomUpdate.mm */; };
 		E5AA8D1D25151CC60051CC45 /* DateInputTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E5AA8D1C25151CC60051CC45 /* DateInputTests.mm */; };
 		EB7067FC2CCC0E9900A94073 /* MixedContentChecker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB6836D32CC967E00073A8E5 /* MixedContentChecker.cpp */; };
+		EB7CE0FB2CF13C2200BECB13 /* URLMatch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB7CE0FA2CF13C2200BECB13 /* URLMatch.cpp */; };
 		EB9AD8C727646E7400D893A4 /* PushDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB9AD8C627646E7300D893A4 /* PushDatabase.cpp */; };
 		EBA75C49275ED7C700D6D31C /* PushMessageCrypto.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EBA75C48275ED7BE00D6D31C /* PushMessageCrypto.cpp */; };
 		ECA680CE1E68CC0900731D20 /* StringUtilities.mm in Sources */ = {isa = PBXBuildFile; fileRef = ECA680CD1E68CC0900731D20 /* StringUtilities.mm */; };
@@ -3636,6 +3637,7 @@
 		EB4D320727C045430081A8E4 /* TestNotificationProvider.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestNotificationProvider.cpp; sourceTree = "<group>"; };
 		EB4D320827C045440081A8E4 /* TestNotificationProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestNotificationProvider.h; sourceTree = "<group>"; };
 		EB6836D32CC967E00073A8E5 /* MixedContentChecker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MixedContentChecker.cpp; sourceTree = "<group>"; };
+		EB7CE0FA2CF13C2200BECB13 /* URLMatch.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = URLMatch.cpp; sourceTree = "<group>"; };
 		EB9AD8C627646E7300D893A4 /* PushDatabase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PushDatabase.cpp; sourceTree = "<group>"; };
 		EBA75C48275ED7BE00D6D31C /* PushMessageCrypto.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PushMessageCrypto.cpp; sourceTree = "<group>"; };
 		EBCD30F72B7C075F00268DA5 /* MemoryFootprintThreshold.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MemoryFootprintThreshold.mm; sourceTree = "<group>"; };
@@ -5719,6 +5721,7 @@
 				5C5E633D1D0B67940085A025 /* UniqueRef.cpp */,
 				3A1337AB28F9177600F29B73 /* UniqueRefVector.cpp */,
 				E3A1E78021B25B79008C6007 /* URL.cpp */,
+				EB7CE0FA2CF13C2200BECB13 /* URLMatch.cpp */,
 				E3A1E78421B25B91008C6007 /* URLParser.cpp */,
 				93C3647A2BDD8800006D8B55 /* UTF8Conversion.cpp */,
 				144D40EC221B46A7004B474F /* UUID.cpp */,
@@ -6819,6 +6822,7 @@
 				3A1337B328F9177600F29B73 /* UniqueRefVector.cpp in Sources */,
 				E3A1E78221B25B7A008C6007 /* URL.cpp in Sources */,
 				E3C21A7C21B25CA2003B31A3 /* URLExtras.mm in Sources */,
+				EB7CE0FB2CF13C2200BECB13 /* URLMatch.cpp in Sources */,
 				E3A1E78521B25B91008C6007 /* URLParser.cpp in Sources */,
 				93C3647B2BDD8800006D8B55 /* UTF8Conversion.cpp in Sources */,
 				7C83E03B1D0A602700FEBCF3 /* UtilitiesCocoa.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/OptionSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/OptionSet.cpp
@@ -494,4 +494,15 @@ TEST(WTF_OptionSet, HashSet)
     EXPECT_TRUE(hashSet.add({ ExampleFlags::A, ExampleFlags::B }).isNewEntry);
 }
 
+TEST(WTF_OptionSet, Size)
+{
+    OptionSet<ExampleFlags> a { ExampleFlags::A, ExampleFlags::B };
+    OptionSet<ExampleFlags> b;
+    static constexpr OptionSet<ExampleFlags> c { ExampleFlags::B };
+
+    EXPECT_EQ(a.size(), 2ul);
+    EXPECT_EQ(b.size(), 0ul);
+    EXPECT_EQ(c.size(), 1ul);
+}
+
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/URLMatch.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URLMatch.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2016 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/URLMatch.h>
+
+#include "Test.h"
+#include "WTFTestUtilities.h"
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringBuilder.h>
+
+namespace TestWebKitAPI {
+
+using namespace URLMatch;
+
+class WTF_URLMatch : public testing::Test {
+protected:
+    void CheckRule(const String& ruleString);
+
+    std::optional<Rule> tryParseRule(const String& ruleString)
+    {
+        auto result = parser.parseLine(ruleString);
+        if (!result)
+            return std::nullopt;
+        return result.value();
+    }
+
+    Rule parseRule(const String& ruleString)
+    {
+        auto result = parser.parseLine(ruleString);
+        return result ? result.value() : Rule();
+    }
+
+    URLMatch::Parser parser;
+};
+
+TEST_F(WTF_URLMatch, ParseLineSimple)
+{
+    auto rule = parseRule("example.com"_s);
+
+    EXPECT_EQ(rule.pattern, "example.com"_s);
+    EXPECT_EQ(rule.elementTypes, Rule::defaultElementTypes());
+    EXPECT_FALSE(rule.activationTypes);
+    EXPECT_TRUE(rule.domains.isEmpty());
+    EXPECT_FALSE(rule.isException);
+    EXPECT_EQ(rule.anchorLeft, Anchor::None);
+    EXPECT_EQ(rule.anchorRight, Anchor::None);
+    EXPECT_EQ(rule.isThirdParty, TriState::DontCare);
+    EXPECT_FALSE(rule.matchCase);
+}
+
+TEST_F(WTF_URLMatch, ParseMultipleLines)
+{
+    auto source = "||example.com\n@@||example.com/images/*$image\n\n!comment\n"_s;
+
+    auto result = parser.parse(source);
+    ASSERT_TRUE(result);
+
+    auto rules = result.value();
+    ASSERT_EQ(rules.size(), 2u);
+
+    EXPECT_EQ(rules[0].pattern, "example.com"_s);
+    EXPECT_FALSE(rules[0].isException);
+
+    EXPECT_EQ(rules[1].pattern, "example.com/images/*"_s);
+    EXPECT_TRUE(rules[1].isException);
+    EXPECT_TRUE(rules[1].elementTypes.contains(ElementType::Image));
+}
+
+TEST_F(WTF_URLMatch, ToStringSimple)
+{
+    URLMatch::Rule rule {
+        .pattern = "Movies"_s,
+        .isException = true,
+        .anchorLeft = Anchor::Boundary,
+        .anchorRight = Anchor::Boundary,
+        .matchCase = true,
+    };
+
+    rule.domains.append("example.com"_s);
+    rule.domains.append("example.net"_s);
+
+    EXPECT_EQ(rule.toString(), "@@|Movies|$match-case,domain=example.com|example.net"_s);
+}
+
+void WTF_URLMatch::CheckRule(const String& ruleString)
+{
+    auto rule = parseRule(ruleString);
+    ASSERT_TRUE(rule.isValid());
+
+    EXPECT_EQ(rule.toString(), ruleString);
+}
+
+TEST_F(WTF_URLMatch, ParseAndBackToString)
+{
+    CheckRule("||example.com^"_s);
+    CheckRule("Movies|$~third-party,domain=example.com"_s);
+    CheckRule("@@|Movies|$match-case,domain=example.com|example.net"_s);
+    CheckRule("||example.com/project/*.jpg$image"_s);
+    CheckRule("||example.com/project/*.jpg$~image"_s);
+    CheckRule("@@||example.com/project/index.html$document"_s);
+    CheckRule("@@||example.com/project/index.html$~script,document"_s);
+}
+
+}


### PR DESCRIPTION
#### d3094cc60a650663e22a51f2ff1d0d43be4a74eb
<pre>
[WTF] Add new class to test matching the URL with pattern.
<a href="https://bugs.webkit.org/show_bug.cgi?id=283632">https://bugs.webkit.org/show_bug.cgi?id=283632</a>
<a href="https://rdar.apple.com/137691088">rdar://137691088</a>

Reviewed by NOBODY (OOPS!).

Adding new utility class to test matching the URL with specific pattern.
This is the first patch to introduce the parser for the rule. Matcher will be following.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/OptionSet.h:
(WTF::OptionSet::clear):
(WTF::OptionSet::size const):
(WTF::OptionSet::all):
* Source/WTF/wtf/URLMatch.cpp: Added.
(WTF::URLMatch::trim):
(WTF::URLMatch::Parser::parse):
(WTF::URLMatch::Parser::parseLine):
(WTF::URLMatch::Parser::parseOptions):
(WTF::URLMatch::Parser::prepareOptionDetailsMap):
(WTF::URLMatch::Parser::canIgnoreError):
(WTF::URLMatch::Rule::toString const):
* Source/WTF/wtf/URLMatch.h: Added.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/OptionSet.cpp:
(TestWebKitAPI::TEST(WTF_OptionSet, Size)):
* Tools/TestWebKitAPI/Tests/WTF/URLMatch.cpp: Added.
(TestWebKitAPI::WTF_URLMatch::tryParseRule):
(TestWebKitAPI::WTF_URLMatch::parseRule):
(TestWebKitAPI::TEST_F(WTF_URLMatch, ParseLineSimple)):
(TestWebKitAPI::TEST_F(WTF_URLMatch, ParseMultipleLines)):
(TestWebKitAPI::TEST_F(WTF_URLMatch, ToStringSimple)):
(TestWebKitAPI::WTF_URLMatch::CheckRule):
(TestWebKitAPI::TEST_F(WTF_URLMatch, ParseAndBackToString)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3094cc60a650663e22a51f2ff1d0d43be4a74eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77968 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82616 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29225 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5296 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61055 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18984 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51050 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67274 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41357 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48413 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24497 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27569 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71112 "Found 6 new JSC stress test failures: stress/get-by-val-hoist-above-structure-2.js.ftl-no-cjit-no-inline-validate, stress/get-by-val-hoist-above-structure.js.ftl-eager-no-cjit-b3o1, stress/get-by-val-hoist-above-structure.js.ftl-no-cjit-small-pool, wasm.yaml/wasm/modules/wasm-imports-js-exports.js.wasm-no-cjit, wasm.yaml/wasm/modules/wasm-imports-js-exports.js.wasm-omg, wasm.yaml/wasm/stress/referenced-function.js.wasm-collect-continuously (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69506 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83978 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77203 "Found 3 new JSC stress test failures: stress/get-by-val-hoist-above-structure-2.js.eager-jettison-no-cjit, stress/get-by-val-hoist-above-structure-2.js.ftl-eager-no-cjit-b3o1, wasm.yaml/wasm/v8/regress/regress-824681.js.wasm-collect-continuously (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5335 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3607 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69274 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/77645 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68529 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12532 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10700 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/99516 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5283 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8036 "Build is in progress. Recent messages:") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21739 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5275 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8707 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7060 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->