### PR TITLE
Prepare for forward declaring AXNotification

### DIFF
--- a/Source/WebCore/accessibility/AXImage.cpp
+++ b/Source/WebCore/accessibility/AXImage.cpp
@@ -76,7 +76,7 @@ std::optional<AXCoreObject::AccessibilityChildrenVector> AXImage::imageOverlayEl
             return;
 
         if (CheckedPtr axObjectCache = imageOverlayHost->document().existingAXObjectCache())
-            axObjectCache->postNotification(imageOverlayHost.get(), AXObjectCache::AXImageOverlayChanged);
+            axObjectCache->postNotification(imageOverlayHost.get(), AXNotification::AXImageOverlayChanged);
     });
 #endif
 

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -153,7 +153,7 @@ void AXLogger::log(const Vector<Ref<AXCoreObject>>& objects)
     }
 }
 
-void AXLogger::log(const std::pair<Ref<AccessibilityObject>, AXObjectCache::AXNotification>& notification)
+void AXLogger::log(const std::pair<Ref<AccessibilityObject>, AXNotification>& notification)
 {
     if (shouldLog()) {
         TextStream stream(TextStream::LineMode::MultipleLine);
@@ -163,7 +163,7 @@ void AXLogger::log(const std::pair<Ref<AccessibilityObject>, AXObjectCache::AXNo
     }
 }
 
-void AXLogger::log(const std::pair<RefPtr<AXCoreObject>, AXObjectCache::AXNotification>& notification)
+void AXLogger::log(const std::pair<RefPtr<AXCoreObject>, AXNotification>& notification)
 {
     if (shouldLog()) {
         TextStream stream(TextStream::LineMode::MultipleLine);
@@ -594,11 +594,11 @@ TextStream& operator<<(WTF::TextStream& stream, const TextUnderElementMode& mode
     return stream;
 }
 
-TextStream& operator<<(TextStream& stream, AXObjectCache::AXNotification notification)
+TextStream& operator<<(TextStream& stream, AXNotification notification)
 {
     switch (notification) {
 #define WEBCORE_LOG_AXNOTIFICATION(name) \
-    case AXObjectCache::AXNotification::AX##name: \
+    case AXNotification::AX##name: \
         stream << "AX" #name; \
         break;
     WEBCORE_AXNOTIFICATION_KEYS(WEBCORE_LOG_AXNOTIFICATION)

--- a/Source/WebCore/accessibility/AXLogger.h
+++ b/Source/WebCore/accessibility/AXLogger.h
@@ -61,8 +61,8 @@ public:
     void log(const AXCoreObject&);
     void log(RefPtr<AXCoreObject>);
     void log(const Vector<Ref<AXCoreObject>>&);
-    void log(const std::pair<Ref<AccessibilityObject>, AXObjectCache::AXNotification>&);
-    void log(const std::pair<RefPtr<AXCoreObject>, AXObjectCache::AXNotification>&);
+    void log(const std::pair<Ref<AccessibilityObject>, AXNotification>&);
+    void log(const std::pair<RefPtr<AXCoreObject>, AXNotification>&);
     void log(const AccessibilitySearchCriteria&);
     void log(AccessibilityObjectInclusion);
     void log(AXRelationType);

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1231,7 +1231,7 @@ void AXObjectCache::handleTextChanged(AccessibilityObject* object)
             postLiveRegionChangeNotification(*ancestor);
 
         if (!notifiedNonNativeTextControl && ancestor->isNonNativeTextControl()) {
-            postNotification(ancestor.get(), ancestor->protectedDocument().get(), AXValueChanged);
+            postNotification(ancestor.get(), ancestor->protectedDocument().get(), AXNotification::AXValueChanged);
             notifiedNonNativeTextControl = true;
         }
 
@@ -1243,17 +1243,17 @@ void AXObjectCache::handleTextChanged(AccessibilityObject* object)
             // If the starting object is a static text, its underlying text has changed.
             if (dependsOnTextUnderElement) {
                 // Inform this ancestor its textUnderElement-dependent data is now out-of-date.
-                postNotification(ancestor.get(), nullptr, AXTextUnderElementChanged);
+                postNotification(ancestor.get(), nullptr, AXNotification::AXTextUnderElementChanged);
             }
 
             // Any objects this ancestor labeled now also need new AccessibilityText.
             auto labeledObjects = ancestor->labelForObjects();
             for (const auto& labeledObject : labeledObjects)
-                postNotification(&downcast<AccessibilityObject>(labeledObject.get()), nullptr, AXTextChanged);
+                postNotification(&downcast<AccessibilityObject>(labeledObject.get()), nullptr, AXNotification::AXTextChanged);
         }
     }
 
-    postNotification(object, object->protectedDocument().get(), AXTextChanged);
+    postNotification(object, object->protectedDocument().get(), AXNotification::AXTextChanged);
     object->recomputeIsIgnored();
 }
 
@@ -1316,12 +1316,12 @@ void AXObjectCache::onEventListenerRemoved(Node& node, const AtomString& eventTy
 
 void AXObjectCache::onExpandedChanged(HTMLDetailsElement& detailsElement)
 {
-    postNotification(get(detailsElement), AXExpandedChanged);
+    postNotification(get(detailsElement), AXNotification::AXExpandedChanged);
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     if (!AXIsolatedTree::treeForPageID(m_pageID))
         return;
     for (auto& summary : descendantsOfType<HTMLSummaryElement>(detailsElement))
-        updateIsolatedTree(get(summary), AXExpandedChanged);
+        updateIsolatedTree(get(summary), AXNotification::AXExpandedChanged);
 #endif
 }
 
@@ -1370,7 +1370,7 @@ void AXObjectCache::handleAllDeferredChildrenChanged()
 #if !PLATFORM(COCOA)
         // Neither the MAC nor IOS_FAMILY ports map AXChildrenChanged to a platform notification.
         for (auto& object : deferredChildrenChangedList)
-            postPlatformNotification(object, AXChildrenChanged);
+            postPlatformNotification(object, AXNotification::AXChildrenChanged);
 #endif
     }
 }
@@ -1433,7 +1433,7 @@ void AXObjectCache::handleChildrenChanged(AccessibilityObject& object)
 
         // If this object is an ARIA text control, notify that its value changed.
         if (parent->isNonNativeTextControl()) {
-            postNotification(parent.get(), parent->protectedDocument().get(), AXValueChanged);
+            postNotification(parent.get(), parent->protectedDocument().get(), AXNotification::AXValueChanged);
 
             // Do not let any ancestor of an editable object update its children.
             shouldUpdateParent = false;
@@ -1445,12 +1445,12 @@ void AXObjectCache::handleChildrenChanged(AccessibilityObject& object)
         }
 
         for (const auto& describedObject : parent->descriptionForObjects())
-            postNotification(&downcast<AccessibilityObject>(describedObject.get()), nullptr, AXExtendedDescriptionChanged);
+            postNotification(&downcast<AccessibilityObject>(describedObject.get()), nullptr, AXNotification::AXExtendedDescriptionChanged);
 
         if (parent->hasTagName(captionTag))
             foundTableCaption = true;
         else if (foundTableCaption && parent->isTable()) {
-            postNotification(parent.get(), nullptr, AXTextChanged);
+            postNotification(parent.get(), nullptr, AXNotification::AXTextChanged);
             foundTableCaption = false;
         }
     }
@@ -1464,7 +1464,7 @@ void AXObjectCache::handleRecomputeCellSlots(AccessibilityTable& axTable)
 {
     axTable.setCellSlotsDirty();
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    updateIsolatedTree(axTable, AXCellSlotsChanged);
+    updateIsolatedTree(axTable, AXNotification::AXCellSlotsChanged);
 #endif
 }
 
@@ -1480,14 +1480,14 @@ void AXObjectCache::onRemoteFrameInitialized(AXRemoteFrame& remoteFrame)
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 void AXObjectCache::handleRowspanChanged(AccessibilityTableCell& axCell)
 {
-    updateIsolatedTree(axCell, AXRowSpanChanged);
+    updateIsolatedTree(axCell, AXNotification::AXRowSpanChanged);
 }
 #endif
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
 void AXObjectCache::onTextRunsChanged(const RenderObject& renderer)
 {
-    postNotification(const_cast<RenderObject*>(&renderer), AXTextRunsChanged);
+    postNotification(const_cast<RenderObject*>(&renderer), AXNotification::AXTextRunsChanged);
 }
 #endif
 
@@ -1496,7 +1496,7 @@ void AXObjectCache::handleMenuOpened(Element& element)
     if (!element.renderer() || !hasRole(element, "menu"_s))
         return;
 
-    postNotification(getOrCreate(element), protectedDocument().ptr(), AXMenuOpened);
+    postNotification(getOrCreate(element), protectedDocument().ptr(), AXNotification::AXMenuOpened);
 }
 
 void AXObjectCache::handleLiveRegionCreated(Element& element)
@@ -1512,7 +1512,7 @@ void AXObjectCache::handleLiveRegionCreated(Element& element)
     }
 
     if (AXCoreObject::liveRegionStatusIsEnabled(liveRegionStatus))
-        postNotification(getOrCreate(element), protectedDocument().ptr(), AXLiveRegionCreated);
+        postNotification(getOrCreate(element), protectedDocument().ptr(), AXNotification::AXLiveRegionCreated);
 }
 
 void AXObjectCache::deferElementAddedOrRemoved(Element* element)
@@ -1572,18 +1572,18 @@ void AXObjectCache::childrenChanged(AccessibilityObject* object)
 
 void AXObjectCache::valueChanged(Element& element)
 {
-    postNotification(&element, AXValueChanged);
+    postNotification(&element, AXNotification::AXValueChanged);
 }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 void AXObjectCache::columnIndexChanged(AccessibilityObject& object)
 {
-    postNotification(object, AXColumnIndexChanged);
+    postNotification(object, AXNotification::AXColumnIndexChanged);
 }
 
 void AXObjectCache::rowIndexChanged(AccessibilityObject& object)
 {
-    postNotification(object, AXRowIndexChanged);
+    postNotification(object, AXNotification::AXRowIndexChanged);
 }
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
@@ -1621,7 +1621,7 @@ void AXObjectCache::notificationPostTimerFired()
         }
 #endif
 
