### PR TITLE
Get Fullscreen.h out of DocumentInlines.h

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5374,6 +5374,11 @@ void Document::noteUserInteractionWithMediaElement()
     updateIsPlayingMedia();
 }
 
+bool Document::isCapturing() const
+{
+    return MediaProducer::isCapturing(m_mediaState);
+}
+
 #if ENABLE(MEDIA_STREAM)
 MediaProducerMediaStateFlags Document::computeCaptureState() const
 {
@@ -8369,6 +8374,31 @@ void Document::addDefaultSpatialTrackingLabelChangedObserver(const DefaultSpatia
 }
 #endif
 
+#if ENABLE(FULLSCREEN_API)
+FullscreenManager& Document::fullscreenManager()
+{
+    if (!m_fullscreenManager)
+        return ensureFullscreenManager();
+    return *m_fullscreenManager;
+}
+
+const FullscreenManager& Document::fullscreenManager() const
+{
+    if (!m_fullscreenManager)
+        return const_cast<Document&>(*this).ensureFullscreenManager();
+    return *m_fullscreenManager;
+}
+
+CheckedRef<FullscreenManager> Document::checkedFullscreenManager()
+{
+    return fullscreenManager();
+}
+
+CheckedRef<const FullscreenManager> Document::checkedFullscreenManager() const
+{
+    return fullscreenManager();
+}
+#endif
 
 #if ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1413,10 +1413,10 @@ public:
 #if ENABLE(FULLSCREEN_API)
     FullscreenManager* fullscreenManagerIfExists() { return m_fullscreenManager.get(); }
     const FullscreenManager* fullscreenManagerIfExists() const { return m_fullscreenManager.get(); }
-    inline FullscreenManager& fullscreenManager();
-    inline const FullscreenManager& fullscreenManager() const;
-    inline CheckedRef<FullscreenManager> checkedFullscreenManager(); // Defined in DocumentInlines.h.
-    inline CheckedRef<const FullscreenManager> checkedFullscreenManager() const; // Defined in DocumentInlines.h.
+    WEBCORE_EXPORT FullscreenManager& fullscreenManager();
+    WEBCORE_EXPORT const FullscreenManager& fullscreenManager() const;
+    CheckedRef<FullscreenManager> checkedFullscreenManager(); // Defined in DocumentInlines.h.
+    CheckedRef<const FullscreenManager> checkedFullscreenManager() const; // Defined in DocumentInlines.h.
 #endif
 
 #if ENABLE(POINTER_LOCK)
@@ -1651,7 +1651,7 @@ public:
     void setActiveSpeechRecognition(SpeechRecognition*);
     MediaProducerMediaStateFlags mediaState() const { return m_mediaState; }
     void noteUserInteractionWithMediaElement();
-    inline bool isCapturing() const;
+    bool isCapturing() const;
     WEBCORE_EXPORT void updateIsPlayingMedia();
 
 #if ENABLE(MEDIA_STREAM) && ENABLE(MEDIA_SESSION)

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -28,11 +28,43 @@
 
 #if ENABLE(FULLSCREEN_API)
 #include "DocumentInlines.h"
+#include "Document.h"
 #include "Element.h"
 #include "EventLoop.h"
+#include "FullscreenManager.h"
 #include "JSDOMPromiseDeferred.h"
 
 namespace WebCore {
+
+bool DocumentFullscreen::webkitFullscreenEnabled(Document& document)
+{
+    return document.fullscreenManager().isFullscreenEnabled();
+}
+
+Element* DocumentFullscreen::webkitFullscreenElement(Document& document)
+{
+    return document.ancestorElementInThisScope(document.fullscreenManager().fullscreenElement());
+}
+
+bool DocumentFullscreen::webkitIsFullScreen(Document& document)
+{
+    return document.fullscreenManager().isFullscreen();
+}
+
+bool DocumentFullscreen::webkitFullScreenKeyboardInputAllowed(Document& document)
+{
+    return document.fullscreenManager().isFullscreenKeyboardInputAllowed();
+}
+
+Element* DocumentFullscreen::webkitCurrentFullScreenElement(Document& document)
+{
+    return document.ancestorElementInThisScope(document.fullscreenManager().currentFullscreenElement());
+}
+
+void DocumentFullscreen::webkitCancelFullScreen(Document& document)
+{
+    document.fullscreenManager().cancelFullscreen();
+}
 
 // https://fullscreen.spec.whatwg.org/#exit-fullscreen
 void DocumentFullscreen::exitFullscreen(Document& document, RefPtr<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/DocumentFullscreen.h
+++ b/Source/WebCore/dom/DocumentFullscreen.h
@@ -27,8 +27,6 @@
 
 #if ENABLE(FULLSCREEN_API)
 
-#include "Document.h"
-#include "FullscreenManager.h"
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -42,13 +40,13 @@ public:
     static void exitFullscreen(Document&, RefPtr<DeferredPromise>&&);
     static bool fullscreenEnabled(Document&);
 
-    static bool webkitFullscreenEnabled(Document& document) { return document.fullscreenManager().isFullscreenEnabled(); }
-    static Element* webkitFullscreenElement(Document& document) { return document.ancestorElementInThisScope(document.fullscreenManager().fullscreenElement()); }
+    WEBCORE_EXPORT static bool webkitFullscreenEnabled(Document&);
+    WEBCORE_EXPORT static Element* webkitFullscreenElement(Document&);
     WEBCORE_EXPORT static void webkitExitFullscreen(Document&);
-    static bool webkitIsFullScreen(Document& document) { return document.fullscreenManager().isFullscreen(); }
-    static bool webkitFullScreenKeyboardInputAllowed(Document& document) { return document.fullscreenManager().isFullscreenKeyboardInputAllowed(); }
-    static Element* webkitCurrentFullScreenElement(Document& document) { return document.ancestorElementInThisScope(document.fullscreenManager().currentFullscreenElement()); }
-    static void webkitCancelFullScreen(Document& document) { document.fullscreenManager().cancelFullscreen(); }
+    WEBCORE_EXPORT static bool webkitIsFullScreen(Document&);
+    WEBCORE_EXPORT static bool webkitFullScreenKeyboardInputAllowed(Document&);
+    WEBCORE_EXPORT static Element* webkitCurrentFullScreenElement(Document&);
+    WEBCORE_EXPORT static void webkitCancelFullScreen(Document&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DocumentInlines.h
+++ b/Source/WebCore/dom/DocumentInlines.h
@@ -34,9 +34,7 @@
 #include "ExtensionStyleSheets.h"
 #include "FocusOptions.h"
 #include "FrameDestructionObserverInlines.h"
-#include "FullscreenManager.h"
 #include "LocalDOMWindow.h"
-#include "MediaProducer.h"
 #include "NodeIterator.h"
 #include "ReportingScope.h"
 #include "SecurityOrigin.h"
@@ -152,11 +150,6 @@ inline void Document::invalidateAccessKeyCache()
 {
     if (UNLIKELY(m_accessKeyCache))
         invalidateAccessKeyCacheSlowCase();
-}
-
-inline bool Document::isCapturing() const
-{
-    return MediaProducer::isCapturing(m_mediaState);
 }
 
 inline bool Document::hasMutationObserversOfType(MutationObserverOptionType type) const
@@ -299,31 +292,5 @@ inline Ref<SecurityOrigin> Document::protectedSecurityOrigin() const
 {
     return SecurityContext::protectedSecurityOrigin().releaseNonNull();
 }
-
-#if ENABLE(FULLSCREEN_API)
-inline FullscreenManager& Document::fullscreenManager()
-{
-    if (!m_fullscreenManager)
-        return ensureFullscreenManager();
-    return *m_fullscreenManager;
-}
-
-inline const FullscreenManager& Document::fullscreenManager() const
-{
-    if (!m_fullscreenManager)
-        return const_cast<Document&>(*this).ensureFullscreenManager();
-    return *m_fullscreenManager;
-}
-
-inline CheckedRef<FullscreenManager> Document::checkedFullscreenManager()
-{
-    return fullscreenManager();
-}
-
-inline CheckedRef<const FullscreenManager> Document::checkedFullscreenManager() const
-{
-    return fullscreenManager();
-}
-#endif
 
 } // namespace WebCore

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -54,6 +54,7 @@
 #include "FrameLoader.h"
 #include "FrameSelection.h"
 #include "FrameTree.h"
+#include "FullscreenManager.h"
 #include "GraphicsContext.h"
 #include "HTMLBodyElement.h"
 #include "HTMLEmbedElement.h"


### PR DESCRIPTION
#### a764e7f2334d721a22dd28f855a81f438d0dce17
<pre>
Get Fullscreen.h out of DocumentInlines.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=283650">https://bugs.webkit.org/show_bug.cgi?id=283650</a>
<a href="https://rdar.apple.com/problem/140544768">rdar://problem/140544768</a>

Reviewed by Timothy Hatcher.

Fullscreen.h pulls in HTMLMediaElement.h which pulls in a lot of media-related headers. It doesn&apos;t seem necessary
for fullscreen-related functions to be inline, so make them out-of-line so we can reduce what DocumentInlines.h pulls in.

Also un-inline functions in `DocumentFullscreen` (which is only used by WebKitLegacy).

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::isCapturing const):
(WebCore::Document::fullscreenManager):
(WebCore::Document::fullscreenManager const):
(WebCore::Document::checkedFullscreenManager):
(WebCore::Document::checkedFullscreenManager const):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::webkitFullscreenEnabled):
(WebCore::DocumentFullscreen::webkitFullscreenElement):
(WebCore::DocumentFullscreen::webkitIsFullScreen):
(WebCore::DocumentFullscreen::webkitFullScreenKeyboardInputAllowed):
(WebCore::DocumentFullscreen::webkitCurrentFullScreenElement):
(WebCore::DocumentFullscreen::webkitCancelFullScreen):
* Source/WebCore/dom/DocumentFullscreen.h:
(WebCore::DocumentFullscreen::webkitFullscreenEnabled): Deleted.
(WebCore::DocumentFullscreen::webkitFullscreenElement): Deleted.
(WebCore::DocumentFullscreen::webkitIsFullScreen): Deleted.
(WebCore::DocumentFullscreen::webkitFullScreenKeyboardInputAllowed): Deleted.
(WebCore::DocumentFullscreen::webkitCurrentFullScreenElement): Deleted.
(WebCore::DocumentFullscreen::webkitCancelFullScreen): Deleted.
* Source/WebCore/dom/DocumentInlines.h:
(WebCore::Document::hasMutationObserversOfType const):
(WebCore::Document::isCapturing const): Deleted.
(WebCore::Document::fullscreenManager): Deleted.
(WebCore::Document::fullscreenManager const): Deleted.
(WebCore::Document::checkedFullscreenManager): Deleted.
(WebCore::Document::checkedFullscreenManager const): Deleted.

Canonical link: <a href="https://commits.webkit.org/287070@main">https://commits.webkit.org/287070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c9345f14393d715f6ac6434aafab563b153d910

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31611 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82892 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29496 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5561 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61267 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19182 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41587 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48605 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24863 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27833 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69695 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84256 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5599 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3769 "28 flakes 1 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69487 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67184 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68745 "Found 1 new API test failure: /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17142 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12750 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11007 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5548 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/8306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5537 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8969 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7326 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->