### PR TITLE
AX: Improve de-virtualization opportunities by ubiquitously using final and strengthening types from AXCoreObject to AccessibilityObject

### DIFF
--- a/Source/WebCore/accessibility/AXImage.h
+++ b/Source/WebCore/accessibility/AXImage.h
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-class AXImage : public AccessibilityRenderObject {
+class AXImage final : public AccessibilityRenderObject {
 public:
     static Ref<AXImage> create(AXID, RenderImage&);
     virtual ~AXImage() = default;
@@ -42,7 +42,7 @@ private:
     explicit AXImage(AXID, RenderImage&);
 
     AccessibilityRole determineAccessibilityRole() final;
-    std::optional<AccessibilityChildrenVector> imageOverlayElements() override;
+    std::optional<AccessibilityChildrenVector> imageOverlayElements() final;
 };
 
 } // namespace WebCore 

--- a/Source/WebCore/accessibility/AXRemoteFrame.h
+++ b/Source/WebCore/accessibility/AXRemoteFrame.h
@@ -38,7 +38,7 @@ public:
 #if PLATFORM(COCOA)
     void initializePlatformElementWithRemoteToken(std::span<const uint8_t>, int);
     std::span<const uint8_t> generateRemoteToken() const;
-    RetainPtr<id> remoteFramePlatformElement() const { return m_remoteFramePlatformElement; }
+    RetainPtr<id> remoteFramePlatformElement() const final { return m_remoteFramePlatformElement; }
     pid_t processIdentifier() const { return m_processIdentifier; }
 #endif
 
@@ -46,10 +46,10 @@ private:
     virtual ~AXRemoteFrame() = default;
     explicit AXRemoteFrame(AXID);
 
-    AccessibilityRole determineAccessibilityRole() { return AccessibilityRole::RemoteFrame; }
-    bool computeIsIgnored() const { return false; }
-    bool isAXRemoteFrame() const { return true; }
-    LayoutRect elementRect() const;
+    AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::RemoteFrame; }
+    bool computeIsIgnored() const final { return false; }
+    bool isAXRemoteFrame() const final { return true; }
+    LayoutRect elementRect() const final;
 
 #if PLATFORM(COCOA)
     RetainPtr<id> m_remoteFramePlatformElement;

--- a/Source/WebCore/accessibility/AccessibilityARIAGridCell.h
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridCell.h
@@ -41,10 +41,10 @@ public:
 private:
     explicit AccessibilityARIAGridCell(AXID, RenderObject&);
     explicit AccessibilityARIAGridCell(AXID, Node&);
-    bool isAccessibilityARIAGridCellInstance() const override { return true; }
+    bool isAccessibilityARIAGridCellInstance() const final { return true; }
 
-    AccessibilityTable* parentTable() const override;
-    String readOnlyValue() const override;
+    AccessibilityTable* parentTable() const final;
+    String readOnlyValue() const final;
 }; 
 
 } // namespace WebCore 

--- a/Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp
@@ -94,12 +94,12 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityARIAGridRow::disclosedRow
     return disclosedRows;
 }
     
-AXCoreObject* AccessibilityARIAGridRow::disclosedByRow() const
+AccessibilityObject* AccessibilityARIAGridRow::disclosedByRow() const
 {
     // The row that discloses this one is the row in the table
     // that is aria-level subtract 1 from this row.
-    RefPtr parent = parentObjectUnignored();
-    if (auto* axTable = dynamicDowncast<AccessibilityTable>(*parent); !axTable || !axTable->isExposable())
+    RefPtr parent = dynamicDowncast<AccessibilityTable>(parentObjectUnignored());
+    if (!parent || !parent->isExposable())
         return nullptr;
 
     // If the level is 1 or less, than nothing discloses this row.
@@ -117,7 +117,7 @@ AXCoreObject* AccessibilityARIAGridRow::disclosedByRow() const
     for (int k = index - 1; k >= 0; --k) {
         auto& row = allRows[k].get();
         if (row.hierarchicalLevel() == level - 1)
-            return &row;
+            return &downcast<AccessibilityObject>(row);
     }
     return nullptr;
 }
@@ -136,11 +136,11 @@ AccessibilityTable* AccessibilityARIAGridRow::parentTable() const
     }));
 }
 
-AXCoreObject* AccessibilityARIAGridRow::rowHeader()
+AccessibilityObject* AccessibilityARIAGridRow::rowHeader()
 {
     for (const auto& child : unignoredChildren()) {
         if (child->roleValue() == AccessibilityRole::RowHeader)
-            return child.ptr();
+            return &downcast<AccessibilityObject>(child.get());
     }
     return nullptr;
 }

--- a/Source/WebCore/accessibility/AccessibilityARIAGridRow.h
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridRow.h
@@ -40,18 +40,17 @@ public:
     static Ref<AccessibilityARIAGridRow> create(AXID, Node&);
     virtual ~AccessibilityARIAGridRow();
 
-    AccessibilityChildrenVector disclosedRows() override;
-    AXCoreObject* disclosedByRow() const override;
+    AccessibilityChildrenVector disclosedRows() final;
+    AccessibilityObject* disclosedByRow() const final;
+    AccessibilityObject* rowHeader() final;
 
-    AXCoreObject* rowHeader() final;
-    
 private:
     explicit AccessibilityARIAGridRow(AXID, RenderObject&);
     explicit AccessibilityARIAGridRow(AXID, Node&);
-    bool isAccessibilityARIAGridRowInstance() const override { return true; }
+    bool isAccessibilityARIAGridRowInstance() const final { return true; }
 
-    bool isARIATreeGridRow() const override;
-    AccessibilityTable* parentTable() const override;
+    bool isARIATreeGridRow() const final;
+    AccessibilityTable* parentTable() const final;
 };
 
 } // namespace WebCore 

--- a/Source/WebCore/accessibility/AccessibilityAttachment.h
+++ b/Source/WebCore/accessibility/AccessibilityAttachment.h
@@ -46,12 +46,12 @@ private:
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::Button; }
 
-    bool isAttachmentElement() const override { return true; }
+    bool isAttachmentElement() const final { return true; }
 
-    String roleDescription() const override;
-    float valueForRange() const override;
-    bool computeIsIgnored() const override;
-    void accessibilityText(Vector<AccessibilityText>&) const override;
+    String roleDescription() const final;
+    float valueForRange() const final;
+    bool computeIsIgnored() const final;
+    void accessibilityText(Vector<AccessibilityText>&) const final;
 };
     
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityImageMapLink.h
+++ b/Source/WebCore/accessibility/AccessibilityImageMapLink.h
@@ -45,29 +45,29 @@ public:
     void setHTMLMapElement(HTMLMapElement* element) { m_mapElement = element; }    
     HTMLMapElement* mapElement() const { return m_mapElement.get(); }
     
-    Node* node() const override { return m_areaElement.get(); }
-        
+    Node* node() const final { return m_areaElement.get(); }
+
     AccessibilityRole determineAccessibilityRole() final;
-    bool isEnabled() const override { return true; }
-    
-    Element* anchorElement() const override;
-    Element* actionElement() const override;
-    URL url() const override;
-    String title() const override;
-    String description() const override;
-    AccessibilityObject* parentObject() const override;
-    
-    LayoutRect elementRect() const override;
+    bool isEnabled() const final { return true; }
+
+    Element* anchorElement() const final;
+    Element* actionElement() const final;
+    URL url() const final;
+    String title() const final;
+    String description() const final;
+    AccessibilityObject* parentObject() const final;
+
+    LayoutRect elementRect() const final;
 
 private:
     explicit AccessibilityImageMapLink(AXID);
 
-    void detachFromParent() override;
-    Path elementPath() const override;
+    void detachFromParent() final;
+    Path elementPath() const final;
     RenderElement* imageMapLinkRenderer() const;
-    void accessibilityText(Vector<AccessibilityText>&) const override;
+    void accessibilityText(Vector<AccessibilityText>&) const final;
     bool isImageMapLink() const final { return true; }
-    bool supportsPath() const override { return true; }
+    bool supportsPath() const final { return true; }
 
     WeakPtr<HTMLAreaElement, WeakPtrImplWithEventTargetData> m_areaElement;
     WeakPtr<HTMLMapElement, WeakPtrImplWithEventTargetData> m_mapElement;

--- a/Source/WebCore/accessibility/AccessibilityListBox.h
+++ b/Source/WebCore/accessibility/AccessibilityListBox.h
@@ -37,19 +37,19 @@ public:
     static Ref<AccessibilityListBox> create(AXID, RenderObject&);
     virtual ~AccessibilityListBox();
 
-    WEBCORE_EXPORT void setSelectedChildren(const AccessibilityChildrenVector&) override;
+    WEBCORE_EXPORT void setSelectedChildren(const AccessibilityChildrenVector&) final;
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::ListBox; }
 
     std::optional<AccessibilityChildrenVector> selectedChildren() final;
     AccessibilityChildrenVector visibleChildren() final;
     
-    void addChildren() override;
+    void addChildren() final;
 
 private:
     explicit AccessibilityListBox(AXID, RenderObject&);
 
-    bool isAccessibilityListBoxInstance() const override { return true; }
+    bool isAccessibilityListBoxInstance() const final { return true; }
     AccessibilityObject* listBoxOptionAccessibilityObject(HTMLElement*) const;
     AccessibilityObject* elementAccessibilityHitTest(const IntPoint&) const final;
 };

--- a/Source/WebCore/accessibility/AccessibilityListBoxOption.cpp
+++ b/Source/WebCore/accessibility/AccessibilityListBoxOption.cpp
@@ -148,11 +148,6 @@ Element* AccessibilityListBoxOption::actionElement() const
     return dynamicDowncast<Element>(m_node.get());
 }
 
-Node* AccessibilityListBoxOption::node() const
-{
-    return m_node.get();
-}
-
 AccessibilityObject* AccessibilityListBoxOption::parentObject() const
 {
     auto* parentNode = listBoxOptionParentNode();

--- a/Source/WebCore/accessibility/AccessibilityListBoxOption.h
+++ b/Source/WebCore/accessibility/AccessibilityListBoxOption.h
@@ -51,7 +51,6 @@ private:
     bool isSelectedOptionActive() const final;
     String stringValue() const final;
     Element* actionElement() const final;
-    Node* node() const final;
     bool canSetSelectedAttribute() const final;
 
     LayoutRect elementRect() const final;

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
@@ -80,7 +80,7 @@ void AccessibilityMathMLElement::addChildren()
     // browsers, so it's already unlikely to be used by web developers, even more so with `display:contents` mixed in.
     m_childrenInitialized = true;
     for (auto& object : AXChildIterator(*this))
-        addChild(&object);
+        addChild(object);
 
     m_subtreeDirty = false;
 }
