### PR TITLE
[SwiftUI] Add more of the main functionality to WebPage and WebView

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/View+WebViewModifiers.swift
+++ b/Source/WebKit/UIProcess/API/Swift/View+WebViewModifiers.swift
@@ -1,0 +1,61 @@
+// Copyright (C) 2024 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI && compiler(>=6.0)
+
+import Foundation
+import SwiftUI
+
+extension EnvironmentValues {
+    @Entry var webViewAllowsBackForwardNavigationGestures = false
+
+    @Entry var webViewAllowsLinkPreview = true
+
+    @Entry var webViewAllowsTabFocusingLinks = false
+
+    @Entry var webViewAllowsTextInteraction = true
+}
+
+extension View {
+    @_spi(Private)
+    public func webViewAllowsBackForwardNavigationGestures(_ value: Bool = true) -> some View {
+        environment(\.webViewAllowsBackForwardNavigationGestures, value)
+    }
+
+    @_spi(Private)
+    public func webViewAllowsLinkPreview(_ value: Bool = true) -> some View {
+        environment(\.webViewAllowsLinkPreview, value)
+    }
+
+    @_spi(Private)
+    public func webViewAllowsTabFocusingLinks(_ value: Bool = true) -> some View {
+        environment(\.webViewAllowsTabFocusingLinks, value)
+    }
+
+    @_spi(Private)
+    public func webViewAllowsTextInteraction(_ value: Bool = true) -> some View {
+        environment(\.webViewAllowsTextInteraction, value)
+    }
+}
+
+#endif

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+FrameInfo.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+FrameInfo.swift
@@ -1,0 +1,47 @@
+// Copyright (C) 2024 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI && compiler(>=6.0)
+
+import Foundation
+internal import WebKit_Internal
+
+extension WebPage_v0 {
+    @MainActor
+    @_spi(Private)
+    public struct FrameInfo: Sendable {
+        public var isMainFrame: Bool { wrapped.isMainFrame }
+
+        public var request: URLRequest { wrapped.request }
+
+        public var securityOrigin: WKSecurityOrigin { wrapped.securityOrigin }
+
+        var wrapped: WKFrameInfo
+
+        init(wrapping wrapped: WKFrameInfo) {
+            self.wrapped = wrapped
+        }
+    }
+}
+
+#endif

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -31,6 +31,10 @@ public import SwiftUI // FIXME: (283455) Do not import SwiftUI in WebKit proper.
 @MainActor
 @Observable
 public class WebPage_v0 {
+    public static func handlesURLScheme(_ scheme: String) -> Bool {
+        WKWebView.handlesURLScheme(scheme)
+    }
+
     public init(configuration: Configuration = Configuration()) {
         self.configuration = configuration
 
@@ -47,6 +51,7 @@ public class WebPage_v0 {
             createObservation(for: \.isLoading, backedBy: \.isLoading),
             createObservation(for: \.serverTrust, backedBy: \.serverTrust),
             createObservation(for: \.hasOnlySecureContent, backedBy: \.hasOnlySecureContent),
+            createObservation(for: \.isWritingToolsActive, backedBy: \.isWritingToolsActive),
             createObservation(for: \.themeColor, backedBy: \.themeColor),
         ]
     }
@@ -85,6 +90,11 @@ public class WebPage_v0 {
     public var hasOnlySecureContent: Bool {
         self.access(keyPath: \.hasOnlySecureContent)
         return backingWebView.hasOnlySecureContent
+    }
+
+    public var isWritingToolsActive: Bool {
+        self.access(keyPath: \.isWritingToolsActive)
+        return backingWebView.isWritingToolsActive
     }
 
     public var themeColor: Color? {
@@ -134,8 +144,82 @@ public class WebPage_v0 {
     }
 
     @discardableResult
+    public func load(_ data: Data, mimeType: String, characterEncoding: String.Encoding, baseURL: URL) -> NavigationID? {
+        let cfEncoding = CFStringConvertNSStringEncodingToEncoding(characterEncoding.rawValue)
+        guard cfEncoding != kCFStringEncodingInvalidId else {
+            preconditionFailure("\(characterEncoding) is not a valid character encoding")
+        }
+
+        guard let convertedEncoding = CFStringConvertEncodingToIANACharSetName(cfEncoding) as? String else {
+            preconditionFailure("\(characterEncoding) is not a valid character encoding")
+        }
+
+        return backingWebView.load(data, mimeType: mimeType, characterEncodingName: convertedEncoding, baseURL: baseURL).map(NavigationID.init(_:))
+    }
+
+    @discardableResult
     public func load(htmlString: String, baseURL: URL) -> NavigationID? {
         backingWebView.loadHTMLString(htmlString, baseURL: baseURL).map(NavigationID.init(_:))
+    }
+
+    @discardableResult
+    public func load(_ request: URLRequest, allowingReadAccessTo readAccessURL: URL) -> NavigationID? {
+        // `WKWebView` annotates this method as returning non-nil, but it may return nil.
+
+        let navigation = backingWebView.loadFileRequest(request, allowingReadAccessTo: readAccessURL) as WKNavigation?
+        return navigation.map(NavigationID.init(_:))
+    }
+
+    @discardableResult
+    public func loadSimulatedRequest(_ request: URLRequest, response: URLResponse, responseData: Data) -> NavigationID? {
+        // `WKWebView` annotates this method as returning non-nil, but it may return nil.
+
+        let navigation = backingWebView.loadSimulatedRequest(request, response: response, responseData: responseData) as WKNavigation?
+        return navigation.map(NavigationID.init(_:))
+    }
+
+    @discardableResult
+    public func loadSimulatedRequest(_ request: URLRequest, responseHTML: String) -> NavigationID? {
+        // `WKWebView` annotates this method as returning non-nil, but it may return nil.
+
+        let navigation = backingWebView.loadSimulatedRequest(request, responseHTML: responseHTML) as WKNavigation?
+        return navigation.map(NavigationID.init(_:))
+    }
+
+    @discardableResult
+    public func reload(fromOrigin: Bool = false) -> NavigationID? {
+        let navigation = fromOrigin ? backingWebView.reloadFromOrigin() : backingWebView.reload()
+        return navigation.map(NavigationID.init(_:))
+    }
+
+    public func stopLoading() {
+        backingWebView.stopLoading()
+    }
+
+    public func callAsyncJavaScript(_ functionBody: String, arguments: [String : Any] = [:], in frame: FrameInfo? = nil, contentWorld: WKContentWorld = .defaultClient) async throws -> Any? {
+        try await backingWebView.callAsyncJavaScript(functionBody, arguments: arguments, in: frame?.wrapped, contentWorld: contentWorld)
+    }
+
+#if canImport(UIKit)
+    public func snapshot(configuration: WKSnapshotConfiguration = .init()) async throws -> UIImage {
+        try await backingWebView.takeSnapshot(configuration: configuration)
+    }
+#else
+    public func snapshot(configuration: WKSnapshotConfiguration = .init()) async throws -> NSImage {
+        try await backingWebView.takeSnapshot(configuration: configuration)
+    }
+#endif
+
+    public func pdf(configuration: WKPDFConfiguration = .init()) async throws -> Data {
+        try await backingWebView.pdf(configuration: configuration)
+    }
+
+    public func webArchiveData() async throws -> Data {
+        try await withCheckedThrowingContinuation { continuation in
+            backingWebView.createWebArchiveData {
+                continuation.resume(with: $0)
+            }
+        }
     }
 
     private func createObservation<Value, BackingValue>(for keyPath: KeyPath<WebPage_v0, Value>, backedBy backingKeyPath: KeyPath<WKWebView, BackingValue>) -> NSKeyValueObservation {

--- a/Source/WebKit/UIProcess/API/Swift/WebView.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebView.swift
@@ -23,6 +23,7 @@
 
 #if ENABLE_SWIFTUI && compiler(>=6.0)
 
+internal import WebKit_Internal
 public import SwiftUI
 
 #if canImport(UIKit)
@@ -103,7 +104,16 @@ fileprivate struct WebViewRepresentable {
     }
 
     func updatePlatformView(_ platformView: WebViewWrapper, context: Context) {
-        platformView.webView = owner.page.backingWebView
+        let webView = owner.page.backingWebView
+        let environment = context.environment
+
+        platformView.webView = webView
+
+        webView.allowsBackForwardNavigationGestures = environment.webViewAllowsBackForwardNavigationGestures
+        webView.allowsLinkPreview = environment.webViewAllowsLinkPreview
+
+        webView.configuration.preferences.isTextInteractionEnabled = environment.webViewAllowsTextInteraction
+        webView.configuration.preferences.tabFocusesLinks = environment.webViewAllowsTabFocusingLinks
     }
 }
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -156,6 +156,8 @@
 		078B04442CF1149200B453A6 /* URLSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04432CF1149200B453A6 /* URLSchemeHandler.swift */; };
 		078B04462CF1154B00B453A6 /* WebPage+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04452CF1154B00B453A6 /* WebPage+Configuration.swift */; };
 		078B04A02CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B049F2CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift */; };
