### PR TITLE
[TextureMapper] Fix backdrop root

### DIFF
--- a/LayoutTests/compositing/overlap-blending/backdrop-opacity-expected.html
+++ b/LayoutTests/compositing/overlap-blending/backdrop-opacity-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+    <style type="text/css" media="screen">
+      div {
+        -webkit-box-sizing: border-box;
+        width: 200px;
+        height: 200px;
+      }
+      .solid {
+        position: absolute;
+        background: green;
+      }
+
+      .opacity { opacity: .5; }
+
+      .composited {
+        position: absolute;
+        transform: translateZ(0);
+        filter: invert();
+      }
+      * { margin: 0; padding: 0; }
+
+    </style>
+  </head>
+    <div class="solid opacity">
+      <div class="solid composited"></div>
+    </div>
+</html>

--- a/LayoutTests/compositing/overlap-blending/backdrop-opacity.html
+++ b/LayoutTests/compositing/overlap-blending/backdrop-opacity.html
@@ -1,0 +1,29 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+    <style type="text/css" media="screen">
+      div {
+        -webkit-box-sizing: border-box;
+        width: 200px;
+        height: 200px;
+      }
+      .solid {
+        position: absolute;
+        background: green;
+      }
+
+      .opacity { opacity: .5; }
+
+      .backdrop {
+        position: absolute;
+        -webkit-backdrop-filter: invert();
+      }
+      * { margin: 0; padding: 0; }
+
+    </style>
+  </head>
+    <div class="solid opacity">
+      <div class="backdrop"></div>
+    </div>
+</html>

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -789,7 +789,7 @@ void TextureMapperLayer::computeOverlapRegions(ComputeOverlapRegionData& data, c
     FloatRect localBoundingRect;
     if (isFlattened() && !m_isBackdrop)
         localBoundingRect = m_flattenedLayer->layerRect();
-    else if (m_backingStore || m_state.masksToBounds || m_state.maskLayer || hasFilters())
+    else if (m_backingStore || m_state.masksToBounds || m_state.maskLayer || hasFilters() || hasBackdrop())
         localBoundingRect = layerRect();
     else if (m_contentsLayer || m_state.solidColor.isVisible())
         localBoundingRect = m_state.contentsRect;
@@ -932,8 +932,7 @@ void TextureMapperLayer::paintIntoSurface(TextureMapperPaintOptions& options)
         SetForScope scopedTransform(options.transform, TransformationMatrix());
         SetForScope scopedReplicaLayer(options.replicaLayer, nullptr);
         SetForScope scopedBackdropLayer(options.backdropLayer, this);
-
-        rootLayer().paintSelfAndChildren(options);
+        backdropRootLayer().paintSelfAndChildren(options);
     } else
         paintSelfAndChildren(options);
 
@@ -965,6 +964,7 @@ void TextureMapperLayer::paintWithIntermediateSurface(TextureMapperPaintOptions&
         SetForScope scopedOpacity(options.opacity, 1);
 
         options.textureMapper.bindSurface(options.surface.get());
+
         paintSelfChildrenReplicaFilterAndMask(options);
     }
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -125,14 +125,19 @@ public:
     FloatRect effectiveLayerRect() const;
 
 private:
-    TextureMapperLayer& rootLayer() const
+    TextureMapperLayer& backdropRootLayer() const
     {
         if (m_effectTarget)
-            return m_effectTarget->rootLayer();
+            return m_effectTarget->backdropRootLayer();
         if (m_parent) {
-            if (m_parent->flattensAsLeafOf3DSceneOr3DPerspective())
+            if (m_parent->flattensAsLeafOf3DSceneOr3DPerspective()
+                || m_parent->m_state.opacity < 1
+                || m_parent->hasMask()
+                || m_parent->hasFilters()) {
                 return *m_parent;
-            return m_parent->rootLayer();
+            }
+
+            return m_parent->backdropRootLayer();
         }
         return const_cast<TextureMapperLayer&>(*this);
     }
@@ -192,6 +197,8 @@ private:
 
     bool preserves3D() const { return m_state.preserves3D; }
     bool isFlattened() const { return !!m_flattenedLayer; }
+    bool hasMask() const { return !!m_state.maskLayer; }
+    bool hasBackdrop() const  { return !!m_state.backdropLayer; }
 
     inline FloatRect layerRect() const
     {


### PR DESCRIPTION
#### 382e5cfc863b809dbe287cb92e682226e33c39b4
<pre>
[TextureMapper] Fix backdrop root
<a href="https://bugs.webkit.org/show_bug.cgi?id=218641">https://bugs.webkit.org/show_bug.cgi?id=218641</a>

Reviewed by Fujii Hironori.

Fix backdrop root according to Filter Effects Module Level 2.

* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::computeOverlapRegions):
(WebCore::TextureMapperLayer::paintIntoSurface):
(WebCore::TextureMapperLayer::paintWithIntermediateSurface):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
(WebCore::TextureMapperLayer::backdropRootLayer const):
(WebCore::TextureMapperLayer::hasMask const):
(WebCore::TextureMapperLayer::hasBackdrop const):
(WebCore::TextureMapperLayer::rootLayer const): Deleted.

Canonical link: <a href="https://commits.webkit.org/287154@main">https://commits.webkit.org/287154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04b259400bd89ee52fdeadb059b70d9631020397

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83211 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29815 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5876 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61530 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19442 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81617 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41836 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48883 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25370 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28152 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69983 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84577 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5915 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4050 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69751 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6076 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67513 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69005 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13024 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11470 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12128 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5862 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/11745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5850 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9284 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->