### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in TextBreakIterator.h

### DIFF
--- a/Source/WTF/wtf/text/TextBreakIterator.h
+++ b/Source/WTF/wtf/text/TextBreakIterator.h
@@ -34,8 +34,6 @@
 #include <wtf/text/NullTextBreakIterator.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 #if PLATFORM(COCOA)
@@ -283,9 +281,9 @@ public:
             return result;
         }
 
-        const UChar* characters() const
+        std::span<const UChar> characters() const
         {
-            return m_priorContext.data() + (m_priorContext.size() - length());
+            return std::span<const UChar>(m_priorContext).last(length());
         }
 
         friend bool operator==(const PriorContext&, const PriorContext&) = default;
@@ -310,11 +308,11 @@ public:
 
     CachedTextBreakIterator& get()
     {
-        const UChar* priorContext = m_priorContext.characters();
+        auto priorContext = m_priorContext.characters();
         if (!m_iterator) {
-            m_iterator = CachedTextBreakIterator(m_stringView, std::span { priorContext, m_priorContext.length() }, WTF::TextBreakIterator::LineMode { m_mode }, m_locale, m_contentAnalysis);
-            m_cachedPriorContext = priorContext;
-        } else if (priorContext != m_cachedPriorContext) {
+            m_iterator = CachedTextBreakIterator(m_stringView, priorContext, WTF::TextBreakIterator::LineMode { m_mode }, m_locale, m_contentAnalysis);
+            m_cachedPriorContext = priorContext.data();
+        } else if (priorContext.data() != m_cachedPriorContext) {
             resetStringAndReleaseIterator(m_stringView, m_locale, m_mode, m_contentAnalysis);
             return get();
         }
@@ -389,5 +387,3 @@ using WTF::NonSharedCharacterBreakIterator;
 using WTF::TextBreakIterator;
 using WTF::TextBreakIteratorCache;
 using WTF::isWordTextBreak;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### ffe5aefb3543de35152ca97abf5c3893b27ff4ac
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in TextBreakIterator.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=283689">https://bugs.webkit.org/show_bug.cgi?id=283689</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/text/TextBreakIterator.h:
(WTF::CachedLineBreakIteratorFactory::PriorContext::characters const):
(WTF::CachedLineBreakIteratorFactory::get):

Canonical link: <a href="https://commits.webkit.org/287083@main">https://commits.webkit.org/287083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4035d916c15711cf7519acaa4aab249bb9e2c778

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82943 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29548 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5609 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61308 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19228 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68451 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41624 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48656 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24940 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27885 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71429 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69747 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84308 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77521 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5649 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3815 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69531 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5808 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67242 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68787 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12797 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11081 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/99829 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12101 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5596 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21803 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5588 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9022 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7374 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->