### PR TITLE
[GTK][WPE] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from MIMETypeRegistryXdg

### DIFF
--- a/Source/WebCore/platform/xdg/MIMETypeRegistryXdg.cpp
+++ b/Source/WebCore/platform/xdg/MIMETypeRegistryXdg.cpp
@@ -62,15 +62,14 @@ String MIMETypeRegistry::preferredExtensionForMIMEType(const String& mimeType)
     if (mimeType.startsWith("text/plain"_s))
         return String();
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
     String returnValue;
     char* extension;
     if (xdg_mime_get_simple_globs(mimeType.utf8().data(), &extension, 1)) {
-        if (extension[0] == '.' && extension[1])
-            returnValue = String::fromUTF8(extension + 1);
+        auto view = std::string_view(extension);
+        if (view[0] == '.' && view.size() > 1)
+            returnValue = String::fromUTF8(view.substr(1).data());
         free(extension);
     }
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return returnValue;
 }
 
@@ -79,15 +78,13 @@ Vector<String> MIMETypeRegistry::extensionsForMIMEType(const String& mimeType)
     if (mimeType.isEmpty())
         return { };
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
     Vector<String> returnValue;
-    char* extensions[MAX_EXTENSION_COUNT];
-    int n = xdg_mime_get_simple_globs(mimeType.utf8().data(), extensions, MAX_EXTENSION_COUNT);
+    std::array <char*, MAX_EXTENSION_COUNT> extensions;
+    int n = xdg_mime_get_simple_globs(mimeType.utf8().data(), extensions.data(), MAX_EXTENSION_COUNT);
     for (int i = 0; i < n; ++i) {
         returnValue.append(String::fromUTF8(extensions[i]));
         free(extensions[i]);
     }
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return returnValue;
 }
 


### PR DESCRIPTION
#### 3d0aa094f36140d21c640fac7fcad21e745745da
<pre>
[GTK][WPE] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from MIMETypeRegistryXdg
<a href="https://bugs.webkit.org/show_bug.cgi?id=283711">https://bugs.webkit.org/show_bug.cgi?id=283711</a>

Reviewed by Adrian Perez de Castro.

Use stdlib features instead of C arrays and raw pointer arithmetic.

* Source/WebCore/platform/xdg/MIMETypeRegistryXdg.cpp:
(WebCore::MIMETypeRegistry::preferredExtensionForMIMEType):
(WebCore::MIMETypeRegistry::extensionsForMIMEType):

Canonical link: <a href="https://commits.webkit.org/287093@main">https://commits.webkit.org/287093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4107c546ebe9b69eb5178a83478dbbdde2c750af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82971 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29576 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80443 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61326 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19248 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81377 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68617 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41642 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48678 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/24987 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27913 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69771 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84336 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5677 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3838 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69548 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5836 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68804 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17153 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12817 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11123 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5624 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8370 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5616 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9050 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7402 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->