### PR TITLE
Make AudioMediaStreamTrackRenderer ref counted

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1681,7 +1681,6 @@ platform/mediarecorder/MediaRecorderPrivate.h
 platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
 platform/mediarecorder/MediaRecorderPrivateMock.cpp
 platform/mediarecorder/cocoa/AudioSampleBufferCompressor.mm
-platform/mediastream/AudioTrackPrivateMediaStream.cpp
 platform/mediastream/MediaStreamTrackDataHolder.cpp
 platform/mediastream/MediaStreamTrackPrivate.cpp
 platform/mediastream/RealtimeMediaSourceCenter.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1044,7 +1044,6 @@ platform/graphics/transforms/RotateTransformOperation.cpp
 platform/mac/ScrollAnimatorMac.mm
 platform/mac/ScrollbarsControllerMac.mm
 platform/mac/WidgetMac.mm
-platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.cpp
 platform/mediastream/mac/CoreAudioCaptureSource.cpp
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
 platform/mock/MockRealtimeMediaSourceCenter.cpp

--- a/Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.cpp
+++ b/Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.cpp
@@ -47,10 +47,10 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioMediaStreamTrackRenderer);
 
-std::unique_ptr<AudioMediaStreamTrackRenderer> AudioMediaStreamTrackRenderer::create(Init&& init)
+RefPtr<AudioMediaStreamTrackRenderer> AudioMediaStreamTrackRenderer::create(Init&& init)
 {
 #if PLATFORM(COCOA)
-    return makeUnique<AudioMediaStreamTrackRendererCocoa>(WTFMove(init));
+    return AudioMediaStreamTrackRendererCocoa::create(WTFMove(init));
 #else
     UNUSED_PARAM(init);
     return nullptr;

--- a/Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.h
+++ b/Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.h
@@ -34,6 +34,7 @@
 #include <wtf/Function.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WTF {
 class MediaTime;
@@ -44,7 +45,7 @@ namespace WebCore {
 class AudioStreamDescription;
 class PlatformAudioData;
 
-class WEBCORE_EXPORT AudioMediaStreamTrackRenderer : public LoggerHelper {
+class WEBCORE_EXPORT AudioMediaStreamTrackRenderer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AudioMediaStreamTrackRenderer, WTF::DestructionThread::Main>, public LoggerHelper {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(AudioMediaStreamTrackRenderer, WEBCORE_EXPORT);
 public:
     struct Init {
@@ -57,7 +58,7 @@ public:
         uint64_t logIdentifier;
 #endif
     };
-    static std::unique_ptr<AudioMediaStreamTrackRenderer> create(Init&&);
+    static RefPtr<AudioMediaStreamTrackRenderer> create(Init&&);
     virtual ~AudioMediaStreamTrackRenderer() = default;
 
     static String defaultDeviceID();

--- a/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.cpp
+++ b/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.cpp
@@ -57,16 +57,13 @@ AudioTrackPrivateMediaStream::~AudioTrackPrivateMediaStream()
 #if USE(LIBWEBRTC)
 static RefPtr<LibWebRTCAudioModule> audioModuleFromSource(RealtimeMediaSource& source)
 {
-    auto* audioSource = dynamicDowncast<RealtimeIncomingAudioSource>(source);
+    RefPtr audioSource = dynamicDowncast<RealtimeIncomingAudioSource>(source);
     return audioSource ? audioSource->audioModule() : nullptr;
 }
 #endif
 
-std::unique_ptr<AudioMediaStreamTrackRenderer> AudioTrackPrivateMediaStream::createRenderer(AudioTrackPrivateMediaStream& stream)
+RefPtr<AudioMediaStreamTrackRenderer> AudioTrackPrivateMediaStream::createRenderer(AudioTrackPrivateMediaStream& stream)
 {
-#if !RELEASE_LOG_DISABLED
-    auto& track = stream.m_streamTrack;
-#endif
     return AudioMediaStreamTrackRenderer::create(AudioMediaStreamTrackRenderer::Init {
         [stream = WeakPtr { stream }] {
             if (stream)
@@ -76,8 +73,8 @@ std::unique_ptr<AudioMediaStreamTrackRenderer> AudioTrackPrivateMediaStream::cre
         , audioModuleFromSource(stream.m_audioSource.get())
 #endif
 #if !RELEASE_LOG_DISABLED
-        , track->logger()
-        , track->logIdentifier()
+        , stream.m_streamTrack->logger()
+        , stream.m_streamTrack->logIdentifier()
 #endif
     });
 }
@@ -92,9 +89,9 @@ void AudioTrackPrivateMediaStream::clear()
     if (m_isPlaying)
         m_audioSource->removeAudioSampleObserver(*this);
 
-    streamTrack().removeObserver(*this);
-    if (m_renderer)
-        m_renderer->clear();
+    m_streamTrack->removeObserver(*this);
+    if (auto renderer = std::exchange(m_renderer, { }))
+        renderer->clear();
 }
 
 void AudioTrackPrivateMediaStream::play()
@@ -120,29 +117,29 @@ void AudioTrackPrivateMediaStream::setMuted(bool muted)
 
 void AudioTrackPrivateMediaStream::setVolume(float volume)
 {
-    if (m_renderer)
-        m_renderer->setVolume(volume);
+    if (RefPtr renderer = m_renderer)
+        renderer->setVolume(volume);
     updateRenderer();
 }
 
 void AudioTrackPrivateMediaStream::setAudioOutputDevice(const String& deviceId)
 {
-    if (m_renderer)
-        m_renderer->setAudioOutputDevice(deviceId);
+    if (RefPtr renderer = m_renderer)
+        renderer->setAudioOutputDevice(deviceId);
 }
 
 float AudioTrackPrivateMediaStream::volume() const
 {
-    if (m_renderer)
-        return m_renderer->volume();
+    if (RefPtr renderer = m_renderer)
+        return renderer->volume();
     return 1;
 }
 
 // May get called on a background thread.
 void AudioTrackPrivateMediaStream::audioSamplesAvailable(const MediaTime& sampleTime, const PlatformAudioData& audioData, const AudioStreamDescription& description, size_t sampleCount)
 {
-    if (m_renderer)
-        m_renderer->pushSamples(sampleTime, audioData, description, sampleCount);
+    if (RefPtr renderer = m_renderer)
+        renderer->pushSamples(sampleTime, audioData, description, sampleCount);
 }
 
 void AudioTrackPrivateMediaStream::trackMutedChanged(MediaStreamTrackPrivate&)
@@ -162,7 +159,7 @@ void AudioTrackPrivateMediaStream::trackEnded(MediaStreamTrackPrivate&)
 
 void AudioTrackPrivateMediaStream::updateRenderer()
 {
-    if (!m_shouldPlay || !volume() || m_muted || streamTrack().muted() || streamTrack().ended() || !streamTrack().enabled()) {
+    if (!m_shouldPlay || !volume() || m_muted || m_streamTrack->muted() || m_streamTrack->ended() || !m_streamTrack->enabled()) {
         stopRenderer();
         return;
     }
@@ -172,13 +169,14 @@ void AudioTrackPrivateMediaStream::updateRenderer()
 void AudioTrackPrivateMediaStream::startRenderer()
 {
     ASSERT(isMainThread());
-    if (m_isPlaying || !m_renderer)
+    RefPtr renderer = m_renderer;
+    if (m_isPlaying || !renderer)
         return;
 
     m_isPlaying = true;
-    m_renderer->start([protectedThis = Ref { *this }] {
+    renderer->start([protectedThis = Ref { *this }] {
         if (protectedThis->m_isPlaying)
-            protectedThis->m_audioSource->addAudioSampleObserver(protectedThis.get());
+            Ref { protectedThis->m_audioSource }->addAudioSampleObserver(protectedThis.get());
     });
 }
 
@@ -190,8 +188,8 @@ void AudioTrackPrivateMediaStream::stopRenderer()
 
     m_isPlaying = false;
     m_audioSource->removeAudioSampleObserver(*this);
-    if (m_renderer)
-        m_renderer->stop();
+    if (RefPtr renderer = m_renderer)
+        renderer->stop();
 }
 
 void AudioTrackPrivateMediaStream::createNewRenderer()
@@ -201,8 +199,8 @@ void AudioTrackPrivateMediaStream::createNewRenderer()
 
     float volume = this->volume();
     m_renderer = createRenderer(*this);
-    if (m_renderer)
-        m_renderer->setVolume(volume);
+    if (RefPtr renderer = m_renderer)
+        renderer->setVolume(volume);
 
     if (isPlaying)
         startRenderer();

--- a/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
+++ b/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
@@ -82,7 +82,7 @@ private:
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
-    static std::unique_ptr<AudioMediaStreamTrackRenderer> createRenderer(AudioTrackPrivateMediaStream&);
+    static RefPtr<AudioMediaStreamTrackRenderer> createRenderer(AudioTrackPrivateMediaStream&);
 
     // AudioTrackPrivate
     Kind kind() const final { return Kind::Main; }
@@ -111,12 +111,12 @@ private:
     bool m_muted { false };
     bool m_isCleared { false };
 
-    Ref<MediaStreamTrackPrivate> m_streamTrack;
-    Ref<RealtimeMediaSource> m_audioSource;
+    const Ref<MediaStreamTrackPrivate> m_streamTrack;
+    const Ref<RealtimeMediaSource> m_audioSource;
     int m_index { 0 };
 
     // Audio thread members
-    std::unique_ptr<AudioMediaStreamTrackRenderer> m_renderer;
+    RefPtr<AudioMediaStreamTrackRenderer> m_renderer;
 };
 
 }

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.h
@@ -35,16 +35,6 @@
 #include <CoreAudio/CoreAudioTypes.h>
 #include <optional>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class AudioMediaStreamTrackRendererCocoa;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::AudioMediaStreamTrackRendererCocoa> : std::true_type { };
-}
 
 namespace WebCore {
 
@@ -52,13 +42,15 @@ class AudioSampleDataSource;
 class AudioSampleBufferList;
 class BaseAudioMediaStreamTrackRendererUnit;
 
-class AudioMediaStreamTrackRendererCocoa : public AudioMediaStreamTrackRenderer, public CanMakeWeakPtr<AudioMediaStreamTrackRendererCocoa, WeakPtrFactoryInitialization::Eager> {
+class AudioMediaStreamTrackRendererCocoa final : public AudioMediaStreamTrackRenderer {
     WTF_MAKE_TZONE_ALLOCATED(AudioMediaStreamTrackRendererCocoa);
 public:
-    AudioMediaStreamTrackRendererCocoa(Init&&);
+    static Ref<AudioMediaStreamTrackRenderer> create(Init&& init) { return adoptRef(*new AudioMediaStreamTrackRendererCocoa(WTFMove(init))); }
     ~AudioMediaStreamTrackRendererCocoa();
 
 private:
+    explicit AudioMediaStreamTrackRendererCocoa(Init&&);
+
     // AudioMediaStreamTrackRenderer
     void pushSamples(const WTF::MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t) final;
     void start(CompletionHandler<void()>&&) final;


### PR DESCRIPTION
#### e7408133b6cfe3982705fdca5e25a3192beb73a6
<pre>
Make AudioMediaStreamTrackRenderer ref counted
<a href="https://rdar.apple.com/140622949">rdar://140622949</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=283757">https://bugs.webkit.org/show_bug.cgi?id=283757</a>

Reviewed by Jean-Yves Avenard.

We make AudioMediaStreamTrackRenderer ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr.
This allows us to  take valid weak pointers and protect the object when using it.
We update AudioTrackPrivateMediaStream to make benefit of it as well.

Drive by improvement, we nullify the renderer within AudioTrackPrivateMediaStream::clear to deallocate sooner the renderer.

* Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.cpp:
(WebCore::AudioMediaStreamTrackRenderer::create):
* Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.h:
* Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.cpp:
(WebCore::audioModuleFromSource):
(WebCore::AudioTrackPrivateMediaStream::createRenderer):
(WebCore::AudioTrackPrivateMediaStream::clear):
(WebCore::AudioTrackPrivateMediaStream::setVolume):
(WebCore::AudioTrackPrivateMediaStream::setAudioOutputDevice):
(WebCore::AudioTrackPrivateMediaStream::volume const):
(WebCore::AudioTrackPrivateMediaStream::audioSamplesAvailable):
(WebCore::AudioTrackPrivateMediaStream::updateRenderer):
(WebCore::AudioTrackPrivateMediaStream::startRenderer):
(WebCore::AudioTrackPrivateMediaStream::stopRenderer):
(WebCore::AudioTrackPrivateMediaStream::createNewRenderer):
* Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h:
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.cpp:
(WebCore::AudioMediaStreamTrackRendererCocoa::start):
(WebCore::AudioMediaStreamTrackRendererCocoa::rendererUnit):
(WebCore::AudioMediaStreamTrackRendererCocoa::stop):
(WebCore::AudioMediaStreamTrackRendererCocoa::setVolume):
(WebCore::AudioMediaStreamTrackRendererCocoa::reset):
(WebCore::AudioMediaStreamTrackRendererCocoa::setRegisteredDataSource):
(WebCore::AudioMediaStreamTrackRendererCocoa::pushSamples):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.h:

Canonical link: <a href="https://commits.webkit.org/287205@main">https://commits.webkit.org/287205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ed26fc1c9ad23d99de044dbbb5a6d0e7d9e0ead

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83352 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29954 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80825 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6017 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61630 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19553 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/70634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41939 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49007 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25628 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28294 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70113 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84721 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4178 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69856 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6219 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67643 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69110 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17217 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13147 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11704 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6002 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/11919 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5988 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9424 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7776 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->