### PR TITLE
[web-animations] Rename `Animation.progress` to `Animation.overallProgress` and use a dedicated run-time flag for it

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/overallProgress.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/overallProgress.tentative-expected.txt
@@ -1,0 +1,8 @@
+
+PASS overallProgress of a newly created animation without an effect is unresolved
+PASS overallProgress of an animation whose currentTime is unresolved is unresolved.
+PASS overallProgress of an animation whose effect's endTime is zero is zero if its currentTime is negative.
+PASS overallProgress of an animation whose effect's endTime is zero is one if its currentTime is non-negative.
+PASS overallProgress of an animation whose effect's endTime is infinity is zero.
+PASS overallProgress of an animation is calculated by currentTime / effect endTime.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/overallProgress.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/overallProgress.tentative.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Animation.progress</title>
+<title>Animation.overallProgress</title>
 <link rel="help"
-href="https://drafts.csswg.org/web-animations-2/#the-progress-of-an-animation">
+href="https://drafts.csswg.org/web-animations-2/#the-overall-progress-of-an-animation">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>
@@ -16,16 +16,16 @@ test(t => {
   const animation = new Animation(null);
   animation.startTime = document.timeline.currentTime;
   assert_time_equals_literal(animation.currentTime, 0, 'currentTime is zero');
-  assert_equals(animation.progress, null, 'progress is unresolved');
-}, 'progress of a newly created animation without an effect is unresolved');
+  assert_equals(animation.overallProgress, null, 'overallProgress is unresolved');
+}, 'overallProgress of a newly created animation without an effect is unresolved');
 
 test(t => {
   // currentTime should be unresolved because the animation has no associated
   // timeline.
   const animation = new Animation(new KeyframeEffect(createDiv(t), null), null);
   assert_equals(animation.currentTime, null, 'currentTime is unresolved');
-  assert_equals(animation.progress, null, 'progress is unresolved');
-}, 'progress of an animation whose currentTime is unresolved is unresolved.');
+  assert_equals(animation.overallProgress, null, 'overallProgress is unresolved');
+}, 'overallProgress of an animation whose currentTime is unresolved is unresolved.');
 
 test(t => {
   const animation = new Animation(new KeyframeEffect(createDiv(t), null,
@@ -33,8 +33,8 @@ test(t => {
   // Set the startTime to 20 seconds into the future.
   animation.startTime = document.timeline.currentTime + 20 * MS_PER_SEC;
   assert_less_than(animation.currentTime, 0, 'currentTime is negative');
-  assert_approx_equals(animation.progress, 0, 0.01, 'progress is zero');
-}, "progress of an animation whose effect's endTime is zero is zero if its " +
+  assert_approx_equals(animation.overallProgress, 0, 0.01, 'overallProgress is zero');
+}, "overallProgress of an animation whose effect's endTime is zero is zero if its " +
    "currentTime is negative.");
 
 test(t => {
@@ -42,12 +42,12 @@ test(t => {
     { duration: 0 }), document.timeline);
   animation.startTime = document.timeline.currentTime;
   assert_time_equals_literal(animation.currentTime, 0, 'currentTime is zero');
-  assert_approx_equals(animation.progress, 1, 0.01, 'progress is one');
+  assert_approx_equals(animation.overallProgress, 1, 0.01, 'overallProgress is one');
 
   animation.startTime = document.timeline.currentTime - 20 * MS_PER_SEC;
   assert_greater_than(animation.currentTime, 0, 'currentTime greater than zero');
-  assert_approx_equals(animation.progress, 1, 0.01, 'progress is one');
-}, "progress of an animation whose effect's endTime is zero is one if its " +
+  assert_approx_equals(animation.overallProgress, 1, 0.01, 'overallProgress is one');
+}, "overallProgress of an animation whose effect's endTime is zero is one if its " +
    "currentTime is non-negative.");
 
 test(t => {
@@ -56,8 +56,8 @@ test(t => {
 
   animation.startTime = document.timeline.currentTime - 20 * MS_PER_SEC;
   assert_greater_than(animation.currentTime, 0, 'currentTime is positive');
-  assert_approx_equals(animation.progress, 0, 0.01, 'progress is zero');
-}, "progress of an animation whose effect's endTime is infinity is zero.");
+  assert_approx_equals(animation.overallProgress, 0, 0.01, 'overallProgress is zero');
+}, "overallProgress of an animation whose effect's endTime is infinity is zero.");
 
 test(t => {
   const animation = new Animation(new KeyframeEffect(createDiv(t), null,
@@ -66,16 +66,16 @@ test(t => {
 
   animation.startTime = document.timeline.currentTime - 50 * MS_PER_SEC;
   assert_time_equals_literal(animation.currentTime, 100 * MS_PER_SEC, 'currentTime is 100s');
-  assert_approx_equals(animation.progress, 0.5, 0.01, 'progress is zero');
+  assert_approx_equals(animation.overallProgress, 0.5, 0.01, 'overallProgress is zero');
 
   animation.startTime = document.timeline.currentTime - 100 * MS_PER_SEC;
   assert_time_equals_literal(animation.currentTime, 200 * MS_PER_SEC, 'currentTime is 200s');
-  assert_approx_equals(animation.progress, 1, 0.01, 'progress is one');
+  assert_approx_equals(animation.overallProgress, 1, 0.01, 'overallProgress is one');
 
   animation.startTime = document.timeline.currentTime - 150 * MS_PER_SEC;
   assert_time_equals_literal(animation.currentTime, 300 * MS_PER_SEC, 'currentTime is 300s');
-  assert_approx_equals(animation.progress, 1, 0.01, 'progress is still one');
-}, "progress of an animation is calculated by currentTime / effect endTime.");
+  assert_approx_equals(animation.overallProgress, 1, 0.01, 'overallProgress is still one');
+}, "overallProgress of an animation is calculated by currentTime / effect endTime.");
 
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/progress.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/progress.tentative-expected.txt
@@ -1,8 +1,0 @@
-
-PASS progress of a newly created animation without an effect is unresolved
-PASS progress of an animation whose currentTime is unresolved is unresolved.
-PASS progress of an animation whose effect's endTime is zero is zero if its currentTime is negative.
-PASS progress of an animation whose effect's endTime is zero is one if its currentTime is non-negative.
-PASS progress of an animation whose effect's endTime is infinity is zero.
-PASS progress of an animation is calculated by currentTime / effect endTime.
-

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-overallProgress.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-overallProgress.tentative-expected.txt
@@ -1,0 +1,6 @@
+
+PASS animation.overallProgress reflects the progress of a scroll animation as a number between 0 and 1
+FAIL animation.overallProgress reflects the overall progress of a scroll animation with multiple iterations. assert_equals: 'actual' unit type must be 'percent' for "undefined" expected (string) "percent" but got (undefined) undefined
+FAIL animation.overallProgress reflects the overall progress of a scroll animation that uses a view-timeline. assert_approx_equals: values do not match for "currentTime reflects progress as a percentage" expected 10.666666666666671 +/- 0.125 but got 100
+FAIL overallProgresss of a view-timeline is bounded between 0 and 1. assert_less_than: currentTime is negative expected a number less than 0 but got 100
+

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-overallProgress.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-overallProgress.tentative.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Animation.progress</title>
+<title>Animation.overallProgress</title>
 <link rel="help"
-href="https://drafts.csswg.org/web-animations-2/#the-progress-of-an-animation">
+href="https://drafts.csswg.org/web-animations-2/#the-overall-progress-of-an-animation">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>
@@ -21,8 +21,8 @@ href="https://drafts.csswg.org/web-animations-2/#the-progress-of-an-animation">
       width: 100%;
     }
     #target {
-      height:  100px;
-      width:  100px;
+      height: 100px;
+      width: 100px;
       background-color: green;
       margin-top: -1000px;
     }
@@ -38,30 +38,30 @@ promise_test(async t => {
 
   assert_equals(animation.currentTime, null,
       "The current time is null in Idle state.");
-  assert_equals(animation.progress, null,
-      "The progress is null since the currentTime is unresolved.");
+  assert_equals(animation.overallProgress, null,
+      "The overallProgress is null since the currentTime is unresolved.");
 
   animation.play();
   assert_true(animation.pending, "Animation is in the pending state.");
   assert_equals(animation.currentTime, null,
       "The current time remains null while in the pending state.");
-  assert_equals(animation.progress, null,
-      "The progress is null since the currentTime is unresolved.");
+  assert_equals(animation.overallProgress, null,
+      "The overallProgress is null since the currentTime is unresolved.");
 
   await animation.ready;
   // Verify initial start and current times once ready.
   assert_percents_equal(animation.currentTime, 0,
       "The current time is resolved when ready.");
-  assert_equals(animation.progress, 0, "The progress is should be zero.");
+  assert_equals(animation.overallProgress, 0, "The overallProgress should be zero.");
 
   scroller.scrollTop = 0.4 * maxScroll;
 
   await waitForNextFrame();
   assert_percents_equal(animation.currentTime, 40,
       "currentTime reflects progress as a percentage");
-  assert_approx_equals(animation.progress, 0.4, 0.01,
-      "The progress is should match the scroll progress.");
-}, "animation.progress reflects the progress of a scroll animation as a "+
+  assert_approx_equals(animation.overallProgress, 0.4, 0.01,
+      "The overallProgress should match the scroll progress.");
+}, "animation.overallProgress reflects the progress of a scroll animation as a "+
    "number between 0 and 1");
 
 promise_test(async t => {
@@ -74,7 +74,7 @@ promise_test(async t => {
   // Verify initial start and current times once ready.
   assert_percents_equal(animation.currentTime, 0,
       "The current time is resolved when ready.");
-  assert_equals(animation.progress, 0, "The progress is should be zero.");
+  assert_equals(animation.overallProgress, 0, "The overallProgress should be zero.");
 
   scroller.scrollTop = 0.4 * maxScroll;
   await waitForNextFrame();
@@ -84,8 +84,8 @@ promise_test(async t => {
   assert_percents_equal(timing.duration, 100);
   assert_percents_equal(animation.currentTime, 40,
       "currentTime reflects progress as a percentage");
-  assert_approx_equals(animation.progress, 0.4, 0.01,
-      "The progress is should match the scroll progress.");
+  assert_approx_equals(animation.overallProgress, 0.4, 0.01,
+      "The overallProgress should match the scroll progress.");
       timing = animation.effect.getComputedTiming();
 
   animation.effect.updateTiming({ iterations: 2 });
@@ -96,9 +96,9 @@ promise_test(async t => {
   assert_percents_equal(timing.duration, 50);
   assert_percents_equal(animation.currentTime, 40,
       "currentTime reflects progress as a percentage");
-  assert_approx_equals(animation.progress, 0.4, 0.01,
-      "The progress is should match the scroll progress.");
-}, "animation.progress reflects the overall progress of a scroll animation " +
+  assert_approx_equals(animation.overallProgress, 0.4, 0.01,
+      "The overallProgress should match the scroll progress.");
+}, "animation.overallProgress reflects the overall progress of a scroll animation " +
    "with multiple iterations.");
 
 promise_test(async t => {
@@ -126,9 +126,9 @@ promise_test(async t => {
   const expected_current_time = timeline_time - start_time;
   assert_percents_equal(animation.currentTime, expected_current_time,
       "currentTime reflects progress as a percentage");
-  assert_approx_equals(animation.progress, target_pct / 100, 0.01,
-    "progress should reflect fraction of view timeline range scroll through.");
-}, "animation.progress reflects the overall progress of a scroll animation " +
+  assert_approx_equals(animation.overallProgress, target_pct / 100, 0.01,
+    "overallProgress should reflect fraction of view timeline range scroll through.");
+}, "animation.overallProgress reflects the overall progress of a scroll animation " +
    "that uses a view-timeline.");
 
 promise_test(async t => {
@@ -151,16 +151,16 @@ promise_test(async t => {
   await waitForNextFrame();
   let timing = animation.effect.getComputedTiming();
   assert_less_than(animation.currentTime.value, 0, "currentTime is negative");
-  assert_approx_equals(animation.progress, 0, 0.01, "progress is zero when " +
+  assert_approx_equals(animation.overallProgress, 0, 0.01, "overallProgress is zero when " +
     "scroll offset is less than range start.");
 
   scroller.scrollTop = 200;
   await waitForNextFrame();
   assert_approx_equals(animation.currentTime.value, timing.endTime.value, 0.01,
     "currentTime has reached endTime");
-  assert_approx_equals(animation.progress, 1, 0.01, "progress is one when " +
+  assert_approx_equals(animation.overallProgress, 1, 0.01, "overallProgress is one when " +
     "scroll offset goes past than range end.");
-}, "progresss of a view-timeline is bounded between 0 and 1.");
+}, "overallProgresss of a view-timeline is bounded between 0 and 1.");
 
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative-expected.txt
@@ -1,6 +1,0 @@
-
-PASS animation.progress reflects the progress of a scroll animation as a number between 0 and 1
-FAIL animation.progress reflects the overall progress of a scroll animation with multiple iterations. assert_equals: 'actual' unit type must be 'percent' for "undefined" expected (string) "percent" but got (undefined) undefined
-FAIL animation.progress reflects the overall progress of a scroll animation that uses a view-timeline. assert_approx_equals: values do not match for "currentTime reflects progress as a percentage" expected 10.666666666666671 +/- 0.125 but got 100
-FAIL progresss of a view-timeline is bounded between 0 and 1. assert_less_than: currentTime is negative expected a number less than 0 but got 100
-

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/style-change-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/style-change-events-expected.txt
@@ -8,7 +8,7 @@ PASS Animation.currentTime produces expected style change events
 PASS Animation.rangeStart produces expected style change events
 PASS Animation.rangeEnd produces expected style change events
 PASS Animation.playbackRate produces expected style change events
-PASS Animation.progress produces expected style change events
+PASS Animation.overallProgress produces expected style change events
 FAIL Animation.frameRate produces expected style change events assert_own_property: Should have a test for 'frameRate' property expected property "frameRate" missing
 PASS Animation.playState produces expected style change events
 PASS Animation.replaceState produces expected style change events

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/style-change-events.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/style-change-events.html
@@ -169,7 +169,7 @@ const tests = {
   // no effect.
   rangeStart: UsePropertyTest(animation => animation.rangeStart),
   rangeEnd:  UsePropertyTest(animation => animation.rangeEnd),
-  progress: UsePropertyTest(animation => animation.progress),
+  overallProgress: UsePropertyTest(animation => animation.overallProgress),
   replaceState: UsePropertyTest(animation => animation.replaceState),
   ready: UsePropertyTest(animation => animation.ready),
   finished: UsePropertyTest(animation => {

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2971,7 +2971,7 @@ imported/w3c/web-platform-tests/svg/text/reftests/text-multiline-001.svg [ Skip 
 imported/w3c/web-platform-tests/svg/text/reftests/text-multiline-002.svg [ Skip ]
 
 imported/w3c/web-platform-tests/scroll-animations/ [ Skip ]
-imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative.html [ Skip ]
+imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-overallProgress.tentative.html [ Skip ]
 
 # webkit.org/b/278316
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_normal_wrapped.html

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8191,6 +8191,20 @@ WebAnimationsCustomFrameRateEnabled:
     WebCore:
       default: false
 
+WebAnimationsOverallProgressPropertyEnabled:
+  type: bool
+  status: testable
+  category: animation
+  humanReadableName: "Web Animations 'overallProgress' property"
+  humanReadableDescription: "Support for Animation's overallProgress property"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 WebArchiveDebugModeEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1825,17 +1825,17 @@ bool WebAnimation::isSkippedContentAnimation() const
     return false;
 }
 
-std::optional<double> WebAnimation::progress() const
+std::optional<double> WebAnimation::overallProgress() const
 {
-    // https://drafts.csswg.org/web-animations-2/#the-progress-of-an-animation
-    // An animation’s progress is the ratio of its current time to its associated effect end.
+    // https://drafts.csswg.org/web-animations-2/#the-overall-progress-of-an-animation
+    // An animation's overallProgress is the ratio of its current time to its associated effect end.
     //
-    // The progress of an animation, animation, is calculated as follows:
+    // The overallProgress of an animation, animation, is calculated as follows:
     //
     // If any of the following are true:
     //     - animation does not have an associated effect, or
-    //     - animation’s current time is an unresolved time value,
-    // animation’s progress is null.
+    //     - animation's current time is an unresolved time value,
+    // animation's overallProgress is null.
     if (!m_effect)
         return std::nullopt;
 
@@ -1845,17 +1845,17 @@ std::optional<double> WebAnimation::progress() const
 
     auto endTime = effectEndTime();
 
-    // If animation’s associated effect end is zero,
-    //     - If animation’s current time is negative, animation’s progress is zero.
-    //     - Otherwise, animation’s progress is one.
+    // If animation's associated effect end is zero,
+    //     - If animation's current time is negative, animation's overallProgress is zero.
+    //     - Otherwise, animation's overallProgress is one.
     if (endTime.isZero())
         return *currentTime < zeroTime() ? 0 : 1;
 
-    // If animation’s associated effect end is infinite, animation’s progress is zero.
+    // If animation's associated effect end is infinite, animation's overallProgress is zero.
     if (endTime.isInfinity())
         return 0;
 
-    // Otherwise, progress = min(max(current time / animation’s associated effect end, 0), 1)
+    // Otherwise, overallProgress = min(max(current time / animation's associated effect end, 0), 1)
     return std::min(std::max(*currentTime / endTime, 0.0), 1.0);
 }
 

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -126,7 +126,7 @@ public:
     void setStartTime(std::optional<WebAnimationTime>);
     virtual std::optional<WebAnimationTime> bindingsCurrentTime() const { return currentTime(); };
     virtual ExceptionOr<void> setBindingsCurrentTime(const std::optional<WebAnimationTime>&);
-    std::optional<double> progress() const;
+    std::optional<double> overallProgress() const;
     virtual PlayState bindingsPlayState() const { return playState(); }
     virtual ReplaceState bindingsReplaceState() const { return replaceState(); }
     virtual bool bindingsPending() const { return pending(); }

--- a/Source/WebCore/animation/WebAnimation.idl
+++ b/Source/WebCore/animation/WebAnimation.idl
@@ -57,7 +57,7 @@ typedef (double or CSSNumericValue) CSSNumberish;
     [ImplementedAs=bindingsRangeStart, EnabledBySetting=ScrollDrivenAnimationsEnabled] attribute (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeStart;
     [ImplementedAs=bindingsRangeEnd, EnabledBySetting=ScrollDrivenAnimationsEnabled] attribute (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeEnd;
     attribute double playbackRate;
-    [EnabledBySetting=ScrollDrivenAnimationsEnabled] readonly attribute double? progress;
+    [EnabledBySetting=WebAnimationsOverallProgressPropertyEnabled] readonly attribute double? overallProgress;
     [ImplementedAs=bindingsFrameRate, EnabledBySetting=WebAnimationsCustomFrameRateEnabled] attribute (FramesPerSecond or AnimationFrameRatePreset) frameRate;
     [ImplementedAs=bindingsPlayState] readonly attribute AnimationPlayState playState;
     [ImplementedAs=bindingsReplaceState] readonly attribute AnimationReplaceState replaceState;


### PR DESCRIPTION
#### 94cc34f9edc79784a1968732aa0ee6eeaf56a8be
<pre>
[web-animations] Rename `Animation.progress` to `Animation.overallProgress` and use a dedicated run-time flag for it
<a href="https://bugs.webkit.org/show_bug.cgi?id=283672">https://bugs.webkit.org/show_bug.cgi?id=283672</a>
<a href="https://rdar.apple.com/140533999">rdar://140533999</a>

Reviewed by Anne van Kesteren.

The `Animation.progress` property has been renamed to `Animation.overallProgress` in
<a href="https://github.com/w3c/csswg-drafts/commit/a92c32c5c351763a84430bee0cb34e29cd5cf335.">https://github.com/w3c/csswg-drafts/commit/a92c32c5c351763a84430bee0cb34e29cd5cf335.</a>
Also, this feature is not tied to Scroll-driven Animations as initially thought, so
it should be guarded by its own run-time flag.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/overallProgress.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/overallProgress.tentative.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/progress.tentative.html.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/progress.tentative-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-overallProgress.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-overallProgress.tentative.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative.html.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-progress.tentative-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/style-change-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/style-change-events.html:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::overallProgress const):
(WebCore::WebAnimation::progress const): Deleted.
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/animation/WebAnimation.idl:

Canonical link: <a href="https://commits.webkit.org/287065@main">https://commits.webkit.org/287065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/147843f73216b491ff2a3434d20322bab1f6f420

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82855 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29459 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80330 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5524 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61235 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19155 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68116 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41552 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48579 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24815 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27796 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71340 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69672 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25171 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84219 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77433 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5562 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3752 "Found 2 new test failures: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69459 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5719 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68716 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12718 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10968 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/99744 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12091 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5511 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/8263 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21787 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5500 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8932 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7289 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->