### PR TITLE
MediaQueryMatcher should be a ContextDestructionObserver

### DIFF
--- a/Source/WebCore/css/MediaQueryMatcher.cpp
+++ b/Source/WebCore/css/MediaQueryMatcher.cpp
@@ -20,6 +20,8 @@
 #include "config.h"
 #include "MediaQueryMatcher.h"
 
+#include "ContextDestructionObserverInlines.h"
+#include "Document.h"
 #include "DocumentView.h"
 #include "EventNames.h"
 #include "FrameDestructionObserverInlines.h"
@@ -40,35 +42,42 @@
 namespace WebCore {
 
 MediaQueryMatcher::MediaQueryMatcher(Document& document)
-    : m_document(document)
+    : ContextDestructionObserver(&document)
 {
 }
 
 MediaQueryMatcher::~MediaQueryMatcher() = default;
 
-void MediaQueryMatcher::documentDestroyed()
+void MediaQueryMatcher::contextDestroyed()
 {
-    m_document = nullptr;
     auto mediaQueryLists = std::exchange(m_mediaQueryLists, { });
     for (auto& mediaQueryList : mediaQueryLists) {
         if (mediaQueryList)
             mediaQueryList->detachFromMatcher();
     }
+    ContextDestructionObserver::contextDestroyed();
+}
+
+Document* MediaQueryMatcher::document() const
+{
+    return downcast<Document>(scriptExecutionContext());
 }
 
 AtomString MediaQueryMatcher::mediaType() const
 {
-    if (!m_document || !m_document->frame() || !m_document->frame()->view())
+    RefPtr document = this->document();
+    if (!document || !document->frame() || !document->frame()->view())
         return nullAtom();
 
-    return protect(m_document->frame()->view())->mediaType();
+    return document->frame()->view()->mediaType();
 }
 
 bool MediaQueryMatcher::evaluate(const MQ::MediaQueryList& queries)
 {
-    if (!m_document)
+    RefPtr document = this->document();
+    if (!document)
         return false;
-    return MQ::MediaQueryEvaluator { mediaType(), *m_document }.evaluate(queries);
+    return MQ::MediaQueryEvaluator { mediaType(), *document }.evaluate(queries);
 }
 
 void MediaQueryMatcher::addMediaQueryList(MediaQueryList& list)
@@ -84,34 +93,33 @@ void MediaQueryMatcher::removeMediaQueryList(MediaQueryList& list)
 
 RefPtr<MediaQueryList> MediaQueryMatcher::matchMedia(const String& query)
 {
-    if (!m_document)
+    RefPtr document = this->document();
+    if (!document)
         return nullptr;
 
-    auto queries = MQ::MediaQueryParser::parse(query, protect(m_document)->cssParserContext());
+    auto queries = MQ::MediaQueryParser::parse(query, document->cssParserContext());
     bool matches = evaluate(queries);
-    return MediaQueryList::create(protect(*m_document), *this, WTF::move(queries), matches);
+    return MediaQueryList::create(*document, *this, WTF::move(queries), matches);
 }
 
 void MediaQueryMatcher::evaluateAll(EventMode eventMode)
 {
-    ASSERT(m_document);
+    RefPtr document = this->document();
+    ASSERT(document);
 
     ++m_evaluationRound;
 
-    if (!m_document)
+    if (!document)
         return;
 
-    LOG_WITH_STREAM(MediaQueries, stream << "MediaQueryMatcher::styleResolverChanged " << m_document->url());
+    LOG_WITH_STREAM(MediaQueries, stream << "MediaQueryMatcher::styleResolverChanged " << document->url());
 
-    MQ::MediaQueryEvaluator evaluator { mediaType(), *m_document };
+    MQ::MediaQueryEvaluator evaluator { mediaType(), *document };
 
     auto mediaQueryLists = m_mediaQueryLists;
     for (auto& list : mediaQueryLists) {
-        if (RefPtr protectedList = list.get()) {
+        if (RefPtr protectedList = list.get())
             protectedList->evaluate(evaluator, eventMode);
-            if (!m_document)
-                break;
-        }
     }
 }
 

--- a/Source/WebCore/css/MediaQueryMatcher.cpp
+++ b/Source/WebCore/css/MediaQueryMatcher.cpp
@@ -39,48 +39,51 @@
 namespace WebCore {
 
 MediaQueryMatcher::MediaQueryMatcher(Document& document)
-    : m_document(document)
+    : ContextDestructionObserver(&document)
 {
 }
 
 MediaQueryMatcher::~MediaQueryMatcher() = default;
 
-void MediaQueryMatcher::documentDestroyed()
+void MediaQueryMatcher::contextDestroyed()
 {
-    m_document = nullptr;
     auto mediaQueryLists = std::exchange(m_mediaQueryLists, { });
     for (auto& mediaQueryList : mediaQueryLists) {
         if (mediaQueryList)
             mediaQueryList->detachFromMatcher();
     }
+    ContextDestructionObserver::contextDestroyed();
 }
 
 AtomString MediaQueryMatcher::mediaType() const
 {
-    if (!m_document || !m_document->frame() || !m_document->frame()->view())
+    RefPtr document = downcast<Document>(scriptExecutionContext());
+    if (!document || !document->frame() || !document->frame()->view())
         return nullAtom();
 
-    return m_document->frame()->view()->mediaType();
+    return document->frame()->view()->mediaType();
 }
 
 std::unique_ptr<RenderStyle> MediaQueryMatcher::documentElementUserAgentStyle() const
 {
-    if (!m_document || !m_document->frame())
+    RefPtr document = downcast<Document>(scriptExecutionContext());
+    if (!document || !document->frame())
         return nullptr;
 
-    auto* documentElement = m_document->documentElement();
+    auto* documentElement = document->documentElement();
     if (!documentElement)
         return nullptr;
 
-    return m_document->styleScope().resolver().styleForElement(*documentElement, { m_document->renderStyle() }, RuleMatchingBehavior::MatchOnlyUserAgentRules).style;
+    return document->styleScope().resolver().styleForElement(*documentElement, { document->renderStyle() }, RuleMatchingBehavior::MatchOnlyUserAgentRules).style;
 }
 
 bool MediaQueryMatcher::evaluate(const MQ::MediaQueryList& queries)
 {
+    RefPtr document = downcast<Document>(scriptExecutionContext());
     auto style = documentElementUserAgentStyle();
     if (!style)
         return false;
-    return MQ::MediaQueryEvaluator { mediaType(), *m_document, style.get() }.evaluate(queries);
+    return MQ::MediaQueryEvaluator { mediaType(), *document, style.get() }.evaluate(queries);
 }
 
 void MediaQueryMatcher::addMediaQueryList(MediaQueryList& list)
@@ -96,17 +99,19 @@ void MediaQueryMatcher::removeMediaQueryList(MediaQueryList& list)
 
 RefPtr<MediaQueryList> MediaQueryMatcher::matchMedia(const String& query)
 {
-    if (!m_document)
+    RefPtr document = downcast<Document>(scriptExecutionContext());
+    if (!document)
         return nullptr;
 
-    auto queries = MQ::MediaQueryParser::parse(query, MediaQueryParserContext(*m_document));
+    auto queries = MQ::MediaQueryParser::parse(query, MediaQueryParserContext(*document));
     bool matches = evaluate(queries);
-    return MediaQueryList::create(*m_document, *this, WTFMove(queries), matches);
+    return MediaQueryList::create(*document, *this, WTFMove(queries), matches);
 }
 
 void MediaQueryMatcher::evaluateAll(EventMode eventMode)
 {
-    ASSERT(m_document);
+    RefPtr document = downcast<Document>(scriptExecutionContext());
+    ASSERT(document);
 
     ++m_evaluationRound;
 
@@ -114,15 +119,15 @@ void MediaQueryMatcher::evaluateAll(EventMode eventMode)
     if (!style)
         return;
 
-    LOG_WITH_STREAM(MediaQueries, stream << "MediaQueryMatcher::styleResolverChanged " << m_document->url());
+    LOG_WITH_STREAM(MediaQueries, stream << "MediaQueryMatcher::styleResolverChanged " << document->url());
 
-    MQ::MediaQueryEvaluator evaluator { mediaType(), *m_document, style.get() };
+    MQ::MediaQueryEvaluator evaluator { mediaType(), *document, style.get() };
 
     auto mediaQueryLists = m_mediaQueryLists;
     for (auto& list : mediaQueryLists) {
         if (RefPtr protectedList = list.get()) {
             protectedList->evaluate(evaluator, eventMode);
-            if (!m_document)
+            if (!document)
                 break;
         }
     }

--- a/Source/WebCore/css/MediaQueryMatcher.h
+++ b/Source/WebCore/css/MediaQueryMatcher.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "ContextDestructionObserver.h"
 #include <memory>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
@@ -40,12 +41,15 @@ using MediaQueryList = Vector<MediaQuery>;
 // is needed and dispatch "change" event on MediaQueryLists if the corresponding
 // query has changed. MediaQueryLists are invoked in the order in which they were added.
 
-class MediaQueryMatcher final : public RefCounted<MediaQueryMatcher> {
+class MediaQueryMatcher final : public ContextDestructionObserver, public RefCounted<MediaQueryMatcher> {
 public:
     static Ref<MediaQueryMatcher> create(Document& document) { return adoptRef(*new MediaQueryMatcher(document)); }
     ~MediaQueryMatcher();
 
-    void documentDestroyed();
+    // ContextDestructionObserver.
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
     void addMediaQueryList(MediaQueryList&);
     void removeMediaQueryList(MediaQueryList&);
 
@@ -62,8 +66,10 @@ public:
 
 private:
     explicit MediaQueryMatcher(Document&);
+    Document* document() const;
 
-    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
+    void contextDestroyed() final;
+
     Vector<WeakPtr<MediaQueryList, WeakPtrImplWithEventTargetData>> m_mediaQueryLists;
 
     // This value is incremented at style selector changes.

--- a/Source/WebCore/css/MediaQueryMatcher.h
+++ b/Source/WebCore/css/MediaQueryMatcher.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "ContextDestructionObserver.h"
 #include <memory>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
@@ -41,12 +42,13 @@ using MediaQueryList = Vector<MediaQuery>;
 // is needed and dispatch "change" event on MediaQueryLists if the corresponding
 // query has changed. MediaQueryLists are invoked in the order in which they were added.
 
-class MediaQueryMatcher final : public RefCounted<MediaQueryMatcher> {
+class MediaQueryMatcher final : public ContextDestructionObserver, public RefCounted<MediaQueryMatcher> {
 public:
     static Ref<MediaQueryMatcher> create(Document& document) { return adoptRef(*new MediaQueryMatcher(document)); }
     ~MediaQueryMatcher();
 
-    void documentDestroyed();
+    void contextDestroyed() override;
+
     void addMediaQueryList(MediaQueryList&);
     void removeMediaQueryList(MediaQueryList&);
 
@@ -65,7 +67,6 @@ private:
     explicit MediaQueryMatcher(Document&);
     std::unique_ptr<RenderStyle> documentElementUserAgentStyle() const;
 
-    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     Vector<WeakPtr<MediaQueryList, WeakPtrImplWithEventTargetData>> m_mediaQueryLists;
 
     // This value is incremented at style selector changes.

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3722,9 +3722,6 @@ void Document::willBeRemovedFromFrame()
     if (!m_wheelEventTargets.isEmptyIgnoringNullReferences() && parentDocument())
         protect(parentDocument())->didRemoveEventTargetNode(*this);
 
-    if (RefPtr mediaQueryMatcher = m_mediaQueryMatcher)
-        mediaQueryMatcher->documentDestroyed();
-
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     if (!m_idToClientMap.isEmpty() && page()) {
         for (WeakPtr weakClient : copyToVector(m_idToClientMap.values())) {

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3503,8 +3503,6 @@ void Document::willBeRemovedFromFrame()
     if (m_wheelEventTargets && !m_wheelEventTargets->isEmptyIgnoringNullReferences() && parentDocument())
         protectedParentDocument()->didRemoveEventTargetNode(*this);
 
-    if (RefPtr mediaQueryMatcher = m_mediaQueryMatcher)
-        mediaQueryMatcher->documentDestroyed();
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     if (!m_clientToIDMap.isEmpty() && page()) {


### PR DESCRIPTION
#### 49a60d7b038f52940ba3b197d6a0ab9806dc4dde
<pre>
MediaQueryMatcher should be a ContextDestructionObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=99240">https://bugs.webkit.org/show_bug.cgi?id=99240</a>

Reviewed by NOBODY (OOPS!).

MediaQueryMatcher should be a ContextDestructionObserver

* Source/WebCore/css/MediaQueryMatcher.cpp:
(WebCore::MediaQueryMatcher::MediaQueryMatcher):
(WebCore::MediaQueryMatcher::contextDestroyed):
(WebCore::MediaQueryMatcher::document const):
(WebCore::MediaQueryMatcher::mediaType const):
(WebCore::MediaQueryMatcher::evaluate):
(WebCore::MediaQueryMatcher::matchMedia):
(WebCore::MediaQueryMatcher::evaluateAll):
(WebCore::MediaQueryMatcher::documentDestroyed): Deleted.
* Source/WebCore/css/MediaQueryMatcher.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::willBeRemovedFromFrame):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49a60d7b038f52940ba3b197d6a0ab9806dc4dde

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183988 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132279 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48026 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135677 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95730 "4 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156468 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116155 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37755 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36119 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32469 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148178 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35960 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186414 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39631 "Found 2 new failures in css/MediaQueryMatcher.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40316 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144589 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48011 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144447 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48690 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32580 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114244 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39348 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120641 "Found 2 new failures in css/MediaQueryMatcher.cpp") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47197 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10924 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46599 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46830 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46657 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->