-        if (note.second == AXMenuOpened) {
+        if (note.second == AXNotification::AXMenuOpened) {
             // Only notify if the object is in fact a menu.
             note.first->updateChildrenIfNecessary();
             if (note.first->roleValue() != AccessibilityRole::Menu)
@@ -1732,7 +1732,7 @@ void AXObjectCache::postNotification(AccessibilityObject& object, AXNotification
 
 void AXObjectCache::checkedStateChanged(Element& element)
 {
-    postNotification(&element, AXCheckedStateChanged);
+    postNotification(&element, AXNotification::AXCheckedStateChanged);
 }
 
 void AXObjectCache::autofillTypeChanged(HTMLInputElement& element)
@@ -1751,7 +1751,7 @@ void AXObjectCache::handleMenuItemSelected(Element* element)
     if (!element->focused() && !equalLettersIgnoringASCIICase(element->attributeWithoutSynchronization(aria_selectedAttr), "true"_s))
         return;
 
-    postNotification(getOrCreate(*element), protectedDocument().ptr(), AXMenuListItemSelected);
+    postNotification(getOrCreate(*element), protectedDocument().ptr(), AXNotification::AXMenuListItemSelected);
 }
 
 // FIXME: Consider also handling updating SelectedChildren of TabLists (this should happen for the oldElement, newElement, and/or the parent of a tab)
@@ -1763,7 +1763,7 @@ void AXObjectCache::handleTabPanelSelected(Element* oldElement, Element* newElem
 
         auto controllers = controlPanel->controllers();
         for (auto& controller : controllers)
-            postNotification(dynamicDowncast<AccessibilityObject>(controller.get()), element.protectedDocument().ptr(), AXSelectedStateChanged);
+            postNotification(dynamicDowncast<AccessibilityObject>(controller.get()), element.protectedDocument().ptr(), AXNotification::AXSelectedStateChanged);
     };
 
 
@@ -1797,7 +1797,7 @@ void AXObjectCache::handleRowCountChanged(AccessibilityObject* axObject, Documen
     if (auto* axTable = dynamicDowncast<AccessibilityTable>(axObject))
         axTable->recomputeIsExposable();
 
-    postNotification(axObject, document, AXRowCountChanged);
+    postNotification(axObject, document, AXNotification::AXRowCountChanged);
 }
 
 void AXObjectCache::onPageActivityStateChange(OptionSet<ActivityState> newState)
@@ -1883,7 +1883,7 @@ void AXObjectCache::onPopoverToggle(const HTMLElement& popover)
         return;
     // There may be multiple elements with popovertarget attributes that point at |popover|.
     for (const auto& invoker : axPopover->controllers())
-        postNotification(dynamicDowncast<AccessibilityObject>(invoker.get()), protectedDocument().ptr(), AXExpandedChanged);
+        postNotification(dynamicDowncast<AccessibilityObject>(invoker.get()), protectedDocument().ptr(), AXNotification::AXExpandedChanged);
 }
 
 void AXObjectCache::deferMenuListValueChange(Element* element)
@@ -1924,7 +1924,7 @@ void AXObjectCache::handleFocusedUIElementChanged(Element* oldElement, Element* 
 
 void AXObjectCache::selectedChildrenChanged(Node* node)
 {
-    postNotification(node, AXSelectedChildrenChanged);
+    postNotification(node, AXNotification::AXSelectedChildrenChanged);
 }
 
 void AXObjectCache::selectedChildrenChanged(RenderObject* renderer)
@@ -1949,15 +1949,15 @@ void AXObjectCache::onScrollbarFrameRectChange(const Scrollbar& scrollbar)
 void AXObjectCache::onSelectedChanged(Element& element)
 {
     if (hasCellARIARole(element))
-        postNotification(&element, AXSelectedCellsChanged);
+        postNotification(&element, AXNotification::AXSelectedCellsChanged);
     else if (is<HTMLOptionElement>(element))
-        postNotification(&element, AXSelectedStateChanged);
+        postNotification(&element, AXNotification::AXSelectedStateChanged);
     else if (auto* axObject = getOrCreate(element)) {
         if (auto* ancestor = Accessibility::findAncestor<AccessibilityObject>(*axObject, false, [] (const auto& object) {
             return object.canHaveSelectedChildren();
         })) {
             selectedChildrenChanged(ancestor->node());
-            postNotification(axObject, element.protectedDocument().ptr(), AXSelectedStateChanged);
+            postNotification(axObject, element.protectedDocument().ptr(), AXNotification::AXSelectedStateChanged);
         }
     }
 
@@ -1980,7 +1980,7 @@ void AXObjectCache::onStyleChange(Element& element, Style::Change change, const 
 void AXObjectCache::onTextSecurityChanged(HTMLInputElement& inputElement)
 {
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    postNotification(get(&inputElement), AXTextSecurityChanged);
+    postNotification(get(&inputElement), AXNotification::AXTextSecurityChanged);
 #else
     UNUSED_PARAM(inputElement);
 #endif
@@ -1988,12 +1988,12 @@ void AXObjectCache::onTextSecurityChanged(HTMLInputElement& inputElement)
 
 void AXObjectCache::onTitleChange(Document& document)
 {
-    postNotification(get(&document), AXTextChanged);
+    postNotification(get(&document), AXNotification::AXTextChanged);
 }
 
 void AXObjectCache::onValidityChange(Element& element)
 {
-    postNotification(get(&element), AXInvalidStatusChanged);
+    postNotification(get(&element), AXNotification::AXInvalidStatusChanged);
 }
 
 void AXObjectCache::onTextCompositionChange(Node& node, CompositionState compositionState, bool valueChanged, const String& text, size_t position, bool handlingAcceptedCandidate)
@@ -2012,17 +2012,17 @@ void AXObjectCache::onTextCompositionChange(Node& node, CompositionState composi
         object = observableObject;
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    updateIsolatedTree(object, AXTextCompositionChanged);
+    updateIsolatedTree(object, AXNotification::AXTextCompositionChanged);
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
     if (compositionState == CompositionState::Started)
-        postNotification(object, node.protectedDocument().ptr(), AXTextCompositionBegan);
+        postNotification(object, node.protectedDocument().ptr(), AXNotification::AXTextCompositionBegan);
 
     if (valueChanged)
-        postNotification(object, node.protectedDocument().ptr(), AXValueChanged);
+        postNotification(object, node.protectedDocument().ptr(), AXNotification::AXValueChanged);
 
     if (compositionState == CompositionState::Ended)
-        postNotification(object, node.protectedDocument().ptr(), AXTextCompositionEnded);
+        postNotification(object, node.protectedDocument().ptr(), AXNotification::AXTextCompositionEnded);
 #else
     UNUSED_PARAM(node);
     UNUSED_PARAM(compositionState);
@@ -2182,7 +2182,7 @@ void AXObjectCache::postTextStateChangeNotification(Node* node, const AXTextStat
 
     postTextStateChangeNotification(getOrCreate(*node), intent, selection);
 #else
-    postNotification(node->renderer(), AXSelectedTextChanged, PostTarget::ObservableParent);
+    postNotification(node->renderer(), AXNotification::AXSelectedTextChanged, PostTarget::ObservableParent);
     UNUSED_PARAM(intent);
     UNUSED_PARAM(selection);
 #endif
@@ -2284,7 +2284,7 @@ void AXObjectCache::postTextStateChangeNotification(Node* node, AXTextEditType t
         return;
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    updateIsolatedTree(*object, AXValueChanged);
+    updateIsolatedTree(*object, AXNotification::AXValueChanged);
 #endif
 
     postTextStateChangePlatformNotification(object, type, text, position);
@@ -2391,7 +2391,7 @@ void AXObjectCache::liveRegionChangedNotificationPostTimerFired()
         return;
 
     for (auto& object : m_liveRegionObjects)
-        postNotification(object.ptr(), object->protectedDocument().get(), AXLiveRegionChanged);
+        postNotification(object.ptr(), object->protectedDocument().get(), AXNotification::AXLiveRegionChanged);
     m_liveRegionObjects.clear();
 }
 
@@ -2464,9 +2464,9 @@ void AXObjectCache::handleAriaExpandedChange(Element& element)
         // Post that the specific row either collapsed or expanded.
         auto role = object->roleValue();
         if (role == AccessibilityRole::Row || role == AccessibilityRole::TreeItem)
-            postNotification(object.get(), protectedDocument().ptr(), object->isExpanded() ? AXRowExpanded : AXRowCollapsed);
+            postNotification(object.get(), protectedDocument().ptr(), object->isExpanded() ? AXNotification::AXRowExpanded : AXNotification::AXRowCollapsed);
         else
-            postNotification(object.get(), protectedDocument().ptr(), AXExpandedChanged);
+            postNotification(object.get(), protectedDocument().ptr(), AXNotification::AXExpandedChanged);
     }
 }
 
@@ -2539,7 +2539,7 @@ void AXObjectCache::handleActiveDescendantChange(Element& element, const AtomStr
 
     // Table cell active descendant changes should trigger selected cell changes.
     if (target->isTable() && activeDescendant->isExposedTableCell())
-        postPlatformNotification(*target, AXSelectedCellsChanged);
+        postPlatformNotification(*target, AXNotification::AXSelectedCellsChanged);
 }
 
 static bool isTableOrRowRole(const AtomString& attrValue)
@@ -2581,7 +2581,7 @@ void AXObjectCache::handleRoleChanged(AccessibilityObject& axObject)
     axObject.recomputeIsIgnored();
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    postNotification(axObject, AXRoleChanged);
+    postNotification(axObject, AXNotification::AXRoleChanged);
 #endif
 }
 
@@ -2671,41 +2671,41 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
             axObject->updateRole();
     }
     else if (attrName == disabledAttr)
-        postNotification(element, AXDisabledStateChanged);
+        postNotification(element, AXNotification::AXDisabledStateChanged);
     else if (attrName == forAttr) {
         if (RefPtr label = dynamicDowncast<HTMLLabelElement>(element)) {
             updateLabelFor(*label);
 
             if (RefPtr oldControl = element->treeScope().getElementById(oldValue))
-                postNotification(oldControl.get(), AXTextChanged);
+                postNotification(oldControl.get(), AXNotification::AXTextChanged);
             if (RefPtr newControl = element->treeScope().getElementById(newValue))
-                postNotification(newControl.get(), AXTextChanged);
+                postNotification(newControl.get(), AXNotification::AXTextChanged);
         }
     } else if (attrName == requiredAttr)
-        postNotification(element, AXRequiredStatusChanged);
+        postNotification(element, AXNotification::AXRequiredStatusChanged);
     else if (attrName == tabindexAttr) {
         if (oldValue.isEmpty() || newValue.isEmpty()) {
             childrenChanged(element->parentNode(), element);
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-            postNotification(element, AXFocusableStateChanged);
+            postNotification(element, AXNotification::AXFocusableStateChanged);
 #endif
         }
     }
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     else if (attrName == langAttr)
-        updateIsolatedTree(get(*element), AXLanguageChanged);
+        updateIsolatedTree(get(*element), AXNotification::AXLanguageChanged);
     else if (attrName == nameAttr)
-        postNotification(get(*element), AXNameChanged);
+        postNotification(get(*element), AXNotification::AXNameChanged);
     else if (attrName == placeholderAttr)
-        postNotification(element, AXPlaceholderChanged);
+        postNotification(element, AXNotification::AXPlaceholderChanged);
     else if (attrName == hrefAttr || attrName == srcAttr)
-        postNotification(element, AXURLChanged);
+        postNotification(element, AXNotification::AXURLChanged);
     else if (attrName == idAttr) {
 #if !LOG_DISABLED
-        updateIsolatedTree(get(*element), AXIdAttributeChanged);
+        updateIsolatedTree(get(*element), AXNotification::AXIdAttributeChanged);
 #endif
     } else if (attrName == accesskeyAttr)
-        updateIsolatedTree(get(*element), AXAccessKeyChanged);
+        updateIsolatedTree(get(*element), AXNotification::AXAccessKeyChanged);
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     else if (attrName == openAttr && is<HTMLDialogElement>(*element)) {
         deferModalChange(*element);
@@ -2714,12 +2714,12 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
         deferRowspanChange(get(*element));
         recomputeParentTableProperties(element, TableProperty::CellSlots);
     } else if (attrName == colspanAttr) {
-        postNotification(element, AXColumnSpanChanged);
+        postNotification(element, AXNotification::AXColumnSpanChanged);
         recomputeParentTableProperties(element, TableProperty::CellSlots);
     } else if (attrName == popovertargetAttr)
-        postNotification(element, AXPopoverTargetChanged);
+        postNotification(element, AXNotification::AXPopoverTargetChanged);
     else if (attrName == scopeAttr)
-        postNotification(element, AXCellScopeChanged);
+        postNotification(element, AXNotification::AXCellScopeChanged);
 
     if (!attrName.localName().string().startsWith("aria-"_s))
         return;
@@ -2727,13 +2727,13 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
     if (attrName == aria_activedescendantAttr)
         handleActiveDescendantChange(*element, oldValue, newValue);
     else if (attrName == aria_atomicAttr)
-        postNotification(element, AXIsAtomicChanged);
+        postNotification(element, AXNotification::AXIsAtomicChanged);
     else if (attrName == aria_busyAttr)
-        postNotification(element, AXElementBusyChanged);
+        postNotification(element, AXNotification::AXElementBusyChanged);
     else if (attrName == aria_controlsAttr)
-        postNotification(element, AXControlledObjectsChanged);
+        postNotification(element, AXNotification::AXControlledObjectsChanged);
     else if (attrName == aria_valuenowAttr || attrName == aria_valuetextAttr)
-        postNotification(element, AXValueChanged);
+        postNotification(element, AXNotification::AXValueChanged);
     else if (attrName == aria_labelAttr && element->hasTagName(htmlTag)) {
         // When aria-label changes on an <html> element, it's the web area who needs to re-compute its accessibility text.
         handleTextChanged(get(element->protectedDocument().ptr()));
@@ -2753,41 +2753,41 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
     else if (attrName == aria_checkedAttr)
         checkedStateChanged(*element);
     else if (attrName == aria_colcountAttr) {
-        postNotification(element, AXColumnCountChanged);
+        postNotification(element, AXNotification::AXColumnCountChanged);
         deferRecomputeTableIsExposed(dynamicDowncast<HTMLTableElement>(element));
     } else if (attrName == aria_colindexAttr) {
-        postNotification(element, AXARIAColumnIndexChanged);
+        postNotification(element, AXNotification::AXARIAColumnIndexChanged);
         recomputeParentTableProperties(element, TableProperty::Exposed);
     } else if (attrName == aria_colspanAttr) {
-        postNotification(element, AXColumnSpanChanged);
+        postNotification(element, AXNotification::AXColumnSpanChanged);
         recomputeParentTableProperties(element, { TableProperty::CellSlots, TableProperty::Exposed });
     }
     else if (attrName == aria_describedbyAttr)
-        postNotification(element, AXDescribedByChanged);
+        postNotification(element, AXNotification::AXDescribedByChanged);
     else if (attrName == aria_descriptionAttr)
-        postNotification(element, AXExtendedDescriptionChanged);
+        postNotification(element, AXNotification::AXExtendedDescriptionChanged);
     else if (attrName == aria_dropeffectAttr)
-        postNotification(element, AXDropEffectChanged);
+        postNotification(element, AXNotification::AXDropEffectChanged);
     else if (attrName == aria_flowtoAttr)
-        postNotification(element, AXFlowToChanged);
+        postNotification(element, AXNotification::AXFlowToChanged);
     else if (attrName == aria_grabbedAttr)
-        postNotification(element, AXGrabbedStateChanged);
+        postNotification(element, AXNotification::AXGrabbedStateChanged);
     else if (attrName == aria_keyshortcutsAttr)
-        postNotification(element, AXKeyShortcutsChanged);
+        postNotification(element, AXNotification::AXKeyShortcutsChanged);
     else if (attrName == aria_levelAttr)
-        postNotification(element, AXLevelChanged);
+        postNotification(element, AXNotification::AXLevelChanged);
     else if (attrName == aria_liveAttr)
-        postNotification(element, AXLiveRegionStatusChanged);
+        postNotification(element, AXNotification::AXLiveRegionStatusChanged);
     else if (attrName == aria_placeholderAttr)
-        postNotification(element, AXPlaceholderChanged);
+        postNotification(element, AXNotification::AXPlaceholderChanged);
     else if (attrName == aria_rowindexAttr) {
-        postNotification(element, AXARIARowIndexChanged);
+        postNotification(element, AXNotification::AXARIARowIndexChanged);
         recomputeParentTableProperties(element, { TableProperty::CellSlots, TableProperty::Exposed });
     }
     else if (attrName == aria_valuemaxAttr)
-        postNotification(element, AXMaximumValueChanged);
+        postNotification(element, AXNotification::AXMaximumValueChanged);
     else if (attrName == aria_valueminAttr)
-        postNotification(element, AXMinimumValueChanged);
+        postNotification(element, AXNotification::AXMinimumValueChanged);
     else if (attrName == aria_multilineAttr) {
         if (auto* axObject = get(*element)) {
             // The role of textarea and textfield objects is dependent on whether they can span multiple lines, so recompute it here.
@@ -2796,21 +2796,21 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
         }
     }
     else if (attrName == aria_multiselectableAttr)
-        postNotification(element, AXMultiSelectableStateChanged);
+        postNotification(element, AXNotification::AXMultiSelectableStateChanged);
     else if (attrName == aria_orientationAttr)
-        postNotification(element, AXOrientationChanged);
+        postNotification(element, AXNotification::AXOrientationChanged);
     else if (attrName == aria_posinsetAttr)
-        postNotification(element, AXPositionInSetChanged);
+        postNotification(element, AXNotification::AXPositionInSetChanged);
     else if (attrName == aria_relevantAttr)
-        postNotification(element, AXLiveRegionRelevantChanged);
+        postNotification(element, AXNotification::AXLiveRegionRelevantChanged);
     else if (attrName == aria_selectedAttr)
         onSelectedChanged(*element);
     else if (attrName == aria_setsizeAttr)
-        postNotification(element, AXSetSizeChanged);
+        postNotification(element, AXNotification::AXSetSizeChanged);
     else if (attrName == aria_expandedAttr)
         handleAriaExpandedChange(*element);
     else if (attrName == aria_haspopupAttr)
-        postNotification(element, AXHasPopupChanged);
+        postNotification(element, AXNotification::AXHasPopupChanged);
     else if (attrName == aria_hiddenAttr) {
         if (RefPtr parent = get(element->parentNode()))
             childrenChanged(parent.get());
@@ -2821,7 +2821,7 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
         }
     }
     else if (attrName == aria_invalidAttr)
-        postNotification(element, AXInvalidStatusChanged);
+        postNotification(element, AXNotification::AXInvalidStatusChanged);
     else if (attrName == aria_modalAttr) {
         // aria-modal changed, so the element may have become modal or un-modal.
         if (isModalElement(*element))
@@ -2831,15 +2831,15 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
         deferModalChange(*element);
     }
     else if (attrName == aria_currentAttr)
-        postNotification(element, AXCurrentStateChanged);
+        postNotification(element, AXNotification::AXCurrentStateChanged);
     else if (attrName == aria_disabledAttr)
-        postNotification(element, AXDisabledStateChanged);
+        postNotification(element, AXNotification::AXDisabledStateChanged);
     else if (attrName == aria_pressedAttr)
-        postNotification(element, AXPressedStateChanged);
+        postNotification(element, AXNotification::AXPressedStateChanged);
     else if (attrName == aria_readonlyAttr)
-        postNotification(element, AXReadOnlyStatusChanged);
+        postNotification(element, AXNotification::AXReadOnlyStatusChanged);
     else if (attrName == aria_requiredAttr)
-        postNotification(element, AXRequiredStatusChanged);
+        postNotification(element, AXNotification::AXRequiredStatusChanged);
     else if (attrName == aria_roledescriptionAttr)
         handleRoleDescriptionChanged(*element);
     else if (attrName == aria_rowcountAttr)
@@ -2848,15 +2848,15 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
         deferRowspanChange(get(*element));
         recomputeParentTableProperties(element, { TableProperty::CellSlots, TableProperty::Exposed });
     } else if (attrName == aria_sortAttr)
-        postNotification(element, AXSortDirectionChanged);
+        postNotification(element, AXNotification::AXSortDirectionChanged);
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     else if (attrName == aria_ownsAttr) {
         if (oldValue.isEmpty() || newValue.isEmpty())
             updateIsolatedTree(get(*element), AXPropertyName::SupportsARIAOwns);
     } else if (attrName == aria_braillelabelAttr)
-        postNotification(element, AXBrailleLabelChanged);
+        postNotification(element, AXNotification::AXBrailleLabelChanged);
     else if (attrName == aria_brailleroledescriptionAttr)
-        postNotification(element, AXBrailleRoleDescriptionChanged);
+        postNotification(element, AXNotification::AXBrailleRoleDescriptionChanged);
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 }
 
@@ -2873,11 +2873,11 @@ void AXObjectCache::handleLabelChanged(AccessibilityObject* object)
         auto labeledObjects = object->labelForObjects();
         for (auto& labeledObject : labeledObjects) {
             updateLabeledBy(RefPtr { labeledObject->element() }.get());
-            postNotification(&downcast<AccessibilityObject>(labeledObject.get()), protectedDocument().ptr(), AXValueChanged);
+            postNotification(&downcast<AccessibilityObject>(labeledObject.get()), protectedDocument().ptr(), AXNotification::AXValueChanged);
         }
     }
 
