### PR TITLE
Make PseudoElement inherit from ContainerNode instead of Element

### DIFF
--- a/Source/WebCore/dom/PseudoElement.h
+++ b/Source/WebCore/dom/PseudoElement.h
@@ -31,17 +31,27 @@
 
 namespace WebCore {
 
-class PseudoElement final : public Element {
+const String& pseudoElementNodeName();
+
+class PseudoElement final : public ContainerNode {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(PseudoElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PseudoElement);
 public:
     static Ref<PseudoElement> create(Element& host, PseudoId);
     virtual ~PseudoElement();
 
+    String nodeName() const override { return pseudoElementNodeName(); }
+
+    Ref<Node> cloneNodeInternal(Document&, CloningOperation) override;
+
     Element* hostElement() const { return m_hostElement.get(); }
     void clearHostElement();
 
-    bool rendererIsNeeded(const RenderStyle&) override;
+    bool rendererIsNeeded(const RenderStyle&);
+
+    const RenderStyle* renderOrDisplayContentsStyle() { return m_displayContentsOrNoneStyle.get(); };
+    void storeDisplayContentsOrNoneStyle(std::unique_ptr<RenderStyle>);
+    void clearDisplayContentsOrNoneStyle();
 
     bool canStartSelection() const override { return false; }
     bool canContainRangeEndPoint() const override { return false; }
@@ -53,9 +63,8 @@ private:
 
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_hostElement;
     PseudoId m_pseudoId;
+    std::unique_ptr<RenderStyle> m_displayContentsOrNoneStyle;
 };
-
-const QualifiedName& pseudoElementTagName();
 
 } // namespace WebCore
 

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -464,35 +464,9 @@ static String computeHasChildSelector(Element& element)
 }
 
 // Returns multiple CSS selectors that uniquely match the target element.
