### PR TITLE
css/css-backgrounds/background-size-001.html is wrong

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-332-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-332-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Computed value for background-image after setting background shorthand
 PASS background_specified_position
-FAIL background_specified_size assert_equals: background specified value for background-size expected "160px" but got "160px auto"
+PASS background_specified_size
 PASS background_specified_repeat
 PASS background_specified_attachment
 PASS background_specified_origin

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-332.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-332.html
@@ -32,7 +32,7 @@
 
         test(function() {
             assert_equals(cs.getPropertyValue("background-size"),
-                "160px", "background specified value for background-size");
+                "160px auto", "background specified value for background-size");
         }, "background_specified_size");
 
         test(function() {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-001-expected.txt
@@ -3,20 +3,20 @@ PASS background-size_initial
 PASS background-size_auto
 PASS background-size_cover
 PASS background-size_contain
-FAIL background-size_length_zero assert_equals: background-size supporting value expected "0px" but got "0px auto"
-FAIL background-size_length_negative_zero assert_equals: background-size supporting value expected "0px" but got "0px auto"
-FAIL background-size_length_positive_zero assert_equals: background-size supporting value expected "0px" but got "0px auto"
-FAIL background-size_length_normal assert_equals: background-size supporting value expected "15px" but got "15px auto"
-FAIL background-size_percentage_min assert_equals: background-size supporting value expected "0%" but got "0% auto"
-FAIL background-size_percentage_normal assert_equals: background-size supporting value expected "50%" but got "50% auto"
-FAIL background-size_percentage_max assert_equals: background-size supporting value expected "100%" but got "100% auto"
+PASS background-size_length_zero
+PASS background-size_length_negative_zero
+PASS background-size_length_positive_zero
+PASS background-size_length_normal
+PASS background-size_percentage_min
+PASS background-size_percentage_normal
+PASS background-size_percentage_max
 PASS background-size_auto_auto
 PASS background-size_auto_length
 PASS background-size_auto_percentage
-FAIL background-size_length_auto assert_equals: background-size supporting value expected "15px" but got "15px auto"
+PASS background-size_length_auto
 PASS background-size_length_length
 PASS background-size_length_percentage
-FAIL background-size_percentage_auto assert_equals: background-size supporting value expected "50%" but got "50% auto"
+PASS background-size_percentage_auto
 PASS background-size_percentage_length
 PASS background-size_percentage_percentage
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-001.html
@@ -39,43 +39,43 @@
         document.getElementById("test").style.backgroundSize = "0px";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "0px", "background-size supporting value");
+                "0px auto", "background-size supporting value");
         }, "background-size_length_zero");
 
         document.getElementById("test").style.backgroundSize = "-0px";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "0px", "background-size supporting value");
+                "0px auto", "background-size supporting value");
         }, "background-size_length_negative_zero");
 
         document.getElementById("test").style.backgroundSize = "+0px";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "0px", "background-size supporting value");
+                "0px auto", "background-size supporting value");
         }, "background-size_length_positive_zero");
 
         document.getElementById("test").style.backgroundSize = "15px";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "15px", "background-size supporting value");
+                "15px auto", "background-size supporting value");
         }, "background-size_length_normal");
 
         document.getElementById("test").style.backgroundSize = "0%";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "0%", "background-size supporting value");
+                "0% auto", "background-size supporting value");
         }, "background-size_percentage_min");
 
         document.getElementById("test").style.backgroundSize = "50%";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "50%", "background-size supporting value");
+                "50% auto", "background-size supporting value");
         }, "background-size_percentage_normal");
 
         document.getElementById("test").style.backgroundSize = "100%";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "100%", "background-size supporting value");
+                "100% auto", "background-size supporting value");
         }, "background-size_percentage_max");
 
         document.getElementById("test").style.backgroundSize = "auto auto";
@@ -99,7 +99,7 @@
         document.getElementById("test").style.backgroundSize = "15px auto";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "15px", "background-size supporting value");
+                "15px auto", "background-size supporting value");
         }, "background-size_length_auto");
 
         document.getElementById("test").style.backgroundSize = "15px 15px";
@@ -117,7 +117,7 @@
         document.getElementById("test").style.backgroundSize = "50% auto";
         test(function() {
             assert_equals(getComputedStyle(document.getElementById("test"), null).getPropertyValue("background-size"),
-                "50%", "background-size supporting value");
+                "50% auto", "background-size supporting value");
         }, "background-size_percentage_auto");
 
         document.getElementById("test").style.backgroundSize = "50% 15px";


### PR DESCRIPTION
#### 3d86280341992fc49475f4a9b7aca7f9c1edad01
<pre>
css/css-backgrounds/background-size-001.html is wrong
<a href="https://bugs.webkit.org/show_bug.cgi?id=254820">https://bugs.webkit.org/show_bug.cgi?id=254820</a>
<a href="https://rdar.apple.com/107475107">rdar://107475107</a>

Reviewed by Tim Nguyen.

This is fixing some WPT tests related to background-size results
being serialized as two values, which is the new behavior of WebKit.
Some tests currently contradict themselves on WPT.
<a href="http://wpt.live/css/css-backgrounds/background-size-001.html">http://wpt.live/css/css-backgrounds/background-size-001.html</a>
<a href="https://wpt.live/css/css-backgrounds/parsing/background-size-computed.html">https://wpt.live/css/css-backgrounds/parsing/background-size-computed.html</a>

So this PR makes it uniform and changes the expectation files.

This is dependent on a resolution from the CSS WG about the two values system.
<a href="https://github.com/w3c/csswg-drafts/issues/7802">https://github.com/w3c/csswg-drafts/issues/7802</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-332-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-332.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-001.html:

Canonical link: <a href="https://commits.webkit.org/287112@main">https://commits.webkit.org/287112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb421635e124dee706ba3bd431ee548afa17ceca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82950 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29555 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61314 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19234 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81356 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68542 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41630 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48662 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24962 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27892 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69754 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84315 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5656 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3822 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69537 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5815 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68793 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12803 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11100 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12112 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5603 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5595 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9029 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7381 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->