-    postNotification(object, protectedDocument().ptr(), AXLabelChanged);
+    postNotification(object, protectedDocument().ptr(), AXNotification::AXLabelChanged);
 }
 
 void AXObjectCache::updateLabelFor(HTMLLabelElement& label)
@@ -4438,10 +4438,10 @@ void AXObjectCache::handleMenuListValueChanged(Element& element)
         return;
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    updateIsolatedTree(*object, AXMenuListValueChanged);
+    updateIsolatedTree(*object, AXNotification::AXMenuListValueChanged);
 #endif
 
-    postPlatformNotification(*object, AXMenuListValueChanged);
+    postPlatformNotification(*object, AXNotification::AXMenuListValueChanged);
 }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -4508,59 +4508,59 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
             continue;
 
         switch (notification.second) {
-        case AXAccessKeyChanged:
+        case AXNotification::AXAccessKeyChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::AccessKey });
             break;
-        case AXAutofillTypeChanged:
+        case AXNotification::AXAutofillTypeChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::ValueAutofillButtonType });
             break;
-        case AXARIAColumnIndexChanged:
+        case AXNotification::AXARIAColumnIndexChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::AXColumnIndex });
             break;
-        case AXARIARowIndexChanged:
+        case AXNotification::AXARIARowIndexChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::AXRowIndex });
             break;
