### PR TITLE
CanvasRenderingContext2DBase::getImageData with ImageDataStorageFormat

### DIFF
--- a/LayoutTests/fast/canvas/imagedata-storageformat-enabled-expected.txt
+++ b/LayoutTests/fast/canvas/imagedata-storageformat-enabled-expected.txt
@@ -33,17 +33,26 @@ PASS created_imageData_float16.data.at(0) is 0
 PASS created_imageData_float16.data.at(1) is 0
 PASS created_imageData_float16.data.at(2) is 0
 PASS created_imageData_float16.data.at(3) is 0
-FIXME: gotten_imageData_float16.data below should eventually become Float16Array.
 PASS gotten_imageData_float16.width is 1
 PASS gotten_imageData_float16.height is 1
-PASS gotten_imageData_float16.data.constructor is Uint8ClampedArray
-PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is 1
+PASS gotten_imageData_float16.data.constructor is Float16Array
+PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is 2
 PASS gotten_imageData_float16.data.length is 4
-PASS gotten_imageData_float16.data.byteLength is 4
-PASS gotten_imageData_float16.data.at(0) is 0
-PASS gotten_imageData_float16.data.at(1) is 128
-PASS gotten_imageData_float16.data.at(2) is 255
-PASS gotten_imageData_float16.data.at(3) is 255
+PASS gotten_imageData_float16.data.byteLength is 8
+PASS gotten_imageData_float16.data.at(0) is within 0.001953125 of 0
+PASS gotten_imageData_float16.data.at(1) is within 0.001953125 of 0.5019607843137255
+PASS gotten_imageData_float16.data.at(2) is within 0.001953125 of 1
+PASS gotten_imageData_float16.data.at(3) is within 0.001953125 of 1
+PASS gotten_imageData_uint8_from_float16.width is 1
+PASS gotten_imageData_uint8_from_float16.height is 1
+PASS gotten_imageData_uint8_from_float16.data.constructor is Uint8ClampedArray
+PASS gotten_imageData_uint8_from_float16.data.BYTES_PER_ELEMENT is 1
+PASS gotten_imageData_uint8_from_float16.data.length is 4
+PASS gotten_imageData_uint8_from_float16.data.byteLength is 4
+PASS gotten_imageData_uint8_from_float16.data.at(0) is 0
+PASS gotten_imageData_uint8_from_float16.data.at(1) is 128
+PASS gotten_imageData_uint8_from_float16.data.at(2) is 255
+PASS gotten_imageData_uint8_from_float16.data.at(3) is 255
 PASS context.createImageData(1, 1, { storageFormat: "foo" }) threw exception TypeError: Type error.
 PASS context.getImageData(0, 0, 1, 1, { storageFormat: "foo" }) threw exception TypeError: Type error.
 PASS successfullyParsed is true

--- a/LayoutTests/fast/canvas/imagedata-storageformat-enabled.html
+++ b/LayoutTests/fast/canvas/imagedata-storageformat-enabled.html
@@ -19,31 +19,50 @@ var a = 255;
 context.fillStyle = `rgb(${r} ${g} ${b})`;
 context.fillRect(0, 0, 1, 1);
 