@@ -218,7 +218,7 @@ bool AccessibilityMathMLElement::isMathTableCell() const
 
 bool AccessibilityMathMLElement::isMathScriptObject(AccessibilityMathScriptObjectType type) const
 {
-    AXCoreObject* parent = parentObjectUnignored();
+    RefPtr parent = parentObjectUnignored();
     if (!parent)
         return false;
 
@@ -227,7 +227,7 @@ bool AccessibilityMathMLElement::isMathScriptObject(AccessibilityMathScriptObjec
 
 bool AccessibilityMathMLElement::isMathMultiscriptObject(AccessibilityMathMultiscriptObjectType type) const
 {
-    AXCoreObject* parent = parentObjectUnignored();
+    RefPtr parent = parentObjectUnignored();
     if (!parent || !parent->isMathMultiscript())
         return false;
 

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.h
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.h
@@ -51,60 +51,60 @@ private:
     AccessibilityRole determineAccessibilityRole() final;
     void addChildren() final;
     String textUnderElement(TextUnderElementMode = TextUnderElementMode()) const final;
-    String stringValue() const override;
+    String stringValue() const final;
     bool isIgnoredElementWithinMathTree() const final;
 
     bool isMathElement() const final { return true; }
 
-    bool isMathFraction() const override;
-    bool isMathFenced() const override;
-    bool isMathSubscriptSuperscript() const override;
-    bool isMathRow() const override;
-    bool isMathUnderOver() const override;
-    bool isMathRoot() const override;
-    bool isMathSquareRoot() const override;
-    bool isMathText() const override;
-    bool isMathNumber() const override;
-    bool isMathOperator() const override;
-    bool isMathFenceOperator() const override;
-    bool isMathSeparatorOperator() const override;
-    bool isMathIdentifier() const override;
-    bool isMathTable() const override;
-    bool isMathTableRow() const override;
-    bool isMathTableCell() const override;
-    bool isMathMultiscript() const override;
-    bool isMathToken() const override;
-    bool isMathScriptObject(AccessibilityMathScriptObjectType) const override;
-    bool isMathMultiscriptObject(AccessibilityMathMultiscriptObjectType) const override;
+    bool isMathFraction() const final;
+    bool isMathFenced() const final;
+    bool isMathSubscriptSuperscript() const final;
+    bool isMathRow() const final;
+    bool isMathUnderOver() const final;
+    bool isMathRoot() const final;
+    bool isMathSquareRoot() const final;
+    bool isMathText() const final;
+    bool isMathNumber() const final;
+    bool isMathOperator() const final;
+    bool isMathFenceOperator() const final;
+    bool isMathSeparatorOperator() const final;
+    bool isMathIdentifier() const final;
+    bool isMathTable() const final;
+    bool isMathTableRow() const final;
+    bool isMathTableCell() const final;
+    bool isMathMultiscript() const final;
+    bool isMathToken() const final;
+    bool isMathScriptObject(AccessibilityMathScriptObjectType) const final;
+    bool isMathMultiscriptObject(AccessibilityMathMultiscriptObjectType) const final;
 
     // Generic components.
-    AXCoreObject* mathBaseObject() override;
+    AXCoreObject* mathBaseObject() final;
 
     // Root components.
-    std::optional<AccessibilityChildrenVector> mathRadicand() override;
-    AXCoreObject* mathRootIndexObject() override;
+    std::optional<AccessibilityChildrenVector> mathRadicand() final;
+    AXCoreObject* mathRootIndexObject() final;
 
     // Fraction components.
-    AXCoreObject* mathNumeratorObject() override;
-    AXCoreObject* mathDenominatorObject() override;
+    AXCoreObject* mathNumeratorObject() final;
+    AXCoreObject* mathDenominatorObject() final;
 
     // Under over components.
-    AXCoreObject* mathUnderObject() override;
-    AXCoreObject* mathOverObject() override;
+    AXCoreObject* mathUnderObject() final;
+    AXCoreObject* mathOverObject() final;
 
     // Subscript/superscript components.
-    AXCoreObject* mathSubscriptObject() override;
-    AXCoreObject* mathSuperscriptObject() override;
+    AXCoreObject* mathSubscriptObject() final;
+    AXCoreObject* mathSuperscriptObject() final;
 
     // Fenced components.
-    String mathFencedOpenString() const override;
-    String mathFencedCloseString() const override;
-    int mathLineThickness() const override;
-    bool isAnonymousMathOperator() const override;
+    String mathFencedOpenString() const final;
+    String mathFencedCloseString() const final;
+    int mathLineThickness() const final;
+    bool isAnonymousMathOperator() const final;
 
     // Multiscripts components.
-    void mathPrescripts(AccessibilityMathMultiscriptPairs&) override;
-    void mathPostscripts(AccessibilityMathMultiscriptPairs&) override;
+    void mathPrescripts(AccessibilityMathMultiscriptPairs&) final;
+    void mathPostscripts(AccessibilityMathMultiscriptPairs&) final;
 
     bool m_isAnonymousOperator;
 };

--- a/Source/WebCore/accessibility/AccessibilityMediaObject.h
+++ b/Source/WebCore/accessibility/AccessibilityMediaObject.h
@@ -55,11 +55,11 @@ private:
     bool computeIsIgnored() const final;
     bool isMediaObject() const final { return true; }
     
-    String stringValue() const override;
-    bool press() override;
-    void increment() override;
-    void decrement() override;
-    
+    String stringValue() const final;
+    bool press() final;
+    void increment() final;
+    void decrement() final;
+
     HTMLMediaElement* mediaElement() const;
     
     void mediaSeek(AXSeekDirection);

--- a/Source/WebCore/accessibility/AccessibilityMenuList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuList.cpp
@@ -39,7 +39,7 @@ AccessibilityMenuList::AccessibilityMenuList(AXID axID, RenderMenuList& renderer
 {
     m_popup->setParent(this);
 
-    addChild(m_popup.ptr());
+    addChild(m_popup.get());
     m_childrenInitialized = true;
 }
 

--- a/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
@@ -117,7 +117,7 @@ void AccessibilityMenuListPopup::addChildren()
     for (const auto& listItem : select->listItems()) {
         if (auto* menuListOptionObject = menuListOptionAccessibilityObject(listItem.get())) {
             menuListOptionObject->setParent(this);
-            addChild(menuListOptionObject, DescendIfIgnored::No);
+            addChild(*menuListOptionObject, DescendIfIgnored::No);
         }
     }
 }

--- a/Source/WebCore/accessibility/AccessibilityMenuListPopup.h
+++ b/Source/WebCore/accessibility/AccessibilityMenuListPopup.h
@@ -38,8 +38,8 @@ class AccessibilityMenuListPopup final : public AccessibilityMockObject {
 public:
     static Ref<AccessibilityMenuListPopup> create(AXID axID) { return adoptRef(*new AccessibilityMenuListPopup(axID)); }
 
-    bool isEnabled() const override;
-    bool isOffScreen() const override;
+    bool isEnabled() const final;
+    bool isOffScreen() const final;
 
     void didUpdateActiveOption(int optionIndex);
 
@@ -51,11 +51,11 @@ private:
     LayoutRect elementRect() const final { return LayoutRect(); }
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::MenuListPopup; }
 
-    bool isVisible() const override;
-    bool press() override;
-    void addChildren() override;
+    bool isVisible() const final;
+    bool press() final;
+    void addChildren() final;
     void handleChildrenChanged();
-    bool computeIsIgnored() const override;
+    bool computeIsIgnored() const final;
     std::optional<AccessibilityChildrenVector> selectedChildren() final;
 
     AccessibilityMenuListOption* menuListOptionAccessibilityObject(HTMLElement*) const;

--- a/Source/WebCore/accessibility/AccessibilityMockObject.h
+++ b/Source/WebCore/accessibility/AccessibilityMockObject.h
@@ -48,7 +48,7 @@ protected:
 
 private:
     bool isMockObject() const final { return true; }
-    bool isDetachedFromParent() override { return !m_parent; }
+    bool isDetachedFromParent() final { return !m_parent; }
 
     bool computeIsIgnored() const override;
 };

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -567,7 +567,7 @@ void AccessibilityNodeObject::updateOwnedChildren()
         // If the child already exists as a DOM child, but is also in the owned objects, then
         // we need to re-order this child in the aria-owns order.
         m_children.removeFirst(child);
-        addChild(child.ptr());
+        addChild(downcast<AccessibilityObject>(child.get()));
     }
 }
 
@@ -854,12 +854,6 @@ bool AccessibilityNodeObject::isChecked() const
     return false;
 }
 
-bool AccessibilityNodeObject::isHovered() const
-{
-    RefPtr element = dynamicDowncast<Element>(node());
-    return element && element->hovered();
-}
-
 bool AccessibilityNodeObject::isMultiSelectable() const
 {
     const AtomString& ariaMultiSelectable = getAttribute(aria_multiselectableAttr);
@@ -1141,7 +1135,7 @@ RefPtr<Element> AccessibilityNodeObject::popoverTargetElement() const
     return formControlElement ? formControlElement->popoverTargetElement() : nullptr;
 }
 
