### PR TITLE
Add script telemetry check when addEventListener is being called

### DIFF
--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -39,6 +39,8 @@
 #include "EventTargetConcrete.h"
 #include "HTMLBodyElement.h"
 #include "HTMLHtmlElement.h"
+#include "HTMLSelectElement.h"
+#include "HTMLTextAreaElement.h"
 #include "InspectorInstrumentation.h"
 #include "JSErrorHandler.h"
 #include "JSEventListener.h"
@@ -87,6 +89,18 @@ bool EventTarget::addEventListener(const AtomString& eventType, Ref<EventListene
 #if ASSERT_ENABLED
     listener->checkValidityForEventTarget(*this);
 #endif
+
+    if (RefPtr context = this->scriptExecutionContext()) {
+        if (context->requiresScriptExecutionTelemetry(ScriptTelemetryCategory::EventListeners)) {
+            if (eventType == eventNames().keydownEvent
+                || eventType == eventNames().keyupEvent
+                || eventType == eventNames().keypressEvent
+                || eventType == eventNames().inputEvent
+                || eventType == eventNames().beforeinputEvent) {
+                return false;
+            }
+        }
+    }
 
     if (options.signal && options.signal->aborted())
         return false;

--- a/Source/WebCore/page/ScriptTelemetryCategory.cpp
+++ b/Source/WebCore/page/ScriptTelemetryCategory.cpp
@@ -69,6 +69,8 @@ ASCIILiteral description(ScriptTelemetryCategory category)
         return "Speech"_s;
     case ScriptTelemetryCategory::FormControls:
         return "FormControls"_s;
+    case ScriptTelemetryCategory::EventListeners:
+        return "EventListeners"_s;
     }
     ASSERT_NOT_REACHED();
     return { };

--- a/Source/WebCore/page/ScriptTelemetryCategory.h
+++ b/Source/WebCore/page/ScriptTelemetryCategory.h
@@ -47,6 +47,7 @@ enum class ScriptTelemetryCategory : uint8_t {
     ScreenOrViewport,
     Speech,
     FormControls,
+    EventListeners
 };
 
 String makeLogMessage(const URL&, ScriptTelemetryCategory);


### PR DESCRIPTION
#### 7b11903fc7a25755624ec9a2eb474dfb6c721176
<pre>
Add script telemetry check when addEventListener is being called
<a href="https://bugs.webkit.org/show_bug.cgi?id=283690">https://bugs.webkit.org/show_bug.cgi?id=283690</a>
<a href="https://rdar.apple.com/140562703">rdar://140562703</a>

Reviewed by NOBODY (OOPS!).

Add script telemetry check when EventTarget::addEventListener is being called on certain eventTypes (keydown, keypress, keyup, input, beforeInput)

* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::addEventListener):
* Source/WebCore/page/ScriptTelemetryCategory.cpp:
(WebCore::description):
* Source/WebCore/page/ScriptTelemetryCategory.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b11903fc7a25755624ec9a2eb474dfb6c721176

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86125 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32585 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83701 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8935 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63661 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21395 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/811 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43950 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/710 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28429 "Failed to checkout and rebase branch from PR 37142") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31038 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72142 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29023 "Failed to checkout and rebase branch from PR 37142") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87563 "Failed to checkout and rebase branch from PR 37142") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8824 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6259 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/87563 "Failed to checkout and rebase branch from PR 37142") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9009 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70077 "Failed to checkout and rebase branch from PR 37142") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/87563 "Failed to checkout and rebase branch from PR 37142") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15298 "Failed to checkout and rebase branch from PR 37142") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14214 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8784 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14312 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8624 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12145 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->