### PR TITLE
[WPE][GTK] Fix various -Werror=unsafe-buffer-usage-in-container build failures

### DIFF
--- a/Source/WTF/wtf/glib/GSpanExtras.cpp
+++ b/Source/WTF/wtf/glib/GSpanExtras.cpp
@@ -24,6 +24,16 @@
 
 namespace WTF {
 
+GMallocSpan<char> gFileGetContents(const char* path, GUniqueOutPtr<GError>& error)
+{
+    char* contents;
+    gsize length;
+    if (!g_file_get_contents(path, &contents, &length, &error.outPtr()))
+        return { };
+
+    return adoptGMallocSpan(unsafeMakeSpan(contents, length));
+}
+
 GMallocSpan<char*, GMallocStrv> gKeyFileGetKeys(GKeyFile* keyFile, const char* groupName, GUniqueOutPtr<GError>& error)
 {
     ASSERT(keyFile);

--- a/Source/WTF/wtf/glib/GSpanExtras.h
+++ b/Source/WTF/wtf/glib/GSpanExtras.h
@@ -64,6 +64,7 @@ GMallocSpan<T, Malloc> adoptGMallocSpan(std::span<T> span)
     return adoptMallocSpan<T, Malloc>(span);
 }
 
+WTF_EXPORT_PRIVATE GMallocSpan<char> gFileGetContents(const char* path, GUniqueOutPtr<GError>&);
 WTF_EXPORT_PRIVATE GMallocSpan<char*, GMallocStrv> gKeyFileGetKeys(GKeyFile*, const char* groupName, GUniqueOutPtr<GError>&);
 WTF_EXPORT_PRIVATE GMallocSpan<GParamSpec*> gObjectClassGetProperties(GObjectClass*);
 WTF_EXPORT_PRIVATE GMallocSpan<const char*> gVariantGetStrv(const GRefPtr<GVariant>&);
@@ -125,6 +126,9 @@ inline std::span<T> span(GRefPtr<GPtrArray>& array)
 
 } // namespace WTF
 
+using WTF::GMallocSpan;
+using WTF::gFileGetContents;
 using WTF::gKeyFileGetKeys;
 using WTF::gObjectClassGetProperties;
+using WTF::gVariantGetStrv;
 using WTF::span;

--- a/Source/WebCore/PAL/pal/crypto/gcrypt/CryptoDigestGCrypt.cpp
+++ b/Source/WebCore/PAL/pal/crypto/gcrypt/CryptoDigestGCrypt.cpp
@@ -88,7 +88,7 @@ Vector<uint8_t> CryptoDigest::computeHash()
     size_t digestLen = gcry_md_get_algo_dlen(m_context->algorithm);
 
     gcry_md_final(m_context->md);
-    Vector<uint8_t> result(std::span<uint8_t> { gcry_md_read(m_context->md, 0), digestLen });
+    Vector<uint8_t> result(unsafeMakeSpan<uint8_t>(gcry_md_read(m_context->md, 0), digestLen));
     gcry_md_close(m_context->md);
 
     return result;

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -41,6 +41,14 @@
 #include <wtf/cf/VectorCF.h>
 #endif
 
+#if USE(GLIB)
+#include <wtf/glib/GSpanExtras.h>
+#endif
+
+#if USE(SKIA)
+#include "SkiaSpanExtras.h"
+#endif
+
 static constexpr size_t minimumPageSize = 4096;
 #if USE(UNIX_DOMAIN_SOCKETS)
 static constexpr bool useUnixDomainSockets = true;
@@ -620,13 +628,13 @@ std::span<const uint8_t> DataSegment::span() const
         [](const RetainPtr<CFDataRef>& data) { return WTF::span(data.get()); },
 #endif
 #if USE(GLIB)
-        [](const GRefPtr<GBytes>& data) -> std::span<const uint8_t> { return { static_cast<const uint8_t*>(g_bytes_get_data(data.get(), nullptr)), g_bytes_get_size(data.get()) }; },
+        [](const GRefPtr<GBytes>& data) -> std::span<const uint8_t> { return WTF::span(data); },
 #endif
 #if USE(GSTREAMER)
-        [](const RefPtr<GstMappedOwnedBuffer>& data) -> std::span<const uint8_t> { return { data->data(), data->size() }; },
+        [](const RefPtr<GstMappedOwnedBuffer>& data) -> std::span<const uint8_t> { return data->span(); },
 #endif
 #if USE(SKIA)