-AXCoreObject* AccessibilityNodeObject::internalLinkElement() const
+AccessibilityObject* AccessibilityNodeObject::internalLinkElement() const
 {
     // We don't currently support ARIA links as internal link elements, so exit early if anchorElement() is not a native HTMLAnchorElement.
     WeakPtr anchor = dynamicDowncast<HTMLAnchorElement>(anchorElement());

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -46,42 +46,41 @@ public:
 
     void init() override;
 
-    bool canvasHasFallbackContent() const override;
+    bool canvasHasFallbackContent() const final;
 
-    bool isBusy() const override;
+    bool isBusy() const final;
     bool isDetached() const override { return !m_node; }
-    bool isRadioInput() const override;
-    bool isFieldset() const override;
-    bool isHovered() const override;
-    bool isInputImage() const override;
+    bool isRadioInput() const final;
+    bool isFieldset() const final;
+    bool isInputImage() const final;
     bool isMultiSelectable() const override;
     bool isNativeImage() const;
-    bool isNativeTextControl() const override;
-    bool isSecureField() const override;
-    bool isSearchField() const override;
+    bool isNativeTextControl() const final;
+    bool isSecureField() const final;
+    bool isSearchField() const final;
 
-    bool isChecked() const override;
+    bool isChecked() const final;
     bool isEnabled() const override;
     bool isIndeterminate() const override;
     bool isPressed() const final;
-    bool isRequired() const override;
+    bool isRequired() const final;
     bool supportsARIAOwns() const final;
 
-    bool supportsDropping() const override;
-    bool supportsDragging() const override;
-    bool isGrabbed() override;
-    Vector<String> determineDropEffects() const override;
+    bool supportsDropping() const final;
+    bool supportsDragging() const final;
+    bool isGrabbed() final;
+    Vector<String> determineDropEffects() const final;
 
     bool canSetSelectedAttribute() const override;
 
-    Node* node() const override { return m_node.get(); }
+    Node* node() const final { return m_node.get(); }
     Document* document() const override;
     LocalFrameView* documentFrameView() const override;
 
     void setFocused(bool) override;
-    bool isFocused() const override;
+    bool isFocused() const final;
     bool canSetFocusAttribute() const override;
-    unsigned headingLevel() const override;
+    unsigned headingLevel() const final;
 
     bool canSetValueAttribute() const override;
 
@@ -93,31 +92,31 @@ public:
 
     AccessibilityOrientation orientation() const override;
 
-    AccessibilityButtonState checkboxOrRadioValue() const override;
+    AccessibilityButtonState checkboxOrRadioValue() const final;
 
     URL url() const override;
-    unsigned hierarchicalLevel() const override;
+    unsigned hierarchicalLevel() const final;
     String textUnderElement(TextUnderElementMode = TextUnderElementMode()) const override;
     String accessibilityDescriptionForChildren() const;
     String description() const override;
     String helpText() const override;
     String title() const override;
-    String text() const override;
+    String text() const final;
     void alternativeText(Vector<AccessibilityText>&) const;
     void helpText(Vector<AccessibilityText>&) const;
     String stringValue() const override;
     WallTime dateTimeValue() const final;
-    SRGBA<uint8_t> colorValue() const override;
-    String ariaLabeledByAttribute() const override;
+    SRGBA<uint8_t> colorValue() const final;
+    String ariaLabeledByAttribute() const final;
     bool hasAccNameAttribute() const;
     bool hasAttributesRequiredForInclusion() const final;
     bool hasClickHandler() const final;
-    void setIsExpanded(bool) override;
+    void setIsExpanded(bool) final;
 
     Element* actionElement() const override;
     Element* anchorElement() const override;
     RefPtr<Element> popoverTargetElement() const final;
-    AXCoreObject* internalLinkElement() const final;
+    AccessibilityObject* internalLinkElement() const final;
     AccessibilityChildrenVector radioButtonGroup() const final;
    
     virtual void changeValueByPercent(float percentChange);
@@ -153,7 +152,7 @@ protected:
     enum class TreatStyleFormatGroupAsInline : bool { No, Yes };
     AccessibilityRole determineAccessibilityRoleFromNode(TreatStyleFormatGroupAsInline = TreatStyleFormatGroupAsInline::No) const;
     AccessibilityRole roleFromInputElement(const HTMLInputElement&) const;
-    AccessibilityRole ariaRoleAttribute() const override { return m_ariaRole; }
+    AccessibilityRole ariaRoleAttribute() const final { return m_ariaRole; }
     virtual AccessibilityRole determineAriaRoleAttribute() const;
     AccessibilityRole remapAriaRoleDueToParent(AccessibilityRole) const;
 
@@ -163,7 +162,7 @@ protected:
     void updateChildrenIfNecessary() override;
     bool canHaveChildren() const override;
     AccessibilityChildrenVector visibleChildren() override;
-    bool isDescendantOfBarrenParent() const override;
+    bool isDescendantOfBarrenParent() const final;
     void updateOwnedChildren();
     AccessibilityObject* ownerParentObject() const;
     
@@ -181,9 +180,9 @@ protected:
 
     bool elementAttributeValue(const QualifiedName&) const;
 
-    const String liveRegionStatus() const override;
-    const String liveRegionRelevant() const override;
-    bool liveRegionAtomic() const override;
+    const String liveRegionStatus() const final;
+    const String liveRegionRelevant() const final;
+    bool liveRegionAtomic() const final;
 
     String accessKey() const final;
     bool isLabelable() const;
@@ -196,8 +195,8 @@ protected:
     Vector<Ref<Element>> ariaLabeledByElements() const;
     String descriptionForElements(const Vector<Ref<Element>>&) const;
     LayoutRect boundingBoxRect() const override;
-    String ariaDescribedByAttribute() const override;
-    
+    String ariaDescribedByAttribute() const final;
+
     AccessibilityObject* captionForFigure() const;
     virtual void labelText(Vector<AccessibilityText>&) const;
 private:
@@ -215,8 +214,8 @@ private:
     LayoutRect checkboxOrRadioRect() const;
 
     void setNeedsToUpdateChildren() override { m_childrenDirty = true; }
-    bool needsToUpdateChildren() const override { return m_childrenDirty; }
-    void setNeedsToUpdateSubtree() override { m_subtreeDirty = true; }
+    bool needsToUpdateChildren() const final { return m_childrenDirty; }
+    void setNeedsToUpdateSubtree() final { m_subtreeDirty = true; }
 
     bool isDescendantOfElementType(const HashSet<QualifiedName>&) const;
 protected:

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -628,12 +628,8 @@ static bool isTableComponent(AXCoreObject& axObject)
 }
 #endif
 
