### PR TITLE
Stop using WTF_ALLOW_UNSAFE_BUFFER_USAGE in CSSPropertyParserConsumer+Contain.cpp

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Contain.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Contain.cpp
@@ -32,8 +32,6 @@
 #include "CSSValueKeywords.h"
 #include "CSSValueList.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
 
@@ -44,12 +42,13 @@ RefPtr<CSSValue> consumeContain(CSSParserTokenRange& range, const CSSParserConte
 
     if (auto singleValue = consumeIdent<CSSValueNone, CSSValueStrict, CSSValueContent>(range))
         return singleValue;
-    RefPtr<CSSPrimitiveValue> values[5];
-    auto& size = values[0];
-    auto& inlineSize = values[1];
-    auto& layout = values[2];
-    auto& style = values[3];
-    auto& paint = values[4];
+
+    RefPtr<CSSPrimitiveValue> size;
+    RefPtr<CSSPrimitiveValue> inlineSize;
+    RefPtr<CSSPrimitiveValue> layout;
+    RefPtr<CSSPrimitiveValue> style;
+    RefPtr<CSSPrimitiveValue> paint;
+
     while (!range.atEnd()) {
         switch (range.peek().id()) {
         case CSSValueSize:
@@ -81,11 +80,19 @@ RefPtr<CSSValue> consumeContain(CSSParserTokenRange& range, const CSSParserConte
             return nullptr;
         }
     }
+
     CSSValueListBuilder list;
-    for (auto& value : values) {
-        if (value)
-            list.append(value.releaseNonNull());
-    }
+    if (size)
+        list.append(size.releaseNonNull());
+    if (inlineSize)
+        list.append(inlineSize.releaseNonNull());
+    if (layout)
+        list.append(layout.releaseNonNull());
+    if (style)
+        list.append(style.releaseNonNull());
+    if (paint)
+        list.append(paint.releaseNonNull());
+
     if (list.isEmpty())
         return nullptr;
     return CSSValueList::createSpaceSeparated(WTFMove(list));
@@ -93,5 +100,3 @@ RefPtr<CSSValue> consumeContain(CSSParserTokenRange& range, const CSSParserConte
 
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### ab5debe1b67e7f91089425149368d918452c28e7
<pre>
Stop using WTF_ALLOW_UNSAFE_BUFFER_USAGE in CSSPropertyParserConsumer+Contain.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=283649">https://bugs.webkit.org/show_bug.cgi?id=283649</a>

Reviewed by Chris Dumez.

Replace temporary c-array with named variables.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Contain.cpp:
(WebCore::CSSPropertyParserHelpers::consumeContain):

Canonical link: <a href="https://commits.webkit.org/287049@main">https://commits.webkit.org/287049@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48e4c1395a8877ebfe40fa2bdfcafcbecfb582a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82728 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29332 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5400 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61140 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19060 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/67698 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41454 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48486 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24643 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27673 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84089 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5439 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3674 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69362 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5595 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68616 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17128 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12613 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10828 "Found 3 new test failures: http/tests/local/blob/navigate-blob.html media/video-src-blob-perf.html webgl/2.0.0/conformance/textures/image_bitmap_from_image/tex-2d-rgb-rgb-unsigned_short_5_6_5.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5387 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8140 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5377 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8809 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7164 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->