### PR TITLE
Use generate-serializers.py for sk_sp<SkColorSpace> and sk_sp<SkData>

### DIFF
--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -1256,6 +1256,43 @@ std::optional<RetainPtr<CFBarRef>> ArgumentCoder<RetainPtr<CFBarRef>>::decode(De
 
 #endif
 
+#if USE(SKIA)
+void ArgumentCoder<SkFooBar>::encode(Encoder& encoder, const SkFooBar& passedInstance)
+{
+    auto instance = CoreIPCSkFooBar(passedInstance);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.foo())>, int>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.bar())>, double>);
+
+    encoder << instance.foo();
+    encoder << instance.bar();
+}
+
+void ArgumentCoder<SkFooBar>::encode(OtherEncoder& encoder, const SkFooBar& passedInstance)
+{
+    auto instance = CoreIPCSkFooBar(passedInstance);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.foo())>, int>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.bar())>, double>);
+
+    encoder << instance.foo();
+    encoder << instance.bar();
+}
+
+std::optional<SkFooBar> ArgumentCoder<SkFooBar>::decode(Decoder& decoder)
+{
+    auto foo = decoder.decode<int>();
+    auto bar = decoder.decode<double>();
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    return {
+        CoreIPCSkFooBar {
+            WTFMove(*foo),
+            WTFMove(*bar)
+        }
+    };
+}
+
+#endif
+
 void ArgumentCoder<WebKit::RValueWithFunctionCalls>::encode(Encoder& encoder, WebKit::RValueWithFunctionCalls&& instance)
 {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.callFunction())>, SandboxExtensionHandle>);

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -120,6 +120,9 @@ class WithoutNamespaceWithAttributes;
 struct SoftLinkedMember;
 struct RequestEncodedWithBody;
 struct RequestEncodedWithBodyRValue;
+#if USE(SKIA)
+class SkFooBar;
+#endif
 
 #if USE(CFBAR)
 typedef struct __CFBar * CFBarRef;
@@ -363,6 +366,14 @@ template<> struct ArgumentCoder<RetainPtr<CFStringRef>> {
         ArgumentCoder<CFStringRef>::encode(encoder, retainPtr.get());
     }
     static std::optional<RetainPtr<CFStringRef>> decode(Decoder&);
+};
+#endif
+
+#if USE(SKIA)
+template<> struct ArgumentCoder<SkFooBar> {
+    static void encode(Encoder&, const SkFooBar&);
+    static void encode(OtherEncoder&, const SkFooBar&);
+    static std::optional<SkFooBar> decode(Decoder&);
 };
 #endif
 

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -441,6 +441,18 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             { "String"_s, "wrapper"_s }
         } },
 #endif // USE(CFSTRING)
