### PR TITLE
Make remaining MessageReceivers ref-counted in WebKit/Network

### DIFF
--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
@@ -60,6 +60,16 @@ WebCookieManager::WebCookieManager(NetworkProcess& process)
 
 WebCookieManager::~WebCookieManager() = default;
 
+void WebCookieManager::ref() const
+{
+    m_process->ref();
+}
+
+void WebCookieManager::deref() const
+{
+    m_process->deref();
+}
+
 Ref<NetworkProcess> WebCookieManager::protectedProcess()
 {
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
@@ -57,6 +57,9 @@ public:
     WebCookieManager(NetworkProcess&);
     ~WebCookieManager();
 
+    void ref() const;
+    void deref() const;
+
     static ASCIILiteral supplementName();
 
     void setHTTPCookieAcceptPolicy(PAL::SessionID, WebCore::HTTPCookieAcceptPolicy, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
  
-messages -> WebCookieManager NotRefCounted {
+messages -> WebCookieManager {
     void GetHostnamesWithCookies(PAL::SessionID sessionID) -> (Vector<String> hostnames)
     void DeleteCookiesForHostnames(PAL::SessionID sessionID, Vector<String> hostnames) -> ()
     void DeleteAllCookies(PAL::SessionID sessionID) -> ()

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
@@ -50,6 +50,16 @@ LegacyCustomProtocolManager::LegacyCustomProtocolManager(NetworkProcess& network
     m_networkProcess->addMessageReceiver(Messages::LegacyCustomProtocolManager::messageReceiverName(), *this);
 }
 
+void LegacyCustomProtocolManager::ref() const
+{
+    m_networkProcess->ref();
+}
+
+void LegacyCustomProtocolManager::deref() const
+{
+    m_networkProcess->deref();
+}
+
 Ref<NetworkProcess> LegacyCustomProtocolManager::protectedNetworkProcess() const
 {
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
@@ -66,6 +66,9 @@ public:
     void unregisterScheme(const String&);
     bool supportsScheme(const String&);
 
+    void ref() const;
+    void deref() const;
+
 #if PLATFORM(COCOA)
     typedef RetainPtr<WKCustomProtocol> CustomProtocol;
 #endif

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.messages.in
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> LegacyCustomProtocolManager NotRefCounted {
+messages -> LegacyCustomProtocolManager {
     DidFailWithError(WebKit::LegacyCustomProtocolID customProtocolID, WebCore::ResourceError error)
     DidLoadData(WebKit::LegacyCustomProtocolID customProtocolID, std::span<const uint8_t> data)
     DidReceiveResponse(WebKit::LegacyCustomProtocolID customProtocolID, WebCore::ResourceResponse response, enum:uint8_t WebKit::CacheStoragePolicy cacheStoragePolicy)

--- a/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp
@@ -46,10 +46,17 @@ static bool isValidClientOrigin(const WebCore::ClientOrigin& clientOrigin)
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkBroadcastChannelRegistry);
 
+Ref<NetworkBroadcastChannelRegistry> NetworkBroadcastChannelRegistry::create(NetworkProcess& networkProcess)
+{
+    return adoptRef(*new NetworkBroadcastChannelRegistry(networkProcess));
+}
+
 NetworkBroadcastChannelRegistry::NetworkBroadcastChannelRegistry(NetworkProcess& networkProcess)
     : m_networkProcess(networkProcess)
 {
 }
+
+NetworkBroadcastChannelRegistry::~NetworkBroadcastChannelRegistry() = default;
 
 void NetworkBroadcastChannelRegistry::registerChannel(IPC::Connection& connection, const WebCore::ClientOrigin& origin, const String& name)
 {

--- a/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.h
+++ b/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.h
@@ -29,6 +29,7 @@
 #include <WebCore/BroadcastChannelIdentifier.h>
 #include <WebCore/ClientOrigin.h>
 #include <wtf/HashMap.h>
+#include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -39,10 +40,11 @@ namespace WebKit {
 
 class NetworkProcess;
 
-class NetworkBroadcastChannelRegistry {
+class NetworkBroadcastChannelRegistry : public RefCounted<NetworkBroadcastChannelRegistry> {
     WTF_MAKE_TZONE_ALLOCATED(NetworkBroadcastChannelRegistry);
 public:
-    explicit NetworkBroadcastChannelRegistry(NetworkProcess&);
+    static Ref<NetworkBroadcastChannelRegistry> create(NetworkProcess&);
+    ~NetworkBroadcastChannelRegistry();
 
     void removeConnection(IPC::Connection&);
 
@@ -53,6 +55,8 @@ public:
     void postMessage(IPC::Connection&, const WebCore::ClientOrigin&, const String& name, WebCore::MessageWithMessagePorts&&, CompletionHandler<void()>&&);
 
 private:
+    explicit NetworkBroadcastChannelRegistry(NetworkProcess&);
+
     Ref<NetworkProcess> m_networkProcess;
     using NameToConnectionIdentifiersMap = HashMap<String, Vector<IPC::Connection::UniqueID>>;
     HashMap<WebCore::ClientOrigin, NameToConnectionIdentifiersMap> m_broadcastChannels;

--- a/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.messages.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> NetworkBroadcastChannelRegistry NotRefCounted {
+messages -> NetworkBroadcastChannelRegistry {
     RegisterChannel(struct WebCore::ClientOrigin origin, String name)
     UnregisterChannel(struct WebCore::ClientOrigin origin, String name)
     PostMessage(struct WebCore::ClientOrigin origin, String name, struct WebCore::MessageWithMessagePorts message) -> ()

--- a/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.cpp
@@ -53,6 +53,16 @@ NetworkContentRuleListManager::~NetworkContentRuleListManager()
     }
 }
 
+void NetworkContentRuleListManager::ref() const
+{
+    m_networkProcess->ref();
+}
+
+void NetworkContentRuleListManager::deref() const
+{
+    m_networkProcess->deref();
+}
+
 Ref<NetworkProcess> NetworkContentRuleListManager::protectedNetworkProcess() const
 {
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.h
+++ b/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.h
@@ -51,6 +51,9 @@ public:
     using BackendCallback = CompletionHandler<void(WebCore::ContentExtensions::ContentExtensionsBackend&)>;
     void contentExtensionsBackend(UserContentControllerIdentifier, BackendCallback&&);
 
+    void ref() const;
+    void deref() const;
+
 private:
     void addContentRuleLists(UserContentControllerIdentifier, Vector<std::pair<WebCompiledContentRuleListData, URL>>&&);
     void removeContentRuleList(UserContentControllerIdentifier, const String& name);

--- a/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(CONTENT_EXTENSIONS)
 
-messages -> NetworkContentRuleListManager NotRefCounted {
+messages -> NetworkContentRuleListManager {
     Remove(WebKit::UserContentControllerIdentifier identifier)
     AddContentRuleLists(WebKit::UserContentControllerIdentifier identifier, Vector<std::pair<WebKit::WebCompiledContentRuleListData, URL>> contentFilters)
     RemoveContentRuleList(WebKit::UserContentControllerIdentifier identifier, String name)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -165,9 +165,9 @@ NetworkProcess::NetworkProcess(AuxiliaryProcessInitializationParameters&& parame
     NetworkProcessPlatformStrategies::initialize();
 
     addSupplementWithoutRefCountedCheck<AuthenticationManager>();
-    addSupplement<WebCookieManager>();
+    addSupplementWithoutRefCountedCheck<WebCookieManager>();
 #if ENABLE(LEGACY_CUSTOM_PROTOCOL_MANAGER)
-    addSupplement<LegacyCustomProtocolManager>();
+    addSupplementWithoutRefCountedCheck<LegacyCustomProtocolManager>();
 #endif
 #if HAVE(LSDATABASECONTEXT)
     addSupplement<LaunchServicesDatabaseObserver>();

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -158,7 +158,7 @@ NetworkSession::NetworkSession(NetworkProcess& networkProcess, const NetworkSess
     , m_persistedDomains(parameters.resourceLoadStatisticsParameters.persistedDomains)
     , m_privateClickMeasurement(managerOrProxy(*this, networkProcess, parameters))
     , m_privateClickMeasurementDebugModeEnabled(parameters.enablePrivateClickMeasurementDebugMode)
-    , m_broadcastChannelRegistry(makeUniqueRef<NetworkBroadcastChannelRegistry>(networkProcess))
+    , m_broadcastChannelRegistry(NetworkBroadcastChannelRegistry::create(networkProcess))
     , m_testSpeedMultiplier(parameters.testSpeedMultiplier)
     , m_allowsServerPreconnect(parameters.allowsServerPreconnect)
     , m_shouldRunServiceWorkersOnMainThreadForTesting(parameters.shouldRunServiceWorkersOnMainThreadForTesting)

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -345,7 +345,7 @@ protected:
     RefPtr<NetworkCache::Cache> m_cache;
     RefPtr<NetworkLoadScheduler> m_networkLoadScheduler;
     WebCore::BlobRegistryImpl m_blobRegistry;
-    UniqueRef<NetworkBroadcastChannelRegistry> m_broadcastChannelRegistry;
+    Ref<NetworkBroadcastChannelRegistry> m_broadcastChannelRegistry;
     unsigned m_testSpeedMultiplier { 1 };
     bool m_allowsServerPreconnect { true };
     bool m_shouldRunServiceWorkersOnMainThreadForTesting { false };


### PR DESCRIPTION
#### 2e9c89771e4c8d425edaf63f79d4a7a07783201c
<pre>
Make remaining MessageReceivers ref-counted in WebKit/Network
<a href="https://bugs.webkit.org/show_bug.cgi?id=283699">https://bugs.webkit.org/show_bug.cgi?id=283699</a>

Reviewed by Darin Adler.

* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp:
(WebKit::WebCookieManager::ref const):
(WebKit::WebCookieManager::deref const):
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h:
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in:
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp:
(WebKit::LegacyCustomProtocolManager::ref const):
(WebKit::LegacyCustomProtocolManager::deref const):
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h:
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.messages.in:
* Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp:
(WebKit::NetworkBroadcastChannelRegistry::create):
* Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.h:
* Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.messages.in:
* Source/WebKit/NetworkProcess/NetworkContentRuleListManager.cpp:
(WebKit::NetworkContentRuleListManager::ref const):
(WebKit::NetworkContentRuleListManager::deref const):
* Source/WebKit/NetworkProcess/NetworkContentRuleListManager.h:
* Source/WebKit/NetworkProcess/NetworkContentRuleListManager.messages.in:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::NetworkSession):
* Source/WebKit/NetworkProcess/NetworkSession.h:

Canonical link: <a href="https://commits.webkit.org/287103@main">https://commits.webkit.org/287103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1829d7f06edca201d59d5e93ab0c2b8e56f8f67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82947 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29552 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61310 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19232 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51312 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41626 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48659 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27889 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69751 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84312 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69535 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5812 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67246 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68791 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12800 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11086 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12110 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5600 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8394 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5592 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9026 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7378 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->