### PR TITLE
[JSC] Set `JSValue` instead of `JSObject` as `JSWrapForValidIterator` internal fields

### DIFF
--- a/Source/JavaScriptCore/runtime/JSWrapForValidIterator.h
+++ b/Source/JavaScriptCore/runtime/JSWrapForValidIterator.h
@@ -64,12 +64,13 @@ public:
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     static JSWrapForValidIterator* createWithInitialValues(VM&, Structure*);
+    static JSWrapForValidIterator* create(VM&, Structure*, JSValue iterator, JSValue nextMethod);
 
     JSObject* iteratedIterator() const { return jsCast<JSObject*>(internalField(Field::IteratedIterator).get()); }
     JSObject* iteratedNextMethod() const { return jsCast<JSObject*>(internalField(Field::IteratedNextMethod).get()); }
 
-    void setIteratedIterator(VM& vm, JSObject* iterator) { internalField(Field::IteratedIterator).set(vm, this, iterator); }
-    void setIteratedNextMethod(VM& vm, JSObject* nextMethod) { internalField(Field::IteratedNextMethod).set(vm, this, nextMethod); }
+    void setIteratedIterator(VM& vm, JSValue iterator) { internalField(Field::IteratedIterator).set(vm, this, iterator); }
+    void setIteratedNextMethod(VM& vm, JSValue nextMethod) { internalField(Field::IteratedNextMethod).set(vm, this, nextMethod); }
 
 private:
     JSWrapForValidIterator(VM& vm, Structure* structure)
@@ -77,7 +78,7 @@ private:
     {
     }
 
-    void finishCreation(VM&);
+    void finishCreation(VM&, JSValue iterator, JSValue nextMethod);
     DECLARE_VISIT_CHILDREN;
 };
 


### PR DESCRIPTION
#### 6390d9eba9d9f1864ff00ce9ac37619993d65899
<pre>
[JSC] Set `JSValue` instead of `JSObject` as `JSWrapForValidIterator` internal fields
<a href="https://bugs.webkit.org/show_bug.cgi?id=283700">https://bugs.webkit.org/show_bug.cgi?id=283700</a>

Reviewed by Yusuke Suzuki.

This patch changes to set `JSValue` instead of `JSObject` as
`JSWrapForValidIterator` internal fields.

* Source/JavaScriptCore/runtime/JSWrapForValidIterator.cpp:
(JSC::JSWrapForValidIterator::createWithInitialValues):
(JSC::JSWrapForValidIterator::create):
(JSC::JSWrapForValidIterator::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSWrapForValidIterator.h:

Canonical link: <a href="https://commits.webkit.org/287108@main">https://commits.webkit.org/287108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcd64b0d9627e30f4ddb1a4e786ad805e4bd9e39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82949 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29554 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5615 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61313 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19233 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51314 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68525 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41629 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48661 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24958 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27891 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71435 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69753 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25322 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84314 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77527 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5655 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69536 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5814 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68792 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17163 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12802 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11095 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/99835 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5602 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21806 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5594 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9028 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7380 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->