### PR TITLE
Annotate Notification related endpoints with feature flags

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1041,6 +1041,8 @@ BuiltInNotificationsEnabled:
       default: false
     WebKit:
       default: false
+  sharedPreferenceForWebProcess: true
+  richJavaScript: true
 
 CFNetworkNetworkLoaderEnabled:
   type: bool
@@ -5447,6 +5449,8 @@ NotificationsEnabled:
       "PLATFORM(IOS_FAMILY)": false
       default: true
   disableInLockdownMode: true
+  sharedPreferenceForWebProcess: true
+  richJavaScript: true
 
 ObservableEnabled:
   type: bool

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -2885,6 +2885,15 @@ NetworkConnectionToWebProcess* NetworkProcess::webProcessConnection(ProcessIdent
     return m_webProcessConnections.get(identifier);
 }
 
+NetworkConnectionToWebProcess* NetworkProcess::webProcessConnection(const IPC::Connection& connection) const
+{
+    for (Ref webProcessConnection : m_webProcessConnections.values()) {
+        if (webProcessConnection->connection().uniqueID() == connection.uniqueID())
+            return webProcessConnection.ptr();
+    }
+    return nullptr;
+}
+
 const Seconds NetworkProcess::defaultServiceWorkerFetchTimeout = 70_s;
 void NetworkProcess::setServiceWorkerFetchTimeoutForTesting(Seconds timeout, CompletionHandler<void()>&& completionHandler)
 {

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -373,6 +373,7 @@ public:
     const OptionSet<NetworkCache::CacheOption>& cacheOptions() const { return m_cacheOptions; }
 
     NetworkConnectionToWebProcess* webProcessConnection(WebCore::ProcessIdentifier) const;
+    NetworkConnectionToWebProcess* webProcessConnection(const IPC::Connection&) const;
     std::optional<WebCore::ProcessIdentifier> webProcessIdentifierForConnection(IPC::Connection&) const;
     WebCore::MessagePortChannelRegistry& messagePortChannelRegistry() { return m_messagePortChannelRegistry; }
 

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -167,7 +167,7 @@ NetworkSession::NetworkSession(NetworkProcess& networkProcess, const NetworkSess
     , m_inspectionForServiceWorkersAllowed(parameters.inspectionForServiceWorkersAllowed)
     , m_storageManager(createNetworkStorageManager(networkProcess, parameters))
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
-    , m_notificationManager(NetworkNotificationManager::create(parameters.sessionID.isEphemeral() ? String { } : parameters.webPushMachServiceName, configurationWithHostAuditToken(networkProcess, parameters.webPushDaemonConnectionConfiguration)))
+    , m_notificationManager(NetworkNotificationManager::create(parameters.sessionID.isEphemeral() ? String { } : parameters.webPushMachServiceName, configurationWithHostAuditToken(networkProcess, parameters.webPushDaemonConnectionConfiguration), networkProcess))
 #endif
 {
     if (!m_sessionID.isEphemeral()) {

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -31,6 +31,7 @@
 #include "DaemonDecoder.h"
 #include "DaemonEncoder.h"
 #include "Logging.h"
+#include "NetworkProcess.h"
 #include "NetworkSession.h"
 #include "PushClientConnectionMessages.h"
 #include "WebPushDaemonConnectionConfiguration.h"
@@ -43,12 +44,13 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkNotificationManager);
 
-Ref<NetworkNotificationManager> NetworkNotificationManager::create(const String& webPushMachServiceName, WebPushD::WebPushDaemonConnectionConfiguration&& configuration)
+Ref<NetworkNotificationManager> NetworkNotificationManager::create(const String& webPushMachServiceName, WebPushD::WebPushDaemonConnectionConfiguration&& configuration, NetworkProcess& networkProcess)
 {
-    return adoptRef(*new NetworkNotificationManager(webPushMachServiceName, WTFMove(configuration)));
+    return adoptRef(*new NetworkNotificationManager(webPushMachServiceName, WTFMove(configuration), networkProcess));
 }
 
-NetworkNotificationManager::NetworkNotificationManager(const String& webPushMachServiceName, WebPushD::WebPushDaemonConnectionConfiguration&& configuration)
+NetworkNotificationManager::NetworkNotificationManager(const String& webPushMachServiceName, WebPushD::WebPushDaemonConnectionConfiguration&& configuration, NetworkProcess& networkProcess)
+    : m_networkProcess(networkProcess)
 {
     if (!webPushMachServiceName.isEmpty())
         m_connection = WebPushD::Connection::create(webPushMachServiceName.utf8(), WTFMove(configuration));
@@ -246,6 +248,12 @@ void NetworkNotificationManager::getPermissionState(WebCore::SecurityOriginData&
 void NetworkNotificationManager::getPermissionStateSync(WebCore::SecurityOriginData&& origin, CompletionHandler<void(WebCore::PushPermissionState)>&& completionHandler)
 {
     getPushPermissionStateImpl(protectedConnection().get(), WTFMove(origin), WTFMove(completionHandler));
+}
+
+std::optional<SharedPreferencesForWebProcess> NetworkNotificationManager::sharedPreferencesForWebProcess(const IPC::Connection& connection) const
+{
+    Ref networkProcess = m_networkProcess;
+    return networkProcess->webProcessConnection(connection)->sharedPreferencesForWebProcess();
 }
 
 RefPtr<WebPushD::Connection> NetworkNotificationManager::protectedConnection() const

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
@@ -27,7 +27,9 @@
 
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
 
+#include "NetworkProcess.h"
 #include "NotificationManagerMessageHandler.h"
+#include "SharedPreferencesForWebProcess.h"
 #include "WebPushDaemonConnection.h"
 #include "WebPushDaemonConnectionConfiguration.h"
 #include "WebPushMessage.h"
@@ -52,7 +54,7 @@ enum class MessageType : uint8_t;
 class NetworkNotificationManager : public NotificationManagerMessageHandler, public RefCounted<NetworkNotificationManager> {
     WTF_MAKE_TZONE_ALLOCATED(NetworkNotificationManager);
 public:
-    static Ref<NetworkNotificationManager> create(const String& webPushMachServiceName, WebPushD::WebPushDaemonConnectionConfiguration&&);
+    static Ref<NetworkNotificationManager> create(const String& webPushMachServiceName, WebPushD::WebPushDaemonConnectionConfiguration&&, NetworkProcess&);
 
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
@@ -80,17 +82,18 @@ public:
     void setAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t> badge) final;
 
 private:
-    NetworkNotificationManager(const String& webPushMachServiceName, WebPushD::WebPushDaemonConnectionConfiguration&&);
+    NetworkNotificationManager(const String& webPushMachServiceName, WebPushD::WebPushDaemonConnectionConfiguration&&, NetworkProcess&);
 
     void showNotification(IPC::Connection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>&&, CompletionHandler<void()>&&) final;
     void cancelNotification(WebCore::SecurityOriginData&&, const WTF::UUID& notificationID) final;
     void didDestroyNotification(const WTF::UUID& notificationID) final;
     void pageWasNotifiedOfNotificationPermission() final { }
     void getPermissionStateSync(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) final;
-
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(const IPC::Connection&) const final;
     RefPtr<WebPushD::Connection> protectedConnection() const;
 
     RefPtr<WebPushD::Connection> m_connection;
+    Ref<NetworkProcess> m_networkProcess;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
+++ b/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "MessageReceiver.h"
+#include "SharedPreferencesForWebProcess.h"
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/NotificationDirection.h>
 #include <wtf/AbstractRefCounted.h>
@@ -53,6 +54,7 @@ public:
     virtual void setAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t> badge) = 0;
     virtual void getPermissionState(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) = 0;
     virtual void getPermissionStateSync(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) = 0;
+    virtual std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(const IPC::Connection&) const = 0;
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);

--- a/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in
+++ b/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in
@@ -20,14 +20,17 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[SharedPreferencesNeedsConnection]
 messages -> NotificationManagerMessageHandler {
-    ShowNotification(struct WebCore::NotificationData notificationData, RefPtr<WebCore::NotificationResources> notificationResources) -> ()
-    CancelNotification(WebCore::SecurityOriginData origin, WTF::UUID notificationID)
-    ClearNotifications(Vector<WTF::UUID> notificationIDs)
-    DidDestroyNotification(WTF::UUID notificationID)
-    PageWasNotifiedOfNotificationPermission()
-    RequestPermission(WebCore::SecurityOriginData origin) -> (bool granted)
-    SetAppBadge(WebCore::SecurityOriginData origin, std::optional<uint64_t> badge)
-    GetPermissionState(WebCore::SecurityOriginData origin) -> (enum:uint8_t WebCore::PushPermissionState permission)
-    GetPermissionStateSync(WebCore::SecurityOriginData origin) -> (enum:uint8_t WebCore::PushPermissionState permission) Synchronous
+    [EnabledBy=NotificationsEnabled] ShowNotification(struct WebCore::NotificationData notificationData, RefPtr<WebCore::NotificationResources> notificationResources) -> ()
+    [EnabledBy=NotificationsEnabled] CancelNotification(WebCore::SecurityOriginData origin, WTF::UUID notificationID)
+    [EnabledBy=NotificationsEnabled] ClearNotifications(Vector<WTF::UUID> notificationIDs)
+    [EnabledBy=NotificationsEnabled] DidDestroyNotification(WTF::UUID notificationID)
+    [EnabledBy=NotificationsEnabled] PageWasNotifiedOfNotificationPermission()
+    [EnabledBy=NotificationsEnabled] RequestPermission(WebCore::SecurityOriginData origin) -> (bool granted)
+#if ENABLE(WEB_PUSH_NOTIFICATIONS)
+    [EnabledBy=BuiltInNotificationsEnabled] SetAppBadge(WebCore::SecurityOriginData origin, std::optional<uint64_t> badge)
+    [EnabledBy=BuiltInNotificationsEnabled] GetPermissionState(WebCore::SecurityOriginData origin) -> (enum:uint8_t WebCore::PushPermissionState permission)
+    [EnabledBy=BuiltInNotificationsEnabled] GetPermissionStateSync(WebCore::SecurityOriginData origin) -> (enum:uint8_t WebCore::PushPermissionState permission) Synchronous
+#endif
 }

--- a/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
+++ b/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
@@ -27,6 +27,7 @@
 #include "ServiceWorkerNotificationHandler.h"
 
 #include "Logging.h"
+#include "WebProcessProxy.h"
 #include "WebsiteDataStore.h"
 #include <WebCore/NotificationData.h>
 #include <wtf/Scope.h>
@@ -96,6 +97,15 @@ void ServiceWorkerNotificationHandler::getPermissionState(WebCore::SecurityOrigi
 void ServiceWorkerNotificationHandler::getPermissionStateSync(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&)
 {
     RELEASE_ASSERT_NOT_REACHED();
+}
+
+std::optional<SharedPreferencesForWebProcess> ServiceWorkerNotificationHandler::sharedPreferencesForWebProcess(const IPC::Connection& connection) const
+{
+    if (auto webProcessProxy = WebProcessProxy::processForConnection(connection))
+        return webProcessProxy->sharedPreferencesForWebProcess();
+
+    ASSERT_NOT_REACHED();
+    return std::nullopt;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h
+++ b/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h
@@ -34,6 +34,8 @@ namespace WebKit {
 
 class WebsiteDataStore;
 
+struct SharedPreferencesForWebProcess;
+
 class ServiceWorkerNotificationHandler final : public NotificationManagerMessageHandler {
 public:
     static ServiceWorkerNotificationHandler& singleton();
@@ -52,7 +54,7 @@ public:
     void setAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t> badge) final { }
     void getPermissionState(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) final;
     void getPermissionStateSync(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) final;
-
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(const IPC::Connection&) const final;
     bool handlesNotification(WTF::UUID value) const { return m_notificationToSessionMap.contains(value); }
 
 private:

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
@@ -29,6 +29,7 @@
 #include "Logging.h"
 #include "ServiceWorkerNotificationHandler.h"
 #include "WebPageProxy.h"
+#include "WebProcessProxy.h"
 #include <WebCore/NotificationData.h>
 #include <wtf/CompletionHandler.h>
 
@@ -127,6 +128,11 @@ void WebNotificationManagerMessageHandler::getPermissionStateSync(WebCore::Secur
 {
     ASSERT_NOT_REACHED();
     completionHandler({ });
+}
+
+std::optional<SharedPreferencesForWebProcess> WebNotificationManagerMessageHandler::sharedPreferencesForWebProcess(const IPC::Connection&) const
+{
+    return protectedPage()->protectedLegacyMainFrameProcess()->sharedPreferencesForWebProcess();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
@@ -48,7 +48,7 @@ private:
     void setAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t>) final { }
     void getPermissionState(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) final;
     void getPermissionStateSync(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) final;
-
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(const IPC::Connection&) const final;
     Ref<WebPageProxy> protectedPage() const;
 
     WeakRef<WebPageProxy> m_webPageProxy;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPreferences.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPreferences.mm
@@ -153,4 +153,10 @@ TEST(WKPreferencesPrivate, DisableRichJavaScriptFeatures)
     }];
     result = (NSString *)[getNextMessage() body];
     EXPECT_WK_STREQ(@"Digital Credentials Disabled", result.get());
+
+    [webView evaluateJavaScript:@"log(window.Notification ? 'Notifications Enabled' : 'Notifications Disabled');" completionHandler:^(id, NSError *error) {
+        EXPECT_NULL(error);
+    }];
+    result = (NSString *)[getNextMessage() body];
+    EXPECT_WK_STREQ(@"Notifications Disabled", result.get());
 }


### PR DESCRIPTION
#### e1bc22c3d8c4ffeefdaa7d57ec50ad2358d8b977
<pre>
Annotate Notification related endpoints with feature flags
<a href="https://bugs.webkit.org/show_bug.cgi?id=283731">https://bugs.webkit.org/show_bug.cgi?id=283731</a>
<a href="https://rdar.apple.com/140592973">rdar://140592973</a>

Reviewed by Sihui Liu.

Annotate Notification related endpoints with feature flags

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
(WebKit::connectionToWebProcess):
(WebKit::NetworkNotificationManager::sharedPreferencesForWebProcess const):
(WebKit::NetworkNotificationManager::clearNotifications): Deleted.
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h:
* Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h:
* Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in:
* Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp:
(WebKit::ServiceWorkerNotificationHandler::sharedPreferencesForWebProcess const):
(WebKit::ServiceWorkerNotificationHandler::clearNotifications): Deleted.
* Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h:
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp:
(WebKit::WebNotificationManagerMessageHandler::sharedPreferencesForWebProcess const):
(WebKit::WebNotificationManagerMessageHandler::clearNotifications): Deleted.
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPreferences.mm:
(DisableRichJavaScriptFeatures)):

Canonical link: <a href="https://commits.webkit.org/287881@main">https://commits.webkit.org/287881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd7c554242beadbe2646a843cc72435edaa52232

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84283 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30766 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81860 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62341 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20182 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82820 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52393 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42645 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49735 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26779 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29206 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/72785 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70868 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85708 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/78875 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4887 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70600 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7161 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68469 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70152 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17659 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13841 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12756 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/101220 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6944 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12549 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/24763 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6812 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10316 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->