-        [](const sk_sp<SkData>& data) -> std::span<const uint8_t> { return { data->bytes(), data->size() }; },
+        [](const sk_sp<SkData>& data) -> std::span<const uint8_t> { return WebCore::span(data); },
 #endif
         [](const FileSystem::MappedFileData& data) { return data.span(); },
         [](const Provider& provider) { return provider.span(); }

--- a/Source/WebCore/platform/SharedBufferChunkReader.cpp
+++ b/Source/WebCore/platform/SharedBufferChunkReader.cpp
@@ -32,6 +32,8 @@
 #include "config.h"
 #include "SharedBufferChunkReader.h"
 
+#include <wtf/text/StringCommon.h>
+
 namespace WebCore {
 
 #if ENABLE(MHTML)
@@ -62,7 +64,7 @@ void SharedBufferChunkReader::setSeparator(const Vector<char>& separator)
 void SharedBufferChunkReader::setSeparator(const char* separator)
 {
     m_separator.clear();
-    m_separator.append(span(separator));
+    m_separator.append(WTF::span(separator));
 }
 
 bool SharedBufferChunkReader::nextChunk(Vector<uint8_t>& chunk, bool includeSeparator)

--- a/Source/WebCore/platform/Skia.cmake
+++ b/Source/WebCore/platform/Skia.cmake
@@ -16,6 +16,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/skia/SkiaHarfBuzzFont.h
     platform/graphics/skia/SkiaHarfBuzzFontCache.h
     platform/graphics/skia/SkiaPaintingEngine.h
+    platform/graphics/skia/SkiaSpanExtras.h
 )
 
 list(APPEND WebCore_LIBRARIES

--- a/Source/WebCore/platform/WebCorePersistentCoders.cpp
+++ b/Source/WebCore/platform/WebCorePersistentCoders.cpp
@@ -45,6 +45,10 @@
 #include <wtf/spi/cocoa/SecuritySPI.h>
 #endif
 
+#if USE(GLIB)
+#include <wtf/glib/GSpanExtras.h>
+#endif
+
 namespace WTF::Persistence {
 
 #if ENABLE(APP_HIGHLIGHTS)
@@ -434,7 +438,7 @@ template<> struct Coder<GRefPtr<GByteArray>> {
     static void encodeForPersistence(Encoder &encoder, const GRefPtr<GByteArray>& byteArray)
     {
         encoder << static_cast<uint32_t>(byteArray->len);
-        encoder.encodeFixedLengthData({ byteArray->data, byteArray->len });
+        encoder.encodeFixedLengthData(span(byteArray));
     }
 
     static std::optional<GRefPtr<GByteArray>> decodeForPersistence(Decoder& decoder)
@@ -446,7 +450,8 @@ template<> struct Coder<GRefPtr<GByteArray>> {
 
         GRefPtr<GByteArray> byteArray = adoptGRef(g_byte_array_sized_new(*size));
         g_byte_array_set_size(byteArray.get(), *size);
-        if (!decoder.decodeFixedLengthData({ byteArray->data, *size }))
+
+        if (!decoder.decodeFixedLengthData(spanConstCast<uint8_t>(span(byteArray))))
             return std::nullopt;
         return byteArray;
     }

--- a/Source/WebCore/platform/audio/glib/AudioBusGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/AudioBusGLib.cpp
@@ -25,6 +25,7 @@
 #include "AudioFileReader.h"
 #include <gio/gio.h>
 #include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GSpanExtras.h>
 #include <wtf/glib/GUniquePtr.h>
 
 #if PLATFORM(GTK)
@@ -40,7 +41,7 @@ RefPtr<AudioBus> AudioBus::loadPlatformResource(const char* name, float sampleRa
     GUniquePtr<char> path(g_strdup_printf(AUDIO_GRESOURCE_PATH "/%s", name));
     GRefPtr<GBytes> data = adoptGRef(g_resources_lookup_data(path.get(), G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
     ASSERT(data);
-    return createBusFromInMemoryAudioFile(std::span(static_cast<const uint8_t*>(g_bytes_get_data(data.get(), nullptr)), g_bytes_get_size(data.get())), false, sampleRate);
+    return createBusFromInMemoryAudioFile(span(data), false, sampleRate);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
@@ -131,7 +131,7 @@ GStreamerAudioDecoder::~GStreamerAudioDecoder()
 Ref<AudioDecoder::DecodePromise> GStreamerAudioDecoder::decode(EncodedData&& data)
 {
     return invokeAsync(gstDecoderWorkQueue(), [value = Vector<uint8_t> { data.data }, isKeyFrame = data.isKeyFrame, timestamp = data.timestamp, duration = data.duration, decoder = m_internalDecoder] {
-        return decoder->decode({ value.data(), value.size() }, isKeyFrame, timestamp, duration);
+        return decoder->decode(value.span(), isKeyFrame, timestamp, duration);
     });
 }
 

--- a/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
@@ -31,6 +31,7 @@
 #include <gst/audio/audio-converter.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/text/StringCommon.h>
 
 GST_DEBUG_CATEGORY(webkit_audio_data_debug);
 #define GST_CAT_DEFAULT webkit_audio_data_debug
@@ -232,7 +233,7 @@ void PlatformRawAudioData::copyTo(std::span<uint8_t> destination, AudioSampleFor
 
     GUniquePtr<GstAudioInfo> sourceInfo(gst_audio_info_copy(self.info()));
     GUniquePtr<char> key(gst_info_strdup_printf("%" GST_PTR_FORMAT ";%" GST_PTR_FORMAT, gst_sample_get_caps(self.sample()), outputCaps.get()));
-    auto converter = getAudioConvertedForFormat(StringView { std::span { key.get(), strlen(key.get()) } }, *sourceInfo.get(), destinationInfo);
+    auto converter = getAudioConvertedForFormat(StringView { span(key.get()) }, *sourceInfo.get(), destinationInfo);
 
     auto inFrames = gst_buffer_get_size(gst_sample_get_buffer(self.sample())) / GST_AUDIO_INFO_BPF(sourceInfo.get());
     auto outFrames = gst_audio_converter_get_out_frames(converter, inFrames);

--- a/Source/WebCore/platform/glib/KeyedDecoderGlib.cpp
+++ b/Source/WebCore/platform/glib/KeyedDecoderGlib.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "KeyedDecoderGlib.h"
 
+#include <wtf/glib/GSpanExtras.h>
 #include <wtf/text/CString.h>
 
 namespace WebCore {
@@ -69,7 +70,7 @@ bool KeyedDecoderGlib::decodeBytes(const String& key, std::span<const uint8_t>& 
     if (!value)
         return false;
 
-    bytes = { static_cast<const uint8_t*>(g_variant_get_data(value.get())), g_variant_get_size(value.get()) };
+    bytes = span(value);
     return true;
 }
 

--- a/Source/WebCore/platform/glib/KeyedEncoderGlib.cpp
+++ b/Source/WebCore/platform/glib/KeyedEncoderGlib.cpp
@@ -27,6 +27,7 @@
 #include "KeyedEncoderGlib.h"
 
 #include "SharedBuffer.h"
+#include <wtf/glib/GSpanExtras.h>
 #include <wtf/text/CString.h>
 
 namespace WebCore {
@@ -137,7 +138,7 @@ RefPtr<SharedBuffer> KeyedEncoderGlib::finishEncoding()
     g_assert(m_variantBuilderStack.last() == &m_variantBuilder);
     GRefPtr<GVariant> variant = g_variant_builder_end(&m_variantBuilder);
     GRefPtr<GBytes> data = adoptGRef(g_variant_get_data_as_bytes(variant.get()));
-    return SharedBuffer::create(std::span { static_cast<const unsigned char*>(g_bytes_get_data(data.get(), nullptr)), static_cast<unsigned>(g_bytes_get_size(data.get())) });
+    return SharedBuffer::create(span(data));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/WOFFFileFormat.cpp
+++ b/Source/WebCore/platform/graphics/WOFFFileFormat.cpp
@@ -47,7 +47,7 @@ static bool readUInt32(SharedBuffer& buffer, size_t& offset, uint32_t& value)
     if (buffer.size() - offset < sizeof(value))
         return false;
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // non-Apple ports
     value = ntohl(*reinterpret_cast_ptr<const uint32_t*>(buffer.span().subspan(offset).data()));
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     offset += sizeof(value);
@@ -61,7 +61,7 @@ static bool readUInt16(SharedBuffer& buffer, size_t& offset, uint16_t& value)
     if (buffer.size() - offset < sizeof(value))
         return false;
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // non-Apple ports
     value = ntohs(*reinterpret_cast_ptr<const uint16_t*>(buffer.span().subspan(offset).data()));
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     offset += sizeof(value);
@@ -72,13 +72,13 @@ static bool readUInt16(SharedBuffer& buffer, size_t& offset, uint16_t& value)
 static bool writeUInt32(Vector<uint8_t>& vector, uint32_t value)
 {
     uint32_t bigEndianValue = htonl(value);
-    return vector.tryAppend(std::span { reinterpret_cast_ptr<uint8_t*>(&bigEndianValue), sizeof(bigEndianValue) });
+    return vector.tryAppend(asByteSpan(bigEndianValue));
 }
 
 static bool writeUInt16(Vector<uint8_t>& vector, uint16_t value)
 {
     uint16_t bigEndianValue = htons(value);
-    return vector.tryAppend(std::span { reinterpret_cast_ptr<uint8_t*>(&bigEndianValue), sizeof(bigEndianValue) });
+    return vector.tryAppend(asByteSpan(bigEndianValue));
 }
 
 static const uint32_t woffSignature = 0x774f4646; /* 'wOFF' */
@@ -109,7 +109,7 @@ public:
     {
         if (!m_vector.tryReserveCapacity(m_vector.size() + n))
             return false;
-        m_vector.append(std::span { static_cast<const uint8_t*>(data), n });
+        m_vector.append(unsafeMakeSpan(static_cast<const uint8_t*>(data), n));
         return true;
     }
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -29,6 +29,7 @@
 #include <gst/video/video-info.h>
 #include <wtf/Logger.h>
 #include <wtf/MediaTime.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
@@ -154,8 +155,8 @@ public:
     bool isValid() const { return m_isValid; }
     uint8_t* data() { RELEASE_ASSERT(m_isValid); return static_cast<uint8_t*>(m_info.data); }
     const uint8_t* data() const { RELEASE_ASSERT(m_isValid); return static_cast<uint8_t*>(m_info.data); }
-    std::span<uint8_t> mutableSpan() { return { data(), size() }; }
-    std::span<const uint8_t> span() const { return { data(), size() }; }
+    std::span<uint8_t> mutableSpan() { return unsafeMakeSpan(data(), size()); }
+    std::span<const uint8_t> span() const { return unsafeMakeSpan(data(), size()); }
     size_t size() const { ASSERT(m_isValid); return m_isValid ? static_cast<size_t>(m_info.size) : 0; }
     MapType* mappedData() const  { ASSERT(m_isValid); return m_isValid ? const_cast<MapType*>(&m_info) : nullptr; }
     Vector<uint8_t> createVector() const;

--- a/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
@@ -131,7 +131,7 @@ void InbandTextTrackPrivateGStreamer::notifyTrackOfSample()
         ASSERT(isMainThread());
         ASSERT(!hasClients() || hasOneClient());
         notifyMainThreadClient([&](auto& client) {
-            downcast<InbandTextTrackPrivateClient>(client).parseWebVTTCueData(std::span { mappedBuffer.data(), mappedBuffer.size() });
+            downcast<InbandTextTrackPrivateClient>(client).parseWebVTTCueData(mappedBuffer.span());
         });
     }
 }

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
@@ -33,6 +33,7 @@
 #include "TrackPrivateBase.h"
 #include <gst/tag/tag.h>
 #include <wtf/text/CString.h>
+#include <wtf/text/StringCommon.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
 GST_DEBUG_CATEGORY_EXTERN(webkit_media_player_debug);
@@ -372,7 +373,7 @@ bool TrackPrivateBaseGStreamer::updateTrackIDFromTags(const GRefPtr<GstTagList>&
     if (!gst_tag_list_get_string(tags.get(), "container-specific-track-id", &trackIDString.outPtr()))
         return false;
 
-    auto trackID = WTF::parseInteger<TrackID>(StringView { std::span { trackIDString.get(), strlen(trackIDString.get()) } });
+    auto trackID = WTF::parseInteger<TrackID>(StringView { span(trackIDString.get()) });
     if (trackID && *trackID != m_trackID.value_or(0)) {
         m_trackID = *trackID;
         ASSERT(m_trackID);

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
@@ -135,7 +135,7 @@ GStreamerVideoDecoder::~GStreamerVideoDecoder()
 Ref<VideoDecoder::DecodePromise> GStreamerVideoDecoder::decode(EncodedFrame&& frame)
 {
     return invokeAsync(gstDecoderWorkQueue(), [value = Vector<uint8_t> { frame.data }, isKeyFrame = frame.isKeyFrame, timestamp = frame.timestamp, duration = frame.duration, decoder = m_internalDecoder] {
-        return decoder->decode({ value.data(), value.size() }, isKeyFrame, timestamp, duration);
+        return decoder->decode(value.span(), isKeyFrame, timestamp, duration);
     });
 }
 

--- a/Source/WebCore/platform/graphics/gtk/ImageAdapterGtk.cpp
+++ b/Source/WebCore/platform/graphics/gtk/ImageAdapterGtk.cpp
@@ -32,6 +32,7 @@
 #include "SharedBuffer.h"
 #include <cairo.h>
 #include <gdk/gdk.h>
+#include <wtf/glib/GSpanExtras.h>
 #include <wtf/glib/GUniquePtr.h>
 
 namespace WebCore {
@@ -42,7 +43,7 @@ static Ref<Image> loadImageFromGResource(const char* iconName)
     GUniquePtr<char> path(g_strdup_printf("/org/webkitgtk/resources/images/%s", iconName));
     GRefPtr<GBytes> data = adoptGRef(g_resources_lookup_data(path.get(), G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
     ASSERT(data);
-    icon->setData(SharedBuffer::create(std::span { static_cast<const uint8_t*>(g_bytes_get_data(data.get(), nullptr)), g_bytes_get_size(data.get()) }), true);
+    icon->setData(SharedBuffer::create(span(data)), true);
     return icon;
 }
 

--- a/Source/WebCore/platform/graphics/skia/SkiaSpanExtras.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaSpanExtras.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Sony Interactive Entertainment Inc.
+ * Copyright (C) 2024 Red Hat Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,37 +25,24 @@
 
 #pragma once
 
-#if USE(SKIA)
-
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-#include <skia/core/SkString.h>
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
-
 #include <wtf/StdLibExtras.h>
 
-namespace WebKit {
+#if USE(SKIA)
 
-class CoreIPCSkString {
-public:
-    CoreIPCSkString(const SkString& string)
-        : m_string(string)
-    {
-    }
+namespace WebCore {
 
-    static SkString create(std::span<const char> span)
-    {
-        return { span.data(), span.size() };
-    }
+inline std::span<const uint8_t> span(SkData* data)
+{
+    return unsafeMakeSpan<const uint8_t>(data->bytes(), data->size());
+}
 
-    std::span<const char> data() const
-    {
-        return unsafeMakeSpan(m_string.data(), m_string.size());
-    }
+inline std::span<const uint8_t> span(const sk_sp<SkData>& data)
+{
+    return span(data.get());
+}
 
-private:
-    const SkString& m_string;
-};
+} // namespace WebCore
 
-} // namespace WebKit
+using WebCore::span;
 
 #endif // USE(SKIA)

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
@@ -37,6 +37,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/OptionSet.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/StringCommon.h>
 #include <wtf/text/StringView.h>
 
 namespace WebCore {
@@ -76,7 +77,7 @@ GStreamerQuirksManager::GStreamerQuirksManager(bool isForTesting, bool loadQuirk
     const char* quirksList = g_getenv("WEBKIT_GST_QUIRKS");
     GST_DEBUG("Attempting to parse requested quirks: %s", GST_STR_NULL(quirksList));
     if (quirksList) {
-        StringView quirks { std::span { quirksList, strlen(quirksList) } };
+        StringView quirks { span(quirksList) };
         if (WTF::equalLettersIgnoringASCIICase(quirks, "help"_s)) {
             WTFLogAlways("Supported quirks for WEBKIT_GST_QUIRKS are: amlogic, broadcom, bcmnexus, realtek, westeros");
             return;
@@ -114,7 +115,7 @@ GStreamerQuirksManager::GStreamerQuirksManager(bool isForTesting, bool loadQuirk
     if (!holePunchQuirk)
         return;
 
-    StringView identifier { std::span { holePunchQuirk, strlen(holePunchQuirk) } };
+    StringView identifier { span(holePunchQuirk) };
     if (WTF::equalLettersIgnoringASCIICase(identifier, "help"_s)) {
         WTFLogAlways("Supported quirks for WEBKIT_GST_HOLE_PUNCH_QUIRK are: fake, westeros, bcmnexus");
         return;

--- a/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
+++ b/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
@@ -1320,7 +1320,7 @@ String PlatformKeyboardEvent::singleCharacterString(unsigned val)
 
         String retVal;
         if (uchar16)
-            retVal = String({ (UChar*)uchar16, static_cast<size_t>(nwc) });
+            retVal = String(unsafeMakeSpan((UChar*)uchar16, static_cast<size_t>(nwc)));
         else
             retVal = String();
 

--- a/Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.cpp
@@ -321,7 +321,7 @@ ICOImageDecoder::ImageType ICOImageDecoder::imageTypeAtIndex(size_t index)
     const uint32_t imageOffset = m_dirEntries[index].m_imageOffset;
     if ((imageOffset > m_data->size()) || ((m_data->size() - imageOffset) < 4))
         return Unknown;
-    return equalSpans(m_data->span().subspan(imageOffset, 4), std::span { "\x89PNG", 4 }) ? PNG : BMP;
+    return equalSpans(m_data->span().subspan(imageOffset, 4), "\x89PNG"_span) ? PNG : BMP;
 }
 
 }

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -490,7 +490,7 @@ void MediaRecorderPrivateBackend::processSample(GRefPtr<GstSample>&& sample)
     Locker locker { m_dataLock };
 
     GST_LOG_OBJECT(m_transcoder.get(), "Queueing %zu bytes of encoded data, caps: %" GST_PTR_FORMAT, buffer.size(), gst_sample_get_caps(sample.get()));
-    m_data.append(std::span<const uint8_t> { buffer.data(), buffer.size() });
+    m_data.append(buffer.span());
 }
 
 void MediaRecorderPrivateBackend::notifyPosition(GstClockTime position)

--- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
+++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
@@ -203,7 +203,7 @@ void NetworkStorageSession::getCredentialFromPersistentStorage(const ProtectionS
             size_t length;
             GRefPtr<SecretValue> secretValue = adoptGRef(secret_item_get_secret(secretItem.get()));
             const char* passwordData = secret_value_get(secretValue.get(), &length);
-            data->completionHandler(Credential(user, String::fromUTF8({ passwordData, length }), CredentialPersistence::Permanent));
+            data->completionHandler(Credential(user, String::fromUTF8(unsafeMakeSpan(passwordData, length)), CredentialPersistence::Permanent));
         }, data.release());
 #else
     UNUSED_PARAM(protectionSpace);

--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -41,6 +41,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/glib/GSpanExtras.h>
 #include <wtf/text/Base64.h>
 #include <wtf/text/CString.h>
 
@@ -88,7 +89,7 @@ private:
             return String();
 
         auto digest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-        digest->addBytes(std::span { certificateData->data, certificateData->len });
+        digest->addBytes(span(certificateData));
 
         return base64EncodeToString(digest->computeHash());
     }

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
@@ -59,6 +59,10 @@
 #include "SystemSettings.h"
 #endif
 
+#if USE(GLIB)
+#include <wtf/glib/GSpanExtras.h>
+#endif
+
 namespace WebCore {
 using namespace WebCore::Adwaita;
 
@@ -231,7 +235,7 @@ String RenderThemeAdwaita::mediaControlsBase64StringForIconNameAndType(const Str
     auto data = adoptGRef(g_resources_lookup_data(path.latin1().data(), G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
     if (!data)
         return emptyString();
-    return base64EncodeToString({ static_cast<const uint8_t*>(g_bytes_get_data(data.get(), nullptr)), g_bytes_get_size(data.get()) });
+    return base64EncodeToString(span(data));
 #elif PLATFORM(WIN)
     auto path = webKitBundlePath(iconName, iconType, "media-controls"_s);
     auto data = FileSystem::readEntireFile(path);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp
@@ -362,7 +362,7 @@ static void resourceDataCallback(API::Data* wkData, GTask* task)
     ResourceGetDataAsyncData* data = static_cast<ResourceGetDataAsyncData*>(g_task_get_task_data(task));
     data->webData = wkData;
     if (!wkData->span().data())
-        data->webData = API::Data::create({ reinterpret_cast<const uint8_t*>(""), 1 });
+        data->webData = API::Data::create(unsafeMakeSpan(reinterpret_cast<const uint8_t*>(""), 1));
     g_task_return_boolean(task, TRUE);
 }
 


### PR DESCRIPTION
#### 769ae115318d950f9c71748e5f381d90176d9874
<pre>
[WPE][GTK] Fix various -Werror=unsafe-buffer-usage-in-container build failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=283684">https://bugs.webkit.org/show_bug.cgi?id=283684</a>

Reviewed by Adrian Perez de Castro.

* Source/WTF/wtf/glib/GSpanExtras.cpp:
(WTF::gFileGetContents):
* Source/WTF/wtf/glib/GSpanExtras.h:
* Source/WebCore/PAL/pal/crypto/gcrypt/CryptoDigestGCrypt.cpp:
(PAL::CryptoDigest::computeHash):
* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::DataSegment::span const):
* Source/WebCore/platform/SharedBufferChunkReader.cpp:
(WebCore::SharedBufferChunkReader::setSeparator):
* Source/WebCore/platform/Skia.cmake:
* Source/WebCore/platform/WebCorePersistentCoders.cpp:
(WTF::Persistence::Coder&lt;GRefPtr&lt;GByteArray&gt;&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;GRefPtr&lt;GByteArray&gt;&gt;::decodeForPersistence):
* Source/WebCore/platform/audio/glib/AudioBusGLib.cpp:
(WebCore::AudioBus::loadPlatformResource):
* Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp:
(WebCore::GStreamerAudioDecoder::decode):
* Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp:
(WebCore::PlatformRawAudioData::copyTo):
* Source/WebCore/platform/glib/KeyedDecoderGlib.cpp:
(WebCore::KeyedDecoderGlib::decodeBytes):
* Source/WebCore/platform/glib/KeyedEncoderGlib.cpp:
(WebCore::KeyedEncoderGlib::finishEncoding):
* Source/WebCore/platform/graphics/WOFFFileFormat.cpp:
(WebCore::readUInt32):
(WebCore::readUInt16):
(WebCore::writeUInt32):
(WebCore::writeUInt16):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::extractGStreamerOptionsFromCommandLine):
(WebCore::GstMappedBuffer::createVector const):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
(WebCore::unmapFunction):
* Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp:
(WebCore::InbandTextTrackPrivateGStreamer::notifyTrackOfSample):
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
(WebCore::TrackPrivateBaseGStreamer::updateTrackIDFromTags):
* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp:
(WebCore::GStreamerVideoDecoder::decode):
* Source/WebCore/platform/graphics/gtk/ImageAdapterGtk.cpp:
(WebCore::loadImageFromGResource):
* Source/WebCore/platform/graphics/skia/SkiaSpanExtras.h: Added.
(WebCore::span):
* Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp:
(WebCore::GStreamerQuirksManager::GStreamerQuirksManager):
* Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp:
(WebCore::PlatformKeyboardEvent::singleCharacterString):
* Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.cpp:
(WebCore::ICOImageDecoder::imageTypeAtIndex):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp:
(WebCore::MediaRecorderPrivateBackend::processSample):
* Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp:
(WebCore::NetworkStorageSession::getCredentialFromPersistentStorage):
* Source/WebCore/platform/network/soup/SoupNetworkSession.cpp:
(WebCore::HostTLSCertificateSet::computeCertificateHash):
* Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp:
(WebCore::RenderThemeAdwaita::mediaControlsBase64StringForIconNameAndType):
* Source/WebKit/Shared/skia/CoreIPCSkString.h:
(WebKit::CoreIPCSkString::data const):
* Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp:
(resourceDataCallback):

Canonical link: <a href="https://commits.webkit.org/287621@main">https://commits.webkit.org/287621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7463e93b87b629f39593d3b4d0ebf1bade672bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80337 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/59343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33818 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/84858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/31319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82448 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68405 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/7644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/84858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/31319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83406 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/52868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/73144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/84858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/50187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27299 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/29778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/73317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/27813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/86292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/79396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/7562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/7644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/86292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/7737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68980 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/86292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/101803 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12421 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/7524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/24809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/7363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/10883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/9169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->