### PR TITLE
Fix: font-family: initial should apply to the font instead of inherit from ancestor

### DIFF
--- a/LayoutTests/fast/text/font-family-initial-01-expected.txt
+++ b/LayoutTests/fast/text/font-family-initial-01-expected.txt
@@ -1,0 +1,13 @@
+PASS getComputedStyle(DivElement1).fontFamily is "fantasy"
+PASS getComputedStyle(DivElement2).fontFamily is "serif"
+PASS getComputedStyle(SpanElement1).fontFamily is "initial"
+PASS getComputedStyle(SpanElement2).fontFamily is "initial"
+PASS getComputedStyle(SpanElement3).fontFamily is "initial"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+The following two lines should look the same:
+
+test
+
+Test1 Test2 Test3

--- a/LayoutTests/fast/text/font-family-initial-01.html
+++ b/LayoutTests/fast/text/font-family-initial-01.html
@@ -1,0 +1,49 @@
+    <html>
+    <head>
+    <script src="../../resources/js-test.js"></script>
+    <style>
+        #div1 {
+            font-family: fantasy;
+        }
+        
+        #div2 {
+            font-family: serif;
+        }
+        
+        #span1 {
+            font-family: initial;
+        }
+        
+        #span2 {
+            font-family: initial;
+        }
+        
+        #span3 {
+            font-family: initial;
+        }
+    </style>
+    </head>
+    <body>
+        <p>The following two lines should look the same:</p>
+        <p>test</p>
+    <div id = "div1">
+        <div id = "div2">
+            <span id = "span1">Test1</span>
+            <span id = "span2">Test2</span>
+            <span id = "span3">Test3</span>
+    </div>
+    </div>
+    <script>      
+            var DivElement1    = document.getElementById('div1');
+            var DivElement2    = document.getElementById('div2');
+            var SpanElement1   = document.getElementById('span1');
+            var SpanElement2   = document.getElementById('span2');
+            var SpanElement3   = document.getElementById('span3');
+            shouldBeEqualToString('getComputedStyle(DivElement1).fontFamily',  "fantasy");
+            shouldBeEqualToString('getComputedStyle(DivElement2).fontFamily',  "serif");
+            shouldBeEqualToString('getComputedStyle(SpanElement1).fontFamily', "initial");
+            shouldBeEqualToString('getComputedStyle(SpanElement2).fontFamily', "initial");
+            shouldBeEqualToString('getComputedStyle(SpanElement3).fontFamily', "initial");
+    </script>
+</body>
+</html>

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -543,8 +543,7 @@ inline void BuilderCustom::applyValueWebkitTextZoom(BuilderState& builderState, 
 
 inline void BuilderCustom::applyInitialFontFamily(BuilderState& builderState)
 {
-    auto& fontDescription = builderState.fontDescription();
-    auto initialDesc = FontCascadeDescription();
+    auto fontDescription = builderState.fontDescription();
 
     // We need to adjust the size to account for the generic family change from monospace to non-monospace.
     if (fontDescription.useFixedDefaultSize()) {
@@ -552,8 +551,7 @@ inline void BuilderCustom::applyInitialFontFamily(BuilderState& builderState)
             builderState.setFontDescriptionFontSize(Style::fontSizeForKeyword(sizeIdentifier, false, builderState.document()));
     }
 
-    if (!initialDesc.firstFamily().name.isEmpty())
-        builderState.setFontDescriptionFamilies(FontFamilies { initialDesc.families(), fontDescription.hasAuthorSpecifiedNonGenericPrimaryFont() });
+    builderState.setFontDescriptionFamilies(FontFamilies { WebKitFontFamilyNames::standardFamily, FontFamilyKind::Generic });
 }
 
 inline void BuilderCustom::applyInheritFontFamily(BuilderState& builderState)

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -774,7 +774,7 @@ inline void BuilderCustom::applyValueBoxShadow(BuilderState& builderState, CSSVa
 
 inline void BuilderCustom::applyInitialFontFamily(BuilderState& builderState)
 {
-    auto& fontDescription = builderState.fontDescription();
+    auto fontDescription = builderState.fontDescription();
     auto initialDesc = FontCascadeDescription();
 
     // We need to adjust the size to account for the generic family change from monospace to non-monospace.
@@ -782,8 +782,9 @@ inline void BuilderCustom::applyInitialFontFamily(BuilderState& builderState)
         if (CSSValueID sizeIdentifier = fontDescription.keywordSizeAsIdentifier())
             builderState.setFontDescriptionFontSize(Style::fontSizeForKeyword(sizeIdentifier, false, builderState.document()));
     }
-    if (!initialDesc.firstFamily().isEmpty())
-        builderState.setFontDescriptionFamilies(initialDesc.families());
+    AtomString standardFontFamily = AtomString { builderState.document().settings().standardFontFamily() };
+    if (!standardFontFamily.isEmpty())
+        fontDescription.setOneFamily(standardFontFamily);
 }
 
 inline void BuilderCustom::applyInheritFontFamily(BuilderState& builderState)


### PR DESCRIPTION
#### 0a824d7ee6fb87ea300d96d9f3a9548e44f1bdb0
<pre>
Fix: font-family: initial should apply to the font instead of inherit from ancestor
<a href="https://bugs.webkit.org/show_bug.cgi?id=200709">https://bugs.webkit.org/show_bug.cgi?id=200709</a>

Reviewed by NOBODY (OOPS!).

As &apos;initialDesc.firstFamily().isEmpty()&apos; was returning 0,
we were incorrectly skipping the font family assignment in &apos;setFamilies&apos;,
causing the font family of the previous ancestor to be applied instead.

* LayoutTests/fast/text/font-family-initial-01-expected.txt: Added.
* LayoutTests/fast/text/font-family-initial-01.html: Added.
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyInitialFontFamily):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a824d7ee6fb87ea300d96d9f3a9548e44f1bdb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183252 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131546 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175543 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47293 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135055 "Found 2 new test failures: fast/text/font-family-initial-01.html imported/w3c/web-platform-tests/css/css-fonts/inheritance.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95279 "1 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176636 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38483 "Found 1 new test failure: fast/text/font-family-initial-01.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155839 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115533 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37124 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-fonts/inheritance.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35486 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31736 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147548 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35333 "Found 2 new test failures: fast/text/font-family-initial-01.html imported/w3c/web-platform-tests/css/css-fonts/inheritance.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185678 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38714 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39686 "Found 2 new test failures: fast/text/font-family-initial-01.html imported/w3c/web-platform-tests/css/css-fonts/inheritance.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143940 "Found 1 new test failure: fast/text/font-family-initial-01.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47278 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155395 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143799 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47957 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31949 "Found 2 new test failures: fast/text/font-family-initial-01.html imported/w3c/web-platform-tests/css/css-fonts/inheritance.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113144 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38721 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119835 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46463 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10288 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45865 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46096 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45924 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->