### PR TITLE
ImageData using storageFormat

### DIFF
--- a/LayoutTests/fast/canvas/imagedata-storageformat-enabled-expected.txt
+++ b/LayoutTests/fast/canvas/imagedata-storageformat-enabled-expected.txt
@@ -3,10 +3,47 @@ Tests that ImageDataSettings contains storageFormat.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+PASS created_imageData_uint8.width is 1
+PASS created_imageData_uint8.height is 1
 PASS created_imageData_uint8.data.constructor is Uint8ClampedArray
+PASS created_imageData_uint8.data.BYTES_PER_ELEMENT is 1
+PASS created_imageData_uint8.data.length is 4
+PASS created_imageData_uint8.data.byteLength is 4
+PASS created_imageData_uint8.data.at(0) is 0
+PASS created_imageData_uint8.data.at(1) is 0
+PASS created_imageData_uint8.data.at(2) is 0
+PASS created_imageData_uint8.data.at(3) is 0
+PASS gotten_imageData_uint8.width is 1
+PASS gotten_imageData_uint8.height is 1
 PASS gotten_imageData_uint8.data.constructor is Uint8ClampedArray
-PASS created_imageData_float16.data.constructor is Uint8ClampedArray
+PASS gotten_imageData_uint8.data.BYTES_PER_ELEMENT is 1
+PASS gotten_imageData_uint8.data.length is 4
+PASS gotten_imageData_uint8.data.byteLength is 4
+PASS gotten_imageData_uint8.data.at(0) is 0
+PASS gotten_imageData_uint8.data.at(1) is 128
+PASS gotten_imageData_uint8.data.at(2) is 255
+PASS gotten_imageData_uint8.data.at(3) is 255
+PASS created_imageData_float16.width is 1
+PASS created_imageData_float16.height is 1
+PASS created_imageData_float16.data.constructor is Float16Array
+PASS created_imageData_float16.data.BYTES_PER_ELEMENT is 2
+PASS created_imageData_float16.data.length is 4
+PASS created_imageData_float16.data.byteLength is 8
+PASS created_imageData_float16.data.at(0) is 0
+PASS created_imageData_float16.data.at(1) is 0
+PASS created_imageData_float16.data.at(2) is 0
+PASS created_imageData_float16.data.at(3) is 0
+FIXME: gotten_imageData_float16.data below should eventually become Float16Array.
+PASS gotten_imageData_float16.width is 1
+PASS gotten_imageData_float16.height is 1
 PASS gotten_imageData_float16.data.constructor is Uint8ClampedArray
+PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is 1
+PASS gotten_imageData_float16.data.length is 4
+PASS gotten_imageData_float16.data.byteLength is 4
+PASS gotten_imageData_float16.data.at(0) is 0
+PASS gotten_imageData_float16.data.at(1) is 128
+PASS gotten_imageData_float16.data.at(2) is 255
+PASS gotten_imageData_float16.data.at(3) is 255
 PASS context.createImageData(1, 1, { storageFormat: "foo" }) threw exception TypeError: Type error.
 PASS context.getImageData(0, 0, 1, 1, { storageFormat: "foo" }) threw exception TypeError: Type error.
 PASS successfullyParsed is true

--- a/LayoutTests/fast/canvas/imagedata-storageformat-enabled.html
+++ b/LayoutTests/fast/canvas/imagedata-storageformat-enabled.html
@@ -12,18 +12,38 @@ var canvas = document.createElement("canvas");
 canvas.width = 10;
 canvas.height = 10;
 var context = canvas.getContext("2d");
+var r = 0;
+var g = 128;
+var b = 255;
+var a = 255;
+context.fillStyle = `rgb(${r} ${g} ${b})`;
+context.fillRect(0, 0, 1, 1);
+
+function verifyImageData(variable, constructor, bytesPerElement, red, green, blue, alpha) {
+    shouldBe(variable + '.width', '1');
+    shouldBe(variable + '.height', '1');
+    shouldBe(variable + '.data.constructor', constructor);
+    shouldBe(variable + '.data.BYTES_PER_ELEMENT', String(bytesPerElement));
+    shouldBe(variable + '.data.length', '4');
+    shouldBe(variable + '.data.byteLength', String(bytesPerElement * 4));
+    shouldBe(variable + '.data.at(0)', String(red));
+    shouldBe(variable + '.data.at(1)', String(green));
+    shouldBe(variable + '.data.at(2)', String(blue));
+    shouldBe(variable + '.data.at(3)', String(alpha));
+}
 
 var created_imageData_uint8 = context.createImageData(1, 1, { storageFormat: "uint8" });