-void AccessibilityObject::insertChild(AXCoreObject* newChild, unsigned index, DescendIfIgnored descendIfIgnored)
+void AccessibilityObject::insertChild(AccessibilityObject& child, unsigned index, DescendIfIgnored descendIfIgnored)
 {
-    if (!newChild)
-        return;
-    auto& child = downcast<AccessibilityObject>(*newChild);
-
     // If the parent is asking for this child's children, then either it's the first time (and clearing is a no-op),
     // or its visibility has changed. In the latter case, this child may have a stale child cached.
     // This can prevent aria-hidden changes from working correctly. Hence, whenever a parent is getting children, ensure data is not stale.
@@ -705,11 +701,6 @@ void AccessibilityObject::insertChild(AXCoreObject* newChild, unsigned index, De
     child.clearIsIgnoredFromParentData();
 }
     
-void AccessibilityObject::addChild(AXCoreObject* child, DescendIfIgnored descendIfIgnored)
-{
-    insertChild(child, m_children.size(), descendIfIgnored);
-}
-
 AXCoreObject::AccessibilityChildrenVector AccessibilityObject::findMatchingObjects(AccessibilitySearchCriteria&& criteria)
 {
     if (auto* cache = axObjectCache())

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -90,11 +90,11 @@ public:
 
     bool hasDirtySubtree() const { return m_subtreeDirty; }
 
-    bool hasDocumentRoleAncestor() const override;
-    bool hasWebApplicationAncestor() const override;
-    bool isInDescriptionListDetail() const override;
-    bool isInDescriptionListTerm() const override;
-    bool isInCell() const override;
+    bool hasDocumentRoleAncestor() const final;
+    bool hasWebApplicationAncestor() const final;
+    bool isInDescriptionListDetail() const final;
+    bool isInDescriptionListTerm() const final;
+    bool isInCell() const final;
     bool isInRow() const;
 
     bool isDetached() const override;
@@ -144,7 +144,7 @@ public:
     AccessibilityChildrenVector rowHeaders() override { return AccessibilityChildrenVector(); }
     AccessibilityChildrenVector visibleRows() override { return AccessibilityChildrenVector(); }
     String cellScope() const final { return getAttribute(HTMLNames::scopeAttr); }
-    AXCoreObject* headerContainer() override { return nullptr; }
+    AccessibilityObject* headerContainer() override { return nullptr; }
     int axColumnCount() const override { return 0; }
     int axRowCount() const override { return 0; }
     virtual Vector<Vector<Markable<AXID>>> cellSlots() { return { }; }
@@ -162,7 +162,7 @@ public:
     // Table column support.
     bool isTableColumn() const override { return false; }
     unsigned columnIndex() const override { return 0; }
-    AXCoreObject* columnHeader() override { return nullptr; }
+    AccessibilityObject* columnHeader() override { return nullptr; }
 
     // Table row support.
     bool isTableRow() const override { return false; }
@@ -172,7 +172,7 @@ public:
     // ARIA tree/grid row support.
     bool isARIATreeGridRow() const override { return false; }
     AccessibilityChildrenVector disclosedRows() override; // ARIATreeItem implementation. AccessibilityARIAGridRow overrides this method.
-    AXCoreObject* disclosedByRow() const override { return nullptr; }
+    AccessibilityObject* disclosedByRow() const override { return nullptr; }
 
     bool isFieldset() const override { return false; }
     virtual bool isImageMapLink() const { return false; }
@@ -180,18 +180,18 @@ public:
     virtual bool isMenuListPopup() const { return false; }
     virtual bool isMenuListOption() const { return false; }
     virtual bool isNativeSpinButton() const { return false; }
-    AXCoreObject* incrementButton() override { return nullptr; }
-    AXCoreObject* decrementButton() override { return nullptr; }
+    AccessibilityObject* incrementButton() override { return nullptr; }
+    AccessibilityObject* decrementButton() override { return nullptr; }
     virtual bool isSpinButtonPart() const { return false; }
     virtual bool isIncrementor() const { return false; }
     bool isMockObject() const override { return false; }
     virtual bool isMediaObject() const { return false; }
     bool isARIATextControl() const;
-    bool isNonNativeTextControl() const override;
+    bool isNonNativeTextControl() const final;
     bool isRangeControl() const;
     bool isStyleFormatGroup() const;
     bool isFigureElement() const;
-    bool isKeyboardFocusable() const override;
+    bool isKeyboardFocusable() const final;
     bool isOutput() const;
 
     bool isChecked() const override { return false; }
@@ -199,7 +199,6 @@ public:
     bool isSelected() const override;
     bool isTabItemSelected() const;
     bool isFocused() const override { return false; }
-    virtual bool isHovered() const { return false; }
     bool isIndeterminate() const override { return false; }
     bool isLoaded() const final;
     bool isMultiSelectable() const override { return false; }
@@ -207,43 +206,43 @@ public:
     bool isPressed() const override { return false; }
     InsideLink insideLink() const final;
     bool isRequired() const override { return false; }
-    bool isExpanded() const override;
+    bool isExpanded() const final;
     bool isVisible() const override { return !isHidden(); }
     virtual bool isCollapsed() const { return false; }
     void setIsExpanded(bool) override { }
-    FloatRect unobscuredContentRect() const override;
-    FloatRect relativeFrame() const override;
+    FloatRect unobscuredContentRect() const final;
+    FloatRect relativeFrame() const final;
 #if PLATFORM(MAC)
-    FloatRect primaryScreenRect() const override;
+    FloatRect primaryScreenRect() const final;
 #endif
-    FloatRect convertFrameToSpace(const FloatRect&, AccessibilityConversionSpace) const override;
-    UncheckedKeyHashMap<String, AXEditingStyleValueVariant> resolvedEditingStyles() const override;
-    
+    FloatRect convertFrameToSpace(const FloatRect&, AccessibilityConversionSpace) const final;
+    UncheckedKeyHashMap<String, AXEditingStyleValueVariant> resolvedEditingStyles() const final;
+
     // In a multi-select list, many items can be selected but only one is active at a time.
     bool isSelectedOptionActive() const override { return false; }
 
     bool hasBoldFont() const override { return false; }
     bool hasItalicFont() const override { return false; }
     Vector<AXTextMarkerRange> misspellingRanges() const final;
-    std::optional<SimpleRange> misspellingRange(const SimpleRange& start, AccessibilitySearchDirection) const override;
+    std::optional<SimpleRange> misspellingRange(const SimpleRange& start, AccessibilitySearchDirection) const final;
     bool hasPlainText() const override { return false; }
     bool hasSameFont(const AXCoreObject&) const override { return false; }
     bool hasSameFontColor(const AXCoreObject&) const override { return false; }
     bool hasSameStyle(const AXCoreObject&) const override { return false; }
     bool hasUnderline() const override { return false; }
-    bool hasHighlighting() const override;
+    bool hasHighlighting() const final;
     AXTextMarkerRange textInputMarkedTextMarkerRange() const final;
 
     WallTime dateTimeValue() const override { return { }; }
-    DateComponentsType dateTimeComponentsType() const override;
-    bool supportsDatetimeAttribute() const override;
-    String datetimeAttributeValue() const override;
+    DateComponentsType dateTimeComponentsType() const final;
+    bool supportsDatetimeAttribute() const final;
+    String datetimeAttributeValue() const final;
 
     bool canSetFocusAttribute() const override { return false; }
     bool canSetValueAttribute() const override { return false; }
     bool canSetSelectedAttribute() const override { return false; }
 
-    Element* element() const override;
+    Element* element() const final;
     Node* node() const override { return nullptr; }
     RenderObject* renderer() const override { return nullptr; }
     const RenderStyle* style() const;
@@ -251,7 +250,7 @@ public:
     // Note: computeIsIgnored does not consider whether an object is ignored due to presence of modals.
     // Use isIgnored as the word of law when determining if an object is ignored.
     virtual bool computeIsIgnored() const { return true; }
-    bool isIgnored() const override;
+    bool isIgnored() const final;
     void recomputeIsIgnored();
     AccessibilityObjectInclusion defaultObjectInclusion() const;
     bool isIgnoredByDefault() const;
@@ -261,7 +260,7 @@ public:
     bool isShowingValidationMessage() const;
     String validationMessage() const;
 
-    unsigned blockquoteLevel() const override;
+    unsigned blockquoteLevel() const final;
     unsigned headingLevel() const override { return 0; }
     AccessibilityButtonState checkboxOrRadioValue() const override;
     String valueDescription() const override { return String(); }
@@ -278,36 +277,36 @@ public:
     bool supportsARIAOwns() const override { return false; }
     bool isActiveDescendantOfFocusedContainer() const;
 
-    String popupValue() const override;
+    String popupValue() const final;
     bool hasDatalist() const;
-    bool supportsHasPopup() const override;
-    bool pressedIsPresent() const override;
+    bool supportsHasPopup() const final;
+    bool pressedIsPresent() const final;
     bool ariaIsMultiline() const;
-    String invalidStatus() const override;
+    String invalidStatus() const final;
     bool supportsPressed() const;
-    bool supportsExpanded() const override;
-    bool supportsChecked() const override;
+    bool supportsExpanded() const final;
+    bool supportsChecked() const final;
     bool supportsRowCountChange() const;
-    AccessibilitySortDirection sortDirection() const override;
+    AccessibilitySortDirection sortDirection() const final;
     virtual bool canvasHasFallbackContent() const { return false; }
-    bool supportsRangeValue() const override;
-    String identifierAttribute() const override;
-    String linkRelValue() const override;
-    Vector<String> classList() const override;
-    AccessibilityCurrentState currentState() const override;
-    bool supportsCurrent() const override;
-    bool supportsKeyShortcuts() const override;
-    String keyShortcuts() const override;
+    bool supportsRangeValue() const final;
+    String identifierAttribute() const final;
+    String linkRelValue() const final;
+    Vector<String> classList() const final;
+    AccessibilityCurrentState currentState() const final;
+    bool supportsCurrent() const final;
+    bool supportsKeyShortcuts() const final;
+    String keyShortcuts() const final;
 
     // This function checks if the object should be ignored when there's a modal dialog displayed.
     virtual bool ignoredFromModalPresence() const;
     bool isModalDescendant(Node&) const;
-    bool isModalNode() const override;
+    bool isModalNode() const final;
 
-    bool supportsSetSize() const override;
-    bool supportsPosInSet() const override;
-    int setSize() const override;
-    int posInSet() const override;
+    bool supportsSetSize() const final;
+    bool supportsPosInSet() const final;
+    int setSize() const final;
+    int posInSet() const final;
 
     // ARIA drag and drop
     bool supportsDropping() const override { return false; }
@@ -346,16 +345,16 @@ public:
     AccessibilityChildrenVector findMatchingObjects(AccessibilitySearchCriteria&&) final;
     virtual bool isDescendantOfBarrenParent() const { return false; }
 
-    bool isDescendantOfRole(AccessibilityRole) const override;
+    bool isDescendantOfRole(AccessibilityRole) const final;
 
     // Text selection
-    Vector<SimpleRange> findTextRanges(const AccessibilitySearchTextCriteria&) const override;
-    Vector<String> performTextOperation(const AccessibilityTextOperation&) override;
+    Vector<SimpleRange> findTextRanges(const AccessibilitySearchTextCriteria&) const final;
+    Vector<String> performTextOperation(const AccessibilityTextOperation&) final;
 
     virtual AccessibilityObject* observableObject() const { return nullptr; }
     virtual AccessibilityObject* controlForLabelElement() const { return nullptr; }
     AccessibilityObject* scrollBar(AccessibilityOrientation) override { return nullptr; }
-    AXCoreObject* internalLinkElement() const override { return nullptr; }
+    AccessibilityObject* internalLinkElement() const override { return nullptr; }
     AccessibilityChildrenVector radioButtonGroup() const override { return { }; }
 
     virtual AccessibilityRole ariaRoleAttribute() const { return AccessibilityRole::Unknown; }
@@ -377,7 +376,7 @@ public:
     String description() const override { return { }; }
     virtual String helpText() const { return { }; }
 
-    std::optional<String> textContent() const override;
+    std::optional<String> textContent() const final;
     bool hasTextContent() const;
 #if PLATFORM(COCOA)
     bool hasAttributedText() const;
@@ -404,13 +403,13 @@ public:
 #endif
     virtual String ariaLabeledByAttribute() const { return String(); }
     virtual String ariaDescribedByAttribute() const { return String(); }
-    const String placeholderValue() const override;
+    const String placeholderValue() const final;
     bool accessibleNameDerivesFromContent() const;
     String brailleLabel() const override { return getAttribute(HTMLNames::aria_braillelabelAttr); }
     String brailleRoleDescription() const override { return getAttribute(HTMLNames::aria_brailleroledescriptionAttr); }
-    String embeddedImageDescription() const override;
+    String embeddedImageDescription() const final;
     std::optional<AccessibilityChildrenVector> imageOverlayElements() override { return std::nullopt; }
-    String extendedDescription() const override;
+    String extendedDescription() const final;
 
     // Abbreviations
     String expandedTextValue() const override { return String(); }
@@ -423,9 +422,9 @@ public:
 
     AccessibilityRole roleValue() const final { return m_role; }
     virtual AccessibilityRole determineAccessibilityRole() = 0;
-    String rolePlatformString() const override;
+    String rolePlatformString() const final;
     String roleDescription() const override;
-    String subrolePlatformString() const override;
+    String subrolePlatformString() const final;
 
     AXObjectCache* axObjectCache() const override;
 
@@ -457,8 +456,8 @@ public:
     VisibleSelection selection() const final;
     String selectedText() const override { return String(); }
     String accessKey() const override { return nullAtom(); }
-    String localizedActionVerb() const override;
-    String actionVerb() const override;
+    String localizedActionVerb() const final;
+    String actionVerb() const final;
 
     bool isWidget() const override { return false; }
     Widget* widget() const override { return nullptr; }
@@ -466,15 +465,15 @@ public:
     Widget* widgetForAttachmentView() const override { return nullptr; }
     bool isPlugin() const override { return false; }
 
-    IntPoint remoteFrameOffset() const override;
+    IntPoint remoteFrameOffset() const final;
 #if PLATFORM(COCOA)
-    RemoteAXObjectRef remoteParentObject() const override;
-    FloatRect convertRectToPlatformSpace(const FloatRect&, AccessibilityConversionSpace) const override;
+    RemoteAXObjectRef remoteParentObject() const final;
+    FloatRect convertRectToPlatformSpace(const FloatRect&, AccessibilityConversionSpace) const final;
     RetainPtr<id> remoteFramePlatformElement() const override { return nil; }
 #endif
     bool hasRemoteFrameChild() const override { return false; }
 
-    Page* page() const override;
+    Page* page() const final;
     Document* document() const override;
     RefPtr<Document> protectedDocument() const;
     LocalFrameView* documentFrameView() const override;
@@ -483,10 +482,10 @@ public:
     Document* topDocument() const;
     RenderView* topRenderer() const;
     ScrollView* scrollView() const override { return nullptr; }
-    String language() const override;
+    String language() const final;
     // 1-based, to match the aria-level spec.
     unsigned hierarchicalLevel() const override { return 0; }
-    bool isInlineText() const override;
+    bool isInlineText() const final;
 
     // Ensures that the view is focused and active before attempting to set focus to an AccessibilityObject.
     // Subclasses that override setFocused should call this base implementation first.
@@ -496,8 +495,8 @@ public:
     void setSelectedTextRange(CharacterRange&&) override { }
     bool setValue(const String&) override { return false; }
     void setValueIgnoringResult(const String& value) final { setValue(value); }
-    bool replaceTextInRange(const String&, const CharacterRange&) override;
-    bool insertText(const String&) override;
+    bool replaceTextInRange(const String&, const CharacterRange&) final;
+    bool insertText(const String&) final;
 
     bool setValue(float) override { return false; }
     void setValueIgnoringResult(float value) final { setValue(value); }
@@ -517,8 +516,21 @@ public:
     const AccessibilityChildrenVector& children(bool updateChildrenIfNeeded = true) override;
     virtual void addChildren() { }
     enum class DescendIfIgnored : bool { No, Yes };
-    void addChild(AXCoreObject*, DescendIfIgnored = DescendIfIgnored::Yes);
-    void insertChild(AXCoreObject*, unsigned, DescendIfIgnored = DescendIfIgnored::Yes);
+    void insertChild(AccessibilityObject&, unsigned, DescendIfIgnored = DescendIfIgnored::Yes);
+    void insertChild(AccessibilityObject* object, unsigned index, DescendIfIgnored descend = DescendIfIgnored::Yes)
+    {
+        if (object)
+            insertChild(*object, index, descend);
+    }
+    void addChild(AccessibilityObject& object, DescendIfIgnored descend = DescendIfIgnored::Yes)
+    {
+        insertChild(object, m_children.size(), descend);
+    }
+    void addChild(AccessibilityObject* object, DescendIfIgnored descend = DescendIfIgnored::Yes)
+    {
+        if (object)
+            addChild(*object, descend);
+    }
     virtual bool canHaveChildren() const { return true; }
     void updateChildrenIfNecessary() override;
     virtual void setNeedsToUpdateChildren() { }
@@ -550,45 +562,45 @@ public:
     AtomString tagName() const;
     bool hasDisplayContents() const;
 
-    std::optional<SimpleRange> simpleRange() const override;
+    std::optional<SimpleRange> simpleRange() const final;
     VisiblePositionRange visiblePositionRange() const override { return { }; }
-    AXTextMarkerRange textMarkerRange() const override;
+    AXTextMarkerRange textMarkerRange() const final;
 
-    std::optional<SimpleRange> visibleCharacterRange() const override;
+    std::optional<SimpleRange> visibleCharacterRange() const final;
     VisiblePositionRange visiblePositionRangeForLine(unsigned) const override { return VisiblePositionRange(); }
 
     static bool replacedNodeNeedsCharacter(Node& replacedNode);
 
-    VisiblePositionRange visiblePositionRangeForUnorderedPositions(const VisiblePosition&, const VisiblePosition&) const override;
-    VisiblePositionRange leftLineVisiblePositionRange(const VisiblePosition&) const override;
-    VisiblePositionRange rightLineVisiblePositionRange(const VisiblePosition&) const override;
-    VisiblePositionRange styleRangeForPosition(const VisiblePosition&) const override;
+    VisiblePositionRange visiblePositionRangeForUnorderedPositions(const VisiblePosition&, const VisiblePosition&) const final;
+    VisiblePositionRange leftLineVisiblePositionRange(const VisiblePosition&) const final;
+    VisiblePositionRange rightLineVisiblePositionRange(const VisiblePosition&) const final;
+    VisiblePositionRange styleRangeForPosition(const VisiblePosition&) const final;
     VisiblePositionRange visiblePositionRangeForRange(const CharacterRange&) const;
-    VisiblePositionRange lineRangeForPosition(const VisiblePosition&) const override;
+    VisiblePositionRange lineRangeForPosition(const VisiblePosition&) const final;
     virtual VisiblePositionRange selectedVisiblePositionRange() const { return { }; }
 
-    std::optional<SimpleRange> rangeForCharacterRange(const CharacterRange&) const override;
+    std::optional<SimpleRange> rangeForCharacterRange(const CharacterRange&) const final;
 #if PLATFORM(COCOA)
-    AXTextMarkerRange textMarkerRangeForNSRange(const NSRange&) const override;
+    AXTextMarkerRange textMarkerRangeForNSRange(const NSRange&) const final;
 #endif
 #if PLATFORM(MAC)
-    AXTextMarkerRange selectedTextMarkerRange() override;
+    AXTextMarkerRange selectedTextMarkerRange() final;
 #endif
     static String stringForVisiblePositionRange(const VisiblePositionRange&);
-    String stringForRange(const SimpleRange&) const override;
+    String stringForRange(const SimpleRange&) const final;
     virtual IntRect boundsForVisiblePositionRange(const VisiblePositionRange&) const { return IntRect(); }
     IntRect boundsForRange(const SimpleRange&) const final;
     void setSelectedVisiblePositionRange(const VisiblePositionRange&) const override { }
 
     VisiblePosition visiblePositionForPoint(const IntPoint&) const final;
-    VisiblePosition nextLineEndPosition(const VisiblePosition&) const override;
-    VisiblePosition previousLineStartPosition(const VisiblePosition&) const override;
-    VisiblePosition visiblePositionForIndex(unsigned, bool /*lastIndexOK */) const override { return VisiblePosition(); }
+    VisiblePosition nextLineEndPosition(const VisiblePosition&) const final;
+    VisiblePosition previousLineStartPosition(const VisiblePosition&) const final;
+    VisiblePosition visiblePositionForIndex(unsigned, bool /* lastIndexOK */) const override { return VisiblePosition(); }
 
     VisiblePosition visiblePositionForIndex(int) const override { return VisiblePosition(); }
     int indexForVisiblePosition(const VisiblePosition&) const override { return 0; }
 
-    int lineForPosition(const VisiblePosition&) const override;
+    int lineForPosition(const VisiblePosition&) const final;
     CharacterRange plainTextRangeForVisiblePositionRange(const VisiblePositionRange&) const;
     virtual int index(const VisiblePosition&) const { return -1; }
 
@@ -602,13 +614,13 @@ public:
     IntRect doAXBoundsForRangeUsingCharacterOffset(const CharacterRange&) const override { return { }; }
     static StringView listMarkerTextForNodeAndPosition(Node*, Position&&);
 
-    unsigned doAXLineForIndex(unsigned) override;
+    unsigned doAXLineForIndex(unsigned) final;
 
-    String computedRoleString() const override;
+    WEBCORE_EXPORT String computedRoleString() const final;
 
     virtual String secureFieldValue() const { return String(); }
-    bool isValueAutofillAvailable() const override;
-    AutoFillButtonType valueAutofillButtonType() const override;
+    bool isValueAutofillAvailable() const final;
+    AutoFillButtonType valueAutofillButtonType() const final;
 
     // Used by an ARIA tree to get all its rows.
     AccessibilityChildrenVector ariaTreeRows() final;
@@ -627,7 +639,7 @@ public:
     virtual String readOnlyValue() const;
 
     bool supportsAutoComplete() const;
-    String autoCompleteValue() const override;
+    String autoCompleteValue() const final;
 
     bool hasARIAValueNow() const { return hasAttribute(HTMLNames::aria_valuenowAttr); }
     bool supportsARIAAttributes() const;
@@ -636,9 +648,9 @@ public:
     OptionSet<SpeakAs> speakAsProperty() const;
 
     // Make this object visible by scrolling as many nested scrollable views as needed.
-    void scrollToMakeVisible() const override;
+    void scrollToMakeVisible() const final;
     // Same, but if the whole object can't be made visible, try for this subrect, in local coordinates.
-    void scrollToMakeVisibleWithSubFocus(IntRect&&) const override;
+    void scrollToMakeVisibleWithSubFocus(IntRect&&) const final;
     // Scroll this object to a given point in global coordinates of the top-level window.
     void scrollToGlobalPoint(IntPoint&&) const final;
 
@@ -703,7 +715,7 @@ public:
     bool isAXHidden() const;
     bool isDOMHidden() const;
     bool isHidden() const { return isAXHidden() || isDOMHidden(); }
-    bool isOnScreen() const override;
+    bool isOnScreen() const final;
 
 #if PLATFORM(COCOA)
     void overrideAttachmentParent(AccessibilityObject* parent);
@@ -718,31 +730,31 @@ public:
 
 #if PLATFORM(IOS_FAMILY)
     unsigned accessibilitySecureFieldLength() final;
-    bool hasTouchEventListener() const override;
+    bool hasTouchEventListener() const final;
 #endif
 
     // allows for an AccessibilityObject to update its render tree or perform
     // other operations update type operations
-    void updateBackingStore() override;
+    void updateBackingStore() final;
 
 #if PLATFORM(COCOA)
-    bool preventKeyboardDOMEventDispatch() const override;
-    void setPreventKeyboardDOMEventDispatch(bool) override;
-    bool fileUploadButtonReturnsValueInTitle() const override;
-    String speechHintAttributeValue() const override;
-    bool hasApplePDFAnnotationAttribute() const override { return hasAttribute(HTMLNames::x_apple_pdf_annotationAttr); }
+    bool preventKeyboardDOMEventDispatch() const final;
+    void setPreventKeyboardDOMEventDispatch(bool) final;
+    bool fileUploadButtonReturnsValueInTitle() const final;
+    String speechHintAttributeValue() const final;
+    bool hasApplePDFAnnotationAttribute() const final { return hasAttribute(HTMLNames::x_apple_pdf_annotationAttr); }
 #endif
 
 #if PLATFORM(MAC)
-    bool caretBrowsingEnabled() const override;
-    void setCaretBrowsingEnabled(bool) override;
+    bool caretBrowsingEnabled() const final;
+    void setCaretBrowsingEnabled(bool) final;
 #endif
 
     bool hasClickHandler() const override { return false; }
     AccessibilityObject* clickableSelfOrAncestor(ClickHandlerFilter filter = ClickHandlerFilter::ExcludeBody) const final { return Accessibility::clickableSelfOrAncestor(*this, filter); };
-    AccessibilityObject* focusableAncestor() override { return Accessibility::focusableAncestor(*this); }
-    AccessibilityObject* editableAncestor() override { return Accessibility::editableAncestor(*this); };
-    AccessibilityObject* highestEditableAncestor() override { return Accessibility::highestEditableAncestor(*this); }
+    AccessibilityObject* focusableAncestor() final { return Accessibility::focusableAncestor(*this); }
+    AccessibilityObject* editableAncestor() final { return Accessibility::editableAncestor(*this); };
+    AccessibilityObject* highestEditableAncestor() final { return Accessibility::highestEditableAncestor(*this); }
     AccessibilityObject* exposedTableAncestor(bool includeSelf = false) const final { return Accessibility::exposedTableAncestor(*this, includeSelf); }
 
     const AccessibilityScrollView* ancestorAccessibilityScrollView(bool includeSelf) const;
@@ -755,13 +767,13 @@ public:
 
     AccessibilityChildrenVector documentLinks() override { return AccessibilityChildrenVector(); }
 
-    AccessibilityChildrenVector relatedObjects(AXRelationType) const override;
+    AccessibilityChildrenVector relatedObjects(AXRelationType) const final;
 
-    String innerHTML() const override;
-    String outerHTML() const override;
+    String innerHTML() const final;
+    String outerHTML() const final;
 
 #if PLATFORM(COCOA) && ENABLE(MODEL_ELEMENT)
-    Vector<RetainPtr<id>> modelElementChildren() override;
+    Vector<RetainPtr<id>> modelElementChildren() final;
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -864,7 +876,7 @@ protected:
     // FIXME: Make more of these member functions private.
 
     void detachRemoteParts(AccessibilityDetachmentType) override;
-    void detachPlatformWrapper(AccessibilityDetachmentType) override;
+    void detachPlatformWrapper(AccessibilityDetachmentType) final;
 
     void setIsIgnoredFromParentData(AccessibilityIsIgnoredFromParentData& data) { m_isIgnoredFromParentData = data; }
     bool ignoredFromPresentationalRole() const;

--- a/Source/WebCore/accessibility/AccessibilityProgressIndicator.h
+++ b/Source/WebCore/accessibility/AccessibilityProgressIndicator.h
@@ -41,16 +41,16 @@ private:
 
     AccessibilityRole determineAccessibilityRole() final;
 
-    String valueDescription() const override;
+    String valueDescription() const final;
     String gaugeRegionValueDescription() const;
-    float valueForRange() const override;
-    float maxValueForRange() const override;
-    float minValueForRange() const override;
+    float valueForRange() const final;
+    float maxValueForRange() const final;
+    float minValueForRange() const final;
 
     HTMLProgressElement* progressElement() const;
     HTMLMeterElement* meterElement() const;
     
-    bool computeIsIgnored() const override;
+    bool computeIsIgnored() const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -58,92 +58,90 @@ public:
     virtual ~AccessibilityRenderObject();
     
     FloatRect frameRect() const final;
-    bool isNonLayerSVGObject() const override;
+    bool isNonLayerSVGObject() const final;
 
-    bool isAttachment() const override;
+    bool isAttachment() const final;
     bool isDetached() const final { return !m_renderer && AccessibilityNodeObject::isDetached(); }
-    bool isOffScreen() const override;
-    bool hasBoldFont() const override;
-    bool hasItalicFont() const override;
-    bool hasPlainText() const override;
-    bool hasSameFont(const AXCoreObject&) const override;
-    bool hasSameFontColor(const AXCoreObject&) const override;
-    bool hasSameStyle(const AXCoreObject&) const override;
-    bool hasUnderline() const override;
+    bool isOffScreen() const final;
+    bool hasBoldFont() const final;
+    bool hasItalicFont() const final;
+    bool hasPlainText() const final;
+    bool hasSameFont(const AXCoreObject&) const final;
+    bool hasSameFontColor(const AXCoreObject&) const final;
+    bool hasSameStyle(const AXCoreObject&) const final;
+    bool hasUnderline() const final;
 
-    void setAccessibleName(const AtomString&) override;
-    
-    int layoutCount() const override;
-    
-    AccessibilityObject* firstChild() const override;
-    AccessibilityObject* lastChild() const override;
+    void setAccessibleName(const AtomString&) final;
+
+    int layoutCount() const final;
+
+    AccessibilityObject* firstChild() const final;
+    AccessibilityObject* lastChild() const final;
     AccessibilityObject* previousSibling() const final;
     AccessibilityObject* nextSibling() const final;
     AccessibilityObject* parentObject() const override;
     AccessibilityObject* observableObject() const override;
-    AXCoreObject* titleUIElement() const override;
+    AccessibilityObject* titleUIElement() const override;
 
     // Should be called on the root accessibility object to kick off a hit test.
-    AccessibilityObject* accessibilityHitTest(const IntPoint&) const override;
+    AccessibilityObject* accessibilityHitTest(const IntPoint&) const final;
 
-    Element* anchorElement() const override;
+    Element* anchorElement() const final;
     
-    LayoutRect boundingBoxRect() const override;
+    LayoutRect boundingBoxRect() const final;
 
     RenderObject* renderer() const final { return m_renderer.get(); }
-    Node* node() const override;
+    Document* document() const final;
 
-    Document* document() const override;
-
-    URL url() const override;
-    CharacterRange selectedTextRange() const override;
-    int insertionPointLineNumber() const override;
+    URL url() const final;
+    CharacterRange selectedTextRange() const final;
+    int insertionPointLineNumber() const final;
     String stringValue() const override;
     String helpText() const override;
     String textUnderElement(TextUnderElementMode = TextUnderElementMode()) const override;
-    String selectedText() const override;
+    String selectedText() const final;
 #if ENABLE(AX_THREAD_TEXT_APIS)
     AXTextRuns textRuns() final;
 #endif
 
-    bool isWidget() const override;
-    Widget* widget() const override;
-    Widget* widgetForAttachmentView() const override;
-    AccessibilityChildrenVector documentLinks() override;
-    LocalFrameView* documentFrameView() const override;
+    bool isWidget() const final;
+    Widget* widget() const final;
+    Widget* widgetForAttachmentView() const final;
+    AccessibilityChildrenVector documentLinks() final;
+    LocalFrameView* documentFrameView() const final;
     bool isPlugin() const final { return is<PluginViewBase>(widget()); }
 
-    void setSelectedTextRange(CharacterRange&&) override;
+    void setSelectedTextRange(CharacterRange&&) final;
     bool setValue(const String&) override;
 
     void addChildren() override;
 
-    IntRect boundsForVisiblePositionRange(const VisiblePositionRange&) const override;
-    void setSelectedVisiblePositionRange(const VisiblePositionRange&) const override;
+    IntRect boundsForVisiblePositionRange(const VisiblePositionRange&) const final;
+    void setSelectedVisiblePositionRange(const VisiblePositionRange&) const final;
     bool isVisiblePositionRangeInDifferentDocument(const VisiblePositionRange&) const;
 
-    VisiblePosition visiblePositionForIndex(unsigned indexValue, bool lastIndexOK) const override;
-    int index(const VisiblePosition&) const override;
+    VisiblePosition visiblePositionForIndex(unsigned indexValue, bool lastIndexOK) const final;
+    int index(const VisiblePosition&) const final;
 
     VisiblePosition visiblePositionForIndex(int) const final;
     int indexForVisiblePosition(const VisiblePosition&) const final;
 
-    CharacterRange doAXRangeForLine(unsigned) const override;
-    CharacterRange doAXRangeForIndex(unsigned) const override;
-    
-    String doAXStringForRange(const CharacterRange&) const override;
-    IntRect doAXBoundsForRange(const CharacterRange&) const override;
-    IntRect doAXBoundsForRangeUsingCharacterOffset(const CharacterRange&) const override;
-    
-    String secureFieldValue() const override;
+    CharacterRange doAXRangeForLine(unsigned) const final;
+    CharacterRange doAXRangeForIndex(unsigned) const final;
+
+    String doAXStringForRange(const CharacterRange&) const final;
+    IntRect doAXBoundsForRange(const CharacterRange&) const final;
+    IntRect doAXBoundsForRangeUsingCharacterOffset(const CharacterRange&) const final;
+
+    String secureFieldValue() const final;
     void labelText(Vector<AccessibilityText>&) const override;
 protected:
     explicit AccessibilityRenderObject(AXID, RenderObject&);
     explicit AccessibilityRenderObject(AXID, Node&);
-    void detachRemoteParts(AccessibilityDetachmentType) override;
-    ScrollableArea* getScrollableAreaIfScrollable() const override;
-    void scrollTo(const IntPoint&) const override;
-    
+    void detachRemoteParts(AccessibilityDetachmentType) final;
+    ScrollableArea* getScrollableAreaIfScrollable() const final;
+    void scrollTo(const IntPoint&) const final;
+
     bool shouldIgnoreAttributeRole() const override;
     AccessibilityRole determineAccessibilityRole() override;
     bool computeIsIgnored() const override;
@@ -160,8 +158,8 @@ private:
     CharacterRange documentBasedSelectedTextRange() const;
     RefPtr<Element> rootEditableElementForPosition(const Position&) const;
     bool elementIsTextControl(const Element&) const;
-    Path elementPath() const override;
-    
+    Path elementPath() const final;
+
     AccessibilityObject* accessibilityImageMapHitTest(HTMLAreaElement&, const IntPoint&) const;
     AccessibilityObject* associatedAXImage(HTMLMapElement&) const;
     AccessibilityObject* elementAccessibilityHitTest(const IntPoint&) const override;
@@ -176,7 +174,7 @@ private:
     AccessibilitySVGRoot* remoteSVGRootElement(CreationChoice createIfNecessary) const;
     AccessibilityObject* remoteSVGElementHitTest(const IntPoint&) const;
     void offsetBoundingBoxForRemoteSVGElement(LayoutRect&) const;
-    bool supportsPath() const override;
+    bool supportsPath() const final;
 
 #if USE(ATSPI)
     void addNodeOnlyChildren();

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.h
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.h
@@ -38,7 +38,7 @@ public:
 
 protected:
     explicit AccessibilitySVGObject(AXID, RenderObject&, AXObjectCache*);
-    AXObjectCache* axObjectCache() const override { return m_axObjectCache.get(); }
+    AXObjectCache* axObjectCache() const final { return m_axObjectCache.get(); }
     AccessibilityRole determineAriaRoleAttribute() const final;
 
 private:

--- a/Source/WebCore/accessibility/AccessibilitySVGRoot.h
+++ b/Source/WebCore/accessibility/AccessibilitySVGRoot.h
@@ -43,8 +43,8 @@ public:
 private:
     explicit AccessibilitySVGRoot(AXID, RenderObject&, AXObjectCache*);
 
-    AccessibilityObject* parentObject() const override;
-    bool isAccessibilitySVGRoot() const override { return true; }
+    AccessibilityObject* parentObject() const final;
+    bool isAccessibilitySVGRoot() const final { return true; }
 
     AccessibilityRole determineAccessibilityRole() final;
 

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -198,7 +198,7 @@ AccessibilityScrollbar* AccessibilityScrollView::addChildScrollbar(Scrollbar* sc
 
     auto& scrollBarObject = uncheckedDowncast<AccessibilityScrollbar>(*cache->getOrCreate(*scrollbar));
     scrollBarObject.setParent(this);
-    addChild(&scrollBarObject);
+    addChild(scrollBarObject);
     return &scrollBarObject;
 }
         
@@ -250,7 +250,7 @@ void AccessibilityScrollView::addRemoteFrameChild()
     } else
         m_remoteFrame->setParent(this);
 
-    addChild(m_remoteFrame.get());
+    addChild(*m_remoteFrame);
 }
 
 void AccessibilityScrollView::addChildren()

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -39,46 +39,46 @@ class AccessibilityScrollView final : public AccessibilityObject {
 public:
     static Ref<AccessibilityScrollView> create(AXID, ScrollView&);
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::ScrollArea; }
-    ScrollView* scrollView() const override { return currentScrollView(); }
+    ScrollView* scrollView() const final { return currentScrollView(); }
 
     virtual ~AccessibilityScrollView();
 
