### PR TITLE
Make more MessageReceivers RefCounted in the UIProcess

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -275,6 +275,7 @@ private:
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     Ref<RemoteSampleBufferDisplayLayerManager> protectedSampleBufferDisplayLayerManager() const;
     UserMediaCaptureManagerProxy& userMediaCaptureManagerProxy();
+    Ref<UserMediaCaptureManagerProxy> protectedUserMediaCaptureManagerProxy();
     RemoteAudioMediaStreamTrackRendererInternalUnitManager& audioMediaStreamTrackRendererInternalUnitManager();
 #endif
 
@@ -364,7 +365,7 @@ private:
 #endif
     PAL::SessionID m_sessionID;
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
-    std::unique_ptr<UserMediaCaptureManagerProxy> m_userMediaCaptureManagerProxy;
+    RefPtr<UserMediaCaptureManagerProxy> m_userMediaCaptureManagerProxy;
     std::unique_ptr<RemoteAudioMediaStreamTrackRendererInternalUnitManager> m_audioMediaStreamTrackRendererInternalUnitManager;
     bool m_isLastToCaptureAudio { false };
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1380,7 +1380,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _allowsBackForwardNavigationGestures = allowsBackForwardNavigationGestures;
 
     if (allowsBackForwardNavigationGestures && !_gestureController) {
-        _gestureController = makeUnique<WebKit::ViewGestureController>(*_page);
+        _gestureController = WebKit::ViewGestureController::create(*_page);
         _gestureController->installSwipeHandler(self, [self scrollView]);
         if (WKWebView *alternateWebView = [_configuration _alternateWebViewForNavigationGestures])
             _gestureController->setAlternateBackForwardListSourcePage(alternateWebView->_page.get());

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -274,7 +274,7 @@ struct PerWebProcessState {
 #if PLATFORM(IOS_FAMILY)
     RetainPtr<WKScrollView> _scrollView;
     RetainPtr<WKContentView> _contentView;
-    std::unique_ptr<WebKit::ViewGestureController> _gestureController;
+    RefPtr<WebKit::ViewGestureController> _gestureController;
     Vector<BlockPtr<void ()>> _visibleContentRectUpdateCallbacks;
     RetainPtr<WKWebViewContentProviderRegistry> _contentProviderRegistry;
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -359,7 +359,7 @@ struct _WebKitWebViewBasePrivate {
 #endif
 
     GtkGesture* touchGestureGroup;
-    std::unique_ptr<ViewGestureController> viewGestureController;
+    RefPtr<ViewGestureController> viewGestureController;
     bool isBackForwardNavigationGestureEnabled { false };
 
 #if GTK_CHECK_VERSION(3, 24, 0)
@@ -2945,7 +2945,7 @@ void webkitWebViewBaseDidRelaunchWebProcess(WebKitWebViewBase* webkitWebViewBase
     if (priv->viewGestureController)
         priv->viewGestureController->connectToProcess();
     else {
-        priv->viewGestureController = makeUnique<WebKit::ViewGestureController>(*priv->pageProxy);
+        priv->viewGestureController = WebKit::ViewGestureController::create(*priv->pageProxy);
         priv->viewGestureController->setSwipeGestureEnabled(priv->isBackForwardNavigationGestureEnabled);
     }
     if (priv->displayID)

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -462,6 +462,11 @@ private:
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(UserMediaCaptureManagerProxy);
 
+Ref<UserMediaCaptureManagerProxy> UserMediaCaptureManagerProxy::create(UniqueRef<ConnectionProxy>&& connectionProxy)
+{
+    return adoptRef(*new UserMediaCaptureManagerProxy(WTFMove(connectionProxy)));
+}
+
 UserMediaCaptureManagerProxy::UserMediaCaptureManagerProxy(UniqueRef<ConnectionProxy>&& connectionProxy)
     : m_connectionProxy(WTFMove(connectionProxy))
 {

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
@@ -56,7 +56,7 @@ namespace WebKit {
 class WebProcessProxy;
 class UserMediaCaptureManagerProxySourceProxy;
 
-class UserMediaCaptureManagerProxy : public IPC::MessageReceiver {
+class UserMediaCaptureManagerProxy : public IPC::MessageReceiver, public RefCounted<UserMediaCaptureManagerProxy> {
     WTF_MAKE_TZONE_ALLOCATED(UserMediaCaptureManagerProxy);
 public:
     class ConnectionProxy {
@@ -83,7 +83,7 @@ public:
         virtual void startMonitoringCaptureDeviceRotation(WebCore::PageIdentifier, const String&) { }
         virtual void stopMonitoringCaptureDeviceRotation(WebCore::PageIdentifier, const String&) { }
     };
-    explicit UserMediaCaptureManagerProxy(UniqueRef<ConnectionProxy>&&);
+    static Ref<UserMediaCaptureManagerProxy> create(UniqueRef<ConnectionProxy>&&);
     ~UserMediaCaptureManagerProxy();
 
     void close();
@@ -98,6 +98,8 @@ public:
     bool hasSourceProxies() const;
 
 private:
+    explicit UserMediaCaptureManagerProxy(UniqueRef<ConnectionProxy>&&);
+
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in
@@ -23,7 +23,7 @@
 
 #if ENABLE(MEDIA_STREAM)
 
-messages -> UserMediaCaptureManagerProxy NotRefCounted {
+messages -> UserMediaCaptureManagerProxy {
     CreateMediaSourceForCaptureDeviceWithConstraints(WebCore::RealtimeMediaSourceIdentifier id, WebCore::CaptureDevice device, struct WebCore::MediaDeviceHashSalts hashSalts, struct WebCore::MediaConstraints constraints, bool shouldUseGPUProcessRemoteFrames, WebCore::PageIdentifier pageIdentifier) -> (struct WebCore::CaptureSourceError error, WebCore::RealtimeMediaSourceSettings settings, WebCore::RealtimeMediaSourceCapabilities capabilities) Async
     StartProducingData(WebCore::RealtimeMediaSourceIdentifier id, WebCore::PageIdentifier pageIdentifier)
     StopProducingData(WebCore::RealtimeMediaSourceIdentifier id)

--- a/Source/WebKit/UIProcess/DigitalCredentials/DigitalCredentialsCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/DigitalCredentials/DigitalCredentialsCoordinatorProxy.cpp
@@ -38,27 +38,28 @@
 namespace WebKit {
 using namespace WebCore;
 
+Ref<DigitalCredentialsCoordinatorProxy> DigitalCredentialsCoordinatorProxy::create(WebPageProxy& page)
+{
+    return adoptRef(*new DigitalCredentialsCoordinatorProxy(page));
+}
+
 DigitalCredentialsCoordinatorProxy::DigitalCredentialsCoordinatorProxy(WebPageProxy& page)
     : m_page(page)
 {
-    Ref pageRef = m_page.get();
-    pageRef->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::DigitalCredentialsCoordinatorProxy::messageReceiverName(), pageRef->webPageIDInMainFrameProcess(), *this);
+    page.protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::DigitalCredentialsCoordinatorProxy::messageReceiverName(), page.webPageIDInMainFrameProcess(), *this);
 }
 
 DigitalCredentialsCoordinatorProxy::~DigitalCredentialsCoordinatorProxy()
 {
-    Ref page = m_page.get();
-    page->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::DigitalCredentialsCoordinatorProxy::messageReceiverName(), page->webPageIDInMainFrameProcess());
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::DigitalCredentialsCoordinatorProxy::messageReceiverName(), page->webPageIDInMainFrameProcess());
 }
 
 std::optional<SharedPreferencesForWebProcess> DigitalCredentialsCoordinatorProxy::sharedPreferencesForWebProcess() const
 {
-    return protectedPage()->protectedLegacyMainFrameProcess()->sharedPreferencesForWebProcess();
-}
-
-Ref<WebPageProxy> DigitalCredentialsCoordinatorProxy::protectedPage() const
-{
-    return m_page.get();
+    if (RefPtr page = m_page.get())
+        return page->protectedLegacyMainFrameProcess()->sharedPreferencesForWebProcess();
+    return std::nullopt;
 }
 
 void DigitalCredentialsCoordinatorProxy::requestDigitalCredential(FrameIdentifier frameId, FrameInfoData&& frameInfo, DigitalCredentialRequestOptions&& options, DigitalRequestCompletionHandler&& handler)

--- a/Source/WebKit/UIProcess/DigitalCredentials/DigitalCredentialsCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/DigitalCredentials/DigitalCredentialsCoordinatorProxy.h
@@ -49,17 +49,18 @@ struct FrameInfoData;
 // we are just initially handling exceptions as we build this out.
 using DigitalRequestCompletionHandler = CompletionHandler<void(const WebCore::ExceptionData&)>;
 
-class DigitalCredentialsCoordinatorProxy final : public IPC::MessageReceiver {
+class DigitalCredentialsCoordinatorProxy final : public IPC::MessageReceiver, public RefCounted<DigitalCredentialsCoordinatorProxy> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(DigitalCredentialsCoordinatorProxy);
-
 public:
-    explicit DigitalCredentialsCoordinatorProxy(WebPageProxy&);
+    static Ref<DigitalCredentialsCoordinatorProxy> create(WebPageProxy&);
     ~DigitalCredentialsCoordinatorProxy();
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
 private:
+    explicit DigitalCredentialsCoordinatorProxy(WebPageProxy&);
+
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
@@ -67,9 +68,7 @@ private:
     void requestDigitalCredential(WebCore::FrameIdentifier, FrameInfoData&&, WebCore::DigitalCredentialRequestOptions&&, DigitalRequestCompletionHandler&&);
     void cancel(CompletionHandler<void()>&&);
 
-    Ref<WebPageProxy> protectedPage() const;
-
-    WeakRef<WebPageProxy> m_page;
+    WeakPtr<WebPageProxy> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/DigitalCredentials/DigitalCredentialsCoordinatorProxy.messages.in
+++ b/Source/WebKit/UIProcess/DigitalCredentials/DigitalCredentialsCoordinatorProxy.messages.in
@@ -25,7 +25,7 @@
 #if ENABLE(WEB_AUTHN)
 
 [EnabledBy=WebAuthenticationEnabled]
-messages -> DigitalCredentialsCoordinatorProxy NotRefCounted {
+messages -> DigitalCredentialsCoordinatorProxy {
     RequestDigitalCredential(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, struct WebCore::DigitalCredentialRequestOptions options) -> (struct WebCore::ExceptionData exception)
     Cancel() -> ()
 }

--- a/Source/WebKit/UIProcess/ViewGestureController.messages.in
+++ b/Source/WebKit/UIProcess/ViewGestureController.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> ViewGestureController NotRefCounted {
+messages -> ViewGestureController {
 #if PLATFORM(MAC)
     DidCollectGeometryForSmartMagnificationGesture(WebCore::FloatPoint origin, WebCore::FloatRect renderRect, WebCore::FloatRect visibleContentBounds, bool fitEntireRect, double viewportMinimumScale, double viewportMaximumScale)
 #endif

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -82,11 +82,11 @@ public:
     virtual void unlockFullscreenOrientation() { }
 };
 
-class WebFullScreenManagerProxy : public IPC::MessageReceiver, public CanMakeCheckedPtr<WebFullScreenManagerProxy> {
+class WebFullScreenManagerProxy : public IPC::MessageReceiver, public CanMakeCheckedPtr<WebFullScreenManagerProxy>, public RefCounted<WebFullScreenManagerProxy> {
     WTF_MAKE_TZONE_ALLOCATED(WebFullScreenManagerProxy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebFullScreenManagerProxy);
 public:
-    WebFullScreenManagerProxy(WebPageProxy&, WebFullScreenManagerProxyClient&);
+    static Ref<WebFullScreenManagerProxy> create(WebPageProxy&, WebFullScreenManagerProxyClient&);
     virtual ~WebFullScreenManagerProxy();
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
@@ -125,7 +125,7 @@ public:
     void unlockFullscreenOrientation();
 
 private:
-    Ref<WebPageProxy> protectedPage() const;
+    WebFullScreenManagerProxy(WebPageProxy&, WebFullScreenManagerProxyClient&);
 
     void supportsFullScreen(bool withKeyboard, CompletionHandler<void(bool)>&&);
     void enterFullScreen(bool blocksReturnToFullscreenFromPictureInPicture, FullScreenMediaDetails&&);
@@ -147,8 +147,8 @@ private:
     WTFLogChannel& logChannel() const;
 #endif
 
-    WeakRef<WebPageProxy> m_page;
-    CheckedRef<WebFullScreenManagerProxyClient> m_client;
+    WeakPtr<WebPageProxy> m_page;
+    CheckedPtr<WebFullScreenManagerProxyClient> m_client;
     FullscreenState m_fullscreenState { FullscreenState::NotInFullscreen };
     bool m_blocksReturnToFullscreenFromPictureInPicture { false };
 #if ENABLE(VIDEO_USES_ELEMENT_FULLSCREEN)

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(FULLSCREEN_API)
 [EnabledBy=FullScreenEnabled || VideoFullscreenRequiresElementFullscreen]
-messages -> WebFullScreenManagerProxy NotRefCounted {
+messages -> WebFullScreenManagerProxy {
     SupportsFullScreen(bool withKeyboard) -> (bool supportsFullScreen) Synchronous
     EnterFullScreen(bool blocksReturnToFullscreenFromPictureInPicture, struct WebKit::FullScreenMediaDetails mediaDetails)
 #if ENABLE(QUICKLOOK_FULLSCREEN)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1495,7 +1495,7 @@ void WebPageProxy::didAttachToRunningProcess()
 
 #if ENABLE(FULLSCREEN_API)
     ASSERT(!m_fullScreenManager);
-    m_fullScreenManager = makeUnique<WebFullScreenManagerProxy>(*this, protectedPageClient()->fullScreenManagerProxyClient());
+    m_fullScreenManager = WebFullScreenManagerProxy::create(*this, protectedPageClient()->fullScreenManagerProxyClient());
 #endif
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     ASSERT(!m_playbackSessionManager);
@@ -1528,12 +1528,12 @@ void WebPageProxy::didAttachToRunningProcess()
     m_webAuthnCredentialsMessenger = WebAuthenticatorCoordinatorProxy::create(*this);
 
     ASSERT(!m_digitalCredentialsMessenger);
-    m_digitalCredentialsMessenger = makeUnique<DigitalCredentialsCoordinatorProxy>(*this);
+    m_digitalCredentialsMessenger = DigitalCredentialsCoordinatorProxy::create(*this);
 #endif
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
     ASSERT(!m_webDeviceOrientationUpdateProviderProxy);
-    m_webDeviceOrientationUpdateProviderProxy = makeUnique<WebDeviceOrientationUpdateProviderProxy>(*this);
+    m_webDeviceOrientationUpdateProviderProxy = WebDeviceOrientationUpdateProviderProxy::create(*this);
 #endif
 
 #if !PLATFORM(IOS_FAMILY)
@@ -1541,7 +1541,7 @@ void WebPageProxy::didAttachToRunningProcess()
 #else
     auto currentOrientation = toScreenOrientationType(m_deviceOrientation);
 #endif
-    m_screenOrientationManager = makeUnique<WebScreenOrientationManagerProxy>(*this, currentOrientation);
+    m_screenOrientationManager = WebScreenOrientationManagerProxy::create(*this, currentOrientation);
 
 #if ENABLE(WEBXR) && !USE(OPENXR)
     ASSERT(!internals().xrSystem);
@@ -11971,8 +11971,7 @@ void WebPageProxy::rotationAngleForCaptureDeviceChanged(const String& persistent
     }
 #endif // ENABLE(GPU_PROCESS)
 
-    if (auto* proxy = protectedLegacyMainFrameProcess()->userMediaCaptureManagerProxy())
-        proxy->rotationAngleForCaptureDeviceChanged(persistentId, rotation);
+    protectedLegacyMainFrameProcess()->protectedUserMediaCaptureManagerProxy()->rotationAngleForCaptureDeviceChanged(persistentId, rotation);
 #endif // HAVE(AVCAPTUREDEVICEROTATIONCOORDINATOR)
 }
 #endif // ENABLE(MEDIA_STREAM)
@@ -14449,8 +14448,7 @@ void WebPageProxy::setOrientationForMediaCapture(WebCore::IntDegrees orientation
 
 #if ENABLE(MEDIA_STREAM)
 #if PLATFORM(COCOA)
-    if (auto* proxy = m_legacyMainFrameProcess->userMediaCaptureManagerProxy())
-        proxy->setOrientation(orientation);
+    m_legacyMainFrameProcess->protectedUserMediaCaptureManagerProxy()->setOrientation(orientation);
 
     RefPtr gpuProcess = m_legacyMainFrameProcess->processPool().gpuProcess();
     if (gpuProcess && preferences().captureVideoInGPUProcessEnabled())

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3327,7 +3327,7 @@ private:
     RefPtr<WebInspectorUIProxy> m_inspector;
 
 #if ENABLE(FULLSCREEN_API)
-    std::unique_ptr<WebFullScreenManagerProxy> m_fullScreenManager;
+    RefPtr<WebFullScreenManagerProxy> m_fullScreenManager;
     std::unique_ptr<API::FullscreenClient> m_fullscreenClient;
 #endif
 
@@ -3367,7 +3367,7 @@ private:
 #endif
 
 #if ENABLE(WEB_AUTHN)
-    std::unique_ptr<DigitalCredentialsCoordinatorProxy> m_digitalCredentialsMessenger;
+    RefPtr<DigitalCredentialsCoordinatorProxy> m_digitalCredentialsMessenger;
     RefPtr<WebAuthenticatorCoordinatorProxy> m_webAuthnCredentialsMessenger;
 #endif
 
@@ -3699,10 +3699,10 @@ private:
     Vector<InjectedBundleMessage> m_pendingInjectedBundleMessages;
         
 #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
-    std::unique_ptr<WebDeviceOrientationUpdateProviderProxy> m_webDeviceOrientationUpdateProviderProxy;
+    RefPtr<WebDeviceOrientationUpdateProviderProxy> m_webDeviceOrientationUpdateProviderProxy;
 #endif
 
-    std::unique_ptr<WebScreenOrientationManagerProxy> m_screenOrientationManager;
+    RefPtr<WebScreenOrientationManagerProxy> m_screenOrientationManager;
 
 #if ENABLE(APP_BOUND_DOMAINS)
     std::optional<NavigatingToAppBoundDomain> m_isNavigatingToAppBoundDomain;

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.h
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.h
@@ -66,6 +66,10 @@ public:
     void addWebProcessProxy(WebProcessProxy&);
     void removeWebProcessProxy(WebProcessProxy&);
 
+    // Do nothing since this is a singleton.
+    void ref() const { }
+    void deref() const { }
+
 #if PLATFORM(COCOA)
     void revokeAccess(WebProcessProxy&);
     std::optional<IPC::AsyncReplyID> grantAccessToCurrentData(WebProcessProxy&, const String& pasteboardName, CompletionHandler<void()>&&);

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> WebPasteboardProxy NotRefCounted {
+messages -> WebPasteboardProxy {
 #if PLATFORM(IOS_FAMILY)
     WriteURLToPasteboard(struct WebCore::PasteboardURL url, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID)
     WriteWebContentToPasteboard(struct WebCore::PasteboardWebContent content, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID)

--- a/Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp
@@ -55,6 +55,16 @@ WebPermissionControllerProxy::~WebPermissionControllerProxy()
     protectedProcess()->removeMessageReceiver(Messages::WebPermissionControllerProxy::messageReceiverName());
 }
 
+void WebPermissionControllerProxy::ref() const
+{
+    m_process->ref();
+}
+
+void WebPermissionControllerProxy::deref() const
+{
+    m_process->deref();
+}
+
 Ref<WebProcessProxy> WebPermissionControllerProxy::protectedProcess() const
 {
     return m_process.get();

--- a/Source/WebKit/UIProcess/WebPermissionControllerProxy.h
+++ b/Source/WebKit/UIProcess/WebPermissionControllerProxy.h
@@ -52,6 +52,9 @@ public:
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
+    void ref() const;
+    void deref() const;
+
 private:
     RefPtr<WebPageProxy> mostReasonableWebPageProxy(const WebCore::SecurityOriginData&, WebCore::PermissionQuerySource) const;
 

--- a/Source/WebKit/UIProcess/WebPermissionControllerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPermissionControllerProxy.messages.in
@@ -23,6 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-messages -> WebPermissionControllerProxy NotRefCounted {
+messages -> WebPermissionControllerProxy {
     Query(struct WebCore::ClientOrigin origin, struct WebCore::PermissionDescriptor descriptor, std::optional<WebKit::WebPageProxyIdentifier> identifier, enum:uint8_t WebCore::PermissionQuerySource source) -> (std::optional<WebCore::PermissionState> state)
 }

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -430,7 +430,8 @@ public:
     void setThrottleStateForTesting(ProcessThrottleState);
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
-    UserMediaCaptureManagerProxy* userMediaCaptureManagerProxy() { return m_userMediaCaptureManagerProxy.get(); }
+    UserMediaCaptureManagerProxy& userMediaCaptureManagerProxy() { return m_userMediaCaptureManagerProxy.get(); }
+    Ref<UserMediaCaptureManagerProxy> protectedUserMediaCaptureManagerProxy();
 #endif
 
 #if ENABLE(GPU_PROCESS)
@@ -731,7 +732,7 @@ private:
     SystemMemoryPressureStatus m_memoryPressureStatus { SystemMemoryPressureStatus::Normal };
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
-    std::unique_ptr<UserMediaCaptureManagerProxy> m_userMediaCaptureManagerProxy;
+    const Ref<UserMediaCaptureManagerProxy> m_userMediaCaptureManagerProxy;
 #endif
 
     bool m_hasCommittedAnyProvisionalLoads { false };
@@ -786,7 +787,7 @@ private:
     std::unique_ptr<SpeechRecognitionRemoteRealtimeMediaSourceManager> m_speechRecognitionRemoteRealtimeMediaSourceManager;
 #endif
     std::unique_ptr<WebLockRegistryProxy> m_webLockRegistry;
-    std::unique_ptr<WebPermissionControllerProxy> m_webPermissionController;
+    UniqueRef<WebPermissionControllerProxy> m_webPermissionController;
 #if ENABLE(ROUTING_ARBITRATION)
     std::unique_ptr<AudioSessionRoutingArbitratorProxy> m_routingArbitrator;
 #endif

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
@@ -41,6 +41,11 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebScreenOrientationManagerProxy);
 
+Ref<WebScreenOrientationManagerProxy> WebScreenOrientationManagerProxy::create(WebPageProxy& page, WebCore::ScreenOrientationType orientation)
+{
+    return adoptRef(*new WebScreenOrientationManagerProxy(page, orientation));
+}
+
 WebScreenOrientationManagerProxy::WebScreenOrientationManagerProxy(WebPageProxy& page, WebCore::ScreenOrientationType orientation)
     : m_page(page)
     , m_currentOrientation(orientation)

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
@@ -40,10 +40,10 @@ namespace WebKit {
 class WebPageProxy;
 struct SharedPreferencesForWebProcess;
 
-class WebScreenOrientationManagerProxy final : public IPC::MessageReceiver {
+class WebScreenOrientationManagerProxy final : public IPC::MessageReceiver, public RefCounted<WebScreenOrientationManagerProxy> {
     WTF_MAKE_TZONE_ALLOCATED(WebScreenOrientationManagerProxy);
 public:
-    WebScreenOrientationManagerProxy(WebPageProxy&, WebCore::ScreenOrientationType);
+    static Ref<WebScreenOrientationManagerProxy> create(WebPageProxy&, WebCore::ScreenOrientationType);
     ~WebScreenOrientationManagerProxy();
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
@@ -56,6 +56,8 @@ public:
     void setCurrentOrientation(WebCore::ScreenOrientationType);
 
 private:
+    WebScreenOrientationManagerProxy(WebPageProxy&, WebCore::ScreenOrientationType);
+
     std::optional<WebCore::Exception> platformShouldRejectLockRequest() const;
 
     // IPC message handlers.

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.messages.in
@@ -24,7 +24,7 @@
  */
 
 [EnabledBy=ScreenOrientationAPIEnabled]
-messages -> WebScreenOrientationManagerProxy NotRefCounted {
+messages -> WebScreenOrientationManagerProxy {
     CurrentOrientation() -> (enum:uint8_t WebCore::ScreenOrientationType orientation) Synchronous
     Lock(enum:uint8_t WebCore::ScreenOrientationLockType orientation) -> (std::optional<WebCore::Exception> exception)
     Unlock()

--- a/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
@@ -337,7 +337,10 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
 {
     ASSERT(targetItem);
 
-    Ref webPageProxy = m_webPageProxy.get();
+    RefPtr webPageProxy = m_webPageProxy.get();
+    if (!webPageProxy)
+        return;
+
     webPageProxy->navigationGestureDidBegin();
 
     willBeginGesture(ViewGestureType::Swipe);
@@ -425,7 +428,8 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
 
 void ViewGestureController::handleSwipeGesture(WebBackForwardListItem*, double, SwipeDirection)
 {
-    gtk_widget_queue_draw(protectedWebPageProxy()->viewWidget());
+    if (RefPtr page = m_webPageProxy.get())
+        gtk_widget_queue_draw(page->viewWidget());
 }
 
 void ViewGestureController::cancelSwipe()
@@ -443,7 +447,10 @@ void ViewGestureController::snapshot(GtkSnapshot* snapshot, GskRenderNode* pageR
 {
     bool swipingLeft = isPhysicallySwipingLeft(m_swipeProgressTracker.direction());
     bool swipingBack = m_swipeProgressTracker.direction() == SwipeDirection::Back;
-    Ref webPageProxy = m_webPageProxy.get();
+    RefPtr webPageProxy = m_webPageProxy.get();
+    if (!webPageProxy)
+        return;
+
     bool isRTL = webPageProxy->userInterfaceLayoutDirection() == WebCore::UserInterfaceLayoutDirection::RTL;
     float progress = m_swipeProgressTracker.progress();
 
@@ -523,7 +530,10 @@ void ViewGestureController::draw(cairo_t* cr, cairo_pattern_t* pageGroup)
 {
     bool swipingLeft = isPhysicallySwipingLeft(m_swipeProgressTracker.direction());
     bool swipingBack = m_swipeProgressTracker.direction() == SwipeDirection::Back;
-    Ref webPageProxy = m_webPageProxy.get();
+    RefPtr webPageProxy = m_webPageProxy.get();
+    if (!webPageProxy)
+        return;
+
     bool isRTL = webPageProxy->userInterfaceLayoutDirection() == WebCore::UserInterfaceLayoutDirection::RTL;
     float progress = m_swipeProgressTracker.progress();
 
@@ -631,7 +641,8 @@ void ViewGestureController::removeSwipeSnapshot()
 
     m_currentSwipeSnapshot = nullptr;
 
-    protectedWebPageProxy()->navigationGestureSnapshotWasRemoved();
+    if (RefPtr page = m_webPageProxy.get())
+        page->navigationGestureSnapshotWasRemoved();
 
     m_backgroundColorForCurrentSnapshot = Color();
 
@@ -683,7 +694,10 @@ void ViewGestureController::setMagnification(double scale, FloatPoint origin)
 
     willBeginGesture(ViewGestureType::Magnification);
 
-    Ref webPageProxy = m_webPageProxy.get();
+    RefPtr webPageProxy = m_webPageProxy.get();
+    if (!webPageProxy)
+        return;
+
     auto minMagnification = webPageProxy->minPageZoomFactor();
     auto maxMagnification = webPageProxy->maxPageZoomFactor();
 

--- a/Source/WebKit/UIProcess/ios/SmartMagnificationController.h
+++ b/Source/WebKit/UIProcess/ios/SmartMagnificationController.h
@@ -39,11 +39,11 @@ namespace WebKit {
 
 class WebPageProxy;
 
-class SmartMagnificationController : private IPC::MessageReceiver {
+class SmartMagnificationController : private IPC::MessageReceiver, public RefCounted<SmartMagnificationController> {
     WTF_MAKE_TZONE_ALLOCATED(SmartMagnificationController);
     WTF_MAKE_NONCOPYABLE(SmartMagnificationController);
 public:
-    SmartMagnificationController(WKContentView *);
+    static Ref<SmartMagnificationController> create(WKContentView *);
     ~SmartMagnificationController();
 
     void handleSmartMagnificationGesture(WebCore::FloatPoint origin);
@@ -52,6 +52,8 @@ public:
     double zoomFactorForTargetRect(WebCore::FloatRect targetRect, bool fitEntireRect, double viewportMinimumScale, double viewportMaximumScale);
 
 private:
+    explicit SmartMagnificationController(WKContentView *);
+
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
@@ -59,7 +61,7 @@ private:
     void scrollToRect(WebCore::FloatPoint origin, WebCore::FloatRect targetRect);
     std::tuple<WebCore::FloatRect, double, double> smartMagnificationTargetRectAndZoomScales(WebCore::FloatRect targetRect, double minimumScale, double maximumScale, bool addMagnificationPadding);
 
-    WeakRef<WebPageProxy> m_webPageProxy;
+    WeakPtr<WebPageProxy> m_webPageProxy;
     WKContentView *m_contentView;
 };
     

--- a/Source/WebKit/UIProcess/ios/SmartMagnificationController.messages.in
+++ b/Source/WebKit/UIProcess/ios/SmartMagnificationController.messages.in
@@ -22,7 +22,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
-messages -> SmartMagnificationController NotRefCounted {
+messages -> SmartMagnificationController {
     DidCollectGeometryForSmartMagnificationGesture(WebCore::FloatPoint origin, WebCore::FloatRect renderRect, WebCore::FloatRect visibleContentBounds, bool fitEntireRect, double viewportMinimumScale, double viewportMaximumScale)
     ScrollToRect(WebCore::FloatPoint origin, WebCore::FloatRect targetRect)
 }

--- a/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
@@ -176,12 +176,16 @@ void ViewGestureController::beginSwipeGesture(_UINavigationInteractiveTransition
     if (m_activeGestureType != ViewGestureType::None)
         return;
 
+    RefPtr page = m_webPageProxy.get();
+    if (!page)
+        return;
+
     willBeginGesture(ViewGestureType::Swipe);
 
-    m_webPageProxy->recordAutomaticNavigationSnapshot();
+    page->recordAutomaticNavigationSnapshot();
 
     RefPtr<WebPageProxy> alternateBackForwardListSourcePage = m_alternateBackForwardListSourcePage.get();
-    m_webPageProxyForBackForwardListForCurrentSwipe = alternateBackForwardListSourcePage ? alternateBackForwardListSourcePage.get() : m_webPageProxy.ptr();
+    m_webPageProxyForBackForwardListForCurrentSwipe = alternateBackForwardListSourcePage ? alternateBackForwardListSourcePage.get() : page.get();
 
     auto& backForwardList = m_webPageProxyForBackForwardListForCurrentSwipe->backForwardList();
     RefPtr targetItem = direction == SwipeDirection::Back ? backForwardList.goBackItemSkippingItemsWithoutUserGesture() : backForwardList.goForwardItemSkippingItemsWithoutUserGesture();
@@ -192,13 +196,13 @@ void ViewGestureController::beginSwipeGesture(_UINavigationInteractiveTransition
     }
 
     m_webPageProxyForBackForwardListForCurrentSwipe->navigationGestureDidBegin();
-    if (m_webPageProxy.ptr() != m_webPageProxyForBackForwardListForCurrentSwipe)
-        m_webPageProxy->navigationGestureDidBegin();
+    if (page.get() != m_webPageProxyForBackForwardListForCurrentSwipe)
+        page->navigationGestureDidBegin();
 
     // Copy the snapshot from this view to the one that owns the back forward list, so that
     // swiping forward will have the correct snapshot.
-    if (m_webPageProxyForBackForwardListForCurrentSwipe != m_webPageProxy.ptr()) {
-        if (auto* currentViewHistoryItem = m_webPageProxy->backForwardList().currentItem())
+    if (m_webPageProxyForBackForwardListForCurrentSwipe != page.get()) {
+        if (auto* currentViewHistoryItem = page->backForwardList().currentItem())
             backForwardList.currentItem()->setSnapshot(currentViewHistoryItem->snapshot());
     }
 
@@ -215,12 +219,12 @@ void ViewGestureController::beginSwipeGesture(_UINavigationInteractiveTransition
 
     RetainPtr<UIColor> backgroundColor = [UIColor whiteColor];
     if (ViewSnapshot* snapshot = targetItem->snapshot()) {
-        float deviceScaleFactor = m_webPageProxy->deviceScaleFactor();
+        float deviceScaleFactor = page->deviceScaleFactor();
         WebCore::FloatSize swipeLayerSizeInDeviceCoordinates(liveSwipeViewFrame.size);
         swipeLayerSizeInDeviceCoordinates.scale(deviceScaleFactor);
         
         BOOL shouldRestoreScrollPosition = targetItem->rootFrameState().shouldRestoreScrollPosition;
-        WebCore::IntPoint currentScrollPosition = WebCore::roundedIntPoint(m_webPageProxy->viewScrollPosition());
+        WebCore::IntPoint currentScrollPosition = WebCore::roundedIntPoint(page->viewScrollPosition());
 
         if (snapshot->hasImage() && snapshot->size() == swipeLayerSizeInDeviceCoordinates && deviceScaleFactor == snapshot->deviceScaleFactor() && (shouldRestoreScrollPosition || (currentScrollPosition == snapshot->viewScrollPosition())))
             [m_snapshotView layer].contents = snapshot->asLayerContents();
@@ -269,7 +273,7 @@ void ViewGestureController::beginSwipeGesture(_UINavigationInteractiveTransition
         if (finish)
             willEndSwipeGesture(*targetItem, !transitionCompleted);
     }];
-    auto pageID = m_webPageProxy->identifier();
+    auto pageID = page->identifier();
     GestureID gestureID = m_currentGestureID;
     [m_swipeTransitionContext _setCompletionHandler:[pageID, gestureID, targetItem] (_UIViewControllerTransitionContext *context, BOOL didComplete) {
         if (auto gestureController = controllerForGesture(pageID, gestureID))
@@ -313,7 +317,8 @@ void ViewGestureController::willEndSwipeGesture(WebBackForwardListItem& targetIt
 
     if (ViewSnapshot* snapshot = targetItem.snapshot()) {
         m_backgroundColorForCurrentSnapshot = snapshot->backgroundColor();
-        m_webPageProxy->didChangeBackgroundColor();
+        if (RefPtr page = m_webPageProxy.get())
+            page->didChangeBackgroundColor();
     }
 }
 
@@ -336,21 +341,22 @@ void ViewGestureController::endSwipeGesture(WebBackForwardListItem* targetItem, 
     [m_transitionContainerView removeFromSuperview];
     m_transitionContainerView = nullptr;
 
+    RefPtr page = m_webPageProxy.get();
     if (cancelled) {
         // removeSwipeSnapshot will clear m_webPageProxyForBackForwardListForCurrentSwipe, so hold on to it here.
         RefPtr<WebPageProxy> webPageProxyForBackForwardListForCurrentSwipe = m_webPageProxyForBackForwardListForCurrentSwipe;
         removeSwipeSnapshot();
         webPageProxyForBackForwardListForCurrentSwipe->navigationGestureDidEnd(false, *targetItem);
-        if (m_webPageProxy.ptr() != webPageProxyForBackForwardListForCurrentSwipe)
-            m_webPageProxy->navigationGestureDidEnd();
+        if (page.get() != webPageProxyForBackForwardListForCurrentSwipe)
+            page->navigationGestureDidEnd();
         return;
     }
 
     m_webPageProxyForBackForwardListForCurrentSwipe->navigationGestureDidEnd(true, *targetItem);
-    if (m_webPageProxy.ptr() != m_webPageProxyForBackForwardListForCurrentSwipe)
-        m_webPageProxy->navigationGestureDidEnd();
+    if (page.get() != m_webPageProxyForBackForwardListForCurrentSwipe)
+        page->navigationGestureDidEnd();
 
-    if (!m_webPageProxy->provisionalDrawingArea()) {
+    if (!page->provisionalDrawingArea()) {
         removeSwipeSnapshot();
         return;
     }
@@ -362,17 +368,18 @@ void ViewGestureController::endSwipeGesture(WebBackForwardListItem* targetItem, 
         return;
     }
 
-    auto pageID = m_webPageProxy->identifier();
+    auto pageID = page->identifier();
     GestureID gestureID = m_currentGestureID;
 
     auto doAfterLoadStart = [this, pageID, gestureID] {
-        auto* drawingArea = m_webPageProxy->provisionalDrawingArea();
+        RefPtr page = m_webPageProxy.get();
+        auto* drawingArea = page ? page->provisionalDrawingArea() : nullptr;
         if (!drawingArea) {
             removeSwipeSnapshot();
             return;
         }
 
-        m_webPageProxy->callAfterNextPresentationUpdate([pageID, gestureID] {
+        page->callAfterNextPresentationUpdate([pageID, gestureID] {
             if (auto gestureController = controllerForGesture(pageID, gestureID))
                 gestureController->willCommitPostSwipeTransitionLayerTree(true);
         });

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -436,7 +436,7 @@ struct ImageAnalysisContextMenuActionData {
     RetainPtr<WKSTextAnimationManager> _textAnimationManager;
 #endif
 
-    std::unique_ptr<WebKit::SmartMagnificationController> _smartMagnificationController;
+    RefPtr<WebKit::SmartMagnificationController> _smartMagnificationController;
 
     WeakObjCPtr<id <UITextInputDelegate>> _inputDelegate;
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1446,7 +1446,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     
     _actionSheetAssistant = adoptNS([[WKActionSheetAssistant alloc] initWithView:self]);
     [_actionSheetAssistant setDelegate:self];
-    _smartMagnificationController = makeUnique<WebKit::SmartMagnificationController>(self);
+    _smartMagnificationController = WebKit::SmartMagnificationController::create(self);
     _touchEventsCanPreventNativeGestures = YES;
     _isExpectingFastSingleTapCommit = NO;
     _potentialTapInProgress = NO;

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h
@@ -35,10 +35,10 @@ namespace WebKit {
 
 class WebPageProxy;
 
-class WebDeviceOrientationUpdateProviderProxy : public WebCore::MotionManagerClient, private IPC::MessageReceiver {
+class WebDeviceOrientationUpdateProviderProxy : public WebCore::MotionManagerClient, private IPC::MessageReceiver, public RefCounted<WebDeviceOrientationUpdateProviderProxy> {
     WTF_MAKE_TZONE_ALLOCATED(WebDeviceOrientationUpdateProviderProxy);
 public:
-    WebDeviceOrientationUpdateProviderProxy(WebPageProxy&);
+    static Ref<WebDeviceOrientationUpdateProviderProxy> create(WebPageProxy&);
     ~WebDeviceOrientationUpdateProviderProxy();
 
     void startUpdatingDeviceOrientation();
@@ -48,6 +48,8 @@ public:
     void stopUpdatingDeviceMotion();
 
 private:
+    explicit WebDeviceOrientationUpdateProviderProxy(WebPageProxy&);
+
     // WebCore::WebCoreMotionManagerClient
     void orientationChanged(double, double, double, double, double) final;
     void motionChanged(double, double, double, double, double, double, std::optional<double>, std::optional<double>, std::optional<double>) final;
@@ -55,7 +57,7 @@ private:
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
-    WeakRef<WebPageProxy> m_page;
+    WeakPtr<WebPageProxy> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.messages.in
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.messages.in
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
-messages -> WebDeviceOrientationUpdateProviderProxy NotRefCounted {
+messages -> WebDeviceOrientationUpdateProviderProxy {
     StartUpdatingDeviceOrientation();
     StopUpdatingDeviceOrientation();
     StartUpdatingDeviceMotion();

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm
@@ -40,15 +40,21 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebDeviceOrientationUpdateProviderProxy);
 
+Ref<WebDeviceOrientationUpdateProviderProxy> WebDeviceOrientationUpdateProviderProxy::create(WebPageProxy& page)
+{
+    return adoptRef(*new WebDeviceOrientationUpdateProviderProxy(page));
+}
+
 WebDeviceOrientationUpdateProviderProxy::WebDeviceOrientationUpdateProviderProxy(WebPageProxy& page)
     : m_page(page)
 {
-    m_page->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), m_page->webPageIDInMainFrameProcess(), *this);
+    page.protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), page.webPageIDInMainFrameProcess(), *this);
 }
 
 WebDeviceOrientationUpdateProviderProxy::~WebDeviceOrientationUpdateProviderProxy()
 {
-    m_page->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), m_page->webPageIDInMainFrameProcess());
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), page->webPageIDInMainFrameProcess());
 }
 
 void WebDeviceOrientationUpdateProviderProxy::startUpdatingDeviceOrientation()
@@ -73,12 +79,14 @@ void WebDeviceOrientationUpdateProviderProxy::stopUpdatingDeviceMotion()
 
 void WebDeviceOrientationUpdateProviderProxy::orientationChanged(double alpha, double beta, double gamma, double compassHeading, double compassAccuracy)
 {
-    m_page->protectedLegacyMainFrameProcess()->send(Messages::WebDeviceOrientationUpdateProvider::DeviceOrientationChanged(alpha, beta, gamma, compassHeading, compassAccuracy), m_page->webPageIDInMainFrameProcess());
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->send(Messages::WebDeviceOrientationUpdateProvider::DeviceOrientationChanged(alpha, beta, gamma, compassHeading, compassAccuracy), m_page->webPageIDInMainFrameProcess());
 }
 
 void WebDeviceOrientationUpdateProviderProxy::motionChanged(double xAcceleration, double yAcceleration, double zAcceleration, double xAccelerationIncludingGravity, double yAccelerationIncludingGravity, double zAccelerationIncludingGravity, std::optional<double> xRotationRate, std::optional<double> yRotationRate, std::optional<double> zRotationRate)
 {
-    m_page->protectedLegacyMainFrameProcess()->send(Messages::WebDeviceOrientationUpdateProvider::DeviceMotionChanged(xAcceleration, yAcceleration, zAcceleration, xAccelerationIncludingGravity, yAccelerationIncludingGravity, zAccelerationIncludingGravity, xRotationRate, yRotationRate, zRotationRate), m_page->webPageIDInMainFrameProcess());
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->send(Messages::WebDeviceOrientationUpdateProvider::DeviceMotionChanged(xAcceleration, yAcceleration, zAcceleration, xAccelerationIncludingGravity, yAccelerationIncludingGravity, zAccelerationIncludingGravity, xRotationRate, yRotationRate, zRotationRate), m_page->webPageIDInMainFrameProcess());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/SecItemShimProxy.h
+++ b/Source/WebKit/UIProcess/mac/SecItemShimProxy.h
@@ -42,6 +42,10 @@ public:
 
     void initializeConnection(IPC::Connection&);
 
+    // Do nothing since this is a singleton.
+    void ref() const { }
+    void deref() const { }
+
 private:
     SecItemShimProxy();
     ~SecItemShimProxy();

--- a/Source/WebKit/UIProcess/mac/SecItemShimProxy.messages.in
+++ b/Source/WebKit/UIProcess/mac/SecItemShimProxy.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> SecItemShimProxy NotRefCounted {
+messages -> SecItemShimProxy {
 
 #if ENABLE(SEC_ITEM_SHIM)
     SecItemRequestSync(WebKit::SecItemRequestData request) -> (std::optional<WebKit::SecItemResponseData> response) Synchronous

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -113,8 +113,11 @@ void ViewGestureController::gestureEventWasNotHandledByWebCore(NSEvent *event, F
 
 void ViewGestureController::handleMagnificationGestureEvent(NSEvent *event, FloatPoint origin)
 {
-    Ref webPageProxy = m_webPageProxy.get();
-    origin.setY(origin.y() - webPageProxy->topContentInset());
+    RefPtr page = m_webPageProxy.get();
+    if (!page)
+        return;
+
+    origin.setY(origin.y() - page->topContentInset());
 
     ASSERT(m_activeGestureType == ViewGestureType::None || m_activeGestureType == ViewGestureType::Magnification);
 
@@ -134,8 +137,8 @@ void ViewGestureController::handleMagnificationGestureEvent(NSEvent *event, Floa
 
     willBeginGesture(ViewGestureType::Magnification);
 
-    auto minMagnification = webPageProxy->minPageZoomFactor();
-    auto maxMagnification = webPageProxy->maxPageZoomFactor();
+    auto minMagnification = page->minPageZoomFactor();
+    auto maxMagnification = page->maxPageZoomFactor();
 
     double scale = event.magnification;
     double scaleWithResistance = resistanceForDelta(scale, m_magnification, minMagnification, maxMagnification) * scale;
@@ -163,8 +166,8 @@ void ViewGestureController::handleSmartMagnificationGesture(FloatPoint gestureLo
 
     LOG_WITH_STREAM(ViewGestures, stream << "ViewGestureController::handleSmartMagnificationGesture - gesture location " << gestureLocationInViewCoordinates);
 
-    Ref webPageProxy = m_webPageProxy.get();
-    webPageProxy->protectedLegacyMainFrameProcess()->send(Messages::ViewGestureGeometryCollector::CollectGeometryForSmartMagnificationGesture(gestureLocationInViewCoordinates), webPageProxy->webPageIDInMainFrameProcess());
+    if (RefPtr page = m_webPageProxy.get())
+        page->protectedLegacyMainFrameProcess()->send(Messages::ViewGestureGeometryCollector::CollectGeometryForSmartMagnificationGesture(gestureLocationInViewCoordinates), page->webPageIDInMainFrameProcess());
 }
 
 static float maximumRectangleComponentDelta(FloatRect a, FloatRect b)
@@ -174,8 +177,11 @@ static float maximumRectangleComponentDelta(FloatRect a, FloatRect b)
 
 void ViewGestureController::didCollectGeometryForSmartMagnificationGesture(FloatPoint gestureLocationInViewCoordinates, FloatRect absoluteTargetRect, FloatRect visibleContentRect, bool fitEntireRect, double viewportMinimumScale, double viewportMaximumScale)
 {
-    Ref webPageProxy = m_webPageProxy.get();
-    double currentScaleFactor = webPageProxy->pageScaleFactor();
+    RefPtr page = m_webPageProxy.get();
+    if (!page)
+        return;
+
+    double currentScaleFactor = page->pageScaleFactor();
 
     LOG_WITH_STREAM(ViewGestures, stream << "ViewGestureController::didCollectGeometryForSmartMagnificationGesture - gesture location " << gestureLocationInViewCoordinates << " absoluteTargetRect " << absoluteTargetRect);
 
@@ -206,8 +212,8 @@ void ViewGestureController::didCollectGeometryForSmartMagnificationGesture(Float
     if (fitEntireRect)
         targetMagnification = std::min(targetMagnification, static_cast<double>(visibleContentRect.height() / viewportConstrainedUnscaledTargetRect.height()));
 
-    auto minMagnification = webPageProxy->minPageZoomFactor();
-    auto maxMagnification = webPageProxy->maxPageZoomFactor();
+    auto minMagnification = page->minPageZoomFactor();
+    auto maxMagnification = page->maxPageZoomFactor();
     targetMagnification = std::min(std::max(targetMagnification, minMagnification), maxMagnification);
 
     // Allow panning between elements via double-tap while magnified, unless the target rect is
@@ -227,12 +233,12 @@ void ViewGestureController::didCollectGeometryForSmartMagnificationGesture(Float
     auto targetCenter = targetRect.center();
     targetOrigin.moveBy(-targetCenter);
 
-    m_initialMagnification = webPageProxy->pageScaleFactor();
+    m_initialMagnification = page->pageScaleFactor();
     m_initialMagnificationOrigin = { };
 
-    auto pageScaleFactor = webPageProxy->pageScaleFactor();
-    webPageProxy->drawingArea()->adjustTransientZoom(pageScaleFactor, scaledMagnificationOrigin(FloatPoint(), pageScaleFactor));
-    webPageProxy->drawingArea()->commitTransientZoom(targetMagnification, targetOrigin);
+    auto pageScaleFactor = page->pageScaleFactor();
+    page->drawingArea()->adjustTransientZoom(pageScaleFactor, scaledMagnificationOrigin(FloatPoint(), pageScaleFactor));
+    page->drawingArea()->commitTransientZoom(targetMagnification, targetOrigin);
 
     m_lastSmartMagnificationUnscaledTargetRect = unscaledTargetRect;
     m_lastSmartMagnificationOrigin = gestureLocationInViewCoordinates;
@@ -386,12 +392,15 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
 {
     ASSERT(m_currentSwipeLiveLayers.isEmpty());
 
-    Ref webPageProxy = m_webPageProxy.get();
-    webPageProxy->navigationGestureDidBegin();
+    RefPtr page = m_webPageProxy.get();
+    if (!page)
+        return;
+
+    page->navigationGestureDidBegin();
 
     willBeginGesture(ViewGestureType::Swipe);
 
-    CALayer *rootContentLayer = webPageProxy->acceleratedCompositingRootLayer();
+    CALayer *rootContentLayer = page->acceleratedCompositingRootLayer();
 
     m_swipeLayer = adoptNS([[CALayer alloc] init]);
     m_swipeSnapshotLayer = adoptNS([[CALayer alloc] init]);
@@ -410,8 +419,8 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
             m_currentSwipeLiveLayers.append(layer);
         }
     } else {
-        swipeArea = [rootContentLayer convertRect:CGRectMake(0, 0, webPageProxy->viewSize().width(), webPageProxy->viewSize().height()) toLayer:nil];
-        topContentInset = webPageProxy->topContentInset();
+        swipeArea = [rootContentLayer convertRect:CGRectMake(0, 0, page->viewSize().width(), page->viewSize().height()) toLayer:nil];
+        topContentInset = page->topContentInset();
         m_currentSwipeLiveLayers.append(rootContentLayer);
     }
 
@@ -436,7 +445,7 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
     [m_swipeLayer setGeometryFlipped:geometryIsFlippedToRoot];
     [m_swipeLayer setDelegate:[WebActionDisablingCALayerDelegate shared]];
 
-    float deviceScaleFactor = webPageProxy->deviceScaleFactor();
+    float deviceScaleFactor = page->deviceScaleFactor();
     [m_swipeSnapshotLayer setContentsGravity:kCAGravityTopLeft];
     [m_swipeSnapshotLayer setContentsScale:deviceScaleFactor];
     [m_swipeSnapshotLayer setAnchorPoint:CGPointZero];
@@ -446,7 +455,7 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
 
     [m_swipeLayer addSublayer:m_swipeSnapshotLayer.get()];
 
-    if (webPageProxy->protectedPreferences()->viewGestureDebuggingEnabled())
+    if (page->protectedPreferences()->viewGestureDebuggingEnabled())
         applyDebuggingPropertiesToSwipeViews();
 
     m_didCallEndSwipeGesture = false;
@@ -461,7 +470,7 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
 
     // We don't know enough about the custom views' hierarchy to apply a shadow.
     if (m_customSwipeViews.isEmpty()) {
-        FloatRect dimmingRect(FloatPoint(), webPageProxy->viewSize());
+        FloatRect dimmingRect(FloatPoint(), page->viewSize());
         m_swipeDimmingLayer = adoptNS([[CALayer alloc] init]);
         [m_swipeDimmingLayer setName:@"Gesture Swipe Dimming Layer"];
         [m_swipeDimmingLayer setBackgroundColor:[NSColor blackColor].CGColor];
@@ -471,7 +480,7 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
         [m_swipeDimmingLayer setGeometryFlipped:geometryIsFlippedToRoot];
         [m_swipeDimmingLayer setDelegate:[WebActionDisablingCALayerDelegate shared]];
 
-        FloatRect shadowRect(-swipeOverlayShadowWidth, topContentInset, swipeOverlayShadowWidth, webPageProxy->viewSize().height() - topContentInset);
+        FloatRect shadowRect(-swipeOverlayShadowWidth, topContentInset, swipeOverlayShadowWidth, page->viewSize().height() - topContentInset);
         m_swipeShadowLayer = adoptNS([[CAGradientLayer alloc] init]);
         [m_swipeShadowLayer setName:@"Gesture Swipe Shadow Layer"];
         [m_swipeShadowLayer setColors:@[
@@ -531,6 +540,9 @@ void ViewGestureController::handleSwipeGesture(WebBackForwardListItem* targetIte
 {
     ASSERT(m_activeGestureType == ViewGestureType::Swipe);
 
+    if (!m_webPageProxy)
+        return;
+
     if (!m_webPageProxy->drawingArea())
         return;
 
@@ -572,7 +584,8 @@ void ViewGestureController::didMoveSwipeSnapshotLayer()
     if (!m_didMoveSwipeSnapshotCallback)
         return;
 
-    m_didMoveSwipeSnapshotCallback(protectedWebPageProxy()->boundsOfLayerInLayerBackedWindowCoordinates(m_swipeLayer.get()));
+    if (RefPtr page = m_webPageProxy.get())
+        m_didMoveSwipeSnapshotCallback(page->boundsOfLayerInLayerBackedWindowCoordinates(m_swipeLayer.get()));
 }
 
 void ViewGestureController::removeSwipeSnapshot()
@@ -619,7 +632,8 @@ void ViewGestureController::resetState()
 
     m_currentSwipeLiveLayers.clear();
 
-    protectedWebPageProxy()->navigationGestureSnapshotWasRemoved();
+    if (RefPtr page = m_webPageProxy.get())
+        page->navigationGestureSnapshotWasRemoved();
 
     m_backgroundColorForCurrentSnapshot = Color();
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -956,7 +956,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     RetainPtr<WKBrowsingContextController> m_browsingContextController;
 ALLOW_DEPRECATED_DECLARATIONS_END
 
-    std::unique_ptr<ViewGestureController> m_gestureController;
+    RefPtr<ViewGestureController> m_gestureController;
     bool m_allowsBackForwardNavigationGestures { false };
     bool m_allowsMagnification { false };
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4658,7 +4658,7 @@ void WebViewImpl::hideTextAnimationView()
 ViewGestureController& WebViewImpl::ensureGestureController()
 {
     if (!m_gestureController)
-        m_gestureController = makeUnique<ViewGestureController>(m_page);
+        m_gestureController = ViewGestureController::create(m_page);
     return *m_gestureController;
 }
 


### PR DESCRIPTION
#### 87afd2df3a371a2eb06adb947775c589e9f277df
<pre>
Make more MessageReceivers RefCounted in the UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=283633">https://bugs.webkit.org/show_bug.cgi?id=283633</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::didClose):
(WebKit::GPUConnectionToWebProcess::userMediaCaptureManagerProxy):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView setAllowsBackForwardNavigationGestures:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseDidRelaunchWebProcess):
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::create):
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in:
* Source/WebKit/UIProcess/DigitalCredentials/DigitalCredentialsCoordinatorProxy.cpp:
(WebKit::DigitalCredentialsCoordinatorProxy::create):
(WebKit::DigitalCredentialsCoordinatorProxy::DigitalCredentialsCoordinatorProxy):
(WebKit::DigitalCredentialsCoordinatorProxy::~DigitalCredentialsCoordinatorProxy):
(WebKit::DigitalCredentialsCoordinatorProxy::sharedPreferencesForWebProcess const):
(WebKit::DigitalCredentialsCoordinatorProxy::protectedPage const): Deleted.
* Source/WebKit/UIProcess/DigitalCredentials/DigitalCredentialsCoordinatorProxy.h:
* Source/WebKit/UIProcess/DigitalCredentials/DigitalCredentialsCoordinatorProxy.messages.in:
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::create):
(WebKit::ViewGestureController::ViewGestureController):
(WebKit::ViewGestureController::~ViewGestureController):
(WebKit::ViewGestureController::disconnectFromProcess):
(WebKit::ViewGestureController::connectToProcess):
(WebKit::ViewGestureController::willBeginGesture):
(WebKit::ViewGestureController::didEndGesture):
(WebKit::ViewGestureController::canSwipeInDirection const):
(WebKit::ViewGestureController::checkForActiveLoads):
(WebKit::ViewGestureController::PendingSwipeTracker::protectedViewGestureController const):
(WebKit::ViewGestureController::PendingSwipeTracker::scrollEventCanBecomeSwipe):
(WebKit::ViewGestureController::PendingSwipeTracker::handleEvent):
(WebKit::ViewGestureController::PendingSwipeTracker::tryToStartSwipe):
(WebKit::ViewGestureController::startSwipeGesture):
(WebKit::ViewGestureController::isPhysicallySwipingLeft const):
(WebKit::ViewGestureController::shouldUseSnapshotForSize):
(WebKit::ViewGestureController::forceRepaintIfNeeded):
(WebKit::ViewGestureController::willEndSwipeGesture):
(WebKit::ViewGestureController::endSwipeGesture):
(WebKit::ViewGestureController::requestRenderTreeSizeNotificationIfNeeded):
(WebKit::ViewGestureController::didCollectGeometryForMagnificationGesture):
(WebKit::ViewGestureController::prepareMagnificationGesture):
(WebKit::ViewGestureController::applyMagnification):
(WebKit::ViewGestureController::endMagnificationGesture):
(WebKit::ViewGestureController::magnification const):
(WebKit::ViewGestureController::protectedWebPageProxy const): Deleted.
(WebKit::ViewGestureController::PendingSwipeTracker::checkedViewGestureController const): Deleted.
(WebKit::ViewGestureController::PendingSwipeTracker::protectedWebPageProxy const): Deleted.
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/ViewGestureController.messages.in:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::create):
(WebKit::WebFullScreenManagerProxy::WebFullScreenManagerProxy):
(WebKit::WebFullScreenManagerProxy::~WebFullScreenManagerProxy):
(WebKit::WebFullScreenManagerProxy::sharedPreferencesForWebProcess const):
(WebKit::WebFullScreenManagerProxy::willEnterFullScreen):
(WebKit::WebFullScreenManagerProxy::didEnterFullScreen):
(WebKit::WebFullScreenManagerProxy::willExitFullScreen):
(WebKit::WebFullScreenManagerProxy::didExitFullScreen):
(WebKit::WebFullScreenManagerProxy::setAnimatingFullScreen):
(WebKit::WebFullScreenManagerProxy::requestRestoreFullScreen):
(WebKit::WebFullScreenManagerProxy::requestExitFullScreen):
(WebKit::WebFullScreenManagerProxy::saveScrollPosition):
(WebKit::WebFullScreenManagerProxy::restoreScrollPosition):
(WebKit::WebFullScreenManagerProxy::setFullscreenInsets):
(WebKit::WebFullScreenManagerProxy::setFullscreenAutoHideDuration):
(WebKit::WebFullScreenManagerProxy::close):
(WebKit::WebFullScreenManagerProxy::isFullScreen):
(WebKit::WebFullScreenManagerProxy::enterFullScreen):
(WebKit::WebFullScreenManagerProxy::updateImageSource):
(WebKit::WebFullScreenManagerProxy::exitFullScreen):
(WebKit::WebFullScreenManagerProxy::beganEnterFullScreen):
(WebKit::WebFullScreenManagerProxy::beganExitFullScreen):
(WebKit::WebFullScreenManagerProxy::lockFullscreenOrientation):
(WebKit::WebFullScreenManagerProxy::unlockFullscreenOrientation):
(WebKit::WebFullScreenManagerProxy::protectedPage const): Deleted.
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didAttachToRunningProcess):
(WebKit::WebPageProxy::rotationAngleForCaptureDeviceChanged):
(WebKit::WebPageProxy::setOrientationForMediaCapture):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPasteboardProxy.h:
(WebKit::WebPasteboardProxy::ref const):
(WebKit::WebPasteboardProxy::deref const):
* Source/WebKit/UIProcess/WebPasteboardProxy.messages.in:
* Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp:
(WebKit::WebPermissionControllerProxy::ref const):
(WebKit::WebPermissionControllerProxy::deref const):
* Source/WebKit/UIProcess/WebPermissionControllerProxy.h:
* Source/WebKit/UIProcess/WebPermissionControllerProxy.messages.in:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::m_webPermissionController):
(WebKit::WebProcessProxy::protectedUserMediaCaptureManagerProxy):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp:
(WebKit::WebScreenOrientationManagerProxy::create):
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h:
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.messages.in:
* Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp:
(WebKit::ViewGestureController::beginSwipeGesture):
(WebKit::ViewGestureController::handleSwipeGesture):
(WebKit::ViewGestureController::snapshot):
(WebKit::ViewGestureController::draw):
(WebKit::ViewGestureController::removeSwipeSnapshot):
(WebKit::ViewGestureController::setMagnification):
* Source/WebKit/UIProcess/ios/SmartMagnificationController.h:
* Source/WebKit/UIProcess/ios/SmartMagnificationController.messages.in:
* Source/WebKit/UIProcess/ios/SmartMagnificationController.mm:
(WebKit::SmartMagnificationController::create):
(WebKit::SmartMagnificationController::~SmartMagnificationController):
(WebKit::SmartMagnificationController::handleSmartMagnificationGesture):
(WebKit::SmartMagnificationController::didCollectGeometryForSmartMagnificationGesture):
* Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm:
(WebKit::ViewGestureController::beginSwipeGesture):
(WebKit::ViewGestureController::willEndSwipeGesture):
(WebKit::ViewGestureController::endSwipeGesture):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView setUpInteraction]):
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h:
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.messages.in:
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm:
(WebKit::WebDeviceOrientationUpdateProviderProxy::create):
(WebKit::WebDeviceOrientationUpdateProviderProxy::WebDeviceOrientationUpdateProviderProxy):
(WebKit::WebDeviceOrientationUpdateProviderProxy::~WebDeviceOrientationUpdateProviderProxy):
(WebKit::WebDeviceOrientationUpdateProviderProxy::orientationChanged):
(WebKit::WebDeviceOrientationUpdateProviderProxy::motionChanged):
* Source/WebKit/UIProcess/mac/SecItemShimProxy.h:
* Source/WebKit/UIProcess/mac/SecItemShimProxy.messages.in:
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::handleMagnificationGestureEvent):
(WebKit::ViewGestureController::handleSmartMagnificationGesture):
(WebKit::ViewGestureController::didCollectGeometryForSmartMagnificationGesture):
(WebKit::ViewGestureController::beginSwipeGesture):
(WebKit::ViewGestureController::handleSwipeGesture):
(WebKit::ViewGestureController::didMoveSwipeSnapshotLayer):
(WebKit::ViewGestureController::resetState):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::ensureGestureController):

Canonical link: <a href="https://commits.webkit.org/287037@main">https://commits.webkit.org/287037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a869f6e88c707b72efe27c60136866b5d2f83e43

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82698 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29304 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61111 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19035 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51105 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67495 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41423 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48465 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27649 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69559 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84060 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5415 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3652 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69333 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5571 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66971 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68587 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12590 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10779 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12080 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5363 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8116 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5353 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8785 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7140 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->