-shouldBe('created_imageData_uint8.data.constructor', 'Uint8ClampedArray');
+verifyImageData('created_imageData_uint8', 'Uint8ClampedArray', 1, 0, 0, 0, 0);
+
 var gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { storageFormat: "uint8" });
-shouldBe('gotten_imageData_uint8.data.constructor', 'Uint8ClampedArray');
+verifyImageData('gotten_imageData_uint8', 'Uint8ClampedArray', 1, r, g, b, a);
 
 var created_imageData_float16 = context.createImageData(1, 1, { storageFormat: "float16" });
-// FIXME: This should eventually become Float16Array.
-shouldBe('created_imageData_float16.data.constructor', 'Uint8ClampedArray');
+verifyImageData('created_imageData_float16', 'Float16Array', 2, 0, 0, 0, 0);
+
 var gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { storageFormat: "float16" });
-// FIXME: This should eventually become Float16Array.
-shouldBe('gotten_imageData_float16.data.constructor', 'Uint8ClampedArray');
+debug('FIXME: gotten_imageData_float16.data below should eventually become Float16Array.');
+verifyImageData('gotten_imageData_float16', 'Uint8ClampedArray', 1, r, g, b, a);
 
 shouldThrowErrorName(`context.createImageData(1, 1, { storageFormat: "foo" })`, "TypeError")
 shouldThrowErrorName(`context.getImageData(0, 0, 1, 1, { storageFormat: "foo" })`, "TypeError")

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1235,7 +1235,6 @@ html/HTMLVideoElement.cpp
 html/HTMLVideoElement.h
 html/HiddenInputType.cpp
 html/ImageBitmap.cpp
-html/ImageData.cpp
 html/ImageDocument.cpp
 html/ImageInputType.cpp
 html/InputType.cpp

