### PR TITLE
Make list-style-position quirk only available in quirks mode

### DIFF
--- a/LayoutTests/fast/lists/inline-before-content-after-list-marker.html
+++ b/LayoutTests/fast/lists/inline-before-content-after-list-marker.html
@@ -3,6 +3,7 @@
 <html>
 <body style="font-family: ahem; font-size: 40px; -webkit-font-smoothing: none;">
 <style>
+li { list-style-position: inside; }
 li:before { content: "PA"; }
 </style>
 <li>SS

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -739,7 +739,6 @@ html/HTMLFrameOwnerElement.cpp
 html/HTMLImageElement.cpp
 html/HTMLImageLoader.cpp
 html/HTMLInputElement.cpp
-html/HTMLLIElement.cpp
 html/HTMLLabelElement.cpp
 html/HTMLMapElement.cpp
 html/HTMLMediaElement.cpp

--- a/Source/WebCore/css/quirks.css
+++ b/Source/WebCore/css/quirks.css
@@ -2,7 +2,7 @@
  * Additonal style sheet used to render HTML pages in quirks mode.
  *
  * Copyright (C) 2000-2003 Lars Knoll (knoll@kde.org)
- * Copyright (C) 2004, 2006, 2007 Apple Inc. All rights reserved.
+ * Copyright (C) 2004, 2006, 2007, 2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -22,6 +22,21 @@
  */
 
 @namespace "http://www.w3.org/1999/xhtml";
+
+/* Force inside position for orphaned lis */
+li {
+    list-style-position: inside;
+}
+
+/* Restore outside position for lists inside lis */
+li :is(ul, ol) {
+    list-style-position: outside;
+}
+
+/* Undo previous two rules for properly nested lists */
+:is(ul, ol) :is(ul, ol, li) {
+    list-style-position: unset;
+}
 
 /* Give floated images margins of 3px */
 img[align="left"] {

--- a/Source/WebCore/html/HTMLLIElement.cpp
+++ b/Source/WebCore/html/HTMLLIElement.cpp
@@ -97,25 +97,4 @@ void HTMLLIElement::collectPresentationalHintsForAttribute(const QualifiedName& 
         HTMLElement::collectPresentationalHintsForAttribute(name, value, style);
 }
 
-void HTMLLIElement::didAttachRenderers()
-{
-    CheckedPtr listItemRenderer = dynamicDowncast<RenderListItem>(*renderer());
-    if (!listItemRenderer)
-        return;
-
-    // Check if there is an enclosing list.
-    bool isInList = false;
-    for (auto& ancestor : ancestorsOfType<HTMLElement>(*this)) {
-        if (is<HTMLUListElement>(ancestor) || is<HTMLOListElement>(ancestor)) {
-            isInList = true;
-            break;
-        }
-    }
-
-    // If we are not in a list, tell the renderer so it can position us inside.
-    // We don't want to change our style to say "inside" since that would affect nested nodes.
-    if (!isInList)
-        listItemRenderer->setNotInList(true);
-}
-
 }

--- a/Source/WebCore/html/HTMLLIElement.h
+++ b/Source/WebCore/html/HTMLLIElement.h
@@ -38,8 +38,6 @@ private:
 
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
-
-    void didAttachRenderers() final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -446,7 +446,7 @@ bool InlineFormattingUtils::isAtSoftWrapOpportunity(const InlineItem& previous, 
     }
     if (previous.layoutBox().isListMarkerBox()) {
         auto& listMarkerBox = downcast<ElementBox>(previous.layoutBox());
-        return !listMarkerBox.isListMarkerInsideList() || !listMarkerBox.isListMarkerOutside();
+        return !listMarkerBox.isListMarkerOutside();
     }
     if (next.layoutBox().isListMarkerBox()) {
         // FIXME: SHould this ever be the case?

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -257,8 +257,6 @@ UniqueRef<Layout::Box> BoxTreeUpdater::createLayoutBox(RenderObject& renderer)
             listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Image);
         if (!listMarkerRenderer->isInside())
             listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Outside);
-        if (listMarkerRenderer->listItem() && !listMarkerRenderer->listItem()->notInList())
-            listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::HasListElementAncestor);
         return makeUniqueRef<Layout::ElementBox>(elementAttributes(renderElement), listMarkerAttributes, WTFMove(style), WTFMove(firstLineStyle));
     }
 
@@ -329,8 +327,6 @@ static void updateListMarkerAttributes(const RenderListMarker& listMarkerRendere
         listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Image);
     if (!listMarkerRenderer.isInside())
         listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Outside);
-    if (listMarkerRenderer.listItem() && !listMarkerRenderer.listItem()->notInList())
-        listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::HasListElementAncestor);
 
     layoutBox.setListMarkerAttributes(listMarkerAttributes);
 }