+#if USE(SKIA)
+        { "SkFooBar"_s, {
+            {
+                "int"_s,
+                "foo()"_s
+            },
+            {
+                "double"_s,
+                "bar()"_s
+            },
+        } },
+#endif // USE(SKIA)
         { "WebKit::RValueWithFunctionCalls"_s, {
             {
                 "SandboxExtensionHandle"_s,

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -282,6 +282,13 @@ additional_forward_declaration: typedef struct __CFBar * CFBarRef
 }
 #endif
 
+#if USE(SKIA)
+[Wrapper=CoreIPCSkFooBar, AdditionalEncoder=OtherEncoder] class SkFooBar {
+    int foo();
+    double bar();
+}
+#endif
+
 [RValue] class WebKit::RValueWithFunctionCalls {
     SandboxExtensionHandle callFunction()
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -33,14 +33,8 @@
 #include <wtf/EnumTraits.h>
 
 #if USE(SKIA)
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-#include <skia/core/SkColorSpace.h>
-#include <skia/core/SkData.h>
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
-#endif
-
-#if PLATFORM(GTK)
-#include "ArgumentCodersGtk.h"
+#include <skia/core/SkFontStyle.h>
+class SkString;
 #endif
 
 namespace WebCore {
@@ -82,18 +76,6 @@ template<> struct ArgumentCoder<SkString> {
 template<> struct ArgumentCoder<SkFontStyle::Slant> {
     static void encode(Encoder&, const SkFontStyle::Slant&);
     static std::optional<SkFontStyle::Slant> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<sk_sp<SkColorSpace>> {
-    static void encode(Encoder&, const sk_sp<SkColorSpace>&);
-    static void encode(StreamConnectionEncoder&, const sk_sp<SkColorSpace>&);
-    static std::optional<sk_sp<SkColorSpace>> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<sk_sp<SkData>> {
-    static void encode(Encoder&, const sk_sp<SkData>&);
-    static void encode(StreamConnectionEncoder&, const sk_sp<SkData>&);
-    static std::optional<sk_sp<SkData>> decode(Decoder&);
 };
 #endif
 

--- a/Source/WebKit/Shared/skia/CoreIPCSkColorSpace.h
+++ b/Source/WebKit/Shared/skia/CoreIPCSkColorSpace.h
@@ -40,12 +40,10 @@ public:
     {
     }
 
-    explicit CoreIPCSkColorSpace(std::span<const uint8_t> data)
-        : m_skColorSpace(SkColorSpace::Deserialize(data.data(), data.size()))
+    static sk_sp<SkColorSpace> create(std::span<const uint8_t> data)
     {
+        return SkColorSpace::Deserialize(data.data(), data.size());
     }
-
-    sk_sp<SkColorSpace> skColorSpace() const { return m_skColorSpace; }
 
     std::span<const uint8_t> dataReference() const
     {

--- a/Source/WebKit/Shared/skia/CoreIPCSkColorSpace.serialization.in
+++ b/Source/WebKit/Shared/skia/CoreIPCSkColorSpace.serialization.in
@@ -1,4 +1,5 @@
 # Copyright (C) 2024 Igalia S.L.
+# Copyright (C) 2024 Sony Interactive Entertainment Inc.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -22,9 +23,9 @@
 
 #if USE(SKIA)
 
-webkit_platform_headers: "CoreIPCSkColorSpace.h"
-
-[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCSkColorSpace {
+additional_forward_declaration: class SkColorSpace;
+headers: "CoreIPCSkColorSpace.h"
+[Wrapper=WebKit::CoreIPCSkColorSpace, CreateUsing=create, AdditionalEncoder=StreamConnectionEncoder] class sk_sp<SkColorSpace> {
     std::span<const uint8_t> dataReference();
 }
 

--- a/Source/WebKit/Shared/skia/CoreIPCSkData.h
+++ b/Source/WebKit/Shared/skia/CoreIPCSkData.h
@@ -38,12 +38,10 @@ public:
     {
     }
 
-    CoreIPCSkData(std::span<const uint8_t> data)
-        : m_skData(SkData::MakeWithCopy(data.data(), data.size()))
+    static sk_sp<SkData> create(std::span<const uint8_t> data)
     {
+        return SkData::MakeWithCopy(data.data(), data.size());
     }
-
-    sk_sp<SkData> skData() const { return m_skData; }
 
     std::span<const uint8_t> dataReference() const
     {

--- a/Source/WebKit/Shared/skia/CoreIPCSkData.serialization.in
+++ b/Source/WebKit/Shared/skia/CoreIPCSkData.serialization.in
@@ -20,8 +20,12 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-webkit_platform_headers: "CoreIPCSkData.h"
+#if USE(SKIA)
 
-[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCSkData {
+additional_forward_declaration: class SkData;
+headers: "CoreIPCSkData.h"
+[Wrapper=WebKit::CoreIPCSkData, CreateUsing=create, AdditionalEncoder=StreamConnectionEncoder] class sk_sp<SkData> {
     std::span<const uint8_t> dataReference();
 }
+
+#endif // USE(SKIA)

--- a/Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.cpp
+++ b/Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.cpp
@@ -28,12 +28,7 @@
 
 #if USE(SKIA)
 
-#include "CoreIPCSkColorSpace.h"
-#include "CoreIPCSkData.h"
-#include "StreamConnectionEncoder.h"
-#include <WebCore/Font.h>
-#include <WebCore/FontCache.h>
-#include <WebCore/FontCustomPlatformData.h>
+#include <skia/core/SkString.h>
 
 namespace IPC {
 
@@ -61,42 +56,6 @@ std::optional<SkFontStyle::Slant> ArgumentCoder<SkFontStyle::Slant>::decode(Deco
     if (UNLIKELY(!decoder.isValid()))
         return std::nullopt;
     return static_cast<SkFontStyle::Slant>(*slant);
-}
-
-void ArgumentCoder<sk_sp<SkColorSpace>>::encode(Encoder& encoder, const sk_sp<SkColorSpace>& colorSpace)
-{
-    encoder << WebKit::CoreIPCSkColorSpace(colorSpace);
-}
-
-void ArgumentCoder<sk_sp<SkColorSpace>>::encode(StreamConnectionEncoder& encoder, const sk_sp<SkColorSpace>& colorSpace)
-{
-    encoder << WebKit::CoreIPCSkColorSpace(colorSpace);
-}
-
-std::optional<sk_sp<SkColorSpace>> ArgumentCoder<sk_sp<SkColorSpace>>::decode(Decoder& decoder)
-{
-    auto colorSpace = decoder.decode<WebKit::CoreIPCSkColorSpace>();
-    if (UNLIKELY(!decoder.isValid()))
-        return std::nullopt;
-    return colorSpace->skColorSpace();
-}
-
-void ArgumentCoder<sk_sp<SkData>>::encode(Encoder& encoder, const sk_sp<SkData>& data)
-{
-    encoder << WebKit::CoreIPCSkData(data);
-}
-
-void ArgumentCoder<sk_sp<SkData>>::encode(StreamConnectionEncoder& encoder, const sk_sp<SkData>& data)
-{
-    encoder << WebKit::CoreIPCSkData(data);
-}
-
-std::optional<sk_sp<SkData>> ArgumentCoder<sk_sp<SkData>>::decode(Decoder& decoder)
-{
-    auto data = decoder.decode<WebKit::CoreIPCSkData>();
-    if (UNLIKELY(!decoder.isValid()))
-        return std::nullopt;
-    return data->skData();
 }
 
 } // namespace IPC


### PR DESCRIPTION
#### a7a1f3de89a04480a8d800d7596400ece745b976
<pre>
Use generate-serializers.py for sk_sp&lt;SkColorSpace&gt; and sk_sp&lt;SkData&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=283774">https://bugs.webkit.org/show_bug.cgi?id=283774</a>

Reviewed by Alex Christensen.

Added a new `Wrapper` attribute to specify a CoreIPC wrapper class for
external types.

* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.__init__):
(SerializedType.namespace_and_name_for_construction):
(generate_one_impl):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;SkFooBar&gt;::encode):
(IPC::ArgumentCoder&lt;SkFooBar&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/skia/CoreIPCSkColorSpace.h:
(WebKit::CoreIPCSkColorSpace::operator sk_sp&lt;SkColorSpace&gt; const):
(WebKit::CoreIPCSkColorSpace::skColorSpace const): Deleted.
* Source/WebKit/Shared/skia/CoreIPCSkColorSpace.serialization.in:
* Source/WebKit/Shared/skia/CoreIPCSkData.h:
(WebKit::CoreIPCSkData::operator sk_sp&lt;SkData&gt; const):
(WebKit::CoreIPCSkData::skData const): Deleted.
* Source/WebKit/Shared/skia/CoreIPCSkData.serialization.in:
* Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.cpp:
(IPC::ArgumentCoder&lt;sk_sp&lt;SkColorSpace&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;sk_sp&lt;SkColorSpace&gt;&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;sk_sp&lt;SkData&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;sk_sp&lt;SkData&gt;&gt;::decode): Deleted.

Canonical link: <a href="https://commits.webkit.org/287247@main">https://commits.webkit.org/287247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73ffd5490bfd6ceb2f6a2a1c5f9c5a645d651ae0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78964 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/58001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83606 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30186 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/67120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61812 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19735 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/82031 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/67120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/71863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42116 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/78474 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/67120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28549 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/67120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84990 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6300 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70043 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67861 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69295 "Found 7 new API test failures: /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit.AboutBlankLoad, /TestWebKit:WebKit.LoadAlternateHTMLStringWithEmptyBaseURL, /TestWebKit:WebKit.FrameMIMETypePNG, /TestWebKit:WebKit2UserMessageRoundTripTest.WKURLRequestRef, /TestWebKit:WebKit.InjectedBundleBasic, /TestWebKit:WebKit.GeolocationBasicWithHighAccuracy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13341 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/12091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12181 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6250 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/12105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/6213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9664 "Failed to checkout and rebase branch from PR 37209") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/8004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->