### PR TITLE
Expose `WKPreferences/tabFocusesLinks` internally on iOS

### DIFF
--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4539,6 +4539,36 @@ bool EventHandler::tabsToLinks(KeyboardEvent* event) const
     return (event && eventInvertsTabsToLinksClientCallResult(*event)) ? !tabsToLinksClientCallResult : tabsToLinksClientCallResult;
 }
 
+bool EventHandler::tabsToAllFormControls(KeyboardEvent* event) const
+{
+#if PLATFORM(COCOA)
+    RefPtr page = m_frame->page();
+    if (!page)
+        return false;
+
+    KeyboardUIMode keyboardUIMode = page->chrome().client().keyboardUIMode();
+    bool handlingOptionTab = event && isKeyboardOptionTab(*event);
+
+    // If tab-to-links is off, option-tab always highlights all controls
+    if (!(keyboardUIMode & KeyboardAccessTabsToLinks) && handlingOptionTab)
+        return true;
+
+    // If system preferences say to include all controls, we always include all controls
+    if (keyboardUIMode & KeyboardAccessFull)
+        return true;
+
+    // Otherwise tab-to-links includes all controls, unless the sense is flipped via option-tab.
+    if (keyboardUIMode & KeyboardAccessTabsToLinks)
+        return !handlingOptionTab;
+
+    return handlingOptionTab;
+#else
+    UNUSED_PARAM(event);
+    // We always allow tabs to all controls
+    return true;
+#endif
+}
+
 void EventHandler::defaultTextInputEventHandler(TextEvent& event)
 {
     if (m_frame->editor().handleTextEvent(event))
@@ -5257,12 +5287,6 @@ bool EventHandler::passWheelEventToWidget(const PlatformWheelEvent& event, Widge
         return false;
 
     return frameView->frame().eventHandler().handleWheelEvent(event, processingSteps).wasHandled();
-}
-
-bool EventHandler::tabsToAllFormControls(KeyboardEvent*) const
-{
-    // We always allow tabs to all controls
-    return true;
 }
 
 bool EventHandler::passWidgetMouseDownEventToWidget(RenderWidget* renderWidget)

--- a/Source/WebCore/page/ios/EventHandlerIOS.mm
+++ b/Source/WebCore/page/ios/EventHandlerIOS.mm
@@ -145,30 +145,6 @@ void EventHandler::touchEvent(WebEvent *event)
 }
 #endif
 
-bool EventHandler::tabsToAllFormControls(KeyboardEvent* event) const
-{
-    RefPtr page = m_frame->page();
-    if (!page)
-        return false;
-
-    KeyboardUIMode keyboardUIMode = page->chrome().client().keyboardUIMode();
-    bool handlingOptionTab = event && isKeyboardOptionTab(*event);
-
-    // If tab-to-links is off, option-tab always highlights all controls.
-    if ((keyboardUIMode & KeyboardAccessTabsToLinks) == 0 && handlingOptionTab)
-        return true;
-
-    // If system preferences say to include all controls, we always include all controls.
-    if (keyboardUIMode & KeyboardAccessFull)
-        return true;
-
-    // Otherwise tab-to-links includes all controls, unless the sense is flipped via option-tab.
-    if (keyboardUIMode & KeyboardAccessTabsToLinks)
-        return !handlingOptionTab;
-
-    return handlingOptionTab;
-}
-
 bool EventHandler::keyEvent(WebEvent *event)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -747,30 +747,6 @@ bool EventHandler::eventActivatedView(const PlatformMouseEvent& event) const
     return m_activationEventNumber == event.eventNumber();
 }
 