--- a/Source/WebCore/bindings/js/JSImageDataCustom.cpp
+++ b/Source/WebCore/bindings/js/JSImageDataCustom.cpp
@@ -40,13 +40,14 @@ using namespace JSC;
 JSValue toJSNewlyCreated(JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Ref<ImageData>&& imageData)
 {
     VM& vm = lexicalGlobalObject->vm();
-    auto& data = imageData->data();
+    auto& imageDataArray = imageData->data();
+    Ref arrayBufferView = imageDataArray.arrayBufferView();
     auto* wrapper = createWrapper<ImageData>(globalObject, WTFMove(imageData));
     Identifier dataName = Identifier::fromString(vm, "data"_s);
-    wrapper->putDirect(vm, dataName, toJS(lexicalGlobalObject, globalObject, data), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+    wrapper->putDirect(vm, dataName, toJS(lexicalGlobalObject, globalObject, arrayBufferView), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     // FIXME: Adopt reportExtraMemoryVisited, and switch to reportExtraMemoryAllocated.
     // https://bugs.webkit.org/show_bug.cgi?id=142595
-    vm.heap.deprecatedReportExtraMemory(data.length());
+    vm.heap.deprecatedReportExtraMemory(imageDataArray.byteLength());
     
     return wrapper;
 }

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -1874,7 +1874,7 @@ private:
                 }
                 write(static_cast<uint32_t>(data->width()));
                 write(static_cast<uint32_t>(data->height()));
-                CheckedUint32 dataLength = data->data().length();
+                CheckedUint32 dataLength = data->data().byteLength();
                 if (dataLength.hasOverflowed()) {
                     code = SerializationReturnCode::DataCloneError;
                     return true;
@@ -4966,16 +4966,12 @@ private:
             if (!m_isDOMGlobalObject)
                 return jsNull();
 
-            auto result = ImageData::createUninitialized(width, height, resultColorSpace);
+            auto result = ImageData::create(width, height, resultColorSpace, { }, std::span(bufferStart, length));
             if (result.hasException()) {
                 SERIALIZE_TRACE("FAIL deserialize");
                 fail();
                 return JSValue();
             }
-            if (length)
-                memcpy(result.returnValue()->data().data(), bufferStart, length);
-            else
-                result.returnValue()->data().zeroFill();
             m_imageDataPool.append(result.returnValue().copyRef());
             return getJSValue(result.releaseReturnValue());
         }

--- a/Source/WebCore/html/ImageData.cpp
+++ b/Source/WebCore/html/ImageData.cpp
@@ -36,9 +36,9 @@
 
 namespace WebCore {
 
-static CheckedUint32 computeDataSize(const IntSize& size)
+static CheckedUint32 computeDataSize(const IntSize& size, ImageDataStorageFormat storageFormat)
 {
-    return PixelBuffer::computeBufferSize(PixelFormat::RGBA8, size);
+    return PixelBuffer::computePixelComponentCount(toPixelFormat(storageFormat), size);
 }
 
 PredefinedColorSpace ImageData::computeColorSpace(std::optional<ImageDataSettings> settings, PredefinedColorSpace defaultColorSpace)
@@ -46,6 +46,11 @@ PredefinedColorSpace ImageData::computeColorSpace(std::optional<ImageDataSetting
     if (settings && settings->colorSpace)
         return *settings->colorSpace;
     return defaultColorSpace;
+}
+
+static ImageDataStorageFormat computeStorageFormat(std::optional<ImageDataSettings> settings, ImageDataStorageFormat defaultStorageFormat = ImageDataStorageFormat::Uint8)
+{
+    return settings ? settings->storageFormat : defaultStorageFormat;
 }
 
 Ref<ImageData> ImageData::create(Ref<ByteArrayPixelBuffer>&& pixelBuffer)
@@ -63,83 +68,74 @@ RefPtr<ImageData> ImageData::create(RefPtr<ByteArrayPixelBuffer>&& pixelBuffer)
 
 RefPtr<ImageData> ImageData::create(const IntSize& size, PredefinedColorSpace colorSpace)
 {
-    auto dataSize = computeDataSize(size);
+    auto dataSize = computeDataSize(size, ImageDataStorageFormat::Uint8);
     if (dataSize.hasOverflowed())
         return nullptr;
-    auto byteArray = Uint8ClampedArray::tryCreateUninitialized(dataSize);
-    if (!byteArray)
+    auto array = ImageDataArray::tryCreate(dataSize, ImageDataStorageFormat::Uint8);
+    if (!array)
         return nullptr;
-    return adoptRef(*new ImageData(size, byteArray.releaseNonNull(), colorSpace));
+    return adoptRef(*new ImageData(size, WTFMove(*array), colorSpace));
 }
 
-RefPtr<ImageData> ImageData::create(const IntSize& size, ImageDataArray&& byteArray, PredefinedColorSpace colorSpace)
+RefPtr<ImageData> ImageData::create(const IntSize& size, ImageDataArray&& array, PredefinedColorSpace colorSpace)
 {
-    auto dataSize = computeDataSize(size);
-    if (dataSize.hasOverflowed() || dataSize != byteArray.length())
+    auto dataSize = computeDataSize(size, array.storageFormat());
+    if (dataSize.hasOverflowed() || dataSize != array.length())
         return nullptr;
-
-    return adoptRef(*new ImageData(size, WTFMove(byteArray), colorSpace));
+    return adoptRef(*new ImageData(size, WTFMove(array), colorSpace));
 }
 
-ExceptionOr<Ref<ImageData>> ImageData::createUninitialized(unsigned rows, unsigned pixelsPerRow, PredefinedColorSpace defaultColorSpace, std::optional<ImageDataSettings> settings)
-{
-    IntSize size(rows, pixelsPerRow);
-    auto dataSize = computeDataSize(size);
-    if (dataSize.hasOverflowed())
-        return Exception { ExceptionCode::RangeError, "Cannot allocate a buffer of this size"_s };
 
-    auto byteArray = Uint8ClampedArray::tryCreateUninitialized(dataSize);
-    if (!byteArray) {
-        // FIXME: Does this need to be a "real" out of memory error with setOutOfMemoryError called on it?
-        return Exception { ExceptionCode::RangeError, "Out of memory"_s };
-    }
-
-    auto colorSpace = computeColorSpace(settings, defaultColorSpace);
-    return adoptRef(*new ImageData(size, byteArray.releaseNonNull(), colorSpace));
-}
-
-ExceptionOr<Ref<ImageData>> ImageData::create(unsigned sw, unsigned sh, std::optional<ImageDataSettings> settings)
+ExceptionOr<Ref<ImageData>> ImageData::create(unsigned sw, unsigned sh, PredefinedColorSpace defaultColorSpace, std::optional<ImageDataSettings> settings, std::span<const uint8_t> optionalBytes)
 {
     if (!sw || !sh)
         return Exception { ExceptionCode::IndexSizeError };
 
     IntSize size(sw, sh);
-    auto dataSize = computeDataSize(size);
+    auto storageFormat = computeStorageFormat(settings);
+    auto dataSize = computeDataSize(size, storageFormat);
     if (dataSize.hasOverflowed())
         return Exception { ExceptionCode::RangeError, "Cannot allocate a buffer of this size"_s };
 
-    auto byteArray = Uint8ClampedArray::tryCreateUninitialized(dataSize);
-    if (!byteArray) {
+    auto array = ImageDataArray::tryCreate(dataSize, storageFormat, optionalBytes);
+    if (!array) {
         // FIXME: Does this need to be a "real" out of memory error with setOutOfMemoryError called on it?
         return Exception { ExceptionCode::RangeError, "Out of memory"_s };
     }
-    byteArray->zeroFill();
 
-    auto colorSpace = computeColorSpace(settings);
-    return adoptRef(*new ImageData(size, byteArray.releaseNonNull(), colorSpace));
+    auto colorSpace = ImageData::computeColorSpace(settings, defaultColorSpace);
+    return adoptRef(*new ImageData(size, WTFMove(*array), colorSpace));
 }
 
-ExceptionOr<Ref<ImageData>> ImageData::create(ImageDataArray&& byteArray, unsigned sw, std::optional<unsigned> sh, std::optional<ImageDataSettings> settings)
+ExceptionOr<Ref<ImageData>> ImageData::create(unsigned sw, unsigned sh, std::optional<ImageDataSettings> settings)
 {
-    unsigned length = byteArray.length();
+    return create(sw, sh, PredefinedColorSpace::SRGB, settings);
+}
+
+ExceptionOr<Ref<ImageData>> ImageData::create(ImageDataArray&& array, unsigned sw, std::optional<unsigned> sh, std::optional<ImageDataSettings> settings)
+{
+    auto length = array.length();
     if (!length || length % 4)
         return Exception { ExceptionCode::InvalidStateError, "Length is not a non-zero multiple of 4"_s };
 
-    length /= 4;
-    if (!sw || length % sw)
+    auto pixels = length / 4;
+    if (!sw || pixels % sw)
         return Exception { ExceptionCode::IndexSizeError, "Length is not a multiple of sw"_s };
 
-    unsigned height = length / sw;
+    Checked<int, RecordOverflow> height = pixels / sw;
+    if (height.hasOverflowed())
+        return Exception { ExceptionCode::IndexSizeError, "Computed height is too big"_s };
+
     if (sh && sh.value() != height)
         return Exception { ExceptionCode::IndexSizeError, "sh value is not equal to height"_s };
 
-    IntSize size(sw, height);
-    auto dataSize = computeDataSize(size);
-    if (dataSize.hasOverflowed() || dataSize != byteArray.length())
+    IntSize size(sw, height.value());
+    auto dataSize = computeDataSize(size, computeStorageFormat(settings));
+    if (dataSize.hasOverflowed() || dataSize != length)
         return Exception { ExceptionCode::RangeError };
 
     auto colorSpace = computeColorSpace(settings);
-    return adoptRef(*new ImageData(size, WTFMove(byteArray), colorSpace));
+    return adoptRef(*new ImageData(size, WTFMove(array), colorSpace));
 }
 
 ImageData::ImageData(const IntSize& size, ImageDataArray&& data, PredefinedColorSpace colorSpace)
@@ -153,13 +149,9 @@ ImageData::~ImageData() = default;
 
 Ref<ByteArrayPixelBuffer> ImageData::pixelBuffer() const
 {
+    Ref uint8Data = m_data.asUint8ClampedArray();
     PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, toDestinationColorSpace(m_colorSpace) };
-    return ByteArrayPixelBuffer::create(format, m_size, m_data.get());
-}
-
-RefPtr<ImageData> ImageData::clone() const
-{
-    return ImageData::create(m_size, Uint8ClampedArray::create(m_data.data(), m_data.length()), m_colorSpace);
+    return ByteArrayPixelBuffer::create(format, m_size, uint8Data.get());
 }
 
 TextStream& operator<<(TextStream& ts, const ImageData& imageData)

--- a/Source/WebCore/html/ImageData.h
+++ b/Source/WebCore/html/ImageData.h
@@ -45,7 +45,8 @@ public:
     WEBCORE_EXPORT static RefPtr<ImageData> create(RefPtr<ByteArrayPixelBuffer>&&);
     WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, PredefinedColorSpace);
     WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, ImageDataArray&&, PredefinedColorSpace);
