### PR TITLE
AX: AccessibilityChildrenVector should be Vector<Ref<AXCoreObject>>, not Vector<RefPtr<AXCoreObject>>

### DIFF
--- a/Source/WebCore/accessibility/AXLogger.h
+++ b/Source/WebCore/accessibility/AXLogger.h
@@ -60,7 +60,7 @@ public:
     void log(const char*);
     void log(const AXCoreObject&);
     void log(RefPtr<AXCoreObject>);
-    void log(const Vector<RefPtr<AXCoreObject>>&);
+    void log(const Vector<Ref<AXCoreObject>>&);
     void log(const std::pair<Ref<AccessibilityObject>, AXObjectCache::AXNotification>&);
     void log(const std::pair<RefPtr<AXCoreObject>, AXObjectCache::AXNotification>&);
     void log(const AccessibilitySearchCriteria&);
@@ -91,6 +91,6 @@ private:
 #endif // !LOG_DISABLED
 
 void streamAXCoreObject(TextStream&, const AXCoreObject&, const OptionSet<AXStreamOptions>&);
-void streamSubtree(TextStream&, const RefPtr<AXCoreObject>&, const OptionSet<AXStreamOptions>&);
+void streamSubtree(TextStream&, const Ref<AXCoreObject>&, const OptionSet<AXStreamOptions>&);
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -448,7 +448,7 @@ public:
     bool elementIsTextControl(const Element&);
 
     AccessibilityObject* objectForID(const AXID id) const { return m_objects.get(id); }
-    template<typename U> Vector<RefPtr<AXCoreObject>> objectsForIDs(const U&) const;
+    template<typename U> Vector<Ref<AXCoreObject>> objectsForIDs(const U&) const;
     Node* nodeForID(std::optional<AXID>) const;
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -872,13 +872,13 @@ private:
 };
 
 template<typename U>
