### PR TITLE
[iOS] Selection handles sometimes unnecessarily flip when extending selection over bidi text

### DIFF
--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-2-expected.txt
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-2-expected.txt
@@ -1,0 +1,12 @@
+Arabic is left to right: مث لهذا النص
+This test verifies that the text selection appears visually contiguous when selecting across bidi text boundaries.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS isVisuallyContiguous is true
+PASS getSelection().toString() is "Arabic is left to right: مث لهذا النص"
+PASS Extended selection grabbers to endpoints
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-2.html
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-2.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true VisuallyContiguousBidiTextSelectionEnabled=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-size: 20px;
+    font-family: system-ui;
+}
+
+.start {
+    border: 1px solid tomato;
+    padding: 4px;
+}
+
+#paragraph {
+    display: inline-block;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+async function distanceBetweenGrabbers() {
+    const startGrabberRect = await UIHelper.getSelectionStartGrabberViewRect();
+    const endGrabberRect = await UIHelper.getSelectionEndGrabberViewRect();
+    return endGrabberRect.width + endGrabberRect.left - startGrabberRect.left;
+}
+
+addEventListener("load", async () => {
+    description("This test verifies that the text selection appears visually contiguous when selecting across bidi text boundaries.");
+
+    const paragraph = document.getElementById("paragraph");
+    const rect = paragraph.getBoundingClientRect();
+
+    await UIHelper.longPressElement(document.querySelector(".start"));
+    await UIHelper.waitForSelectionToAppear();
+
+    const start = UIHelper.midPointOfRect(await UIHelper.getSelectionEndGrabberViewRect());
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(start.x, start.y)
+        .move(rect.width + rect.left - 20, start.y, 0.5)
+        .end()
+        .takeResult());
+    await UIHelper.ensurePresentationUpdate();
+
+    selectionRects = await UIHelper.getUISelectionViewRects();
+    isVisuallyContiguous = await UIHelper.isSelectionVisuallyContiguous();
+
+    shouldBeTrue("isVisuallyContiguous");
+    shouldBeEqualToString("getSelection().toString()", paragraph.textContent);
+
+    while (true) {
+        const distance = await distanceBetweenGrabbers();
+        if (distance >= 300) {
+            testPassed("Extended selection grabbers to endpoints");
+            break;
+        }
+    }
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <p id="paragraph"><span class="start">Arabic</span> is left to right: مث لهذا النص</p>
+    <div id="description"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/editing/Editing.h
+++ b/Source/WebCore/editing/Editing.h
@@ -44,6 +44,8 @@ class VisibleSelection;
 
 struct SimpleRange;
 
+enum class TextDirection : bool;
+
 // -------------------------------------------------------------------------
 // Node
 // -------------------------------------------------------------------------
@@ -110,6 +112,7 @@ bool positionBeforeOrAfterNodeIsCandidate(Node&);
 // SimpleRange
 // -------------------------------------------------------------------------
 
+PositionRange positionsForRange(const SimpleRange&);
 WEBCORE_EXPORT HashSet<RefPtr<HTMLImageElement>> visibleImageElementsInRangeWithNonLoadedImages(const SimpleRange&);
 WEBCORE_EXPORT SimpleRange adjustToVisuallyContiguousRange(const SimpleRange&);
 
@@ -139,6 +142,7 @@ unsigned numEnclosingMailBlockquotes(const Position&);
 void updatePositionForNodeRemoval(Position&, Node&);
 
 WEBCORE_EXPORT TextDirection directionOfEnclosingBlock(const Position&);
+TextDirection primaryDirectionForSingleLineRange(const Position& start, const Position& end);
 
 // -------------------------------------------------------------------------
 // VisiblePosition

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1191,7 +1191,7 @@ private:
     struct SelectionGeometries {
         Vector<SelectionGeometry> geometries;
         int maxLineNumber { 0 };
-        bool hasAnyRightToLeftText { false };
+        bool hasBidirectionalText { false };
     };
     WEBCORE_EXPORT static SelectionGeometries collectSelectionGeometriesInternal(const SimpleRange&);
 #endif


### PR DESCRIPTION
#### 6f849acb124ba787747bbd501cd289145cdf7a22
<pre>
[iOS] Selection handles sometimes unnecessarily flip when extending selection over bidi text
<a href="https://bugs.webkit.org/show_bug.cgi?id=283683">https://bugs.webkit.org/show_bug.cgi?id=283683</a>
<a href="https://rdar.apple.com/140550161">rdar://140550161</a>

Reviewed by Richard Robinson.

Currently, selection handles sometimes show up on the wrong side when adjusting the text selection
in bidi text. This is because:

-   The side on which selection handles are rendered is determined by whether a selection rect that
    contains either the start or end is marked LTR or RTL.

-   In the process of coalescing selection rects that span bidi text, this information can be lost,
    if LTR selection geometries are coalesced into RTL selections or vice versa.

To fix this, we add a second step after coalescing selection rects to adjust text directions of the
selection endpoints, computed based on the direction of the minimum bidi level that contains either
the whole selection (for a single-line selection) or the selected parts of the first and last lines
(for a multi-line selection).

* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-2-expected.txt: Added.
* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-2.html: Added.

Add a layout test to exercise this change.

* Source/WebCore/editing/Editing.cpp:
(WebCore::advanceInDirection):
(WebCore::forEachRenderedBoxBetween):

Pull out logic to iterate over leaf text boxes between the two given rendered positions (inclusive)
into a static helper, which we can use in a couple of places below.

(WebCore::positionsForRange):
(WebCore::primaryDirectionForSingleLineRange):

Add a new helper function to return the &quot;primary direction&quot; of a range that spans a single line,
i.e. the direction of the text box with the minimum bidi level in the text range.

(WebCore::adjustToVisuallyContiguousRange):
* Source/WebCore/editing/Editing.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::adjustTextDirectionForCoalescedGeometries):
(WebCore::RenderObject::collectSelectionGeometriesInternal):
(WebCore::RenderObject::collectSelectionGeometries):
* Source/WebCore/rendering/RenderObject.h:

Canonical link: <a href="https://commits.webkit.org/287106@main">https://commits.webkit.org/287106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0dc7f3313d593622af584780f26fb85373da5c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82916 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29521 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80388 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5582 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61287 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19201 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81322 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51282 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68317 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41604 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48629 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24892 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27858 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84277 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5622 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3793 "Found 2 new test failures: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69507 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5781 "Failed to checkout and rebase branch from PR 37133") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68762 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17159 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12771 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11036 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5569 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8327 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5561 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8995 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7347 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->