### PR TITLE
Reduce WebPage.h and WebFrame.h includes in Web Extension code.

### DIFF
--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -23,6 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+
 #import <WebCore/Icon.h>
 #import <wtf/HashSet.h>
 #import <wtf/OptionSet.h>
@@ -155,3 +157,5 @@ HashSet<String> toImpl(NSSet *);
 HashMap<String, Ref<API::Data>> toDataMap(NSDictionary *);
 
 } // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -30,6 +30,8 @@
 #import "config.h"
 #import "CocoaHelpers.h"
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+
 #import "APIData.h"
 #import "JSWebExtensionWrapper.h"
 #import "Logging.h"
@@ -543,3 +545,5 @@ HashMap<String, Ref<API::Data>> toDataMap(NSDictionary *dictionary)
 }
 
 } // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -370,7 +370,6 @@ WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm
 WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
-WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
 WebProcess/FileAPI/BlobRegistryProxy.cpp
 WebProcess/FullScreen/WebFullScreenManager.cpp
 WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
@@ -37,6 +37,8 @@
 #import "Logging.h"
 #import "WebExtensionAPITabs.h"
 #import "WebExtensionMessageSenderParameters.h"
+#import "WebFrame.h"
+#import <WebCore/LocalFrame.h>
 #import <objc/runtime.h>
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
@@ -35,7 +35,6 @@
 #import "WKWebExtensionControllerInternal.h"
 #import "WKWebViewInternal.h"
 #import "WebExtensionController.h"
-#import "WebPageProxy.h"
 #import "WebProcessProxy.h"
 #import <wtf/EnumTraits.h>
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -42,7 +42,6 @@
 #import "WebExtensionMessagePort.h"
 #import "WebExtensionMessageSenderParameters.h"
 #import "WebExtensionUtilities.h"
-#import "WebPageProxy.h"
 #import <wtf/BlockPtr.h>
 #import <wtf/CallbackAggregator.h>
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -45,7 +45,6 @@
 #import "WebExtensionTabIdentifier.h"
 #import "WebExtensionUtilities.h"
 #import "WebExtensionWindowIdentifier.h"
-#import "WebPageProxy.h"
 #import <WebCore/ImageBufferUtilitiesCG.h>
 #import <wtf/CallbackAggregator.h>
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
@@ -41,7 +41,9 @@
 #import "WebExtensionContextMessages.h"
 #import "WebExtensionContextProxy.h"
 #import "WebExtensionUtilities.h"
+#import "WebFrame.h"
 #import "WebProcess.h"
