### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER in WebCore/rendering

### DIFF
--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -49,8 +49,6 @@
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 using namespace HTMLNames;
@@ -1055,7 +1053,7 @@ CellSpan RenderTableSection::spannedRows(const LayoutRect& flippedRect, ShouldIn
     if (m_rowPos[nextRow] >= flippedRect.maxY())
         endRow = nextRow;
     else {
-        endRow = std::upper_bound(m_rowPos.begin() + static_cast<int32_t>(nextRow), m_rowPos.end(), flippedRect.maxY()) - m_rowPos.begin();
+        endRow = std::upper_bound(m_rowPos.subspan(static_cast<int32_t>(nextRow)).data(), m_rowPos.end(), flippedRect.maxY()) - m_rowPos.begin();
         if (endRow == m_rowPos.size())
             endRow = m_rowPos.size() - 1;
     }
@@ -1086,7 +1084,7 @@ CellSpan RenderTableSection::spannedColumns(const LayoutRect& flippedRect, Shoul
     if (columnPos[nextColumn] >= flippedRect.maxX())
         endColumn = nextColumn;
     else {
-        endColumn = std::upper_bound(columnPos.begin() + static_cast<int32_t>(nextColumn), columnPos.end(), flippedRect.maxX()) - columnPos.begin();
+        endColumn = std::upper_bound(columnPos.subspan(static_cast<int32_t>(nextColumn)).data(), columnPos.end(), flippedRect.maxX()) - columnPos.begin();
         if (endColumn == columnPos.size())
             endColumn = columnPos.size() - 1;
     }
@@ -1590,5 +1588,3 @@ void RenderTableSection::setLogicalPositionForCell(RenderTableCell* cell, unsign
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -33,8 +33,6 @@
 #include "RenderText.h"
 #include "RenderTheme.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 static void computeStyleForPseudoElementStyle(StyledMarkedText::Style& style, const RenderStyle* pseudoElementStyle, const PaintInfo& paintInfo)
@@ -180,36 +178,37 @@ static Vector<StyledMarkedText> coalesceAdjacentWithSameRanges(Vector<StyledMark
     ASSERT(!styledTexts.isEmpty());
     Vector<StyledMarkedText> frontmostMarkedTexts;
     frontmostMarkedTexts.append(styledTexts[0]);
-    for (auto it = styledTexts.begin() + 1, end = styledTexts.end(); it != end; ++it) {
-        StyledMarkedText& previousStyledMarkedText = frontmostMarkedTexts.last();
+    for (size_t i = 1; i < styledTexts.size(); ++i) {
+        auto& text = styledTexts[i];
+        auto& previousStyledMarkedText = frontmostMarkedTexts.last();
         // StyledMarkedTexts completely cover each other.
-        if (previousStyledMarkedText.startOffset == it->startOffset && previousStyledMarkedText.endOffset == it->endOffset) {
+        if (previousStyledMarkedText.startOffset == text.startOffset && previousStyledMarkedText.endOffset == text.endOffset) {
             // If either background for two different custom highlight StyledMarkedTexts are not opaque, blend colors together.
-            if (previousStyledMarkedText.highlightName != it->highlightName
+            if (previousStyledMarkedText.highlightName != text.highlightName
                 && (!previousStyledMarkedText.style.backgroundColor.isOpaque()
-                    || !it->style.backgroundColor.isOpaque()
-                    || (it->highlightName.isNull() && it->style.backgroundColor.isVisible())))
-                        previousStyledMarkedText.style.backgroundColor = blendSourceOver(previousStyledMarkedText.style.backgroundColor, it->style.backgroundColor);
+                    || !text.style.backgroundColor.isOpaque()
+                    || (text.highlightName.isNull() && text.style.backgroundColor.isVisible())))
+                        previousStyledMarkedText.style.backgroundColor = blendSourceOver(previousStyledMarkedText.style.backgroundColor, text.style.backgroundColor);
             // Take text color of StyledMarkedText, maintaining insertion and priority order.
-            if (it->type != MarkedText::Type::Unmarked && it->style.textStyles.hasExplicitlySetFillColor)
-                previousStyledMarkedText.style.textStyles.fillColor = it->style.textStyles.fillColor;
+            if (text.type != MarkedText::Type::Unmarked && text.style.textStyles.hasExplicitlySetFillColor)
+                previousStyledMarkedText.style.textStyles.fillColor = text.style.textStyles.fillColor;
             // Take the highlightName of the latest StyledMarkedText, regardless of priority.
-            if (!it->highlightName.isNull())
-                previousStyledMarkedText.highlightName = it->highlightName;
+            if (!text.highlightName.isNull())
+                previousStyledMarkedText.highlightName = text.highlightName;
 
-            if (previousStyledMarkedText.priority <= it->priority) {
-                previousStyledMarkedText.priority = it->priority;
+            if (previousStyledMarkedText.priority <= text.priority) {
+                previousStyledMarkedText.priority = text.priority;
                 // If highlight, combine textDecorationStyles accordingly.
                 // FIXME: Check for taking textDecorationStyles needs to accommodate other MarkedText type.
-                if (!it->highlightName.isNull())
-                    previousStyledMarkedText.style.textDecorationStyles = computeStylesForTextDecorations(previousStyledMarkedText.style.textDecorationStyles, it->style.textDecorationStyles);
+                if (!text.highlightName.isNull())
+                    previousStyledMarkedText.style.textDecorationStyles = computeStylesForTextDecorations(previousStyledMarkedText.style.textDecorationStyles, text.style.textDecorationStyles);
                 // If higher or same priority and opaque, override background color.
-                if (it->style.backgroundColor.isOpaque())
-                    previousStyledMarkedText.style.backgroundColor = it->style.backgroundColor;
+                if (text.style.backgroundColor.isOpaque())
+                    previousStyledMarkedText.style.backgroundColor = text.style.backgroundColor;
             }
             continue;
         }
-        frontmostMarkedTexts.append(WTFMove(*it));
+        frontmostMarkedTexts.append(WTFMove(text));
     }
     return frontmostMarkedTexts;
 }
@@ -288,14 +287,15 @@ Vector<StyledMarkedText> StyledMarkedText::subdivideAndResolve(const Vector<Mark
     Vector<StyledMarkedText> frontmostMarkedTexts;
     frontmostMarkedTexts.reserveInitialCapacity(markedTexts.size());
     frontmostMarkedTexts.append(resolveStyleForMarkedText(markedTexts[0], baseStyle, renderer, lineStyle, paintInfo));
-    for (auto it = markedTexts.begin() + 1, end = markedTexts.end(); it != end; ++it) {
-        StyledMarkedText& previousStyledMarkedText = frontmostMarkedTexts.last();
+    for (size_t i = 1; i < markedTexts.size(); ++i) {
+        auto& text = markedTexts[i];
+        auto& previousStyledMarkedText = frontmostMarkedTexts.last();
         // Marked texts completely cover each other.
-        if (previousStyledMarkedText.startOffset == it->startOffset && previousStyledMarkedText.endOffset == it->endOffset) {
-            previousStyledMarkedText = resolveStyleForMarkedText(*it, previousStyledMarkedText.style, renderer, lineStyle, paintInfo);
+        if (previousStyledMarkedText.startOffset == text.startOffset && previousStyledMarkedText.endOffset == text.endOffset) {
+            previousStyledMarkedText = resolveStyleForMarkedText(text, previousStyledMarkedText.style, renderer, lineStyle, paintInfo);
             continue;
         }
-        frontmostMarkedTexts.append(resolveStyleForMarkedText(*it, baseStyle, renderer, lineStyle, paintInfo));
+        frontmostMarkedTexts.append(resolveStyleForMarkedText(text, baseStyle, renderer, lineStyle, paintInfo));
     }
 
     return frontmostMarkedTexts;
@@ -314,13 +314,14 @@ static Vector<StyledMarkedText> coalesceAdjacent(const Vector<StyledMarkedText>&
     Vector<StyledMarkedText> styledMarkedTexts;
     styledMarkedTexts.reserveInitialCapacity(textsToCoalesce.size());
     styledMarkedTexts.append(textsToCoalesce[0]);
-    for (auto it = textsToCoalesce.begin() + 1, end = textsToCoalesce.end(); it != end; ++it) {
-        StyledMarkedText& previousStyledMarkedText = styledMarkedTexts.last();
-        if (areAdjacentMarkedTextsWithSameStyle(previousStyledMarkedText, *it)) {
-            previousStyledMarkedText.endOffset = it->endOffset;
+    for (size_t i = 1; i < textsToCoalesce.size(); ++i) {
+        auto& text = textsToCoalesce[i];
+        auto& previousStyledMarkedText = styledMarkedTexts.last();
+        if (areAdjacentMarkedTextsWithSameStyle(previousStyledMarkedText, text)) {
+            previousStyledMarkedText.endOffset = text.endOffset;
             continue;
         }
-        styledMarkedTexts.append(*it);
+        styledMarkedTexts.append(text);
     }
 
     return styledMarkedTexts;
@@ -347,5 +348,3 @@ Vector<StyledMarkedText> StyledMarkedText::coalesceAdjacentWithEqualDecorations(
     });
 }
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -35,8 +35,6 @@
 #include "ShadowData.h"
 #include "TextRun.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 /*
@@ -123,24 +121,23 @@ static DashArray translateIntersectionPointsToSkipInkBoundaries(const DashArray&
     
     // Step 1: Make pairs so we can sort based on range starting-point. We dilate the ranges in this step as well.
     Vector<std::pair<float, float>> tuples;
-    for (auto i = intersections.begin(); i != intersections.end(); i++, i++)
-        tuples.append(std::make_pair(*i - dilationAmount, *(i + 1) + dilationAmount));
+    for (size_t i = 0; i < intersections.size(); i += 2)
+        tuples.append(std::pair { intersections[i] - dilationAmount, intersections[i + 1] + dilationAmount });
     std::sort(tuples.begin(), tuples.end(), &compareTuples);
 
     // Step 2: Deal with intersecting ranges.
     Vector<std::pair<float, float>> intermediateTuples;
     if (tuples.size() >= 2) {
-        intermediateTuples.append(*tuples.begin());
-        for (auto i = tuples.begin() + 1; i != tuples.end(); i++) {
+        intermediateTuples.append(tuples.first());
+        for (size_t i = 1; i < tuples.size(); ++i) {
+            auto [secondStart, secondEnd] = tuples[i];
             float& firstEnd = intermediateTuples.last().second;
-            float secondStart = i->first;
-            float secondEnd = i->second;
             if (secondStart <= firstEnd && secondEnd <= firstEnd) {
                 // Ignore this range completely
             } else if (secondStart <= firstEnd)
                 firstEnd = secondEnd;
             else
-                intermediateTuples.append(*i);
+                intermediateTuples.append(std::pair { secondStart, secondEnd });
         }
     } else {
         // XXX(274780): A plain assignment or move here makes Clang generate bad code in LTO builds.
@@ -424,5 +421,3 @@ OptionSet<TextDecorationLine> TextDecorationPainter::textDecorationsInEffectForS
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -67,8 +67,6 @@
 #import <pal/ios/UIKitSoftLink.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 @interface WebCoreRenderThemeBundle : NSObject
 @end
 
@@ -241,8 +239,8 @@ static inline FontSelectionValue cssWeightOfSystemFont(CTFontRef font)
     resultRef = static_cast<CFNumberRef>(CFDictionaryGetValue(traits.get(), kCTFontWeightTrait));
     CFNumberGetValue(resultRef.get(), kCFNumberFloatType, &result);
     // These numbers were experimentally gathered from weights of the system font.
-    static constexpr float weightThresholds[] = { -0.6, -0.365, -0.115, 0.130, 0.235, 0.350, 0.5, 0.7 };
-    for (unsigned i = 0; i < std::size(weightThresholds); ++i) {
+    static constexpr std::array weightThresholds { -0.6f, -0.365f, -0.115f, 0.130f, 0.235f, 0.350f, 0.5f, 0.7f };
+    for (unsigned i = 0; i < weightThresholds.size(); ++i) {
         if (result < weightThresholds[i])
             return FontSelectionValue((static_cast<int>(i) + 1) * 100);
     }
@@ -296,5 +294,3 @@ Color RenderThemeCocoa::platformGrammarMarkerColor(OptionSet<StyleColorOptions> 
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/rendering/line/BreakingContext.h
+++ b/Source/WebCore/rendering/line/BreakingContext.h
@@ -46,8 +46,6 @@
 #include <wtf/text/StringView.h>
 #include <wtf/unicode/CharacterNames.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 // We don't let our line box tree for a single line get any deeper than this.
@@ -759,9 +757,9 @@ inline TrailingObjects::CollapseFirstSpace checkWhitespaceCollapsingTransitions(
     // shave it off the list, and shave off a trailing space if the previous end point doesn't
     // preserve whitespace.
     if (lBreak.renderer() && lineWhitespaceCollapsingState.numTransitions() && !(lineWhitespaceCollapsingState.numTransitions() % 2)) {
-        const LegacyInlineIterator* transitions = lineWhitespaceCollapsingState.transitions().data();
-        const LegacyInlineIterator& endpoint = transitions[lineWhitespaceCollapsingState.numTransitions() - 2];
-        const LegacyInlineIterator& startpoint = transitions[lineWhitespaceCollapsingState.numTransitions() - 1];
+        auto transitions = lineWhitespaceCollapsingState.transitions().span();
+        auto& endpoint = transitions[lineWhitespaceCollapsingState.numTransitions() - 2];
+        auto& startpoint = transitions[lineWhitespaceCollapsingState.numTransitions() - 1];
         LegacyInlineIterator currpoint = endpoint;
         while (!currpoint.atEnd() && currpoint != startpoint && currpoint != lBreak)
             currpoint.increment();
@@ -827,5 +825,3 @@ inline LegacyInlineIterator BreakingContext::handleEndOfLine()
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/rendering/mac/RenderThemeMac.h
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.h
@@ -143,11 +143,10 @@ private:
 
     bool searchFieldShouldAppearAsTextField(const RenderStyle&) const final;
 
-    const IntSize* menuListSizes() const;
-
-    const IntSize* searchFieldSizes() const;
-    const IntSize* cancelButtonSizes() const;
-    const IntSize* resultsButtonSizes() const;
+    std::span<const IntSize, 4> menuListSizes() const;
+    std::span<const IntSize, 4> searchFieldSizes() const;
+    std::span<const IntSize, 4> cancelButtonSizes() const;
+    std::span<const IntSize, 4> resultsButtonSizes() const;
     void setSearchFieldSize(RenderStyle&) const;
 
 #if ENABLE(SERVICE_CONTROLS)

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -83,8 +83,6 @@
 #include "ImageControlsMac.h"
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 @interface WebCoreRenderThemeNotificationObserver : NSObject
 @end
 
@@ -406,8 +404,8 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
-    NSUInteger pixel[4];
-    [offscreenRep getPixel:pixel atX:0 y:0];
+    std::array<NSUInteger, 4> pixel;
+    [offscreenRep getPixel:pixel.data() atX:0 y:0];
 
     return makeFromComponentsClamping<SRGBA<uint8_t>>(pixel[0], pixel[1], pixel[2], pixel[3]);
 }
@@ -714,7 +712,7 @@ bool RenderThemeMac::isControlStyled(const RenderStyle& style, const RenderStyle
     return RenderTheme::isControlStyled(style, userAgentStyle);
 }
 
-static FloatRect inflateRect(const FloatRect& rect, const IntSize& size, const int* margins, float zoomLevel)
+static FloatRect inflateRect(const FloatRect& rect, const IntSize& size, std::span<const int, 4> margins, float zoomLevel)
 {
     // Only do the inflation if the available width/height are too small. Otherwise try to
     // fit the glow/check space into the available box's width/height.
@@ -732,7 +730,7 @@ static FloatRect inflateRect(const FloatRect& rect, const IntSize& size, const i
     return result;
 }
 
-static NSControlSize controlSizeFromPixelSize(const IntSize* sizes, const IntSize& minSize, float zoomLevel)
+static NSControlSize controlSizeFromPixelSize(std::span<const IntSize, 4> sizes, const IntSize& minSize, float zoomLevel)
 {
     if (ThemeMac::supportsLargeFormControls()
         && minSize.width() >= static_cast<int>(sizes[NSControlSizeLarge].width() * zoomLevel)
@@ -750,39 +748,36 @@ static NSControlSize controlSizeFromPixelSize(const IntSize* sizes, const IntSiz
     return NSControlSizeMini;
 }
 
-static const int* popupButtonMargins(NSControlSize size)
+static std::span<const int, 4> popupButtonMargins(NSControlSize size)
 {
-    static const int margins[4][4] =
-    {
-        { 0, 3, 1, 3 },
-        { 0, 3, 2, 3 },
-        { 0, 1, 0, 1 },
-        { 0, 6, 2, 6 },
+    static constexpr std::array margins {
+        std::array { 0, 3, 1, 3 },
+        std::array { 0, 3, 2, 3 },
+        std::array { 0, 1, 0, 1 },
+        std::array { 0, 6, 2, 6 },
     };
     return margins[size];
 }
 
-static const IntSize* popupButtonSizes()
+static std::span<const IntSize, 4> popupButtonSizes()
 {
-    static const IntSize sizes[4] = { IntSize(0, 21), IntSize(0, 18), IntSize(0, 15), IntSize(0, 24) };
+    static constexpr std::array sizes { IntSize(0, 21), IntSize(0, 18), IntSize(0, 15), IntSize(0, 24) };
     return sizes;
 }
 
-static const int* popupButtonPadding(NSControlSize size, bool isRTL)
+static std::span<const int, 4> popupButtonPadding(NSControlSize size, bool isRTL)
 {
-    static const int paddingLTR[4][4] =
-    {
-        { 2, 26, 3, 8 },
-        { 2, 23, 3, 8 },
-        { 2, 22, 3, 10 },
-        { 2, 26, 3, 8 },
+    static constexpr std::array paddingLTR {
+        std::array { 2, 26, 3, 8 },
+        std::array { 2, 23, 3, 8 },
+        std::array { 2, 22, 3, 10 },
+        std::array { 2, 26, 3, 8 },
     };
-    static const int paddingRTL[4][4] =
-    {
-        { 2, 8, 3, 26 },
-        { 2, 8, 3, 23 },
-        { 2, 8, 3, 22 },
-        { 2, 8, 3, 26 },
+    static constexpr std::array paddingRTL {
+        std::array { 2, 8, 3, 26 },
+        std::array { 2, 8, 3, 23 },
+        std::array { 2, 8, 3, 22 },
+        std::array { 2, 8, 3, 26 },
     };
     return isRTL ? paddingRTL[size] : paddingLTR[size];
 }
@@ -865,7 +860,7 @@ static NSControlSize controlSizeForFont(const RenderStyle& style)
     return NSControlSizeMini;
 }
 
-static IntSize sizeForFont(const RenderStyle& style, const IntSize* sizes)
+static IntSize sizeForFont(const RenderStyle& style, std::span<const IntSize, 4> sizes)
 {
     if (style.usedZoom() != 1.0f) {
         IntSize result = sizes[controlSizeForFont(style)];
@@ -874,7 +869,7 @@ static IntSize sizeForFont(const RenderStyle& style, const IntSize* sizes)
     return sizes[controlSizeForFont(style)];
 }
 
-static IntSize sizeForSystemFont(const RenderStyle& style, const IntSize* sizes)
+static IntSize sizeForSystemFont(const RenderStyle& style, std::span<const IntSize, 4> sizes)
 {
     if (style.usedZoom() != 1.0f) {
         IntSize result = sizes[controlSizeForSystemFont(style)];
@@ -883,7 +878,7 @@ static IntSize sizeForSystemFont(const RenderStyle& style, const IntSize* sizes)
     return sizes[controlSizeForSystemFont(style)];
 }
 
-static void setSizeFromFont(RenderStyle& style, const IntSize* sizes)
+static void setSizeFromFont(RenderStyle& style, std::span<const IntSize, 4> sizes)
 {
     // FIXME: Check is flawed, since it doesn't take min-width/max-width into account.
     IntSize size = sizeForFont(style, sizes);
@@ -963,9 +958,9 @@ const int styledPopupPaddingLeft = 8;
 const int styledPopupPaddingTop = 1;
 const int styledPopupPaddingBottom = 2;
 
-static const IntSize* menuListButtonSizes()
+static std::span<const IntSize, 4> menuListButtonSizes()
 {
-    static const IntSize sizes[4] = { IntSize(0, 21), IntSize(0, 18), IntSize(0, 15), IntSize(0, 28) };
+    static constexpr std::array sizes { IntSize(0, 21), IntSize(0, 18), IntSize(0, 15), IntSize(0, 28) };
     return sizes;
 }
 
@@ -998,7 +993,7 @@ void RenderThemeMac::adjustMenuListStyle(RenderStyle& style, const Element* e) c
 LengthBox RenderThemeMac::popupInternalPaddingBox(const RenderStyle& style) const
 {
     if (style.usedAppearance() == StyleAppearance::Menulist) {
-        const int* padding = popupButtonPadding(controlSizeForFont(style), style.writingMode().isBidiRTL());
+        auto padding = popupButtonPadding(controlSizeForFont(style), style.writingMode().isBidiRTL());
         return { static_cast<int>(padding[topPadding] * style.usedZoom()),
             static_cast<int>(padding[rightPadding] * style.usedZoom()),
             static_cast<int>(padding[bottomPadding] * style.usedZoom()),
@@ -1050,9 +1045,9 @@ void RenderThemeMac::adjustMenuListButtonStyle(RenderStyle& style, const Element
     style.setLineHeight(RenderStyle::initialLineHeight());
 }
 
-const IntSize* RenderThemeMac::menuListSizes() const
+std::span<const IntSize, 4> RenderThemeMac::menuListSizes() const
 {
-    static const IntSize sizes[4] = { IntSize(9, 0), IntSize(5, 0), IntSize(0, 0), IntSize(13, 0) };
+    static constexpr std::array sizes { IntSize(9, 0), IntSize(5, 0), IntSize(0, 0), IntSize(13, 0) };
     return sizes;
 }
 
@@ -1072,9 +1067,9 @@ void RenderThemeMac::adjustSliderThumbStyle(RenderStyle& style, const Element* e
     style.setBoxShadow(nullptr);
 }
 
-const IntSize* RenderThemeMac::searchFieldSizes() const
+std::span<const IntSize, 4> RenderThemeMac::searchFieldSizes() const
 {
-    static const IntSize sizes[4] = { IntSize(0, 22), IntSize(0, 19), IntSize(0, 17), IntSize(0, 30) };
+    static constexpr std::array sizes { IntSize(0, 22), IntSize(0, 19), IntSize(0, 17), IntSize(0, 30) };
     return sizes;
 }
 
@@ -1120,9 +1115,9 @@ void RenderThemeMac::adjustSearchFieldStyle(RenderStyle& style, const Element*) 
     style.setBoxShadow(nullptr);
 }
 
-const IntSize* RenderThemeMac::cancelButtonSizes() const
+std::span<const IntSize, 4> RenderThemeMac::cancelButtonSizes() const
 {
-    static const IntSize sizes[4] = { IntSize(22, 22), IntSize(19, 19), IntSize(15, 15), IntSize(22, 22) };
+    static constexpr std::array sizes { IntSize(22, 22), IntSize(19, 19), IntSize(15, 15), IntSize(22, 22) };
     return sizes;
 }
 
@@ -1134,10 +1129,10 @@ void RenderThemeMac::adjustSearchFieldCancelButtonStyle(RenderStyle& style, cons
     style.setBoxShadow(nullptr);
 }
 
-const int resultsArrowWidth = 5;
-const IntSize* RenderThemeMac::resultsButtonSizes() const
+constexpr int resultsArrowWidth = 5;
+std::span<const IntSize, 4> RenderThemeMac::resultsButtonSizes() const
 {
-    static const IntSize sizes[4] = { IntSize(19, 22), IntSize(17, 19), IntSize(17, 15), IntSize(19, 22) };
+    static constexpr std::array sizes { IntSize(19, 22), IntSize(17, 19), IntSize(17, 15), IntSize(19, 22) };
     return sizes;
 }
 
@@ -1525,7 +1520,5 @@ bool RenderThemeMac::paintAttachment(const RenderObject& renderer, const PaintIn
 #endif // ENABLE(ATTACHMENT_ELEMENT)
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/rendering/mathml/MathOperator.cpp
+++ b/Source/WebCore/rendering/mathml/MathOperator.cpp
@@ -35,8 +35,6 @@
 static const unsigned kRadicalOperator = 0x221A;
 static const unsigned kMaximumExtensionCount = 128;
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 static inline FloatRect boundsForGlyph(const GlyphData& data)
@@ -70,21 +68,21 @@ struct StretchyCharacter {
     UChar middleChar;
 };
 
-static const StretchyCharacter stretchyCharacters[14] = {
-    { 0x28  , 0x239b, 0x239c, 0x239d, 0x0    }, // left parenthesis
-    { 0x29  , 0x239e, 0x239f, 0x23a0, 0x0    }, // right parenthesis
-    { 0x5b  , 0x23a1, 0x23a2, 0x23a3, 0x0    }, // left square bracket
-    { 0x5d  , 0x23a4, 0x23a5, 0x23a6, 0x0    }, // right square bracket
-    { 0x7b  , 0x23a7, 0x23aa, 0x23a9, 0x23a8 }, // left curly bracket
-    { 0x7d  , 0x23ab, 0x23aa, 0x23ad, 0x23ac }, // right curly bracket
-    { 0x2308, 0x23a1, 0x23a2, 0x23a2, 0x0    }, // left ceiling
-    { 0x2309, 0x23a4, 0x23a5, 0x23a5, 0x0    }, // right ceiling
-    { 0x230a, 0x23a2, 0x23a2, 0x23a3, 0x0    }, // left floor
-    { 0x230b, 0x23a5, 0x23a5, 0x23a6, 0x0    }, // right floor
-    { 0x7c  , 0x7c,   0x7c,   0x7c,   0x0    }, // vertical bar
-    { 0x2016, 0x2016, 0x2016, 0x2016, 0x0    }, // double vertical line
-    { 0x2225, 0x2225, 0x2225, 0x2225, 0x0    }, // parallel to
-    { 0x222b, 0x2320, 0x23ae, 0x2321, 0x0    } // integral sign
+static constexpr std::array stretchyCharacters {
+    StretchyCharacter { 0x28  , 0x239b, 0x239c, 0x239d, 0x0    }, // left parenthesis
+    StretchyCharacter { 0x29  , 0x239e, 0x239f, 0x23a0, 0x0    }, // right parenthesis
+    StretchyCharacter { 0x5b  , 0x23a1, 0x23a2, 0x23a3, 0x0    }, // left square bracket
+    StretchyCharacter { 0x5d  , 0x23a4, 0x23a5, 0x23a6, 0x0    }, // right square bracket
+    StretchyCharacter { 0x7b  , 0x23a7, 0x23aa, 0x23a9, 0x23a8 }, // left curly bracket
+    StretchyCharacter { 0x7d  , 0x23ab, 0x23aa, 0x23ad, 0x23ac }, // right curly bracket
+    StretchyCharacter { 0x2308, 0x23a1, 0x23a2, 0x23a2, 0x0    }, // left ceiling
+    StretchyCharacter { 0x2309, 0x23a4, 0x23a5, 0x23a5, 0x0    }, // right ceiling
+    StretchyCharacter { 0x230a, 0x23a2, 0x23a2, 0x23a3, 0x0    }, // left floor
+    StretchyCharacter { 0x230b, 0x23a5, 0x23a5, 0x23a6, 0x0    }, // right floor
+    StretchyCharacter { 0x7c  , 0x7c,   0x7c,   0x7c,   0x0    }, // vertical bar
+    StretchyCharacter { 0x2016, 0x2016, 0x2016, 0x2016, 0x0    }, // double vertical line
+    StretchyCharacter { 0x2225, 0x2225, 0x2225, 0x2225, 0x0    }, // parallel to
+    StretchyCharacter { 0x222b, 0x2320, 0x23ae, 0x2321, 0x0    } // integral sign
 };
 
 MathOperator::MathOperator()
@@ -198,16 +196,14 @@ void MathOperator::setGlyphAssembly(const RenderStyle& style, const GlyphAssembl
 // The MathML specification recommends avoiding combining characters.
 // See https://www.w3.org/TR/MathML/chapter7.html#chars.comb-chars
 // However, many math fonts do not provide constructions for the non-combining equivalent.
-const unsigned maxFallbackPerCharacter = 3;
-static const char32_t characterFallback[][maxFallbackPerCharacter] = {
-    { 0x005E, 0x0302, 0 }, // CIRCUMFLEX ACCENT
-    { 0x005F, 0x0332, 0 }, // LOW LINE
-    { 0x007E, 0x0303, 0 }, // TILDE
-    { 0x00AF, 0x0304, 0x0305 }, // MACRON
-    { 0x02C6, 0x0302, 0 }, // MODIFIER LETTER CIRCUMFLEX ACCENT
-    { 0x02C7, 0x030C, 0 } // CARON
+static constexpr std::array characterFallback {
+    std::array<char32_t, 3> { 0x005E, 0x0302, 0 }, // CIRCUMFLEX ACCENT
+    std::array<char32_t, 3> { 0x005F, 0x0332, 0 }, // LOW LINE
+    std::array<char32_t, 3> { 0x007E, 0x0303, 0 }, // TILDE
+    std::array<char32_t, 3> { 0x00AF, 0x0304, 0x0305 }, // MACRON
+    std::array<char32_t, 3> { 0x02C6, 0x0302, 0 }, // MODIFIER LETTER CIRCUMFLEX ACCENT
+    std::array<char32_t, 3> { 0x02C7, 0x030C, 0 } // CARON
 };
-const unsigned characterFallbackSize = std::size(characterFallback);
 
 void MathOperator::getMathVariantsWithFallback(const RenderStyle& style, bool isVertical, Vector<Glyph>& sizeVariants, Vector<OpenTypeMathData::AssemblyPart>& assemblyParts)
 {
@@ -220,12 +216,12 @@ void MathOperator::getMathVariantsWithFallback(const RenderStyle& style, bool is
         return;
 
     // Otherwise, we try and find fallback constructions using similar characters.
-    for (unsigned i = 0; i < characterFallbackSize; i++) {
+    for (auto& fallbacks : characterFallback) {
         unsigned j = 0;
-        if (characterFallback[i][j] == m_baseCharacter) {
-            for (j++; j < maxFallbackPerCharacter && characterFallback[i][j]; j++) {
+        if (fallbacks[j] == m_baseCharacter) {
+            for (j++; j < fallbacks.size() && fallbacks[j]; j++) {
                 GlyphData glyphData;
-                if (!getGlyph(style, characterFallback[i][j], glyphData))
+                if (!getGlyph(style, fallbacks[j], glyphData))
                     continue;
                 glyphData.font->mathData()->getMathVariants(glyphData.glyph, isVertical, sizeVariants, assemblyParts);
                 if (!sizeVariants.isEmpty() || !assemblyParts.isEmpty())
@@ -407,10 +403,9 @@ void MathOperator::calculateStretchyData(const RenderStyle& style, bool calculat
 
         // If the font does not have a MATH table, we fallback to the Unicode-only constructions.
         const StretchyCharacter* stretchyCharacter = nullptr;
-        const unsigned maxIndex = std::size(stretchyCharacters);
-        for (unsigned index = 0; index < maxIndex; ++index) {
-            if (stretchyCharacters[index].character == m_baseCharacter) {
-                stretchyCharacter = &stretchyCharacters[index];
+        for (auto& character : stretchyCharacters) {
+            if (character.character == m_baseCharacter) {
+                stretchyCharacter = &character;
                 break;
             }
         }
@@ -734,7 +729,5 @@ void MathOperator::paint(const RenderStyle& style, PaintInfo& info, const Layout
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebCore/rendering/style/TextSizeAdjustment.cpp
+++ b/Source/WebCore/rendering/style/TextSizeAdjustment.cpp
@@ -31,8 +31,6 @@
 #include "RenderStyle.h"
 #include "RenderStyleInlines.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 bool AutosizeStatus::probablyContainsASmallFixedNumberOfLines(const RenderStyle& style)
@@ -120,7 +118,11 @@ float AutosizeStatus::idempotentTextSize(float specifiedSize, float pageScale)
         return specifiedSize;
 
     // This describes a piecewise curve when the page scale is 2/3.
-    FloatPoint points[] = { {0.0f, 0.0f}, {6.0f, 9.0f}, {14.0f, 17.0f} };
+    static constexpr std::array points = {
+        FloatPoint { 0.0f, 0.0f },
+        FloatPoint { 6.0f, 9.0f },
+        FloatPoint { 14.0f, 17.0f }
+    };
 
     // When the page scale is 1, the curve should be the identity.
     // Linearly interpolate between the curve above and identity based on the page scale.
@@ -135,8 +137,8 @@ float AutosizeStatus::idempotentTextSize(float specifiedSize, float pageScale)
     if (specifiedSize <= 0)
         return 0;
 
-    float result = scalePoint(points[std::size(points) - 1]).y();
-    for (size_t i = 1; i < std::size(points); ++i) {
+    float result = scalePoint(points.back()).y();
+    for (size_t i = 1; i < points.size(); ++i) {
         if (points[i].x() < specifiedSize)
             continue;
         auto leftPoint = scalePoint(points[i - 1]);
@@ -150,7 +152,5 @@ float AutosizeStatus::idempotentTextSize(float specifiedSize, float pageScale)
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif


### PR DESCRIPTION
#### 911d0d32b1e8f02d8dd8dd34688359018b5d3ec6
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER in WebCore/rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=283780">https://bugs.webkit.org/show_bug.cgi?id=283780</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/rendering/RenderTableSection.cpp:
* Source/WebCore/rendering/StyledMarkedText.cpp:
* Source/WebCore/rendering/TextDecorationPainter.cpp:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::cssWeightOfSystemFont):
* Source/WebCore/rendering/line/BreakingContext.h:
* Source/WebCore/rendering/mac/RenderThemeMac.h:
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::inflateRect):
(WebCore::controlSizeFromPixelSize):
(WebCore::popupButtonMargins):
(WebCore::popupButtonSizes):
(WebCore::popupButtonPadding):
(WebCore::sizeForFont):
(WebCore::sizeForSystemFont):
(WebCore::setSizeFromFont):
(WebCore::menuListButtonSizes):
(WebCore::RenderThemeMac::popupInternalPaddingBox const):
(WebCore::RenderThemeMac::menuListSizes const):
(WebCore::RenderThemeMac::searchFieldSizes const):
(WebCore::RenderThemeMac::cancelButtonSizes const):
(WebCore::RenderThemeMac::resultsButtonSizes const):
* Source/WebCore/rendering/mathml/MathOperator.cpp:
* Source/WebCore/rendering/style/QuotesData.cpp:
* Source/WebCore/rendering/style/TextSizeAdjustment.cpp:

Canonical link: <a href="https://commits.webkit.org/287157@main">https://commits.webkit.org/287157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96bba88023438e875bbd98723746cf5e48d3c560

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83210 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29814 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80682 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5875 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61524 "Found 1 new test failure: media/modern-media-controls/css/transformed-media-crash.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19441 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81616 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51535 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69787 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41835 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48881 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25367 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28151 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84576 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4051 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69749 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6075 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67511 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69003 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13025 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11468 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12129 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5861 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/11757 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5849 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9283 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->