### PR TITLE
Fix debug crashes introduced by 287107@main

### DIFF
--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -31,17 +31,22 @@ class RenderListItem;
 class StyleRuleCounterStyle;
 
 struct ListMarkerTextContent {
-    String textWithoutSuffix;
-    String suffix;
+    String textWithSuffix;
+    uint32_t textWithoutSuffixLength { 0 };
     TextDirection textDirection { TextDirection::LTR };
     bool isEmpty() const
     {
-        return textWithoutSuffix.isEmpty() && suffix.isEmpty();
+        return textWithSuffix.isEmpty();
     }
 
-    String textWithSuffix() const
+    StringView textWithoutSuffix() const
     {
-        return makeString(textWithoutSuffix, suffix);
+        return StringView { textWithSuffix }.left(textWithoutSuffixLength);
+    }
+
+    StringView suffix() const
+    {
+        return StringView { textWithSuffix }.substring(textWithoutSuffixLength);
     }
 };
 
@@ -54,8 +59,8 @@ public:
     RenderListMarker(RenderListItem&, RenderStyle&&);
     virtual ~RenderListMarker();
 
-    String textWithoutSuffix() const { return m_textContent.textWithoutSuffix; };
-    String textWithSuffix() const { return m_textContent.textWithSuffix(); };
+    String textWithoutSuffix() const { return m_textContent.textWithoutSuffix().toString(); };
+    String textWithSuffix() const { return m_textContent.textWithSuffix; };
 
     bool isInside() const;
 


### PR DESCRIPTION
#### 1f3630a70928390bd096be3befe21c3d7d54dafe
<pre>
Fix debug crashes introduced by 287107@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=283745">https://bugs.webkit.org/show_bug.cgi?id=283745</a>
<a href="https://rdar.apple.com/140613216">rdar://140613216</a>

Reviewed by Fujii Hironori.

Revert parts where we using a temporary string for `textWithSuffix`, go back to the old approach of getting substrings of the full string.

Also add a missing bounds check for `list-style: &quot;&quot;`.

These tests were crashing (first 4 were due to the temporary string, last 2 were due to the missing bounds check):

accessibility/mac/attributed-string-with-listitem-multiple-lines.html
accessibility/mac/listmarker-suffix.html
accessibility/mac/string-range-contains-listmarker.html
accessibility/mac/text-marker-range-selection-in-list-items.html
imported/w3c/web-platform-tests/css/css-lists/list-style-type-string-003.html
imported/w3c/web-platform-tests/css/css-lists/list-style-type-string-007.html

* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::textRunForContent):
(WebCore::RenderListMarker::updateContent):
* Source/WebCore/rendering/RenderListMarker.h:
(WebCore::ListMarkerTextContent::isEmpty const):
(WebCore::ListMarkerTextContent::textWithoutSuffix const):
(WebCore::ListMarkerTextContent::suffix const):
(WebCore::ListMarkerTextContent::textWithSuffix const): Deleted.

Canonical link: <a href="https://commits.webkit.org/287128@main">https://commits.webkit.org/287128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49751a1ff150ad8cf651762d1c14abf4f75df35b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31838 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/83117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29721 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5782 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/83117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/19360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81523 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/51452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/69254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/83117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/48798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/25203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/28058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/69895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/25573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84483 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5821 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/3965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/69668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5982 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/67446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/68923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/12945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/11319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12121 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5768 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/9040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5757 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9190 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7543 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->