### PR TITLE
Update MessageReceivers to be ref-counted in the GPUProcess

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -631,7 +631,7 @@ Ref<UserMediaCaptureManagerProxy> GPUConnectionToWebProcess::protectedUserMediaC
 RemoteAudioMediaStreamTrackRendererInternalUnitManager& GPUConnectionToWebProcess::audioMediaStreamTrackRendererInternalUnitManager()
 {
     if (!m_audioMediaStreamTrackRendererInternalUnitManager)
-        m_audioMediaStreamTrackRendererInternalUnitManager = makeUnique<RemoteAudioMediaStreamTrackRendererInternalUnitManager>(*this);
+        m_audioMediaStreamTrackRendererInternalUnitManager = makeUniqueWithoutRefCountedCheck<RemoteAudioMediaStreamTrackRendererInternalUnitManager>(*this);
 
     return *m_audioMediaStreamTrackRendererInternalUnitManager;
 }
@@ -674,7 +674,7 @@ Ref<RemoteAudioSessionProxy> GPUConnectionToWebProcess::protectedAudioSessionPro
 RemoteImageDecoderAVFProxy& GPUConnectionToWebProcess::imageDecoderAVFProxy()
 {
     if (!m_imageDecoderAVFProxy)
-        m_imageDecoderAVFProxy = makeUnique<RemoteImageDecoderAVFProxy>(*this);
+        m_imageDecoderAVFProxy = makeUniqueWithoutRefCountedCheck<RemoteImageDecoderAVFProxy>(*this);
 
     return *m_imageDecoderAVFProxy;
 }
@@ -845,7 +845,7 @@ void GPUConnectionToWebProcess::ensureAudioSession(EnsureAudioSessionCompletion&
 RemoteMediaSessionHelperProxy& GPUConnectionToWebProcess::mediaSessionHelperProxy()
 {
     if (!m_mediaSessionHelperProxy)
-        m_mediaSessionHelperProxy = makeUnique<RemoteMediaSessionHelperProxy>(*this);
+        m_mediaSessionHelperProxy = makeUniqueWithoutRefCountedCheck<RemoteMediaSessionHelperProxy>(*this);
     return *m_mediaSessionHelperProxy;
 }
 
@@ -879,7 +879,7 @@ Ref<RemoteLegacyCDMFactoryProxy> GPUConnectionToWebProcess::protectedLegacyCdmFa
 RemoteMediaEngineConfigurationFactoryProxy& GPUConnectionToWebProcess::mediaEngineConfigurationFactoryProxy()
 {
     if (!m_mediaEngineConfigurationFactoryProxy)
-        m_mediaEngineConfigurationFactoryProxy = makeUnique<RemoteMediaEngineConfigurationFactoryProxy>();
+        m_mediaEngineConfigurationFactoryProxy = makeUniqueWithoutRefCountedCheck<RemoteMediaEngineConfigurationFactoryProxy>(*this);
     return *m_mediaEngineConfigurationFactoryProxy;
 }
 #endif

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -421,7 +421,7 @@ private:
     RemoteAudioHardwareListenerMap m_remoteAudioHardwareListenerMap;
 
 #if USE(GRAPHICS_LAYER_WC)
-    using RemoteWCLayerTreeHostMap = HashMap<WCLayerTreeHostIdentifier, std::unique_ptr<RemoteWCLayerTreeHost>>;
+    using RemoteWCLayerTreeHostMap = HashMap<WCLayerTreeHostIdentifier, Ref<RemoteWCLayerTreeHost>>;
     RemoteWCLayerTreeHostMap m_remoteWCLayerTreeHostMap;
 #endif
 

--- a/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
@@ -55,9 +55,9 @@ IPC::StreamConnectionWorkQueue& remoteGraphicsStreamWorkQueue()
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteWCLayerTreeHost);
 
