### PR TITLE
[WPE][CMake] Clean build fails due to missing output directory for inspector resources

### DIFF
--- a/Source/cmake/FindGLibCompileResources.cmake
+++ b/Source/cmake/FindGLibCompileResources.cmake
@@ -48,10 +48,15 @@ function(GLIB_COMPILE_RESOURCES)
             ${ARG_SOURCE_XML} ${ARG_OUTPUT} ${ARG_OUTPUT}.deps)
     endif ()
 
+    get_filename_component(output_dir "${ARG_OUTPUT}" DIRECTORY)
+    get_filename_component(output_dir "${output_dir}" ABSOLUTE)
+    get_filename_component(ARG_OUTPUT "${ARG_OUTPUT}" ABSOLUTE)
+
     add_custom_command(
         OUTPUT  ${ARG_OUTPUT} ${ARG_OUTPUT}.deps
         DEPENDS ${ARG_SOURCE_XML}
         DEPFILE ${ARG_OUTPUT}.deps
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${output_dir}"
         COMMAND ${GLIB_COMPILE_RESOURCES_EXECUTABLE}
                 --generate
                 --target=${ARG_OUTPUT}


### PR DESCRIPTION
#### 795fdaece398b18bdefcd3954e0da2312ca92ee9
<pre>
[WPE][CMake] Clean build fails due to missing output directory for inspector resources
<a href="https://bugs.webkit.org/show_bug.cgi?id=283733">https://bugs.webkit.org/show_bug.cgi?id=283733</a>

Reviewed by Carlos Garcia Campos.

* Source/cmake/FindGLibCompileResources.cmake: Calculate absolute path
  to the output directory, and pre-create it to ensure it exists. While
  at it, also use absolute paths for the output files.

Canonical link: <a href="https://commits.webkit.org/287116@main">https://commits.webkit.org/287116@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bad296b7d29f3ed8f5713b95e802f8722e898421

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78368 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83029 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29633 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61362 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19284 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68895 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41678 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48725 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27970 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71514 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69819 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84394 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77606 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5734 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3889 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69590 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5895 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68845 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12868 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11206 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/99914 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12116 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5680 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21823 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5670 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9103 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7456 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->