--- a/Source/WebCore/layout/layouttree/LayoutElementBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutElementBox.h
@@ -46,7 +46,6 @@ public:
     enum class ListMarkerAttribute : uint8_t {
         Image = 1 << 0,
         Outside = 1 << 1,
-        HasListElementAncestor = 1 << 2
     };
     ElementBox(ElementAttributes&&, OptionSet<ListMarkerAttribute>, RenderStyle&&, std::unique_ptr<RenderStyle>&& firstLineStyle = nullptr);
 
@@ -95,7 +94,6 @@ public:
 
     bool isListMarkerImage() const { return m_replacedData && m_replacedData->listMarkerAttributes.contains(ListMarkerAttribute::Image); }
     bool isListMarkerOutside() const { return m_replacedData && m_replacedData->listMarkerAttributes.contains(ListMarkerAttribute::Outside); }
-    bool isListMarkerInsideList() const { return m_replacedData && m_replacedData->listMarkerAttributes.contains(ListMarkerAttribute::HasListElementAncestor); }
 
     // FIXME: This doesn't belong.
     CachedImage* cachedImage() const { return m_replacedData ? m_replacedData->cachedImage : nullptr; }

--- a/Source/WebCore/rendering/RenderListItem.h
+++ b/Source/WebCore/rendering/RenderListItem.h
@@ -41,9 +41,6 @@ public:
     int value() const;
     void updateValue();
 
-    void setNotInList(bool notInList) { m_notInList = notInList; }
-    bool notInList() const { return m_notInList; }
-
     WEBCORE_EXPORT String markerTextWithoutSuffix() const;
     String markerTextWithSuffix() const;
 
@@ -74,7 +71,6 @@ private:
 
     SingleThreadWeakPtr<RenderListMarker> m_marker;
     mutable std::optional<int> m_value;
-    bool m_notInList { false };
 };
 
 bool isHTMLListElement(const Node&);

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -433,7 +433,7 @@ LayoutUnit RenderListMarker::baselinePosition(FontBaseline baselineType, bool fi
 
 bool RenderListMarker::isInside() const
 {
-    return m_listItem->notInList() || style().listStylePosition() == ListStylePosition::Inside;
+    return style().listStylePosition() == ListStylePosition::Inside;
 }
 
 const RenderListItem* RenderListMarker::listItem() const


### PR DESCRIPTION
#### 3be0078f2601ceca057ebd096ae3384d75cdd8b4
<pre>
Make list-style-position quirk only available in quirks mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=283738">https://bugs.webkit.org/show_bug.cgi?id=283738</a>
<a href="https://rdar.apple.com/140602985">rdar://140602985</a>

Reviewed by Oriol Brufau.

There is a quirk that treats list items outside of ul/ol elements as `list-style-position: inside`.
This was a quirk to imitate the behavior in IE, however it is not spec compliant.

Implement this behavior using CSS and restrict it to quirks mode only. This matches Firefox and the specification.

Chrome use counter shows only 0.7% of page loads using this quirk: <a href="https://chromestatus.com/metrics/feature/timeline/popularity/5000">https://chromestatus.com/metrics/feature/timeline/popularity/5000</a>
None of the affected sites are particularly popular.

This makes any potential impact manageable using quirks if needed.

* LayoutTests/fast/lists/inline-before-content-after-list-marker.html:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/css/quirks.css:
(@namespace &quot;<a href="http://www.w3.org/1999/xhtml&quot">http://www.w3.org/1999/xhtml&quot</a>;;):
(li :is(ul, ol)):
(:is(ul, ol) :is(ul, ol, li)):
* Source/WebCore/html/HTMLLIElement.cpp:
(WebCore::HTMLLIElement::didAttachRenderers): Deleted.
* Source/WebCore/html/HTMLLIElement.h:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
(WebCore::Layout::InlineFormattingUtils::isAtSoftWrapOpportunity const):
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::BoxTreeUpdater::createLayoutBox):
(WebCore::LayoutIntegration::updateListMarkerAttributes):
* Source/WebCore/layout/layouttree/LayoutElementBox.h:
(WebCore::Layout::ElementBox::isListMarkerOutside const):
(WebCore::Layout::ElementBox::isListMarkerInsideList const): Deleted.
* Source/WebCore/rendering/RenderListItem.h:
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::isInside const):

Canonical link: <a href="https://commits.webkit.org/287114@main">https://commits.webkit.org/287114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b5dceb0dae92b4e6a636aa8b8ff5a50bb0dfd68

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83068 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/29672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80540 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5734 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/61398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/29672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81474 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/51412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/69076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/41711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/48759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/25135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28009 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/69854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/25505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84434 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5773 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/69624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5934 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/67419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/68879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/12905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/11259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12114 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5719 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8574 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5709 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9142 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7495 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->