-    AccessibilityObject* webAreaObject() const override;
-    void setNeedsToUpdateChildren() override { m_childrenDirty = true; }
+    AccessibilityObject* webAreaObject() const final;
+    void setNeedsToUpdateChildren() final { m_childrenDirty = true; }
 
 private:
     explicit AccessibilityScrollView(AXID, ScrollView&);
-    void detachRemoteParts(AccessibilityDetachmentType) override;
+    void detachRemoteParts(AccessibilityDetachmentType) final;
 
     ScrollView* currentScrollView() const;
-    ScrollableArea* getScrollableAreaIfScrollable() const override { return currentScrollView(); }
-    void scrollTo(const IntPoint&) const override;
-    bool computeIsIgnored() const override;
-    bool isAccessibilityScrollViewInstance() const override { return true; }
-    bool isEnabled() const override { return true; }
+    ScrollableArea* getScrollableAreaIfScrollable() const final { return currentScrollView(); }
+    void scrollTo(const IntPoint&) const final;
+    bool computeIsIgnored() const final;
+    bool isAccessibilityScrollViewInstance() const final { return true; }
+    bool isEnabled() const final { return true; }
     bool hasRemoteFrameChild() const final { return m_remoteFrame; }
 
-    bool isAttachment() const override;
-    PlatformWidget platformWidget() const override;
-    Widget* widgetForAttachmentView() const override { return currentScrollView(); }
-    
-    AccessibilityObject* scrollBar(AccessibilityOrientation) override;
-    void addChildren() override;
-    void clearChildren() override;
-    AccessibilityObject* accessibilityHitTest(const IntPoint&) const override;
-    void updateChildrenIfNecessary() override;
+    bool isAttachment() const final;
+    PlatformWidget platformWidget() const final;
+    Widget* widgetForAttachmentView() const final { return currentScrollView(); }
+
+    AccessibilityObject* scrollBar(AccessibilityOrientation) final;
+    void addChildren() final;
+    void clearChildren() final;
+    AccessibilityObject* accessibilityHitTest(const IntPoint&) const final;
+    void updateChildrenIfNecessary() final;
     void updateScrollbars();
