### PR TITLE
[scroll-animations] progress-based timelines should update their current time only during page rendering

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/get-animations-inactive-timeline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/get-animations-inactive-timeline-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL getAnimations includes inactive scroll-linked animations that have not been canceled assert_equals: Inactive timeline when timeline's source element cannot be scrolled expected null but got object "0%"
+PASS getAnimations includes inactive scroll-linked animations that have not been canceled
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-with-transform-on-subject-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-with-transform-on-subject-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL ViewTimeline use untransformed box for range calculations assert_approx_equals: progress at contain 50% expected 0.5 +/- 0.000001 but got 0.5744000244140625
+FAIL ViewTimeline use untransformed box for range calculations assert_approx_equals: progress at contain 0% expected 0 +/- 0.000001 but got 0.56
 

--- a/LayoutTests/webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-ios.html
+++ b/LayoutTests/webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-ios.html
@@ -23,10 +23,12 @@ promise_test(async () => {
 
     await UIHelper.scrollTo(0, -100, unconstrained);
     await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
 
     assert_equals(scrollTimeline.currentTime.toString(), "0%");
 
     await UIHelper.scrollTo(0, 2100, unconstrained);
+    await UIHelper.renderingUpdate();
     await UIHelper.renderingUpdate();
 
     assert_equals(scrollTimeline.currentTime.toString(), "100%");

--- a/LayoutTests/webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-mac.html
+++ b/LayoutTests/webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-mac.html
@@ -79,6 +79,7 @@ promise_test(async () => {
 
     await scrollToRubberBand();
     await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
 
     assert_equals(scrollTimeline.currentTime.toString(), "0%");
 }, "The current time of a scroll timeline remains at 0% while rubber-banding.");

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -84,8 +84,10 @@ ScrollTimeline::ScrollTimeline(ScrollTimelineOptions&& options)
     , m_source(WTFMove(options.source))
     , m_axis(options.axis)
 {
-    if (m_source)
+    if (m_source) {
         m_source->protectedDocument()->ensureTimelinesController().addTimeline(*this);
+        cacheCurrentTime();
+    }
 }
 
 ScrollTimeline::ScrollTimeline(const AtomString& name, ScrollAxis axis)
@@ -198,8 +200,28 @@ AnimationTimelinesController* ScrollTimeline::controller() const
     return nullptr;
 }
 
+void ScrollTimeline::cacheCurrentTime()
+{
+    m_cachedCurrentTimeData = [&] -> CurrentTimeData {
+        RefPtr source = this->source();
+        if (!source)
+            return { };
+        auto* sourceScrollableArea = scrollableAreaForSourceRenderer(source->renderer(), source->document());
+        if (!sourceScrollableArea)
+            return { };
+        float scrollOffset = axis() == ScrollAxis::Block ? sourceScrollableArea->scrollOffset().y() : sourceScrollableArea->scrollOffset().x();
+        float maxScrollOffset = axis() == ScrollAxis::Block ? sourceScrollableArea->maximumScrollOffset().y() : sourceScrollableArea->maximumScrollOffset().x();
+        // Chrome appears to clip the current time of a scroll timeline in the [0-100] range.
+        // We match this behavior for compatibility reasons, see https://github.com/w3c/csswg-drafts/issues/11033.
+        if (maxScrollOffset > 0)
+            scrollOffset = std::clamp(scrollOffset, 0.f, maxScrollOffset);
+        return { scrollOffset, maxScrollOffset };
+    }();
+}
+
 AnimationTimeline::ShouldUpdateAnimationsAndSendEvents ScrollTimeline::documentWillUpdateAnimationsAndSendEvents()
 {
+    cacheCurrentTime();
     if (m_source && m_source->isConnected())
         return AnimationTimeline::ShouldUpdateAnimationsAndSendEvents::Yes;
     return AnimationTimeline::ShouldUpdateAnimationsAndSendEvents::No;
@@ -236,26 +258,11 @@ TimelineRange ScrollTimeline::defaultRange() const
 
 ScrollTimeline::Data ScrollTimeline::computeTimelineData(const TimelineRange& range) const
 {
+    if (!m_cachedCurrentTimeData.scrollOffset && !m_cachedCurrentTimeData.maxScrollOffset)
+        return { };
     if ((range.start.name != SingleTimelineRange::Name::Normal && range.start.name != SingleTimelineRange::Name::Omitted) || (range.end.name != SingleTimelineRange::Name::Normal && range.end.name != SingleTimelineRange::Name::Omitted))
         return { };
-
-    RefPtr source = this->source();
-    if (!source)
-        return { };
-
-    auto* sourceScrollableArea = scrollableAreaForSourceRenderer(source->renderer(), source->document());
-    if (!sourceScrollableArea)
-        return { };
-
-    float maxScrollOffset = axis() == ScrollAxis::Block ? sourceScrollableArea->maximumScrollOffset().y() : sourceScrollableArea->maximumScrollOffset().x();
-    float scrollOffset = axis() == ScrollAxis::Block ? sourceScrollableArea->scrollOffset().y() : sourceScrollableArea->scrollOffset().x();
-
-    // Chrome appears to clip the current time of a scroll timeline in the [0-100] range.
-    // We match this behavior for compatibility reasons, see https://github.com/w3c/csswg-drafts/issues/11033.
-    if (maxScrollOffset > 0)
-        scrollOffset = std::clamp(scrollOffset, 0.f, maxScrollOffset);
-
-    return { scrollOffset, floatValueForOffset(range.start.offset, maxScrollOffset), floatValueForOffset(range.end.offset, maxScrollOffset) };
+    return { m_cachedCurrentTimeData.scrollOffset, floatValueForOffset(range.start.offset, m_cachedCurrentTimeData.maxScrollOffset), floatValueForOffset(range.end.offset, m_cachedCurrentTimeData.maxScrollOffset) };
 }
 
 std::optional<WebAnimationTime> ScrollTimeline::currentTime(const TimelineRange& timelineRange)

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -94,11 +94,19 @@ private:
 
     void animationTimingDidChange(WebAnimation&) override;
 
+    struct CurrentTimeData {
+        float scrollOffset { 0 };
+        float maxScrollOffset { 0 };
+    };
+
+    void cacheCurrentTime();
+
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_source;
     ScrollAxis m_axis { ScrollAxis::Block };
     AtomString m_name;
     Scroller m_scroller { Scroller::Self };
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_timelineScopeElement;
+    CurrentTimeData m_cachedCurrentTimeData { };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CSSNumericValue.h"
+#include "Length.h"
 #include "ScrollTimeline.h"
 #include "ViewTimelineOptions.h"
 #include <wtf/Ref.h>
@@ -80,8 +81,20 @@ private:
     Ref<CSSValue> toCSSValue(const RenderStyle&) const final;
     bool isViewTimeline() const final { return true; }
 
+    struct CurrentTimeData {
+        float scrollOffset { 0 };
+        float scrollContainerSize { 0 };
+        float subjectOffset { 0 };
+        float subjectSize { 0 };
+        Length insetStart { };
+        Length insetEnd { };
+    };
+
+    void cacheCurrentTime();
+
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_subject;
     ViewTimelineInsets m_insets;
+    CurrentTimeData m_cachedCurrentTimeData { };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 53f891ac8282b99b9f95b9ae5b6dc0de804713f8
<pre>
[scroll-animations] progress-based timelines should update their current time only during page rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=283715">https://bugs.webkit.org/show_bug.cgi?id=283715</a>
<a href="https://rdar.apple.com/140580999">rdar://140580999</a>

Reviewed by Tim Nguyen.

Until now, querying the current time of a progress-based timeline would look at the current
state of the source. However, the Web Animations specification clearly states that timelines
update their current time during the &quot;update animations and send events&quot; procedure (see
<a href="https://drafts.csswg.org/web-animations-1/#update-animations-and-send-events).">https://drafts.csswg.org/web-animations-1/#update-animations-and-send-events).</a>

We update `ScrollTimeline` and `ViewTimeline` to compute a snapshot of the data used to
compute the current time as the page is rendered.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/get-animations-inactive-timeline-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-with-transform-on-subject-expected.txt:
* LayoutTests/webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-ios.html:
* LayoutTests/webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-mac.html:
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::ScrollTimeline):
(WebCore::ScrollTimeline::cacheCurrentTime):
(WebCore::ScrollTimeline::documentWillUpdateAnimationsAndSendEvents):
(WebCore::ScrollTimeline::computeTimelineData const):
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::ViewTimeline):
(WebCore::ViewTimeline::cacheCurrentTime):
(WebCore::ViewTimeline::documentWillUpdateAnimationsAndSendEvents):
(WebCore::ViewTimeline::computeTimelineData const):
* Source/WebCore/animation/ViewTimeline.h:

Canonical link: <a href="https://commits.webkit.org/287100@main">https://commits.webkit.org/287100@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01d042aac782c0dfa5993631753dac32164a9726

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/82979 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29584 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80451 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5645 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61334 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19257 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68657 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41650 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48686 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25000 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27921 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69779 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84344 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5685 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3848 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69559 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67287 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68814 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12829 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11135 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12108 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5632 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8377 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5624 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9058 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7410 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->