### PR TITLE
Make JSTests/wasm/stress/try-and-block-with-v128-results.js less chatty.

### DIFF
--- a/JSTests/wasm/stress/try-and-block-with-v128-results.js
+++ b/JSTests/wasm/stress/try-and-block-with-v128-results.js
@@ -5,8 +5,10 @@ if (globalThis.callerIsBBQOrOMGCompiled) {
     let bytes = read(filename, 'binary');
     return WebAssembly.instantiate(bytes, importObject, 'x');
   }
-  const log = debug;
-  const report = $.agent.report;
+  const verbose = false;
+  const nullLog = function () { }
+  const log = verbose ? debug : nullLog;
+  const report = verbose ? $.agent.report : nullLog;
   const isJIT = callerIsBBQOrOMGCompiled;
   tools = {log, report, isJIT, instantiate: instantiateJsc};
 } else {


### PR DESCRIPTION
#### 95d081948f17c1a45026dc409dbd10e446d5f86c
<pre>
Make JSTests/wasm/stress/try-and-block-with-v128-results.js less chatty.
<a href="https://bugs.webkit.org/show_bug.cgi?id=283642">https://bugs.webkit.org/show_bug.cgi?id=283642</a>
<a href="https://rdar.apple.com/140490961">rdar://140490961</a>

Reviewed by Keith Miller.

The test is currently logging text when it is not failing.  We should suppress this so
that it will not make logging from real failures difficult to spot.

* JSTests/wasm/stress/try-and-block-with-v128-results.js:
(globalThis.callerIsBBQOrOMGCompiled.const.nullLog):

Canonical link: <a href="https://commits.webkit.org/287030@main">https://commits.webkit.org/287030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a43b4ece2054c91c8a47e88fc2248179b97efc2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82702 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29308 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5380 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61117 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19036 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41429 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48468 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27653 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71196 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69562 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24943 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84064 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77288 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5419 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3654 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69336 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/navigation/opt-in-removed-during-transition.html imported/w3c/web-platform-tests/css/css-view-transitions/navigation/root-element-transition-iframe.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5575 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66977 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68590 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12589 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10784 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/99600 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12078 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5367 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21761 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5357 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8789 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7144 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->