-        case AXBrailleLabelChanged:
+        case AXNotification::AXBrailleLabelChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::BrailleLabel });
             break;
-        case AXBrailleRoleDescriptionChanged:
+        case AXNotification::AXBrailleRoleDescriptionChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::BrailleRoleDescription });
             break;
-        case AXCellSlotsChanged:
+        case AXNotification::AXCellSlotsChanged:
             ASSERT(notification.first->isTable());
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::CellSlots });
             break;
-        case AXCheckedStateChanged:
+        case AXNotification::AXCheckedStateChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::IsChecked });
             break;
-        case AXCurrentStateChanged:
+        case AXNotification::AXCurrentStateChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::CurrentState });
             break;
-        case AXColumnCountChanged:
+        case AXNotification::AXColumnCountChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::AXColumnCount });
             break;
-        case AXColumnIndexChanged:
+        case AXNotification::AXColumnIndexChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::ColumnIndexRange, AXPropertyName::ColumnIndex } });
             break;
-        case AXColumnSpanChanged:
+        case AXNotification::AXColumnSpanChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::ColumnIndexRange });
             break;
-        case AXDisabledStateChanged:
+        case AXNotification::AXDisabledStateChanged:
             tree->updatePropertiesForSelfAndDescendants(notification.first.get(), { { AXPropertyName::CanSetFocusAttribute, AXPropertyName::IsEnabled } });
             break;
-        case AXExpandedChanged:
+        case AXNotification::AXExpandedChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::IsExpanded });
             break;
-        case AXExtendedDescriptionChanged:
+        case AXNotification::AXExtendedDescriptionChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::AccessibilityText, AXPropertyName::ExtendedDescription } });
             break;
-        case AXFocusableStateChanged:
+        case AXNotification::AXFocusableStateChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::CanSetFocusAttribute });
             break;
-        case AXMaximumValueChanged:
+        case AXNotification::AXMaximumValueChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::MaxValueForRange, AXPropertyName::ValueForRange } });
             break;
-        case AXMenuListItemSelected: {
+        case AXNotification::AXMenuListItemSelected: {
             RefPtr ancestor = Accessibility::findAncestor<AccessibilityObject>(notification.first.get(), false, [] (const auto& object) {
                 return object.isMenu() || object.isMenuBar();
             });
@@ -4570,114 +4570,114 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
             }
             break;
         }
-        case AXMinimumValueChanged:
+        case AXNotification::AXMinimumValueChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::MinValueForRange, AXPropertyName::ValueForRange } });
             break;
-        case AXNameChanged:
+        case AXNotification::AXNameChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::NameAttribute });
             break;
-        case AXOrientationChanged:
+        case AXNotification::AXOrientationChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::Orientation });
             break;
-        case AXPositionInSetChanged:
+        case AXNotification::AXPositionInSetChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::PosInSet, AXPropertyName::SupportsPosInSet } });
             break;
-        case AXPopoverTargetChanged:
+        case AXNotification::AXPopoverTargetChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::SupportsExpanded, AXPropertyName::IsExpanded } });
             break;
-        case AXSelectedTextChanged:
+        case AXNotification::AXSelectedTextChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::SelectedTextRange });
             break;
-        case AXSortDirectionChanged:
+        case AXNotification::AXSortDirectionChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::SortDirection });
             break;
-        case AXIdAttributeChanged:
+        case AXNotification::AXIdAttributeChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::IdentifierAttribute });
             break;
-        case AXReadOnlyStatusChanged:
+        case AXNotification::AXReadOnlyStatusChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::CanSetValueAttribute });
             break;
-        case AXRequiredStatusChanged:
+        case AXNotification::AXRequiredStatusChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::IsRequired });
             break;
-        case AXRoleDescriptionChanged:
+        case AXNotification::AXRoleDescriptionChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::RoleDescription });
             break;
-        case AXRowIndexChanged:
+        case AXNotification::AXRowIndexChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::RowIndexRange, AXPropertyName::RowIndex } });
             break;
-        case AXRowSpanChanged:
+        case AXNotification::AXRowSpanChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::RowIndexRange });
             break;
-        case AXCellScopeChanged:
+        case AXNotification::AXCellScopeChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::CellScope, AXPropertyName::IsColumnHeader, AXPropertyName::IsRowHeader } });
             break;
         //  FIXME: Contrary to the name "AXSelectedCellsChanged", this notification can be posted on a cell
         //  who has changed selected state, not just on table or grid who has changed its selected cells.
-        case AXSelectedCellsChanged:
-        case AXSelectedStateChanged:
+        case AXNotification::AXSelectedCellsChanged:
+        case AXNotification::AXSelectedStateChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::IsSelected });
             break;
-        case AXSetSizeChanged:
+        case AXNotification::AXSetSizeChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::SetSize, AXPropertyName::SupportsSetSize } });
             break;
-        case AXTextCompositionChanged:
+        case AXNotification::AXTextCompositionChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::TextInputMarkedTextMarkerRange });
             break;
-        case AXTextUnderElementChanged:
+        case AXNotification::AXTextUnderElementChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::AccessibilityText, AXPropertyName::Title } });
             if (notification.first->isAccessibilityLabelInstance() || notification.first->roleValue() == AccessibilityRole::TextField)
                 tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::StringValue });
             break;
 #if ENABLE(AX_THREAD_TEXT_APIS)
-        case AXTextRunsChanged:
+        case AXNotification::AXTextRunsChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::TextRuns });
             break;
 #endif
-        case AXURLChanged:
+        case AXNotification::AXURLChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::URL, AXPropertyName::InternalLinkElement } });
             break;
-        case AXKeyShortcutsChanged:
+        case AXNotification::AXKeyShortcutsChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::KeyShortcuts });
             break;
-        case AXVisibilityChanged:
+        case AXNotification::AXVisibilityChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::IsVisible });
             break;
-        case AXActiveDescendantChanged:
-        case AXRoleChanged:
-        case AXControlledObjectsChanged:
-        case AXDescribedByChanged:
-        case AXDropEffectChanged:
-        case AXElementBusyChanged:
-        case AXFlowToChanged:
-        case AXGrabbedStateChanged:
-        case AXHasPopupChanged:
-        case AXInvalidStatusChanged:
-        case AXIsAtomicChanged:
-        case AXLevelChanged:
-        case AXLiveRegionStatusChanged:
-        case AXLiveRegionRelevantChanged:
-        case AXPlaceholderChanged:
-        case AXMenuListValueChanged:
-        case AXMultiSelectableStateChanged:
-        case AXPressedStateChanged:
-        case AXSelectedChildrenChanged:
-        case AXTextChanged:
-        case AXTextSecurityChanged:
-        case AXValueChanged:
+        case AXNotification::AXActiveDescendantChanged:
+        case AXNotification::AXRoleChanged:
+        case AXNotification::AXControlledObjectsChanged:
+        case AXNotification::AXDescribedByChanged:
+        case AXNotification::AXDropEffectChanged:
+        case AXNotification::AXElementBusyChanged:
+        case AXNotification::AXFlowToChanged:
+        case AXNotification::AXGrabbedStateChanged:
+        case AXNotification::AXHasPopupChanged:
+        case AXNotification::AXInvalidStatusChanged:
+        case AXNotification::AXIsAtomicChanged:
+        case AXNotification::AXLevelChanged:
+        case AXNotification::AXLiveRegionStatusChanged:
+        case AXNotification::AXLiveRegionRelevantChanged:
+        case AXNotification::AXPlaceholderChanged:
+        case AXNotification::AXMenuListValueChanged:
+        case AXNotification::AXMultiSelectableStateChanged:
+        case AXNotification::AXPressedStateChanged:
+        case AXNotification::AXSelectedChildrenChanged:
+        case AXNotification::AXTextChanged:
+        case AXNotification::AXTextSecurityChanged:
+        case AXNotification::AXValueChanged:
             updateNode(notification.first);
             break;
