### PR TITLE
Do not mute CoreAudioSharedUnit if capturing page is going away

### DIFF
--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -397,7 +397,7 @@ void RealtimeMediaSource::start()
 
 void RealtimeMediaSource::stop()
 {
-    if (!m_isProducingData)
+    if (!m_isProducingData || m_isEnded)
         return;
 
     ALWAYS_LOG_IF(m_logger, LOGIDENTIFIER);

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -247,6 +247,14 @@ void CoreAudioCaptureSource::stopProducingData()
     CoreAudioSharedUnit::singleton().stopProducingData();
 }
 
+void CoreAudioCaptureSource::endProducingData()
+{
+    ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER);
+    CoreAudioSharedUnit::singleton().removeClient(*this);
+    if (isProducingData())
+        CoreAudioSharedUnit::singleton().stopProducingData();
+}
+
 const RealtimeMediaSourceCapabilities& CoreAudioCaptureSource::capabilities()
 {
     if (!m_capabilities) {

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -81,6 +81,7 @@ private:
     bool isCaptureSource() const final { return true; }
     void startProducingData() final;
     void stopProducingData() final;
+    void endProducingData() final;
 
     void delaySamples(Seconds) final;
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -174,12 +174,15 @@ private:
     void unduck();
 
     void verifyIsCapturing();
+    void updateMutedStateTimerFired();
 
     void updateVoiceActivityDetection(bool shouldDisableVoiceActivityDetection = false);
     bool shouldEnableVoiceActivityDetection() const;
     RetainPtr<WebCoreAudioInputMuteChangeListener> createAudioInputMuteChangeListener();
     void setMutedState(bool isMuted);
-    void updateMutedState();
+
+    enum class SyncUpdate : bool { No, Yes };
+    void updateMutedState(SyncUpdate = SyncUpdate::No);
 
     CreationCallback m_creationCallback;
     GetSampleRateCallback m_getSampleRateCallback;
@@ -213,6 +216,8 @@ private:
     uint64_t m_microphoneProcsCalled { 0 };
     uint64_t m_microphoneProcsCalledLastTime { 0 };
     Timer m_verifyCapturingTimer;
+
+    Timer m_updateMutedStateTimer;
 
     std::optional<size_t> m_minimumMicrophoneSampleFrames;
     bool m_isReconfiguring { false };

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
@@ -85,6 +85,7 @@ private:
     // RealtimeMediaSource
     void startProducingData() final { m_proxy.startProducingData(*pageIdentifier()); }
     void stopProducingData() final { m_proxy.stopProducingData(); }
+    void endProducingData() final { m_proxy.endProducingData(); }
     bool isCaptureSource() const final { return true; }
     void applyConstraints(const WebCore::MediaConstraints&, ApplyConstraintsHandler&&) final;
     void didEnd() final;

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
@@ -57,11 +57,6 @@ RemoteRealtimeVideoSource::RemoteRealtimeVideoSource(RemoteRealtimeMediaSourcePr
 
 RemoteRealtimeVideoSource::~RemoteRealtimeVideoSource() = default;
 
-void RemoteRealtimeVideoSource::endProducingData()
-{
-    proxy().endProducingData();
-}
-
 bool RemoteRealtimeVideoSource::setShouldApplyRotation(bool shouldApplyRotation)
 {
     connection().send(Messages::UserMediaCaptureManagerProxy::SetShouldApplyRotation { identifier(), shouldApplyRotation }, 0);

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.h
@@ -53,7 +53,6 @@ private:
     RemoteRealtimeVideoSource(RemoteRealtimeMediaSourceProxy&&, WebCore::MediaDeviceHashSalts&&, UserMediaCaptureManager&, std::optional<WebCore::PageIdentifier>);
 
     Ref<RealtimeMediaSource> clone() final;
-    void endProducingData() final;
     bool setShouldApplyRotation(bool) final;
     double observedFrameRate() const final { return m_observedFrameRate; }
 


### PR DESCRIPTION
#### 1f39259fc689b6378cb21d319d893e7aec752d74
<pre>
Do not mute CoreAudioSharedUnit if capturing page is going away
<a href="https://rdar.apple.com/140620024">rdar://140620024</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=283751">https://bugs.webkit.org/show_bug.cgi?id=283751</a>

Reviewed by Jean-Yves Avenard.

If a page that is capturing and playing audio gets navigated away, we do not want to mute the CoreAudioSharedUnit.
This would trigger a mute notification that is not meaningful since capture and playing audio is finishing.

To do this, we make sure to end sources right when the last track related to the source is stopped.
Before the patch, we would stop the source and later on, after GC, we would end things.
This is done by updating RemoteRealtimeMediaSource.

We also implement CoreAudioCaptureSource::endProducingData to first unregister as a client and then stop the CoreAudioSharedUnit.
This way, when stopping the CoreAudioSharedUnit, we know whether all sources are gone or whether some sources are temporarily muted.

When stopping and there is no remaining CoreAudioSharedUnit clients, we do not mute the CoreAudioSharedUnit right away, as we may be stopping the CoreAudioSharedUnit very soon.
Instead we schedule a timer that will mute if needed.

Manually tested by doing the following:
1. Load <a href="https://webrtc.github.io/samples/src/content/peerconnection/pc1/">https://webrtc.github.io/samples/src/content/peerconnection/pc1/</a>, click start, call. Reload the page and observe the OS is not playing the mute notification.
2. Load <a href="https://webrtc.github.io/samples/src/content/peerconnection/pc1/">https://webrtc.github.io/samples/src/content/peerconnection/pc1/</a>, and from web inspector, stop the video track and the audio track. After 1 second, the mute notification will be played and the microphone OS indicator will go away.

* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSource::endProducingData):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::CoreAudioSharedUnit):
(WebCore::CoreAudioSharedUnit::updateMutedState):
(WebCore::CoreAudioSharedUnit::updateMutedStateTimerFired):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h:
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp:
(WebKit::RemoteRealtimeVideoSource::endProducingData): Deleted.
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.h:

Canonical link: <a href="https://commits.webkit.org/287206@main">https://commits.webkit.org/287206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a8eaef614fed58d5ca0d221b43a724ace46661c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83354 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29956 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80827 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6019 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61629 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19554 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/70627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41938 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49008 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25626 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28296 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70114 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84723 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6059 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69857 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6221 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67642 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69111 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17219 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13149 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11702 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6004 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/11921 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5990 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9426 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7778 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->