-std::unique_ptr<RemoteWCLayerTreeHost> RemoteWCLayerTreeHost::create(GPUConnectionToWebProcess& connectionToWebProcess, WebKit::WCLayerTreeHostIdentifier identifier, uint64_t nativeWindow, bool usesOffscreenRendering)
+Ref<RemoteWCLayerTreeHost> RemoteWCLayerTreeHost::create(GPUConnectionToWebProcess& connectionToWebProcess, WebKit::WCLayerTreeHostIdentifier identifier, uint64_t nativeWindow, bool usesOffscreenRendering)
 {
-    return makeUnique<RemoteWCLayerTreeHost>(connectionToWebProcess, identifier, nativeWindow, usesOffscreenRendering);
+    return adoptRef(*new RemoteWCLayerTreeHost(connectionToWebProcess, identifier, nativeWindow, usesOffscreenRendering));
 }
 
 RemoteWCLayerTreeHost::RemoteWCLayerTreeHost(GPUConnectionToWebProcess& connectionToWebProcess, WebKit::WCLayerTreeHostIdentifier identifier, uint64_t nativeWindow, bool usesOffscreenRendering)

--- a/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.h
+++ b/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.h
@@ -33,6 +33,7 @@
 #include "WCLayerTreeHostIdentifier.h"
 #include "WCSharedSceneContextHolder.h"
 #include <WebCore/ProcessIdentifier.h>
+#include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace IPC {
@@ -45,16 +46,17 @@ class WCScene;
 struct UpdateInfo;
 struct WCUpdateInfo;
 
-class RemoteWCLayerTreeHost : public IPC::MessageReceiver, private IPC::MessageSender {
+class RemoteWCLayerTreeHost : public IPC::MessageReceiver, private IPC::MessageSender, public RefCounted<RemoteWCLayerTreeHost> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteWCLayerTreeHost);
 public:
-    static std::unique_ptr<RemoteWCLayerTreeHost> create(GPUConnectionToWebProcess&, WebKit::WCLayerTreeHostIdentifier, uint64_t nativeWindow, bool usesOffscreenRendering);
-    RemoteWCLayerTreeHost(GPUConnectionToWebProcess&, WebKit::WCLayerTreeHostIdentifier, uint64_t nativeWindow, bool usesOffscreenRendering);
+    static Ref<RemoteWCLayerTreeHost> create(GPUConnectionToWebProcess&, WebKit::WCLayerTreeHostIdentifier, uint64_t nativeWindow, bool usesOffscreenRendering);
     ~RemoteWCLayerTreeHost();
     // message handlers
     void update(WCUpdateInfo&&, CompletionHandler<void(std::optional<WebKit::UpdateInfo>)>&&);
 
 private:
+    RemoteWCLayerTreeHost(GPUConnectionToWebProcess&, WebKit::WCLayerTreeHostIdentifier, uint64_t nativeWindow, bool usesOffscreenRendering);
+
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
     // IPC::MessageSender

--- a/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.messages.in
@@ -22,7 +22,7 @@
 
 #if USE(GRAPHICS_LAYER_WC)
 