+		078B04B42CF1A27F00B453A6 /* WebPage+FrameInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04B32CF1A27F00B453A6 /* WebPage+FrameInfo.swift */; };
+		078B04B62CF2B4D300B453A6 /* View+WebViewModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04B52CF2B4D300B453A6 /* View+WebViewModifiers.swift */; };
 		0792314B239CBCB8009598E2 /* RemoteMediaPlayerManagerProxyMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07923145239CBCB7009598E2 /* RemoteMediaPlayerManagerProxyMessageReceiver.cpp */; };
 		0792314C239CBCB8009598E2 /* RemoteMediaPlayerManagerProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 07923146239CBCB7009598E2 /* RemoteMediaPlayerManagerProxyMessages.h */; };
 		079D1D9A26960CD300883577 /* SystemStatusSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 079D1D9926960CD300883577 /* SystemStatusSPI.h */; };
@@ -3177,6 +3179,8 @@
 		078B04432CF1149200B453A6 /* URLSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSchemeHandler.swift; sourceTree = "<group>"; };
 		078B04452CF1154B00B453A6 /* WebPage+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+Configuration.swift"; sourceTree = "<group>"; };
 		078B049F2CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+NavigationPreferences.swift"; sourceTree = "<group>"; };
+		078B04B32CF1A27F00B453A6 /* WebPage+FrameInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+FrameInfo.swift"; sourceTree = "<group>"; };
+		078B04B52CF2B4D300B453A6 /* View+WebViewModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+WebViewModifiers.swift"; sourceTree = "<group>"; };
 		07923130239B3B0C009598E2 /* RemoteMediaPlayerManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaPlayerManager.cpp; sourceTree = "<group>"; };
 		07923131239B3B0C009598E2 /* MediaPlayerPrivateRemote.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MediaPlayerPrivateRemote.cpp; sourceTree = "<group>"; };
 		07923132239B3B0C009598E2 /* MediaPlayerPrivateRemote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaPlayerPrivateRemote.h; sourceTree = "<group>"; };
@@ -8785,6 +8789,8 @@
 			children = (
 				078B04432CF1149200B453A6 /* URLSchemeHandler.swift */,
 				078B04452CF1154B00B453A6 /* WebPage+Configuration.swift */,
