### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/

### DIFF
--- a/Source/WebCore/storage/StorageUtilities.cpp
+++ b/Source/WebCore/storage/StorageUtilities.cpp
@@ -38,8 +38,6 @@
 #include <wtf/RunLoop.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 namespace StorageUtilities {
 
@@ -62,7 +60,7 @@ std::optional<ClientOrigin> readOriginFromFile(const String& filePath)
     if (!originContent)
         return std::nullopt;
 
-    WTF::Persistence::Decoder decoder({ originContent->data(), originContent->size() });
+    WTF::Persistence::Decoder decoder(originContent->span());
     std::optional<ClientOrigin> origin;
     decoder >> origin;
     return origin;
@@ -101,5 +99,3 @@ String encodeSecurityOriginForFileName(FileSystem::Salt salt, const SecurityOrig
 
 } // namespace StorageUtilities
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/svg/SVGPathByteStreamSource.cpp
+++ b/Source/WebCore/svg/SVGPathByteStreamSource.cpp
@@ -23,14 +23,13 @@
 namespace WebCore {
 
 SVGPathByteStreamSource::SVGPathByteStreamSource(const SVGPathByteStream& stream)
-    : m_streamCurrent(stream.begin())
-    , m_streamEnd(stream.end())
+    : m_streamCurrent(stream.bytes().span())
 {
 }
 
 bool SVGPathByteStreamSource::hasMoreData() const
 {
-    return m_streamCurrent < m_streamEnd;
+    return !m_streamCurrent.empty();
 }
 
 SVGPathSegType SVGPathByteStreamSource::nextCommand(SVGPathSegType)

--- a/Source/WebCore/svg/SVGPathByteStreamSource.h
+++ b/Source/WebCore/svg/SVGPathByteStreamSource.h
@@ -22,6 +22,7 @@
 #include "FloatPoint.h"
 #include "SVGPathByteStream.h"
 #include "SVGPathSource.h"
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 
@@ -53,12 +54,8 @@ private:
     {
         DataType data;
         size_t dataSize = sizeof(DataType);
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        ASSERT_WITH_SECURITY_IMPLICATION(m_streamCurrent + dataSize <= m_streamEnd);
-        memcpy(&data, m_streamCurrent, dataSize);
-        m_streamCurrent += dataSize;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        memcpySpan(asMutableByteSpan(data), m_streamCurrent.first(dataSize));
+        m_streamCurrent = m_streamCurrent.subspan(dataSize);
         return data;
     }
 
@@ -83,8 +80,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         return readType<FloatPoint>();
     }
 
-    SVGPathByteStream::DataIterator m_streamCurrent;
-    SVGPathByteStream::DataIterator m_streamEnd;
+    std::span<const uint8_t> m_streamCurrent;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -415,8 +415,6 @@ using JSC::PropertySlot;
 using JSC::ScriptExecutable;
 using JSC::StackVisitor;
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Internals);
@@ -7744,5 +7742,3 @@ void Internals::setTopDocumentURLForQuirks(const String& urlString)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.h
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.h
@@ -28,8 +28,6 @@
 
 #include <wtf/Compiler.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 #include "FetchOptions.h"
 #include "WorkerThreadType.h"
 #include <JavaScriptCore/Debugger.h>
@@ -40,8 +38,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <wtf/MessageQueue.h>
 #include <wtf/NakedPtr.h>
 #include <wtf/TZoneMalloc.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace JSC {
 class AbstractModuleRecord;

--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
@@ -45,8 +45,6 @@
 #include <wtf/persistence/PersistentDecoder.h>
 #include <wtf/text/MakeString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SWRegistrationDatabase);
@@ -476,12 +474,12 @@ std::optional<Vector<ServiceWorkerScripts>> SWRegistrationDatabase::updateRegist
             || statement->bindText(6, StringView { convertUpdateViaCacheToString(data.registration.updateViaCache) }) != SQLITE_OK
             || statement->bindText(7, data.scriptURL.string()) != SQLITE_OK
             || statement->bindText(8, StringView { convertWorkerTypeToString(data.workerType) }) != SQLITE_OK
-            || statement->bindBlob(9, std::span(cspEncoder.buffer(), cspEncoder.bufferSize())) != SQLITE_OK
-            || statement->bindBlob(10, std::span(coepEncoder.buffer(), coepEncoder.bufferSize())) != SQLITE_OK
+            || statement->bindBlob(9, cspEncoder.span()) != SQLITE_OK
+            || statement->bindBlob(10, coepEncoder.span()) != SQLITE_OK
             || statement->bindText(11, data.referrerPolicy) != SQLITE_OK
-            || statement->bindBlob(12, std::span(scriptResourceMapEncoder.buffer(), scriptResourceMapEncoder.bufferSize())) != SQLITE_OK
-            || statement->bindBlob(13, std::span(certificateInfoEncoder.buffer(), certificateInfoEncoder.bufferSize())) != SQLITE_OK
-            || statement->bindBlob(14, std::span(navigationPreloadStateEncoder.buffer(), navigationPreloadStateEncoder.bufferSize())) != SQLITE_OK
+            || statement->bindBlob(12, scriptResourceMapEncoder.span()) != SQLITE_OK
+            || statement->bindBlob(13, certificateInfoEncoder.span()) != SQLITE_OK
+            || statement->bindBlob(14, navigationPreloadStateEncoder.span()) != SQLITE_OK
             || statement->step() != SQLITE_DONE) {
             RELEASE_LOG_ERROR(ServiceWorker, "SWRegistrationDatabase::updateRegistrations failed to insert record (%i) - %s", m_database->lastError(), m_database->lastErrorMsg());
             return std::nullopt;
@@ -519,7 +517,5 @@ void SWRegistrationDatabase::clearAllRegistrations()
     FileSystem::deleteNonEmptyDirectory(scriptDirectoryPath(m_directory));
     FileSystem::deleteEmptyDirectory(m_directory);
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } // namespace WebCore


### PR DESCRIPTION
#### 9e3cb261a443562b88f372e56583416ebe6b60ca
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/
<a href="https://bugs.webkit.org/show_bug.cgi?id=283687">https://bugs.webkit.org/show_bug.cgi?id=283687</a>

Reviewed by Darin Adler.

* Source/WebCore/storage/StorageUtilities.cpp:
(WebCore::StorageUtilities::readOriginFromFile):
* Source/WebCore/svg/SVGPathByteStreamSource.cpp:
(WebCore::SVGPathByteStreamSource::SVGPathByteStreamSource):
(WebCore::SVGPathByteStreamSource::hasMoreData const):
* Source/WebCore/svg/SVGPathByteStreamSource.h:
* Source/WebCore/testing/Internals.cpp:
* Source/WebCore/workers/WorkerOrWorkletScriptController.h:
* Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp:
(WebCore::SWRegistrationDatabase::updateRegistrations):

Canonical link: <a href="https://commits.webkit.org/287081@main">https://commits.webkit.org/287081@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/360129305437442d81f4a35d76bcfad4c1a55aff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82927 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29532 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80399 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5593 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61295 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19211 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68355 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41612 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48640 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24906 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27869 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69732 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25270 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84292 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5633 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3801 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69517 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5792 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68772 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12780 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11049 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12100 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5580 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/8334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5572 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9006 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7358 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->