### PR TITLE
[iOS] [Visual Bidi Selection] Support visually-contiguous selections in multiline bidi text

### DIFF
--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-multiline-expected.txt
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-multiline-expected.txt
@@ -1,0 +1,14 @@
+Arabic is left to right مث لهذا النص
+الإنجليزية من اليسار إلى اليمين like this text
+This test verifies that the text selection appears visually contiguous when selecting across bidi text boundaries that span multiple lines.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS selectionRectsBeforeEndingTouch.length is 3
+PASS selectionRectsBeforeEndingTouch[2]?.width is >= 100
+PASS selectedText.startsWith('Arabic') is true
+PASS selectedText.endsWith('text') is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-multiline.html
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-multiline.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true VisuallyContiguousBidiTextSelectionEnabled=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-size: 20px;
+    font-family: monospace;
+    margin: 0;
+}
+
+.start {
+    border: 1px solid tomato;
+}
+
+.container {
+    width: 300px;
+    box-sizing: border-box;
+    border: 1px solid black;
+    line-height: 150%;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that the text selection appears visually contiguous when selecting across bidi text boundaries that span multiple lines.");
+
+    await UIHelper.longPressElement(document.querySelector(".start"));
+    await UIHelper.waitForSelectionToAppear();
+
+    const range = document.createRange();
+    const bottomText = document.querySelector(".line[dir='rtl']").childNodes[0];
+    range.setStart(bottomText, 33); // Select to "ik" the word "like".
+    range.setEnd(bottomText, 35);
+    const targetRect = range.getBoundingClientRect();
+    targetRect.y += 20; // Account for the vertical range adjustment offset.
+    const target = UIHelper.midPointOfRect(targetRect);
+
+    const start = UIHelper.midPointOfRect(await UIHelper.getSelectionEndGrabberViewRect());
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(start.x, start.y)
+        .move(target.x, target.y, 0.5)
+        .takeResult());
+    await UIHelper.ensurePresentationUpdate();
+
+    selectionRectsBeforeEndingTouch = await UIHelper.getUISelectionViewRects();
+    // The last selection rect should span most of the last line.
+    shouldBe("selectionRectsBeforeEndingTouch.length", "3");
+    shouldBeGreaterThanOrEqual("selectionRectsBeforeEndingTouch[2]?.width", "100");
+
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder().end().takeResult());
+    await UIHelper.ensurePresentationUpdate();
+
+    // The whole text content (both paragraphs) should be selected after ending the selection.
+    selectedText = getSelection().toString();
+    shouldBeTrue("selectedText.startsWith('Arabic')");
+    shouldBeTrue("selectedText.endsWith('text')");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="container">
+        <div class="line"><span class="start">Arabic</span> is left to right مث لهذا النص</div>
+        <div class="line" dir="rtl">الإنجليزية من اليسار إلى اليمين like this text</div>
+    </div>
+    <div id="description"></div>
+    <div id="console"></div>
+</body>
+</html>


### PR DESCRIPTION
#### 022bfa3b7e29116c5be21a63ea341445452d0db5
<pre>
[iOS] [Visual Bidi Selection] Support visually-contiguous selections in multiline bidi text
<a href="https://bugs.webkit.org/show_bug.cgi?id=283729">https://bugs.webkit.org/show_bug.cgi?id=283729</a>
<a href="https://rdar.apple.com/140594373">rdar://140594373</a>

Reviewed by Richard Robinson.

Refactor logic under `collectSelectionGeometries` to correctly extract selection geometries in
visually-contiguous multiline bidi text selections. See below for more details.

* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-multiline-expected.txt: Added.
* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-multiline.html: Added.

Add a layout test to exercise this behavior change, by sanity checking the last selection rect&apos;s
width in an LTR text run embedded inside of an RTL paragraph.

* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::directionForFirstLine):
(WebCore::directionForLastLine):
(WebCore::makeBidiSelectionVisuallyContiguousIfNeeded):

Rewrite this to handle text selections in both RTL and LTR paragraphs. The current logic only works
for an LTR paragraph that contains bidi text; in contrast, the new logic works for all scenarios by
using the following approach:

1.  Pass through interior text selection geometries (i.e. neither on the first line nor the last
    line) to be a part of the final list.

2.  For all selection geometries on the first line, expand the selection from the start caret
    position to the trailing edge of the first line (i.e. right edge in LTR, left edge for RTL).

3.  For all selection geometries on the last line, expand the selection from the end caret
    position to the leading edge of the last line (i.e. left edge in LTR, right edge for RTL).

(WebCore::adjustTextDirectionForCoalescedGeometries):

Pull this functionality out into a couple of static helper functions (above), so that we can use
them in `makeBidiSelectionVisuallyContiguousIfNeeded`.

(WebCore::RenderObject::collectSelectionGeometries):

Only call `adjustTextDirectionForCoalescedGeometries` if the selection endpoint directions weren&apos;t
already adjusted as a part of `makeBidiSelectionVisuallyContiguousIfNeeded`.

Canonical link: <a href="https://commits.webkit.org/287218@main">https://commits.webkit.org/287218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/010cf7e62e0774ea29ac2d153ae58be10465afca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83025 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29630 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80497 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5691 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61359 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19287 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51372 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68884 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41675 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25071 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27966 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69813 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25439 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84390 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3885 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69587 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5890 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68842 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17225 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12863 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11200 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5677 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8421 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5666 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9100 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7453 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->