+				078B04B52CF2B4D300B453A6 /* View+WebViewModifiers.swift */,
+				078B04B32CF1A27F00B453A6 /* WebPage+FrameInfo.swift */,
 				07FAA74A2CE947AA00128360 /* WebPage+Navigation.swift */,
 				078B049F2CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift */,
 				07CB79952CE9435700199C49 /* WebPage.swift */,
@@ -20025,6 +20031,7 @@
 				CD491B171E73525500009066 /* UserMediaCaptureManagerProxyMessageReceiver.cpp in Sources */,
 				3F418EF91887BD97002795FD /* VideoPresentationManagerMessageReceiver.cpp in Sources */,
 				3F418EFB1887BD97002795FD /* VideoPresentationManagerProxyMessageReceiver.cpp in Sources */,
+				078B04B62CF2B4D300B453A6 /* View+WebViewModifiers.swift in Sources */,
 				2D1B5D5D185869C8006C6596 /* ViewGestureControllerMessageReceiver.cpp in Sources */,
 				2D819BA11862800E001F03D1 /* ViewGestureGeometryCollectorMessageReceiver.cpp in Sources */,
 				2684055218B86ED60022C38B /* ViewUpdateDispatcherMessageReceiver.cpp in Sources */,
@@ -20145,6 +20152,7 @@
 				E3816B3D27E2463A005EAFC0 /* WebMockContentFilterManager.cpp in Sources */,
 				31BA924D148831260062EDB5 /* WebNotificationManagerMessageReceiver.cpp in Sources */,
 				078B04462CF1154B00B453A6 /* WebPage+Configuration.swift in Sources */,