+#import <WebCore/LocalFrame.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import <UIKit/UIKit.h>
@@ -640,7 +642,7 @@ void WebExtensionAPIAction::setPopup(NSDictionary *details, Ref<WebExtensionCall
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPIAction::openPopup(WebPage& page, NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIAction::openPopup(WebPageProxyIdentifier webPageProxyIdentifier, NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/openPopup
 
@@ -649,7 +651,7 @@ void WebExtensionAPIAction::openPopup(WebPage& page, NSDictionary *details, Ref<
     if (!parseActionDetails(details, windowIdentifier, tabIdentifier, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionOpenPopup(page.webPageProxyIdentifier(), windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionOpenPopup(webPageProxyIdentifier, windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm
@@ -41,7 +41,9 @@
 #import "WebExtensionContextMessages.h"
 #import "WebExtensionContextProxy.h"
 #import "WebExtensionUtilities.h"
+#import "WebFrame.h"
 #import "WebProcess.h"
+#import <WebCore/LocalFrame.h>
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsExtensionPanelCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsExtensionPanelCocoa.mm
@@ -36,6 +36,7 @@
 #import "JSWebExtensionWrapper.h"
 #import "MessageSenderInlines.h"
 #import "WebExtensionAPINamespace.h"
+#import "WebFrame.h"
 #import "WebProcess.h"
 
 namespace WebKit {

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
@@ -49,7 +49,7 @@ static NSString * const valueKey = @"value";
 
 namespace WebKit {
 
-void WebExtensionAPIDevToolsInspectedWindow::eval(WebPage& page, NSString *expression, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIDevToolsInspectedWindow::eval(WebPageProxyIdentifier webPageProxyIdentifier, NSString *expression, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow/eval
 
@@ -72,7 +72,7 @@ void WebExtensionAPIDevToolsInspectedWindow::eval(WebPage& page, NSString *expre
         }
     }
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DevToolsInspectedWindowEval(page.webPageProxyIdentifier(), expression, frameURL), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Expected<std::span<const uint8_t>, WebCore::ExceptionDetails>, WebExtensionError>&& result) mutable {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DevToolsInspectedWindowEval(webPageProxyIdentifier, expression, frameURL), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Expected<std::span<const uint8_t>, WebCore::ExceptionDetails>, WebExtensionError>&& result) mutable {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -94,7 +94,7 @@ void WebExtensionAPIDevToolsInspectedWindow::eval(WebPage& page, NSString *expre
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPIDevToolsInspectedWindow::reload(WebPage& page, NSDictionary *options, NSString **outExceptionString)
+void WebExtensionAPIDevToolsInspectedWindow::reload(WebPageProxyIdentifier webPageProxyIdentifier, NSDictionary *options, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow/reload
 
@@ -111,7 +111,7 @@ void WebExtensionAPIDevToolsInspectedWindow::reload(WebPage& page, NSDictionary 
     if (NSNumber *value = options[ignoreCacheKey])
         ignoreCache = value.boolValue;
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::DevToolsInspectedWindowReload(page.webPageProxyIdentifier(), ignoreCache), extensionContext().identifier());
+    WebProcess::singleton().send(Messages::WebExtensionContext::DevToolsInspectedWindowReload(webPageProxyIdentifier, ignoreCache), extensionContext().identifier());
 }
 
 double WebExtensionAPIDevToolsInspectedWindow::tabId(WebPage& page)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm
@@ -48,11 +48,11 @@ RefPtr<WebExtensionAPIDevToolsExtensionPanel> WebExtensionAPIDevToolsPanels::ext
     return m_extensionPanels.get(identifier);
 }
 
-void WebExtensionAPIDevToolsPanels::createPanel(WebPage& page, NSString *title, NSString *iconPath, NSString *pagePath, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIDevToolsPanels::createPanel(WebPageProxyIdentifier webPageProxyIdentifier, NSString *title, NSString *iconPath, NSString *pagePath, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/create
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DevToolsPanelsCreate(page.webPageProxyIdentifier(), title, iconPath, pagePath), [this, protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Inspector::ExtensionTabID, WebExtensionError>&& result) mutable {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DevToolsPanelsCreate(webPageProxyIdentifier, title, iconPath, pagePath), [this, protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Inspector::ExtensionTabID, WebExtensionError>&& result) mutable {
         if (!result) {
             callback->reportError(result.error());
             return;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
@@ -91,9 +91,9 @@ void WebExtensionAPIEvent::invokeListenersWithArgument(id argument1, id argument
         listener->call(argument1, argument2, argument3);
 }
 
-void WebExtensionAPIEvent::addListener(WebFrame& frame, RefPtr<WebExtensionCallbackHandler> listener)
+void WebExtensionAPIEvent::addListener(WebCore::FrameIdentifier frameIdentifier, RefPtr<WebExtensionCallbackHandler> listener)
 {
-    m_frameIdentifier = frame.frameID();
+    m_frameIdentifier = frameIdentifier;
     m_listeners.append(listener);
 
     if (!hasExtensionContext())
@@ -102,7 +102,7 @@ void WebExtensionAPIEvent::addListener(WebFrame& frame, RefPtr<WebExtensionCallb
     WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(*m_frameIdentifier, m_type, contentWorldType()), extensionContext().identifier());
 }
 
-void WebExtensionAPIEvent::removeListener(WebFrame& frame, RefPtr<WebExtensionCallbackHandler> listener)
+void WebExtensionAPIEvent::removeListener(WebCore::FrameIdentifier frameIdentifier, RefPtr<WebExtensionCallbackHandler> listener)
 {
     auto removedCount = m_listeners.removeAllMatching([&](auto& entry) {
         return entry->callbackFunction() == listener->callbackFunction();
@@ -111,7 +111,7 @@ void WebExtensionAPIEvent::removeListener(WebFrame& frame, RefPtr<WebExtensionCa
     if (!removedCount)
         return;
 
-    ASSERT(frame.frameID() == m_frameIdentifier);
+    ASSERT(frameIdentifier == m_frameIdentifier);
 
     if (!hasExtensionContext())
         return;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
@@ -44,7 +44,9 @@
 #import "WebExtensionMenuItemParameters.h"
 #import "WebExtensionTabParameters.h"
 #import "WebExtensionUtilities.h"
+#import "WebFrame.h"
 #import "WebProcess.h"
+#import <WebCore/LocalFrame.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 static NSString * const checkedKey = @"checked";

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -36,6 +36,10 @@
 #import "WKWebExtensionPermission.h"
 #import "WebExtensionControllerProxy.h"
 
+#if ENABLE(INSPECTOR_EXTENSIONS) || ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+#import "WebPage.h"
+#endif
+
 namespace WebKit {
 
 bool WebExtensionAPINamespace::isPropertyAllowed(const ASCIILiteral& name, WebPage* page)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
@@ -66,7 +66,7 @@ bool WebExtensionAPIStorageArea::isPropertyAllowed(const ASCIILiteral& propertyN
     return false;
 }
 
-void WebExtensionAPIStorageArea::get(WebPage& page, id items, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIStorageArea::get(WebPageProxyIdentifier webPageProxyIdentifier, id items, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/get
 
@@ -100,7 +100,7 @@ void WebExtensionAPIStorageArea::get(WebPage& page, id items, Ref<WebExtensionCa
     if (NSString *key = dynamic_objc_cast<NSString>(items))
         keysVector = { key };
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGet(page.webPageProxyIdentifier(), m_type, keysVector), [keysWithDefaultValues, protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGet(webPageProxyIdentifier, m_type, keysVector), [keysWithDefaultValues, protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -116,9 +116,9 @@ void WebExtensionAPIStorageArea::get(WebPage& page, id items, Ref<WebExtensionCa
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPIStorageArea::getKeys(WebPage& page, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIStorageArea::getKeys(WebPageProxyIdentifier webPageProxyIdentifier, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGetKeys(page.webPageProxyIdentifier(), m_type), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Vector<String>, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGetKeys(webPageProxyIdentifier, m_type), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Vector<String>, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -128,7 +128,7 @@ void WebExtensionAPIStorageArea::getKeys(WebPage& page, Ref<WebExtensionCallback
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPIStorageArea::getBytesInUse(WebPage& page, id keys, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIStorageArea::getBytesInUse(WebPageProxyIdentifier webPageProxyIdentifier, id keys, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/getBytesInUse
 
@@ -144,7 +144,7 @@ void WebExtensionAPIStorageArea::getBytesInUse(WebPage& page, id keys, Ref<WebEx
     else if (NSString *key = dynamic_objc_cast<NSString>(keys))
         keysVector = { key };
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGetBytesInUse(page.webPageProxyIdentifier(), m_type, keysVector), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<size_t, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGetBytesInUse(webPageProxyIdentifier, m_type, keysVector), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<size_t, WebExtensionError>&& result) {
         if (!result)
             callback->reportError(result.error());
         else
@@ -152,7 +152,7 @@ void WebExtensionAPIStorageArea::getBytesInUse(WebPage& page, id keys, Ref<WebEx
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPIStorageArea::set(WebPage& page, NSDictionary *items, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIStorageArea::set(WebPageProxyIdentifier webPageProxyIdentifier, NSDictionary *items, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set
 
@@ -191,7 +191,7 @@ void WebExtensionAPIStorageArea::set(WebPage& page, NSDictionary *items, Ref<Web
         return;
     }
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageSet(page.webPageProxyIdentifier(), m_type, encodeJSONString(serializedData)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageSet(webPageProxyIdentifier, m_type, encodeJSONString(serializedData)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result)
             callback->reportError(result.error());
         else
@@ -199,7 +199,7 @@ void WebExtensionAPIStorageArea::set(WebPage& page, NSDictionary *items, Ref<Web
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPIStorageArea::remove(WebPage& page, id keys, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIStorageArea::remove(WebPageProxyIdentifier webPageProxyIdentifier, id keys, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/remove
 
@@ -208,7 +208,7 @@ void WebExtensionAPIStorageArea::remove(WebPage& page, id keys, Ref<WebExtension
 
     Vector<String> keysVector = [keys isKindOfClass:NSArray.class] ? makeVector<String>((NSArray *)keys) : Vector<String> { keys };
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageRemove(page.webPageProxyIdentifier(), m_type, keysVector), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageRemove(webPageProxyIdentifier, m_type, keysVector), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result)
             callback->reportError(result.error());
         else
@@ -216,9 +216,9 @@ void WebExtensionAPIStorageArea::remove(WebPage& page, id keys, Ref<WebExtension
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPIStorageArea::clear(WebPage& page, Ref<WebExtensionCallbackHandler>&& callback)
+void WebExtensionAPIStorageArea::clear(WebPageProxyIdentifier webPageProxyIdentifier, Ref<WebExtensionCallbackHandler>&& callback)
 {
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageClear(page.webPageProxyIdentifier(), m_type), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageClear(webPageProxyIdentifier, m_type), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result)
             callback->reportError(result.error());
         else
@@ -226,7 +226,7 @@ void WebExtensionAPIStorageArea::clear(WebPage& page, Ref<WebExtensionCallbackHa
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPIStorageArea::setAccessLevel(WebPage& page, NSDictionary *accessOptions, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIStorageArea::setAccessLevel(WebPageProxyIdentifier webPageProxyIdentifier, NSDictionary *accessOptions, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     static auto *requiredKeys = @[
         accessLevelKey,
@@ -247,7 +247,7 @@ void WebExtensionAPIStorageArea::setAccessLevel(WebPage& page, NSDictionary *acc
 
     WebExtensionStorageAccessLevel accessLevel = [accessLevelString isEqualToString:accessLevelTrustedContexts] ? WebExtensionStorageAccessLevel::TrustedContexts : WebExtensionStorageAccessLevel::TrustedAndUntrustedContexts;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageSetAccessLevel(page.webPageProxyIdentifier(), m_type, accessLevel), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageSetAccessLevel(webPageProxyIdentifier, m_type, accessLevel), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result)
             callback->reportError(result.error());
         else

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -48,6 +48,8 @@
 #import "WebExtensionTabQueryParameters.h"
 #import "WebExtensionUtilities.h"
 #import "WebExtensionWindowIdentifier.h"
+#import "WebFrame.h"
+#import "WebPage.h"
 #import "WebProcess.h"
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/Base64.h>
@@ -588,7 +590,7 @@ bool WebExtensionAPITabs::isPropertyAllowed(const ASCIILiteral& name, WebPage*)
     return false;
 }
 
-void WebExtensionAPITabs::createTab(WebPage& page, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::createTab(WebPageProxyIdentifier webPageProxyIdentifier, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/create
 
@@ -596,7 +598,7 @@ void WebExtensionAPITabs::createTab(WebPage& page, NSDictionary *properties, Ref
     if (!parseTabCreateOptions(properties, parameters, @"properties", outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsCreate(page.webPageProxyIdentifier(), WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<std::optional<WebExtensionTabParameters>, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsCreate(webPageProxyIdentifier, WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<std::optional<WebExtensionTabParameters>, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -606,7 +608,7 @@ void WebExtensionAPITabs::createTab(WebPage& page, NSDictionary *properties, Ref
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPITabs::query(WebPage& page, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::query(WebPageProxyIdentifier webPageProxyIdentifier, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/query
 
@@ -614,7 +616,7 @@ void WebExtensionAPITabs::query(WebPage& page, NSDictionary *options, Ref<WebExt
     if (!parseTabQueryOptions(options, parameters, @"info", outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsQuery(page.webPageProxyIdentifier(), WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Vector<WebExtensionTabParameters>, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsQuery(webPageProxyIdentifier, WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Vector<WebExtensionTabParameters>, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -642,11 +644,11 @@ void WebExtensionAPITabs::get(double tabID, Ref<WebExtensionCallbackHandler>&& c
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPITabs::getCurrent(WebPage& page, Ref<WebExtensionCallbackHandler>&& callback)
+void WebExtensionAPITabs::getCurrent(WebPageProxyIdentifier webPageProxyIdentifier, Ref<WebExtensionCallbackHandler>&& callback)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getCurrent
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGetCurrent(page.webPageProxyIdentifier()), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<std::optional<WebExtensionTabParameters>, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGetCurrent(webPageProxyIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<std::optional<WebExtensionTabParameters>, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -656,7 +658,7 @@ void WebExtensionAPITabs::getCurrent(WebPage& page, Ref<WebExtensionCallbackHand
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPITabs::getSelected(WebPage& page, double windowID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::getSelected(WebPageProxyIdentifier webPageProxyIdentifier, double windowID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getSelected
 
@@ -668,7 +670,7 @@ void WebExtensionAPITabs::getSelected(WebPage& page, double windowID, Ref<WebExt
     parameters.windowIdentifier = windowIdentifer.value_or(WebExtensionWindowConstants::CurrentIdentifier);
     parameters.active = true;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsQuery(page.webPageProxyIdentifier(), WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Vector<WebExtensionTabParameters>, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsQuery(webPageProxyIdentifier, WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Vector<WebExtensionTabParameters>, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -708,7 +710,7 @@ void WebExtensionAPITabs::duplicate(double tabID, NSDictionary *properties, Ref<
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPITabs::update(WebPage& page, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::update(WebPageProxyIdentifier webPageProxyIdentifier, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/update
 
@@ -720,7 +722,7 @@ void WebExtensionAPITabs::update(WebPage& page, double tabID, NSDictionary *prop
     if (!parseTabUpdateOptions(properties, parameters, @"properties", outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsUpdate(page.webPageProxyIdentifier(), tabIdentifer, WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<std::optional<WebExtensionTabParameters>, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsUpdate(webPageProxyIdentifier, tabIdentifer, WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<std::optional<WebExtensionTabParameters>, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -771,7 +773,7 @@ void WebExtensionAPITabs::remove(NSObject *tabIDs, Ref<WebExtensionCallbackHandl
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPITabs::reload(WebPage& page, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::reload(WebPageProxyIdentifier webPageProxyIdentifier, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/reload
 
@@ -791,7 +793,7 @@ void WebExtensionAPITabs::reload(WebPage& page, double tabID, NSDictionary *prop
     NSNumber *bypassCacheNumber = objectForKey<NSNumber>(properties, bypassCacheKey);
     ReloadFromOrigin reloadFromOrigin = bypassCacheNumber.boolValue ? ReloadFromOrigin::Yes : ReloadFromOrigin::No;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsReload(page.webPageProxyIdentifier(), tabIdentifer, reloadFromOrigin), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsReload(webPageProxyIdentifier, tabIdentifer, reloadFromOrigin), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -801,7 +803,7 @@ void WebExtensionAPITabs::reload(WebPage& page, double tabID, NSDictionary *prop
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPITabs::goBack(WebPage& page, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::goBack(WebPageProxyIdentifier webPageProxyIdentifier, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/goBack
 
@@ -809,7 +811,7 @@ void WebExtensionAPITabs::goBack(WebPage& page, double tabID, Ref<WebExtensionCa
     if (tabIdentifer && !isValid(tabIdentifer, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGoBack(page.webPageProxyIdentifier(), tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGoBack(webPageProxyIdentifier, tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -819,7 +821,7 @@ void WebExtensionAPITabs::goBack(WebPage& page, double tabID, Ref<WebExtensionCa
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPITabs::goForward(WebPage& page, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::goForward(WebPageProxyIdentifier webPageProxyIdentifier, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/goForward
 
@@ -827,7 +829,7 @@ void WebExtensionAPITabs::goForward(WebPage& page, double tabID, Ref<WebExtensio
     if (tabIdentifer && !isValid(tabIdentifer, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGoForward(page.webPageProxyIdentifier(), tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGoForward(webPageProxyIdentifier, tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -837,7 +839,7 @@ void WebExtensionAPITabs::goForward(WebPage& page, double tabID, Ref<WebExtensio
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPITabs::getZoom(WebPage& page, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::getZoom(WebPageProxyIdentifier webPageProxyIdentifier, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getZoom
 
@@ -845,7 +847,7 @@ void WebExtensionAPITabs::getZoom(WebPage& page, double tabID, Ref<WebExtensionC
     if (tabIdentifer && !isValid(tabIdentifer, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGetZoom(page.webPageProxyIdentifier(), tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<double, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGetZoom(webPageProxyIdentifier, tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<double, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -855,7 +857,7 @@ void WebExtensionAPITabs::getZoom(WebPage& page, double tabID, Ref<WebExtensionC
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPITabs::setZoom(WebPage& page, double tabID, double zoomFactor, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::setZoom(WebPageProxyIdentifier webPageProxyIdentifier, double tabID, double zoomFactor, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/setZoom
 
@@ -863,7 +865,7 @@ void WebExtensionAPITabs::setZoom(WebPage& page, double tabID, double zoomFactor
     if (tabIdentifer && !isValid(tabIdentifer, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsSetZoom(page.webPageProxyIdentifier(), tabIdentifer, zoomFactor), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsSetZoom(webPageProxyIdentifier, tabIdentifer, zoomFactor), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -873,7 +875,7 @@ void WebExtensionAPITabs::setZoom(WebPage& page, double tabID, double zoomFactor
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPITabs::detectLanguage(WebPage& page, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::detectLanguage(WebPageProxyIdentifier webPageProxyIdentifier, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/detectLanguage
 
@@ -881,7 +883,7 @@ void WebExtensionAPITabs::detectLanguage(WebPage& page, double tabID, Ref<WebExt
     if (tabIdentifer && !isValid(tabIdentifer, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsDetectLanguage(page.webPageProxyIdentifier(), tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsDetectLanguage(webPageProxyIdentifier, tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -896,7 +898,7 @@ void WebExtensionAPITabs::detectLanguage(WebPage& page, double tabID, Ref<WebExt
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPITabs::toggleReaderMode(WebPage& page, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::toggleReaderMode(WebPageProxyIdentifier webPageProxyIdentifier, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/toggleReaderMode
 
@@ -904,7 +906,7 @@ void WebExtensionAPITabs::toggleReaderMode(WebPage& page, double tabID, Ref<WebE
     if (tabIdentifer && !isValid(tabIdentifer, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsToggleReaderMode(page.webPageProxyIdentifier(), tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsToggleReaderMode(webPageProxyIdentifier, tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -914,7 +916,7 @@ void WebExtensionAPITabs::toggleReaderMode(WebPage& page, double tabID, Ref<WebE
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPITabs::captureVisibleTab(WebPage& page, double windowID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::captureVisibleTab(WebPageProxyIdentifier webPageProxyIdentifier, double windowID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/captureVisibleTab
 
@@ -928,7 +930,7 @@ void WebExtensionAPITabs::captureVisibleTab(WebPage& page, double windowID, NSDi
     if (!parseCaptureVisibleTabOptions(options, imageFormat, imageQuality, @"options", outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsCaptureVisibleTab(page.webPageProxyIdentifier(), windowIdentifier, imageFormat, imageQuality), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<URL, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsCaptureVisibleTab(webPageProxyIdentifier, windowIdentifier, imageFormat, imageQuality), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<URL, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -1017,7 +1019,7 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPITabs::connect(WebFrame& frame, JSCont
         documentIdentifier.value(),
     };
 
-    auto port = WebExtensionAPIPort::create(*this, *frame.page(), WebExtensionContentWorldType::ContentScript, resolvedName);
+    Ref port = WebExtensionAPIPort::create(*this, frame.protectedPage()->webPageProxyIdentifier(), WebExtensionContentWorldType::ContentScript, resolvedName);
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsConnect(tabIdentifer.value(), port->channelIdentifier(), resolvedName, targetParameters, senderParameters), [=, this, protectedThis = Ref { *this }, globalContext = JSRetainPtr { JSContextGetGlobalContext(context) }](Expected<void, WebExtensionError>&& result) {
         if (result)
@@ -1030,7 +1032,7 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPITabs::connect(WebFrame& frame, JSCont
     return port;
 }
 
-void WebExtensionAPITabs::executeScript(WebPage& page, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler> && callback, NSString **outExceptionString)
+void WebExtensionAPITabs::executeScript(WebPageProxyIdentifier webPageProxyIdentifier, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler> && callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/executeScript
 
@@ -1042,7 +1044,7 @@ void WebExtensionAPITabs::executeScript(WebPage& page, double tabID, NSDictionar
     if (options && !parseScriptOptions(options, parameters, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsExecuteScript(page.webPageProxyIdentifier(), tabIdentifier, parameters), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Vector<WebExtensionScriptInjectionResultParameters>, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsExecuteScript(webPageProxyIdentifier, tabIdentifier, parameters), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Vector<WebExtensionScriptInjectionResultParameters>, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -1052,7 +1054,7 @@ void WebExtensionAPITabs::executeScript(WebPage& page, double tabID, NSDictionar
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPITabs::insertCSS(WebPage& page, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler> && callback, NSString **outExceptionString)
+void WebExtensionAPITabs::insertCSS(WebPageProxyIdentifier webPageProxyIdentifier, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler> && callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/insertCSS
 
@@ -1064,7 +1066,7 @@ void WebExtensionAPITabs::insertCSS(WebPage& page, double tabID, NSDictionary *o
     if (options && !parseScriptOptions(options, parameters, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsInsertCSS(page.webPageProxyIdentifier(), tabIdentifier, parameters), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsInsertCSS(webPageProxyIdentifier, tabIdentifier, parameters), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -1074,7 +1076,7 @@ void WebExtensionAPITabs::insertCSS(WebPage& page, double tabID, NSDictionary *o
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPITabs::removeCSS(WebPage& page, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler> && callback, NSString **outExceptionString)
+void WebExtensionAPITabs::removeCSS(WebPageProxyIdentifier webPageProxyIdentifier, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler> && callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/removeCSS
 
@@ -1086,7 +1088,7 @@ void WebExtensionAPITabs::removeCSS(WebPage& page, double tabID, NSDictionary *o
     if (options && !parseScriptOptions(options, parameters, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsRemoveCSS(page.webPageProxyIdentifier(), tabIdentifier, parameters), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsRemoveCSS(webPageProxyIdentifier, tabIdentifier, parameters), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
@@ -36,6 +36,7 @@
 #import "WebExtensionControllerMessages.h"
 #import "WebExtensionControllerProxy.h"
 #import "WebExtensionEventListenerType.h"
+#import "WebPage.h"
 #import "WebProcess.h"
 #import <JavaScriptCore/APICast.h>
 #import <JavaScriptCore/ScriptCallStack.h>

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebPageNamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebPageNamespaceCocoa.mm
@@ -37,6 +37,7 @@
 #import "WebExtensionAPITest.h"
 #import "WebExtensionContextProxy.h"
 #import "WebExtensionControllerProxy.h"
+#import "WebPage.h"
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -408,7 +408,7 @@ void WebExtensionAPIWindows::createWindow(NSDictionary *data, Ref<WebExtensionCa
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPIWindows::get(WebPage& page, double windowID, NSDictionary *info, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIWindows::get(WebPageProxyIdentifier webPageProxyIdentifier, double windowID, NSDictionary *info, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/get
 
@@ -421,7 +421,7 @@ void WebExtensionAPIWindows::get(WebPage& page, double windowID, NSDictionary *i
     if (!parseWindowGetOptions(info, populate, filter, @"info", outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGet(page.webPageProxyIdentifier(), windowIdentifer.value(), filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<WebExtensionWindowParameters, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGet(webPageProxyIdentifier, windowIdentifer.value(), filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<WebExtensionWindowParameters, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -431,7 +431,7 @@ void WebExtensionAPIWindows::get(WebPage& page, double windowID, NSDictionary *i
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPIWindows::getCurrent(WebPage& page, NSDictionary *info, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIWindows::getCurrent(WebPageProxyIdentifier webPageProxyIdentifier, NSDictionary *info, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getCurrent
 
@@ -440,7 +440,7 @@ void WebExtensionAPIWindows::getCurrent(WebPage& page, NSDictionary *info, Ref<W
     if (!parseWindowGetOptions(info, populate, filter, @"info", outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGet(page.webPageProxyIdentifier(), WebExtensionWindowConstants::CurrentIdentifier, filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<WebExtensionWindowParameters, WebExtensionError>&& result) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGet(webPageProxyIdentifier, WebExtensionWindowConstants::CurrentIdentifier, filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<WebExtensionWindowParameters, WebExtensionError>&& result) {
         if (!result) {
             callback->reportError(result.error());
             return;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h
@@ -30,6 +30,7 @@
 #include "JSWebExtensionAPIAction.h"
 #include "WebExtensionAPIEvent.h"
 #include "WebExtensionAPIObject.h"
+#include "WebPageProxyIdentifier.h"
 
 OBJC_CLASS NSDictionary;
 OBJC_CLASS NSString;
@@ -58,7 +59,7 @@ public:
 
     void getPopup(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void setPopup(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void openPopup(WebPage&, NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void openPopup(WebPageProxyIdentifier, NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     WebExtensionAPIEvent& onClicked();
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsInspectedWindow.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsInspectedWindow.h
@@ -30,6 +30,7 @@
 #include "JSWebExtensionAPIDevToolsInspectedWindow.h"
 #include "WebExtensionAPIEvent.h"
 #include "WebExtensionAPIObject.h"
+#include "WebPageProxyIdentifier.h"
 
 namespace WebKit {
 
@@ -40,8 +41,8 @@ class WebExtensionAPIDevToolsInspectedWindow : public WebExtensionAPIObject, pub
 
 public:
 #if PLATFORM(COCOA)
-    void eval(WebPage&, NSString *expression, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void reload(WebPage&, NSDictionary *options, NSString **outExceptionString);
+    void eval(WebPageProxyIdentifier, NSString *expression, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void reload(WebPageProxyIdentifier, NSDictionary *options, NSString **outExceptionString);
 
     double tabId(WebPage&);
 #endif

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsPanels.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsPanels.h
@@ -31,6 +31,7 @@
 #include "WebExtensionAPIDevToolsExtensionPanel.h"
 #include "WebExtensionAPIEvent.h"
 #include "WebExtensionAPIObject.h"
+#include "WebPageProxyIdentifier.h"
 
 namespace WebKit {
 
@@ -43,7 +44,7 @@ public:
 #if PLATFORM(COCOA)
     RefPtr<WebExtensionAPIDevToolsExtensionPanel> extensionPanel(Inspector::ExtensionTabID) const;
 
-    void createPanel(WebPage&, NSString *title, NSString *iconPath, NSString *pagePath, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void createPanel(WebPageProxyIdentifier, NSString *title, NSString *iconPath, NSString *pagePath, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     NSString *themeName();
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
@@ -49,8 +49,8 @@ public:
 
     const ListenerVector& listeners() const { return m_listeners; }
 
-    void addListener(WebFrame&, RefPtr<WebExtensionCallbackHandler>);
-    void removeListener(WebFrame&, RefPtr<WebExtensionCallbackHandler>);
+    void addListener(WebCore::FrameIdentifier, RefPtr<WebExtensionCallbackHandler>);
+    void removeListener(WebCore::FrameIdentifier, RefPtr<WebExtensionCallbackHandler>);
     bool hasListener(RefPtr<WebExtensionCallbackHandler>);
 
     void removeAllListeners();

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
@@ -32,6 +32,7 @@
 #include "WebExtensionAPIObject.h"
 #include "WebExtensionMessageSenderParameters.h"
 #include "WebExtensionPortChannelIdentifier.h"
+#include "WebPageProxyIdentifier.h"
 #include <wtf/WeakPtr.h>
 
 OBJC_CLASS NSDictionary;
@@ -89,30 +90,30 @@ private:
         ASSERT(isQuarantined());
     }
 
-    explicit WebExtensionAPIPort(const WebExtensionAPIObject& parentObject, WebPage& page, WebExtensionContentWorldType targetContentWorldType, const String& name)
+    explicit WebExtensionAPIPort(const WebExtensionAPIObject& parentObject, WebPageProxyIdentifier owningPageProxyIdentifier, WebExtensionContentWorldType targetContentWorldType, const String& name)
         : WebExtensionAPIObject(parentObject)
         , m_targetContentWorldType(targetContentWorldType)
-        , m_owningPageProxyIdentifier(page.webPageProxyIdentifier())
+        , m_owningPageProxyIdentifier(owningPageProxyIdentifier)
         , m_channelIdentifier(WebExtensionPortChannelIdentifier::generate())
         , m_name(name)
     {
         add();
     }
 
-    explicit WebExtensionAPIPort(WebExtensionContentWorldType contentWorldType, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebPage& page, WebExtensionContentWorldType targetContentWorldType, const String& name)
+    explicit WebExtensionAPIPort(WebExtensionContentWorldType contentWorldType, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebPageProxyIdentifier owningPageProxyIdentifier, WebExtensionContentWorldType targetContentWorldType, const String& name)
         : WebExtensionAPIObject(contentWorldType, runtime, context)
         , m_targetContentWorldType(targetContentWorldType)
-        , m_owningPageProxyIdentifier(page.webPageProxyIdentifier())
+        , m_owningPageProxyIdentifier(owningPageProxyIdentifier)
         , m_channelIdentifier(WebExtensionPortChannelIdentifier::generate())
         , m_name(name)
     {
         add();
     }
 
-    explicit WebExtensionAPIPort(const WebExtensionAPIObject& parentObject, WebPage& page, WebExtensionContentWorldType targetContentWorldType, const String& name, const WebExtensionMessageSenderParameters& senderParameters)
+    explicit WebExtensionAPIPort(const WebExtensionAPIObject& parentObject, WebPageProxyIdentifier owningPageProxyIdentifier, WebExtensionContentWorldType targetContentWorldType, const String& name, const WebExtensionMessageSenderParameters& senderParameters)
         : WebExtensionAPIObject(parentObject)
         , m_targetContentWorldType(targetContentWorldType)
-        , m_owningPageProxyIdentifier(page.webPageProxyIdentifier())
+        , m_owningPageProxyIdentifier(owningPageProxyIdentifier)
         , m_channelIdentifier(WebExtensionPortChannelIdentifier::generate())
         , m_name(name)
         , m_senderParameters(senderParameters)
@@ -120,10 +121,10 @@ private:
         add();
     }
 
-    explicit WebExtensionAPIPort(const WebExtensionAPIObject& parentObject, WebPage& page, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier, const String& name, const WebExtensionMessageSenderParameters& senderParameters)
+    explicit WebExtensionAPIPort(const WebExtensionAPIObject& parentObject, WebPageProxyIdentifier owningPageProxyIdentifier, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier, const String& name, const WebExtensionMessageSenderParameters& senderParameters)
         : WebExtensionAPIObject(parentObject)
         , m_targetContentWorldType(targetContentWorldType)
-        , m_owningPageProxyIdentifier(page.webPageProxyIdentifier())
+        , m_owningPageProxyIdentifier(owningPageProxyIdentifier)
         , m_channelIdentifier(channelIdentifier)
         , m_name(name)
         , m_senderParameters(senderParameters)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
@@ -31,6 +31,7 @@
 #include "JSWebExtensionAPIWebPageRuntime.h"
 #include "WebExtensionAPIEvent.h"
 #include "WebExtensionAPIObject.h"
+#include "WebPageProxyIdentifier.h"
 
 OBJC_CLASS NSDictionary;
 OBJC_CLASS NSString;
@@ -80,11 +81,11 @@ public:
 
     JSValue *lastError();
 
-    void sendMessage(WebFrame&, NSString *extensionID, NSString *messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    RefPtr<WebExtensionAPIPort> connect(WebFrame&, JSContextRef, NSString *extensionID, NSDictionary *options, NSString **outExceptionString);
+    void sendMessage(WebPageProxyIdentifier, WebFrame&, NSString *extensionID, NSString *messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    RefPtr<WebExtensionAPIPort> connect(WebPageProxyIdentifier, WebFrame&, JSContextRef, NSString *extensionID, NSDictionary *options, NSString **outExceptionString);
 
     void sendNativeMessage(WebFrame&, NSString *applicationID, NSString *messageJSON, Ref<WebExtensionCallbackHandler>&&);
-    RefPtr<WebExtensionAPIPort> connectNative(WebFrame&, JSContextRef, NSString *applicationID);
+    RefPtr<WebExtensionAPIPort> connectNative(WebPageProxyIdentifier, JSContextRef, NSString *applicationID);
 
     WebExtensionAPIEvent& onConnect();
     WebExtensionAPIEvent& onInstalled();
@@ -114,8 +115,8 @@ public:
     WebExtensionAPIWebPageRuntime& runtime() const final { return const_cast<WebExtensionAPIWebPageRuntime&>(*this); }
 
 #if PLATFORM(COCOA)
-    void sendMessage(WebFrame&, NSString *extensionID, NSString *messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    RefPtr<WebExtensionAPIPort> connect(WebFrame&, JSContextRef, NSString *extensionID, NSDictionary *options, NSString **outExceptionString);
+    void sendMessage(WebPage&, WebFrame&, NSString *extensionID, NSString *messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    RefPtr<WebExtensionAPIPort> connect(WebPage&, WebFrame&, JSContextRef, NSString *extensionID, NSDictionary *options, NSString **outExceptionString);
 #endif
 };
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
@@ -32,6 +32,7 @@
 #include "WebExtensionAPIEvent.h"
 #include "WebExtensionAPIObject.h"
 #include "WebExtensionDataType.h"
+#include "WebPageProxyIdentifier.h"
 
 namespace WebKit {
 
@@ -42,17 +43,17 @@ public:
 #if PLATFORM(COCOA)
     bool isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*);
 
-    void get(WebPage&, id items, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void getKeys(WebPage&, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void getBytesInUse(WebPage&, id keys, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void set(WebPage&, NSDictionary *items, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void remove(WebPage&, id keys, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void clear(WebPage&, Ref<WebExtensionCallbackHandler>&&);
+    void get(WebPageProxyIdentifier, id items, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void getKeys(WebPageProxyIdentifier, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void getBytesInUse(WebPageProxyIdentifier, id keys, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void set(WebPageProxyIdentifier, NSDictionary *items, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void remove(WebPageProxyIdentifier, id keys, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void clear(WebPageProxyIdentifier, Ref<WebExtensionCallbackHandler>&&);
 
     double quotaBytes();
 
     // Exposed only by storage.session.
-    void setAccessLevel(WebPage&, NSDictionary *, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void setAccessLevel(WebPageProxyIdentifier, NSDictionary *, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     // Exposed only by storage.sync.
     double quotaBytesPerItem();

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
@@ -32,6 +32,7 @@
 #include "WebExtensionAPIObject.h"
 #include "WebExtensionFrameIdentifier.h"
 #include "WebExtensionTab.h"
+#include "WebPageProxyIdentifier.h"
 
 OBJC_CLASS NSDictionary;
 OBJC_CLASS NSString;
@@ -51,35 +52,35 @@ public:
 #if PLATFORM(COCOA)
     bool isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*);
 
-    void createTab(WebPage&, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void createTab(WebPageProxyIdentifier, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void query(WebPage&, NSDictionary *info, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void query(WebPageProxyIdentifier, NSDictionary *info, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     void get(double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void getCurrent(WebPage&, Ref<WebExtensionCallbackHandler>&&);
-    void getSelected(WebPage&, double windowID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void getCurrent(WebPageProxyIdentifier, Ref<WebExtensionCallbackHandler>&&);
+    void getSelected(WebPageProxyIdentifier, double windowID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     void duplicate(double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void update(WebPage&, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void update(WebPageProxyIdentifier, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void remove(NSObject *tabIDs, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void reload(WebPage&, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void goBack(WebPage&, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void goForward(WebPage&, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void reload(WebPageProxyIdentifier, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void goBack(WebPageProxyIdentifier, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void goForward(WebPageProxyIdentifier, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void getZoom(WebPage&, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void setZoom(WebPage&, double tabID, double zoomFactor, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void getZoom(WebPageProxyIdentifier, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void setZoom(WebPageProxyIdentifier, double tabID, double zoomFactor, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void detectLanguage(WebPage&, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void toggleReaderMode(WebPage&, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void captureVisibleTab(WebPage&, double windowID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void detectLanguage(WebPageProxyIdentifier, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void toggleReaderMode(WebPageProxyIdentifier, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void captureVisibleTab(WebPageProxyIdentifier, double windowID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     void sendMessage(WebFrame&, double tabID, NSString *message, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     RefPtr<WebExtensionAPIPort> connect(WebFrame&, JSContextRef, double tabID, NSDictionary *options, NSString **outExceptionString);
 
-    void executeScript(WebPage&, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void insertCSS(WebPage&, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void removeCSS(WebPage&, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void executeScript(WebPageProxyIdentifier, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void insertCSS(WebPageProxyIdentifier, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void removeCSS(WebPageProxyIdentifier, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     double tabIdentifierNone() const { return -1; }
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
@@ -51,8 +51,8 @@ public:
 
     const ListenerVector& listeners() const { return m_listeners; }
 
-    void addListener(WebFrame&, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, NSString **outExceptionString);
-    void removeListener(WebFrame&, RefPtr<WebExtensionCallbackHandler>);
+    void addListener(WebCore::FrameIdentifier, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, NSString **outExceptionString);
+    void removeListener(WebCore::FrameIdentifier, RefPtr<WebExtensionCallbackHandler>);
     bool hasListener(RefPtr<WebExtensionCallbackHandler>);
 
     void removeAllListeners();

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
@@ -49,8 +49,8 @@ public:
 
     const ListenerVector& listeners() const { return m_listeners; }
 
-    void addListener(WebFrame&, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, id extraInfoSpec, NSString **outExceptionString);
-    void removeListener(WebFrame&, RefPtr<WebExtensionCallbackHandler>);
+    void addListener(WebCore::FrameIdentifier, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, id extraInfoSpec, NSString **outExceptionString);
+    void removeListener(WebCore::FrameIdentifier, RefPtr<WebExtensionCallbackHandler>);
     bool hasListener(RefPtr<WebExtensionCallbackHandler>);
 
     void invokeListenersWithArgument(NSDictionary *argument, WebExtensionTabIdentifier, WebExtensionWindowIdentifier, const ResourceLoadInfo&);

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindows.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindows.h
@@ -32,6 +32,7 @@
 #include "WebExtensionAPIWindowsEvent.h"
 #include "WebExtensionWindow.h"
 #include "WebExtensionWindowIdentifier.h"
+#include "WebPageProxyIdentifier.h"
 
 OBJC_CLASS NSDictionary;
 OBJC_CLASS NSString;
@@ -52,8 +53,8 @@ public:
 
     void createWindow(NSDictionary *data, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void get(WebPage&, double windowID, NSDictionary *info, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void getCurrent(WebPage&, NSDictionary *info, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void get(WebPageProxyIdentifier, double windowID, NSDictionary *info, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void getCurrent(WebPageProxyIdentifier, NSDictionary *info, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void getLastFocused(NSDictionary *info, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void getAll(NSDictionary *info, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h
@@ -49,8 +49,8 @@ public:
 
     const ListenerVector& listeners() const { return m_listeners; }
 
-    void addListener(WebFrame&, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, NSString **outExceptionString);
-    void removeListener(WebFrame&, RefPtr<WebExtensionCallbackHandler>);
+    void addListener(WebCore::FrameIdentifier, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, NSString **outExceptionString);
+    void removeListener(WebCore::FrameIdentifier, RefPtr<WebExtensionCallbackHandler>);
     bool hasListener(RefPtr<WebExtensionCallbackHandler>);
 
     void removeAllListeners();

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
@@ -29,6 +29,8 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "JSWebExtensionWrappable.h"
+#include "WebFrame.h"
+#include "WebPage.h"
 #include <JavaScriptCore/JSObjectRef.h>
 #include <JavaScriptCore/JSWeakObjectMapRefPrivate.h>
 
@@ -126,6 +128,19 @@ void JSWebExtensionWrapper::finalize(JSObjectRef object)
         JSObjectSetPrivate(object, nullptr);
         wrappable->deref();
     }
+}
+
+RefPtr<WebFrame> toWebFrame(JSContextRef context)
+{
+    ASSERT(context);
+    return WebFrame::frameForContext(JSContextGetGlobalContext(context));
+}
+
+RefPtr<WebPage> toWebPage(JSContextRef context)
+{
+    ASSERT(context);
+    auto frame = toWebFrame(context);
+    return frame ? frame->page() : nullptr;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json
@@ -79,10 +79,22 @@
         "NeedsFrameWithCallbackHandler": {
             "contextsAllowed": ["interface"]
         },
+        "NeedsFrameIdentifier": {
+            "contextsAllowed": ["attribute", "operation"]
+        },
+        "NeedsFrameIdentifierWithCallbackHandler": {
+            "contextsAllowed": ["interface"]
+        },
         "NeedsPage": {
             "contextsAllowed": ["attribute", "operation"]
         },
         "NeedsPageWithCallbackHandler": {
+            "contextsAllowed": ["interface"]
+        },
+        "NeedsPageIdentifier": {
+            "contextsAllowed": ["attribute", "operation"]
+        },
+        "NeedsPageIdentifierWithCallbackHandler": {
             "contextsAllowed": ["interface"]
         },
         "NeedsScriptContext": {

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
@@ -38,6 +38,7 @@
 #import "WebExtensionContextMessages.h"
 #import "WebExtensionContextProxyMessages.h"
 #import "WebExtensionControllerProxy.h"
+#import "WebPage.h"
 #import "WebProcess.h"
 #import "_WKWebExtensionLocalization.h"
 #import <wtf/HashMap.h>

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAction.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAction.idl
@@ -46,7 +46,7 @@
 
     [RaisesException] void setPopup([NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
     [RaisesException] void getPopup([Optional, NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
-    [RaisesException, NeedsPage] void openPopup([Optional, NSDictionary=NullAllowed] any options, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPageIdentifier] void openPopup([Optional, NSDictionary=NullAllowed] any options, [Optional, CallbackHandler] function callback);
 
     readonly attribute WebExtensionAPIEvent onClicked;
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDevToolsInspectedWindow.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDevToolsInspectedWindow.idl
@@ -28,8 +28,8 @@
     ReturnsPromiseWhenCallbackIsOmitted,
 ] interface WebExtensionAPIDevToolsInspectedWindow {
 
-    [RaisesException, NeedsPage] void eval([CannotBeEmpty] DOMString expression, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
-    [RaisesException, NeedsPage] void reload([Optional, NSDictionary] any options);
+    [RaisesException, NeedsPageIdentifier] void eval([CannotBeEmpty] DOMString expression, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPageIdentifier] void reload([Optional, NSDictionary] any options);
 
     [NeedsPage] readonly attribute double tabId;
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDevToolsPanels.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDevToolsPanels.idl
@@ -28,7 +28,7 @@
     ReturnsPromiseWhenCallbackIsOmitted,
 ] interface WebExtensionAPIDevToolsPanels {
 
-    [RaisesException, ImplementedAs=createPanel, NeedsPage] void create([CannotBeEmpty] DOMString title, [CannotBeEmpty] DOMString iconPath, [CannotBeEmpty] DOMString pagePath, [Optional, CallbackHandler] function callback);
+    [RaisesException, ImplementedAs=createPanel, NeedsPageIdentifier] void create([CannotBeEmpty] DOMString title, [CannotBeEmpty] DOMString iconPath, [CannotBeEmpty] DOMString pagePath, [Optional, CallbackHandler] function callback);
 
     readonly attribute DOMString themeName;
     readonly attribute WebExtensionAPIEvent onThemeChanged;

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIEvent.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIEvent.idl
@@ -27,8 +27,8 @@
     Conditional=WK_WEB_EXTENSIONS,
 ] interface WebExtensionAPIEvent {
 
-    [NeedsFrame] void addListener([CallbackHandler] function listener);
-    [NeedsFrame] void removeListener([CallbackHandler] function listener);
+    [NeedsFrameIdentifier] void addListener([CallbackHandler] function listener);
+    [NeedsFrameIdentifier] void removeListener([CallbackHandler] function listener);
     boolean hasListener([CallbackHandler] function listener);
 
 };

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl
@@ -44,11 +44,11 @@
 
     [MainWorldOnly] readonly attribute any lastError;
 
-    [ProcessArgumentsLeftToRight, RaisesException, NeedsFrame] void sendMessage([Optional] DOMString extensionID, [Serialization=JSON] any message, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
-    [RaisesException, NeedsFrame, NeedsScriptContext] WebExtensionAPIPort connect([Optional] DOMString extensionID, [Optional, NSDictionary] any options);
+    [ProcessArgumentsLeftToRight, RaisesException, NeedsPageIdentifier, NeedsFrame] void sendMessage([Optional] DOMString extensionID, [Serialization=JSON] any message, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPageIdentifier, NeedsFrame, NeedsScriptContext] WebExtensionAPIPort connect([Optional] DOMString extensionID, [Optional, NSDictionary] any options);
 
     [MainWorldOnly, Dynamic, NeedsFrame] void sendNativeMessage([Optional] DOMString applicationID, [Serialization=JSON] any message, [Optional, CallbackHandler] function callback);
-    [MainWorldOnly, Dynamic, NeedsFrame, NeedsScriptContext] WebExtensionAPIPort connectNative([Optional] DOMString applicationID);
+    [MainWorldOnly, Dynamic, NeedsPageIdentifier, NeedsScriptContext] WebExtensionAPIPort connectNative([Optional] DOMString applicationID);
 
     readonly attribute WebExtensionAPIEvent onConnect;
     readonly attribute WebExtensionAPIEvent onMessage;

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea.idl
@@ -26,7 +26,7 @@
 [
     Conditional=WK_WEB_EXTENSIONS,
     ReturnsPromiseWhenCallbackIsOmitted,
-    NeedsPageWithCallbackHandler,
+    NeedsPageIdentifierWithCallbackHandler,
 ] interface WebExtensionAPIStorageArea {
 
     [RaisesException] void get([Optional, NSObject=StopAtTopLevel, DOMString] any items, [Optional, CallbackHandler] function callback);
@@ -34,7 +34,7 @@
     [RaisesException] void getBytesInUse([Optional, NSObject, DOMString] any keys, [Optional, CallbackHandler] function callback);
     [RaisesException] void set([NSDictionary=StopAtTopLevel] any items, [Optional, CallbackHandler] function callback);
     [RaisesException] void remove([NSObject] any keys, [Optional, CallbackHandler] function callback);
-    [NeedsPage] void clear([Optional, CallbackHandler] function callback);
+    void clear([Optional, CallbackHandler] function callback);
 
     [RaisesException, Dynamic, MainWorldOnly] void setAccessLevel([NSDictionary] any accessOptions, [Optional, CallbackHandler] function callback);
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
@@ -29,34 +29,34 @@
     ReturnsPromiseWhenCallbackIsOmitted,
 ] interface WebExtensionAPITabs {
 
-    [RaisesException, NeedsPage, ImplementedAs=createTab] void create([NSDictionary] any properties, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPageIdentifier, ImplementedAs=createTab] void create([NSDictionary] any properties, [Optional, CallbackHandler] function callback);
 
-    [RaisesException, NeedsPage] void query([NSDictionary] any info, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPageIdentifier] void query([NSDictionary] any info, [Optional, CallbackHandler] function callback);
 
     [RaisesException] void get(double tabID, [Optional, CallbackHandler] function callback);
-    [NeedsPage] void getCurrent([Optional, CallbackHandler] function callback);
-    [RaisesException, Dynamic, NeedsPage] void getSelected([Optional] double windowID, [Optional, CallbackHandler] function callback);
+    [NeedsPageIdentifier] void getCurrent([Optional, CallbackHandler] function callback);
+    [RaisesException, Dynamic, NeedsPageIdentifier] void getSelected([Optional] double windowID, [Optional, CallbackHandler] function callback);
 
     [RaisesException] void duplicate(double tabID, [Optional, NSDictionary] any properties, [Optional, CallbackHandler] function callback);
-    [RaisesException, NeedsPage] void update([Optional] double tabID, [NSDictionary] any properties, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPageIdentifier] void update([Optional] double tabID, [NSDictionary] any properties, [Optional, CallbackHandler] function callback);
     [RaisesException] void remove([NSObject] any tabIDs, [Optional, CallbackHandler] function callback);
 
-    [RaisesException, NeedsPage] void reload([Optional] double tabID, [Optional, NSDictionary] any properties, [Optional, CallbackHandler] function callback);
-    [RaisesException, NeedsPage] void goBack([Optional] double tabID, [Optional, CallbackHandler] function callback);
-    [RaisesException, NeedsPage] void goForward([Optional] double tabID, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPageIdentifier] void reload([Optional] double tabID, [Optional, NSDictionary] any properties, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPageIdentifier] void goBack([Optional] double tabID, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPageIdentifier] void goForward([Optional] double tabID, [Optional, CallbackHandler] function callback);
 
-    [RaisesException, NeedsPage] void getZoom([Optional] double tabID, [Optional, CallbackHandler] function callback);
-    [RaisesException, NeedsPage] void setZoom([Optional] double tabID, double zoomFactor, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPageIdentifier] void getZoom([Optional] double tabID, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPageIdentifier] void setZoom([Optional] double tabID, double zoomFactor, [Optional, CallbackHandler] function callback);
 
-    [RaisesException, NeedsPage] void detectLanguage([Optional] double tabID, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPageIdentifier] void detectLanguage([Optional] double tabID, [Optional, CallbackHandler] function callback);
 
-    [RaisesException, NeedsPage] void toggleReaderMode([Optional] double tabID, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPageIdentifier] void toggleReaderMode([Optional] double tabID, [Optional, CallbackHandler] function callback);
 
-    [RaisesException, NeedsPage] void captureVisibleTab([Optional] double windowID, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPageIdentifier] void captureVisibleTab([Optional] double windowID, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
 
-    [RaisesException, Dynamic, NeedsPage] void executeScript([Optional] double tabID, [NSDictionary] any details, [Optional, CallbackHandler] function callback);
-    [RaisesException, Dynamic, NeedsPage] void insertCSS([Optional] double tabID, [NSDictionary] any details, [Optional, CallbackHandler] function callback);
-    [RaisesException, Dynamic, NeedsPage] void removeCSS([Optional] double tabID, [NSDictionary] any details, [Optional, CallbackHandler] function callback);
+    [RaisesException, Dynamic, NeedsPageIdentifier] void executeScript([Optional] double tabID, [NSDictionary] any details, [Optional, CallbackHandler] function callback);
+    [RaisesException, Dynamic, NeedsPageIdentifier] void insertCSS([Optional] double tabID, [NSDictionary] any details, [Optional, CallbackHandler] function callback);
+    [RaisesException, Dynamic, NeedsPageIdentifier] void removeCSS([Optional] double tabID, [NSDictionary] any details, [Optional, CallbackHandler] function callback);
 
     [ProcessArgumentsLeftToRight, RaisesException, NeedsFrame] void sendMessage(double tabID, [Serialization=JSON] any message, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
     [RaisesException, NeedsFrame, NeedsScriptContext] WebExtensionAPIPort connect(double tabID, [Optional, NSDictionary] any options);

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigationEvent.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigationEvent.idl
@@ -28,8 +28,8 @@
     MainWorldOnly,
 ] interface WebExtensionAPIWebNavigationEvent {
 
-    [NeedsFrame, RaisesException] void addListener([CallbackHandler] function listener, [NSDictionary, Optional] any filter);
-    [NeedsFrame] void removeListener([CallbackHandler] function listener);
+    [NeedsFrameIdentifier, RaisesException] void addListener([CallbackHandler] function listener, [NSDictionary, Optional] any filter);
+    [NeedsFrameIdentifier] void removeListener([CallbackHandler] function listener);
     boolean hasListener([CallbackHandler] function listener);
 
 };

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebPageRuntime.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebPageRuntime.idl
@@ -28,7 +28,7 @@
     ReturnsPromiseWhenCallbackIsOmitted
 ] interface WebExtensionAPIWebPageRuntime {
 
-    [RaisesException, NeedsFrame, ProcessArgumentsLeftToRight] void sendMessage(DOMString extensionId, [Serialization=JSON] any message, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
-    [RaisesException, NeedsFrame, NeedsScriptContext] WebExtensionAPIPort connect(DOMString extensionId, [Optional, NSDictionary] any options);
+    [RaisesException, NeedsPage, NeedsFrame, ProcessArgumentsLeftToRight] void sendMessage(DOMString extensionId, [Serialization=JSON] any message, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPage, NeedsFrame, NeedsScriptContext] WebExtensionAPIPort connect(DOMString extensionId, [Optional, NSDictionary] any options);
 
 };

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequestEvent.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequestEvent.idl
@@ -28,8 +28,8 @@
     MainWorldOnly,
 ] interface WebExtensionAPIWebRequestEvent {
 
-    [NeedsFrame, RaisesException] void addListener([CallbackHandler] function listener, [NSDictionary, Optional] any filter, [NSArray=NSString, Optional] array extraInfoSpec);
-    [NeedsFrame] void removeListener([CallbackHandler] function listener);
+    [NeedsFrameIdentifier, RaisesException] void addListener([CallbackHandler] function listener, [NSDictionary, Optional] any filter, [NSArray=NSString, Optional] array extraInfoSpec);
+    [NeedsFrameIdentifier] void removeListener([CallbackHandler] function listener);
     boolean hasListener([CallbackHandler] function listener);
 
 };

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWindows.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWindows.idl
@@ -31,8 +31,8 @@
 
     [RaisesException, Dynamic, ImplementedAs=createWindow] void create([Optional, NSDictionary] any info, [Optional, CallbackHandler] function callback);
 
-    [RaisesException, NeedsPage] void get(double windowID, [Optional, NSDictionary] any properties, [Optional, CallbackHandler] function callback);
-    [RaisesException, NeedsPage] void getCurrent([Optional, NSDictionary] any info, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPageIdentifier] void get(double windowID, [Optional, NSDictionary] any properties, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPageIdentifier] void getCurrent([Optional, NSDictionary] any info, [Optional, CallbackHandler] function callback);
     [RaisesException] void getLastFocused([Optional, NSDictionary] any info, [Optional, CallbackHandler] function callback);
     [RaisesException] void getAll([Optional, NSDictionary] any info, [Optional, CallbackHandler] function callback);
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWindowsEvent.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWindowsEvent.idl
@@ -28,8 +28,8 @@
     MainWorldOnly,
 ] interface WebExtensionAPIWindowsEvent {
 
-    [NeedsFrame, RaisesException] void addListener([CallbackHandler] function listener, [Optional, NSDictionary] any filter);
-    [NeedsFrame] void removeListener([CallbackHandler] function listener);
+    [NeedsFrameIdentifier, RaisesException] void addListener([CallbackHandler] function listener, [Optional, NSDictionary] any filter);
+    [NeedsFrameIdentifier] void removeListener([CallbackHandler] function listener);
     boolean hasListener([CallbackHandler] function listener);
 
 };


### PR DESCRIPTION
#### 596fac2b7c3264b575d234416a752f4386b8be56
<pre>
Reduce WebPage.h and WebFrame.h includes in Web Extension code.
<a href="https://webkit.org/b/283776">https://webkit.org/b/283776</a>
<a href="https://rdar.apple.com/problem/140641563">rdar://problem/140641563</a>

Reviewed by Simon Fraser.

Remove WebPage.h and WebFrame.h from JSWebExtensionWrapper.h and remove complex inline
functions from that file.

Added new NedsPageIdentifier and NeedsFrameIdentifier attributes to the code generator
since most APIs just need the identifiers and not the full object.

* Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm:
(WebKit::WebExtensionAPIAction::openPopup):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsExtensionPanelCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm:
(WebKit::WebExtensionAPIDevToolsInspectedWindow::eval):
(WebKit::WebExtensionAPIDevToolsInspectedWindow::reload):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm:
(WebKit::WebExtensionAPIDevToolsPanels::createPanel):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm:
(WebKit::WebExtensionAPIEvent::addListener):
(WebKit::WebExtensionAPIEvent::removeListener):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::sendMessage):
(WebKit::WebExtensionAPIRuntime::connect):
(WebKit::WebExtensionAPIRuntime::connectNative):
(WebKit::WebExtensionAPIWebPageRuntime::sendMessage):
(WebKit::WebExtensionAPIWebPageRuntime::connect):
(WebKit::WebExtensionContextProxy::internalDispatchRuntimeMessageEvent):
(WebKit::WebExtensionContextProxy::internalDispatchRuntimeConnectEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
(WebKit::WebExtensionAPIStorageArea::get):
(WebKit::WebExtensionAPIStorageArea::getKeys):
(WebKit::WebExtensionAPIStorageArea::getBytesInUse):
(WebKit::WebExtensionAPIStorageArea::set):
(WebKit::WebExtensionAPIStorageArea::remove):
(WebKit::WebExtensionAPIStorageArea::clear):
(WebKit::WebExtensionAPIStorageArea::setAccessLevel):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::createTab):
(WebKit::WebExtensionAPITabs::query):
(WebKit::WebExtensionAPITabs::getCurrent):
(WebKit::WebExtensionAPITabs::getSelected):
(WebKit::WebExtensionAPITabs::update):
(WebKit::WebExtensionAPITabs::reload):
(WebKit::WebExtensionAPITabs::goBack):
(WebKit::WebExtensionAPITabs::goForward):
(WebKit::WebExtensionAPITabs::getZoom):
(WebKit::WebExtensionAPITabs::setZoom):
(WebKit::WebExtensionAPITabs::detectLanguage):
(WebKit::WebExtensionAPITabs::toggleReaderMode):
(WebKit::WebExtensionAPITabs::captureVisibleTab):
(WebKit::WebExtensionAPITabs::connect):
(WebKit::WebExtensionAPITabs::executeScript):
(WebKit::WebExtensionAPITabs::insertCSS):
(WebKit::WebExtensionAPITabs::removeCSS):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm:
(WebKit::WebExtensionAPIWebNavigationEvent::addListener):
(WebKit::WebExtensionAPIWebNavigationEvent::removeListener):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebPageNamespaceCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm:
(WebKit::WebExtensionAPIWebRequestEvent::addListener):
(WebKit::WebExtensionAPIWebRequestEvent::removeListener):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
(WebKit::WebExtensionAPIWindows::get):
(WebKit::WebExtensionAPIWindows::getCurrent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm:
(WebKit::WebExtensionAPIWindowsEvent::addListener):
(WebKit::WebExtensionAPIWindowsEvent::removeListener):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsInspectedWindow.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsPanels.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h:
(WebKit::WebExtensionAPIPort::WebExtensionAPIPort):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindows.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h:
* Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm:
(WebKit::toJSError):
(WebKit::toJSString):
(WebKit::toJSValueRefOrJSNull):
(WebKit::toNSArray):
(WebKit::toJSContext):
(WebKit::toJSValue):
(WebKit::toWindowObject):
(WebKit::toJSValueRef):
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp:
(WebKit::toWebFrame):
(WebKit::toWebPage):
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h:
(WebKit::toWebFrame): Deleted.
(WebKit::toWebPage): Deleted.
(WebKit::toNSArray): Deleted.
(WebKit::toJSContext): Deleted.
(WebKit::toJSValue): Deleted.
(WebKit::toWindowObject): Deleted.
(WebKit::toJSValueRef): Deleted.
(WebKit::toJSError): Deleted.
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_generateImplementationFile):
(_includeHeaders):
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json:
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAction.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDevToolsInspectedWindow.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDevToolsPanels.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIEvent.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigationEvent.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebPageRuntime.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequestEvent.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWindows.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWindowsEvent.idl:

Canonical link: <a href="https://commits.webkit.org/287163@main">https://commits.webkit.org/287163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/722a1a7c42de204b9bfe87d9667be61eb236cd1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83248 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29852 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80720 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61555 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19474 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51569 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41865 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48915 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25431 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28190 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70016 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25805 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84616 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5952 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4089 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69780 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6113 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67544 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69034 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13061 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11525 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12134 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5899 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/11850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5887 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9321 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7674 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->