-static Vector<Vector<String>> selectorsForTarget(Element& element, ElementSelectorCache& cache)
+static Vector<Vector<String>> selectorsForTarget(Node& element, ElementSelectorCache& cache)
 {
-    if (RefPtr pseudoElement = dynamicDowncast<PseudoElement>(element)) {
-        RefPtr host = pseudoElement->hostElement();
-        if (!host)
-            return { };
-
-        auto pseudoSelector = [&]() -> String {
-            if (element.isBeforePseudoElement())
-                return "::before"_s;
-
-            if (element.isAfterPseudoElement())
-                return "::after"_s;
-
-            return { };
-        }();
-
-        if (pseudoSelector.isEmpty())
-            return { };
-
-        auto selectors = selectorsForTarget(*host, cache);
-        if (selectors.isEmpty())
-            return { };
-
-        for (auto& selector : selectors.last())
-            selector = makeString(selector, pseudoSelector);
-
-        return selectors;
-    }
+    // FIXME: Support pseudo-elements.
 
     Vector<Vector<String>> selectorsIncludingShadowHost;
     if (RefPtr shadowHost = element.shadowHost()) {

--- a/Source/WebCore/rendering/RenderCounter.cpp
+++ b/Source/WebCore/rendering/RenderCounter.cpp
@@ -61,8 +61,7 @@ static CounterMaps& counterMaps()
 
 static Element* ancestorStyleContainmentObject(const Element& element)
 {
-    auto* pseudoElement = dynamicDowncast<PseudoElement>(element);
-    Element* ancestor = pseudoElement ? pseudoElement->hostElement() : element.parentElement();
+    auto* ancestor = element.parentElement();
     while (ancestor) {
         if (auto* style = ancestor->existingComputedStyle()) {
             if (style->containsStyle())
@@ -119,14 +118,6 @@ static Element* previousSiblingOrParentElement(const Element& element)
             return previous;
     }
 
-    if (auto* pseudoElement = dynamicDowncast<PseudoElement>(element)) {
-        auto* hostElement = pseudoElement->hostElement();
-        ASSERT(hostElement);
-        if (hostElement->renderer())
-            return hostElement;
-        return previousSiblingOrParentElement(*hostElement);
-    }
-    
     auto* parent = element.parentElement();
     if (parent && !parent->renderer())
         parent = previousSiblingOrParentElement(*parent);

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -97,8 +97,7 @@ bool isHTMLListElement(const Node& node)
 static Element* enclosingList(const RenderListItem& listItem)
 {
     auto& element = listItem.element();
-    auto* pseudoElement = dynamicDowncast<PseudoElement>(element);
-    auto* parent = pseudoElement ? pseudoElement->hostElement() : element.parentElement();
+    auto* parent = element.parentElement();
     for (auto* ancestor = parent; ancestor; ancestor = ancestor->parentElement()) {
         if (isHTMLListElement(*ancestor) || (ancestor->renderer() && ancestor->renderer()->shouldApplyStyleContainment()))
             return ancestor;

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.h
@@ -60,7 +60,7 @@ private:
     void updateRenderTree(ContainerNode& root);
     void updateTextRenderer(Text&, const Style::TextUpdate*, const ContainerNode* root = nullptr);
     void createTextRenderer(Text&, const Style::TextUpdate*);
-    void updateElementRenderer(Element&, const Style::ElementUpdate&);
+    void updateElementRenderer(std::variant<PseudoElement, Element>&, const Style::ElementUpdate&);
     void updateSVGRenderer(Element&);
     void updateRendererStyle(RenderElement&, RenderStyle&&, StyleDifference);
     void updateRenderViewStyle();
@@ -95,8 +95,8 @@ private:
 
     // FIXME: Use OptionSet.
     enum class TeardownType { Full, FullAfterSlotOrShadowRootChange, RendererUpdate, RendererUpdateCancelingAnimations };
-    static void tearDownRenderers(Element&, TeardownType);
-    static void tearDownRenderers(Element&, TeardownType, RenderTreeBuilder&);
+    static void tearDownRenderers(std::variant<PseudoElement, Element>&, TeardownType);
+    static void tearDownRenderers(std::variant<PseudoElement, Element>&, TeardownType, RenderTreeBuilder&);
     enum class NeedsRepaintAndLayout : bool { No, Yes };
     static void tearDownTextRenderer(Text&, const ContainerNode* root, RenderTreeBuilder&, NeedsRepaintAndLayout = NeedsRepaintAndLayout::Yes);
     static void tearDownLeftoverChildrenOfComposedTree(Element&, RenderTreeBuilder&);

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -97,9 +97,6 @@ static KeyframeEffectStack* keyframeEffectStackForElementAndPseudoId(const Eleme
 
 static bool elementIsTargetedByKeyframeEffectRequiringPseudoElement(const Element* element, PseudoId pseudoId)
 {
-    if (auto* pseudoElement = dynamicDowncast<PseudoElement>(element))
-        return elementIsTargetedByKeyframeEffectRequiringPseudoElement(pseudoElement->hostElement(), pseudoId);
-
     if (element) {
         if (auto* stack = keyframeEffectStackForElementAndPseudoId(*element, pseudoId))
             return stack->requiresPseudoElement();

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -939,10 +939,6 @@ bool Scope::updateQueryContainerState(QueryContainerUpdateContext& context)
     for (auto& containerRenderer : m_document->renderView()->containerQueryBoxes()) {
         CheckedPtr containerElement = containerRenderer.element();
 
-        // Invalidation uses real elements, replace ::before/::after with its host.
-        if (auto* pseudoElement = dynamicDowncast<PseudoElement>(containerElement.get()))
-            containerElement = pseudoElement->hostElement();
-
         if (!containerElement)
             continue;
 

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -56,8 +56,6 @@ struct Styleable {
 
     static const Styleable fromElement(Element& element)
     {
-        if (auto* pseudoElement = dynamicDowncast<PseudoElement>(element))
-            return Styleable(*pseudoElement->hostElement(), Style::PseudoElementIdentifier { element.pseudoId() });
         ASSERT(element.pseudoId() == PseudoId::None);
         return Styleable(element, std::nullopt);
     }


### PR DESCRIPTION
#### bcd9faa6bbc4a1968c83daf22b2be6b296fc6a0e
<pre>
Make PseudoElement inherit from ContainerNode instead of Element
<a href="https://bugs.webkit.org/show_bug.cgi?id=283691">https://bugs.webkit.org/show_bug.cgi?id=283691</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Draft, does not build.

* Source/WebCore/dom/PseudoElement.cpp:
(WebCore::pseudoElementNodeName):
(WebCore::PseudoElement::PseudoElement):
(WebCore::PseudoElement::storeDisplayContentsOrNoneStyle):
(WebCore::PseudoElement::clearDisplayContentsOrNoneStyle):
(WebCore::PseudoElement::cloneNodeInternal):
(WebCore::pseudoElementTagName): Deleted.
* Source/WebCore/dom/PseudoElement.h:
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::selectorsForTarget):
* Source/WebCore/rendering/RenderCounter.cpp:
(WebCore::ancestorStyleContainmentObject):
(WebCore::previousSiblingOrParentElement):
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::enclosingList):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateElementRenderer):
(WebCore::RenderTreeUpdater::tearDownRenderers):
* Source/WebCore/rendering/updating/RenderTreeUpdater.h:
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::elementIsTargetedByKeyframeEffectRequiringPseudoElement):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::updateQueryContainerState):
* Source/WebCore/style/Styleable.h:
(WebCore::Styleable::fromElement):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcd9faa6bbc4a1968c83daf22b2be6b296fc6a0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78283 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/57329 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/31665 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/82944 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/29549 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/80416 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/66480 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/5610 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/82944 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/29549 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/81350 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/66480 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/31665 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/82944 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/66480 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/31665 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/27886 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/66480 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/31665 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/84309 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/5650 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/5610 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/84309 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/5809 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/31665 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/84309 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/31665 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/5597 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/8345 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/5589 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/9023 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/7375 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->