-    WEBCORE_EXPORT static ExceptionOr<Ref<ImageData>> createUninitialized(unsigned rows, unsigned pixelsPerRow, PredefinedColorSpace defaultColorSpace, std::optional<ImageDataSettings> = std::nullopt);
+
+    WEBCORE_EXPORT static ExceptionOr<Ref<ImageData>> create(unsigned sw, unsigned sh, PredefinedColorSpace defaultColorSpace, std::optional<ImageDataSettings> = std::nullopt, std::span<const uint8_t> = { });
     WEBCORE_EXPORT static ExceptionOr<Ref<ImageData>> create(unsigned sw, unsigned sh, std::optional<ImageDataSettings>);
     WEBCORE_EXPORT static ExceptionOr<Ref<ImageData>> create(ImageDataArray&&, unsigned sw, std::optional<unsigned> sh, std::optional<ImageDataSettings>);
 
@@ -57,12 +58,11 @@ public:
 
     int width() const { return m_size.width(); }
     int height() const { return m_size.height(); }
-    Uint8ClampedArray& data() const { return m_data.get(); }
+    const ImageDataArray& data() const { return m_data; }
     PredefinedColorSpace colorSpace() const { return m_colorSpace; }
+    ImageDataStorageFormat storageFormat() const { return m_data.storageFormat(); }
 
     Ref<ByteArrayPixelBuffer> pixelBuffer() const;