-inline Vector<RefPtr<AXCoreObject>> AXObjectCache::objectsForIDs(const U& axIDs) const
+inline Vector<Ref<AXCoreObject>> AXObjectCache::objectsForIDs(const U& axIDs) const
 {
     ASSERT(isMainThread());
 
-    return WTF::compactMap(axIDs, [&](auto& axID) -> std::optional<RefPtr<AXCoreObject>> {
+    return WTF::compactMap(axIDs, [&](auto& axID) -> std::optional<Ref<AXCoreObject>> {
         if (auto* object = objectForID(axID))
-            return RefPtr { object };
+            return Ref { *object };
         return std::nullopt;
     });
 }

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -38,9 +38,9 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AXSearchManager);
 
 // This function determines if the given `axObject` is a radio button part of a different ad-hoc radio group
 // than `referenceObject`, where ad-hoc radio group membership is determined by comparing `name` attributes.
-static bool isRadioButtonInDifferentAdhocGroup(RefPtr<AXCoreObject> axObject, AXCoreObject* referenceObject)
+static bool isRadioButtonInDifferentAdhocGroup(Ref<AXCoreObject> axObject, AXCoreObject* referenceObject)
 {
-    if (!axObject || !axObject->isRadioButton())
+    if (!axObject->isRadioButton())
         return false;
 
     // If the `referenceObject` is not a radio button and this `axObject` is, their radio group membership is different because
@@ -51,7 +51,7 @@ static bool isRadioButtonInDifferentAdhocGroup(RefPtr<AXCoreObject> axObject, AX
     return axObject->nameAttribute() != referenceObject->nameAttribute();
 }
 
-bool AXSearchManager::matchForSearchKeyAtIndex(RefPtr<AXCoreObject> axObject, const AccessibilitySearchCriteria& criteria, size_t index)
+bool AXSearchManager::matchForSearchKeyAtIndex(Ref<AXCoreObject> axObject, const AccessibilitySearchCriteria& criteria, size_t index)
 {
     switch (criteria.searchKeys[index]) {
     case AccessibilitySearchKey::AnyType:
@@ -164,11 +164,8 @@ bool AXSearchManager::matchForSearchKeyAtIndex(RefPtr<AXCoreObject> axObject, co
     }
 }
 
-bool AXSearchManager::match(RefPtr<AXCoreObject> axObject, const AccessibilitySearchCriteria& criteria)
+bool AXSearchManager::match(Ref<AXCoreObject> axObject, const AccessibilitySearchCriteria& criteria)
 {
-    if (!axObject)
-        return false;
-
     for (size_t i = 0; i < criteria.searchKeys.size(); ++i) {
         if (matchForSearchKeyAtIndex(axObject, criteria, i))
             return criteria.visibleOnly ? axObject->isOnScreen() : true;
@@ -176,11 +173,8 @@ bool AXSearchManager::match(RefPtr<AXCoreObject> axObject, const AccessibilitySe
     return false;
 }
 
-bool AXSearchManager::matchText(RefPtr<AXCoreObject> axObject, const String& searchText)
+bool AXSearchManager::matchText(Ref<AXCoreObject> axObject, const String& searchText)
 {
-    if (!axObject)
-        return false;
-
     // If text is empty we return true.
     if (searchText.isEmpty())
         return true;
@@ -190,7 +184,7 @@ bool AXSearchManager::matchText(RefPtr<AXCoreObject> axObject, const String& sea
         || containsPlainText(axObject->stringValue(), searchText, FindOption::CaseInsensitive);
 }
 
-bool AXSearchManager::matchWithResultsLimit(RefPtr<AXCoreObject> object, const AccessibilitySearchCriteria& criteria, AXCoreObject::AccessibilityChildrenVector& results)
+bool AXSearchManager::matchWithResultsLimit(Ref<AXCoreObject> object, const AccessibilitySearchCriteria& criteria, AXCoreObject::AccessibilityChildrenVector& results)
 {
     if (match(object, criteria) && matchText(object, criteria.searchText)) {
         results.append(object);
@@ -203,10 +197,12 @@ bool AXSearchManager::matchWithResultsLimit(RefPtr<AXCoreObject> object, const A
     return false;
 }
 
-static void appendAccessibilityObject(RefPtr<AXCoreObject> object, AccessibilityObject::AccessibilityChildrenVector& results)
+static void appendAccessibilityObject(Ref<AXCoreObject> object, AccessibilityObject::AccessibilityChildrenVector& results)
 {
-    // Find the next descendant of this attachment object so search can continue through frames.
-    if (object->isAttachment()) {
+    if (LIKELY(!object->isAttachment()))
+        results.append(object);
+    else {
+        // Find the next descendant of this attachment object so search can continue through frames.
         Widget* widget = object->widgetForAttachmentView();
         auto* frameView = dynamicDowncast<LocalFrameView>(widget);
         if (!frameView)
@@ -215,14 +211,13 @@ static void appendAccessibilityObject(RefPtr<AXCoreObject> object, Accessibility
         if (!document || !document->hasLivingRenderTree())
             return;
 
-        object = object->axObjectCache()->getOrCreate(*document);
+        CheckedPtr cache = object->axObjectCache();
+        if (auto* axDocument = cache ? cache->getOrCreate(*document) : nullptr)
+            results.append(*axDocument);
     }
-
-    if (object)
-        results.append(object);
 }
 
-static void appendChildrenToArray(RefPtr<AXCoreObject> object, bool isForward, RefPtr<AXCoreObject> startObject, AXCoreObject::AccessibilityChildrenVector& results)
+static void appendChildrenToArray(Ref<AXCoreObject> object, bool isForward, RefPtr<AXCoreObject> startObject, AXCoreObject::AccessibilityChildrenVector& results)
 {
     // A table's children includes elements whose own children are also the table's children (due to the way the Mac exposes tables).
     // The rows from the table should be queried, since those are direct descendants of the table, and they contain content.
@@ -240,7 +235,7 @@ static void appendChildrenToArray(RefPtr<AXCoreObject> object, bool isForward, R
         RefPtr<AXCoreObject> parentObject = startObject->parentObject();
         // Go up the parent chain to find the highest ancestor that's also being ignored.
         while (parentObject && parentObject->isIgnored()) {
-            if (parentObject == object)
+            if (parentObject == object.ptr())
                 break;
             startObject = parentObject;
             parentObject = parentObject->parentObject();
@@ -248,6 +243,7 @@ static void appendChildrenToArray(RefPtr<AXCoreObject> object, bool isForward, R
 
         // We should only ever hit this case with a live object (not an isolated object), as it would require startObject to be ignored,
         // and we should never have created an isolated object from an ignored live object.
+        // FIXME: This is not true for ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE), fix this before shipping it.
         ASSERT(is<AccessibilityObject>(startObject));
         auto* newStartObject = dynamicDowncast<AccessibilityObject>(startObject.get());
         // Get the un-ignored sibling based on the search direction, and update the searchPosition.
@@ -256,7 +252,7 @@ static void appendChildrenToArray(RefPtr<AXCoreObject> object, bool isForward, R
         startObject = newStartObject;
     }
 
-    size_t searchPosition = startObject ? searchChildren.find(startObject) : notFound;
+    size_t searchPosition = startObject ? searchChildren.find(Ref { *startObject }) : notFound;
 
     if (searchPosition != notFound) {
         if (isForward)
@@ -307,7 +303,7 @@ AXCoreObject::AccessibilityChildrenVector AXSearchManager::findMatchingObjectsIn
         // already behind/ahead of start element.
         AXCoreObject::AccessibilityChildrenVector searchStack;
         if (!criteria.immediateDescendantsOnly || startObject == criteria.anchorObject)
-            appendChildrenToArray(startObject, isForward, previousObject, searchStack);
+            appendChildrenToArray(*startObject, isForward, previousObject, searchStack);
 
         // This now does a DFS at the current level of the parent.
         while (!searchStack.isEmpty()) {
@@ -325,7 +321,7 @@ AXCoreObject::AccessibilityChildrenVector AXSearchManager::findMatchingObjectsIn
             break;
 
         // When moving backwards, the parent object needs to be checked, because technically it's "before" the starting element.
-        if (!isForward && startObject != criteria.anchorObject && matchWithResultsLimit(startObject, criteria, results))
+        if (!isForward && startObject != criteria.anchorObject && matchWithResultsLimit(*startObject, criteria, results))
             break;
 
         previousObject = startObject;
@@ -353,7 +349,7 @@ std::optional<AXTextMarkerRange> AXSearchManager::findMatchingRange(Accessibilit
     AXLOG(startObject);
 
     bool forward = criteria.searchDirection == AccessibilitySearchDirection::Next;
-    if (match(startObject, criteria)) {
+    if (match(*startObject, criteria)) {
         ASSERT(m_misspellingRanges.contains(startObject->objectID()));
         const auto& ranges = m_misspellingRanges.get(startObject->objectID());
         ASSERT(!ranges.isEmpty());
@@ -374,11 +370,10 @@ std::optional<AXTextMarkerRange> AXSearchManager::findMatchingRange(Accessibilit
 
     // Didn't find a matching range for startObject, thus move to the next/previous object.
     auto objects = findMatchingObjectsInternal(criteria);
-    if (!objects.isEmpty() && objects[0]) {
-        auto& object = *objects[0];
-        AXLOG(object);
-        ASSERT(m_misspellingRanges.contains(object.objectID()));
-        const auto& ranges = m_misspellingRanges.get(object.objectID());
+    if (!objects.isEmpty()) {
+        Ref object = objects[0];
+        ASSERT(m_misspellingRanges.contains(object->objectID()));
+        const auto& ranges = m_misspellingRanges.get(object->objectID());
         ASSERT(!ranges.isEmpty());
         return forward ? ranges[0] : ranges.last();
     }

--- a/Source/WebCore/accessibility/AXSearchManager.h
+++ b/Source/WebCore/accessibility/AXSearchManager.h
@@ -96,10 +96,10 @@ public:
     std::optional<AXTextMarkerRange> findMatchingRange(AccessibilitySearchCriteria&&);
 private:
     AXCoreObject::AccessibilityChildrenVector findMatchingObjectsInternal(const AccessibilitySearchCriteria&);
-    bool matchWithResultsLimit(RefPtr<AXCoreObject>, const AccessibilitySearchCriteria&, AXCoreObject::AccessibilityChildrenVector&);
-    bool match(RefPtr<AXCoreObject>, const AccessibilitySearchCriteria&);
-    bool matchText(RefPtr<AXCoreObject>, const String&);
-    bool matchForSearchKeyAtIndex(RefPtr<AXCoreObject>, const AccessibilitySearchCriteria&, size_t);
+    bool matchWithResultsLimit(Ref<AXCoreObject>, const AccessibilitySearchCriteria&, AXCoreObject::AccessibilityChildrenVector&);
+    bool match(Ref<AXCoreObject>, const AccessibilitySearchCriteria&);
+    bool matchText(Ref<AXCoreObject>, const String&);
+    bool matchForSearchKeyAtIndex(Ref<AXCoreObject>, const AccessibilitySearchCriteria&, size_t);
 
     // Keeps the ranges of misspellings for each object.
     UncheckedKeyHashMap<AXID, Vector<AXTextMarkerRange>> m_misspellingRanges;

--- a/Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp
@@ -76,22 +76,21 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityARIAGridRow::disclosedRow
 
     // Search for rows that match the correct level. 
     // Only take the subsequent rows from this one that are +1 from this row's level.
-    int index = rowIndex();
-    if (index < 0)
+    int rowIndex = this->rowIndex();
+    if (rowIndex < 0)
         return disclosedRows;
 
     unsigned level = hierarchicalLevel();
     auto allRows = parent->rows();
     int rowCount = allRows.size();
-    for (int k = index + 1; k < rowCount; ++k) {
-        RefPtr row = allRows[k].get();
+    for (int k = rowIndex + 1; k < rowCount; ++k) {
+        auto& row = allRows[k].get();
         // Stop at the first row that doesn't match the correct level.
-        if (row->hierarchicalLevel() != level + 1)
+        if (row.hierarchicalLevel() != level + 1)
             break;
 
         disclosedRows.append(row);
     }
-
     return disclosedRows;
 }
     
@@ -116,11 +115,10 @@ AXCoreObject* AccessibilityARIAGridRow::disclosedByRow() const
         return nullptr;
 
     for (int k = index - 1; k >= 0; --k) {
-        auto* row = allRows[k].get();
-        if (row->hierarchicalLevel() == level - 1)
-            return row;
+        auto& row = allRows[k].get();
+        if (row.hierarchicalLevel() == level - 1)
+            return &row;
     }
-
     return nullptr;
 }
 
@@ -142,9 +140,8 @@ AXCoreObject* AccessibilityARIAGridRow::rowHeader()
 {
     for (const auto& child : unignoredChildren()) {
         if (child->roleValue() == AccessibilityRole::RowHeader)
-            return child.get();
+            return child.ptr();
     }
-
     return nullptr;
 }
 

--- a/Source/WebCore/accessibility/AccessibilityListBox.cpp
+++ b/Source/WebCore/accessibility/AccessibilityListBox.cpp
@@ -148,7 +148,7 @@ AccessibilityObject* AccessibilityListBox::elementAccessibilityHitTest(const Int
         // The cast to HTMLElement below is safe because the only other possible listItem type
         // would be a WMLElement, but WML builds don't use accessibility features at all.
         if (rect.contains(point)) {
-            listBoxOption = downcast<AccessibilityObject>(children[i].get());
+            listBoxOption = &downcast<AccessibilityObject>(children[i].get());
             break;
         }
     }

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
@@ -275,7 +275,7 @@ AXCoreObject* AccessibilityMathMLElement::mathRootIndexObject()
     if (children.size() < 2)
         return nullptr;
 
-    return children[1].get();
+    return children[1].ptr();
 }
 
 AXCoreObject* AccessibilityMathMLElement::mathNumeratorObject()
@@ -287,7 +287,7 @@ AXCoreObject* AccessibilityMathMLElement::mathNumeratorObject()
     if (children.size() != 2)
         return nullptr;
 
-    return children[0].get();
+    return children[0].ptr();
 }
 
 AXCoreObject* AccessibilityMathMLElement::mathDenominatorObject()
@@ -299,7 +299,7 @@ AXCoreObject* AccessibilityMathMLElement::mathDenominatorObject()
     if (children.size() != 2)
         return nullptr;
 
-    return children[1].get();
+    return children[1].ptr();
 }
 
 AXCoreObject* AccessibilityMathMLElement::mathUnderObject()
@@ -312,7 +312,7 @@ AXCoreObject* AccessibilityMathMLElement::mathUnderObject()
         return nullptr;
 
     if (node()->hasTagName(MathMLNames::munderTag) || node()->hasTagName(MathMLNames::munderoverTag))
-        return children[1].get();
+        return children[1].ptr();
 
     return nullptr;
 }
@@ -322,13 +322,12 @@ AXCoreObject* AccessibilityMathMLElement::mathOverObject()
     if (!isMathUnderOver() || !node())
         return nullptr;
 
-    const auto& children = this->unignoredChildren();
-
+    const auto& children = unignoredChildren();
     if (children.size() >= 2 && node()->hasTagName(MathMLNames::moverTag))
-        return children[1].get();
+        return children[1].ptr();
 
     if (children.size() >= 3 && node()->hasTagName(MathMLNames::munderoverTag))
-        return children[2].get();
+        return children[2].ptr();
 
     return nullptr;
 }
@@ -338,10 +337,10 @@ AXCoreObject* AccessibilityMathMLElement::mathBaseObject()
     if (!isMathSubscriptSuperscript() && !isMathUnderOver() && !isMathMultiscript())
         return nullptr;
 
-    const auto& children = this->unignoredChildren();
+    const auto& children = unignoredChildren();
     // The base object in question is always the first child.
     if (children.size() > 0)
-        return children[0].get();
+        return children[0].ptr();
 
     return nullptr;
 }
@@ -351,12 +350,12 @@ AXCoreObject* AccessibilityMathMLElement::mathSubscriptObject()
     if (!isMathSubscriptSuperscript() || !node())
         return nullptr;
 
-    const auto& children = this->unignoredChildren();
+    const auto& children = unignoredChildren();
     if (children.size() < 2)
         return nullptr;
 
     if (node()->hasTagName(MathMLNames::msubTag) || node()->hasTagName(MathMLNames::msubsupTag))
-        return children[1].get();
+        return children[1].ptr();
 
     return nullptr;
 }
@@ -366,14 +365,14 @@ AXCoreObject* AccessibilityMathMLElement::mathSuperscriptObject()
     if (!isMathSubscriptSuperscript() || !node())
         return nullptr;
 
-    const auto& children = this->unignoredChildren();
+    const auto& children = unignoredChildren();
     unsigned count = children.size();
 
     if (count >= 2 && node()->hasTagName(MathMLNames::msupTag))
-        return children[1].get();
+        return children[1].ptr();
 
     if (count >= 3 && node()->hasTagName(MathMLNames::msubsupTag))
-        return children[2].get();
+        return children[2].ptr();
 
     return nullptr;
 }

--- a/Source/WebCore/accessibility/AccessibilityMenuList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuList.cpp
@@ -123,7 +123,7 @@ void AccessibilityMenuList::didUpdateActiveOption(int optionIndex)
     const auto& childObjects = unignoredChildren();
     if (!childObjects.isEmpty()) {
         ASSERT(childObjects.size() == 1);
-        ASSERT(is<AccessibilityMenuListPopup>(*childObjects[0]));
+        ASSERT(is<AccessibilityMenuListPopup>(childObjects[0].get()));
 
         // We might be calling this method in situations where the renderers for list items
         // associated to the menu list have not been created (e.g. they might be rendered
@@ -133,7 +133,8 @@ void AccessibilityMenuList::didUpdateActiveOption(int optionIndex)
         // You can reproduce the issue in the GTK+ port by removing this check and running
         // accessibility/insert-selected-option-into-select-causes-crash.html (will crash).
         int popupChildrenSize = static_cast<int>(childObjects[0]->unignoredChildren().size());
-        if (RefPtr accessibilityMenuListPopup = dynamicDowncast<AccessibilityMenuListPopup>(*childObjects[0]); accessibilityMenuListPopup && optionIndex >= 0 && optionIndex < popupChildrenSize)
+        RefPtr accessibilityMenuListPopup = dynamicDowncast<AccessibilityMenuListPopup>(childObjects[0].get());
+        if (accessibilityMenuListPopup && optionIndex >= 0 && optionIndex < popupChildrenSize)
             accessibilityMenuListPopup->didUpdateActiveOption(optionIndex);
     }
 

--- a/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
@@ -124,16 +124,16 @@ void AccessibilityMenuListPopup::addChildren()
 
 void AccessibilityMenuListPopup::handleChildrenChanged()
 {
-    auto* cache = axObjectCache();
+    CheckedPtr cache = axObjectCache();
     if (!cache)
         return;
 
     const auto& children = unignoredChildren(/* updateChildrenIfNeeded */ false);
     for (size_t i = children.size(); i > 0; --i) {
-        auto* child = children[i - 1].get();
-        if (child->actionElement() && !child->actionElement()->inRenderedDocument()) {
-            child->detachFromParent();
-            cache->remove(child->objectID());
+        auto& child = children[i - 1].get();
+        if (RefPtr actionElement = child.actionElement(); actionElement && !actionElement->inRenderedDocument()) {
+            child.detachFromParent();
+            cache->remove(child.objectID());
         }
     }
 
@@ -148,13 +148,13 @@ void AccessibilityMenuListPopup::didUpdateActiveOption(int optionIndex)
     const auto& children = unignoredChildren();
     ASSERT_ARG(optionIndex, optionIndex < static_cast<int>(children.size()));
 
-    auto* cache = axObjectCache();
+    CheckedPtr cache = axObjectCache();
     if (!cache)
         return;
 
-    RefPtr child = downcast<AccessibilityObject>(children[optionIndex].get());
-    cache->postNotification(child.get(), document(), AXObjectCache::AXFocusedUIElementChanged);
-    cache->postNotification(child.get(), document(), AXObjectCache::AXMenuListItemSelected);
+    auto& child = downcast<AccessibilityObject>(children[optionIndex].get());
+    cache->postNotification(&child, document(), AXObjectCache::AXFocusedUIElementChanged);
+    cache->postNotification(&child, document(), AXObjectCache::AXMenuListItemSelected);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -563,11 +563,11 @@ void AccessibilityNodeObject::clearChildren()
 
 void AccessibilityNodeObject::updateOwnedChildren()
 {
-    for (RefPtr child : ownedObjects()) {
+    for (Ref child : ownedObjects()) {
         // If the child already exists as a DOM child, but is also in the owned objects, then
         // we need to re-order this child in the aria-owns order.
         m_children.removeFirst(child);
-        addChild(child.get());
+        addChild(child.ptr());
     }
 }
 
@@ -950,7 +950,7 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityNodeObject::radioButtonGr
             if (!cache)
                 break;
             if (auto* object = cache->getOrCreate(radioSibling.ptr()))
-                result.append(object);
+                result.append(*object);
         }
     }
 
@@ -1631,7 +1631,7 @@ String AccessibilityNodeObject::textAsLabelFor(const AccessibilityObject& labele
     if (isAccessibilityLabelInstance()) {
         StringBuilder builder;
         for (const auto& child : const_cast<AccessibilityNodeObject*>(this)->unignoredChildren()) {
-            if (child.get() == &labeledObject)
+            if (child.ptr() == &labeledObject)
                 continue;
 
             if (child->isListBox()) {
@@ -2416,7 +2416,7 @@ String AccessibilityNodeObject::stringValue() const
             if (!child->isListBox())
                 continue;
 
-            if (auto selection = child->selectedChildren(); selection && selection->size() && selection->first())
+            if (auto selection = child->selectedChildren(); selection && selection->size())
                 return selection->first()->stringValue();
             break;
         }

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -751,7 +751,7 @@ public:
     AccessibilityObject* containingWebArea() const;
 
     void clearIsIgnoredFromParentData() { m_isIgnoredFromParentData = { }; }
-    void setIsIgnoredFromParentDataForChild(AccessibilityObject*);
+    void setIsIgnoredFromParentDataForChild(AccessibilityObject&);
 
     AccessibilityChildrenVector documentLinks() override { return AccessibilityChildrenVector(); }
 

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1666,7 +1666,7 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityRenderObject::documentLin
             RefPtr axObject = cache->getOrCreate(*renderer);
             ASSERT(axObject);
             if (!axObject->isIgnored() && axObject->isLink())
-                result.append(axObject);
+                result.append(axObject.releaseNonNull());
         } else {
             auto* parent = current->parentNode();
             if (auto* parentMap = dynamicDowncast<HTMLMapElement>(parent); parentMap && is<HTMLAreaElement>(*current)) {
@@ -1684,7 +1684,7 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityRenderObject::documentLin
                     areaObject.setHTMLAreaElement(uncheckedDowncast<HTMLAreaElement>(current));
                     areaObject.setHTMLMapElement(parentMap);
                     areaObject.setParent(associatedAXImage(*parentMap));
-                    result.append(&areaObject);
+                    result.append(areaObject);
                 }
             }
         }
@@ -2445,13 +2445,13 @@ void AccessibilityRenderObject::addNodeOnlyChildren()
             if (childObject && childObject->isIgnored()) {
                 const auto& children = childObject->unignoredChildren();
                 if (children.size())
-                    childObject = children.last().get();
+                    childObject = children.last().ptr();
                 else
                     childObject = nullptr;
             }
 
             if (childObject)
-                insertionIndex = m_children.find(childObject) + 1;
+                insertionIndex = m_children.find(Ref { *childObject }) + 1;
             continue;
         }
 
@@ -2562,7 +2562,7 @@ void AccessibilityRenderObject::addChildren()
             return;
 #endif
         auto owners = object.owners();
-        if (owners.size() && !owners.contains(this))
+        if (owners.size() && !owners.contains(Ref { *this }))
             return;
 
         addChild(&object);

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -174,10 +174,13 @@ void AccessibilityScrollView::updateScrollbars()
     
 void AccessibilityScrollView::removeChildScrollbar(AccessibilityObject* scrollbar)
 {
-    size_t pos = m_children.find(scrollbar);
-    if (pos != notFound) {
-        m_children[pos]->detachFromParent();
-        m_children.remove(pos);
+    if (!scrollbar)
+        return;
+
+    size_t position = m_children.find(Ref { *scrollbar });
+    if (position != notFound) {
+        m_children[position]->detachFromParent();
+        m_children.remove(position);
 
         if (CheckedPtr cache = axObjectCache())
             cache->remove(scrollbar->objectID());

--- a/Source/WebCore/accessibility/AccessibilitySpinButton.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySpinButton.cpp
@@ -59,14 +59,14 @@ AXCoreObject* AccessibilitySpinButton::incrementButton()
 {
     ASSERT(m_childrenInitialized);
     RELEASE_ASSERT(m_children.size() == 2);
-    return m_children[0].get();
+    return m_children[0].ptr();
 }
    
 AXCoreObject* AccessibilitySpinButton::decrementButton()
 {
     ASSERT(m_childrenInitialized);
     RELEASE_ASSERT(m_children.size() == 2);
-    return m_children[1].get();
+    return m_children[1].ptr();
 }
     
 LayoutRect AccessibilitySpinButton::elementRect() const

--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -272,13 +272,13 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityTableCell::rowHeaders()
 
     for (unsigned column = 0; column < colRange.first; column++) {
         RefPtr tableCell = parent->cellForColumnAndRow(column, rowRange.first);
-        if (!tableCell || tableCell == this || headers.contains(tableCell))
+        if (!tableCell || tableCell == this || headers.contains(Ref { *tableCell }))
             continue;
 
-        if (tableCell->cellScope() == "rowgroup"_s && isTableCellInSameRowGroup(tableCell.get()))
-            headers.append(tableCell);
+        if (tableCell->cellScope() == "rowgroup"_s && isTableCellInSameRowGroup(*tableCell))
+            headers.append(tableCell.releaseNonNull());
         else if (tableCell->isRowHeader())
-            headers.append(tableCell);
+            headers.append(tableCell.releaseNonNull());
     }
 
     return headers;
@@ -288,7 +288,7 @@ AccessibilityTableRow* AccessibilityTableCell::ariaOwnedByParent() const
 {
     auto owners = this->owners();
     if (owners.size() == 1 && owners[0]->isTableRow())
-        return downcast<AccessibilityTableRow>(owners[0].get());
+        return dynamicDowncast<AccessibilityTableRow>(owners[0].get());
     return nullptr;
 }
 

--- a/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
@@ -72,7 +72,7 @@ AXCoreObject* AccessibilityTableColumn::columnHeader()
 
     for (const auto& cell : unignoredChildren()) {
         if (cell->roleValue() == AccessibilityRole::ColumnHeader)
-            return cell.get();
+            return cell.ptr();
     }
     return nullptr;
 }
@@ -114,7 +114,7 @@ void AccessibilityTableColumn::addChildren()
             continue;
 
         // make sure the last one isn't the same as this one (rowspan cells)
-        if (m_children.size() > 0 && m_children.last() == cell.get())
+        if (m_children.size() > 0 && m_children.last().ptr() == cell.get())
             continue;
 
         addChild(cell.get());

--- a/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
@@ -70,7 +70,7 @@ void AccessibilityTableHeaderContainer::addChildren()
         return;
 
     for (auto& columnHeader : parentTable->columnHeaders())
-        addChild(columnHeader.get());
+        addChild(columnHeader.ptr());
 
     for (const auto& child : m_children)
         m_headerRect.unite(child->elementRect());

--- a/Source/WebCore/accessibility/AccessibilityTableRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.cpp
@@ -133,8 +133,8 @@ AXCoreObject* AccessibilityTableRow::rowHeader()
     if (rowChildren.isEmpty())
         return nullptr;
     
-    RefPtr firstCell = rowChildren[0].get();
-    if (!firstCell || !firstCell->node() || !firstCell->node()->hasTagName(thTag))
+    Ref firstCell = rowChildren[0].get();
+    if (!firstCell->node() || !firstCell->node()->hasTagName(thTag))
         return nullptr;
 
     // Verify that the row header is not part of an entire row of headers.
@@ -142,7 +142,7 @@ AXCoreObject* AccessibilityTableRow::rowHeader()
     for (const auto& child : rowChildren) {
         // We found a non-header cell, so this is not an entire row of headers -- return the original header cell.
         if (child->node() && !child->node()->hasTagName(thTag))
-            return firstCell.get();
+            return firstCell.ptr();
     }
     return nullptr;
 }
@@ -153,7 +153,7 @@ void AccessibilityTableRow::addChildren()
     auto ownedObjects = this->ownedObjects();
     if (ownedObjects.size()) {
         for (auto& object : ownedObjects)
-            addChild(object.get(), DescendIfIgnored::No);
+            addChild(object.ptr(), DescendIfIgnored::No);
         m_childrenInitialized = true;
         m_subtreeDirty = false;
     }

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
@@ -35,7 +35,7 @@ typedef struct _GVariantBuilder GVariantBuilder;
 
 namespace WebCore {
 
-using RelationMap = UncheckedKeyHashMap<Atspi::Relation, Vector<RefPtr<AccessibilityObjectAtspi>>, IntHash<Atspi::Relation>, WTF::StrongEnumHashTraits<Atspi::Relation>>;
+using RelationMap = UncheckedKeyHashMap<Atspi::Relation, Vector<Ref<AccessibilityObjectAtspi>>, IntHash<Atspi::Relation>, WTF::StrongEnumHashTraits<Atspi::Relation>>;
 
 class AccessibilityObjectAtspi final : public RefCounted<AccessibilityObjectAtspi> {
 public:
@@ -87,7 +87,7 @@ public:
     WEBCORE_EXPORT String locale() const;
     WEBCORE_EXPORT Atspi::Role role() const;
     WEBCORE_EXPORT unsigned childCount() const;
-    WEBCORE_EXPORT Vector<RefPtr<AccessibilityObjectAtspi>> children() const;
+    WEBCORE_EXPORT Vector<Ref<AccessibilityObjectAtspi>> children() const;
     WEBCORE_EXPORT AccessibilityObjectAtspi* childAt(unsigned) const;
     WEBCORE_EXPORT OptionSet<Atspi::State> states() const;
     bool isDefunct() const;
@@ -145,7 +145,7 @@ public:
     void activeDescendantChanged();
 
     WEBCORE_EXPORT unsigned selectionCount() const;
-    WEBCORE_EXPORT Vector<RefPtr<AccessibilityObjectAtspi>> selectedChildren() const;
+    WEBCORE_EXPORT Vector<Ref<AccessibilityObjectAtspi>> selectedChildren() const;
     WEBCORE_EXPORT AccessibilityObjectAtspi* selectedChild(unsigned) const;
     WEBCORE_EXPORT bool setChildSelected(unsigned, bool) const;
     WEBCORE_EXPORT bool clearSelection() const;
@@ -154,13 +154,13 @@ public:
     WEBCORE_EXPORT AccessibilityObjectAtspi* cell(unsigned row, unsigned column) const;
     WEBCORE_EXPORT unsigned rowCount() const;
     WEBCORE_EXPORT unsigned columnCount() const;
-    WEBCORE_EXPORT Vector<RefPtr<AccessibilityObjectAtspi>> cells() const;
-    WEBCORE_EXPORT Vector<RefPtr<AccessibilityObjectAtspi>> rows() const;
-    WEBCORE_EXPORT Vector<RefPtr<AccessibilityObjectAtspi>> rowHeaders() const;
-    WEBCORE_EXPORT Vector<RefPtr<AccessibilityObjectAtspi>> columnHeaders() const;
+    WEBCORE_EXPORT Vector<Ref<AccessibilityObjectAtspi>> cells() const;
+    WEBCORE_EXPORT Vector<Ref<AccessibilityObjectAtspi>> rows() const;
+    WEBCORE_EXPORT Vector<Ref<AccessibilityObjectAtspi>> rowHeaders() const;
+    WEBCORE_EXPORT Vector<Ref<AccessibilityObjectAtspi>> columnHeaders() const;
 
-    WEBCORE_EXPORT Vector<RefPtr<AccessibilityObjectAtspi>> cellRowHeaders() const;
-    WEBCORE_EXPORT Vector<RefPtr<AccessibilityObjectAtspi>> cellColumnHeaders() const;
+    WEBCORE_EXPORT Vector<Ref<AccessibilityObjectAtspi>> cellRowHeaders() const;
+    WEBCORE_EXPORT Vector<Ref<AccessibilityObjectAtspi>> cellColumnHeaders() const;
     WEBCORE_EXPORT unsigned rowSpan() const;
     WEBCORE_EXPORT unsigned columnSpan() const;
     WEBCORE_EXPORT std::pair<std::optional<unsigned>, std::optional<unsigned>> cellPosition() const;
@@ -168,7 +168,7 @@ public:
 private:
     AccessibilityObjectAtspi(AXCoreObject*, AccessibilityRootAtspi*);
 
-    Vector<RefPtr<AccessibilityObjectAtspi>> wrapperVector(const Vector<RefPtr<AXCoreObject>>&) const;
+    Vector<Ref<AccessibilityObjectAtspi>> wrapperVector(const Vector<Ref<AXCoreObject>>&) const;
     void childAdded(AccessibilityObjectAtspi&);
     void childRemoved(AccessibilityObjectAtspi&);
 
@@ -260,8 +260,8 @@ private:
             Atspi::CollectionMatchType type;
         } interfaces;
     };
-    Vector<RefPtr<AccessibilityObjectAtspi>> matches(CollectionMatchRule&, Atspi::CollectionSortOrder, uint32_t maxResultCount, bool traverse);
-    void addMatchesInCanonicalOrder(Vector<RefPtr<AccessibilityObjectAtspi>>&, CollectionMatchRule&, uint32_t maxResultCount, bool traverse);
+    Vector<Ref<AccessibilityObjectAtspi>> matches(CollectionMatchRule&, Atspi::CollectionSortOrder, uint32_t maxResultCount, bool traverse);
+    void addMatchesInCanonicalOrder(Vector<Ref<AccessibilityObjectAtspi>>&, CollectionMatchRule&, uint32_t maxResultCount, bool traverse);
 
     static OptionSet<Interface> interfacesForObject(AXCoreObject&);
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectCollectionAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectCollectionAtspi.cpp
@@ -324,7 +324,7 @@ bool AccessibilityObjectAtspi::CollectionMatchRule::match(AccessibilityObjectAts
     return true;
 }
 
-void AccessibilityObjectAtspi::addMatchesInCanonicalOrder(Vector<RefPtr<AccessibilityObjectAtspi>>& matchList, CollectionMatchRule& rule, uint32_t maxResultCount, bool traverse)
+void AccessibilityObjectAtspi::addMatchesInCanonicalOrder(Vector<Ref<AccessibilityObjectAtspi>>& matchList, CollectionMatchRule& rule, uint32_t maxResultCount, bool traverse)
 {
     const auto& children = m_coreObject->children();
     for (auto& child : children) {
@@ -333,7 +333,7 @@ void AccessibilityObjectAtspi::addMatchesInCanonicalOrder(Vector<RefPtr<Accessib
             continue;
 
         if (rule.match(*wrapper)) {
-            matchList.append(wrapper);
+            matchList.append(*wrapper);
             if (maxResultCount && matchList.size() >= maxResultCount)
                 return;
         }
@@ -346,12 +346,12 @@ void AccessibilityObjectAtspi::addMatchesInCanonicalOrder(Vector<RefPtr<Accessib
     }
 }
 
-Vector<RefPtr<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::matches(CollectionMatchRule& rule, Atspi::CollectionSortOrder sortOrder, uint32_t maxResultCount, bool traverse)
+Vector<Ref<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::matches(CollectionMatchRule& rule, Atspi::CollectionSortOrder sortOrder, uint32_t maxResultCount, bool traverse)
 {
     if (!m_coreObject)
         return { };
 
-    Vector<RefPtr<AccessibilityObjectAtspi>> matchList;
+    Vector<Ref<AccessibilityObjectAtspi>> matchList;
 
     switch (sortOrder) {
     case Atspi::CollectionSortOrder::SortOrderInvalid:

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectSelectionAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectSelectionAtspi.cpp
@@ -86,7 +86,7 @@ unsigned AccessibilityObjectAtspi::selectionCount() const
     return selectedChildren ? selectedChildren->size() : 0;
 }
 
-Vector<RefPtr<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::selectedChildren() const
+Vector<Ref<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::selectedChildren() const
 {
     if (!m_coreObject)
         return { };

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTableAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTableAtspi.cpp
@@ -187,7 +187,7 @@ std::optional<unsigned> AccessibilityObjectAtspi::cellIndex(unsigned row, unsign
 
     auto cells = m_coreObject->cells();
     AXCoreObject::AccessibilityChildrenVector::iterator position;
-    position = std::find(cells.begin(), cells.end(), cell);
+    position = std::find(cells.begin(), cells.end(), Ref { *cell });
     if (position == cells.end())
         return std::nullopt;
     return position - cells.begin();
@@ -329,7 +329,7 @@ unsigned AccessibilityObjectAtspi::columnExtent(unsigned row, unsigned column) c
     return cell ? cell->columnIndexRange().second : 0;
 }
 
-Vector<RefPtr<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::cells() const
+Vector<Ref<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::cells() const
 {
     if (!m_coreObject)
         return { };
@@ -337,7 +337,7 @@ Vector<RefPtr<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::cells() const
     return wrapperVector(m_coreObject->cells());
 }
 
-Vector<RefPtr<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::rows() const
+Vector<Ref<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::rows() const
 {
     if (!m_coreObject)
         return { };
@@ -345,7 +345,7 @@ Vector<RefPtr<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::rows() const
     return wrapperVector(m_coreObject->rows());
 }
 
-Vector<RefPtr<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::rowHeaders() const
+Vector<Ref<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::rowHeaders() const
 {
     if (!m_coreObject)
         return { };
@@ -353,7 +353,7 @@ Vector<RefPtr<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::rowHeaders() 
     return wrapperVector(m_coreObject->rowHeaders());
 }
 
-Vector<RefPtr<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::columnHeaders() const
+Vector<Ref<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::columnHeaders() const
 {
     if (!m_coreObject)
         return { };

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTableCellAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTableCellAtspi.cpp
@@ -90,7 +90,7 @@ GDBusInterfaceVTable AccessibilityObjectAtspi::s_tableCellFunctions = {
     { nullptr }
 };
 
-Vector<RefPtr<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::cellRowHeaders() const
+Vector<Ref<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::cellRowHeaders() const
 {
     if (!m_coreObject)
         return { };
@@ -98,7 +98,7 @@ Vector<RefPtr<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::cellRowHeader
     return wrapperVector(m_coreObject->rowHeaders());
 }
 
-Vector<RefPtr<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::cellColumnHeaders() const
+Vector<Ref<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::cellColumnHeaders() const
 {
     if (!m_coreObject)
         return { };

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -839,11 +839,8 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
         return { WTFMove(defaultAttributes), -1, -1 };
 
     if (!*utf16Offset && m_hasListMarkerAtStart) {
-        auto* axObject = m_coreObject->children()[0].get();
-        RELEASE_ASSERT(axObject);
-
         // Always consider list marker an independent run.
-        auto attributes = accessibilityTextAttributes(*axObject, defaultAttributes);
+        auto attributes = accessibilityTextAttributes(m_coreObject->children()[0].get(), defaultAttributes);
         if (!includeDefault)
             return { WTFMove(attributes), 0, 1 };
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -673,9 +673,9 @@ const AXCoreObject::AccessibilityChildrenVector& AXIsolatedObject::children(bool
         updateBackingStore();
 
         if (m_childrenDirty) {
-            m_children = WTF::compactMap(m_childrenIDs, [&](auto& childID) -> std::optional<RefPtr<AXCoreObject>> {
+            m_children = WTF::compactMap(m_childrenIDs, [&](auto& childID) -> std::optional<Ref<AXCoreObject>> {
                 if (RefPtr child = tree()->objectForID(childID))
-                    return child;
+                    return child.releaseNonNull();
                 return std::nullopt;
             });
             m_childrenDirty = false;
@@ -701,7 +701,7 @@ std::optional<AXCoreObject::AccessibilityChildrenVector> AXIsolatedObject::selec
 
 void AXIsolatedObject::setSelectedChildren(const AccessibilityChildrenVector& selectedChildren)
 {
-    ASSERT(selectedChildren.isEmpty() || (selectedChildren[0] && selectedChildren[0]->isAXIsolatedObjectInstance()));
+    ASSERT(selectedChildren.isEmpty() || selectedChildren[0]->isAXIsolatedObjectInstance());
 
     auto childrenIDs = axIDs(selectedChildren);
     performFunctionOnMainThread([selectedChildrenIDs = WTFMove(childrenIDs), protectedThis = Ref { *this }] (auto* object) {
@@ -779,7 +779,7 @@ void AXIsolatedObject::mathPostscripts(AccessibilityMathMultiscriptPairs& pairs)
 std::optional<AXCoreObject::AccessibilityChildrenVector> AXIsolatedObject::mathRadicand()
 {
     if (m_propertyMap.contains(AXPropertyName::MathRadicand)) {
-        Vector<RefPtr<AXCoreObject>> radicand;
+        Vector<Ref<AXCoreObject>> radicand;
         fillChildrenVectorForProperty(AXPropertyName::MathRadicand, radicand);
         return { radicand };
     }
@@ -1238,7 +1238,7 @@ void AXIsolatedObject::fillChildrenVectorForProperty(AXPropertyName propertyName
     children.reserveCapacity(childIDs.size());
     for (const auto& childID : childIDs) {
         if (RefPtr object = tree()->objectForID(childID))
-            children.append(object);
+            children.append(object.releaseNonNull());
     }
 }
 
@@ -2066,27 +2066,26 @@ AXCoreObject::AccessibilityChildrenVector AXIsolatedObject::rowHeaders()
         auto rowsCopy = rows();
         for (const auto& row : rowsCopy) {
             if (auto* header = row->rowHeader())
-                headers.append(header);
+                headers.append(*header);
         }
     } else if (isExposedTableCell()) {
-        auto* parent = exposedTableAncestor();
+        RefPtr parent = exposedTableAncestor();
         if (!parent)
             return { };
 
         auto rowRange = rowIndexRange();
         auto colRange = columnIndexRange();
         for (unsigned column = 0; column < colRange.first; column++) {
-            auto* tableCell = parent->cellForColumnAndRow(column, rowRange.first);
-            if (!tableCell || tableCell == this || headers.contains(tableCell))
+            RefPtr tableCell = parent->cellForColumnAndRow(column, rowRange.first);
+            if (!tableCell || tableCell == this || headers.contains(Ref { *tableCell }))
                 continue;
 
-            if (tableCell->cellScope() == "rowgroup"_s && isTableCellInSameRowGroup(tableCell))
-                headers.append(tableCell);
+            if (tableCell->cellScope() == "rowgroup"_s && isTableCellInSameRowGroup(*tableCell))
+                headers.append(tableCell.releaseNonNull());
             else if (tableCell->isRowHeader())
-                headers.append(tableCell);
+                headers.append(tableCell.releaseNonNull());
         }
     }
-
     return headers;
 }
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -555,7 +555,7 @@ private:
     Markable<AXID> m_parentID;
     bool m_childrenDirty { true };
     Vector<AXID> m_childrenIDs;
-    Vector<RefPtr<AXCoreObject>> m_children;
+    Vector<Ref<AXCoreObject>> m_children;
     AXPropertyMap m_propertyMap;
     OptionSet<AXPropertyFlag> m_propertyFlags;
     // Some objects (e.g. display:contents) form their geometry through their children.

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -354,7 +354,7 @@ public:
     WEBCORE_EXPORT RefPtr<AXIsolatedObject> focusedNode();
 
     RefPtr<AXIsolatedObject> objectForID(std::optional<AXID>) const;
-    template<typename U> Vector<RefPtr<AXCoreObject>> objectsForIDs(const U&);
+    template<typename U> Vector<Ref<AXCoreObject>> objectsForIDs(const U&);
 
     void generateSubtree(AccessibilityObject&);
     bool shouldCreateNodeChange(AccessibilityObject&);
@@ -592,16 +592,15 @@ inline RefPtr<AXIsolatedTree> AXIsolatedTree::treeForPageID(std::optional<PageId
 }
 
 template<typename U>
-inline Vector<RefPtr<AXCoreObject>> AXIsolatedTree::objectsForIDs(const U& axIDs)
+inline Vector<Ref<AXCoreObject>> AXIsolatedTree::objectsForIDs(const U& axIDs)
 {
     ASSERT(!isMainThread());
 
-    Vector<RefPtr<AXCoreObject>> result;
+    Vector<Ref<AXCoreObject>> result;
     result.reserveInitialCapacity(axIDs.size());
     for (const auto& axID : axIDs) {
-        RefPtr object = objectForID(axID);
-        if (object)
-            result.append(WTFMove(object));
+        if (RefPtr object = objectForID(axID))
+            result.append(object.releaseNonNull());
     }
     result.shrinkToFit();
     return result;

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -157,7 +157,7 @@ AXTextMarkerRange AXIsolatedObject::textMarkerRange() const
 
         auto thisMarker = AXTextMarker { *this, 0 };
         AXTextMarkerRange range { thisMarker, thisMarker };
-        auto endMarker = thisMarker.findLastBefore(stopObject ? stopObject->objectID() : std::nullopt);
+        auto endMarker = thisMarker.findLastBefore(stopObject ? std::optional { stopObject->objectID() } : std::nullopt);
         if (endMarker.isValid() && endMarker.isInTextRun()) {
             // One or more of our descendants have text, so let's form a range from the first and last text positions.
             range = { thisMarker.toTextRunMarker(), WTFMove(endMarker) };

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -265,9 +265,6 @@ static NSArray *convertMathPairsToNSArray(const AccessibilityObject::Accessibili
 NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& children)
 {
     return createNSArray(children, [] (const auto& child) -> id {
-        if (!child)
-            return nil;
-
         auto wrapper = child->wrapper();
         // We want to return the attachment view instead of the object representing the attachment,
         // otherwise, we get palindrome errors in the AX hierarchy.

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -1366,9 +1366,8 @@ static void convertToVector(NSArray* array, AccessibilityObject::AccessibilityCh
     unsigned length = [array count];
     vector.reserveInitialCapacity(length);
     for (unsigned i = 0; i < length; ++i) {
-        AXCoreObject* obj = [[array objectAtIndex:i] axBackingObject];
-        if (obj)
-            vector.append(obj);
+        if (auto* object = [[array objectAtIndex:i] axBackingObject])
+            vector.append(*object);
     }
 }
 
@@ -1449,7 +1448,7 @@ static void WebTransformCGPathToNSBezierPath(void* info, const CGPathElement *el
 }
 
 // `unignoredChildren` must be the children of `backingObject`.
-static NSArray *transformSpecialChildrenCases(AXCoreObject& backingObject, const Vector<RefPtr<AXCoreObject>>& unignoredChildren)
+static NSArray *transformSpecialChildrenCases(AXCoreObject& backingObject, const Vector<Ref<AXCoreObject>>& unignoredChildren)
 {
 #if ENABLE(MODEL_ELEMENT)
     if (backingObject.isModel()) {
@@ -3902,8 +3901,6 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     size_t childCount = children.size();
     for (size_t i = 0; i < childCount; i++) {
         const auto& child = children[i];
-        if (!child)
-            continue;
         WebAccessibilityObjectWrapper *childWrapper = child->wrapper();
         if (childWrapper == targetChild || (child->isAttachment() && [childWrapper attachmentView] == targetChild)
             || (child->isRemoteFrame() && child->remoteFramePlatformElement() == targetChild)) {

--- a/Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp
@@ -93,11 +93,11 @@ ExceptionOr<RefPtr<Node>> InspectorAuditAccessibilityObject::getActiveDescendant
 
 static void addChildren(AXCoreObject& parentObject, Vector<Ref<Node>>& childNodes)
 {
-    for (const auto& childObject : parentObject.children()) {
+    for (const auto& childObject : parentObject.unignoredChildren()) {
         if (RefPtr childNode = childObject->node())
             childNodes.append(childNode.releaseNonNull());
         else
-            addChildren(*childObject, childNodes);
+            addChildren(childObject.get(), childNodes);
     }
 }
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -2176,7 +2176,7 @@ Ref<Inspector::Protocol::DOM::EventListener> InspectorDOMAgent::buildObjectForEv
 
 void InspectorDOMAgent::processAccessibilityChildren(AXCoreObject& axObject, JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>& childNodeIds)
 {
-    const auto& children = axObject.children();
+    const auto& children = axObject.unignoredChildren();
     if (!children.size())
         return;
 
@@ -2184,7 +2184,7 @@ void InspectorDOMAgent::processAccessibilityChildren(AXCoreObject& axObject, JSO
         if (Node* childNode = childObject->node())
             childNodeIds.addItem(pushNodePathToFrontend(childNode));
         else
-            processAccessibilityChildren(*childObject, childNodeIds);
+            processAccessibilityChildren(childObject.get(), childNodeIds);
     }
 }
     

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityControllerAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityControllerAtspi.cpp
@@ -54,7 +54,7 @@ static WebCore::AccessibilityObjectAtspi* findAccessibleObjectById(WebCore::Acce
         return &axObject;
 
     for (const auto& child : axObject.children()) {
-        if (auto* element = findAccessibleObjectById(*child, elementID))
+        if (auto* element = findAccessibleObjectById(child, elementID))
             return element;
     }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -114,11 +114,8 @@ static RefPtr<AccessibilityUIElement> elementForRelationAtIndex(WebCore::Accessi
     if (targets.isEmpty() || index >= targets.size())
         return nullptr;
 
-    auto target = targets[index];
-    if (!target)
-        return nullptr;
-
-    return AccessibilityUIElement::create(target.get());
+    Ref target = targets[index];
+    return AccessibilityUIElement::create(target.ptr());
 }
 
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::linkedUIElementAtIndex(unsigned index)
@@ -211,7 +208,7 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::rowAtIndex(unsigned index
     if (index >= rows.size())
         return nullptr;
 
-    return AccessibilityUIElement::create(rows[index].get());
+    return AccessibilityUIElement::create(rows[index].ptr());
 }
 
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::selectedChildAtIndex(unsigned index) const
@@ -341,24 +338,24 @@ static String attributesOfElement(AccessibilityUIElement& element)
     return builder.toString();
 }
 
-static String attributesOfElements(Vector<RefPtr<AccessibilityUIElement>>& elements)
+static String attributesOfElements(Vector<Ref<AccessibilityUIElement>>& elements)
 {
     StringBuilder builder;
     for (auto& element : elements)
-        builder.append(attributesOfElement(*element), "\n------------\n"_s);
+        builder.append(attributesOfElement(element), "\n------------\n"_s);
     return builder.toString();
 }
 
-static Vector<RefPtr<AccessibilityUIElement>> elementsVector(const Vector<RefPtr<WebCore::AccessibilityObjectAtspi>>& wrappers)
+static Vector<Ref<AccessibilityUIElement>> elementsVector(const Vector<Ref<WebCore::AccessibilityObjectAtspi>>& wrappers)
 {
-    Vector<RefPtr<AccessibilityUIElement>> elements;
+    Vector<Ref<AccessibilityUIElement>> elements;
     elements.reserveInitialCapacity(wrappers.size());
     for (auto& wrapper : wrappers)
-        elements.append(AccessibilityUIElement::create(wrapper.get()));
+        elements.append(AccessibilityUIElement::create(wrapper.ptr()));
     return elements;
 }
 
-static String attributesOfElements(const Vector<RefPtr<WebCore::AccessibilityObjectAtspi>>& wrappers)
+static String attributesOfElements(const Vector<Ref<WebCore::AccessibilityObjectAtspi>>& wrappers)
 {
     auto elements = elementsVector(wrappers);
     return attributesOfElements(elements);
@@ -485,12 +482,12 @@ JSValueRef AccessibilityUIElement::uiElementArrayAttributeValue(JSContextRef, JS
     return nullptr;
 }
 
-static JSValueRef makeJSArray(JSContextRef context, const Vector<RefPtr<AccessibilityUIElement>>& elements)
+static JSValueRef makeJSArray(JSContextRef context, const Vector<Ref<AccessibilityUIElement>>& elements)
 {
     size_t elementCount = elements.size();
     auto valueElements = makeUniqueArray<JSValueRef>(elementCount);
     for (size_t i = 0; i < elementCount; i++)
-        valueElements[i] = JSObjectMake(context, elements[i]->wrapperClass(), elements[i].get());
+        valueElements[i] = JSObjectMake(context, elements[i]->wrapperClass(), elements[i].ptr());
 
     return JSObjectMakeArray(context, elementCount, valueElements.get(), nullptr);
 }


### PR DESCRIPTION
#### 0dcbff7496d08c073d80ce69ab7f8f53e6133388
<pre>
AX: AccessibilityChildrenVector should be Vector&lt;Ref&lt;AXCoreObject&gt;&gt;, not Vector&lt;RefPtr&lt;AXCoreObject&gt;&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=283634">https://bugs.webkit.org/show_bug.cgi?id=283634</a>
<a href="https://rdar.apple.com/140480178">rdar://140480178</a>

Reviewed by Chris Fleizach.

AccessibilityChildrenVector should be Vector&lt;Ref&lt;AXCoreObject&gt;&gt;, not Vector&lt;RefPtr&lt;AXCoreObject&gt;&gt;. Having a null object
in these vectors never makes sense, so this commit prevents it from happening using the Ref type. Allowing null objects
has caused numerous crashes over the years in places where we forget to null-check before building an
AccessibilityChildrenVector. Making this a Ref also allows us to remove null checks from some of our hottest code paths.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::unignoredChildren):
(WebCore::AXCoreObject::nextInPreOrder):
(WebCore::AXCoreObject::nextSiblingIncludingIgnored const):
(WebCore::AXCoreObject::nextUnignoredSibling const):
(WebCore::AXCoreObject::contents):
(WebCore::AXCoreObject::selectedRadioButton):
(WebCore::AXCoreObject::selectedTabItem):
(WebCore::AXCoreObject::columnHeaders):
(WebCore::AXCoreObject::isTableCellInSameRowGroup):
(WebCore::AXCoreObject::activeDescendant const):
(WebCore::AXCoreObject::selectedCells):
(WebCore::AXCoreObject::titleUIElement const):
(WebCore::AXCoreObject::linkedObjects const):
(WebCore::AXCoreObject::appendRadioButtonDescendants const):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::Accessibility::findUnignoredChild):
(WebCore::Accessibility::enumerateDescendantsIncludingIgnored):
(WebCore::Accessibility::enumerateUnignoredDescendants):
(WebCore::AXCoreObject::isDescendantOfObject const):
(WebCore::AXCoreObject::isAncestorOfObject const):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::AXLogger::log):
(WebCore::operator&lt;&lt;):
(WebCore::streamSubtree):
* Source/WebCore/accessibility/AXLogger.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::focusedImageMapUIElement):
(WebCore::AXObjectCache::handleTextChanged):
(WebCore::AXObjectCache::handleChildrenChanged):
(WebCore::AXObjectCache::handleActiveDescendantChange):
(WebCore::AXObjectCache::handleLabelChanged):
(WebCore::AXObjectCache::treeData):
* Source/WebCore/accessibility/AXObjectCache.h:
(WebCore::AXObjectCache::objectsForIDs const):
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::isRadioButtonInDifferentAdhocGroup):
(WebCore::AXSearchManager::matchForSearchKeyAtIndex):
(WebCore::AXSearchManager::match):
(WebCore::AXSearchManager::matchText):
(WebCore::AXSearchManager::matchWithResultsLimit):
(WebCore::appendAccessibilityObject):
(WebCore::appendChildrenToArray):
(WebCore::AXSearchManager::findMatchingObjectsInternal):
(WebCore::AXSearchManager::findMatchingRange):
* Source/WebCore/accessibility/AXSearchManager.h:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::appendChildren):
(WebCore::AXTextMarker::characterRangeForLine const):
(WebCore::AXTextMarker::lineNumberForIndex const):
* Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp:
(WebCore::AccessibilityARIAGridRow::disclosedRows):
(WebCore::AccessibilityARIAGridRow::disclosedByRow const):
(WebCore::AccessibilityARIAGridRow::rowHeader):
* Source/WebCore/accessibility/AccessibilityListBox.cpp:
(WebCore::AccessibilityListBox::elementAccessibilityHitTest const):
* Source/WebCore/accessibility/AccessibilityMathMLElement.cpp:
(WebCore::AccessibilityMathMLElement::mathRootIndexObject):
(WebCore::AccessibilityMathMLElement::mathNumeratorObject):
(WebCore::AccessibilityMathMLElement::mathDenominatorObject):
(WebCore::AccessibilityMathMLElement::mathUnderObject):
(WebCore::AccessibilityMathMLElement::mathOverObject):
(WebCore::AccessibilityMathMLElement::mathBaseObject):
(WebCore::AccessibilityMathMLElement::mathSubscriptObject):
(WebCore::AccessibilityMathMLElement::mathSuperscriptObject):
* Source/WebCore/accessibility/AccessibilityMenuList.cpp:
(WebCore::AccessibilityMenuList::didUpdateActiveOption):
* Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp:
(WebCore::AccessibilityMenuListPopup::handleChildrenChanged):
(WebCore::AccessibilityMenuListPopup::didUpdateActiveOption):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::updateOwnedChildren):
(WebCore::AccessibilityNodeObject::radioButtonGroup const):
(WebCore::AccessibilityNodeObject::textAsLabelFor const):
(WebCore::AccessibilityNodeObject::stringValue const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::insertChild):
(WebCore::AccessibilityObject::ariaTreeRows):
(WebCore::AccessibilityObject::ariaSelectedRows):
(WebCore::AccessibilityObject::selectedChildren):
(WebCore::AccessibilityObject::setIsIgnoredFromParentDataForChild):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::documentLinks):
(WebCore::AccessibilityRenderObject::addNodeOnlyChildren):
(WebCore::AccessibilityRenderObject::addChildren):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::removeChildScrollbar):
* Source/WebCore/accessibility/AccessibilitySpinButton.cpp:
(WebCore::AccessibilitySpinButton::incrementButton):
(WebCore::AccessibilitySpinButton::decrementButton):
* Source/WebCore/accessibility/AccessibilityTable.cpp:
(WebCore::AccessibilityTable::updateChildrenRoles):
(WebCore::AccessibilityTable::addChildren):
(WebCore::AccessibilityTable::computeCellSlots):
(WebCore::AccessibilityTable::rowHeaders):
(WebCore::AccessibilityTable::visibleRows):
* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
(WebCore::AccessibilityTableCell::rowHeaders):
(WebCore::AccessibilityTableCell::ariaOwnedByParent const):
* Source/WebCore/accessibility/AccessibilityTableColumn.cpp:
(WebCore::AccessibilityTableColumn::columnHeader):
(WebCore::AccessibilityTableColumn::addChildren):
* Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp:
(WebCore::AccessibilityTableHeaderContainer::addChildren):
* Source/WebCore/accessibility/AccessibilityTableRow.cpp:
(WebCore::AccessibilityTableRow::rowHeader):
(WebCore::AccessibilityTableRow::addChildren):
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::wrapperVector const):
(WebCore::AccessibilityObjectAtspi::children const):
(WebCore::AccessibilityObjectAtspi::indexInParent const):
(WebCore::AccessibilityObjectAtspi::relationMap const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectCollectionAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::addMatchesInCanonicalOrder):
(WebCore::AccessibilityObjectAtspi::matches):
* Source/WebCore/accessibility/atspi/AccessibilityObjectSelectionAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::selectedChildren const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectTableAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::cellIndex const):
(WebCore::AccessibilityObjectAtspi::cells const):
(WebCore::AccessibilityObjectAtspi::rows const):
(WebCore::AccessibilityObjectAtspi::rowHeaders const):
(WebCore::AccessibilityObjectAtspi::columnHeaders const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectTableCellAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::cellRowHeaders const):
(WebCore::AccessibilityObjectAtspi::cellColumnHeaders const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::textAttributes const):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityHeaderElements]):
(-[WebAccessibilityObjectWrapper accessibilityRowRange]):
(accessibleElementsForObjects):
(-[WebAccessibilityObjectWrapper accessibilityLinkedElement]):
(-[WebAccessibilityObjectWrapper accessibilityIsFirstItemInSuggestion]):
(-[WebAccessibilityObjectWrapper accessibilityIsLastItemInSuggestion]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::children):
(WebCore::AXIsolatedObject::setSelectedChildren):
(WebCore::AXIsolatedObject::mathRadicand):
(WebCore::AXIsolatedObject::fillChildrenVectorForProperty const):
(WebCore::AXIsolatedObject::rowHeaders):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::collectNodeChangesForSubtree):
(WebCore::AXIsolatedTree::updateDependentProperties):
(WebCore::AXIsolatedTree::updateChildren):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::objectsForIDs):
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::textMarkerRange const):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(makeNSArray):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(convertToVector):
(transformSpecialChildrenCases):
(-[WebAccessibilityObjectWrapper accessibilityIndexOfChild:]):
* Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp:
(WebCore::addChildren):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::processAccessibilityChildren):
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityControllerAtspi.cpp:
(WTR::findAccessibleObjectById):
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp:
(WTR::elementForRelationAtIndex):
(WTR::AccessibilityUIElement::rowAtIndex):
(WTR::attributesOfElements):
(WTR::elementsVector):
(WTR::makeJSArray):

Canonical link: <a href="https://commits.webkit.org/287044@main">https://commits.webkit.org/287044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ec7a9766263f28732f32649b59215983bdc8e29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82743 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29348 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80216 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61152 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19075 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51140 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67749 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41465 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48499 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24662 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27688 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69594 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25015 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84104 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5454 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3684 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69373 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5610 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68627 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17124 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12625 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10844 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5402 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8155 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5392 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8824 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7180 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->