+				078B04B42CF1A27F00B453A6 /* WebPage+FrameInfo.swift in Sources */,
 				07FAA74B2CE947AA00128360 /* WebPage+Navigation.swift in Sources */,
 				078B04A02CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift in Sources */,
 				07CB79962CE9435700199C49 /* WebPage.swift in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPage.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPage.swift
@@ -195,6 +195,22 @@ struct WebPageTests {
 
         // FIXME: (283456) Make this test more comprehensive once Observation supports observing a stream of changes to properties.
     }
+
+    @Test
+    func javaScriptEvaluation() async throws {
+        let page = WebPage_v0()
+
+        let arguments = [
+            "a": 1,
+            "b": 2,
+        ]
+
+        let result = try await page.callAsyncJavaScript("return a + b;", arguments: arguments) as! Int
+        #expect(result == 3)
+
+        let nilResult = try await page.callAsyncJavaScript("console.log('hi')")
+        #expect(nilResult == nil)
+    }
 }
 
 #endif


### PR DESCRIPTION
#### 408608a269ff1452e2d40ca05aeab6470c4d289b
<pre>
[SwiftUI] Add more of the main functionality to WebPage and WebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=283653">https://bugs.webkit.org/show_bug.cgi?id=283653</a>
<a href="https://rdar.apple.com/140507710">rdar://140507710</a>

Reviewed by Abrar Rahman Protyasha.

This adds most of the missing capabilities to WebPage and WebView.

* Source/WebKit/UIProcess/API/Swift/View+WebViewModifiers.swift: Added.
(View.webViewAllowsBackForwardNavigationGestures(_:)):
(View.webViewAllowsLinkPreview(_:)):
(View.webViewAllowsTabFocusingLinks(_:)):
(View.webViewAllowsTextInteraction(_:)):
* Source/WebKit/UIProcess/API/Swift/WebPage+FrameInfo.swift: Added.
(FrameInfo.isMainFrame):
(FrameInfo.request):
(FrameInfo.securityOrigin):
(FrameInfo.wrapped):
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(WebPage_v0.isWritingToolsActive):
(WebPage_v0.handlesURLScheme(_:)):
(WebPage_v0.load(_:mimeType:characterEncoding:baseURL:)):
(WebPage_v0.load(_:allowingReadAccessTo:)):
(WebPage_v0.loadSimulatedRequest(_:response:responseData:)):
(WebPage_v0.loadSimulatedRequest(_:responseHTML:)):
(WebPage_v0.reload(_:)):
(WebPage_v0.stopLoading):
(WebPage_v0.callAsyncJavaScript(_:arguments:in:contentWorld:)):
(WebPage_v0.snapshot(_:)):
(WebPage_v0.pdf(_:)):
(WebPage_v0.webArchiveData):
* Source/WebKit/UIProcess/API/Swift/WebView.swift:
(WebViewRepresentable.updatePlatformView(_:context:)):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/MiniBrowser/SwiftUI/ContentView.swift:
(UnifiedBar.body):
(ContentView.body):
(ContentView.urlFieldIsFocused): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit Swift/WebPage.swift:
(WebPageTests.javaScriptEvaluation):

Canonical link: <a href="https://commits.webkit.org/287428@main">https://commits.webkit.org/287428@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d8a80c9e74fdf0b534b5c2bde3cd399fbc91380

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84127 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30639 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81682 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6836 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62209 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20068 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82619 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72472 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42517 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26634 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29056 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70736 "") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85538 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6814 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4752 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70457 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6979 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68334 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69702 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13731 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12623 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12304 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6766 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12454 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6663 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10142 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8461 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->