-        case AXLabelChanged: {
+        case AXNotification::AXLabelChanged: {
             updateNode(notification.first);
             updateDependentProperties(notification.first);
             break;
         }
-        case AXLanguageChanged:
-        case AXRowCountChanged:
+        case AXNotification::AXLanguageChanged:
+        case AXNotification::AXRowCountChanged:
             updateNode(notification.first);
             FALLTHROUGH;
-        case AXRowCollapsed:
-        case AXRowExpanded:
+        case AXNotification::AXRowCollapsed:
+        case AXNotification::AXRowExpanded:
             updateChildren(notification.first);
             break;
         default:
@@ -5372,7 +5372,7 @@ void AXObjectCache::selectedTextRangeTimerFired()
     if (m_lastDebouncedTextRangeObject) {
         for (auto* axObject = objectForID(*m_lastDebouncedTextRangeObject); axObject; axObject = axObject->parentObject()) {
             if (axObject->isTextControl())
-                postNotification(*axObject, AXSelectedTextChanged);
+                postNotification(*axObject, AXNotification::AXSelectedTextChanged);
         }
     }
 
@@ -5395,7 +5395,7 @@ void AXObjectCache::processQueuedIsolatedNodeUpdates()
 void AXObjectCache::onWidgetVisibilityChanged(RenderWidget& widget)
 {
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    postNotification(get(widget), AXVisibilityChanged);
+    postNotification(get(widget), AXNotification::AXVisibilityChanged);
 #else
     UNUSED_PARAM(widget);
 #endif

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -256,6 +256,12 @@ protected:
     WEBCORE_AXNOTIFICATION_KEYS_DEFAULT(macro)
 #endif
 
+enum class AXNotification {
+#define WEBCORE_DEFINE_AXNOTIFICATION_ENUM(name) AX##name,
+WEBCORE_AXNOTIFICATION_KEYS(WEBCORE_DEFINE_AXNOTIFICATION_ENUM)
+#undef WEBCORE_DEFINE_AXNOTIFICATION_ENUM
+};
+
 #if !PLATFORM(COCOA)
 enum AXTextChange { AXTextInserted, AXTextDeleted, AXTextAttributesChanged };
 #endif
@@ -505,12 +511,6 @@ public:
     
     // Index
     CharacterOffset characterOffsetForIndex(int, const AXCoreObject*);
-
-    enum AXNotification {
-#define WEBCORE_DEFINE_AXNOTIFICATION_ENUM(name) AX##name,
-    WEBCORE_AXNOTIFICATION_KEYS(WEBCORE_DEFINE_AXNOTIFICATION_ENUM)
-#undef WEBCORE_DEFINE_AXNOTIFICATION_ENUM
-    };
 
     void postNotification(RenderObject*, AXNotification, PostTarget = PostTarget::Element);
     void postNotification(Node*, AXNotification, PostTarget = PostTarget::Element);
@@ -947,6 +947,6 @@ bool isNodeFocused(Node&);
 
 bool isDOMHidden(const RenderStyle*);
 
-WTF::TextStream& operator<<(WTF::TextStream&, AXObjectCache::AXNotification);
+WTF::TextStream& operator<<(WTF::TextStream&, AXNotification);
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityMenuList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuList.cpp
@@ -55,13 +55,13 @@ bool AccessibilityMenuList::press()
 
 #if !PLATFORM(IOS_FAMILY)
     RefPtr element = this->element();
-    AXObjectCache::AXNotification notification = AXObjectCache::AXPressDidFail;
+    auto notification = AXNotification::AXPressDidFail;
     if (CheckedPtr menuList = dynamicDowncast<RenderMenuList>(renderer()); menuList && element && !element->isDisabledFormControl()) {
         if (menuList->popupIsVisible())
             menuList->hidePopup();
         else
             menuList->showPopup();
-        notification = AXObjectCache::AXPressDidSucceed;
+        notification = AXNotification::AXPressDidSucceed;
     }
     if (CheckedPtr cache = axObjectCache())
         cache->postNotification(element.get(), notification);

--- a/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
@@ -153,8 +153,8 @@ void AccessibilityMenuListPopup::didUpdateActiveOption(int optionIndex)
         return;
 
     auto& child = downcast<AccessibilityObject>(children[optionIndex].get());
-    cache->postNotification(&child, document(), AXObjectCache::AXFocusedUIElementChanged);
-    cache->postNotification(&child, document(), AXObjectCache::AXMenuListItemSelected);
+    cache->postNotification(&child, document(), AXNotification::AXFocusedUIElementChanged);
+    cache->postNotification(&child, document(), AXNotification::AXMenuListItemSelected);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -1353,7 +1353,7 @@ void AccessibilityNodeObject::setNodeValue(StepAction stepAction, float value)
 
     if (didSet) {
         if (auto* cache = axObjectCache())
-            cache->postNotification(this, document(), AXObjectCache::AXValueChanged);
+            cache->postNotification(this, document(), AXNotification::AXValueChanged);
     } else
         postKeyboardKeysForValueChange(stepAction);
 }

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -163,7 +163,7 @@ void AccessibilityObject::detachRemoteParts(AccessibilityDetachmentType detachme
     // Menu close events need to notify the platform. No element is used in the notification because it's a destruction event.
     if (detachmentType == AccessibilityDetachmentType::ElementDestroyed && roleValue() == AccessibilityRole::Menu) {
         if (auto* cache = axObjectCache())
-            cache->postNotification(nullptr, &cache->document(), AXObjectCache::AXMenuClosed);
+            cache->postNotification(nullptr, &cache->document(), AXNotification::AXMenuClosed);
     }
 
     // Clear any children and call detachFromParent on them so that

--- a/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
@@ -72,25 +72,25 @@ void AXObjectCache::postPlatformNotification(AccessibilityObject& coreObject, AX
         return;
 
     switch (notification) {
-    case AXCheckedStateChanged:
+    case AXNotification::AXCheckedStateChanged:
         if (coreObject.isCheckboxOrRadio() || coreObject.isSwitch())
             wrapper->stateChanged("checked", coreObject.isChecked());
         break;
-    case AXSelectedStateChanged:
+    case AXNotification::AXSelectedStateChanged:
         wrapper->stateChanged("selected", coreObject.isSelected());
         break;
-    case AXMenuListItemSelected: {
+    case AXNotification::AXMenuListItemSelected: {
         // Menu list popup items are handled by AXSelectedStateChanged.
         auto* parent = coreObject.parentObjectUnignored();
         if (parent && !parent->isMenuListPopup())
             wrapper->stateChanged("selected", coreObject.isSelected());
         break;
     }
-    case AXSelectedCellsChanged:
-    case AXSelectedChildrenChanged:
+    case AXNotification::AXSelectedCellsChanged:
+    case AXNotification::AXSelectedChildrenChanged:
         wrapper->selectionChanged();
         break;
-    case AXMenuListValueChanged: {
+    case AXNotification::AXMenuListValueChanged: {
         const auto& children = coreObject.children();
         if (children.size() == 1) {
             if (auto* childWrapper = children[0]->wrapper())
@@ -98,47 +98,47 @@ void AXObjectCache::postPlatformNotification(AccessibilityObject& coreObject, AX
         }
         break;
     }
-    case AXValueChanged:
+    case AXNotification::AXValueChanged:
         if (wrapper->interfaces().contains(AccessibilityObjectAtspi::Interface::Value))
             wrapper->valueChanged(coreObject.valueForRange());
         break;
-    case AXInvalidStatusChanged:
+    case AXNotification::AXInvalidStatusChanged:
         wrapper->stateChanged("invalid-entry", coreObject.invalidStatus() != "false"_s);
         break;
-    case AXElementBusyChanged:
+    case AXNotification::AXElementBusyChanged:
         wrapper->stateChanged("busy", coreObject.isBusy());
         break;
-    case AXCurrentStateChanged:
+    case AXNotification::AXCurrentStateChanged:
         wrapper->stateChanged("active", coreObject.currentState() != AccessibilityCurrentState::False);
         break;
-    case AXRowExpanded:
+    case AXNotification::AXRowExpanded:
         wrapper->stateChanged("expanded", true);
         break;
-    case AXRowCollapsed:
+    case AXNotification::AXRowCollapsed:
         wrapper->stateChanged("expanded", false);
         break;
-    case AXExpandedChanged:
+    case AXNotification::AXExpandedChanged:
         wrapper->stateChanged("expanded", coreObject.isExpanded());
         break;
-    case AXDisabledStateChanged: {
+    case AXNotification::AXDisabledStateChanged: {
         bool enabledState = coreObject.isEnabled();
         wrapper->stateChanged("enabled", enabledState);
         wrapper->stateChanged("sensitive", enabledState);
         break;
     }
-    case AXPressedStateChanged:
+    case AXNotification::AXPressedStateChanged:
         wrapper->stateChanged("pressed", coreObject.isPressed());
         break;
-    case AXReadOnlyStatusChanged:
+    case AXNotification::AXReadOnlyStatusChanged:
         wrapper->stateChanged("read-only", !coreObject.canSetValueAttribute());
         break;
-    case AXRequiredStatusChanged:
+    case AXNotification::AXRequiredStatusChanged:
         wrapper->stateChanged("required", coreObject.isRequired());
         break;
-    case AXActiveDescendantChanged:
+    case AXNotification::AXActiveDescendantChanged:
         wrapper->activeDescendantChanged();
         break;
-    case AXChildrenChanged:
+    case AXNotification::AXChildrenChanged:
         coreObject.updateChildrenIfNecessary();
         break;
     default:

--- a/Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm
+++ b/Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm
@@ -47,43 +47,43 @@ ASCIILiteral AXObjectCache::notificationPlatformName(AXNotification notification
     ASCIILiteral name;
 
     switch (notification) {
-    case AXActiveDescendantChanged:
-    case AXFocusedUIElementChanged:
+    case AXNotification::AXActiveDescendantChanged:
+    case AXNotification::AXFocusedUIElementChanged:
         name = "AXFocusChanged"_s;
         break;
-    case AXImageOverlayChanged:
+    case AXNotification::AXImageOverlayChanged:
         name = "AXImageOverlayChanged"_s;
         break;
-    case AXPageScrolled:
+    case AXNotification::AXPageScrolled:
         name = "AXPageScrolled"_s;
         break;
-    case AXSelectedCellsChanged:
+    case AXNotification::AXSelectedCellsChanged:
         name = "AXSelectedCellsChanged"_s;
         break;
-    case AXSelectedTextChanged:
+    case AXNotification::AXSelectedTextChanged:
         name = "AXSelectedTextChanged"_s;
         break;
-    case AXLiveRegionChanged:
-    case AXLiveRegionCreated:
+    case AXNotification::AXLiveRegionChanged:
+    case AXNotification::AXLiveRegionCreated:
         name = "AXLiveRegionChanged"_s;
         break;
-    case AXInvalidStatusChanged:
+    case AXNotification::AXInvalidStatusChanged:
         name = "AXInvalidStatusChanged"_s;
         break;
-    case AXCheckedStateChanged:
-    case AXValueChanged:
+    case AXNotification::AXCheckedStateChanged:
+    case AXNotification::AXValueChanged:
         name = "AXValueChanged"_s;
         break;
-    case AXExpandedChanged:
+    case AXNotification::AXExpandedChanged:
         name = "AXExpandedChanged"_s;
         break;
-    case AXCurrentStateChanged:
+    case AXNotification::AXCurrentStateChanged:
         name = "AXCurrentStateChanged"_s;
         break;
-    case AXSortDirectionChanged:
+    case AXNotification::AXSortDirectionChanged:
         name = "AXSortDirectionChanged"_s;
         break;
-    case AXAnnouncementRequested:
+    case AXNotification::AXAnnouncementRequested:
         name = "AXAnnouncementRequested"_s;
         break;
     default:
@@ -115,7 +115,7 @@ void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNoti
 
 void AXObjectCache::postPlatformAnnouncementNotification(const String& message)
 {
-    auto notificationName = notificationPlatformName(AXAnnouncementRequested).createNSString();
+    auto notificationName = notificationPlatformName(AXNotification::AXAnnouncementRequested).createNSString();
     NSString *nsMessage = static_cast<NSString *>(message);
     if (RefPtr root = getOrCreate(m_document->view())) {
         [root->wrapper() accessibilityOverrideProcessNotification:notificationName.get() notificationData:[nsMessage dataUsingEncoding:NSUTF8StringEncoding]];
@@ -129,25 +129,25 @@ void AXObjectCache::postPlatformAnnouncementNotification(const String& message)
 void AXObjectCache::postTextStateChangePlatformNotification(AccessibilityObject* object, const AXTextStateChangeIntent&, const VisibleSelection&)
 {
     if (object)
-        postPlatformNotification(*object, AXSelectedTextChanged);
+        postPlatformNotification(*object, AXNotification::AXSelectedTextChanged);
 }
 
 void AXObjectCache::postTextStateChangePlatformNotification(AccessibilityObject* object, AXTextEditType, const String&, const VisiblePosition&)
 {
     if (object)
-        postPlatformNotification(*object, AXValueChanged);
+        postPlatformNotification(*object, AXNotification::AXValueChanged);
 }
 
 void AXObjectCache::postTextReplacementPlatformNotification(AccessibilityObject* object, AXTextEditType, const String&, AXTextEditType, const String&, const VisiblePosition&)
 {
     if (object)
-        postPlatformNotification(*object, AXValueChanged);
+        postPlatformNotification(*object, AXNotification::AXValueChanged);
 }
 
 void AXObjectCache::postTextReplacementPlatformNotificationForTextControl(AccessibilityObject* object, const String&, const String&)
 {
     if (object)
-        postPlatformNotification(*object, AXValueChanged);
+        postPlatformNotification(*object, AXNotification::AXValueChanged);
 }
 
 void AXObjectCache::frameLoadingEventPlatformNotification(AccessibilityObject* axFrameObject, AXLoadingEvent loadingEvent)
@@ -156,12 +156,12 @@ void AXObjectCache::frameLoadingEventPlatformNotification(AccessibilityObject* a
         return;
 
     if (loadingEvent == AXLoadingFinished && axFrameObject->document() == axFrameObject->topDocument())
-        postPlatformNotification(*axFrameObject, AXLoadComplete);
+        postPlatformNotification(*axFrameObject, AXNotification::AXLoadComplete);
 }
 
 void AXObjectCache::platformHandleFocusedUIElementChanged(Element*, Element* newElement)
 {
-    postNotification(newElement, AXFocusedUIElementChanged);
+    postNotification(newElement, AXNotification::AXFocusedUIElementChanged);
 }
 
 void AXObjectCache::handleScrolledToAnchor(const Node&)

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -1648,7 +1648,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     BOOL result = self.axBackingObject->scrollByPage(scrollDirection);
 
     if (result) {
-        auto notificationName = AXObjectCache::notificationPlatformName(AXObjectCache::AXNotification::AXPageScrolled).createNSString();
+        auto notificationName = AXObjectCache::notificationPlatformName(AXNotification::AXPageScrolled).createNSString();
         [self accessibilityOverrideProcessNotification:notificationName.get() notificationData:nil];
 
         CGPoint scrollPos = [self _accessibilityScrollPosition];

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -210,7 +210,7 @@ void AXIsolatedTree::reportLoadingProgress(double processingProgress)
             { AXPropertyName::TitleAttributeValue, WTFMove(title) },
         });
         if (cache)
-            cache->postPlatformNotification(*axWebArea, AXObjectCache::AXNotification::AXLayoutComplete);
+            cache->postPlatformNotification(*axWebArea, AXNotification::AXLayoutComplete);
     }
 }
 

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -328,29 +328,29 @@ void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNoti
     // Some notifications are unique to Safari and do not have NSAccessibility equivalents.
     NSString *macNotification;
     switch (notification) {
-    case AXActiveDescendantChanged:
+    case AXNotification::AXActiveDescendantChanged:
         macNotification = @"AXActiveElementChanged";
         break;
-    case AXAutocorrectionOccured:
+    case AXNotification::AXAutocorrectionOccured:
         macNotification = @"AXAutocorrectionOccurred";
         break;
-    case AXCurrentStateChanged:
+    case AXNotification::AXCurrentStateChanged:
         macNotification = NSAccessibilityCurrentStateChangedNotification;
         break;
-    case AXFocusedUIElementChanged:
+    case AXNotification::AXFocusedUIElementChanged:
         macNotification = NSAccessibilityFocusedUIElementChangedNotification;
         break;
-    case AXImageOverlayChanged:
+    case AXNotification::AXImageOverlayChanged:
         macNotification = @"AXImageOverlayChanged";
         break;
-    case AXLayoutComplete:
+    case AXNotification::AXLayoutComplete:
         macNotification = @"AXLayoutComplete";
         break;
-    case AXLabelChanged:
+    case AXNotification::AXLabelChanged:
         macNotification = NSAccessibilityTitleChangedNotification;
         break;
-    case AXLoadComplete:
-    case AXFrameLoadComplete:
+    case AXNotification::AXLoadComplete:
+    case AXNotification::AXFrameLoadComplete:
         macNotification = @"AXLoadComplete";
         // Frame loading events are handled by the UIProcess on macOS to improve reliability.
         // On macOS, before notifications are allowed by AppKit to be sent to clients, you need to have a client (e.g. VoiceOver)
@@ -358,84 +358,84 @@ void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNoti
         // miss AXLoadComplete notifications. By moving them to the UIProcess, we can eliminate that issue.
         skipSystemNotification = true;
         break;
-    case AXInvalidStatusChanged:
+    case AXNotification::AXInvalidStatusChanged:
         macNotification = @"AXInvalidStatusChanged";
         break;
-    case AXSelectedChildrenChanged:
+    case AXNotification::AXSelectedChildrenChanged:
         if (object.isTable() && object.isExposable())
             macNotification = NSAccessibilitySelectedRowsChangedNotification;
         else
             macNotification = NSAccessibilitySelectedChildrenChangedNotification;
         break;
-    case AXSelectedCellsChanged:
+    case AXNotification::AXSelectedCellsChanged:
         macNotification = NSAccessibilitySelectedCellsChangedNotification;
         break;
-    case AXSelectedTextChanged:
+    case AXNotification::AXSelectedTextChanged:
         macNotification = NSAccessibilitySelectedTextChangedNotification;
         break;
-    case AXCheckedStateChanged:
-    case AXValueChanged:
+    case AXNotification::AXCheckedStateChanged:
+    case AXNotification::AXValueChanged:
         macNotification = NSAccessibilityValueChangedNotification;
         break;
-    case AXLiveRegionCreated:
+    case AXNotification::AXLiveRegionCreated:
         macNotification = NSAccessibilityLiveRegionCreatedNotification;
         break;
-    case AXLiveRegionChanged:
+    case AXNotification::AXLiveRegionChanged:
         macNotification = NSAccessibilityLiveRegionChangedNotification;
         break;
-    case AXRowCountChanged:
+    case AXNotification::AXRowCountChanged:
         macNotification = NSAccessibilityRowCountChangedNotification;
         break;
-    case AXRowExpanded:
+    case AXNotification::AXRowExpanded:
         macNotification = NSAccessibilityRowExpandedNotification;
         break;
-    case AXRowCollapsed:
+    case AXNotification::AXRowCollapsed:
         macNotification = NSAccessibilityRowCollapsedNotification;
         break;
-    case AXElementBusyChanged:
+    case AXNotification::AXElementBusyChanged:
         macNotification = @"AXElementBusyChanged";
         break;
-    case AXExpandedChanged:
+    case AXNotification::AXExpandedChanged:
         macNotification = @"AXExpandedChanged";
         break;
-    case AXSortDirectionChanged:
+    case AXNotification::AXSortDirectionChanged:
         macNotification = @"AXSortDirectionChanged";
         break;
-    case AXMenuClosed:
+    case AXNotification::AXMenuClosed:
         macNotification = (id)kAXMenuClosedNotification;
         break;
-    case AXMenuListItemSelected:
-    case AXMenuListValueChanged:
+    case AXNotification::AXMenuListItemSelected:
+    case AXNotification::AXMenuListValueChanged:
         macNotification = (id)kAXMenuItemSelectedNotification;
         break;
-    case AXPressDidSucceed:
+    case AXNotification::AXPressDidSucceed:
         macNotification = @"AXPressDidSucceed";
         break;
-    case AXPressDidFail:
+    case AXNotification::AXPressDidFail:
         macNotification = @"AXPressDidFail";
         break;
-    case AXMenuOpened:
+    case AXNotification::AXMenuOpened:
         macNotification = (id)kAXMenuOpenedNotification;
         break;
-    case AXDraggingStarted:
+    case AXNotification::AXDraggingStarted:
         macNotification = (id)kAXDraggingSourceDragBeganNotification;
         break;
-    case AXDraggingEnded:
+    case AXNotification::AXDraggingEnded:
         macNotification = (id)kAXDraggingSourceDragEndedNotification;
         break;
-    case AXDraggingEnteredDropZone:
+    case AXNotification::AXDraggingEnteredDropZone:
         macNotification = (id)kAXDraggingDestinationDropAllowedNotification;
         break;
-    case AXDraggingDropped:
+    case AXNotification::AXDraggingDropped:
         macNotification = (id)kAXDraggingDestinationDragAcceptedNotification;
         break;
-    case AXDraggingExitedDropZone:
+    case AXNotification::AXDraggingExitedDropZone:
         macNotification = (id)kAXDraggingDestinationDragNotAcceptedNotification;
         break;
-    case AXTextCompositionBegan:
+    case AXNotification::AXTextCompositionBegan:
         macNotification = NSAccessibilityTextInputMarkingSessionBeganNotification;
         break;
-    case AXTextCompositionEnded:
+    case AXNotification::AXTextCompositionEnded:
         macNotification = NSAccessibilityTextInputMarkingSessionEndedNotification;
         break;
     default:
@@ -713,9 +713,9 @@ void AXObjectCache::frameLoadingEventPlatformNotification(AccessibilityObject* a
 
     if (loadingEvent == AXLoadingFinished) {
         if (axFrameObject->document() == axFrameObject->topDocument())
-            postNotification(axFrameObject, axFrameObject->document(), AXLoadComplete);
+            postNotification(axFrameObject, axFrameObject->document(), AXNotification::AXLoadComplete);
         else
-            postNotification(axFrameObject, axFrameObject->document(), AXFrameLoadComplete);
+            postNotification(axFrameObject, axFrameObject->document(), AXNotification::AXFrameLoadComplete);
     }
 }
 

--- a/Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp
+++ b/Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp
@@ -66,15 +66,15 @@ static AXCoreObject* notifyChildrenSelectionChange(AXCoreObject* object)
     return items.at(changedItemIndex).ptr();
 }
 
-static AXObjectCache::AXNotification checkInteractableObjects(AXCoreObject* object)
+static AXNotification checkInteractableObjects(AXCoreObject* object)
 {
     if (!object->isEnabled())
-        return AXObjectCache::AXNotification::AXPressDidFail;
+        return AXNotification::AXPressDidFail;
 
     if (object->isTextControl() && !object->canSetValueAttribute()) // Also determine whether it is readonly
-        return AXObjectCache::AXNotification::AXPressDidFail;
+        return AXNotification::AXPressDidFail;
 
-    return AXObjectCache::AXNotification::AXPressDidSucceed;
+    return AXNotification::AXPressDidSucceed;
 }
 
 void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNotification notification)
@@ -128,7 +128,7 @@ void AXObjectCache::frameLoadingEventPlatformNotification(AccessibilityObject* o
 void AXObjectCache::handleScrolledToAnchor(const Node& scrolledToNode)
 {
     if (RefPtr object = AccessibilityObject::firstAccessibleObjectFromNode(&scrolledToNode))
-        postPlatformNotification(*object, AXScrolledToAnchor);
+        postPlatformNotification(*object, AXNotification::AXScrolledToAnchor);
 }
 
 void AXObjectCache::platformHandleFocusedUIElementChanged(Element*, Element* newFocus)
@@ -141,7 +141,7 @@ void AXObjectCache::platformHandleFocusedUIElementChanged(Element*, Element* new
         return;
 
     if (RefPtr focusedObject = focusedObjectForPage(page))
-        postPlatformNotification(*focusedObject, AXFocusedUIElementChanged);
+        postPlatformNotification(*focusedObject, AXNotification::AXFocusedUIElementChanged);
 }
 
 void AXObjectCache::platformPerformDeferredCacheUpdate()

--- a/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
+++ b/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
@@ -61,7 +61,7 @@ void AXObjectCache::handleScrolledToAnchor(const Node& anchorNode)
     // The anchor node may not be accessible. Post the notification for the
     // first accessible object.
     if (RefPtr object = AccessibilityObject::firstAccessibleObjectFromNode(&anchorNode))
-        postPlatformNotification(*object, AXScrolledToAnchor);
+        postPlatformNotification(*object, AXNotification::AXScrolledToAnchor);
 }
 
 void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNotification notification)
@@ -76,33 +76,33 @@ void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNoti
 
     DWORD msaaEvent;
     switch (notification) {
-        case AXCheckedStateChanged:
+        case AXNotification::AXCheckedStateChanged:
             msaaEvent = EVENT_OBJECT_STATECHANGE;
             break;
 
-        case AXFocusedUIElementChanged:
-        case AXActiveDescendantChanged:
+        case AXNotification::AXFocusedUIElementChanged:
+        case AXNotification::AXActiveDescendantChanged:
             msaaEvent = EVENT_OBJECT_FOCUS;
             break;
 
-        case AXScrolledToAnchor:
+        case AXNotification::AXScrolledToAnchor:
             msaaEvent = EVENT_SYSTEM_SCROLLINGSTART;
             break;
 
-        case AXLayoutComplete:
+        case AXNotification::AXLayoutComplete:
             msaaEvent = EVENT_OBJECT_REORDER;
             break;
 
-        case AXLoadComplete:
+        case AXNotification::AXLoadComplete:
             msaaEvent = IA2_EVENT_DOCUMENT_LOAD_COMPLETE;
             break;
 
-        case AXValueChanged:
-        case AXMenuListValueChanged:
+        case AXNotification::AXValueChanged:
+        case AXNotification::AXMenuListValueChanged:
             msaaEvent = EVENT_OBJECT_VALUECHANGE;
             break;
 
-        case AXMenuListItemSelected:
+        case AXNotification::AXMenuListItemSelected:
             msaaEvent = EVENT_OBJECT_SELECTION;
             break;
 
@@ -156,7 +156,7 @@ void AXObjectCache::platformHandleFocusedUIElementChanged(Element*, Element* new
 
     if (RefPtr focusedObject = focusedObjectForPage(page)) {
         ASSERT(!focusedObject->isIgnored());
-        postPlatformNotification(*focusedObject, AXFocusedUIElementChanged);
+        postPlatformNotification(*focusedObject, AXNotification::AXFocusedUIElementChanged);
     }
 }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3925,11 +3925,11 @@ void Document::implicitClose()
 
         axObjectCache()->getOrCreate(renderView());
         if (this == &topDocument())
-            axObjectCache()->postNotification(renderView(), AXObjectCache::AXNewDocumentLoadComplete);
+            axObjectCache()->postNotification(renderView(), AXNotification::AXNewDocumentLoadComplete);
         else {
             // AXLoadComplete can only be posted on the top document, so if it's a document
             // in an iframe that just finished loading, post AXLayoutComplete instead.
-            axObjectCache()->postNotification(renderView(), AXObjectCache::AXLayoutComplete);
+            axObjectCache()->postNotification(renderView(), AXNotification::AXLayoutComplete);
         }
     }
 #endif

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -817,7 +817,7 @@ void Editor::respondToChangedContents(const VisibleSelection& endingSelection)
     if (AXObjectCache::accessibilityEnabled()) {
         auto node = endingSelection.start().protectedDeprecatedNode();
         if (AXObjectCache* cache = document().existingAXObjectCache())
-            cache->postNotification(node.get(), AXObjectCache::AXValueChanged, PostTarget::ObservableParent);
+            cache->postNotification(node.get(), AXNotification::AXValueChanged, PostTarget::ObservableParent);
     }
 
     updateMarkersForWordsAffectedByEditing(true);
@@ -3269,7 +3269,7 @@ void Editor::markAndReplaceFor(const SpellCheckRequest& request, const Vector<Te
 
                 if (AXObjectCache* cache = document->existingAXObjectCache()) {
                     if (RefPtr root = document->selection().selection().rootEditableElement())
-                        cache->postNotification(root.get(), AXObjectCache::AXAutocorrectionOccured);
+                        cache->postNotification(root.get(), AXNotification::AXAutocorrectionOccured);
                 }
 
                 // Skip all other results for the replaced text.

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -690,7 +690,7 @@ void HTMLTextFormControlElement::setInnerTextValue(String&& value)
             }
 #endif
             if (AXObjectCache* cache = document().existingAXObjectCache())
-                cache->postNotification(this, AXObjectCache::AXValueChanged, PostTarget::ObservableParent);
+                cache->postNotification(this, AXNotification::AXValueChanged, PostTarget::ObservableParent);
         }
 #endif
 

--- a/Source/WebCore/loader/EmptyClients.h
+++ b/Source/WebCore/loader/EmptyClients.h
@@ -180,7 +180,7 @@ class EmptyChromeClient : public ChromeClient {
 #endif
 
 #if PLATFORM(PLAYSTATION)
-    void postAccessibilityNotification(AccessibilityObject&, AXObjectCache::AXNotification) final { }
+    void postAccessibilityNotification(AccessibilityObject&, AXNotification) final { }
     void postAccessibilityNodeTextChangeNotification(AccessibilityObject*, AXTextChange, unsigned, const String&) final { }
     void postAccessibilityFrameLoadingEventNotification(AccessibilityObject*, AXObjectCache::AXLoadingEvent) final { }
 #endif

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -512,7 +512,7 @@ public:
 #endif
 
 #if PLATFORM(PLAYSTATION)
-    virtual void postAccessibilityNotification(AccessibilityObject&, AXObjectCache::AXNotification) = 0;
+    virtual void postAccessibilityNotification(AccessibilityObject&, AXNotification) = 0;
     virtual void postAccessibilityNodeTextChangeNotification(AccessibilityObject*, AXTextChange, unsigned, const String&) = 0;
     virtual void postAccessibilityFrameLoadingEventNotification(AccessibilityObject*, AXObjectCache::AXLoadingEvent) = 0;
 #endif

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2491,15 +2491,15 @@ bool EventHandler::dispatchDragEvent(const AtomString& eventType, Element& dragT
     if (CheckedPtr cache = frame->document()->existingAXObjectCache()) {
         auto& eventNames = WebCore::eventNames();
         if (eventType == eventNames.dragstartEvent)
-            cache->postNotification(&dragTarget, AXObjectCache::AXDraggingStarted);
+            cache->postNotification(&dragTarget, AXNotification::AXDraggingStarted);
         else if (eventType == eventNames.dragendEvent)
-            cache->postNotification(&dragTarget, AXObjectCache::AXDraggingEnded);
+            cache->postNotification(&dragTarget, AXNotification::AXDraggingEnded);
         else if (eventType == eventNames.dragenterEvent)
-            cache->postNotification(&dragTarget, AXObjectCache::AXDraggingEnteredDropZone);
+            cache->postNotification(&dragTarget, AXNotification::AXDraggingEnteredDropZone);
         else if (eventType == eventNames.dragleaveEvent)
-            cache->postNotification(&dragTarget, AXObjectCache::AXDraggingExitedDropZone);
+            cache->postNotification(&dragTarget, AXNotification::AXDraggingExitedDropZone);
         else if (eventType == eventNames.dropEvent)
-            cache->postNotification(&dragTarget, AXObjectCache::AXDraggingDropped);
+            cache->postNotification(&dragTarget, AXNotification::AXDraggingDropped);
     }
 
     return dragEvent->defaultPrevented();

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -552,7 +552,7 @@ bool FocusController::setInitialFocus(FocusDirection direction, KeyboardEvent* p
     // of handleFocusedUIElementChanged, because this will send the notification even if the element is the same.
     RefPtr focusedOrMainFrame = this->focusedOrMainFrame();
     if (CheckedPtr cache = focusedOrMainFrame ? focusedOrMainFrame->document()->existingAXObjectCache() : nullptr)
-        cache->postNotification(focusedOrMainFrame->document(), AXObjectCache::AXFocusedUIElementChanged);
+        cache->postNotification(focusedOrMainFrame->document(), AXNotification::AXFocusedUIElementChanged);
 
     return didAdvanceFocus;
 }

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1309,7 +1309,7 @@ void LocalFrameView::didLayout(SingleThreadWeakPtr<RenderElement> layoutRoot, bo
 
 #if PLATFORM(COCOA) || PLATFORM(WIN) || PLATFORM(GTK)
     if (CheckedPtr cache = document->existingAXObjectCache())
-        cache->postNotification(layoutRoot.get(), AXObjectCache::AXLayoutComplete);
+        cache->postNotification(layoutRoot.get(), AXNotification::AXLayoutComplete);
 #else
     UNUSED_PARAM(layoutRoot);
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1762,7 +1762,7 @@ void WebChromeClient::setMockWebAuthenticationConfiguration(const MockWebAuthent
 #endif
 
 #if PLATFORM(PLAYSTATION)
-void WebChromeClient::postAccessibilityNotification(WebCore::AccessibilityObject&, WebCore::AXObjectCache::AXNotification)
+void WebChromeClient::postAccessibilityNotification(WebCore::AccessibilityObject&, WebCore::AXNotification)
 {
     notImplemented();
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -250,7 +250,7 @@ private:
 #endif
 
 #if PLATFORM(PLAYSTATION)
-    void postAccessibilityNotification(WebCore::AccessibilityObject&, WebCore::AXObjectCache::AXNotification) final;
+    void postAccessibilityNotification(WebCore::AccessibilityObject&, WebCore::AXNotification) final;
     void postAccessibilityNodeTextChangeNotification(WebCore::AccessibilityObject*, WebCore::AXTextChange, unsigned, const String&) final;
     void postAccessibilityFrameLoadingEventNotification(WebCore::AccessibilityObject*, WebCore::AXObjectCache::AXLoadingEvent) final;
 #endif


### PR DESCRIPTION
#### d3ba8e33b3c58fab99ce0c2c74f5f138ee749667
<pre>
Prepare for forward declaring AXNotification
<a href="https://bugs.webkit.org/show_bug.cgi?id=283770">https://bugs.webkit.org/show_bug.cgi?id=283770</a>
<a href="https://rdar.apple.com/140633827">rdar://140633827</a>

Reviewed by Tyler Wilcock.

Move the AXNotification enum out of AXObjectCache and make it an enum class.

This is preparation for removing AXObjectCache.h from ChromeClient.h.

* Source/WebCore/accessibility/AXImage.cpp:
(WebCore::AXImage::imageOverlayElements):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::AXLogger::log):
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXLogger.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleTextChanged):
(WebCore::AXObjectCache::onExpandedChanged):
(WebCore::AXObjectCache::handleAllDeferredChildrenChanged):
(WebCore::AXObjectCache::handleChildrenChanged):
(WebCore::AXObjectCache::handleRecomputeCellSlots):
(WebCore::AXObjectCache::handleRowspanChanged):
(WebCore::AXObjectCache::onTextRunsChanged):
(WebCore::AXObjectCache::handleMenuOpened):
(WebCore::AXObjectCache::handleLiveRegionCreated):
(WebCore::AXObjectCache::valueChanged):
(WebCore::AXObjectCache::columnIndexChanged):
(WebCore::AXObjectCache::rowIndexChanged):
(WebCore::AXObjectCache::notificationPostTimerFired):
(WebCore::AXObjectCache::checkedStateChanged):
(WebCore::AXObjectCache::handleMenuItemSelected):
(WebCore::AXObjectCache::handleTabPanelSelected):
(WebCore::AXObjectCache::handleRowCountChanged):
(WebCore::AXObjectCache::onPopoverToggle):
(WebCore::AXObjectCache::selectedChildrenChanged):
(WebCore::AXObjectCache::onSelectedChanged):
(WebCore::AXObjectCache::onTextSecurityChanged):
(WebCore::AXObjectCache::onTitleChange):
(WebCore::AXObjectCache::onValidityChange):
(WebCore::AXObjectCache::onTextCompositionChange):
(WebCore::AXObjectCache::postTextStateChangeNotification):
(WebCore::AXObjectCache::liveRegionChangedNotificationPostTimerFired):
(WebCore::AXObjectCache::handleAriaExpandedChange):
(WebCore::AXObjectCache::handleActiveDescendantChange):
(WebCore::AXObjectCache::handleRoleChanged):
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::AXObjectCache::handleLabelChanged):
(WebCore::AXObjectCache::handleMenuListValueChanged):
(WebCore::AXObjectCache::updateIsolatedTree):
(WebCore::AXObjectCache::selectedTextRangeTimerFired):
(WebCore::AXObjectCache::onWidgetVisibilityChanged):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityMenuList.cpp:
(WebCore::AccessibilityMenuList::press):
* Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp:
(WebCore::AccessibilityMenuListPopup::didUpdateActiveOption):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::setNodeValue):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::detachRemoteParts):
* Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp:
(WebCore::AXObjectCache::postPlatformNotification):
* Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm:
(WebCore::AXObjectCache::notificationPlatformName):
(WebCore::AXObjectCache::postPlatformAnnouncementNotification):
(WebCore::AXObjectCache::postTextStateChangePlatformNotification):
(WebCore::AXObjectCache::postTextReplacementPlatformNotification):
(WebCore::AXObjectCache::postTextReplacementPlatformNotificationForTextControl):
(WebCore::AXObjectCache::frameLoadingEventPlatformNotification):
(WebCore::AXObjectCache::platformHandleFocusedUIElementChanged):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityScroll:]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::reportLoadingProgress):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::postPlatformNotification):
(WebCore::AXObjectCache::frameLoadingEventPlatformNotification):
* Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp:
(WebCore::checkInteractableObjects):
(WebCore::AXObjectCache::handleScrolledToAnchor):
(WebCore::AXObjectCache::platformHandleFocusedUIElementChanged):
* Source/WebCore/accessibility/win/AXObjectCacheWin.cpp:
(WebCore::AXObjectCache::handleScrolledToAnchor):
(WebCore::AXObjectCache::platformHandleFocusedUIElementChanged):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::implicitClose):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::respondToChangedContents):
(WebCore::Editor::markAndReplaceFor):
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::setInnerTextValue):
* Source/WebCore/loader/EmptyClients.h:
* Source/WebCore/page/ChromeClient.h:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::dispatchDragEvent):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setInitialFocus):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::didLayout):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::postAccessibilityNotification):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:

Canonical link: <a href="https://commits.webkit.org/287134@main">https://commits.webkit.org/287134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f75cb18d8f0fcdb0b0d44f621584559d22af7e8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78476 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83137 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29741 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80609 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66672 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5802 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61461 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19379 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69378 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41773 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48820 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25242 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28078 "Hash f75cb18d for PR 37205 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69917 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84503 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69687 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6002 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/67462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68942 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17180 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12962 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11355 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5788 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/9179 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5776 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9210 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7563 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->