### PR TITLE
Update quirks.cpp to change twitter.com by x.com

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -406,7 +406,7 @@ bool Quirks::shouldDisableElementFullscreenQuirk() const
     // (Ref: rdar://116531089)
     // Instagram.com stories flow under the notch and status bar
     // (Ref: rdar://121014613)
-    // Twitter.com video embeds have controls that are too tiny and
+    // x.com (Twitter) video embeds have controls that are too tiny and
     // show page behind fullscreen.
     // (Ref: rdar://121473410)
     // YouTube.com does not provide AirPlay controls in fullscreen
@@ -416,7 +416,7 @@ bool Quirks::shouldDisableElementFullscreenQuirk() const
             || isDomain("instagram.com"_s)
             || (PAL::currentUserInterfaceIdiomIsSmallScreen() && isDomain("digitaltrends.com"_s))
             || (PAL::currentUserInterfaceIdiomIsSmallScreen() && isDomain("as.com"_s))
-            || isEmbedDomain("twitter.com"_s)
+            || isEmbedDomain("x.com"_s)
             || (PAL::currentUserInterfaceIdiomIsSmallScreen() && (isYouTube() || isYoutubeEmbedDomain()));
     }
 
@@ -864,14 +864,14 @@ bool Quirks::shouldSilenceWindowResizeEvents() const
         return false;
 
     // We silence window resize events during the 'homing out' snapshot sequence when on nytimes.com
-    // to address <rdar://problem/59763843>, and on twitter.com to address <rdar://problem/58804852> &
+    // to address <rdar://problem/59763843>, and on x.com (twitter) to address <rdar://problem/58804852> &
     // <rdar://problem/61731801>.
     auto* page = m_document->page();
     if (!page || !page->isTakingSnapshotsForApplicationSuspension())
         return false;
 
     if (!m_quirksData.shouldSilenceWindowResizeEvents)
-        m_quirksData.shouldSilenceWindowResizeEvents = isDomain("nytimes.com"_s) || isDomain("twitter.com"_s) || isDomain("zillow.com"_s) || isDomain("365scores.com"_s);
+        m_quirksData.shouldSilenceWindowResizeEvents = isDomain("nytimes.com"_s) || isDomain("x.com"_s) || isDomain("zillow.com"_s) || isDomain("365scores.com"_s);
 
     return *m_quirksData.shouldSilenceWindowResizeEvents;
 #else
@@ -885,14 +885,14 @@ bool Quirks::shouldSilenceMediaQueryListChangeEvents() const
     if (!needsQuirks())
         return false;
 
-    // We silence MediaQueryList's change events during the 'homing out' snapshot sequence when on twitter.com
+    // We silence MediaQueryList's change events during the 'homing out' snapshot sequence when on x.com (twitter)
     // to address <rdar://problem/58804852> & <rdar://problem/61731801>.
     auto* page = m_document->page();
     if (!page || !page->isTakingSnapshotsForApplicationSuspension())
         return false;
 
     if (!m_quirksData.shouldSilenceMediaQueryListChangeEvents)
-        m_quirksData.shouldSilenceMediaQueryListChangeEvents = isDomain("twitter.com"_s);
+        m_quirksData.shouldSilenceMediaQueryListChangeEvents = isDomain("x.com"_s);
 
     return *m_quirksData.shouldSilenceMediaQueryListChangeEvents;
 #else
@@ -1402,7 +1402,7 @@ bool Quirks::needsVP9FullRangeFlagQuirk() const
 bool Quirks::requiresUserGestureToPauseInPictureInPicture() const
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    // Facebook, Twitter, and Reddit will naively pause a <video> element that has scrolled out of the viewport,
+    // Facebook, X (twitter), and Reddit will naively pause a <video> element that has scrolled out of the viewport,
     // regardless of whether that element is currently in PiP mode.
     // We should remove the quirk once <rdar://problem/67273166>, <rdar://problem/73369869>, and <rdar://problem/80645747> have been fixed.
     if (!needsQuirks())
@@ -1410,7 +1410,7 @@ bool Quirks::requiresUserGestureToPauseInPictureInPicture() const
 
     if (!m_quirksData.requiresUserGestureToPauseInPictureInPictureQuirk) {
         auto domain = RegistrableDomain(topDocumentURL()).string();
-        m_quirksData.requiresUserGestureToPauseInPictureInPictureQuirk = isDomain("facebook.com"_s) || isDomain("twitter.com"_s) || isDomain("reddit.com"_s) || isDomain("forbes.com"_s);
+        m_quirksData.requiresUserGestureToPauseInPictureInPictureQuirk = isDomain("facebook.com"_s) || isDomain("x.com"_s) || isDomain("reddit.com"_s) || isDomain("forbes.com"_s);
     }
 
     return *m_quirksData.requiresUserGestureToPauseInPictureInPictureQuirk;
@@ -1433,14 +1433,14 @@ bool Quirks::returnNullPictureInPictureElementDuringFullscreenChange() const
 bool Quirks::requiresUserGestureToLoadInPictureInPicture() const
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    // Twitter will remove the "src" attribute of a <video> element that has scrolled out of the viewport and
+    // X (Twitter) will remove the "src" attribute of a <video> element that has scrolled out of the viewport and
     // load the <video> element with an empty "src" regardless of whether that element is currently in PiP mode.
     // We should remove the quirk once <rdar://problem/73369869> has been fixed.
     if (!needsQuirks())
         return false;
 
     if (!m_quirksData.requiresUserGestureToLoadInPictureInPictureQuirk)
-        m_quirksData.requiresUserGestureToLoadInPictureInPictureQuirk = isDomain("twitter.com"_s);
+        m_quirksData.requiresUserGestureToLoadInPictureInPictureQuirk = isDomain("x.com"_s);
 
     return *m_quirksData.requiresUserGestureToLoadInPictureInPictureQuirk;
 #else


### PR DESCRIPTION
#### d3a90084d1c958a442dc0db14c88c4b688ecfcba
<pre>
Update quirks.cpp to change twitter.com by x.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=275315">https://bugs.webkit.org/show_bug.cgi?id=275315</a>
<a href="https://rdar.apple.com/129993390">rdar://129993390</a>

Reviewed by Tim Nguyen.

This update ensures x.com domains are recognized and handled
appropriately in the quirks.cpp file. We removed mentions of
twitter as the domain name twitter.com is being redirected to
x.com

Co-authored-by: filippofinke &lt;filippofinke@protonmail.ch&gt;

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldDisableElementFullscreenQuirk const):
(WebCore::Quirks::shouldSilenceWindowResizeEvents const):
(WebCore::Quirks::shouldSilenceMediaQueryListChangeEvents const):
(WebCore::Quirks::requiresUserGestureToPauseInPictureInPicture const):
(WebCore::Quirks::requiresUserGestureToLoadInPictureInPicture const):

Canonical link: <a href="https://commits.webkit.org/287198@main">https://commits.webkit.org/287198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a813f273d22372dd797027e024a02673e9111b7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83168 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29772 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80640 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5833 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61488 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19407 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69556 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41800 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48847 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25295 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28109 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69946 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25669 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84534 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5872 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4011 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69713 "Found 1 new test failure: webanimations/accelerated-translate-animation-underlying-value-changed-in-flight.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68968 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12989 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11404 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12155 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5819 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/10031 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5807 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9241 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7594 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->