### PR TITLE
[GStreamer][WebRTC] Fix a couple unsafe-buffer-usage warnings

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -61,9 +61,7 @@ public:
     }
     bool shouldEmitLogMessage(const WTFLogChannel& channel) const final
     {
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib
-        return g_str_has_prefix(channel.name, "WebRTC");
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        return StringView::fromLatin1(channel.name).startsWith("WebRTC"_s);
     }
 };
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -288,6 +288,15 @@ static void ensureDebugCategoryInitialized()
     });
 }
 
+enum class NextSDPField {
+    None,
+    Typ,
+    Raddr,
+    Rport,
+    TcpType,
+    Ufrag
+};
+
 std::optional<RTCIceCandidate::Fields> parseIceCandidateSDP(const String& sdp)
 {
     ensureDebugCategoryInitialized();
@@ -308,67 +317,82 @@ std::optional<RTCIceCandidate::Fields> parseIceCandidateSDP(const String& sdp)
     String relatedAddress;
     guint16 relatedPort = 0;
     String usernameFragment;
-    auto tokens = sdp.convertToASCIILowercase().substring(10).split(' ');
+    StringView view(sdp.convertToASCIILowercase().substring(10));
+    unsigned i = 0;
+    NextSDPField nextSdpField { NextSDPField::None };
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-    for (auto it = tokens.begin(); it != tokens.end(); ++it) {
-        auto i = std::distance(tokens.begin(), it);
-        auto token = *it;
+    for (auto token : view.split(' ')) {
+        auto tokenString = token.toStringWithoutCopying();
         switch (i) {
         case 0:
-            foundation = token;
+            foundation = tokenString;
             break;
         case 1:
             if (auto value = parseInteger<unsigned>(token))
                 componentId = *value;
             else {
-                GST_WARNING("Invalid SDP candidate component ID: %s", token.ascii().data());
+                GST_WARNING("Invalid SDP candidate component ID: %s", tokenString.utf8().data());
                 return { };
             }
             break;
         case 2:
-            transport = token;
+            transport = tokenString;
             break;
         case 3:
             if (auto value = parseInteger<unsigned>(token))
                 priority = *value;
             else {
-                GST_WARNING("Invalid SDP candidate priority: %s", token.ascii().data());
+                GST_WARNING("Invalid SDP candidate priority: %s", tokenString.utf8().data());
                 return { };
             }
             break;
         case 4:
-            address = token;
+            address = tokenString;
             break;
         case 5:
             if (auto value = parseInteger<unsigned>(token))
                 port = *value;
             else {
-                GST_WARNING("Invalid SDP candidate port: %s", token.ascii().data());
+                GST_WARNING("Invalid SDP candidate port: %s", tokenString.utf8().data());
                 return { };
             }
             break;
         default:
-            if (it + 1 == tokens.end()) {
-                GST_WARNING("Incomplete SDP candidate");
-                return { };
-            }
-
-            it++;
             if (token == "typ"_s)
-                type = *it;
+                nextSdpField = NextSDPField::Typ;
             else if (token == "raddr"_s)
-                relatedAddress = *it;
+                nextSdpField = NextSDPField::Raddr;
             else if (token == "rport"_s)
-                relatedPort = parseInteger<unsigned>(*it).value_or(0);
+                nextSdpField = NextSDPField::Rport;
             else if (token == "tcptype"_s)
-                tcptype = *it;
+                nextSdpField = NextSDPField::TcpType;
             else if (token == "ufrag"_s)
-                usernameFragment = *it;
+                nextSdpField = NextSDPField::Ufrag;
+            else {
+                switch (nextSdpField) {
+                case NextSDPField::None:
+                    break;
+                case NextSDPField::Typ:
+                    type = tokenString;
+                    break;
+                case NextSDPField::Raddr:
+                    relatedAddress = tokenString;
+                    break;
+                case NextSDPField::Rport:
+                    relatedPort = parseInteger<unsigned>(token).value_or(0);
+                    break;
+                case NextSDPField::TcpType:
+                    tcptype = tokenString;
+                    break;
+                case NextSDPField::Ufrag:
+                    usernameFragment = tokenString;
+                    break;
+                }
+            }
             break;
         }
+        i++;
     }
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     if (type.isEmpty()) {
         GST_WARNING("Unable to parse candidate type");


### PR DESCRIPTION
#### a423b105a20657060d2596cd368d0d83a4dca266
<pre>
[GStreamer][WebRTC] Fix a couple unsafe-buffer-usage warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=283706">https://bugs.webkit.org/show_bug.cgi?id=283706</a>

Reviewed by Xabier Rodriguez-Calvar.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::parseIceCandidateSDP):

Canonical link: <a href="https://commits.webkit.org/287118@main">https://commits.webkit.org/287118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c43be7dd77ca65c6ce2cca4bc91dae8545eb67c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78410 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83071 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29675 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80543 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5737 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/61401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19320 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51420 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41714 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48767 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25141 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28012 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69863 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84437 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3926 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/69628 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5937 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/67422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68883 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17168 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12907 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11265 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5722 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8588 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5712 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9145 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->