### PR TITLE
Set dynamically injected scripts as tainted

### DIFF
--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -323,10 +323,8 @@ void ScriptElement::updateTaintedOriginFromSourceURL()
     if (!page)
         return;
 
-    if (!page->requiresScriptTelemetryForURL(hasSourceAttribute() ? document->completeURL(sourceAttributeValue()) : document->url()))
-        return;
-
-    m_taintedOrigin = JSC::SourceTaintedOrigin::KnownTainted;
+    if (page->requiresScriptTelemetryForURL(hasSourceAttribute() ? document->completeURL(sourceAttributeValue()) : document->url()) || m_setFromDOMString)
+        m_taintedOrigin = JSC::SourceTaintedOrigin::KnownTainted;
 }
 
 bool ScriptElement::requestClassicScript(const String& sourceURL)
@@ -645,6 +643,7 @@ String ScriptElement::scriptContent() const
 
 void ScriptElement::setTrustedScriptText(const String& text)
 {
+    m_setFromDOMString = true;
     m_trustedScriptText = text;
 }
 

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -150,6 +150,7 @@ private:
     bool m_forceAsync : 1;
     bool m_willExecuteInOrder : 1 { false };
     bool m_childrenChangedByAPI : 1 { false };
+    bool m_setFromDOMString : 1 { false };
     ScriptType m_scriptType : bitWidthOfScriptType { ScriptType::Classic };
     AtomString m_characterEncoding;
     AtomString m_fallbackCharacterEncoding;


### PR DESCRIPTION
#### e46e3f45310e93459f9decedd826b62fded39b52
<pre>
Set dynamically injected scripts as tainted
<a href="https://bugs.webkit.org/show_bug.cgi?id=283773">https://bugs.webkit.org/show_bug.cgi?id=283773</a>
<a href="https://rdar.apple.com/140636725">rdar://140636725</a>

Reviewed by NOBODY (OOPS!).

Set dynamically injected scripts as tainted.

* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::updateTaintedOriginFromSourceURL):
(WebCore::ScriptElement::setTrustedScriptText):
* Source/WebCore/dom/ScriptElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e46e3f45310e93459f9decedd826b62fded39b52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86115 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32576 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83692 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8926 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63657 "Found 1 new test failure: js/taintedness-innerhtml.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21391 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84651 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/801 "Found 1 new test failure: js/taintedness-innerhtml.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74236 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43946 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/698 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28416 "Found 1 new test failure: js/taintedness-innerhtml.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31029 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72135 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29010 "Found 1 new test failure: js/taintedness-innerhtml.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87550 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8815 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6252 "Found 2 new test failures: http/wpt/mediarecorder/pause-recording.html js/taintedness-innerhtml.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71986 "Found 1 new test failure: js/taintedness-innerhtml.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8996 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70064 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71222 "Failed to checkout and rebase branch from PR 37206") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15291 "Failed to checkout and rebase branch from PR 37206") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14203 "Found 1 new test failure: js/taintedness-innerhtml.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8775 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14303 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8613 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12137 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10421 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->