### PR TITLE
Adopt hasClassName() a bit more in ImageOverlay

### DIFF
--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -304,18 +304,17 @@ static Elements updateSubtree(HTMLElement& element, const TextRecognitionResult&
             if (!childElement->hasClass())
                 continue;
 
-            auto& classes = childElement->classList();
-            if (classes.contains(imageOverlayDataDetectorClass())) {
+            if (childElement->hasClassName(imageOverlayDataDetectorClass())) {
                 elements.dataDetectors.append(childElement.get());
                 continue;
             }
 
-            if (classes.contains(imageOverlayBlockClass())) {
+            if (childElement->hasClassName(imageOverlayBlockClass())) {
                 elements.blocks.append(childElement.get());
                 continue;
             }
 
-            ASSERT(classes.contains(imageOverlayLineClass()));
+            ASSERT(childElement->hasClassName(imageOverlayLineClass()));
             Vector<Ref<HTMLElement>> lineChildren;
             for (Ref text : childrenOfType<HTMLDivElement>(childElement.get()))
                 lineChildren.append(text.get());


### PR DESCRIPTION
#### e5f600069d461e87967b7be349867e9864185a9d
<pre>
Adopt hasClassName() a bit more in ImageOverlay
<a href="https://bugs.webkit.org/show_bug.cgi?id=283705">https://bugs.webkit.org/show_bug.cgi?id=283705</a>

Reviewed by Tim Nguyen.

* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::updateSubtree):

Canonical link: <a href="https://commits.webkit.org/287091@main">https://commits.webkit.org/287091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea04c7a56c41690db92e3a70e8c09c3310d3f9e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82960 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29565 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80432 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5626 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61321 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19241 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68564 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41637 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48665 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24969 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27902 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69757 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84325 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5666 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3826 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69540 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/content-smaller-than-box-size.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5825 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68796 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17151 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12809 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11105 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5613 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8361 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5605 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9039 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7391 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->