### PR TITLE
Correct a minor type issue in AccessibilityNodeObject

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -2176,13 +2176,9 @@ static bool displayTypeNeedsSpace(DisplayType type)
         || type == DisplayType::TableCell;
 }
 
-static bool needsSpaceFromDisplay(AXCoreObject& coreObject)
+static bool needsSpaceFromDisplay(AccessibilityObject& axObject)
 {
-    // We should always be dealing with non-isolated objects here. Ideally in the future we can strengthen the types
-    // to make this issue impossible.
-    Ref axObject = downcast<AccessibilityObject>(coreObject);
-
-    CheckedPtr renderer = axObject->renderer();
+    CheckedPtr renderer = axObject.renderer();
     if (is<RenderText>(renderer)) {
         // Never add a space for RenderTexts. They are inherently inline, but take their parent's style, which may
         // be block, erroneously adding a space.
@@ -2191,12 +2187,12 @@ static bool needsSpaceFromDisplay(AXCoreObject& coreObject)
 
     const auto* style = renderer ? &renderer->style() : nullptr;
     if (!style)
-        style = axObject->style();
+        style = axObject.style();
 
     return style ? displayTypeNeedsSpace(style->display()) : false;
 }
 
-static bool shouldPrependSpace(AXCoreObject& object, AXCoreObject* previousObject)
+static bool shouldPrependSpace(AccessibilityObject& object, AccessibilityObject* previousObject)
 {
     return needsSpaceFromDisplay(object)
         || (previousObject && needsSpaceFromDisplay(*previousObject))
@@ -2233,7 +2229,7 @@ String AccessibilityNodeObject::textUnderElement(TextUnderElementMode mode) cons
     }
 
     StringBuilder builder;
-    RefPtr<AXCoreObject> previous;
+    RefPtr<AccessibilityObject> previous;
     bool previousRequiresSpace = false;
     auto appendTextUnderElement = [&] (auto& object) {
         // We don't want to trim whitespace in these intermediate calls to textUnderElement, as doing so will wipe out


### PR DESCRIPTION
#### d0a4425685cfe07095af36e54d4c6c5302269110
<pre>
Correct a minor type issue in AccessibilityNodeObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=283679">https://bugs.webkit.org/show_bug.cgi?id=283679</a>

Reviewed by Tyler Wilcock.

* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::needsSpaceFromDisplay):
(WebCore::shouldPrependSpace):
(WebCore::AccessibilityNodeObject::textUnderElement const):

Canonical link: <a href="https://commits.webkit.org/287073@main">https://commits.webkit.org/287073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16c602279a447c0bf13c3368b0773afede544ecb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82889 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29493 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61264 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19181 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51260 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68224 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41584 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48606 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24861 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27830 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69696 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25221 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84253 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5596 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3770 "Found 2 new test failures: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69486 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-transforms/animation/scale-and-rotate-both-specified-on-animation-keyframes.html imported/w3c/web-platform-tests/css/css-values/vh-interpolate-pct.html imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-ready-promise.html imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-setup-transition.html imported/w3c/web-platform-tests/css/css-view-transitions/shadow-part-with-name-nested.html imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-empty-iframe.html webanimations/accelerated-animation-after-forward-filling-animation.html webanimations/accelerated-transform-animation-from-scale-zero-and-implicit-to-kefyrame.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5753 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67183 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68744 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17144 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12752 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11006 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5545 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/8303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5534 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8966 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7323 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->