### PR TITLE
MockRealtimeVideoSourceMac should call captureFailed on main thread

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.h
+++ b/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.h
@@ -48,11 +48,11 @@ class ImageTransferSessionVT;
 class MockRealtimeVideoSourceMac final : public MockRealtimeVideoSource {
 public:
     static Ref<MockRealtimeVideoSource> createForMockDisplayCapturer(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&, std::optional<PageIdentifier>);
+    static Ref<MockRealtimeVideoSource> create(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&& salt, std::optional<PageIdentifier> pageIdentifier) { return adoptRef(*new MockRealtimeVideoSourceMac(WTFMove(deviceID), WTFMove(name), WTFMove(salt), WTFMove(pageIdentifier))); }
 
-    virtual ~MockRealtimeVideoSourceMac();
+    ~MockRealtimeVideoSourceMac();
 
 private:
-    friend class MockRealtimeVideoSource;
     MockRealtimeVideoSourceMac(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&, std::optional<PageIdentifier>);
 
     PlatformLayer* platformLayer() const;
@@ -61,7 +61,6 @@ private:
 
     std::unique_ptr<ImageTransferSessionVT> m_imageTransferSession;
     IntSize m_presetSize;
-    Ref<WorkQueue> m_workQueue;
     size_t m_pixelGenerationFailureCount { 0 };
 };
 

--- a/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm
@@ -62,7 +62,7 @@ CaptureSourceOrError MockRealtimeVideoSource::create(String&& deviceID, AtomStri
         return CaptureSourceOrError({ "No mock camera device"_s , MediaAccessDenialReason::PermissionDenied });
 #endif
 
-    Ref<RealtimeMediaSource> source = adoptRef(*new MockRealtimeVideoSourceMac(WTFMove(deviceID), WTFMove(name), WTFMove(hashSalts), pageIdentifier));
+    Ref<RealtimeMediaSource> source = MockRealtimeVideoSourceMac::create(WTFMove(deviceID), WTFMove(name), WTFMove(hashSalts), pageIdentifier);
     if (constraints) {
         if (auto error = source->applyConstraints(*constraints))
             return CaptureSourceOrError(CaptureSourceError { error->invalidConstraint });
@@ -78,7 +78,6 @@ Ref<MockRealtimeVideoSource> MockRealtimeVideoSourceMac::createForMockDisplayCap
 
 MockRealtimeVideoSourceMac::MockRealtimeVideoSourceMac(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&& hashSalts, std::optional<PageIdentifier> pageIdentifier)
     : MockRealtimeVideoSource(WTFMove(deviceID), WTFMove(name), WTFMove(hashSalts), pageIdentifier)
-    , m_workQueue(WorkQueue::create("MockRealtimeVideoSource Render Queue"_s, WorkQueue::QOS::UserInteractive))
 {
 }
 
@@ -86,6 +85,8 @@ MockRealtimeVideoSourceMac::~MockRealtimeVideoSourceMac() = default;
 
 void MockRealtimeVideoSourceMac::updateSampleBuffer()
 {
+    ASSERT(!isMainThread());
+
     RefPtr imageBuffer = this->imageBufferInternal();
     if (!imageBuffer)
         return;
@@ -103,18 +104,18 @@ void MockRealtimeVideoSourceMac::updateSampleBuffer()
     auto videoFrame = m_imageTransferSession->createVideoFrame(platformImage.get(), presentationTime, size(), videoFrameRotation());
     if (!videoFrame) {
         static const size_t MaxPixelGenerationFailureCount = 150;
-        if (++m_pixelGenerationFailureCount > MaxPixelGenerationFailureCount)
-            captureFailed();
+        if (++m_pixelGenerationFailureCount > MaxPixelGenerationFailureCount) {
+            callOnMainThread([protectedThis = Ref { *this }] {
+                protectedThis->captureFailed();
+            });
+        }
         return;
     }
 
     m_pixelGenerationFailureCount = 0;
-    auto captureTime = MonotonicTime::now().secondsSinceEpoch();
-    m_workQueue->dispatch([this, protectedThis = Ref { *this }, videoFrame = WTFMove(videoFrame), captureTime]() mutable {
-        VideoFrameTimeMetadata metadata;
-        metadata.captureTime = captureTime;
-        dispatchVideoFrameToObservers(*videoFrame, metadata);
-    });
+    VideoFrameTimeMetadata metadata;
+    metadata.captureTime = MonotonicTime::now().secondsSinceEpoch();
+    dispatchVideoFrameToObservers(*videoFrame, metadata);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 1a1e6be08dd99345d9f57e16198282195a6527d5
<pre>
MockRealtimeVideoSourceMac should call captureFailed on main thread
<a href="https://rdar.apple.com/140649652">rdar://140649652</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=283788">https://bugs.webkit.org/show_bug.cgi?id=283788</a>

Reviewed by Philippe Normand.

Hop to main thread before calling captureFailed.
We also remove MockRealtimeVideoSourceMac work queue since there is a run loop in MockRealtimeVideoSource that does the work of generating frames.
We do a small clean-up on MockRealtimeVideoSourceMac as well.

* Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.h:
* Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm:
(WebCore::MockRealtimeVideoSource::create):
(WebCore::MockRealtimeVideoSourceMac::MockRealtimeVideoSourceMac):
(WebCore::MockRealtimeVideoSourceMac::updateSampleBuffer):

Canonical link: <a href="https://commits.webkit.org/287148@main">https://commits.webkit.org/287148@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc9d2ce2631100785b1de96266d5caf09abe4814

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83171 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29775 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80643 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66706 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5836 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61493 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19409 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81577 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69575 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41805 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48850 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25302 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28112 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69949 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84537 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5875 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4014 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69719 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6036 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/67484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68973 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17190 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12992 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11410 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5822 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/10213 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5810 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9244 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7597 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->