### PR TITLE
Synchronize sources of LASX to CMakeList.txt and back port simde's fix for loong64 platform

### DIFF
--- a/Source/ThirdParty/skia/CMakeLists.txt
+++ b/Source/ThirdParty/skia/CMakeLists.txt
@@ -182,6 +182,7 @@ add_library(Skia STATIC
     src/core/SkBitmapProcState_matrixProcs.cpp
     src/core/SkBitmapProcState_opts.cpp
     src/core/SkBitmapProcState_opts_ssse3.cpp
+    src/core/SkBitmapProcState_opts_lasx.cpp
     src/core/SkBlendMode.cpp
     src/core/SkBlendModeBlender.cpp
     src/core/SkBlitMask_opts.cpp
@@ -189,6 +190,7 @@ add_library(Skia STATIC
     src/core/SkBlitRow_D32.cpp
     src/core/SkBlitRow_opts.cpp
     src/core/SkBlitRow_opts_hsw.cpp
+    src/core/SkBlitRow_opts_lasx.cpp
     src/core/SkBlitter.cpp
     src/core/SkBlitter_A8.cpp
     src/core/SkBlitter_ARGB32.cpp
@@ -344,6 +346,7 @@ add_library(Skia STATIC
     src/core/SkSwizzler_opts.cpp
     src/core/SkSwizzler_opts_hsw.cpp
     src/core/SkSwizzler_opts_ssse3.cpp
+    src/core/SkSwizzler_opts_lasx.cpp
     src/core/SkTaskGroup.cpp
     src/core/SkTextBlob.cpp
     src/core/SkTypeface.cpp
@@ -883,6 +886,7 @@ add_library(Skia STATIC
 
     src/opts/SkOpts_hsw.cpp
     src/opts/SkOpts_skx.cpp
+    src/opts/SkOpts_lasx.cpp
 
     src/ports/SkGlobalInitialization_default.cpp
     src/ports/SkImageGenerator_skia.cpp


### PR DESCRIPTION
#### fb61eb02429072643a1fb76178714424c3654467
<pre>
Synchronize sources of LASX to CMakeList.txt and back port simde&apos;s fix for loong64 platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=280505">https://bugs.webkit.org/show_bug.cgi?id=280505</a>
<a href="https://github.com/simd-everywhere/simde/pull/1224">https://github.com/simd-everywhere/simde/pull/1224</a>

Reviewed by NOBODY (OOPS!).

Synchronize sources about LASX from BUILD.gn to CMakeList.txt
to fix error during linking on loong64 platform, like:

`ld.lld: error: undefined hidden symbol: SkOpts::Init_lasx()`

Fixed the compilation issue on the loong64 platform with clang:

` ../test/x86/avx512/../../../simde/simde-f16.h:100:11: error: _Float16 is not supported on this target.`

* Source/ThirdParty/skia/CMakeLists.txt:
Add:
src/core/SkBitmapProcState_opts_lasx.cpp
src/core/SkBlitRow_opts_lasx.cpp
src/core/SkSwizzler_opts_lasx.cpp
src/opts/SkOpts_lasx.cpp
* Source/WTF/wtf/simde/arm/neon.h:
use a portable version to avoid compilation errors in loongarch&apos;s float16
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb61eb02429072643a1fb76178714424c3654467

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78429 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83090 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29694 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5756 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61426 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19343 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51433 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69184 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41739 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48780 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25173 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28031 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71575 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69876 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84456 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77667 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3943 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69651 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68906 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12925 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11294 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/99975 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5741 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21833 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5731 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9164 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7517 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->