### PR TITLE
[GTK][WPE] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in TextCheckerEnchant

### DIFF
--- a/Source/WebCore/platform/text/enchant/TextCheckerEnchant.cpp
+++ b/Source/WebCore/platform/text/enchant/TextCheckerEnchant.cpp
@@ -117,9 +117,7 @@ Vector<String> TextCheckerEnchant::getGuessesForWord(const String& word)
     auto utf8Word = word.utf8();
     for (auto& dictionary : m_enchantDictionaries) {
         size_t numberOfSuggestions;
-        size_t i;
 
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
         char** suggestions = enchant_dict_suggest(dictionary.get(), utf8Word.data(), utf8Word.length(), &numberOfSuggestions);
         if (numberOfSuggestions <= 0)
             continue;
@@ -127,9 +125,8 @@ Vector<String> TextCheckerEnchant::getGuessesForWord(const String& word)
         if (numberOfSuggestions > maximumNumberOfSuggestions)
             numberOfSuggestions = maximumNumberOfSuggestions;
 
-        for (i = 0; i < numberOfSuggestions; i++)
-            guesses.append(String::fromUTF8(suggestions[i]));
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        for (const auto suggestion : unsafeMakeSpan(suggestions, numberOfSuggestions))
+            guesses.append(String::fromUTF8(suggestion));
 
         enchant_dict_free_string_list(dictionary.get(), suggestions);
     }


### PR DESCRIPTION
#### d9f8159df36667538c091cbe01a664b696047ac8
<pre>
[GTK][WPE] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in TextCheckerEnchant
<a href="https://bugs.webkit.org/show_bug.cgi?id=283676">https://bugs.webkit.org/show_bug.cgi?id=283676</a>

Reviewed by Adrian Perez de Castro.

* Source/WebCore/platform/text/enchant/TextCheckerEnchant.cpp:
(WebCore::TextCheckerEnchant::getGuessesForWord):

Canonical link: <a href="https://commits.webkit.org/287063@main">https://commits.webkit.org/287063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61ca305b3f423fb319de44819c5dbd01bd386a84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31581 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82863 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29467 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5532 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61242 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/19159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51237 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68142 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41559 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/48586 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24828 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27804 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/69678 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25184 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84227 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5570 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3756 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69467 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68723 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12726 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10979 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12090 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5519 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/8271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5508 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8940 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7297 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->