### PR TITLE
[JSC][GLib] Provide deferred promise creation api

### DIFF
--- a/Source/JavaScriptCore/API/glib/JSCValue.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCValue.cpp
@@ -2145,3 +2145,61 @@ char* jsc_value_to_json(JSCValue* value, unsigned indent)
 
     return json;
 }
+
+/**
+ * JSCExecutor:
+ * @resolve: #JSCValue function to call to resolve the promise
+ * @reject: #JSCValue function to call to reject the promise
+ * @user_data: user data
+ *
+ * A function passed to @jsc_value_new_promise called during initialization
+ *
+ * It is called like a JavaScript function, so exceptions raised will not be propagated
+ * to the context, but handled by the promise causing a rejection.
+ * @resolve and @reject can be reffed for later use to handle async task completion.
+ *
+ * Since: 2.48
+ */
+
+/**
+ * jsc_value_new_promise:
+ * @context: a #JSCContext
+ * @executor: (scope call) (closure user_data): an initialization callback
+ * @user_data: (nullable): user data passed in @executor
+ *
+ * Creates a new Promise. @executor will be invoked during promise initialization
+ * and it receives the @resolve and @reject objects than can be called to resolve
+ * or reject the promise. It is called like a JavaScript function, so exceptions raised
+ * during the executor invocation will not be propagated to the context, but
+ * handled by the promise causing a rejection.
+ *
+ * Returns: (transfer full): a deferred promise object
+ *
+ * Since: 2.48
+ */
+JSCValue* jsc_value_new_promise(JSCContext* context, JSCExecutor executor, gpointer userData)
+{
+    g_return_val_if_fail(JSC_IS_CONTEXT(context), nullptr);
+    auto* jsContext = jscContextGetJSContext(context);
+    JSObjectRef resolveObj = nullptr;
+    JSObjectRef rejectObj = nullptr;
+    JSValueRef exception = nullptr;
+    JSObjectRef promise = JSObjectMakeDeferredPromise(jsContext, &resolveObj, &rejectObj, &exception);
+    if (jscContextHandleExceptionIfNeeded(context, exception))
+        return nullptr;
+
+    const size_t argumentCount = 2;
+    JSValueRef arguments[argumentCount];
+    arguments[0] = resolveObj;
+    arguments[1] = rejectObj;
+
+    auto callbackData = jscContextPushCallback(context, nullptr, promise, argumentCount, arguments);
+    GRefPtr<JSCValue> resolve = jscContextGetOrCreateValue(context, resolveObj);
+    GRefPtr<JSCValue> reject = jscContextGetOrCreateValue(context, rejectObj);
+    executor(resolve.get(), reject.get(), userData);
+    if (JSCException* unhandledException = jsc_context_get_exception(context))
+        g_object_unref(jsc_value_function_call(reject.get(), JSC_TYPE_EXCEPTION, unhandledException, G_TYPE_NONE));
+    jscContextPopCallback(context, WTFMove(callbackData));
+
+    return jscContextGetOrCreateValue(context, promise).leakRef();
+}

--- a/Source/JavaScriptCore/API/glib/JSCValue.h.in
+++ b/Source/JavaScriptCore/API/glib/JSCValue.h.in
@@ -322,6 +322,15 @@ JSC_API char *
 jsc_value_to_json                         (JSCValue             *value,
                                            guint                 indent);
 
+typedef void  (*JSCExecutor)              (JSCValue             *resolve,
+                                           JSCValue             *reject,
+                                           gpointer              user_data);
+
+JSC_API JSCValue *
+jsc_value_new_promise                     (JSCContext           *context,
+                                           JSCExecutor           executor,
+                                           gpointer              user_data);
+
 G_END_DECLS
 
 #endif /* JSCValue_h */


### PR DESCRIPTION
#### f4cbe7bf3972971aa4feba14a2e466b81af92980
<pre>
[JSC][GLib] Provide deferred promise creation api
<a href="https://bugs.webkit.org/show_bug.cgi?id=283708">https://bugs.webkit.org/show_bug.cgi?id=283708</a>

Reviewed by Carlos Garcia Campos.

This commit implements an API to create promises in JSC GLib.
It is a copy from the Objective-C valueWithNewPromiseInContext.
An executor is required, it will be invoked during promise initialization
and it receives the @resolve and @reject objects than can be called to resolve
or reject the promise. It is called like a js function, so exceptions raised
during the executor invocation will not be propagated to the context, but
handled by the promise causing a rejection.

* Source/JavaScriptCore/API/glib/JSCValue.cpp:
(jsc_value_new_promise):
* Source/JavaScriptCore/API/glib/JSCValue.h.in:
* Tools/TestWebKitAPI/Tests/JavaScriptCore/glib/TestJSC.cpp:
(fooSuccessSource):
(fooSuccessExecutor):
(getAsyncResolvedPromise):
(fooFailureSource):
(fooFailureExecutor):
(getAsyncRejectedPromise):
(getRejectedPromise):
(getExceptionPromise):
(getResolvedPromise):
(testJSCPromises):

Canonical link: <a href="https://commits.webkit.org/288688@main">https://commits.webkit.org/288688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c47c978d72f30224b2d7a04c8b5b39ce8b7cf171

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89098 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35031 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11609 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65349 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23192 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76343 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45642 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2713 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30567 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34080 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/76987 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73676 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90476 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/83040 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73803 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11512 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73020 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17310 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2634 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13018 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11240 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16712 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105459 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11088 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25478 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14564 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12860 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->