### PR TITLE
Make more MessageReceiver objects RefCounted in the NetworkProcess

### DIFF
--- a/Source/WebCore/workers/service/server/SWServerRegistration.cpp
+++ b/Source/WebCore/workers/service/server/SWServerRegistration.cpp
@@ -143,7 +143,7 @@ void SWServerRegistration::fireUpdateFoundEvent()
 void SWServerRegistration::forEachConnection(const Function<void(SWServer::Connection&)>& apply)
 {
     for (auto connectionIdentifierWithClients : m_connectionsWithClientRegistrations.values()) {
-        if (CheckedPtr connection = protectedServer()->connection(connectionIdentifierWithClients))
+        if (RefPtr connection = protectedServer()->connection(connectionIdentifierWithClients))
             apply(*connection);
     }
 }
@@ -202,7 +202,7 @@ void SWServerRegistration::notifyClientsOfControllerChange()
 {
     std::optional<ServiceWorkerData> newController = activeWorker() ? std::optional { activeWorker()->data() } : std::nullopt;
     for (auto& item : m_clientsUsingRegistration) {
-        if (CheckedPtr connection = protectedServer()->connection(item.key))
+        if (RefPtr connection = protectedServer()->connection(item.key))
             connection->notifyClientsOfControllerChange(item.value, newController);
     }
 }

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -252,6 +252,7 @@ public:
 
 #if ENABLE(WEB_RTC)
     NetworkMDNSRegister& mdnsRegister() { return m_mdnsRegister; }