-    void setFocused(bool) override;
-    bool canSetFocusAttribute() const override;
-    bool isFocused() const override;
+    void setFocused(bool) final;
+    bool canSetFocusAttribute() const final;
+    bool isFocused() const final;
     void addRemoteFrameChild();
 
-    Document* document() const override;
-    LocalFrameView* documentFrameView() const override;
-    LayoutRect elementRect() const override;
-    AccessibilityObject* parentObject() const override;
+    Document* document() const final;
+    LocalFrameView* documentFrameView() const final;
+    LayoutRect elementRect() const final;
+    AccessibilityObject* parentObject() const final;
 
-    AccessibilityObject* firstChild() const override { return webAreaObject(); }
+    AccessibilityObject* firstChild() const final { return webAreaObject(); }
     AccessibilityScrollbar* addChildScrollbar(Scrollbar*);
     void removeChildScrollbar(AccessibilityObject*);
 

--- a/Source/WebCore/accessibility/AccessibilityScrollbar.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollbar.h
@@ -41,19 +41,19 @@ public:
 private:
     explicit AccessibilityScrollbar(AXID, Scrollbar&);
 
-    bool canSetValueAttribute() const override { return true; }
+    bool canSetValueAttribute() const final { return true; }
 
-    bool isAccessibilityScrollbar() const override { return true; }
-    LayoutRect elementRect() const override;
-    
+    bool isAccessibilityScrollbar() const final { return true; }
+    LayoutRect elementRect() const final;
+
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::ScrollBar; }
-    AccessibilityOrientation orientation() const override;
-    Document* document() const override;
-    bool isEnabled() const override;
-    
+    AccessibilityOrientation orientation() const final;
+    Document* document() const final;
+    bool isEnabled() const final;
+
     // Assumes float [0..1]
-    bool setValue(float) override;
-    float valueForRange() const override;
+    bool setValue(float) final;
+    float valueForRange() const final;
 
     Ref<Scrollbar> m_scrollbar;
 };

--- a/Source/WebCore/accessibility/AccessibilitySlider.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySlider.cpp
@@ -102,7 +102,7 @@ void AccessibilitySlider::addChildren()
     if (thumb->isIgnored())
         cache->remove(thumb->objectID());
     else
-        addChild(thumb.ptr());
+        addChild(thumb.get());
 }
 
 AccessibilityObject* AccessibilitySlider::elementAccessibilityHitTest(const IntPoint& point) const