-function verifyImageData(variable, constructor, bytesPerElement, red, green, blue, alpha) {
+function shouldBeAround(to_eval, targetNumber, tolerance, quiet)
+{
+    if (!tolerance)
+        return shouldBe(to_eval, String(targetNumber), quiet);
+    return shouldBeCloseTo(to_eval, targetNumber, tolerance, quiet);
+}
+
+function verifyImageData(variable, constructor, bytesPerElement, red, green, blue, alpha, tolerance) {
     shouldBe(variable + '.width', '1');
     shouldBe(variable + '.height', '1');
     shouldBe(variable + '.data.constructor', constructor);
     shouldBe(variable + '.data.BYTES_PER_ELEMENT', String(bytesPerElement));
     shouldBe(variable + '.data.length', '4');
     shouldBe(variable + '.data.byteLength', String(bytesPerElement * 4));
-    shouldBe(variable + '.data.at(0)', String(red));
-    shouldBe(variable + '.data.at(1)', String(green));
-    shouldBe(variable + '.data.at(2)', String(blue));
-    shouldBe(variable + '.data.at(3)', String(alpha));
+    shouldBeAround(variable + '.data.at(0)', red, tolerance);
+    shouldBeAround(variable + '.data.at(1)', green, tolerance);
+    shouldBeAround(variable + '.data.at(2)', blue, tolerance);
+    shouldBeAround(variable + '.data.at(3)', alpha, tolerance);
 }
 
+const uint8_bytes_per_element = 1;
+const float16_bytes_per_element = 2;
+// Less than half the range of a color component [0..255]/255 unit.
+const float16_nonzero_tolerance = (1 / 256) / 2;
+
 var created_imageData_uint8 = context.createImageData(1, 1, { storageFormat: "uint8" });
-verifyImageData('created_imageData_uint8', 'Uint8ClampedArray', 1, 0, 0, 0, 0);
+verifyImageData('created_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, 0, 0, 0, 0);
 
 var gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { storageFormat: "uint8" });
-verifyImageData('gotten_imageData_uint8', 'Uint8ClampedArray', 1, r, g, b, a);
+verifyImageData('gotten_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a);
 
 var created_imageData_float16 = context.createImageData(1, 1, { storageFormat: "float16" });
-verifyImageData('created_imageData_float16', 'Float16Array', 2, 0, 0, 0, 0);
+verifyImageData('created_imageData_float16', 'Float16Array', float16_bytes_per_element, 0, 0, 0, 0, 0);
 
+// This verifies the basic float16->uint8 conversion.
 var gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { storageFormat: "float16" });
-debug('FIXME: gotten_imageData_float16.data below should eventually become Float16Array.');
-verifyImageData('gotten_imageData_float16', 'Uint8ClampedArray', 1, r, g, b, a);
+verifyImageData('gotten_imageData_float16', 'Float16Array', float16_bytes_per_element, r / 255, g / 255, b / 255, a / 255, float16_nonzero_tolerance);
+
+// Put the float16 ImageData back into the (uint8-backed) canvas, and get a default (uint8) ImageData.
+// This verifies the basic uint8->float16 conversion:
+context.clearRect(0, 0, 1, 1);
+context.putImageData(gotten_imageData_float16, 0, 0);
+var gotten_imageData_uint8_from_float16 = context.getImageData(0, 0, 1, 1);
+verifyImageData('gotten_imageData_uint8_from_float16', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a);
 
 shouldThrowErrorName(`context.createImageData(1, 1, { storageFormat: "foo" })`, "TypeError")
 shouldThrowErrorName(`context.getImageData(0, 0, 1, 1, { storageFormat: "foo" })`, "TypeError")

--- a/Source/WebCore/html/ImageData.cpp
+++ b/Source/WebCore/html/ImageData.cpp
@@ -53,20 +53,20 @@ static ImageDataStorageFormat computeStorageFormat(std::optional<ImageDataSettin
     return settings ? settings->storageFormat : defaultStorageFormat;
 }
 
-Ref<ImageData> ImageData::create(Ref<ByteArrayPixelBuffer>&& pixelBuffer)
+Ref<ImageData> ImageData::create(Ref<ByteArrayPixelBuffer>&& pixelBuffer, std::optional<ImageDataStorageFormat> overridingStorageFormat)
 {
     auto colorSpace = toPredefinedColorSpace(pixelBuffer->format().colorSpace);
-    return adoptRef(*new ImageData(pixelBuffer->size(), pixelBuffer->takeData(), *colorSpace));
+    return adoptRef(*new ImageData(pixelBuffer->size(), pixelBuffer->takeData(), *colorSpace, overridingStorageFormat));
 }
 
-RefPtr<ImageData> ImageData::create(RefPtr<ByteArrayPixelBuffer>&& pixelBuffer)
+RefPtr<ImageData> ImageData::create(RefPtr<ByteArrayPixelBuffer>&& pixelBuffer, std::optional<ImageDataStorageFormat> overridingStorageFormat)
 {
     if (!pixelBuffer)
         return nullptr;
-    return create(pixelBuffer.releaseNonNull());
+    return create(pixelBuffer.releaseNonNull(), overridingStorageFormat);
 }
 
-RefPtr<ImageData> ImageData::create(const IntSize& size, PredefinedColorSpace colorSpace)
+RefPtr<ImageData> ImageData::create(const IntSize& size, PredefinedColorSpace colorSpace, ImageDataStorageFormat imageDataStorageFormat)
 {
     auto dataSize = computeDataSize(size, ImageDataStorageFormat::Uint8);
     if (dataSize.hasOverflowed())
@@ -74,7 +74,7 @@ RefPtr<ImageData> ImageData::create(const IntSize& size, PredefinedColorSpace co
     auto array = ImageDataArray::tryCreate(dataSize, ImageDataStorageFormat::Uint8);
     if (!array)
         return nullptr;
-    return adoptRef(*new ImageData(size, WTFMove(*array), colorSpace));
+    return adoptRef(*new ImageData(size, WTFMove(*array), colorSpace, imageDataStorageFormat));
 }
 
 RefPtr<ImageData> ImageData::create(const IntSize& size, ImageDataArray&& array, PredefinedColorSpace colorSpace)
@@ -141,6 +141,13 @@ ExceptionOr<Ref<ImageData>> ImageData::create(ImageDataArray&& array, unsigned s
 ImageData::ImageData(const IntSize& size, ImageDataArray&& data, PredefinedColorSpace colorSpace)
     : m_size(size)
     , m_data(WTFMove(data))
+    , m_colorSpace(colorSpace)
+{
+}
+
+ImageData::ImageData(const IntSize& size, ImageDataArray&& data, PredefinedColorSpace colorSpace, std::optional<ImageDataStorageFormat> overridingStorageFormat)
+    : m_size(size)
+    , m_data(WTFMove(data), overridingStorageFormat)
     , m_colorSpace(colorSpace)
 {
 }

--- a/Source/WebCore/html/ImageData.h
+++ b/Source/WebCore/html/ImageData.h
@@ -41,9 +41,9 @@ namespace WebCore {
 
 class ImageData : public RefCounted<ImageData> {
 public:
-    WEBCORE_EXPORT static Ref<ImageData> create(Ref<ByteArrayPixelBuffer>&&);
-    WEBCORE_EXPORT static RefPtr<ImageData> create(RefPtr<ByteArrayPixelBuffer>&&);
-    WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, PredefinedColorSpace);
+    WEBCORE_EXPORT static Ref<ImageData> create(Ref<ByteArrayPixelBuffer>&&, std::optional<ImageDataStorageFormat> = { });
+    WEBCORE_EXPORT static RefPtr<ImageData> create(RefPtr<ByteArrayPixelBuffer>&&, std::optional<ImageDataStorageFormat> = { });
+    WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, PredefinedColorSpace, ImageDataStorageFormat = ImageDataStorageFormat::Uint8);
     WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, ImageDataArray&&, PredefinedColorSpace);
 
     WEBCORE_EXPORT static ExceptionOr<Ref<ImageData>> create(unsigned sw, unsigned sh, PredefinedColorSpace defaultColorSpace, std::optional<ImageDataSettings> = std::nullopt, std::span<const uint8_t> = { });
@@ -66,6 +66,7 @@ public:
 
 private:
     explicit ImageData(const IntSize&, ImageDataArray&&, PredefinedColorSpace);
+    explicit ImageData(const IntSize&, ImageDataArray&&, PredefinedColorSpace, std::optional<ImageDataStorageFormat>);
 
     IntSize m_size;
     ImageDataArray m_data;

--- a/Source/WebCore/html/ImageDataArray.h
+++ b/Source/WebCore/html/ImageDataArray.h
@@ -44,6 +44,7 @@ public:
 
     ImageDataArray(Ref<JSC::Uint8ClampedArray>&&);
     ImageDataArray(Ref<JSC::Float16Array>&&);
+    ImageDataArray(ImageDataArray&& original, std::optional<ImageDataStorageFormat> overridingStorageFormat);
 
     static std::optional<ImageDataArray> tryCreate(size_t, ImageDataStorageFormat, std::span<const uint8_t> = { });
 
@@ -63,6 +64,8 @@ public:
 
 private:
     ImageDataArray(Ref<JSC::ArrayBufferView>&&);
+
+    Ref<ArrayBufferView> extractBufferViewWithStorageFormat(std::optional<ImageDataStorageFormat>) &&;
 
     // Needed by `toJS<IDLUnion<IDLUint8ClampedArray, ...>, const ImageDataArray&>()`
     template<typename IDL, bool needsState, bool needsGlobalObject> friend struct JSConverterOverloader;


### PR DESCRIPTION
#### d4570c2ebeca6f19cf3016be1679e5f9aa3a74ee
<pre>
CanvasRenderingContext2DBase::getImageData with ImageDataStorageFormat
<a href="https://bugs.webkit.org/show_bug.cgi?id=284414">https://bugs.webkit.org/show_bug.cgi?id=284414</a>
<a href="https://rdar.apple.com/problem/141249363">rdar://problem/141249363</a>

Reviewed by Cameron McCormack.

`context.getImageData(..., {storageFormat:&quot;float16&quot;})` now works and
returns a Float16Array, which is currently converted from the canvas&apos;
always-uint8 buffer.

`TypedArrayItemConverter&lt;Float16Array, Uint8ClampedArray&gt;::convert`
tweaked to round towards nearest (so 0.5 gets converted to 128), as
per specs <a href="https://github.com/w3c/ColorWeb-CG/blob/main/canvas_float.md">https://github.com/w3c/ColorWeb-CG/blob/main/canvas_float.md</a>

* LayoutTests/fast/canvas/imagedata-storageformat-enabled-expected.txt:
* LayoutTests/fast/canvas/imagedata-storageformat-enabled.html:
* Source/WebCore/html/ImageData.cpp:
(WebCore::ImageData::create):
(WebCore::ImageData::ImageData):
* Source/WebCore/html/ImageData.h:
(WebCore::ImageData::create):
* Source/WebCore/html/ImageDataArray.cpp:
(WebCore::ImageDataArray::ImageDataArray):
(WebCore::ImageDataArray::extractBufferViewWithStorageFormat):
* Source/WebCore/html/ImageDataArray.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::getImageData const):

Canonical link: <a href="https://commits.webkit.org/289717@main">https://commits.webkit.org/289717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34886941784d08837e1f8563ef572108b9f8940d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87759 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42145 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92624 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38509 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89810 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15446 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67757 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25502 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79404 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48126 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5632 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33810 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37616 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76030 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94510 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14927 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10968 "Found 1 new test failure: imported/w3c/web-platform-tests/trusted-types/block-text-node-insertion-into-svg-script-element.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76606 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15182 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75260 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75842 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18651 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20212 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18643 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7915 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14943 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20246 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14687 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18131 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16469 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->