### PR TITLE
[visionOS] Layers that `containsBitmapOnly` should not use Dynamic Content Scaling

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
@@ -86,10 +86,11 @@ IPC::StreamConnectionWorkQueue& RemoteImageBufferSet::workQueue() const
     return m_backend->workQueue();
 }
 
-void RemoteImageBufferSet::updateConfiguration(const WebCore::FloatSize& logicalSize, WebCore::RenderingMode renderingMode, float resolutionScale, const WebCore::DestinationColorSpace& colorSpace, WebCore::ImageBufferPixelFormat pixelFormat)
+void RemoteImageBufferSet::updateConfiguration(const WebCore::FloatSize& logicalSize, WebCore::RenderingMode renderingMode, WebCore::RenderingPurpose renderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace& colorSpace, WebCore::ImageBufferPixelFormat pixelFormat)
 {
     m_logicalSize = logicalSize;
     m_renderingMode = renderingMode;
+    m_renderingPurpose = renderingPurpose;
     m_resolutionScale = resolutionScale;
     m_colorSpace = colorSpace;
     m_pixelFormat = pixelFormat;
@@ -147,10 +148,10 @@ void RemoteImageBufferSet::ensureBufferForDisplay(ImageBufferSetPrepareBufferFor
     if (!m_frontBuffer) {
         WebCore::ImageBufferCreationContext creationContext;
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-        creationContext.dynamicContentScalingResourceCache = ensureDynamicContentScalingResourceCache();
+        if (m_renderingPurpose == RenderingPurpose::LayerBacking || m_renderingPurpose == RenderingPurpose::DOM)
+            creationContext.dynamicContentScalingResourceCache = ensureDynamicContentScalingResourceCache();
 #endif
-
-        m_frontBuffer = backend->allocateImageBuffer(m_logicalSize, m_renderingMode, WebCore::RenderingPurpose::LayerBacking, m_resolutionScale, m_colorSpace, m_pixelFormat, WTFMove(creationContext), WebCore::RenderingResourceIdentifier::generate());
+        m_frontBuffer = backend->allocateImageBuffer(m_logicalSize, m_renderingMode, m_renderingPurpose, m_resolutionScale, m_colorSpace, m_pixelFormat, WTFMove(creationContext), WebCore::RenderingResourceIdentifier::generate());
         m_frontBufferIsCleared = true;
     }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h
@@ -70,7 +70,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     // Messages
-    void updateConfiguration(const WebCore::FloatSize&, WebCore::RenderingMode, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::ImageBufferPixelFormat);
+    void updateConfiguration(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::ImageBufferPixelFormat);
     void endPrepareForDisplay(RenderingUpdateID);
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
@@ -89,6 +89,7 @@ private:
 
     WebCore::FloatSize m_logicalSize;
     WebCore::RenderingMode m_renderingMode;
+    WebCore::RenderingPurpose m_renderingPurpose;
     float m_resolutionScale { 1.0f };
     WebCore::DestinationColorSpace m_colorSpace { WebCore::DestinationColorSpace::SRGB() };
     WebCore::ImageBufferPixelFormat m_pixelFormat;

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.messages.in
@@ -23,7 +23,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteImageBufferSet Stream {
-    UpdateConfiguration(WebCore::FloatSize logicalSize, WebCore::RenderingMode renderingMode, float resolutionScale, WebCore::DestinationColorSpace colorSpace, enum:uint8_t WebCore::ImageBufferPixelFormat pixelFormat)
+    UpdateConfiguration(WebCore::FloatSize logicalSize, WebCore::RenderingMode renderingMode, WebCore::RenderingPurpose renderingPurpose, float resolutionScale, WebCore::DestinationColorSpace colorSpace, enum:uint8_t WebCore::ImageBufferPixelFormat pixelFormat)
     EndPrepareForDisplay(WebKit::RenderingUpdateID renderingUpdateID)
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
@@ -273,7 +273,7 @@ void RemoteImageBufferSetProxy::willPrepareForDisplay()
         return;
 
     if (m_remoteNeedsConfigurationUpdate) {
-        send(Messages::RemoteImageBufferSet::UpdateConfiguration(m_size, m_renderingMode, m_scale, m_colorSpace, m_pixelFormat));
+        send(Messages::RemoteImageBufferSet::UpdateConfiguration(m_size, m_renderingMode, m_renderingPurpose, m_scale, m_colorSpace, m_pixelFormat));
 
         OptionSet<WebCore::ImageBufferOptions> options;
         if (m_renderingMode == RenderingMode::Accelerated)


### PR DESCRIPTION
#### 65e7eccfee023f44061910753ac1ae3e968acf9d
<pre>
[visionOS] Layers that `containsBitmapOnly` should not use Dynamic Content Scaling
<a href="https://bugs.webkit.org/show_bug.cgi?id=283674">https://bugs.webkit.org/show_bug.cgi?id=283674</a>
&lt;<a href="https://rdar.apple.com/140420051">rdar://140420051</a>&gt;

Reviewed by Mike Wyrzykowski.

Make the rendering purpose part of the RemoteImageBufferSet&apos;s
configuration so that we can skip dynamic content scaling when allocating
image buffers for bitmap only layer backings.
(The RemoteRenderingBackend already had the rendering purpose check.)

* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
(WebKit::RemoteImageBufferSetProxy::willPrepareForDisplay):
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::updateConfiguration):
Pass down the new configuration parameter.

(WebKit::RemoteImageBufferSet::ensureBufferForDisplay):
Don&apos;t create a dynamic content scaling resource cache for bitmap only
layers.

Canonical link: <a href="https://commits.webkit.org/287262@main">https://commits.webkit.org/287262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13ec2def1e761d1d3bf574aa5f539bb1748b86b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57923 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83537 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30138 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67071 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61771 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19700 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51811 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71762 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42074 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49161 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28481 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70275 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26375 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84909 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69996 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6405 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67801 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69247 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17268 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13294 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12032 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6188 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12066 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6169 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9608 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7960 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->