### PR TITLE
Web Inspector: Graphics: Recording: WebGL objects are not highlighted correctly

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.css
+++ b/Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.css
@@ -106,26 +106,6 @@ body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .
     background-color: var(--value-changed-highlight);
 }
 
-.item.recording-action > .titles .context-replacer::after {
-    content: ".";
-}
-
-.item.recording-action.attribute > .titles .parameters::before {
-    content: " = ";
-}
-
-.item.recording-action:not(.attribute) > .titles .parameters::before {
-    content: "(";
-}
-
-.item.recording-action:not(.attribute) > .titles .parameters::after {
-    content: ")";
-}
-
-.item.recording-action > .titles .parameter:not(:last-child)::after {
-    content: ", ";
-}
-
 .item.recording-action:not(.selected) > .titles .parameter.swizzled {
     color: var(--text-color-gray-medium);
 }


### PR DESCRIPTION
#### 6027c342f898dd4eb0cb8a013aea6832da007318
<pre>
Web Inspector: Graphics: Recording: WebGL objects are not highlighted correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=283736">https://bugs.webkit.org/show_bug.cgi?id=283736</a>

Reviewed by Tim Nguyen.

* Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.js:
(WI.RecordingActionTreeElement):
(WI.RecordingActionTreeElement._generateDOM):
(WI.RecordingActionTreeElement._generateDOM.createParameterElement):
(WI.RecordingActionTreeElement.prototype.populateContextMenu):
(WI.RecordingActionTreeElement.prototype.customTitleTooltip): Deleted.
Give the paremeter type text the same styling as the object handle by having both be text in the same element.
As such, we no longer need to generate and save the text that would be copied since it exactly matches what&apos;s shown.

* Source/WebInspectorUI/UserInterface/Views/RecordingActionTreeElement.css:
(.item.recording-action &gt; .titles .context-replacer::after): Deleted.
(.item.recording-action.attribute &gt; .titles .parameters::before): Deleted.
(.item.recording-action:not(.attribute) &gt; .titles .parameters::before): Deleted.
(.item.recording-action:not(.attribute) &gt; .titles .parameters::after): Deleted.
(.item.recording-action &gt; .titles .parameter:not(:last-child)::after): Deleted.
There is a bug in `Source/JavaScriptCore/Scripts/cssmin.py` that will cause `content: &quot;, &quot;` to be transformed into `content: &quot;,&quot;`.
Instead, just move the text content into the DOM where it should be anyways.  This also helps with the above.

Canonical link: <a href="https://commits.webkit.org/287127@main">https://commits.webkit.org/287127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d20b4e97c355e54f8c8cbc66ba744b80f05a24ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83040 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29644 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5706 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61376 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19296 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51385 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/68930 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41689 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48732 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25089 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/27981 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69827 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84405 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5745 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69600 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5906 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67357 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68855 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17175 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12885 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11217 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5691 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5681 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9114 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7467 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->