### PR TITLE
[::marker] Factor list item marker contents into a struct

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -791,9 +791,9 @@ String AccessibilityRenderObject::stringValue() const
 
     if (auto* renderListMarker = dynamicDowncast<RenderListMarker>(m_renderer.get())) {
 #if USE(ATSPI)
-        return renderListMarker->textWithSuffix().toString();
+        return renderListMarker->textWithSuffix();
 #else
-        return renderListMarker->textWithoutSuffix().toString();
+        return renderListMarker->textWithoutSuffix();
 #endif
     }
 

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -295,14 +295,14 @@ void RenderListItem::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
     RenderBlockFlow::paint(paintInfo, paintOffset);
 }
 
-StringView RenderListItem::markerTextWithoutSuffix() const
+String RenderListItem::markerTextWithoutSuffix() const
 {
     if (!m_marker)
         return { };
     return m_marker->textWithoutSuffix();
 }
 
-StringView RenderListItem::markerTextWithSuffix() const
+String RenderListItem::markerTextWithSuffix() const
 {
     if (!m_marker)
         return { };

--- a/Source/WebCore/rendering/RenderListItem.h
+++ b/Source/WebCore/rendering/RenderListItem.h
@@ -44,8 +44,8 @@ public:
     void setNotInList(bool notInList) { m_notInList = notInList; }
     bool notInList() const { return m_notInList; }
 
-    WEBCORE_EXPORT StringView markerTextWithoutSuffix() const;
-    StringView markerTextWithSuffix() const;
+    WEBCORE_EXPORT String markerTextWithoutSuffix() const;
+    String markerTextWithSuffix() const;
 
     void updateListMarkerNumbers();
 

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -30,6 +30,21 @@ class CSSCounterStyle;
 class RenderListItem;
 class StyleRuleCounterStyle;
 
+struct ListMarkerTextContent {
+    String textWithoutSuffix;
+    String suffix;
+    TextDirection textDirection { TextDirection::LTR };
+    bool isEmpty() const
+    {
+        return textWithoutSuffix.isEmpty() && suffix.isEmpty();
+    }
+
+    String textWithSuffix() const
+    {
+        return makeString(textWithoutSuffix, suffix);
+    }
+};
+
 // Used to render the list item's marker.
 // The RenderListMarker always has to be a child of a RenderListItem.
 class RenderListMarker final : public RenderBox {
@@ -39,8 +54,8 @@ public:
     RenderListMarker(RenderListItem&, RenderStyle&&);
     virtual ~RenderListMarker();
 
-    StringView textWithoutSuffix() const;
-    StringView textWithSuffix() const { return m_textWithSuffix; }
+    String textWithoutSuffix() const { return m_textContent.textWithoutSuffix; };
+    String textWithSuffix() const { return m_textContent.textWithSuffix(); };
 
     bool isInside() const;
 
@@ -75,16 +90,12 @@ private:
     FloatRect relativeMarkerRect();
     LayoutRect localSelectionRect();
 
-    struct TextRunWithUnderlyingString;
-    TextRunWithUnderlyingString textRun() const;
-
     RefPtr<CSSCounterStyle> counterStyle() const;
     bool widthUsesMetricsOfPrimaryFont() const;
 
-    String m_textWithSuffix;
-    uint8_t m_textWithoutSuffixLength { 0 };
-    bool m_textIsLeftToRightDirection { true };
+    ListMarkerTextContent m_textContent;
     RefPtr<StyleImage> m_image;
+
     SingleThreadWeakPtr<RenderListItem> m_listItem;
     LayoutUnit m_lineOffsetForListItem;
     LayoutUnit m_lineLogicalOffsetForListItem;

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -356,7 +356,7 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
         ts << " [r=" << cell->rowIndex() << " c=" << cell->col() << " rs=" << cell->rowSpan() << " cs=" << cell->colSpan() << "]";
 
     if (auto* listMarker = dynamicDowncast<RenderListMarker>(o)) {
-        String text = listMarker->textWithoutSuffix().toString();
+        auto text = listMarker->textWithoutSuffix();
         if (!text.isEmpty()) {
             if (text.length() != 1)
                 text = quoteAndEscapeNonPrintables(text);
@@ -897,7 +897,7 @@ String markerTextForListItem(Element* element)
     auto* renderer = dynamicDowncast<RenderListItem>(element->renderer());
     if (!renderer)
         return String();
-    return renderer->markerTextWithoutSuffix().toString();
+    return renderer->markerTextWithoutSuffix();
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 48815528eb1ae739d681dda5460717c27db95304
<pre>
[::marker] Factor list item marker contents into a struct
<a href="https://bugs.webkit.org/show_bug.cgi?id=283730">https://bugs.webkit.org/show_bug.cgi?id=283730</a>
<a href="https://rdar.apple.com/140595246">rdar://140595246</a>

Reviewed by Dan Glastonbury.

Factor them into a struct to make it easier to move out painting/content code from RenderListMarker.

Also store the suffix + textWithoutSuffix, instead of generating substrings in various places.

* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::stringValue const):
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::markerTextWithoutSuffix const):
(WebCore::RenderListItem::markerTextWithSuffix const):
* Source/WebCore/rendering/RenderListItem.h:
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::textRunForContent):
(WebCore::RenderListMarker::paint):
(WebCore::RenderListMarker::updateContent):
(WebCore::RenderListMarker::computePreferredLogicalWidths):
(WebCore::RenderListMarker::updateMargins):
(WebCore::RenderListMarker::relativeMarkerRect):
(WebCore::RenderListMarker::TextRunWithUnderlyingString::operator const TextRun&amp; const): Deleted.
(WebCore::RenderListMarker::textRun const): Deleted.
(WebCore::RenderListMarker::textWithoutSuffix const): Deleted.
* Source/WebCore/rendering/RenderListMarker.h:
(WebCore::ListMarkerTextContent::isEmpty const):
(WebCore::ListMarkerTextContent::textWithSuffix const):
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::RenderTreeAsText::writeRenderObject):
(WebCore::markerTextForListItem):

Canonical link: <a href="https://commits.webkit.org/287107@main">https://commits.webkit.org/287107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c63f98aba95696e0374eed6fec775093baeb88a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83027 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29631 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80499 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5693 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61360 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19291 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51377 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41676 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/48724 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25074 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27968 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69818 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84392 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5732 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3887 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69588 "Found 8 new test failures: animations/additive-transform-animations.html compositing/animation/repaint-after-clearing-shared-backing.html imported/w3c/web-platform-tests/css/css-view-transitions/iframe-and-main-frame-transition-new-main-new-iframe.html imported/w3c/web-platform-tests/css/css-view-transitions/iframe-old-has-scrollbar.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-offscreen-old.html imported/w3c/web-platform-tests/css/css-view-transitions/navigation/opt-in-removed-during-transition.html imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-fired-before-old-state-capture.html imported/w3c/web-platform-tests/css/css-view-transitions/root-to-shared-animation-start.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67344 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68843 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/17162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12865 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11203 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5678 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8423 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5668 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9101 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7454 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->