### PR TITLE
Remove some RenderObject.h and RenderBlockFlow.h includes

### DIFF
--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -36,6 +36,7 @@
 #include "CSSValueList.h"
 #include "CSSValuePool.h"
 #include "CachedResourceLoader.h"
+#include "CaretRectComputation.h"
 #include "ChangeListTypeCommand.h"
 #include "Chrome.h"
 #include "ChromeClient.h"

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -28,6 +28,7 @@
 
 #include "AXObjectCache.h"
 #include "CSSPrimitiveValueMappings.h"
+#include "CaretRectComputation.h"
 #include "ChromeClient.h"
 #include "CommonAtomStrings.h"
 #include "DocumentInlines.h"

--- a/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
@@ -32,6 +32,7 @@
 #include "HTMLTableCellElement.h"
 #include "HTMLTableColElement.h"
 #include "HTMLTableElement.h"
+#include "InlineDisplayContent.h"
 #include "LayoutBox.h"
 #include "LayoutBoxGeometry.h"
 #include "LayoutChildIterator.h"

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -22,13 +22,10 @@
 
 #pragma once
 
-#include "CaretRectComputation.h"
 #include "FloatingObjects.h"
 #include "LegacyLineLayout.h"
 #include "LineWidth.h"
 #include "RenderBlock.h"
-#include "RenderLineBoxList.h"
-#include "TrailingObjects.h"
 #include <memory>
 #include <wtf/TZoneMalloc.h>
 
@@ -43,6 +40,7 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::RenderBlockF
 
 namespace WebCore {
 
+class FloatingObjects;
 class LineBreaker;
 class RenderMultiColumnFlow;
 

--- a/Source/WebCore/rendering/RenderBlockFlowInlines.h
+++ b/Source/WebCore/rendering/RenderBlockFlowInlines.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "CaretRectComputation.h"
 #include "RenderBlockFlow.h"
 
 namespace WebCore {

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "CachedImageClient.h"
-#include "Element.h"
 #include "FloatQuad.h"
 #include "FrameDestructionObserverInlines.h"
 #include "HTMLNames.h"

--- a/Source/WebCore/rendering/RenderTableCell.h
+++ b/Source/WebCore/rendering/RenderTableCell.h
@@ -271,15 +271,6 @@ inline unsigned RenderTableCell::rowIndex() const
     return row()->rowIndex();
 }
 
-inline bool RenderTableCell::isBaselineAligned() const
-{
-    if (auto alignContent = style().alignContent(); !alignContent.isNormal())
-        return alignContent.position() == ContentPosition::Baseline;
-
-    VerticalAlign va = style().verticalAlign();
-    return va == VerticalAlign::Baseline || va == VerticalAlign::TextBottom || va == VerticalAlign::TextTop || va == VerticalAlign::Super || va == VerticalAlign::Sub || va == VerticalAlign::Length;
-}
-
 inline RenderTableCell* RenderTableRow::firstCell() const
 {
     return downcast<RenderTableCell>(RenderBox::firstChild());

--- a/Source/WebCore/rendering/RenderTableCellInlines.h
+++ b/Source/WebCore/rendering/RenderTableCellInlines.h
@@ -21,6 +21,7 @@
 
 #include "RenderStyleInlines.h"
 #include "RenderTableCell.h"
+#include "StyleContentAlignmentData.h"
 
 namespace WebCore {
 
@@ -70,6 +71,15 @@ inline Length RenderTableCell::styleOrColLogicalWidth() const
     if (RenderTableCol* firstColumn = table()->colElement(col()))
         return logicalWidthFromColumns(firstColumn, styleWidth);
     return styleWidth;
+}
+
+inline bool RenderTableCell::isBaselineAligned() const
+{
+    if (auto alignContent = style().alignContent(); !alignContent.isNormal())
+        return alignContent.position() == ContentPosition::Baseline;
+
+    VerticalAlign va = style().verticalAlign();
+    return va == VerticalAlign::Baseline || va == VerticalAlign::TextBottom || va == VerticalAlign::TextTop || va == VerticalAlign::Super || va == VerticalAlign::Sub || va == VerticalAlign::Length;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "TextBoxPainter.h"
 
+#include "CaretRectComputation.h"
 #include "CompositionHighlight.h"
 #include "DocumentInlines.h"
 #include "DocumentMarkerController.h"


### PR DESCRIPTION
#### cd0a2c8bfdca65a40f20af467792560d38670132
<pre>
Remove some RenderObject.h and RenderBlockFlow.h includes
<a href="https://bugs.webkit.org/show_bug.cgi?id=283766">https://bugs.webkit.org/show_bug.cgi?id=283766</a>
<a href="https://rdar.apple.com/140628573">rdar://140628573</a>

Reviewed by Tim Nguyen.

We can remove Element.h from RenderObject.h, and a few other includes from RenderBlockFlow.h.

`RenderTableCell::isBaselineAligned()` is moved to RenderTableCellInlines.h.

* Source/WebCore/editing/Editor.cpp:
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
* Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp:
* Source/WebCore/rendering/RenderBlockFlow.h:
* Source/WebCore/rendering/RenderBlockFlowInlines.h:
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/RenderTableCell.h:
(WebCore::RenderTableCell::isBaselineAligned const): Deleted.
* Source/WebCore/rendering/RenderTableCellInlines.h:
(WebCore::RenderTableCell::isBaselineAligned const):
* Source/WebCore/rendering/TextBoxPainter.cpp:

Canonical link: <a href="https://commits.webkit.org/287138@main">https://commits.webkit.org/287138@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1939a7cda9adc68e05d4c0642082b98efddbd6b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83120 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29724 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80592 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61443 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19366 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81526 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51458 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41756 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48804 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25211 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28061 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69901 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84486 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5824 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69674 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5985 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/67450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68929 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17183 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12947 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11327 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5771 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/9043 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5760 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9193 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7546 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->