+    Ref<NetworkMDNSRegister> protectedMDNSRegister() { return m_mdnsRegister; }
 #endif
 
     WebSWServerToContextConnection* swContextConnection() { return m_swContextConnection.get(); }

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -661,7 +661,7 @@ void NetworkResourceLoader::transferToNewWebProcess(NetworkConnectionToWebProces
 
     ASSERT(m_responseCompletionHandler || m_cacheEntryWaitingForContinueDidReceiveResponse || m_serviceWorkerFetchTask);
     if (m_serviceWorkerRegistration) {
-        if (auto* swConnection = newConnection.swConnection())
+        if (RefPtr swConnection = newConnection.swConnection())
             swConnection->transferServiceWorkerLoadToNewWebProcess(*this, *m_serviceWorkerRegistration, m_connection->webProcessIdentifier());
     }
     if (m_workerStart)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
@@ -63,8 +63,8 @@ void WebSWOriginStore::clearStore()
 void WebSWOriginStore::importComplete()
 {
     m_isImported = true;
-    for (auto& connection : m_webSWServerConnections)
-        connection.send(Messages::WebSWClientConnection::SetSWOriginTableIsImported());
+    for (Ref connection : m_webSWServerConnections)
+        connection->send(Messages::WebSWClientConnection::SetSWOriginTableIsImported());
 }
 
 void WebSWOriginStore::registerSWServerConnection(WebSWServerConnection& connection)
@@ -93,8 +93,8 @@ void WebSWOriginStore::sendStoreHandle(WebSWServerConnection& connection)
 
 void WebSWOriginStore::didInvalidateSharedMemory()
 {
-    for (auto& connection : m_webSWServerConnections)
-        sendStoreHandle(CheckedRef { connection }.get());
+    for (Ref connection : m_webSWServerConnections)
+        sendStoreHandle(connection.get());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
@@ -73,9 +73,8 @@ struct SharedPreferencesForWebProcess;
 
 class WebSWServerConnection final : public WebCore::SWServer::Connection, public IPC::MessageSender, public IPC::MessageReceiver {
     WTF_MAKE_TZONE_ALLOCATED(WebSWServerConnection);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebSWServerConnection);
 public:
-    WebSWServerConnection(NetworkConnectionToWebProcess&, WebCore::SWServer&, IPC::Connection&, WebCore::ProcessIdentifier);
+    static Ref<WebSWServerConnection> create(NetworkConnectionToWebProcess&, WebCore::SWServer&, IPC::Connection&, WebCore::ProcessIdentifier);
     WebSWServerConnection(const WebSWServerConnection&) = delete;
     ~WebSWServerConnection() final;
 
@@ -101,6 +100,8 @@ public:
     void unregisterServiceWorkerClient(const WebCore::ScriptExecutionContextIdentifier&);
 
 private:
+    WebSWServerConnection(NetworkConnectionToWebProcess&, WebCore::SWServer&, IPC::Connection&, WebCore::ProcessIdentifier);
+
     // Implement SWServer::Connection (Messages to the client WebProcess)
     void rejectJobInClient(WebCore::ServiceWorkerJobIdentifier, const WebCore::ExceptionData&) final;
     void resolveRegistrationJobInClient(WebCore::ServiceWorkerJobIdentifier, const WebCore::ServiceWorkerRegistrationData&, WebCore::ShouldNotifyWhenResolved) final;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> WebSWServerConnection NotRefCounted {
+messages -> WebSWServerConnection {
     # When possible, these messages can be implemented directly by WebCore::SWClientConnection
     ScheduleJobInServer(struct WebCore::ServiceWorkerJobData jobData)
     ScheduleUnregisterJobInServer(WebCore::ServiceWorkerJobIdentifier jobIdentifier, WebCore::ServiceWorkerRegistrationIdentifier identifier, WebCore::ServiceWorkerOrClientIdentifier documentIdentifier) -> (Expected<bool, WebCore::ExceptionData> result)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -148,7 +148,7 @@ uint64_t WebSWServerToContextConnection::messageSenderDestinationID() const
 void WebSWServerToContextConnection::postMessageToServiceWorkerClient(const ScriptExecutionContextIdentifier& destinationIdentifier, const MessageWithMessagePorts& message, ServiceWorkerIdentifier sourceIdentifier, const String& sourceOrigin)
 {
     RefPtr server = this->server();
-    if (CheckedPtr connection = server ? server->connection(destinationIdentifier.processIdentifier()) : nullptr)
+    if (RefPtr connection = server ? server->connection(destinationIdentifier.processIdentifier()) : nullptr)
         connection->postMessageToServiceWorkerClient(destinationIdentifier, message, sourceIdentifier, sourceOrigin);
 }
 
@@ -386,7 +386,7 @@ void WebSWServerToContextConnection::unregisterDownload(ServiceWorkerDownloadTas
 void WebSWServerToContextConnection::focus(ScriptExecutionContextIdentifier clientIdentifier, CompletionHandler<void(std::optional<WebCore::ServiceWorkerClientData>&&)>&& callback)
 {
     RefPtr server = this->server();
-    CheckedPtr connection = server ? server->connection(clientIdentifier.processIdentifier()) : nullptr;
+    RefPtr connection = server ? server->connection(clientIdentifier.processIdentifier()) : nullptr;
     if (!connection) {
         callback({ });
         return;

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
@@ -131,10 +131,10 @@ void WebSharedWorkerServerToContextConnection::launchSharedWorker(WebSharedWorke
     if (auto contextIdentifier = initializationData.clientIdentifier) {
         initializationData.clientIdentifier = WebCore::ScriptExecutionContextIdentifier { contextIdentifier->object(), *webProcessIdentifier() };
         if (RefPtr serviceWorkerOldConnection = connection->protectedNetworkProcess()->webProcessConnection(contextIdentifier->processIdentifier())) {
-            if (CheckedPtr swOldConnection = serviceWorkerOldConnection->swConnection()) {
+            if (RefPtr swOldConnection = serviceWorkerOldConnection->swConnection()) {
                 if (auto clientData = swOldConnection->gatherClientData(*contextIdentifier)) {
                     swOldConnection->unregisterServiceWorkerClient(*contextIdentifier);
-                    if (CheckedPtr swNewConnection = connection->swConnection()) {
+                    if (RefPtr swNewConnection = connection->swConnection()) {
                         clientData->serviceWorkerClientData.identifier = *initializationData.clientIdentifier;
                         swNewConnection->registerServiceWorkerClient(WTFMove(clientData->clientOrigin), WTFMove(clientData->serviceWorkerClientData), clientData->controllingServiceWorkerRegistrationIdentifier, WTFMove(clientData->userAgent));
                     }

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
@@ -47,6 +47,16 @@ NetworkMDNSRegister::NetworkMDNSRegister(NetworkConnectionToWebProcess& connecti
 
 NetworkMDNSRegister::~NetworkMDNSRegister() = default;
 
+void NetworkMDNSRegister::ref() const
+{
+    m_connection->ref();
+}
+
+void NetworkMDNSRegister::deref() const
+{
+    m_connection->deref();
+}
+
 bool NetworkMDNSRegister::hasRegisteredName(const String& name) const
 {
     return m_registeredNames.contains(name);
@@ -104,7 +114,7 @@ static void registerMDNSNameCallback(DNSServiceRef service, DNSRecordRef record,
     MDNS_RELEASE_LOG_IN_CALLBACK(request->sessionID, "registerMDNSNameCallback with error %d", errorCode);
 
     if (errorCode) {
-        request->connection->mdnsRegister().closeAndForgetService(service);
+        request->connection->protectedMDNSRegister()->closeAndForgetService(service);
         request->completionHandler(request->name, WebCore::MDNSRegisterError::DNSSD);
         return;
     }

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h
@@ -68,6 +68,9 @@ public:
     NetworkMDNSRegister(NetworkConnectionToWebProcess&);
     ~NetworkMDNSRegister();
 
+    void ref() const;
+    void deref() const;
+
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 
 #if ENABLE_MDNS

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(WEB_RTC)
 
-messages -> NetworkMDNSRegister NotRefCounted {
+messages -> NetworkMDNSRegister {
     UnregisterMDNSNames(WebCore::ScriptExecutionContextIdentifier documentIdentifier)
     RegisterMDNSName(WebCore::ScriptExecutionContextIdentifier documentIdentifier, String ipAddress) -> (String mdnsName, std::optional<WebCore::MDNSRegisterError> error)
 }

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
@@ -182,7 +182,7 @@ void NetworkRTCProvider::createResolver(LibWebRTCResolverIdentifier identifier, 
     }
 
     RefPtr connection = m_connection.get();
-    if (connection && connection->mdnsRegister().hasRegisteredName(address)) {
+    if (connection && connection->protectedMDNSRegister()->hasRegisteredName(address)) {
         Vector<WebKit::RTC::Network::IPAddress> ipAddresses;
         Ref rtcMonitor = m_rtcMonitor;
         if (!rtcMonitor->ipv4().isUnspecified())


### PR DESCRIPTION
#### ed3a7530bf62452f86894eb65160399ccd558c45
<pre>
Make more MessageReceiver objects RefCounted in the NetworkProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=283657">https://bugs.webkit.org/show_bug.cgi?id=283657</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::Connection::finishFetchingScriptInServer):
(WebCore::SWServer::Connection::didResolveRegistrationPromise):
(WebCore::SWServer::Connection::doRegistrationMatching):
(WebCore::SWServer::Connection::addServiceWorkerRegistrationInServer):
(WebCore::SWServer::Connection::removeServiceWorkerRegistrationInServer):
(WebCore::SWServer::rejectJob):
(WebCore::SWServer::resolveRegistrationJob):
(WebCore::SWServer::resolveUnregistrationJob):
(WebCore::SWServer::startScriptFetch):
(WebCore::SWServer::contextConnectionCreated):
(WebCore::SWServer::addConnection):
(WebCore::SWServer::resolveRegistrationReadyRequests):
(WebCore::SWServer::Connection::storeRegistrationsOnDisk):
(WebCore::SWServer::Connection::startBackgroundFetch):
(WebCore::SWServer::Connection::backgroundFetchInformation):
(WebCore::SWServer::Connection::backgroundFetchIdentifiers):
(WebCore::SWServer::Connection::abortBackgroundFetch):
(WebCore::SWServer::Connection::matchBackgroundFetch):
(WebCore::SWServer::Connection::retrieveRecordResponse):
(WebCore::SWServer::Connection::retrieveRecordResponseBody):
* Source/WebCore/workers/service/server/SWServer.h:
(WebCore::SWServer::Connection::server):
(WebCore::SWServer::Connection::server const):
(WebCore::SWServer::connections const):
(WebCore::SWServer::Connection::protectedServer const): Deleted.
* Source/WebCore/workers/service/server/SWServerRegistration.cpp:
(WebCore::SWServerRegistration::forEachConnection):
(WebCore::SWServerRegistration::notifyClientsOfControllerChange):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::unregisterSWConnection):
(WebKit::NetworkConnectionToWebProcess::establishSWServerConnection):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::timeoutTimerFired):
(WebKit::ServiceWorkerFetchTask::softUpdateIfNeeded):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp:
(WebKit::WebSWOriginStore::didInvalidateSharedMemory):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::create):
(WebKit::WebSWServerConnection::~WebSWServerConnection):
(WebKit::WebSWServerConnection::controlClient):
(WebKit::WebSWServerConnection::createFetchTask):
(WebKit::WebSWServerConnection::startFetch):
(WebKit::WebSWServerConnection::postMessageToServiceWorker):
(WebKit::WebSWServerConnection::scheduleJobInServer):
(WebKit::WebSWServerConnection::clientURLFromIdentifier):
(WebKit::WebSWServerConnection::scheduleUnregisterJobInServer):
(WebKit::WebSWServerConnection::postMessageToServiceWorkerClient):
(WebKit::WebSWServerConnection::getRegistrations):
(WebKit::WebSWServerConnection::registerServiceWorkerClientInternal):
(WebKit::WebSWServerConnection::unregisterServiceWorkerClient):
(WebKit::WebSWServerConnection::computeThrottleState const):
(WebKit::WebSWServerConnection::updateThrottleState):
(WebKit::WebSWServerConnection::subscribeToPushService):
(WebKit::WebSWServerConnection::unsubscribeFromPushService):
(WebKit::WebSWServerConnection::getPushSubscription):
(WebKit::WebSWServerConnection::getPushPermissionState):
(WebKit::WebSWServerConnection::terminateWorkerFromClient):
(WebKit::WebSWServerConnection::sessionID const):
(WebKit::WebSWServerConnection::fetchTaskTimedOut):
(WebKit::WebSWServerConnection::enableNavigationPreload):
(WebKit::WebSWServerConnection::disableNavigationPreload):
(WebKit::WebSWServerConnection::setNavigationPreloadHeaderValue):
(WebKit::WebSWServerConnection::getNavigationPreloadState):
(WebKit::WebSWServerConnection::gatherClientData):
(WebKit::WebSWServerConnection::retrieveRecordResponseBody):
(WebKit::WebSWServerConnection::addCookieChangeSubscriptions):
(WebKit::WebSWServerConnection::removeCookieChangeSubscriptions):
(WebKit::WebSWServerConnection::cookieChangeSubscriptions):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::postMessageToServiceWorkerClient):
(WebKit::WebSWServerToContextConnection::focus):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp:
(WebKit::WebSharedWorkerServerToContextConnection::launchSharedWorker):
* Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp:
(WebKit::NetworkMDNSRegister::ref const):
(WebKit::NetworkMDNSRegister::deref const):
* Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.messages.in:

Canonical link: <a href="https://commits.webkit.org/287078@main">https://commits.webkit.org/287078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd0bb7b5ff706a87654b27fd044e57d5cae4de0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31640 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82902 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29506 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80377 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61273 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19190 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81311 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51266 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68343 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41593 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48612 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24903 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27843 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69702 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84266 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5609 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3785 "Found 2 new test failures: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69492 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5766 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67212 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68750 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12760 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11046 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12098 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5558 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/8316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5547 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7336 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->