### PR TITLE
generate-serializers.py: Removed dead code added by 269951@main

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -527,19 +527,11 @@ def one_argument_coder_declaration(type, template_argument):
         name_with_template = name_with_template + '<' + template_argument.namespace + '::' + template_argument.name + '>'
     result.append('template<> struct ArgumentCoder<' + name_with_template + '> {')
     for encoder in type.encoders:
-        if type.cf_type is not None:
-            result.append('    static void encode(' + encoder + '&, ' + name_with_template + ');')
-            result.append('    static void encode(' + encoder + '& encoder, const RetainPtr<' + name_with_template + '>& retainPtr)')
-            result.append('    {')
-            result.append('        ArgumentCoder<' + name_with_template + '>::encode(encoder, retainPtr.get());')
-            result.append('    }')
-        elif type.rvalue:
+        if type.rvalue:
             result.append('    static void encode(' + encoder + '&, ' + name_with_template + '&&);')
         else:
             result.append('    static void encode(' + encoder + '&, const ' + name_with_template + '&);')
-    if type.cf_type is not None:
-        result.append('    static std::optional<RetainPtr<' + name_with_template + '>> decode(Decoder&);')
-    elif type.return_ref:
+    if type.return_ref:
         result.append('    static std::optional<Ref<' + name_with_template + '>> decode(Decoder&);')
     else:
         result.append('    static std::optional<' + name_with_template + '> decode(Decoder&);')
@@ -843,7 +835,6 @@ def decode_cf_type(type):
     result.append('    auto result = decoder.decode<' + type.cf_wrapper_type() + '>();')
     result.append('    if (UNLIKELY(!decoder.isValid()))')
     result.append('        return std::nullopt;')
-    cf_method = 'toCF'
     if type.to_cf_method is not None:
         result.append('    return ' + type.to_cf_method + ';')
     else:


### PR DESCRIPTION
#### c1b34daff95e662b92849354faa99a4674f1516a
<pre>
generate-serializers.py: Removed dead code added by 269951@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=283769">https://bugs.webkit.org/show_bug.cgi?id=283769</a>

Reviewed by Alex Christensen.

Removed unused code and variable.

* Source/WebKit/Scripts/generate-serializers.py:
(one_argument_coder_declaration):
(decode_cf_type):

Canonical link: <a href="https://commits.webkit.org/287246@main">https://commits.webkit.org/287246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/feee90efeaa6fc6d786f9cf9fa33486dc3068394

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83130 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29734 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5795 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61454 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19371 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69347 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41766 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/77980 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48813 "Build is in progress. Recent messages:OS: Sonoma (14.6), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 4 pre-existing failure based on results-db; Uploaded test results") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28071 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69910 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25602 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84496 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5834 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3976 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69678 "Found 17 new test failures: imported/w3c/web-platform-tests/css/css-transitions/pseudo-element-transform.html imported/w3c/web-platform-tests/css/css-values/vh-interpolate-pct.html imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html imported/w3c/web-platform-tests/css/css-view-transitions/animating-new-content-subset.html imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-from-id-shadow.html imported/w3c/web-platform-tests/css/css-view-transitions/iframe-new-has-scrollbar.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-right-of-viewport-partially-onscreen-new.html imported/w3c/web-platform-tests/css/css-view-transitions/new-content-escapes-clip-with-abspos-child.html imported/w3c/web-platform-tests/css/css-view-transitions/old-content-escapes-clip-with-abspos-child.html imported/w3c/web-platform-tests/css/css-view-transitions/old-content-intrinsic-aspect-ratio.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5995 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67456 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68933 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12954 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11345 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12180 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5781 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/9153 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5769 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9203 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7556 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->