### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER in WTF/

### DIFF
--- a/Source/WTF/wtf/BloomFilter.h
+++ b/Source/WTF/wtf/BloomFilter.h
@@ -26,9 +26,8 @@
 #pragma once
 
 #include <array>
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/AtomString.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WTF {
 
@@ -104,9 +103,10 @@ inline std::pair<unsigned, unsigned> BloomFilter<keyBits>::keysFromHash(const st
 {
     // We could use larger k value than 2 for long hashes.
     static_assert(hashSize >= 2 * sizeof(unsigned), "Hash array too short");
+    std::span hashSpan { hash };
     return {
-        *reinterpret_cast_ptr<const unsigned*>(hash.data()),
-        *reinterpret_cast_ptr<const unsigned*>(hash.data() + sizeof(unsigned))
+        reinterpretCastSpanStartTo<unsigned>(hashSpan),
+        reinterpretCastSpanStartTo<unsigned>(hashSpan.subspan(sizeof(unsigned)))
     };
 }
 
@@ -266,5 +266,3 @@ bool CountingBloomFilter<keyBits>::isClear() const
 
 using WTF::BloomFilter;
 using WTF::CountingBloomFilter;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/Brigand.h
+++ b/Source/WTF/wtf/Brigand.h
@@ -64,8 +64,6 @@
 #include <boost/variant.hpp>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace brigand
 {
   template <class... T> struct list {};
@@ -454,11 +452,14 @@ namespace brigand
 {
 namespace detail
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     constexpr std::size_t count_bools(bool const * const begin, bool const * const end,
         std::size_t n)
     {
         return begin == end ? n : detail::count_bools(begin + 1, end, n + *begin);
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
     template <bool... Bs>
     struct template_count_bools
     {
@@ -2488,5 +2489,3 @@ namespace brigand
   template<std::uint64_t Value>
   struct double_ : real_<double, std::uint64_t,Value> {};
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/ParallelJobs.h
+++ b/Source/WTF/wtf/ParallelJobs.h
@@ -30,8 +30,6 @@
 #include <wtf/Assertions.h>
 #include <wtf/Vector.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 // Usage:
 //
 //     // Initialize parallel jobs
@@ -100,5 +98,3 @@ private:
 } // namespace WTF
 
 using WTF::ParallelJobs;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/ParallelJobsLibdispatch.h
+++ b/Source/WTF/wtf/ParallelJobsLibdispatch.h
@@ -56,7 +56,9 @@ public:
     {
         static dispatch_queue_t globalQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         dispatch_apply(m_numberOfJobs, globalQueue, ^(size_t i) { (*m_threadFunction)(parameters + (m_sizeOfParameter * i)); });
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
 private:

--- a/Source/WTF/wtf/TinyLRUCache.h
+++ b/Source/WTF/wtf/TinyLRUCache.h
@@ -53,7 +53,7 @@ public:
             return valueForNull;
         }
 
-        auto* cacheBuffer = this->cacheBuffer();
+        auto cacheBuffer = this->cacheBuffer();
         for (size_t i = m_size; i-- > 0;) {
             if (cacheBuffer[i].first == key) {
                 if (i < m_size - 1) {
@@ -81,9 +81,9 @@ public:
 
 private:
     using Entry = std::pair<KeyType, ValueType>;
-    Entry* cacheBuffer() { return reinterpret_cast_ptr<Entry*>(m_cacheBuffer); }
+    std::span<Entry, capacity> cacheBuffer() { return m_cacheBuffer; }
 
-    alignas(Entry) std::byte m_cacheBuffer[capacity * sizeof(Entry)];
+    alignas(Entry) std::array<Entry, capacity> m_cacheBuffer;
     size_t m_size { 0 };
 };
 


### PR DESCRIPTION
#### 03cb2e5592d3dd3bd3f9925ca524d66abcb24ee1
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER in WTF/
<a href="https://bugs.webkit.org/show_bug.cgi?id=283775">https://bugs.webkit.org/show_bug.cgi?id=283775</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/BloomFilter.h:
(WTF::BloomFilter&lt;keyBits&gt;::keysFromHash):
* Source/WTF/wtf/Brigand.h:
* Source/WTF/wtf/ParallelJobs.h:
* Source/WTF/wtf/ParallelJobsLibdispatch.h:
(WTF::ParallelEnvironment::execute):
* Source/WTF/wtf/TinyLRUCache.h:
(WTF::TinyLRUCache::get):
(WTF::TinyLRUCache::cacheBuffer):

Canonical link: <a href="https://commits.webkit.org/287158@main">https://commits.webkit.org/287158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/143a062a3f81f4c4fa10746ebdfc72bb0192b98e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83212 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29816 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5877 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61529 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19446 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41840 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48885 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25374 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28153 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71697 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69985 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84578 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77788 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5916 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69754 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6077 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69008 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13027 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11474 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/100097 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12130 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5863 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21865 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5851 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9285 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7638 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->