### PR TITLE
Remove expectations for css3/filters/composited-during-animation-layertree.html on macOS

### DIFF
--- a/LayoutTests/platform/mac-ventura/css3/filters/composited-during-animation-layertree-expected.txt
+++ b/LayoutTests/platform/mac-ventura/css3/filters/composited-during-animation-layertree-expected.txt
@@ -13,22 +13,18 @@
         (GraphicsLayer
           (position 18.00 18.00)
           (bounds 160.00 90.00)
-          (drawsContent 1)
         )
         (GraphicsLayer
           (position 18.00 132.00)
           (bounds 160.00 90.00)
-          (drawsContent 1)
         )
         (GraphicsLayer
           (position 18.00 246.00)
           (bounds 160.00 90.00)
-          (drawsContent 1)
         )
         (GraphicsLayer
           (position 18.00 360.00)
           (bounds 160.00 90.00)
-          (drawsContent 1)
         )
       )
     )

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -373,7 +373,6 @@ webkit.org/b/142258 fast/css/object-fit/object-fit-canvas.html [ Pass ImageOnlyF
 
 # --- Compositing ----
 css3/filters/composited-during-transition-layertree.html
-webkit.org/b/95622 css3/filters/composited-during-animation-layertree.html [ Pass Failure ]
 
 platform/mac/fast/text/combining-character-sequence-fallback.html [ Pass Failure ]
 


### PR DESCRIPTION
#### 2020ece42d14b661924f2863f3f199aabefc6264
<pre>
Remove expectations for css3/filters/composited-during-animation-layertree.html on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=95622">https://bugs.webkit.org/show_bug.cgi?id=95622</a>
<a href="https://rdar.apple.com/12229951">rdar://12229951</a>

Reviewed by Tim Horton.

The test is producing expected output these days, though it does need a
small tweak.

* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/platform/mac/css3/filters/composited-during-animation-layertree-expected.txt:
* LayoutTests/platform/mac-ventura/css3/filters/composited-during-animation-layertree-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/287140@main">https://commits.webkit.org/287140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5527c9fa409bca6dc7befccf9a9e02e600f4db8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78495 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83156 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29760 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61480 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19397 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81562 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/51493 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69494 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41792 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48839 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25277 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28097 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69937 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84522 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4002 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69705 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6021 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/67475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68960 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12980 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11388 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12124 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5807 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5795 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9229 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7582 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->