### PR TITLE
[GLib] Add sysprof profiling documentation

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -597,6 +597,7 @@ GI_DOCGEN(WebKit${WEBKITGTK_API_INFIX} gtk/gtk${GTK_API_VERSION}-webkitgtk.toml.
     CONTENT_TEMPLATES
         gtk/gtk${GTK_API_VERSION}-urlmap.js
         glib/environment-variables.md
+        glib/profiling.md
 )
 
 if (ENABLE_2022_GLIB_API)

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -769,6 +769,7 @@ GI_INTROSPECT(WPEWebKit ${WPE_API_VERSION} wpe/webkit.h
 GI_DOCGEN(WPEWebKit wpe/wpewebkit.toml.in
     CONTENT_TEMPLATES
         glib/environment-variables.md
+        glib/profiling.md
 )
 
 if (ENABLE_2022_GLIB_API)

--- a/Source/WebKit/glib/profiling.md.in
+++ b/Source/WebKit/glib/profiling.md.in
@@ -1,0 +1,106 @@
+Title: Profiling
+Slug: profiling
+
+# Profiling with Sysprof
+
+## Prerequisites
+
+To work with [Sysprof](https://gitlab.gnome.org/GNOME/sysprof/) one needs to install it first:
+
+- ubuntu:
+```
+apt install sysprof
+```
+- fedora
+```
+dnf install sysprof
+```
+
+## Profiling
+
+To start the profiling one must either:
+
+- start `sysprof-cli` to get a system-wide capture:
+```
+sysprof-cli -f
+```
+- or wrap a command with `sysprof-cli` to get a capture focused on the execution of a particular process tree created by the given command:
+```
+sysprof-cli -f -- MiniBrowser 'http://webkit.org'
+```
+
+For more information, please refer to `sysprof-cli --help`:
+```
+Usage:
+  sysprof-cli [OPTION…] [CAPTURE_FILE] [-- COMMAND ARGS]
+(...)
+```
+
+
+### Profiling WebKit in the SDK
+
+When profiling WebKit in the [SDK](https://github.com/Igalia/webkit-container-sdk), one must use the `Tools/Scripts/run-minibrowser` script as it contains plumbing that makes `sysprof-cli` work correctly:
+
+```
+#if WPE
+WPE_BROWSER=minibrowser sysprof-cli -f -- Tools/Scripts/run-minibrowser --wpe --release 'https://igalia.com'
+#elif GTK
+sysprof-cli -f -- Tools/Scripts/run-minibrowser --gtk --release 'https://igalia.com'
+#endif
+```
+
+## Working with capture files
+
+Once the sysprof capture file (`.syscap`) is produced using `sysprof-cli`, it's possible:
+
+- to visualize the captured data using the Sysprof GUI
+- to further transform it into textual format format that can be used for playing around with the data
+
+### Visualizing captured data
+
+To visualize the captured data, the `sysprof` application needs to be launched and the capture file needs to be loaded. It's possible to open multiple capture files and have them visualized in separate windows.
+
+### Transforming captured data into text
+
+Visualizing sysprof captures is very feature rich, but sometimes one needs to process the data using scripts to e.g. perform statistical analysis etc. For that, sysprof capture file needs to be transformed from binary format, the textual format that can be easily parsed and processed further. This can be easily done using `sysprof-cat`:
+
+```
+sysprof-cat capture.syscap
+sysprof-cat --no-callgraph --no-counters capture.syscap
+```
+
+The output format is "CSS-inspired" yet it's very easy to write a custom parser for it.
+
+## Known problems
+
+### `sysprof-cli` not starting in SDK
+
+If basic `sysprof-cli -f` command yields errors such as:
+```
+(...)
+Sampler: Failed to record copy of “kallsyms” to capture: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: Not authorized to make request
+Sampler: Failed to load Perf event stream for CPU 0: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: Not authorized to make request
+Sampler: Failed to load Perf event stream for CPU 1: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: Not authorized to make request
+Sampler: Failed to load Perf event stream for CPU 2: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: Not authorized to make request
+Sampler: Failed to load Perf event stream for CPU 3: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: Not authorized to make request
+(...)
+```
+
+This means that D-Bus calls to the system bus cannot be authorized. To make sure that's the case, one can run the command:
+```
+dbus-send --system --print-reply --dest=org.gnome.Sysprof3 /org/gnome/Sysprof3 org.gnome.Sysprof3.Service.ListProcesses
+```
+
+and confirm it outputs:
+```
+Error org.freedesktop.DBus.Error.AccessDenied: Not authorized to make request
+```
+
+This means the host system does not have Polkit agent running that would normally be used to ask the user for their password. In such case one needs to install and run a Polkit agentN.
+
+E.g. on ubuntu, the following should do the job:
+
+```
+sudo apt install policykit-1-gnome
+/usr/lib/policykit-1-gnome/polkit-gnome-authentication-agent-1
+```

--- a/Source/WebKit/gtk/gtk3-webkitgtk.toml.in
+++ b/Source/WebKit/gtk/gtk3-webkitgtk.toml.in
@@ -42,4 +42,5 @@ urlmap_file = "gtk@GTK_API_VERSION@-urlmap.js"
 [extra]
 content_files = [
     "environment-variables.md",
+    "profiling.md",
 ]

--- a/Source/WebKit/gtk/gtk4-webkitgtk.toml.in
+++ b/Source/WebKit/gtk/gtk4-webkitgtk.toml.in
@@ -41,6 +41,7 @@ base_url = "https://github.com/WebKit/WebKit/tree/main/"
 content_files = [
     "overview.md",
     "environment-variables.md",
+    "profiling.md",
     "migrating-to-webkitgtk-6.0.md"
 ]
 

--- a/Source/WebKit/wpe/wpewebkit.toml.in
+++ b/Source/WebKit/wpe/wpewebkit.toml.in
@@ -35,5 +35,6 @@ base_url = "https://github.com/WebKit/WebKit/tree/main/"
 [extra]
 urlmap_file = "wpe@WPE_API_MAJOR_VERSION@-urlmap.js"
 content_files = [
-    "environment-variables.md"
+    "environment-variables.md",
+    "profiling.md",
 ]


### PR DESCRIPTION
#### dcb5f9b201fc42a1c40b5e4a389cc1a1a8f8767f
<pre>
[GLib] Add sysprof profiling documentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=283758">https://bugs.webkit.org/show_bug.cgi?id=283758</a>

Reviewed by Adrian Perez de Castro.

This change introduces a sysprof profiling documentation for GTK and WPE ports.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/glib/profiling.md.in: Added.
* Source/WebKit/gtk/gtk3-webkitgtk.toml.in:
* Source/WebKit/gtk/gtk4-webkitgtk.toml.in:
* Source/WebKit/wpe/wpewebkit.toml.in:

Canonical link: <a href="https://commits.webkit.org/287145@main">https://commits.webkit.org/287145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36881aebddaf0dd7bc008d3946883d01fb9c081a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83174 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29778 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61494 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19411 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51508 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69585 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41806 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48854 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28115 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69953 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84540 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5878 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4017 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69721 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-animations/translation-animation-subpixel-offset.html imported/w3c/web-platform-tests/css/css-pseudo/marker-animate-002.html imported/w3c/web-platform-tests/css/css-transforms/backface-visibility-hidden-animated-001.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6039 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/67485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68975 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17189 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12995 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11413 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5825 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/10269 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5813 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9247 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7600 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->