-
-    RefPtr<ImageData> clone() const;
 
 private:
     explicit ImageData(const IntSize&, ImageDataArray&&, PredefinedColorSpace);

--- a/Source/WebCore/html/ImageData.idl
+++ b/Source/WebCore/html/ImageData.idl
@@ -26,6 +26,8 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+typedef (Uint8ClampedArray or Float16Array) ImageDataArray;
+
 [
     CustomToJSObject,
     ExportMacro=WEBCORE_EXPORT,
@@ -33,9 +35,11 @@
 ] interface ImageData {
     constructor(unsigned long sw, unsigned long sh, optional ImageDataSettings settings);
     constructor(Uint8ClampedArray data, unsigned long sw, optional unsigned long sh, optional ImageDataSettings settings);
+    [EnabledBySetting=CanvasPixelFormatEnabled] constructor(Float16Array data, unsigned long sw, optional unsigned long sh, optional ImageDataSettings settings);
 
     readonly attribute unsigned long width;
     readonly attribute unsigned long height;
-    readonly attribute Uint8ClampedArray data;
+    readonly attribute ImageDataArray data;
     [EnabledBySetting=CanvasColorSpaceEnabled] readonly attribute PredefinedColorSpace colorSpace;
+    [EnabledBySetting=CanvasPixelFormatEnabled] readonly attribute ImageDataStorageFormat storageFormat;
 };

--- a/Source/WebCore/html/ImageDataArray.cpp
+++ b/Source/WebCore/html/ImageDataArray.cpp
@@ -29,6 +29,163 @@
 #include "config.h"
 #include "ImageDataArray.h"
 