-bool EventHandler::tabsToAllFormControls(KeyboardEvent* event) const
-{
-    RefPtr page = m_frame->page();
-    if (!page)
-        return false;
-
-    KeyboardUIMode keyboardUIMode = page->chrome().client().keyboardUIMode();
-    bool handlingOptionTab = event && isKeyboardOptionTab(*event);
-
-    // If tab-to-links is off, option-tab always highlights all controls
-    if ((keyboardUIMode & KeyboardAccessTabsToLinks) == 0 && handlingOptionTab)
-        return true;
-    
-    // If system preferences say to include all controls, we always include all controls
-    if (keyboardUIMode & KeyboardAccessFull)
-        return true;
-    
-    // Otherwise tab-to-links includes all controls, unless the sense is flipped via option-tab.
-    if (keyboardUIMode & KeyboardAccessTabsToLinks)
-        return !handlingOptionTab;
-    
-    return handlingOptionTab;
-}
-
 bool EventHandler::needsKeyboardEventDisambiguationQuirks() const
 {
     return m_frame->settings().needsKeyboardEventDisambiguationQuirks();

--- a/Source/WebKit/Modules/Internal/WebKitInternal.h
+++ b/Source/WebKit/Modules/Internal/WebKitInternal.h
@@ -25,4 +25,5 @@
 
 // Add project-level Objective-C header files here to be able to access them from within Swift sources.
 
+#import "WKPreferencesInternal.h"
 #import "WKWebViewInternal.h"

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -79,9 +79,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     
     [coder encodeBool:self.shouldPrintBackgrounds forKey:@"shouldPrintBackgrounds"];
 
-#if PLATFORM(MAC)
     [coder encodeBool:self.tabFocusesLinks forKey:@"tabFocusesLinks"];
-#endif
     [coder encodeBool:self.textInteractionEnabled forKey:@"textInteractionEnabled"];
 }
 
@@ -99,9 +97,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     
     self.shouldPrintBackgrounds = [coder decodeBoolForKey:@"shouldPrintBackgrounds"];
 
-#if PLATFORM(MAC)
     self.tabFocusesLinks = [coder decodeBoolForKey:@"tabFocusesLinks"];
-#endif
     if ([coder containsValueForKey:@"textInteractionEnabled"])
         self.textInteractionEnabled = [coder decodeBoolForKey:@"textInteractionEnabled"];
 
@@ -211,10 +207,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return _preferences->backgroundWebContentRunningBoardThrottlingEnabled() ? (_preferences->shouldTakeNearSuspendedAssertions() ? WKInactiveSchedulingPolicyThrottle : WKInactiveSchedulingPolicySuspend) : WKInactiveSchedulingPolicyNone;
 }
 
-#pragma mark OS X-specific methods
-
-#if PLATFORM(MAC)
-
 - (BOOL)tabFocusesLinks
 {
     return _preferences->tabsToLinks();
@@ -224,8 +216,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     _preferences->setTabsToLinks(tabFocusesLinks);
 }
-
-#endif
 
 #pragma mark WKObject protocol implementation
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesInternal.h
@@ -25,6 +25,8 @@
 
 #import "WKPreferencesPrivate.h"
 
+#ifdef __cplusplus
+
 #import "WKObject.h"
 #import "WebPreferences.h"
 
@@ -40,5 +42,15 @@ template<> struct WrapperTraits<WebPreferences> {
 @package
     API::ObjectStorage<WebKit::WebPreferences> _preferences;
 }
+
+@end
+
+#endif
+
+@interface WKPreferences ()
+
+#if PLATFORM(IOS_FAMILY)
+@property (nonatomic) BOOL tabFocusesLinks;
+#endif
 
 @end

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Coding.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Coding.mm
@@ -28,6 +28,14 @@
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <wtf/RetainPtr.h>
 
+#if PLATFORM(IOS_FAMILY)
+@interface WKPreferences (TabFocusesLinks)
+
+@property (nonatomic) BOOL tabFocusesLinks;
+
+@end
+#endif
+
 template<typename T>
 RetainPtr<T> encodeAndDecode(T* t)
 {
@@ -50,11 +58,11 @@ TEST(Coding, WKPreferences)
     [a setMinimumFontSize:10];
     [a setJavaScriptEnabled:NO];
     [a setShouldPrintBackgrounds:YES];
+    [a setTabFocusesLinks:YES];
 #if PLATFORM(IOS_FAMILY)
     [a setJavaScriptCanOpenWindowsAutomatically:YES];
 #else
     [a setJavaScriptCanOpenWindowsAutomatically:NO];
-    [a setTabFocusesLinks:YES];
 #endif
 
     auto b = encodeAndDecode(a.get());
@@ -63,10 +71,7 @@ TEST(Coding, WKPreferences)
     EXPECT_EQ([a javaScriptEnabled], [b javaScriptEnabled]);
     EXPECT_EQ([a javaScriptCanOpenWindowsAutomatically], [b javaScriptCanOpenWindowsAutomatically]);
     EXPECT_EQ([a shouldPrintBackgrounds], [b shouldPrintBackgrounds]);
-
-#if PLATFORM(MAC)
     EXPECT_EQ([a tabFocusesLinks], [b tabFocusesLinks]);
-#endif
 }
 
 TEST(Coding, WKProcessPool_Shared)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Copying.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Copying.mm