--- a/Source/WebCore/accessibility/AccessibilitySlider.h
+++ b/Source/WebCore/accessibility/AccessibilitySlider.h
@@ -35,7 +35,7 @@ namespace WebCore {
 
 class HTMLInputElement;
 
-class AccessibilitySlider : public AccessibilityRenderObject {
+class AccessibilitySlider final : public AccessibilityRenderObject {
 public:
     static Ref<AccessibilitySlider> create(AXID, RenderObject&);
     virtual ~AccessibilitySlider() = default;
@@ -48,15 +48,15 @@ private:
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::Slider; }
 
-    void addChildren() override;
+    void addChildren() final;
+
+    bool canSetValueAttribute() const final { return true; }
     
-    bool canSetValueAttribute() const override { return true; }
-    
-    bool setValue(const String&) override;
-    float valueForRange() const override;
-    float maxValueForRange() const override;
-    float minValueForRange() const override;
-    AccessibilityOrientation orientation() const override;
+    bool setValue(const String&) final;
+    float valueForRange() const final;
+    float maxValueForRange() const final;
+    float minValueForRange() const final;
+    AccessibilityOrientation orientation() const final;
 };
 
 class AccessibilitySliderThumb final : public AccessibilityMockObject {
@@ -65,13 +65,13 @@ public:
     virtual ~AccessibilitySliderThumb() = default;
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::SliderThumb; }
-    LayoutRect elementRect() const override;
+    LayoutRect elementRect() const final;
 
 private:
     explicit AccessibilitySliderThumb(AXID);
 
-    bool isSliderThumb() const override { return true; }
-    bool computeIsIgnored() const override;
+    bool isSliderThumb() const final { return true; }
+    bool computeIsIgnored() const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilitySpinButton.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySpinButton.cpp
@@ -48,25 +48,25 @@ AccessibilitySpinButton::AccessibilitySpinButton(AXID axID, AXObjectCache& cache
     m_decrementor->setIsIncrementor(false);
     m_decrementor->setParent(this);
 
-    addChild(m_incrementor.ptr());
-    addChild(m_decrementor.ptr());
+    addChild(m_incrementor.get());
+    addChild(m_decrementor.get());
     m_childrenInitialized = true;
 }
 
 AccessibilitySpinButton::~AccessibilitySpinButton() = default;
     
-AXCoreObject* AccessibilitySpinButton::incrementButton()
+AccessibilitySpinButtonPart* AccessibilitySpinButton::incrementButton()
 {
     ASSERT(m_childrenInitialized);
     RELEASE_ASSERT(m_children.size() == 2);
-    return m_children[0].ptr();
+    return &downcast<AccessibilitySpinButtonPart>(m_children[0].get());
 }
    
-AXCoreObject* AccessibilitySpinButton::decrementButton()
+AccessibilitySpinButtonPart* AccessibilitySpinButton::decrementButton()
 {
     ASSERT(m_childrenInitialized);
     RELEASE_ASSERT(m_children.size() == 2);
-    return m_children[1].ptr();
+    return &downcast<AccessibilitySpinButtonPart>(m_children[1].get());
 }
     
 LayoutRect AccessibilitySpinButton::elementRect() const

--- a/Source/WebCore/accessibility/AccessibilitySpinButton.h
+++ b/Source/WebCore/accessibility/AccessibilitySpinButton.h
@@ -39,8 +39,8 @@ public:
 
     void setSpinButtonElement(SpinButtonElement* spinButton) { m_spinButtonElement = spinButton; }
 
-    AXCoreObject* incrementButton() final;
-    AXCoreObject* decrementButton() final;
+    AccessibilitySpinButtonPart* incrementButton() final;
+    AccessibilitySpinButtonPart* decrementButton() final;
 
     void step(int amount);
 
@@ -48,10 +48,10 @@ private:
     explicit AccessibilitySpinButton(AXID, AXObjectCache&);
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::SpinButton; }
-    bool isNativeSpinButton() const override { return true; }
+    bool isNativeSpinButton() const final { return true; }
     void clearChildren() final { };
     void addChildren() final;
-    LayoutRect elementRect() const override;
+    LayoutRect elementRect() const final;
 
     WeakPtr<SpinButtonElement, WeakPtrImplWithEventTargetData> m_spinButtonElement;
     // FIXME: Nothing calls AXObjectCache::remove for m_incrementor and m_decrementor.

--- a/Source/WebCore/accessibility/AccessibilitySpinButtonPart.h
+++ b/Source/WebCore/accessibility/AccessibilitySpinButtonPart.h
@@ -51,5 +51,10 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AccessibilitySpinButtonPart) \
+    static bool isType(const WebCore::AXCoreObject& object) \
+    { \
+        auto* axObject = dynamicDowncast<WebCore::AccessibilityObject>(object); \
+        return axObject && axObject->isSpinButtonPart(); \
+    } \
     static bool isType(const WebCore::AccessibilityObject& object) { return object.isSpinButtonPart(); } \
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/accessibility/AccessibilityTable.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTable.cpp
@@ -475,7 +475,7 @@ void AccessibilityTable::addChildren()
         column->setColumnIndex(i);
         column->setParent(this);
         m_columns.append(column);
-        addChild(column.ptr(), DescendIfIgnored::No);
+        addChild(column.get(), DescendIfIgnored::No);
     }
     addChild(headerContainer(), DescendIfIgnored::No);
 
@@ -637,7 +637,7 @@ unsigned AccessibilityTable::computeCellSlots()
         m_rows.append(*row);
         row->setRowIndex(yCurrent);
 #if !ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
-        addChild(row);
+        addChild(*row);
 #endif // !ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
 
         // Step 16: If current cell is the last td or th element child in the tr element being processed, then increase ycurrent by 1, abort this set of steps, and return to the algorithm above.
@@ -710,7 +710,7 @@ unsigned AccessibilityTable::computeCellSlots()
             // Step 6: Associate the first caption element child of the table element with the table.
             if (!didAddCaption) {
                 if (RefPtr axCaption = cache->getOrCreate(*caption)) {
-                    addChild(axCaption.get(), DescendIfIgnored::No);
+                    addChild(*axCaption, DescendIfIgnored::No);
                     didAddCaption = true;
                 }
             }
@@ -778,7 +778,7 @@ unsigned AccessibilityTable::computeCellSlots()
     return xWidth;
 }
 
-AXCoreObject* AccessibilityTable::headerContainer()
+AccessibilityObject* AccessibilityTable::headerContainer()
 {
     if (m_headerContainer)
         return m_headerContainer.get();

--- a/Source/WebCore/accessibility/AccessibilityTable.h
+++ b/Source/WebCore/accessibility/AccessibilityTable.h
@@ -66,7 +66,7 @@ public:
     AccessibilityChildrenVector visibleRows() final;
 
     // Returns an object that contains, as children, all the objects that act as headers.
-    AXCoreObject* headerContainer() final;
+    AccessibilityObject* headerContainer() final;
 
     bool isTable() const final { return true; }
     // Returns whether it is exposed as an AccessibilityTable to the platform.

--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -284,18 +284,8 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityTableCell::rowHeaders()
     return headers;
 }
 
-AccessibilityTableRow* AccessibilityTableCell::ariaOwnedByParent() const
-{
-    auto owners = this->owners();
-    if (owners.size() == 1 && owners[0]->isTableRow())
-        return dynamicDowncast<AccessibilityTableRow>(owners[0].get());
-    return nullptr;
-}
-
 AccessibilityTableRow* AccessibilityTableCell::parentRow() const
 {
-    if (auto ownerParent = ariaOwnedByParent())
-        return ownerParent;
     return dynamicDowncast<AccessibilityTableRow>(parentObjectUnignored());
 }
 

--- a/Source/WebCore/accessibility/AccessibilityTableCell.h
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.h
@@ -44,8 +44,8 @@ public:
 
     bool isExposedTableCell() const final;
     bool isTableHeaderCell() const;
-    bool isColumnHeader() const override;
-    bool isRowHeader() const override;
+    bool isColumnHeader() const final;
+    bool isRowHeader() const final;
 
     std::optional<AXID> rowGroupAncestorID() const final;
 
@@ -56,10 +56,10 @@ public:
     // Returns the start location and column span of the cell.
     std::pair<unsigned, unsigned> columnIndexRange() const final;
 
-    AccessibilityChildrenVector rowHeaders() override;
+    AccessibilityChildrenVector rowHeaders() final;
 
-    int axColumnIndex() const override;
-    int axRowIndex() const override;
+    int axColumnIndex() const final;
+    int axRowIndex() const final;
     unsigned colSpan() const;
     unsigned rowSpan() const;
     void incrementEffectiveRowSpan() { ++m_effectiveRowSpan; }
@@ -87,7 +87,6 @@ private:
     bool computeIsIgnored() const final;
     String expandedTextValue() const final;
     bool supportsExpandedTextValue() const final;
-    AccessibilityTableRow* ariaOwnedByParent() const;
     void ensureIndexesUpToDate() const;
 
     unsigned m_rowIndex { 0 };

--- a/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
@@ -64,7 +64,7 @@ LayoutRect AccessibilityTableColumn::elementRect() const
     return columnRect;
 }
 
-AXCoreObject* AccessibilityTableColumn::columnHeader()
+AccessibilityObject* AccessibilityTableColumn::columnHeader()
 {
     auto* parentTable = dynamicDowncast<AccessibilityTable>(m_parent.get());
     if (!parentTable || !parentTable->isExposable())
@@ -72,7 +72,7 @@ AXCoreObject* AccessibilityTableColumn::columnHeader()
 
     for (const auto& cell : unignoredChildren()) {
         if (cell->roleValue() == AccessibilityRole::ColumnHeader)
-            return cell.ptr();
+            return &downcast<AccessibilityObject>(cell.get());
     }
     return nullptr;
 }
@@ -117,7 +117,7 @@ void AccessibilityTableColumn::addChildren()
         if (m_children.size() > 0 && m_children.last().ptr() == cell.get())
             continue;
 
-        addChild(cell.get());
+        addChild(*cell);
     }
 }
     

--- a/Source/WebCore/accessibility/AccessibilityTableColumn.h
+++ b/Source/WebCore/accessibility/AccessibilityTableColumn.h
@@ -39,23 +39,23 @@ public:
     static Ref<AccessibilityTableColumn> create(AXID);
     virtual ~AccessibilityTableColumn();
 
-    AXCoreObject* columnHeader() override;
+    AccessibilityObject* columnHeader() final;
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::Column; }
 
     void setColumnIndex(unsigned);
-    unsigned columnIndex() const override { return m_columnIndex; }
+    unsigned columnIndex() const final { return m_columnIndex; }
 
-    void addChildren() override;
-    void setParent(AccessibilityObject*) override;
-    
-    LayoutRect elementRect() const override;
-    
+    void addChildren() final;
+    void setParent(AccessibilityObject*) final;
+
+    LayoutRect elementRect() const final;
+
 private:
     explicit AccessibilityTableColumn(AXID);
     
-    bool computeIsIgnored() const override;
-    bool isTableColumn() const override { return true; }
+    bool computeIsIgnored() const final;
+    bool isTableColumn() const final { return true; }
 
     bool isAccessibilityTableColumnInstance() const final { return true; }
     unsigned m_columnIndex;

--- a/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
@@ -70,7 +70,7 @@ void AccessibilityTableHeaderContainer::addChildren()
         return;
 
     for (auto& columnHeader : parentTable->columnHeaders())
-        addChild(columnHeader.ptr());
+        addChild(downcast<AccessibilityObject>(columnHeader.get()));
 
     for (const auto& child : m_children)
         m_headerRect.unite(child->elementRect());

--- a/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.h
+++ b/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.h
@@ -41,14 +41,14 @@ public:
     
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::TableHeaderContainer; }
 
