### PR TITLE
TestWTF.WTF_URLParser.ParserDifferences fails with ICU 76.1

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/URLParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URLParser.cpp
@@ -31,6 +31,7 @@
 #include <wtf/URLParser.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/unicode/icu/ICUHelpers.h>
 
 namespace TestWebKitAPI {
 
@@ -944,8 +945,13 @@ TEST_F(WTF_URLParser, ParserDifferences)
     checkURL(utf16String(u"http://ԛәлп.com"), { "http"_s, ""_s, ""_s, "xn--k1ai47bhi.com"_s, 0, "/"_s, ""_s, ""_s, "http://xn--k1ai47bhi.com/"_s });
     checkURLDifferences(utf16String(u"http://Ⱥbby.com"),
         { "http"_s, ""_s, ""_s, "xn--bby-iy0b.com"_s, 0, "/"_s, ""_s, ""_s, "http://xn--bby-iy0b.com/"_s });
-    checkURLDifferences(utf16String(u"http://\u2132"),
-        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, utf16String(u"http://Ⅎ") });
+    if (WTF::ICU::majorVersion() >= 76) {
+        checkURLDifferences(utf16String(u"http://\u2132"),
+            { "http"_s, ""_s, ""_s, "xn--73g"_s, 0, "/"_s, ""_s, ""_s, utf16String(u"http://xn--73g/") });
+    } else {
+        checkURLDifferences(utf16String(u"http://\u2132"),
+            { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, utf16String(u"http://Ⅎ") });
+    }
     checkURLDifferences(utf16String(u"http://\u05D9\u05B4\u05D5\u05D0\u05B8/"),
         { "http"_s, ""_s, ""_s, "xn--cdbi5etas"_s, 0, "/"_s, ""_s, ""_s, "http://xn--cdbi5etas/"_s }, TestTabs::No);
     checkURLDifferences(utf16String(u"http://bidirectional\u0786\u07AE\u0782\u07B0\u0795\u07A9\u0793\u07A6\u0783\u07AA/"),


### PR DESCRIPTION
#### 8c1b94022359f400945e981528e2f9eb711162ec
<pre>
TestWTF.WTF_URLParser.ParserDifferences fails with ICU 76.1
<a href="https://bugs.webkit.org/show_bug.cgi?id=283655">https://bugs.webkit.org/show_bug.cgi?id=283655</a>

Reviewed by Yusuke Suzuki and Anne van Kesteren.

After Windows port bumpped ICU to 76.1, the test was failing. Unicode
16 contains IDNA changes.
&lt;<a href="https://www.unicode.org/versions/Unicode16.0.0/">https://www.unicode.org/versions/Unicode16.0.0/</a>&gt;

Added a new expectation for u&quot;<a href="http://\u2132&quot">http://\u2132&quot</a>; test for ICU 76.

* Tools/TestWebKitAPI/Tests/WTF/URLParser.cpp:
(TestWebKitAPI::TEST_F(WTF_URLParser, ParserDifferences)):

Canonical link: <a href="https://commits.webkit.org/287189@main">https://commits.webkit.org/287189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d1dbd3e408b75d19cb90475899198443c4f9a52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83389 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29991 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80862 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6054 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61656 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19581 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/70935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41964 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49034 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25706 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28331 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70142 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84758 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4210 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69881 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-transforms/individual-transform/animation/individual-transform-combine.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67673 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69135 "Found 6 new API test failures: /TestWebKit:WebKit.FrameMIMETypeHTML, /TestWebKit:WebKit2UserMessageRoundTripTest.WKURL, /TestWebKit:WebKit.DownloadDecideDestinationCrash, /TestWebKit:WebKit2UserMessageRoundTripTest.WKURLRequestRef, /TestWebKit:WebKit2UserMessageRoundTripTest.WKString, /TestWebKit:WebKit.Find (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13177 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11772 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12151 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6039 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6025 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9461 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7813 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->