@@ -27,6 +27,14 @@
 
 #import <wtf/RetainPtr.h>
 
+#if PLATFORM(IOS_FAMILY)
+@interface WKPreferences (TabFocusesLinks)
+
+@property (nonatomic) BOOL tabFocusesLinks;
+
+@end
+#endif
+
 TEST(Copying, WKPreferences)
 {
     // Change all defaults to something else.
@@ -34,11 +42,11 @@ TEST(Copying, WKPreferences)
     [a setMinimumFontSize:10];
     [a setJavaScriptEnabled:NO];
     [a setShouldPrintBackgrounds:YES];
+    [a setTabFocusesLinks:YES];
 #if PLATFORM(IOS_FAMILY)
     [a setJavaScriptCanOpenWindowsAutomatically:YES];
 #else
     [a setJavaScriptCanOpenWindowsAutomatically:NO];
-    [a setTabFocusesLinks:YES];
 #endif
 
     // Check that values are equal in both instances.
@@ -47,20 +55,20 @@ TEST(Copying, WKPreferences)
     EXPECT_EQ([a javaScriptEnabled], [b javaScriptEnabled]);
     EXPECT_EQ([a javaScriptCanOpenWindowsAutomatically], [b javaScriptCanOpenWindowsAutomatically]);
     EXPECT_EQ([a shouldPrintBackgrounds], [b shouldPrintBackgrounds]);
+    EXPECT_EQ([a tabFocusesLinks], [b tabFocusesLinks]);
 #if PLATFORM(MAC)
     EXPECT_EQ([a javaEnabled], [b javaEnabled]);
-    EXPECT_EQ([a tabFocusesLinks], [b tabFocusesLinks]);
 #endif
 
     // Change all defaults on the copied instance.
     [b setMinimumFontSize:13];
     [b setJavaScriptEnabled:YES];
     [b setShouldPrintBackgrounds:NO];
+    [b setTabFocusesLinks:NO];
 #if PLATFORM(IOS_FAMILY)
     [b setJavaScriptCanOpenWindowsAutomatically:NO];
 #else
     [b setJavaScriptCanOpenWindowsAutomatically:YES];
-    [b setTabFocusesLinks:NO];
 #endif
 
     // Check that the mutations of 'b' did not affect 'a'.
@@ -68,8 +76,6 @@ TEST(Copying, WKPreferences)
     EXPECT_NE([a javaScriptEnabled], [b javaScriptEnabled]);
     EXPECT_NE([a javaScriptCanOpenWindowsAutomatically], [b javaScriptCanOpenWindowsAutomatically]);
     EXPECT_NE([a shouldPrintBackgrounds], [b shouldPrintBackgrounds]);
-#if PLATFORM(MAC)
     EXPECT_NE([a tabFocusesLinks], [b tabFocusesLinks]);
-#endif
 
 }


### PR DESCRIPTION
#### 22f1a23dde6d414c7c6e860d970cc3f8e038178a
<pre>
Expose `WKPreferences/tabFocusesLinks` internally on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=283651">https://bugs.webkit.org/show_bug.cgi?id=283651</a>
<a href="https://rdar.apple.com/140508437">rdar://140508437</a>

Reviewed by Wenson Hsieh.

The logic for having the tab key switch focus to forms and links is already platform-agnostic, so this
just exposes it for iOS.

Also de-duplicate some code.

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::tabsToAllFormControls const):
* Source/WebCore/page/ios/EventHandlerIOS.mm:
(WebCore::EventHandler::tabsToAllFormControls const): Deleted.
* Source/WebCore/page/mac/EventHandlerMac.mm:
(WebCore::EventHandler::tabsToAllFormControls const): Deleted.
* Source/WebKit/Modules/Internal/WebKitInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences encodeWithCoder:]):
(-[WKPreferences initWithCoder:]):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesInternal.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Coding.mm:
(TEST(Coding, WKPreferences)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Copying.mm:
(TEST(Copying, WKPreferences)):

Canonical link: <a href="https://commits.webkit.org/287221@main">https://commits.webkit.org/287221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cae73c22b2055c15b459409877bc19ef1ba971c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78839 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83497 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30100 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6164 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/61744 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19674 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81906 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51779 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/71694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/42051 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49125 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/25924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28441 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70238 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/26333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84868 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6204 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/69971 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6366 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/67771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/69225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17227 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/13268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/11995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6149 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6132 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9569 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7923 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->