+#include <JavaScriptCore/Float16Array.h>
+#include <JavaScriptCore/Uint8ClampedArray.h>
+
+// Needed for `downcast` below.
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Uint8ClampedArray)
+    static bool isType(const JSC::ArrayBufferView& arrayBufferView) { return arrayBufferView.getType() == JSC::TypeUint8Clamped; }
+SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Float16Array)
+    static bool isType(const JSC::ArrayBufferView& arrayBufferView) { return arrayBufferView.getType() == JSC::TypeFloat16; }
+SPECIALIZE_TYPE_TRAITS_END()
+
 namespace WebCore {
+
+template <typename F>
+static auto visitArrayBufferView(JSC::ArrayBufferView& bufferView, F&& f)
+{
+    // Always try Uint8ClampedArray first, as it should be the most frequent.
+    if (auto* array = dynamicDowncast<JSC::Uint8ClampedArray>(bufferView))
+        return std::forward<F>(f)(*array);
+    if (auto* array = dynamicDowncast<JSC::Float16Array>(bufferView))
+        return std::forward<F>(f)(*array);
+    RELEASE_ASSERT_NOT_REACHED("Unexpected ArrayBufferView type");
+}
+
+ImageDataArray::ImageDataArray(Ref<JSC::ArrayBufferView>&& arrayBufferView)
+    : m_arrayBufferView(WTFMove(arrayBufferView))
+{
+    ASSERT(isSupported(m_arrayBufferView.get()));
+}
+
+ImageDataArray::ImageDataArray(Ref<JSC::Uint8ClampedArray>&& data)
+    : ImageDataArray(Ref<JSC::ArrayBufferView>(WTFMove(data)))
+{ }
+
+ImageDataArray::ImageDataArray(Ref<JSC::Float16Array>&& data)
+    : ImageDataArray(Ref<JSC::ArrayBufferView>(WTFMove(data)))
+{ }
+
+template <typename TypedArray>
+static void fillTypedArray(TypedArray& typedArray, std::span<const uint8_t> optionalBytes)
+{
+    if (optionalBytes.empty())
+        return typedArray.zeroFill();
+    auto bufferViewSpan = typedArray.mutableSpan();
+    RELEASE_ASSERT(bufferViewSpan.size_bytes() == optionalBytes.size_bytes(), "Caller should provide correctly-sized buffer to copy");
+    memcpy(bufferViewSpan.data(), optionalBytes.data(), optionalBytes.size_bytes());
+}
+
+std::optional<ImageDataArray> ImageDataArray::tryCreate(size_t length, ImageDataStorageFormat storageFormat, std::span<const uint8_t> optionalBytes)
+{
+    std::optional<ImageDataArray> array;
+    switch (storageFormat) {
+    case ImageDataStorageFormat::Uint8:
+        if (RefPtr typedArray = JSC::Uint8ClampedArray::tryCreateUninitialized(length)) {
+            fillTypedArray(*typedArray, optionalBytes);
+            array.emplace(typedArray.releaseNonNull());
+        }
+        break;
+    case ImageDataStorageFormat::Float16:
+        if (RefPtr typedArray = JSC::Float16Array::tryCreateUninitialized(length)) {
+            fillTypedArray(*typedArray, optionalBytes);
+            array.emplace(typedArray.releaseNonNull());
+        }
+    }
+    return array;
+}
+
+bool ImageDataArray::isSupported(const JSC::ArrayBufferView& arrayBufferView)
+{
+    return isSupported(arrayBufferView.getType());
+}
+
+ImageDataStorageFormat ImageDataArray::storageFormat() const
+{
+    auto imageDataStorageFormat = toImageDataStorageFormat(m_arrayBufferView->getType());
+    RELEASE_ASSERT(!!imageDataStorageFormat);
+    return *imageDataStorageFormat;
+}
+
+template <typename From, typename To>
+struct TypedArrayItemConverter;
+
+template <>
+struct TypedArrayItemConverter<JSC::Uint8ClampedArray, JSC::Float16Array> {
+    static constexpr JSC::Float16Adaptor::Type convert(JSC::Uint8ClampedAdaptor::Type value)
+    {
+        return double(value) / 255.0;
+    }
+};
+
+template <>
+struct TypedArrayItemConverter<JSC::Float16Array, JSC::Uint8ClampedArray> {
+    static constexpr JSC::Uint8ClampedAdaptor::Type convert(JSC::Float16Adaptor::Type value)
+    {
+        auto d = double(value);
+        if (d <= 0)
+            return 0;
+        if (d >= 1)
+            return 255;
+        return d * 255.0;
+    }
+};
+
+template <typename ToTypeArray>
+static Ref<ToTypeArray> convertToTypedArray(const ImageDataArray& fromImageDataArray)
+{
+    Ref arrayBufferView = fromImageDataArray.arrayBufferView();
+    return visitArrayBufferView(arrayBufferView, []<typename FromTypedArray>(FromTypedArray& fromTypedArray) {
+        if constexpr (std::is_same_v<FromTypedArray, ToTypeArray>)
+            return Ref(fromTypedArray);
+        else {
+            using Converter = TypedArrayItemConverter<FromTypedArray, ToTypeArray>;
+            auto length = fromTypedArray.length();
+            Ref<ToTypeArray> toArray = ToTypeArray::create(length);
+            for (size_t i = 0; i < length; ++i)
+                toArray->set(i, Converter::convert(fromTypedArray.item(i)));
+            return toArray;
+        }
+    });
+}
+
+Ref<JSC::Uint8ClampedArray> ImageDataArray::asUint8ClampedArray() const
+{
+    return convertToTypedArray<JSC::Uint8ClampedArray>(*this);
+}
+
+Ref<JSC::Float16Array> ImageDataArray::asFloat16Array() const
+{
+    return convertToTypedArray<JSC::Float16Array>(*this);
+}
+
+size_t ImageDataArray::length() const
+{
+    return visitArrayBufferView(
+        m_arrayBufferView.get(),
+        [](const auto& array) {
+            return array.length();
+        });
+}
+
+Ref<JSON::Value> ImageDataArray::copyToJSONArray() const
+{
+    return visitArrayBufferView(m_arrayBufferView.get(), []<typename T>(const T& array) -> Ref<JSON::Value> {
+        static_assert(std::is_same_v<T, JSC::Uint8ClampedArray> || std::is_same_v<T, JSC::Float16Array>);
+        using CType = std::conditional_t<std::is_same_v<T, JSC::Uint8ClampedArray>, int, double>;
+        Ref jsArray = JSON::ArrayOf<CType>::create();
+        for (const auto& item : array.typedSpan())
+            jsArray->addItem(CType(item));
+        return jsArray;
+    });
+}
+
+ImageDataArray::operator Variant() const
+{
+    return visitArrayBufferView(m_arrayBufferView.get(), [](auto& a) {
+        return Variant(RefPtr(&a));
+    });
+}
 
 } // namespace WebCore

