### PR TITLE
SVGToOTFFontConversion.cpp:169:29: error: use of overloaded operator '[]' is ambiguous (with operand types 'ASCIILiteral' and 'int')

### DIFF
--- a/Source/WebCore/svg/SVGToOTFFontConversion.cpp
+++ b/Source/WebCore/svg/SVGToOTFFontConversion.cpp
@@ -166,10 +166,10 @@ private:
 
     void append32BitCode(ASCIILiteral code)
     {
-        m_result.append(code[0]);
-        m_result.append(code[1]);
-        m_result.append(code[2]);
-        m_result.append(code[3]);
+        m_result.append(code[0uz]);
+        m_result.append(code[1uz]);
+        m_result.append(code[2uz]);
+        m_result.append(code[3uz]);
     }
 
     void append16(uint16_t value)
@@ -1505,10 +1505,10 @@ void SVGToOTFFontConverter::appendTable(ASCIILiteral identifier, FontAppendingFu
         m_result.append(0);
     ASSERT(isFourByteAligned(m_result.size()));
     size_t directoryEntryOffset = headerSize + m_tablesAppendedCount * directoryEntrySize;
-    m_result[directoryEntryOffset] = identifier[0];
-    m_result[directoryEntryOffset + 1] = identifier[1];
-    m_result[directoryEntryOffset + 2] = identifier[2];
-    m_result[directoryEntryOffset + 3] = identifier[3];
+    m_result[directoryEntryOffset] = identifier[0uz];
+    m_result[directoryEntryOffset + 1] = identifier[1uz];
+    m_result[directoryEntryOffset + 2] = identifier[2uz];
+    m_result[directoryEntryOffset + 3] = identifier[3uz];
     overwrite32(directoryEntryOffset + 4, calculateChecksum(offset, m_result.size()));
     overwrite32(directoryEntryOffset + 8, offset);
     overwrite32(directoryEntryOffset + 12, unpaddedSize);


### PR DESCRIPTION
#### 0b149ed6d30f64ba6353c79c8d7738edad2947c7
<pre>
SVGToOTFFontConversion.cpp:169:29: error: use of overloaded operator &apos;[]&apos; is ambiguous (with operand types &apos;ASCIILiteral&apos; and &apos;int&apos;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=283768">https://bugs.webkit.org/show_bug.cgi?id=283768</a>

Reviewed by Fujii Hironori.

Specify the type of the integer literal to be size_t to disambiguate
which operator[] to use. I&apos;m not actually sure where the built-in
operator[]s are coming from, but that probably doesn&apos;t matter since we
surely want to use the one defined in ASCIILiteral.

* Source/WebCore/svg/SVGToOTFFontConversion.cpp:
(WebCore::SVGToOTFFontConverter::append32BitCode):
(WebCore::SVGToOTFFontConverter::appendTable):

Canonical link: <a href="https://commits.webkit.org/287287@main">https://commits.webkit.org/287287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d438ad39e4334d283f3f2617c477ac2cc2c0acc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/79064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83703 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30278 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/81197 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/67208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61881 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19800 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82131 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51923 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42184 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/26168 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28642 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85090 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70121 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6552 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67938 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69370 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17282 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13415 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12200 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6339 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6299 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9751 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8092 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->