### PR TITLE
[ Sequoia ] 3x TestWebKitAPI.ResourceLoad* (api-tests) are constant failures

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadDelegate.mm
@@ -203,12 +203,7 @@ TEST(ResourceLoadDelegate, ResourceType)
         EXPECT_EQ(loadInfos[i].get().resourceType, expectedTypes[i]);
 }
 
-// rdar://136524076
-#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 150000
-TEST(ResourceLoadDelegate, DISABLED_LoadInfo)
-#else
 TEST(ResourceLoadDelegate, LoadInfo)
-#endif
 {
     __block bool clearedStore = false;
     [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
@@ -312,8 +307,10 @@ TEST(ResourceLoadDelegate, LoadInfo)
     checkFrames(7, sub, main, _WKResourceLoadInfoResourceTypeFetch);
     checkFrames(8, sub, main, _WKResourceLoadInfoResourceTypeFetch);
 
+    String requestClass = NSStringFromClass([otherParameters[0] class]);
+
     EXPECT_EQ(otherParameters.size(), 12ull);
-    EXPECT_WK_STREQ(NSStringFromClass([otherParameters[0] class]), "NSMutableURLRequest");
+    EXPECT_TRUE(requestClass == "NSURLRequest"_s || requestClass == "NSMutableURLRequest"_s);
     EXPECT_WK_STREQ([otherParameters[0] URL].path, "/");
     EXPECT_WK_STREQ(NSStringFromClass([otherParameters[1] class]), "NSHTTPURLResponse");
     EXPECT_WK_STREQ([otherParameters[1] URL].path, "/");

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
@@ -1713,12 +1713,7 @@ TEST(ResourceLoadStatistics, StorageAccessOnRedirectSitesWithOutQuirk)
     TestWebKitAPI::Util::run(&done);
 }
 
-// rdar://136524076
-#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 150000
-TEST(ResourceLoadStatistics, DISABLED_StorageAccessOnRedirectSitesWithQuirk)
-#else
 TEST(ResourceLoadStatistics, StorageAccessOnRedirectSitesWithQuirk)
-#endif
 {
     using namespace TestWebKitAPI;
     HTTPServer httpServer({
@@ -2009,12 +2004,7 @@ TEST(ResourceLoadStatistics, StorageAccessSupportMultipleSubFrameDomains)
     gotRequestStorageAccessPanelForQuirksForDomain = false;
 }
 
-// rdar://136524076
-#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 150000
-TEST(ResourceLoadStatistics, DISABLED_StorageAccessGrantMultipleSubFrameDomains)
-#else
 TEST(ResourceLoadStatistics, StorageAccessGrantMultipleSubFrameDomains)
-#endif
 {
     using namespace TestWebKitAPI;
 


### PR DESCRIPTION
#### 77ff8499a1f0b440c2d08b3b085101e045a843c9
<pre>
[ Sequoia ] 3x TestWebKitAPI.ResourceLoad* (api-tests) are constant failures
<a href="https://rdar.apple.com/136525714">rdar://136525714</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=280202">https://bugs.webkit.org/show_bug.cgi?id=280202</a>

Reviewed by Chris Dumez.

We relax a bit the URL request class check to allow both mutable ans immutable NS url request classes.
ResourceRequest can either wrap a NSURLRequest or recreate a NSMutableURLRequest, depending on how the request is sent through IPC or manipulated.
If ResourceLoad delegates were API, it might be worth ensuring that the exposed request is NSURLRequest.
But this is not needed for this API test.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadDelegate.mm:
(LoadInfo)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm:
(TEST(ResourceLoadStatistics, StorageAccessOnRedirectSitesWithQuirk)):
(TEST(ResourceLoadStatistics, StorageAccessGrantMultipleSubFrameDomains)):

Canonical link: <a href="https://commits.webkit.org/287288@main">https://commits.webkit.org/287288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b6c8afc58eb82cb2a659ba800398b4da216a4e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82861 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29465 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5530 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61240 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19161 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41557 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48585 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24823 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27802 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69677 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84225 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5568 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3755 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69465 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68721 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17285 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12724 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10975 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5517 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5506 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8938 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7295 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->