--- a/Source/WebCore/html/ImageDataStorageFormat.h
+++ b/Source/WebCore/html/ImageDataStorageFormat.h
@@ -25,11 +25,38 @@
 
 #pragma once
 
+#include "PixelFormat.h"
+#include <JavaScriptCore/TypedArrayType.h>
+
 namespace WebCore {
 
 enum class ImageDataStorageFormat : bool {
     Uint8,
     Float16,
 };
+
+constexpr PixelFormat toPixelFormat(ImageDataStorageFormat storageFormat)
+{
+    switch (storageFormat) {
+    case ImageDataStorageFormat::Uint8:
+        break;
+    case ImageDataStorageFormat::Float16:
+#if HAVE(HDR_SUPPORT)
+        return PixelFormat::RGBA16F;
+#else
+        break;
+#endif
+    }
+    return PixelFormat::RGBA8;
+}
+
+constexpr std::optional<ImageDataStorageFormat> toImageDataStorageFormat(JSC::TypedArrayType typedArrayType)
+{
+    switch (typedArrayType) {
+    case JSC::TypeUint8Clamped: return ImageDataStorageFormat::Uint8;
+    case JSC::TypeFloat16: return ImageDataStorageFormat::Float16;
+    default: return std::nullopt;
+    }
+}
 
 }

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -3218,7 +3218,8 @@ ExceptionOr<void> WebGLRenderingContextBase::texImageSource(TexImageFunctionID f
     if (m_unpackFlipY)
         adjustedSourceImageRect.setY(source.height() - adjustedSourceImageRect.maxY());
 
-    std::span imageData { source.data().data(), source.data().byteLength() };
+    Ref uint8Data = source.data().asUint8ClampedArray();
+    std::span imageData = uint8Data->typedSpan();
     Vector<uint8_t> data;
 
     // The data from ImageData is always of format RGBA8.

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -1395,12 +1395,8 @@ Ref<JSON::ArrayOf<JSON::Value>> InspectorCanvas::buildArrayForCanvasPattern(cons
 
 Ref<JSON::ArrayOf<JSON::Value>> InspectorCanvas::buildArrayForImageData(const ImageData& imageData)
 {
-    auto data = JSON::ArrayOf<int>::create();
-    for (size_t i = 0; i < imageData.data().length(); ++i)
-        data->addItem(imageData.data().item(i));
-
     auto array = JSON::ArrayOf<JSON::Value>::create();
-    array->addItem(WTFMove(data));
+    array->addItem(imageData.data().copyToJSONArray());
     array->addItem(imageData.width());
     array->addItem(imageData.height());
     return array;


### PR DESCRIPTION
#### 6f2ac99d8410ead797a23036ba1b442669f61fa7
<pre>
ImageData using storageFormat
<a href="https://bugs.webkit.org/show_bug.cgi?id=284004">https://bugs.webkit.org/show_bug.cgi?id=284004</a>
<a href="https://rdar.apple.com/problem/140877760">rdar://problem/140877760</a>

Reviewed by Said Abou-Hallawa.

ImageData now supports:
- The IDL property `storageFormat` of type `ImageDataStorageFormat`, which
  reflects the ImageDataSettings.storageFormat value given during construction.
- The IDL property `data` can now be `Uint8ClampedArray` or `Float16Array`,
  depending on the storageFormat.

The main difference for now, is that
`context.createImageData(w, h, { storageFormat: &quot;float16&quot; })`
should correctly output an ImageData with data of type Float16Array.

Otherwise most uses of ImageData, like in CanvasRenderingContext2DBase, enforce
the use of Uint8ClampedArray, so there shouldn&apos;t be any visible changes in most
cases, including when requesting
`context.getImageData(w, h, { storageFormat: &quot;float16&quot; })`
(to be implemented in future PRs).

* LayoutTests/fast/canvas/imagedata-storageformat-enabled-expected.txt:
* LayoutTests/fast/canvas/imagedata-storageformat-enabled.html:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/bindings/js/JSImageDataCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpIfTerminal):
(WebCore::CloneDeserializer::readTerminal):
* Source/WebCore/html/ImageData.cpp:
(WebCore::computeDataSize):
(WebCore::computeStorageFormat):
(WebCore::ImageData::create):
(WebCore::ImageData::pixelBuffer const):
(WebCore::ImageData::createUninitialized): Deleted.
(WebCore::ImageData::clone const): Deleted.
* Source/WebCore/html/ImageData.h:
(WebCore::ImageData::create):
(WebCore::ImageData::data const):
(WebCore::ImageData::storageFormat const):
* Source/WebCore/html/ImageData.idl:
* Source/WebCore/html/ImageDataArray.cpp:
(isType):
(WebCore::visitArrayBufferView):
(WebCore::ImageDataArray::ImageDataArray):
(WebCore::fillTypedArray):
(WebCore::ImageDataArray::tryCreate):
(WebCore::ImageDataArray::isSupported):
(WebCore::ImageDataArray::storageFormat const):
(WebCore::convertToTypedArray):
(WebCore::ImageDataArray::asUint8ClampedArray const):
(WebCore::ImageDataArray::asFloat16Array const):
(WebCore::ImageDataArray::length const):
(WebCore::ImageDataArray::copyToJSONArray const):
(WebCore::ImageDataArray::operator Variant const):
* Source/WebCore/html/ImageDataArray.h:
(WebCore::ImageDataArray::isSupported):
(WebCore::ImageDataArray::tryCreate):
(WebCore::ImageDataArray::arrayBufferView const):
(WebCore::ImageDataArray::protectedArrayBufferView const):
(WebCore::ImageDataArray::byteLength const):
(WebCore::ImageDataArray::isDetached const):
(WebCore::ImageDataArray::span const):
(WebCore::ImageDataArray::ImageDataArray): Deleted.
(WebCore::ImageDataArray::length const): Deleted.
(WebCore::ImageDataArray::get const): Deleted.
(WebCore::ImageDataArray::data const): Deleted.
* Source/WebCore/html/ImageDataStorageFormat.h:
(WebCore::toPixelFormat):
(WebCore::toImageDataStorageFormat):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::createImageData const):
(WebCore::CanvasRenderingContext2DBase::cacheImageDataIfPossible):
(WebCore::CanvasRenderingContext2DBase::makeImageDataIfContentsCached const):
(WebCore::CanvasRenderingContext2DBase::getImageData const):
(WebCore::initializeEmptyImageData): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImageSource):
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::buildArrayForImageData):

Canonical link: <a href="https://commits.webkit.org/287598@main">https://commits.webkit.org/287598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/227d673009541c0dd1ba4930e17ee22cb2810df7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84732 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31191 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62704 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20517 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83284 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73051 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43012 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/50103 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27206 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29652 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71232 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27716 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86165 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7435 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5263 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70977 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7610 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68891 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70219 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17484 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14213 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13162 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7399 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12916 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7238 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10758 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9043 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->