-messages -> RemoteWCLayerTreeHost NotRefCounted {
+messages -> RemoteWCLayerTreeHost {
     Update(struct WebKit::WCUpdateInfo updateInfo) -> (std::optional<WebKit::UpdateInfo> updateInfo)
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
@@ -176,7 +176,7 @@ RemoteCDMInstanceProxy* RemoteCDMFactoryProxy::getInstance(const RemoteCDMInstan
     return m_instances.get(identifier);
 }
 
-void RemoteCDMFactoryProxy::addSession(const RemoteCDMInstanceSessionIdentifier& identifier, std::unique_ptr<RemoteCDMInstanceSessionProxy>&& session)
+void RemoteCDMFactoryProxy::addSession(const RemoteCDMInstanceSessionIdentifier& identifier, Ref<RemoteCDMInstanceSessionProxy>&& session)
 {
     ASSERT(!m_sessions.contains(identifier));
     m_sessions.set(identifier, WTFMove(session));

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h
@@ -73,7 +73,7 @@ public:
     void removeInstance(const RemoteCDMInstanceIdentifier&);
     RemoteCDMInstanceProxy* getInstance(const RemoteCDMInstanceIdentifier&);
 
-    void addSession(const RemoteCDMInstanceSessionIdentifier&, std::unique_ptr<RemoteCDMInstanceSessionProxy>&&);
+    void addSession(const RemoteCDMInstanceSessionIdentifier&, Ref<RemoteCDMInstanceSessionProxy>&&);
     void removeSession(const RemoteCDMInstanceSessionIdentifier&);
 
     RefPtr<GPUConnectionToWebProcess> gpuConnectionToWebProcess() { return m_gpuConnectionToWebProcess.get(); }
@@ -102,7 +102,7 @@ private:
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
     HashMap<RemoteCDMIdentifier, RefPtr<RemoteCDMProxy>> m_proxies;
     HashMap<RemoteCDMInstanceIdentifier, Ref<RemoteCDMInstanceProxy>> m_instances;
-    HashMap<RemoteCDMInstanceSessionIdentifier, std::unique_ptr<RemoteCDMInstanceSessionProxy>> m_sessions;
+    HashMap<RemoteCDMInstanceSessionIdentifier, Ref<RemoteCDMInstanceSessionProxy>> m_sessions;
 
 #if !RELEASE_LOG_DISABLED
     mutable RefPtr<Logger> m_logger;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
@@ -97,7 +97,7 @@ private:
     Ref<WebCore::CDMInstance> m_instance;
     UniqueRef<RemoteCDMInstanceConfiguration> m_configuration;
     RemoteCDMInstanceIdentifier m_identifier;
-    HashMap<RemoteCDMInstanceSessionIdentifier, std::unique_ptr<RemoteCDMInstanceSessionProxy>> m_sessions;
+    HashMap<RemoteCDMInstanceSessionIdentifier, Ref<RemoteCDMInstanceSessionProxy>> m_sessions;
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
@@ -38,9 +38,9 @@ namespace WebKit {
 
 using namespace WebCore;
 
-std::unique_ptr<RemoteCDMInstanceSessionProxy> RemoteCDMInstanceSessionProxy::create(WeakPtr<RemoteCDMProxy>&& proxy, Ref<WebCore::CDMInstanceSession>&& session, uint64_t logIdentifier, RemoteCDMInstanceSessionIdentifier identifier)
+Ref<RemoteCDMInstanceSessionProxy> RemoteCDMInstanceSessionProxy::create(WeakPtr<RemoteCDMProxy>&& proxy, Ref<WebCore::CDMInstanceSession>&& session, uint64_t logIdentifier, RemoteCDMInstanceSessionIdentifier identifier)
 {
-    auto sessionProxy = std::unique_ptr<RemoteCDMInstanceSessionProxy>(new RemoteCDMInstanceSessionProxy(WTFMove(proxy), WTFMove(session), logIdentifier, identifier));
+    Ref sessionProxy = adoptRef(*new RemoteCDMInstanceSessionProxy(WTFMove(proxy), WTFMove(session), logIdentifier, identifier));
     WeakPtr<WebCore::CDMInstanceSessionClient> client = sessionProxy.get();
     sessionProxy->protectedSession()->setClient(WTFMove(client));
     return sessionProxy;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
@@ -33,6 +33,7 @@
 #include "RemoteCDMProxy.h"
 #include <WebCore/CDMInstanceSession.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -41,9 +42,9 @@ class SharedBuffer;
 
 namespace WebKit {
 
-class RemoteCDMInstanceSessionProxy final : private IPC::MessageReceiver, private WebCore::CDMInstanceSessionClient {
+class RemoteCDMInstanceSessionProxy final : private IPC::MessageReceiver, private WebCore::CDMInstanceSessionClient, public RefCounted<RemoteCDMInstanceSessionProxy> {
 public:
-    static std::unique_ptr<RemoteCDMInstanceSessionProxy> create(WeakPtr<RemoteCDMProxy>&&, Ref<WebCore::CDMInstanceSession>&&, uint64_t logIdentifier, RemoteCDMInstanceSessionIdentifier);
+    static Ref<RemoteCDMInstanceSessionProxy> create(WeakPtr<RemoteCDMProxy>&&, Ref<WebCore::CDMInstanceSession>&&, uint64_t logIdentifier, RemoteCDMInstanceSessionIdentifier);
     virtual ~RemoteCDMInstanceSessionProxy();
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.messages.in
@@ -26,7 +26,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(ENCRYPTED_MEDIA)
 
 [EnabledBy=EncryptedMediaAPIEnabled]
-messages -> RemoteCDMInstanceSessionProxy NotRefCounted {
+messages -> RemoteCDMInstanceSessionProxy {
     SetLogIdentifier(uint64_t logIdentifier)
     RequestLicense(WebCore::CDMInstanceSession::LicenseType type, enum:bool WebCore::CDMKeyGroupingStrategy keyGroupingStrategy, AtomString initDataType, RefPtr<WebCore::SharedBuffer> initData) -> (RefPtr<WebCore::SharedBuffer> message, String sessionId, bool needsIndividualization, bool succeeded)
     UpdateLicense(String sessionId, WebCore::CDMInstanceSession::LicenseType type, RefPtr<WebCore::SharedBuffer> response) -> (bool sessionWasClosed, std::optional<WebCore::CDMInstanceSession::KeyStatusVector> changedKeys, std::optional<double> changedExpiration, std::optional<WebCore::CDMInstanceSession::Message> message, bool succeeded)

--- a/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp
@@ -50,6 +50,16 @@ RemoteImageDecoderAVFProxy::RemoteImageDecoderAVFProxy(GPUConnectionToWebProcess
 {
 }
 
+void RemoteImageDecoderAVFProxy::ref() const
+{
+    m_connectionToWebProcess.get()->ref();
+}
+
+void RemoteImageDecoderAVFProxy::deref() const
+{
+    m_connectionToWebProcess.get()->deref();
+}
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteImageDecoderAVFProxy);
 
 void RemoteImageDecoderAVFProxy::createDecoder(const IPC::SharedBufferReference& data, const String& mimeType, CompletionHandler<void(std::optional<ImageDecoderIdentifier>&&)>&& completionHandler)

--- a/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.h
@@ -58,6 +58,9 @@ public:
 
     bool allowsExitUnderMemoryPressure() const;
 
+    void ref() const;
+    void deref() const;
+
 private:
     void createDecoder(const IPC::SharedBufferReference&, const String& mimeType, CompletionHandler<void(std::optional<WebCore::ImageDecoderIdentifier>&&)>&&);
     void deleteDecoder(WebCore::ImageDecoderIdentifier);

--- a/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.messages.in
@@ -27,7 +27,7 @@
 
 #if ENABLE(GPU_PROCESS) && HAVE(AVASSETREADER)
 
-messages -> RemoteImageDecoderAVFProxy NotRefCounted {
+messages -> RemoteImageDecoderAVFProxy {
     CreateDecoder(IPC::SharedBufferReference data, String mimeType) -> (std::optional<WebCore::ImageDecoderIdentifier> identifier) Synchronous
     DeleteDecoder(WebCore::ImageDecoderIdentifier identifier)
     SetExpectedContentSize(WebCore::ImageDecoderIdentifier identifier, long long expectedContentSize)

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h
@@ -62,10 +62,10 @@ public:
     bool didReceiveSyncCDMMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
     bool didReceiveSyncCDMSessionMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
 
-    void addProxy(RemoteLegacyCDMIdentifier, std::unique_ptr<RemoteLegacyCDMProxy>&&);
+    void addProxy(RemoteLegacyCDMIdentifier, Ref<RemoteLegacyCDMProxy>&&);
     void removeProxy(RemoteLegacyCDMIdentifier);
 
-    void addSession(RemoteLegacyCDMSessionIdentifier, std::unique_ptr<RemoteLegacyCDMSessionProxy>&&);
+    void addSession(RemoteLegacyCDMSessionIdentifier, Ref<RemoteLegacyCDMSessionProxy>&&);
     void removeSession(RemoteLegacyCDMSessionIdentifier, CompletionHandler<void()>&&);
     RemoteLegacyCDMSessionProxy* getSession(const RemoteLegacyCDMSessionIdentifier&) const;
 
@@ -91,8 +91,8 @@ private:
     void supportsKeySystem(const String& keySystem, std::optional<String> mimeType, CompletionHandler<void(bool)>&&);
 
     WeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
-    HashMap<RemoteLegacyCDMIdentifier, std::unique_ptr<RemoteLegacyCDMProxy>> m_proxies;
-    HashMap<RemoteLegacyCDMSessionIdentifier, std::unique_ptr<RemoteLegacyCDMSessionProxy>> m_sessions;
+    HashMap<RemoteLegacyCDMIdentifier, Ref<RemoteLegacyCDMProxy>> m_proxies;
+    HashMap<RemoteLegacyCDMSessionIdentifier, Ref<RemoteLegacyCDMSessionProxy>> m_sessions;
 
 #if !RELEASE_LOG_DISABLED
     mutable RefPtr<Logger> m_logger;

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
@@ -36,9 +36,9 @@ namespace WebKit {
 
 using namespace WebCore;
 
-std::unique_ptr<RemoteLegacyCDMProxy> RemoteLegacyCDMProxy::create(WeakPtr<RemoteLegacyCDMFactoryProxy> factory, std::optional<MediaPlayerIdentifier> playerId, Ref<WebCore::LegacyCDM>&& cdm)
+Ref<RemoteLegacyCDMProxy> RemoteLegacyCDMProxy::create(WeakPtr<RemoteLegacyCDMFactoryProxy> factory, std::optional<MediaPlayerIdentifier> playerId, Ref<WebCore::LegacyCDM>&& cdm)
 {
-    return std::unique_ptr<RemoteLegacyCDMProxy>(new RemoteLegacyCDMProxy(WTFMove(factory), playerId, WTFMove(cdm)));
+    return adoptRef(*new RemoteLegacyCDMProxy(WTFMove(factory), playerId, WTFMove(cdm)));
 }
 
 RemoteLegacyCDMProxy::RemoteLegacyCDMProxy(WeakPtr<RemoteLegacyCDMFactoryProxy>&& factory, std::optional<MediaPlayerIdentifier> playerId, Ref<WebCore::LegacyCDM>&& cdm)
@@ -68,7 +68,7 @@ void RemoteLegacyCDMProxy::createSession(const String& keySystem, uint64_t logId
     }
 
     auto sessionIdentifier = RemoteLegacyCDMSessionIdentifier::generate();
-    auto session = RemoteLegacyCDMSessionProxy::create(*factory, logIdentifier, sessionIdentifier, protectedCDM());
+    Ref session = RemoteLegacyCDMSessionProxy::create(*factory, logIdentifier, sessionIdentifier, protectedCDM());
     factory->addSession(sessionIdentifier, WTFMove(session));
     callback(WTFMove(sessionIdentifier));
 }

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
@@ -38,13 +38,11 @@
 
 namespace WebKit {
 
-class RemoteLegacyCDMProxy
-    : public IPC::MessageReceiver
-    , public WebCore::LegacyCDMClient {
+class RemoteLegacyCDMProxy : public IPC::MessageReceiver, public WebCore::LegacyCDMClient, public RefCounted<RemoteLegacyCDMProxy> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLegacyCDMProxy);
 public:
-    static std::unique_ptr<RemoteLegacyCDMProxy> create(WeakPtr<RemoteLegacyCDMFactoryProxy>, std::optional<WebCore::MediaPlayerIdentifier>, Ref<WebCore::LegacyCDM>&&);
+    static Ref<RemoteLegacyCDMProxy> create(WeakPtr<RemoteLegacyCDMFactoryProxy>, std::optional<WebCore::MediaPlayerIdentifier>, Ref<WebCore::LegacyCDM>&&);
     ~RemoteLegacyCDMProxy();
 
     RemoteLegacyCDMFactoryProxy* factory() const { return m_factory.get(); }

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(LEGACY_ENCRYPTED_MEDIA)
 
 [EnabledBy=LegacyEncryptedMediaAPIEnabled]
-messages -> RemoteLegacyCDMProxy NotRefCounted {
+messages -> RemoteLegacyCDMProxy {
     SupportsMIMEType(String mimeType) -> (bool supports) Synchronous
     CreateSession(String mediaKeysStorageDirectory, uint64_t logIdentifier) -> (std::optional<WebKit::RemoteLegacyCDMSessionIdentifier> identifier) Synchronous
     SetPlayerId(std::optional<WebCore::MediaPlayerIdentifier> playerId)

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
@@ -42,9 +42,9 @@ namespace WebKit {
 
 using namespace WebCore;
 
-std::unique_ptr<RemoteLegacyCDMSessionProxy> RemoteLegacyCDMSessionProxy::create(RemoteLegacyCDMFactoryProxy& factory, uint64_t logIdentifier, RemoteLegacyCDMSessionIdentifier sessionIdentifier, WebCore::LegacyCDM& cdm)
+Ref<RemoteLegacyCDMSessionProxy> RemoteLegacyCDMSessionProxy::create(RemoteLegacyCDMFactoryProxy& factory, uint64_t logIdentifier, RemoteLegacyCDMSessionIdentifier sessionIdentifier, WebCore::LegacyCDM& cdm)
 {
-    return std::unique_ptr<RemoteLegacyCDMSessionProxy>(new RemoteLegacyCDMSessionProxy(factory, logIdentifier, sessionIdentifier, cdm));
+    return adoptRef(*new RemoteLegacyCDMSessionProxy(factory, logIdentifier, sessionIdentifier, cdm));
 }
 
 RemoteLegacyCDMSessionProxy::RemoteLegacyCDMSessionProxy(RemoteLegacyCDMFactoryProxy& factory, uint64_t parentLogIdentifier, RemoteLegacyCDMSessionIdentifier sessionIdentifier, WebCore::LegacyCDM& cdm)

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
@@ -30,6 +30,7 @@
 #include "RemoteLegacyCDMSessionIdentifier.h"
 #include <WebCore/LegacyCDMSession.h>
 #include <wtf/Forward.h>
+#include <wtf/RefCounted.h>
 #include <wtf/UniqueRef.h>
 
 #if ENABLE(GPU_PROCESS) && ENABLE(LEGACY_ENCRYPTED_MEDIA)
@@ -45,11 +46,10 @@ namespace WebKit {
 class RemoteLegacyCDMProxy;
 class RemoteMediaPlayerProxy;
 
-class RemoteLegacyCDMSessionProxy
-    : public IPC::MessageReceiver
-    , public WebCore::LegacyCDMSessionClient {
+class RemoteLegacyCDMSessionProxy : public IPC::MessageReceiver, public WebCore::LegacyCDMSessionClient, public RefCounted<RemoteLegacyCDMSessionProxy> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
-    static std::unique_ptr<RemoteLegacyCDMSessionProxy> create(RemoteLegacyCDMFactoryProxy&, uint64_t logIdentifier, RemoteLegacyCDMSessionIdentifier, WebCore::LegacyCDM&);
+    static Ref<RemoteLegacyCDMSessionProxy> create(RemoteLegacyCDMFactoryProxy&, uint64_t logIdentifier, RemoteLegacyCDMSessionIdentifier, WebCore::LegacyCDM&);
     ~RemoteLegacyCDMSessionProxy();
 
     void invalidate();

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(LEGACY_ENCRYPTED_MEDIA)
 
 [EnabledBy=LegacyEncryptedMediaAPIEnabled]
-messages -> RemoteLegacyCDMSessionProxy NotRefCounted {
+messages -> RemoteLegacyCDMSessionProxy {
     GenerateKeyRequest(String mimeType, RefPtr<WebCore::SharedBuffer> initData) -> (RefPtr<WebCore::SharedBuffer> nextMessage, String destinationURL, unsigned short errorCode, uint32_t systemCode) Synchronous
     ReleaseKeys()
     Update(RefPtr<WebCore::SharedBuffer> update) -> (bool succeeded, RefPtr<WebCore::SharedBuffer> nextMessage, unsigned short errorCode, uint32_t systemCode) Synchronous

--- a/Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
+#include "GPUConnectionToWebProcess.h"
 #include <WebCore/MediaCapabilitiesDecodingInfo.h>
 #include <WebCore/MediaCapabilitiesEncodingInfo.h>
 #include <WebCore/MediaDecodingConfiguration.h>
@@ -42,7 +43,8 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaEngineConfigurationFactoryProxy);
 
-RemoteMediaEngineConfigurationFactoryProxy::RemoteMediaEngineConfigurationFactoryProxy()
+RemoteMediaEngineConfigurationFactoryProxy::RemoteMediaEngineConfigurationFactoryProxy(GPUConnectionToWebProcess& connection)
+    : m_connection(connection)
 {
 }
 
@@ -60,6 +62,16 @@ void RemoteMediaEngineConfigurationFactoryProxy::createEncodingConfiguration(Web
     MediaEngineConfigurationFactory::createEncodingConfiguration(WTFMove(configuration), [completion = WTFMove(completion)] (auto info) mutable {
         completion(WTFMove(info));
     });
+}
+
+void RemoteMediaEngineConfigurationFactoryProxy::ref() const
+{
+    m_connection.get()->ref();
+}
+
+void RemoteMediaEngineConfigurationFactoryProxy::deref() const
+{
+    m_connection.get()->deref();
 }
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.h
@@ -36,13 +36,18 @@
 
 namespace WebKit {
 
+class GPUConnectionToWebProcess;
+
 class RemoteMediaEngineConfigurationFactoryProxy final : private IPC::MessageReceiver {
     WTF_MAKE_TZONE_ALLOCATED(RemoteMediaEngineConfigurationFactoryProxy);
 public:
-    RemoteMediaEngineConfigurationFactoryProxy();
+    explicit RemoteMediaEngineConfigurationFactoryProxy(GPUConnectionToWebProcess&);
     virtual ~RemoteMediaEngineConfigurationFactoryProxy();
 
     void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
+
+    void ref() const;
+    void deref() const;
 
 private:
     friend class GPUProcessConnection;
@@ -52,6 +57,8 @@ private:
     // Messages
     void createDecodingConfiguration(WebCore::MediaDecodingConfiguration&&, CompletionHandler<void(WebCore::MediaCapabilitiesDecodingInfo&&)>&&);
     void createEncodingConfiguration(WebCore::MediaEncodingConfiguration&&, CompletionHandler<void(WebCore::MediaCapabilitiesEncodingInfo&&)>&&);
+
+    ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_connection; // Cannot be null.
 };
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.messages.in
@@ -23,7 +23,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
-messages -> RemoteMediaEngineConfigurationFactoryProxy NotRefCounted {
+messages -> RemoteMediaEngineConfigurationFactoryProxy {
     CreateDecodingConfiguration(struct WebCore::MediaDecodingConfiguration configuration) -> (struct WebCore::MediaCapabilitiesDecodingInfo decodingInfo)
     CreateEncodingConfiguration(struct WebCore::MediaEncodingConfiguration configuration) -> (struct WebCore::MediaCapabilitiesEncodingInfo decodingInfo)
 }

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
@@ -52,6 +52,16 @@ RemoteMediaSessionHelperProxy::~RemoteMediaSessionHelperProxy()
     MediaSessionHelper::sharedHelper().removeClient(*this);
 }
 
+void RemoteMediaSessionHelperProxy::ref() const
+{
+    m_gpuConnection.get()->ref();
+}
+
+void RemoteMediaSessionHelperProxy::deref() const
+{
+    m_gpuConnection.get()->deref();
+}
+
 void RemoteMediaSessionHelperProxy::startMonitoringWirelessRoutes()
 {
     if (m_isMonitoringWirelessRoutes)

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h
@@ -50,6 +50,9 @@ public:
     void overridePresentingApplicationPIDIfNeeded();
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
+    void ref() const;
+    void deref() const;
+
 private:
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.messages.in
@@ -23,7 +23,7 @@
 
 #if ENABLE(GPU_PROCESS) && PLATFORM(IOS_FAMILY)
 
-messages -> RemoteMediaSessionHelperProxy NotRefCounted {
+messages -> RemoteMediaSessionHelperProxy {
 #if !PLATFORM(WATCHOS)
     [EnabledBy=MediaSessionEnabled] StartMonitoringWirelessRoutes()
     [EnabledBy=MediaSessionEnabled] StopMonitoringWirelessRoutes()

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -113,8 +113,16 @@ RemoteAudioMediaStreamTrackRendererInternalUnitManager::RemoteAudioMediaStreamTr
 {
 }
 
-RemoteAudioMediaStreamTrackRendererInternalUnitManager::~RemoteAudioMediaStreamTrackRendererInternalUnitManager()
+RemoteAudioMediaStreamTrackRendererInternalUnitManager::~RemoteAudioMediaStreamTrackRendererInternalUnitManager() = default;
+
+void RemoteAudioMediaStreamTrackRendererInternalUnitManager::ref() const
 {
+    m_gpuConnectionToWebProcess.get()->ref();
+}
+
+void RemoteAudioMediaStreamTrackRendererInternalUnitManager::deref() const
+{
+    m_gpuConnectionToWebProcess.get()->deref();
 }
 
 void RemoteAudioMediaStreamTrackRendererInternalUnitManager::createUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, const String& deviceID,  CompletionHandler<void(std::optional<WebCore::CAAudioStreamDescription>, size_t)>&& callback)

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
@@ -62,6 +62,9 @@ public:
 
     void notifyLastToCaptureAudioChanged();
 
+    void ref() const;
+    void deref() const;
+
 private:
     // Messages
     void createUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier, const String&, CompletionHandler<void(std::optional<WebCore::CAAudioStreamDescription>, size_t)>&& callback);

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in
@@ -23,7 +23,7 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_STREAM) && PLATFORM(COCOA)
 
-messages -> RemoteAudioMediaStreamTrackRendererInternalUnitManager NotRefCounted {
+messages -> RemoteAudioMediaStreamTrackRendererInternalUnitManager {
     CreateUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, String deviceID) -> (std::optional<WebCore::CAAudioStreamDescription> description, size_t frameChunkSize)
     DeleteUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
 


### PR DESCRIPTION
#### 0d0550b23c47b746fd88d4f5dc1c1cb2caa76e14
<pre>
Update MessageReceivers to be ref-counted in the GPUProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=283737">https://bugs.webkit.org/show_bug.cgi?id=283737</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::audioMediaStreamTrackRendererInternalUnitManager):
(WebKit::GPUConnectionToWebProcess::imageDecoderAVFProxy):
(WebKit::GPUConnectionToWebProcess::mediaSessionHelperProxy):
(WebKit::GPUConnectionToWebProcess::mediaEngineConfigurationFactoryProxy):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp:
(WebKit::RemoteWCLayerTreeHost::create):
* Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.h:
* Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.messages.in:
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp:
(WebKit::RemoteCDMFactoryProxy::addSession):
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp:
(WebKit::RemoteCDMInstanceSessionProxy::create):
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp:
(WebKit::RemoteImageDecoderAVFProxy::ref const):
(WebKit::RemoteImageDecoderAVFProxy::deref const):
* Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.h:
* Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp:
(WebKit::RemoteLegacyCDMFactoryProxy::addProxy):
(WebKit::RemoteLegacyCDMFactoryProxy::addSession):
(WebKit::RemoteLegacyCDMFactoryProxy::removeSession):
(WebKit::RemoteLegacyCDMFactoryProxy::getSession const):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp:
(WebKit::RemoteLegacyCDMProxy::create):
(WebKit::RemoteLegacyCDMProxy::createSession):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp:
(WebKit::RemoteLegacyCDMSessionProxy::create):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.cpp:
(WebKit::RemoteMediaEngineConfigurationFactoryProxy::RemoteMediaEngineConfigurationFactoryProxy):
(WebKit::RemoteMediaEngineConfigurationFactoryProxy::ref const):
(WebKit::RemoteMediaEngineConfigurationFactoryProxy::deref const):
* Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.messages.in:
* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp:
(WebKit::RemoteMediaSessionHelperProxy::ref const):
(WebKit::RemoteMediaSessionHelperProxy::deref const):
* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h:
* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.messages.in:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::ref const):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::deref const):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::~RemoteAudioMediaStreamTrackRendererInternalUnitManager): Deleted.
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in:

Canonical link: <a href="https://commits.webkit.org/287131@main">https://commits.webkit.org/287131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3d9ae2bc2c235c1ae3b94d0624142ade2318e59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83043 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29647 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66579 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61378 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19298 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41691 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48738 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27984 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69833 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25464 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84409 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3902 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69605 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5909 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68859 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12883 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11222 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12122 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5694 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8439 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5684 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9117 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7470 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->