-    void addChildren() override;
-    
-    LayoutRect elementRect() const override;
-    
+    void addChildren() final;
+
+    LayoutRect elementRect() const final;
+
 private:
     explicit AccessibilityTableHeaderContainer(AXID);
     
-    bool computeIsIgnored() const override;
+    bool computeIsIgnored() const final;
 
     LayoutRect m_headerRect;
 }; 

--- a/Source/WebCore/accessibility/AccessibilityTableRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.cpp
@@ -127,7 +127,7 @@ void AccessibilityTableRow::setRowIndex(unsigned rowIndex)
 #endif
 }
 
-AXCoreObject* AccessibilityTableRow::rowHeader()
+AccessibilityObject* AccessibilityTableRow::rowHeader()
 {
     const auto& rowChildren = unignoredChildren();
     if (rowChildren.isEmpty())
@@ -142,7 +142,7 @@ AXCoreObject* AccessibilityTableRow::rowHeader()
     for (const auto& child : rowChildren) {
         // We found a non-header cell, so this is not an entire row of headers -- return the original header cell.
         if (child->node() && !child->node()->hasTagName(thTag))
-            return firstCell.ptr();
+            return &downcast<AccessibilityObject>(firstCell.get());
     }
     return nullptr;
 }
@@ -153,7 +153,7 @@ void AccessibilityTableRow::addChildren()
     auto ownedObjects = this->ownedObjects();
     if (ownedObjects.size()) {
         for (auto& object : ownedObjects)
-            addChild(object.ptr(), DescendIfIgnored::No);
+            addChild(downcast<AccessibilityObject>(object.get()), DescendIfIgnored::No);
         m_childrenInitialized = true;
         m_subtreeDirty = false;
     }

--- a/Source/WebCore/accessibility/AccessibilityTableRow.h
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.h
@@ -41,7 +41,7 @@ public:
     virtual ~AccessibilityTableRow();
 
     // retrieves the "row" header (a th tag in the rightmost column)
-    AXCoreObject* rowHeader() override;
+    AccessibilityObject* rowHeader() override;
     virtual AccessibilityTable* parentTable() const;
 
     void setRowIndex(unsigned);
@@ -51,10 +51,10 @@ public:
     // in the row, but their col/row spans overlap into it
     void appendChild(AccessibilityObject*);
     
-    void addChildren() override;
+    void addChildren() final;
 
-    int axColumnIndex() const override;
-    int axRowIndex() const override;
+    int axColumnIndex() const final;
+    int axRowIndex() const final;
 
 protected:
     explicit AccessibilityTableRow(AXID, RenderObject&);

--- a/Source/WebCore/accessibility/AccessibilityTree.h
+++ b/Source/WebCore/accessibility/AccessibilityTree.h
@@ -44,8 +44,8 @@ public:
 private:
     explicit AccessibilityTree(AXID, RenderObject&);
     explicit AccessibilityTree(AXID, Node&);
-    bool computeIsIgnored() const override;
-    AccessibilityRole determineAccessibilityRole() override;
+    bool computeIsIgnored() const final;
+    AccessibilityRole determineAccessibilityRole() final;
     bool isTreeValid() const;
 };
     

--- a/Source/WebCore/accessibility/AccessibilityTreeItem.h
+++ b/Source/WebCore/accessibility/AccessibilityTreeItem.h
@@ -38,13 +38,13 @@ public:
     static Ref<AccessibilityTreeItem> create(AXID, Node&);
     virtual ~AccessibilityTreeItem();
 
-    bool supportsCheckedState() const override;
+    bool supportsCheckedState() const final;
 
 private:
     explicit AccessibilityTreeItem(AXID, RenderObject&);
     explicit AccessibilityTreeItem(AXID, Node&);
     bool shouldIgnoreAttributeRole() const final { return !m_isTreeItemValid; }
-    AccessibilityRole determineAccessibilityRole() override;
+    AccessibilityRole determineAccessibilityRole() final;
     bool m_isTreeItemValid;
 };
     

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -277,7 +277,7 @@ private:
     Vector<String> determineDropEffects() const final;
     AXIsolatedObject* accessibilityHitTest(const IntPoint&) const final;
     AXIsolatedObject* focusedUIElement() const final;
-    AXCoreObject* internalLinkElement() const final { return objectAttributeValue(AXPropertyName::InternalLinkElement); }
+    AXIsolatedObject* internalLinkElement() const final { return objectAttributeValue(AXPropertyName::InternalLinkElement); }
     AccessibilityChildrenVector radioButtonGroup() const final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXPropertyName::RadioButtonGroup)); }
     AXIsolatedObject* scrollBar(AccessibilityOrientation) final;
     const String placeholderValue() const final { return stringAttributeValue(AXPropertyName::PlaceholderValue); }


### PR DESCRIPTION
#### 226ab951753332583cb5104079fffbb5dd160aae
<pre>
AX: Improve de-virtualization opportunities by ubiquitously using final and strengthening types from AXCoreObject to AccessibilityObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=283685">https://bugs.webkit.org/show_bug.cgi?id=283685</a>
<a href="https://rdar.apple.com/140554675">rdar://140554675</a>

Reviewed by Chris Fleizach.

Add final everywhere we can in accessibility, and strengthen types from AXCoreObject to AccessibilityObject, giving the
compiler the ability to de-virtualize more function calls.

Strengthening the types also makes our code more logical. An AccessibilityObject function that returns an AXCoreObject*
implicitly means it could return either an AccessibilityObject, or an AXIsolatedObject. Returning the latter would be
a major issue. By strengthening the types, this becomes impossible.

This patch also adds an overload of `addChildren` that takes an `AccessibilityObject&amp;` to allow us to skip a null check
in contexts where we&apos;ve already done a null check (which is most of them).

* Source/WebCore/accessibility/AXImage.h:
* Source/WebCore/accessibility/AXRemoteFrame.h:
* Source/WebCore/accessibility/AccessibilityARIAGridCell.h:
* Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp:
(WebCore::AccessibilityARIAGridRow::disclosedByRow const):
(WebCore::AccessibilityARIAGridRow::rowHeader):
* Source/WebCore/accessibility/AccessibilityARIAGridRow.h:
* Source/WebCore/accessibility/AccessibilityAttachment.h:
* Source/WebCore/accessibility/AccessibilityImageMapLink.h:
* Source/WebCore/accessibility/AccessibilityListBox.h:
* Source/WebCore/accessibility/AccessibilityListBoxOption.cpp:
(WebCore::AccessibilityListBoxOption::node const): Deleted.
* Source/WebCore/accessibility/AccessibilityListBoxOption.h:
* Source/WebCore/accessibility/AccessibilityMathMLElement.cpp:
(WebCore::AccessibilityMathMLElement::addChildren):
(WebCore::AccessibilityMathMLElement::isMathScriptObject const):
(WebCore::AccessibilityMathMLElement::isMathMultiscriptObject const):
* Source/WebCore/accessibility/AccessibilityMathMLElement.h:
* Source/WebCore/accessibility/AccessibilityMediaObject.h:
* Source/WebCore/accessibility/AccessibilityMenuList.cpp:
(WebCore::AccessibilityMenuList::AccessibilityMenuList):
* Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp:
(WebCore::AccessibilityMenuListPopup::addChildren):
* Source/WebCore/accessibility/AccessibilityMenuListPopup.h:
* Source/WebCore/accessibility/AccessibilityMockObject.h:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::updateOwnedChildren):
(WebCore::AccessibilityNodeObject::internalLinkElement const):
(WebCore::AccessibilityNodeObject::isHovered const): Deleted.
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::insertChild):
(WebCore::AccessibilityObject::addChild): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::insertChild):
(WebCore::AccessibilityObject::addChild):
(WebCore::AccessibilityObject::isHovered const): Deleted.
* Source/WebCore/accessibility/AccessibilityProgressIndicator.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::AccessibilityRenderObject):
(WebCore::AccessibilityRenderObject::titleUIElement const):
(WebCore::AccessibilityRenderObject::computeIsIgnored const):
(WebCore::AccessibilityRenderObject::addImageMapChildren):
(WebCore::AccessibilityRenderObject::addTextFieldChildren):
(WebCore::AccessibilityRenderObject::addRemoteSVGChildren):
(WebCore::AccessibilityRenderObject::addNodeOnlyChildren):
(WebCore::AccessibilityRenderObject::addChildren):
(WebCore::AccessibilityRenderObject::node const): Deleted.
* Source/WebCore/accessibility/AccessibilityRenderObject.h:
* Source/WebCore/accessibility/AccessibilitySVGObject.h:
* Source/WebCore/accessibility/AccessibilitySVGRoot.h:
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::addChildScrollbar):
(WebCore::AccessibilityScrollView::addRemoteFrameChild):
* Source/WebCore/accessibility/AccessibilityScrollView.h:
* Source/WebCore/accessibility/AccessibilityScrollbar.h:
* Source/WebCore/accessibility/AccessibilitySlider.cpp:
(WebCore::AccessibilitySlider::addChildren):
* Source/WebCore/accessibility/AccessibilitySlider.h:
* Source/WebCore/accessibility/AccessibilitySpinButton.cpp:
(WebCore::AccessibilitySpinButton::AccessibilitySpinButton):
(WebCore::AccessibilitySpinButton::incrementButton):
(WebCore::AccessibilitySpinButton::decrementButton):
* Source/WebCore/accessibility/AccessibilitySpinButton.h:
* Source/WebCore/accessibility/AccessibilitySpinButtonPart.h:
(isType):
* Source/WebCore/accessibility/AccessibilityTable.cpp:
(WebCore::AccessibilityTable::addChildren):
(WebCore::AccessibilityTable::computeCellSlots):
(WebCore::AccessibilityTable::headerContainer):
* Source/WebCore/accessibility/AccessibilityTable.h:
* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
(WebCore::AccessibilityTableCell::parentRow const):
(WebCore::AccessibilityTableCell::ariaOwnedByParent const): Deleted.
* Source/WebCore/accessibility/AccessibilityTableCell.h:
* Source/WebCore/accessibility/AccessibilityTableColumn.cpp:
(WebCore::AccessibilityTableColumn::columnHeader):
(WebCore::AccessibilityTableColumn::addChildren):
* Source/WebCore/accessibility/AccessibilityTableColumn.h:
* Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp:
(WebCore::AccessibilityTableHeaderContainer::addChildren):
* Source/WebCore/accessibility/AccessibilityTableHeaderContainer.h:
* Source/WebCore/accessibility/AccessibilityTableRow.cpp:
(WebCore::AccessibilityTableRow::rowHeader):
(WebCore::AccessibilityTableRow::addChildren):
* Source/WebCore/accessibility/AccessibilityTableRow.h:
* Source/WebCore/accessibility/AccessibilityTree.h:
* Source/WebCore/accessibility/AccessibilityTreeItem.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:

Canonical link: <a href="https://commits.webkit.org/287130@main">https://commits.webkit.org/287130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/377ec95f1e0e91432ae9f0deaf4898f495d1aeec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82920 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29525 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66456 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61289 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19210 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68349 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41606 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48634 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24905 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27862 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69726 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84285 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5626 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3797 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69512 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67213 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68767 "Found 3 new API test failures: /TestWebKit:WebKit.FrameMIMETypePNG, /TestWebKit:WebKit.CanHandleRequest, /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17177 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12775 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11048 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5573 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8330 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5565 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8999 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7351 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->