### PR TITLE
Some downcast/dynamicDowncast cleanup in a11y code

### DIFF
--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -1270,7 +1270,8 @@ void streamAXCoreObject(TextStream& stream, const AXCoreObject& object, const Op
     if (options & AXStreamOptions::Role)
         stream.dumpProperty("role", object.roleValue());
 
-    if (auto* axObject = dynamicDowncast<AccessibilityObject>(object)) {
+    auto* axObject = dynamicDowncast<AccessibilityObject>(object);
+    if (axObject) {
         if (auto* renderer = axObject->renderer())
             stream.dumpProperty("renderer", renderer->debugDescription());
         else if (auto* node = axObject->node())
@@ -1301,18 +1302,18 @@ void streamAXCoreObject(TextStream& stream, const AXCoreObject& object, const Op
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
     if (options & AXStreamOptions::TextRuns) {
-        if (auto* isolatedObject = dynamicDowncast<AXIsolatedObject>(&object)) {
+        if (auto* isolatedObject = dynamicDowncast<AXIsolatedObject>(object)) {
             if (auto* runs = isolatedObject->textRuns(); runs && runs->size())
                 streamTextRuns(stream, *runs);
-        } else if (auto* liveObject = dynamicDowncast<AccessibilityObject>(&object)) {
-            if (auto runs = const_cast<AccessibilityObject*>(liveObject)->textRuns(); runs.size())
+        } else if (axObject) {
+            if (auto runs = const_cast<AccessibilityObject*>(axObject)->textRuns(); runs.size())
                 streamTextRuns(stream, runs);
         }
     }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
     if (options & AXStreamOptions::DisplayContents) {
-        if (auto* axObject = dynamicDowncast<AccessibilityObject>(&object); axObject && axObject->hasDisplayContents())
+        if (axObject && axObject->hasDisplayContents())
             stream.dumpProperty("hasDisplayContents", true);
     }
 

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -456,7 +456,7 @@ static AXIsolatedObject* findObjectWithRuns(AXIsolatedObject& start, AXDirection
                 return nullptr;
 
             if (searchObject->hasTextRuns())
-                return dynamicDowncast<AXIsolatedObject>(searchObject.get());
+                return dynamicDowncast<AXIsolatedObject>(searchObject);
 
             appendChildren(searchObject, isForward, nullptr, searchStack);
         }

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -318,7 +318,7 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
         return AccessibilityRole::WebCoreLink;
     if (RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(*element))
         return selectElement->multiple() ? AccessibilityRole::ListBox : AccessibilityRole::PopUpButton;
-    if (RefPtr imgElement = dynamicDowncast<HTMLImageElement>(*element); imgElement && imgElement->hasAttributeWithoutSynchronization(usemapAttr))
+    if (is<HTMLImageElement>(*element) && element->hasAttributeWithoutSynchronization(usemapAttr))
         return AccessibilityRole::ImageMap;
 
     if (element->hasTagName(liTag))
@@ -2180,13 +2180,10 @@ static bool needsSpaceFromDisplay(AXCoreObject& coreObject)
 {
     // We should always be dealing with non-isolated objects here. Ideally in the future we can strengthen the types
     // to make this issue impossible.
-    RELEASE_ASSERT(is<AccessibilityObject>(coreObject));
-    RefPtr axObject = dynamicDowncast<AccessibilityObject>(coreObject);
-    if (!axObject)
-        return false;
+    Ref axObject = downcast<AccessibilityObject>(coreObject);
 
     CheckedPtr renderer = axObject->renderer();
-    if (is<RenderText>(renderer.get())) {
+    if (is<RenderText>(renderer)) {
         // Never add a space for RenderTexts. They are inherently inline, but take their parent's style, which may
         // be block, erroneously adding a space.
         return false;

--- a/Source/WebCore/accessibility/AccessibilityTable.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTable.cpp
@@ -706,7 +706,7 @@ unsigned AccessibilityTable::computeCellSlots()
 
 #if !ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
         // Not needed for ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE) because we add captions via AccessibilityRenderObject::addChildren().
-        if (auto* caption = dynamicDowncast<HTMLTableCaptionElement>(node)) {
+        if (auto* caption = dynamicDowncast<HTMLTableCaptionElement>(element)) {
             // Step 6: Associate the first caption element child of the table element with the table.
             if (!didAddCaption) {
                 if (RefPtr axCaption = cache->getOrCreate(*caption)) {


### PR DESCRIPTION
#### 550670934ff2ed5c3eeff1845e8c61cf9c1e6ca5
<pre>
Some downcast/dynamicDowncast cleanup in a11y code
<a href="https://bugs.webkit.org/show_bug.cgi?id=283665">https://bugs.webkit.org/show_bug.cgi?id=283665</a>

Reviewed by Tyler Wilcock.

* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::streamAXCoreObject):
* Source/WebCore/accessibility/AXTextMarker.cpp:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::determineAccessibilityRoleFromNode const):
(WebCore::needsSpaceFromDisplay):
* Source/WebCore/accessibility/AccessibilityTable.cpp:
(WebCore::AccessibilityTable::computeCellSlots):

Canonical link: <a href="https://commits.webkit.org/287066@main">https://commits.webkit.org/287066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21eaf7e99bcb1613c9f1c761023916f2567910de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82817 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29421 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80292 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5486 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61207 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19132 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51197 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68033 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41521 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48554 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24767 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27758 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69650 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25124 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84181 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5524 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3732 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69430 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5681 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68686 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12685 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10933 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12092 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5473 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8225 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5462 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8894 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7251 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->