### PR TITLE
[SOUP] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in PublicSuffixStoreSoup

### DIFF
--- a/Source/WebCore/platform/soup/PublicSuffixStoreSoup.cpp
+++ b/Source/WebCore/platform/soup/PublicSuffixStoreSoup.cpp
@@ -60,21 +60,17 @@ static String permissiveTopPrivateDomain(StringView domain)
 
 String PublicSuffixStore::platformTopPrivatelyControlledDomain(StringView domain) const
 {
-    CString domainUTF8 = domain.utf8();
-
     // This function is expected to work with the format used by cookies, so skip any leading dots.
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
     unsigned position = 0;
-    while (domainUTF8.data()[position] == '.')
+    while (domain[position] == '.')
         position++;
 
-    if (position == domainUTF8.length())
+    if (position == domain.length())
         return String();
 
     GUniqueOutPtr<GError> error;
-    if (const char* baseDomain = soup_tld_get_base_domain(domainUTF8.data() + position, &error.outPtr()))
+    if (const char* baseDomain = soup_tld_get_base_domain(domain.substring(position).utf8().data(), &error.outPtr()))
         return String::fromUTF8(baseDomain);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     if (g_error_matches(error.get(), SOUP_TLD_ERROR, SOUP_TLD_ERROR_NO_BASE_DOMAIN)) {
         if (domain.endsWithIgnoringASCIICase("web-platform.test"_s))


### PR DESCRIPTION
#### 81ca2e9fb66634cea993ad9619ba51d0f0854476
<pre>
[SOUP] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in PublicSuffixStoreSoup
<a href="https://bugs.webkit.org/show_bug.cgi?id=283669">https://bugs.webkit.org/show_bug.cgi?id=283669</a>

Reviewed by Adrian Perez de Castro.

Use StringView API instead of raw char* manipulation.

* Source/WebCore/platform/soup/PublicSuffixStoreSoup.cpp:
(WebCore::PublicSuffixStore::platformTopPrivatelyControlledDomain const):

Canonical link: <a href="https://commits.webkit.org/287061@main">https://commits.webkit.org/287061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e02ea90aead6e6f60d41eef5151e9976567923ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82835 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29439 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80310 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5504 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61220 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19139 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68062 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41535 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48564 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24785 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27776 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69659 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84199 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5542 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3740 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69445 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5699 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68700 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12701 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10943 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12088 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5491 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/8243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5480 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8912 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->