### PR TITLE
[scroll-animations] account for start and end delays for progress-based animations

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7360,7 +7360,6 @@ webkit.org/b/283107 imported/w3c/web-platform-tests/scroll-animations/scroll-tim
 # webkit.org/b/263871 [scroll-animations] some WPT tests are failures or flaky failures
 imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none.html [ Pass Failure ]
 imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic.html [ Pass Failure ]
-imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming.html [ Pass Failure ]
 imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-root-source.html [ Pass Failure ]
 
 webkit.org/b/282373 imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative.html [ Pass Failure ]
@@ -7374,7 +7373,6 @@ imported/w3c/web-platform-tests/scroll-animations/css/printing/scroll-timeline-d
 imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-default-writing-mode-rl.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-transform.html [ Pass ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/layout-changes-on-percentage-based-timeline.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/progress-based-effect-delay.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline-cancel-one.html [ Pass ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline.html [ Pass ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/view-timelines/range-boundary.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-ignored.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-ignored.tentative-expected.txt
@@ -2,6 +2,6 @@
 FAIL Changing animation-timeline changes the timeline (sanity check) assert_equals: expected "140px" but got "0px"
 FAIL animation-timeline ignored after setting timeline with JS (ScrollTimeline from JS) assert_equals: expected "180px" but got "0px"
 FAIL animation-timeline ignored after setting timeline with JS (ScrollTimeline from CSS) assert_equals: expected "140px" but got "0px"
-FAIL animation-timeline ignored after setting timeline with JS (document timeline) assert_equals: expected "120px" but got "100.001999px"
+PASS animation-timeline ignored after setting timeline with JS (document timeline)
 FAIL animation-timeline ignored after setting timeline with JS (null) assert_equals: expected "120px" but got "0px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/progress-based-animation-animation-longhand-properties.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/progress-based-animation-animation-longhand-properties.tentative-expected.txt
@@ -1,6 +1,6 @@
 
 PASS animation-duration
-FAIL animation-duration: 0s assert_equals: expected "100px" but got "25px"
+PASS animation-duration: 0s
 PASS animation-iteration-count
 PASS animation-iteration-count: 0
 PASS animation-iteration-count: infinite
@@ -8,7 +8,7 @@ PASS animation-direction: normal
 PASS animation-direction: reverse
 FAIL animation-direction: alternate assert_equals: expected "80px" but got "79.999992px"
 FAIL animation-direction: alternate-reverse assert_equals: expected "20px" but got "20.000008px"
-FAIL animation-delay with a positive value assert_equals: expected "0px" but got "50px"
-FAIL animation-delay with a negative value assert_equals: expected "60px" but got "20px"
-FAIL animation-fill-mode assert_equals: expected "none" but got "25px"
+PASS animation-delay with a positive value
+PASS animation-delay with a negative value
+PASS animation-fill-mode
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming-expected.txt
@@ -1,9 +1,9 @@
 
 PASS Allows setting the delay to a positive number
-FAIL Allows setting the delay to a negative number assert_approx_equals: values do not match for "getComputedTiming().endTime after set delay -100" expected 0 +/- 0.125 but got 100
-FAIL Allows setting the delay of an animation in progress: positive delay that causes the animation to be no longer in-effect assert_equals: expected (object) null but got (number) 0
-FAIL Allows setting the delay of an animation in progress: negative delay that seeks into the active interval assert_equals: expected 0.5 but got 0
-FAIL Allows setting the delay of an animation in progress: large negative delay that causes the animation to be finished assert_equals: expected 1 but got 0
+PASS Allows setting the delay to a negative number
+PASS Allows setting the delay of an animation in progress: positive delay that causes the animation to be no longer in-effect
+PASS Allows setting the delay of an animation in progress: negative delay that seeks into the active interval
+PASS Allows setting the delay of an animation in progress: large negative delay that causes the animation to be finished
 PASS Throws when setting invalid delay value: NaN
 PASS Throws when setting invalid delay value: Infinity
 PASS Throws when setting invalid delay value: -Infinity
@@ -26,10 +26,10 @@ PASS Allows setting iterations to a double value
 FAIL Throws when setting iterations to Infinity assert_throws_js: test function "() => {
     anim.effect.updateTiming({ iterations: Infinity });
   }" did not throw
-FAIL Allows setting the iterations of an animation in progress assert_equals: 'actual' unit type must be 'percent' for "duration when animation is finished" expected (string) "percent" but got (undefined) undefined
-FAIL Allows setting the iterations of an animation in progress with duration "auto" assert_equals: 'actual' unit type must be 'percent' for "duration when animation is finished" expected (string) "percent" but got (undefined) undefined
-FAIL Allows setting the duration to 123.45 assert_approx_equals: Updates specified duration expected a number but got a "string"
-FAIL Allows setting the duration to auto assert_equals: 'actual' unit type must be 'percent' for "Updates computed duration" expected (string) "percent" but got (undefined) undefined
+PASS Allows setting the iterations of an animation in progress
+FAIL Allows setting the iterations of an animation in progress with duration "auto" assert_equals: progress after adding an iteration expected 1 but got 0
+PASS Allows setting the duration to 123.45
+PASS Allows setting the duration to auto
 PASS Throws when setting invalid duration: -1
 PASS Throws when setting invalid duration: NaN
 FAIL Throws when setting invalid duration: Infinity assert_throws_js: function "() => {
@@ -40,7 +40,7 @@ PASS Throws when setting invalid duration: -Infinity
 PASS Throws when setting invalid duration: "abc"
 PASS Throws when setting invalid duration: "100"
 PASS Allows setting the duration of an animation in progress
-FAIL Allows setting the duration of an animation in progress such that the the start and current time do not change assert_equals: 'actual' unit type must be 'percent' for "Initial duration should be as set on KeyframeEffect" expected (string) "percent" but got (undefined) undefined
+PASS Allows setting the duration of an animation in progress such that the the start and current time do not change
 PASS Allows setting the direction to each of the possible keywords
 PASS Allows setting the direction of an animation in progress from 'normal' to 'reverse'
 PASS Allows setting the direction of an animation in progress from 'normal' to 'reverse' while at start of active interval

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/intrinsic-iteration-duration.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/intrinsic-iteration-duration.tentative-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL Computed duration in percent even when specified in ms assert_equals: 'actual' unit type must be 'percent' for "undefined" expected (string) "percent" but got (undefined) undefined
-FAIL Time-based duration normalized to fill animation range. assert_equals: 'actual' unit type must be 'percent' for "undefined" expected (string) "percent" but got (undefined) undefined
-FAIL Time-based duration normalized to preserve proportional delays. assert_equals: 'actual' unit type must be 'percent' for "undefined" expected (string) "percent" but got (undefined) undefined
-FAIL Intrinsic iteration duration fills timeline. assert_equals: 'actual' unit type must be 'percent' for "undefined" expected (string) "percent" but got (undefined) undefined
-FAIL Intrinsic iteration duration accounts for animation range. assert_equals: 'actual' unit type must be 'percent' for "undefined" expected (string) "percent" but got (undefined) undefined
-FAIL Intrinsic iteration duration accounts for number of iterations assert_equals: 'actual' unit type must be 'percent' for "undefined" expected (string) "percent" but got (undefined) undefined
+PASS Computed duration in percent even when specified in ms
+FAIL Time-based duration normalized to fill animation range. assert_approx_equals: values do not match for "undefined" expected 60 +/- 0.125 but got 100
+PASS Time-based duration normalized to preserve proportional delays.
+PASS Intrinsic iteration duration fills timeline.
+FAIL Intrinsic iteration duration accounts for animation range. assert_approx_equals: values do not match for "undefined" expected 60 +/- 0.125 but got 100
+PASS Intrinsic iteration duration accounts for number of iterations
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-fill-modes.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-fill-modes.tentative-expected.txt
@@ -1,28 +1,28 @@
 
 PASS Scroll based animation effect fill mode should return 'auto' for getTiming() and should return 'none' for getComputedTiming().
-FAIL Applied effect value before start delay with fill: none assert_equals: animation effect applied property value expected 1 but got 0.34
-FAIL Applied effect value at start delay with fill: none assert_equals: animation effect applied property value expected 0.3 but got 0.4
+PASS Applied effect value before start delay with fill: none
+PASS Applied effect value at start delay with fill: none
 PASS Applied effect value at midpoint with fill: none
-FAIL Applied effect value at effect end with fill: none assert_equals: animation effect applied property value expected 1 but got 0.6
-FAIL Applied effect value after effect end with fill: none assert_equals: animation effect applied property value expected 1 but got 0.66
-FAIL Applied effect value before start delay with fill: backwards assert_equals: animation effect applied property value expected 0.3 but got 0.34
-FAIL Applied effect value at start delay with fill: backwards assert_equals: animation effect applied property value expected 0.3 but got 0.4
+PASS Applied effect value at effect end with fill: none
+PASS Applied effect value after effect end with fill: none
+PASS Applied effect value before start delay with fill: backwards
+PASS Applied effect value at start delay with fill: backwards
 PASS Applied effect value at midpoint with fill: backwards
-FAIL Applied effect value at effect end with fill: backwards assert_equals: animation effect applied property value expected 1 but got 0.6
-FAIL Applied effect value after effect end with fill: backwards assert_equals: animation effect applied property value expected 1 but got 0.66
-FAIL Applied effect value before timeline start with fill: forwards assert_equals: animation effect applied property value expected 1 but got 0.34
-FAIL Applied effect value at timeline start with fill: forwards assert_equals: animation effect applied property value expected 0.3 but got 0.4
+PASS Applied effect value at effect end with fill: backwards
+PASS Applied effect value after effect end with fill: backwards
+PASS Applied effect value before timeline start with fill: forwards
+PASS Applied effect value at timeline start with fill: forwards
 PASS Applied effect value in timeline range with fill: forwards
-FAIL Applied effect value at timeline end with fill: forwards assert_equals: animation effect applied property value expected 0.7 but got 0.6
-FAIL Applied effect value after timeline end with fill: forwards assert_equals: animation effect applied property value expected 0.7 but got 0.66
-FAIL Applied effect value before timeline start with fill: both assert_equals: animation effect applied property value expected 0.3 but got 0.34
-FAIL Applied effect value at timeline start with fill: both assert_equals: animation effect applied property value expected 0.3 but got 0.4
+PASS Applied effect value at timeline end with fill: forwards
+PASS Applied effect value after timeline end with fill: forwards
+PASS Applied effect value before timeline start with fill: both
+PASS Applied effect value at timeline start with fill: both
 PASS Applied effect value in timeline range with fill: both
-FAIL Applied effect value at timeline end with fill: both assert_equals: animation effect applied property value expected 0.7 but got 0.6
-FAIL Applied effect value after timeline end with fill: both assert_equals: animation effect applied property value expected 0.7 but got 0.66
-FAIL Applied effect value before timeline start with fill: auto assert_equals: animation effect applied property value expected 1 but got 0.34
-FAIL Applied effect value at timeline start with fill: auto assert_equals: animation effect applied property value expected 0.3 but got 0.4
+PASS Applied effect value at timeline end with fill: both
+PASS Applied effect value after timeline end with fill: both
+PASS Applied effect value before timeline start with fill: auto
+PASS Applied effect value at timeline start with fill: auto
 PASS Applied effect value in timeline range with fill: auto
-FAIL Applied effect value at timeline end with fill: auto assert_equals: animation effect applied property value expected 1 but got 0.6
-FAIL Applied effect value after timeline end with fill: auto assert_equals: animation effect applied property value expected 1 but got 0.66
+PASS Applied effect value at timeline end with fill: auto
+PASS Applied effect value after timeline end with fill: auto
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-phases.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-phases.tentative-expected.txt
@@ -2,30 +2,30 @@
 PASS Current times and effect phase at start when delay = 0 and endDelay = 0 |
 PASS Current times and effect phase in active range when delay = 0 and endDelay = 0 |
 PASS Current times and effect phase at effect end time when delay = 0 and endDelay = 0 |
-FAIL Current times and effect phase at timeline start when delay = 500 and endDelay = 0 | assert_equals: animation effect progress expected (object) null but got (number) 0
-FAIL Current times and effect phase before start delay when delay = 500 and endDelay = 0 | assert_equals: animation effect progress expected (object) null but got (number) 0.25
-FAIL Current times and effect phase at start delay when delay = 500 and endDelay = 0 | assert_approx_equals: animation effect progress expected 0 +/- 0.001 but got 0.5
-FAIL Current times and effect phase in active range when delay = 500 and endDelay = 0 | assert_approx_equals: animation effect progress expected 0.5 +/- 0.001 but got 0.75
+PASS Current times and effect phase at timeline start when delay = 500 and endDelay = 0 |
+PASS Current times and effect phase before start delay when delay = 500 and endDelay = 0 |
+PASS Current times and effect phase at start delay when delay = 500 and endDelay = 0 |
+PASS Current times and effect phase in active range when delay = 500 and endDelay = 0 |
 PASS Current times and effect phase at effect end time when delay = 500 and endDelay = 0 |
 PASS Current times and effect phase at timeline start when delay = 0 and endDelay = 500 |
-FAIL Current times and effect phase in active range when delay = 0 and endDelay = 500 | assert_approx_equals: animation effect progress expected 0.5 +/- 0.001 but got 0.25
-FAIL Current times and effect phase at effect end time when delay = 0 and endDelay = 500 | assert_equals: animation effect progress expected (object) null but got (number) 0.5
-FAIL Current times and effect phase after effect end time when delay = 0 and endDelay = 500 | assert_equals: animation effect progress expected (object) null but got (number) 0.75
-FAIL Current times and effect phase at timeline boundary when delay = 0 and endDelay = 500 | assert_equals: animation effect progress expected (object) null but got (number) 1
-FAIL Current times and effect phase at timeline start when delay = 250 and endDelay = 250 | assert_equals: animation effect progress expected (object) null but got (number) 0
-FAIL Current times and effect phase before start delay when delay = 250 and endDelay = 250 | assert_equals: animation effect progress expected (object) null but got (number) 0.1
-FAIL Current times and effect phase at start delay when delay = 250 and endDelay = 250 | assert_approx_equals: animation effect progress expected 0 +/- 0.001 but got 0.25
+PASS Current times and effect phase in active range when delay = 0 and endDelay = 500 |
+PASS Current times and effect phase at effect end time when delay = 0 and endDelay = 500 |
+PASS Current times and effect phase after effect end time when delay = 0 and endDelay = 500 |
+PASS Current times and effect phase at timeline boundary when delay = 0 and endDelay = 500 |
+PASS Current times and effect phase at timeline start when delay = 250 and endDelay = 250 |
+PASS Current times and effect phase before start delay when delay = 250 and endDelay = 250 |
+PASS Current times and effect phase at start delay when delay = 250 and endDelay = 250 |
 PASS Current times and effect phase in active range when delay = 250 and endDelay = 250 |
-FAIL Current times and effect phase at effect end time when delay = 250 and endDelay = 250 | assert_equals: animation effect progress expected (object) null but got (number) 0.75
-FAIL Current times and effect phase after effect end time when delay = 250 and endDelay = 250 | assert_equals: animation effect progress expected (object) null but got (number) 0.9
-FAIL Current times and effect phase at timeline boundary when delay = 250 and endDelay = 250 | assert_equals: animation effect progress expected (object) null but got (number) 1
-FAIL Current times and effect phase at timeline start when delay = -125 and endDelay = -125 | assert_approx_equals: animation effect progress expected 0.25 +/- 0.001 but got 0
+PASS Current times and effect phase at effect end time when delay = 250 and endDelay = 250 |
+PASS Current times and effect phase after effect end time when delay = 250 and endDelay = 250 |
+PASS Current times and effect phase at timeline boundary when delay = 250 and endDelay = 250 |
+PASS Current times and effect phase at timeline start when delay = -125 and endDelay = -125 |
 PASS Current times and effect phase in active range when delay = -125 and endDelay = -125 |
-FAIL Current times and effect phase at timeline end when delay = -125 and endDelay = -125 | assert_approx_equals: animation effect progress expected 0.75 +/- 0.001 but got 1
-FAIL Playback rate affects whether active phase boundary is inclusive. assert_equals: Animation effect is in before phase when current time is 0% (progress is null with 'none' fill mode) expected (object) null but got (number) 0
-FAIL Verify that (play -> pause -> play) doesn't change phase/progress. assert_equals: expected (object) null but got (number) 0
-FAIL Pause in before phase, scroll timeline into active phase, animation should remain in the before phase assert_equals: expected (object) null but got (number) 0
-FAIL Pause in before phase, set animation current time to be in active range, animation should become active. Scrolling should have no effect. assert_equals: expected (object) null but got (number) 0
+PASS Current times and effect phase at timeline end when delay = -125 and endDelay = -125 |
+FAIL Playback rate affects whether active phase boundary is inclusive. assert_equals: Animation effect is in after phase when current time is 50% (progress is null with 'none' fill mode) expected (object) null but got (number) 0.2500000000000001
+PASS Verify that (play -> pause -> play) doesn't change phase/progress.
+PASS Pause in before phase, scroll timeline into active phase, animation should remain in the before phase
+PASS Pause in before phase, set animation current time to be in active range, animation should become active. Scrolling should have no effect.
 PASS Make scroller inactive, then set current time to an in range time
 PASS Animation effect is still applied after pausing and making timeline inactive.
 PASS Make timeline inactive, force style update then pause the animation. No crashing indicates test success.

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative-expected.txt
@@ -13,6 +13,6 @@ FAIL Switching from a null timeline to a scroll timeline on an animation with a 
 FAIL Switching from one scroll timeline to another updates currentTime promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
 PASS Switching from a document timeline to a scroll timeline updates currentTime when unpaused via CSS.
 PASS Switching from a document timeline to a scroll timeline and updating currentTime preserves the progress while paused.
-FAIL Switching from a document timeline to a scroll timeline on an infinite duration animation. assert_equals: 'actual' unit type must be 'percent' for "undefined" expected (string) "percent" but got (undefined) undefined
+FAIL Switching from a document timeline to a scroll timeline on an infinite duration animation. assert_approx_equals: values do not match for "undefined" expected 100 +/- 0.125 but got 200
 FAIL Changing from a scroll-timeline to a view-timeline updates start time. assert_approx_equals: Timeline's currentTime aligns with the scroll position even when paused expected a number but got a "object"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/zero-intrinsic-iteration-duration.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/zero-intrinsic-iteration-duration.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Intrinsic iteration duration is non-negative assert_equals: 'actual' unit type must be 'percent' for "Default duration is 100%" expected (string) "percent" but got (undefined) undefined
+FAIL Intrinsic iteration duration is non-negative assert_approx_equals: values do not match for "Duration is zero when boundaries coincide" expected 0 +/- 0.125 but got 100
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-overallProgress.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-overallProgress.tentative-expected.txt
@@ -1,6 +1,6 @@
 
 PASS animation.overallProgress reflects the progress of a scroll animation as a number between 0 and 1
-FAIL animation.overallProgress reflects the overall progress of a scroll animation with multiple iterations. assert_equals: 'actual' unit type must be 'percent' for "undefined" expected (string) "percent" but got (undefined) undefined
+PASS animation.overallProgress reflects the overall progress of a scroll animation with multiple iterations.
 FAIL animation.overallProgress reflects the overall progress of a scroll animation that uses a view-timeline. assert_approx_equals: values do not match for "currentTime reflects progress as a percentage" expected 10.666666666666671 +/- 0.125 but got 100
 FAIL overallProgresss of a view-timeline is bounded between 0 and 1. assert_less_than: currentTime is negative expected a number less than 0 but got 100
 

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1002,6 +1002,7 @@ webkit.org/b/116961 perf/show-hide-table-rows.html [ Failure Pass ]
 
 webkit.org/b/263872 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-animatable-interface.html [ ImageOnlyFailure ]
 webkit.org/b/263872 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-display-none.html [ ImageOnlyFailure ]
+webkit.org/b/263872 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/progress-based-effect-delay.tentative.html [ ImageOnlyFailure ]
 
 # These tests started to time out (or time out more often) since the FTL merge
 webkit.org/b/119253 [ Debug ] js/dfg-osr-entry-hoisted-clobbered-structure-check.html [ Timeout Pass ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7189,6 +7189,7 @@ fast/overflow/infiniteRecursion.html [ Failure Pass ]
 tables/mozilla/bugs/bug2479-2.html [ Failure Pass ]
 
 webkit.org/b/263872 imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-default-iframe.html [ ImageOnlyFailure ]
+webkit.org/b/263872 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/progress-based-effect-delay.tentative.html [ ImageOnlyFailure ]
 
 webkit.org/b/283366 imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-001.html [ Pass Failure ]
 webkit.org/b/283366 imported/w3c/web-platform-tests/scroll-animations/view-timelines/svg-graphics-element-002.html [ Pass Failure ]

--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -27,6 +27,7 @@
 #include "AnimationEffect.h"
 
 #include "CSSAnimation.h"
+#include "CSSNumericFactory.h"
 #include "CSSNumericValue.h"
 #include "CSSPropertyParserConsumer+TimingFunction.h"
 #include "CSSTimingFunctionValue.h"
@@ -56,39 +57,21 @@ void AnimationEffect::setAnimation(WebAnimation* animation)
         animation->updateRelevance();
 }
 
-enum class IsComputed : bool { No, Yes };
-static std::variant<double, RefPtr<CSSNumericValue>, String> durationAPIValue(const WebAnimationTime& duration, IsComputed isComputed)
-{
-    if (duration.percentage())
-        return autoAtom();
-
-    ASSERT(duration.time());
-    if (duration.isZero()) {
-        if (isComputed == IsComputed::Yes)
-            return 0.0;
-        return autoAtom();
-    }
-
-    CSSNumberish numberishDuration { duration };
-    if (auto* doubleValue = std::get_if<double>(&numberishDuration))
-        return *doubleValue;
-
-    ASSERT(std::holds_alternative<RefPtr<CSSNumericValue>>(numberishDuration));
-    return std::get<RefPtr<CSSNumericValue>>(numberishDuration);
-}
-
 EffectTiming AnimationEffect::getBindingsTiming() const
 {
     if (auto* styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation()))
         styleOriginatedAnimation->flushPendingStyleChanges();
 
     EffectTiming timing;
-    timing.delay = secondsToWebAnimationsAPITime(m_timing.delay);
-    timing.endDelay = secondsToWebAnimationsAPITime(m_timing.endDelay);
+    timing.delay = secondsToWebAnimationsAPITime(m_timing.specifiedStartDelay);
+    timing.endDelay = secondsToWebAnimationsAPITime(m_timing.specifiedEndDelay);
     timing.fill = m_timing.fill;
     timing.iterationStart = m_timing.iterationStart;
     timing.iterations = m_timing.iterations;
-    timing.duration = durationAPIValue(m_timing.iterationDuration, IsComputed::No);
+    if (auto specifiedDuration = m_timing.specifiedIterationDuration)
+        timing.duration = secondsToWebAnimationsAPITime(*specifiedDuration);
+    else
+        timing.duration = autoAtom();
     timing.direction = m_timing.direction;
     timing.easing = m_timing.timingFunction->cssText();
     return timing;
@@ -110,30 +93,46 @@ AnimationEffectTiming::ResolutionData AnimationEffect::resolutionData(std::optio
     };
 }
 
-BasicEffectTiming AnimationEffect::getBasicTiming(std::optional<WebAnimationTime> startTime) const
+BasicEffectTiming AnimationEffect::getBasicTiming(std::optional<WebAnimationTime> startTime)
 {
+    updateComputedTimingPropertiesIfNeeded();
     return m_timing.getBasicTiming(resolutionData(startTime));
 }
 
-ComputedEffectTiming AnimationEffect::getBindingsComputedTiming() const
+ComputedEffectTiming AnimationEffect::getBindingsComputedTiming()
 {
     if (auto* styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation()))
         styleOriginatedAnimation->flushPendingStyleChanges();
     return getComputedTiming();
 }
 
-ComputedEffectTiming AnimationEffect::getComputedTiming(std::optional<WebAnimationTime> startTime) const
+ComputedEffectTiming AnimationEffect::getComputedTiming(std::optional<WebAnimationTime> startTime)
 {
+    updateComputedTimingPropertiesIfNeeded();
+
     auto data = resolutionData(startTime);
     auto resolvedTiming = m_timing.resolve(data);
 
+    // https://drafts.csswg.org/web-animations-2/#dom-animationeffect-getcomputedtiming
+    // The description of the duration attribute of the object needs to indicate that if timing.duration
+    // is the string auto, this attribute will return the current calculated value of the intrinsic iteration
+    // duration, which may be a expressed as a double representing the duration in milliseconds or a percentage
+    // when the effect is associated with a progress-based timeline.
+    auto computedDuration = [&]() -> DoubleOrCSSNumericValueOrString {
+        auto& duration = m_timing.specifiedIterationDuration ? m_timing.iterationDuration : m_timing.intrinsicIterationDuration;
+        if (auto percent = duration.percentage())
+            return CSSNumericFactory::percent(*percent);
+        ASSERT(duration.time());
+        return secondsToWebAnimationsAPITime(*duration.time());
+    }();
+
     ComputedEffectTiming computedTiming;
-    computedTiming.delay = secondsToWebAnimationsAPITime(m_timing.delay);
-    computedTiming.endDelay = secondsToWebAnimationsAPITime(m_timing.endDelay);
+    computedTiming.delay = secondsToWebAnimationsAPITime(m_timing.specifiedStartDelay);
+    computedTiming.endDelay = secondsToWebAnimationsAPITime(m_timing.specifiedEndDelay);
     computedTiming.fill = m_timing.fill == FillMode::Auto ? FillMode::None : m_timing.fill;
     computedTiming.iterationStart = m_timing.iterationStart;
     computedTiming.iterations = m_timing.iterations;
-    computedTiming.duration = durationAPIValue(m_timing.intrinsicIterationDuration, IsComputed::Yes);
+    computedTiming.duration = computedDuration;
     computedTiming.direction = m_timing.direction;
     computedTiming.easing = m_timing.timingFunction->cssText();
     computedTiming.endTime = m_timing.endTime;
@@ -197,7 +196,7 @@ ExceptionOr<void> AnimationEffect::updateTiming(Document& document, std::optiona
         auto timingFunctionResult = CSSPropertyParserHelpers::parseTimingFunction(timing->easing, parsingContext);
         if (!timingFunctionResult)
             return Exception { ExceptionCode::TypeError };
-        m_timing.timingFunction = WTFMove(timingFunctionResult);
+        setTimingFunction(WTFMove(timingFunctionResult));
     }
 
     // 5. Assign each member present in input to the corresponding timing property of effect as follows:
@@ -211,64 +210,35 @@ ExceptionOr<void> AnimationEffect::updateTiming(Document& document, std::optiona
     //    direction → playback direction
     //    easing → timing function
 
-    if (timing->delay)
-        m_timing.delay = Seconds::fromMilliseconds(timing->delay.value());
+    if (auto delay = timing->delay)
+        setDelay(Seconds::fromMilliseconds(*delay));
 
-    if (timing->endDelay)
-        m_timing.endDelay = Seconds::fromMilliseconds(timing->endDelay.value());
+    if (auto endDelay = timing->endDelay)
+        setEndDelay(Seconds::fromMilliseconds(*endDelay));
 
-    if (timing->fill)
-        m_timing.fill = timing->fill.value();
+    if (auto fill = timing->fill)
+        setFill(*fill);
 
-    if (timing->iterationStart)
-        m_timing.iterationStart = timing->iterationStart.value();
+    if (auto iterationStart = timing->iterationStart)
+        setIterationStart(*iterationStart);
 
-    if (timing->iterations)
-        m_timing.iterations = timing->iterations.value();
+    if (auto iterations = timing->iterations)
+        setIterations(*iterations);
 
     if (auto duration = timing->duration) {
-        m_hasAutoDuration = std::holds_alternative<String>(*duration);
-        normalizeSpecifiedTiming(*duration);
+        if (auto* durationDouble = std::get_if<double>(&*duration))
+            setIterationDuration(Seconds::fromMilliseconds(*durationDouble));
+        else
+            setIterationDuration(std::nullopt);
     }
 
-    if (timing->direction)
-        m_timing.direction = timing->direction.value();
-
-    updateStaticTimingProperties();
+    if (auto direction = timing->direction)
+        setDirection(*direction);
 
     if (m_animation)
         m_animation->effectTimingDidChange();
 
     return { };
-}
-
-void AnimationEffect::normalizeSpecifiedTiming(std::variant<double, String> duration)
-{
-    // https://drafts.csswg.org/web-animations-2/#normalize-specified-timing
-    m_timing.iterationDuration = [&]() {
-        if (m_animation) {
-            if (RefPtr timeline = m_animation->timeline()) {
-                if (timeline->duration())
-                    return WebAnimationTime::fromPercentage(100);
-            }
-        }
-        if (auto* doubleValue = std::get_if<double>(&duration))
-            return WebAnimationTime::fromMilliseconds(*doubleValue);
-        return WebAnimationTime::fromMilliseconds(0);
-    }();
-}
-
-void AnimationEffect::updateStaticTimingProperties()
-{
-    m_timing.updateComputedProperties([&]() {
-        if (RefPtr animation = m_animation.get()) {
-            if (RefPtr timeline = animation->timeline()) {
-                if (timeline->isProgressBased())
-                    return AnimationEffectTiming::IsProgressBased::Yes;
-            }
-        }
-        return AnimationEffectTiming::IsProgressBased::No;
-    }());
 }
 
 ExceptionOr<void> AnimationEffect::setIterationStart(double iterationStart)
@@ -299,24 +269,39 @@ ExceptionOr<void> AnimationEffect::setIterations(double iterations)
         return { };
         
     m_timing.iterations = iterations;
+    m_timingDidMutate = true;
 
     return { };
 }
 
+WebAnimationTime AnimationEffect::delay()
+{
+    updateComputedTimingPropertiesIfNeeded();
+    return m_timing.startDelay;
+}
+
 void AnimationEffect::setDelay(const Seconds& delay)
 {
-    if (m_timing.delay == delay)
+    if (m_timing.specifiedStartDelay == delay)
         return;
 
-    m_timing.delay = delay;
+    m_timing.specifiedStartDelay = delay;
+    m_timingDidMutate = true;
+}
+
+WebAnimationTime AnimationEffect::endDelay()
+{
+    updateComputedTimingPropertiesIfNeeded();
+    return m_timing.endDelay;
 }
 
 void AnimationEffect::setEndDelay(const Seconds& endDelay)
 {
-    if (m_timing.endDelay == endDelay)
+    if (m_timing.specifiedEndDelay == endDelay)
         return;
 
-    m_timing.endDelay = endDelay;
+    m_timing.specifiedEndDelay = endDelay;
+    m_timingDidMutate = true;
 }
 
 void AnimationEffect::setFill(FillMode fill)
@@ -327,12 +312,19 @@ void AnimationEffect::setFill(FillMode fill)
     m_timing.fill = fill;
 }
 
-void AnimationEffect::setIterationDuration(const Seconds& duration)
+WebAnimationTime AnimationEffect::iterationDuration()
 {
-    if (m_timing.iterationDuration == duration)
+    updateComputedTimingPropertiesIfNeeded();
+    return m_timing.iterationDuration;
+}
+
+void AnimationEffect::setIterationDuration(const std::optional<Seconds>& duration)
+{
+    if (m_timing.specifiedIterationDuration == duration)
         return;
 
-    m_timing.iterationDuration = duration;
+    m_timing.specifiedIterationDuration = duration;
+    m_timingDidMutate = true;
 }
 
 void AnimationEffect::setDirection(PlaybackDirection direction)
@@ -348,6 +340,18 @@ void AnimationEffect::setTimingFunction(const RefPtr<TimingFunction>& timingFunc
     m_timing.timingFunction = timingFunction;
 }
 
+WebAnimationTime AnimationEffect::activeDuration()
+{
+    updateComputedTimingPropertiesIfNeeded();
+    return m_timing.activeDuration;
+}
+
+WebAnimationTime AnimationEffect::endTime()
+{
+    updateComputedTimingPropertiesIfNeeded();
+    return m_timing.endTime;
+}
+
 std::optional<double> AnimationEffect::progressUntilNextStep(double iterationProgress) const
 {
     RefPtr stepsTimingFunction = dynamicDowncast<StepsTimingFunction>(m_timing.timingFunction);
@@ -359,7 +363,7 @@ std::optional<double> AnimationEffect::progressUntilNextStep(double iterationPro
     return nextStepProgress - iterationProgress;
 }
 
-Seconds AnimationEffect::timeToNextTick(const BasicEffectTiming& timing) const
+Seconds AnimationEffect::timeToNextTick(const BasicEffectTiming& timing)
 {
     switch (timing.phase) {
     case AnimationEffectPhase::Before:
@@ -391,16 +395,36 @@ Seconds AnimationEffect::timeToNextTick(const BasicEffectTiming& timing) const
 
 void AnimationEffect::animationTimelineDidChange(const AnimationTimeline*)
 {
-    if (m_hasAutoDuration) {
-        if (auto percentage = iterationDuration().percentage())
-            normalizeSpecifiedTiming(*percentage);
-        else {
-            ASSERT(iterationDuration().time());
-            normalizeSpecifiedTiming(iterationDuration().time()->seconds());
-        }
-    }
+    m_timingDidMutate = true;
+}
 
-    updateStaticTimingProperties();
+void AnimationEffect::animationPlaybackRateDidChange()
+{
+    m_timingDidMutate = true;
+}
+
+void AnimationEffect::updateComputedTimingPropertiesIfNeeded()
+{
+    if (!m_timingDidMutate)
+        return;
+
+    m_timingDidMutate = false;
+
+    auto timelineDuration = [&] -> std::optional<WebAnimationTime> {
+        if (m_animation) {
+            if (RefPtr timeline = m_animation->timeline())
+                return timeline->duration();
+        }
+        return std::nullopt;
+    }();
+
+    auto playbackRate = [&] {
+        if (m_animation)
+            return m_animation->playbackRate();
+        return 1.0;
+    }();
+
+    m_timing.updateComputedProperties(timelineDuration, playbackRate);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/AnimationEffectTiming.h
+++ b/Source/WebCore/animation/AnimationEffectTiming.h
@@ -52,8 +52,11 @@ struct AnimationEffectTiming {
     PlaybackDirection direction { PlaybackDirection::Normal };
     double iterationStart { 0 };
     double iterations { 1 };
-    Seconds delay { 0_s };
-    Seconds endDelay { 0_s };
+    Seconds specifiedStartDelay { 0_s };
+    Seconds specifiedEndDelay { 0_s };
+    std::optional<Seconds> specifiedIterationDuration;
+    WebAnimationTime startDelay { 0_s };
+    WebAnimationTime endDelay { 0_s };
     WebAnimationTime iterationDuration { 0_s };
     WebAnimationTime intrinsicIterationDuration { 0_s };
     WebAnimationTime activeDuration { 0_s };
@@ -67,8 +70,7 @@ struct AnimationEffectTiming {
         double playbackRate { 0 };
     };
 
-    enum class IsProgressBased : bool { No, Yes };
-    void updateComputedProperties(IsProgressBased);
+    void updateComputedProperties(std::optional<WebAnimationTime> timelineDuration, double playbackRate);
     BasicEffectTiming getBasicTiming(const ResolutionData&) const;
     ResolvedEffectTiming resolve(const ResolutionData&) const;
 };

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -110,8 +110,12 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
     if (!m_overriddenProperties.contains(Property::Delay))
         animationEffect->setDelay(Seconds(animation.delay()));
 
-    if (!m_overriddenProperties.contains(Property::Duration))
-        animationEffect->setIterationDuration(Seconds(animation.duration().value_or(0)));
+    if (!m_overriddenProperties.contains(Property::Duration)) {
+        if (auto duration = animation.duration())
+            animationEffect->setIterationDuration(Seconds(*duration));
+        else
+            animationEffect->setIterationDuration(std::nullopt);
+    }
 
     if (!m_overriddenProperties.contains(Property::CompositeOperation)) {
         if (auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(animationEffect))
@@ -141,7 +145,6 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
     if (!m_overriddenProperties.contains(Property::Range))
         setRange(animation.range());
 
-    animationEffect->updateStaticTimingProperties();
     effectTimingDidChange();
 
     // Synchronize the play state

--- a/Source/WebCore/animation/CSSTransition.cpp
+++ b/Source/WebCore/animation/CSSTransition.cpp
@@ -92,7 +92,6 @@ void CSSTransition::setTimingProperties(Seconds delay, Seconds duration)
     animationEffect->setDelay(delay);
     animationEffect->setIterationDuration(duration);
     animationEffect->setTimingFunction(backingAnimation().timingFunction());
-    animationEffect->updateStaticTimingProperties();
     effectTimingDidChange();
 
     unsuspendEffectInvalidation();

--- a/Source/WebCore/animation/EffectTiming.h
+++ b/Source/WebCore/animation/EffectTiming.h
@@ -35,9 +35,10 @@
 namespace WebCore {
 
 using OptionalDoubleOrString = std::optional<std::variant<double, String>>;
+using DoubleOrCSSNumericValueOrString = std::variant<double, RefPtr<CSSNumericValue>, String>;
 
 struct EffectTiming {
-    std::variant<double, RefPtr<CSSNumericValue>, String> duration { autoAtom() };
+    DoubleOrCSSNumericValueOrString duration { autoAtom() };
     double delay { 0 };
     double endDelay { 0 };
     double iterationStart { 0 };

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -672,14 +672,13 @@ void KeyframeEffect::copyPropertiesFromSource(Ref<KeyframeEffect>&& source)
     m_parsedKeyframes = WTFMove(parsedKeyframes);
 
     setFill(source->fill());
-    setDelay(source->delay());
-    setEndDelay(source->endDelay());
+    setDelay(source->specifiedDelay());
+    setEndDelay(source->specifiedEndDelay());
     setDirection(source->direction());
     setIterations(source->iterations());
     setTimingFunction(source->timingFunction());
     setIterationStart(source->iterationStart());
-    setIterationDuration(source->iterationDuration());
-    updateStaticTimingProperties();
+    setIterationDuration(source->specifiedIterationDuration());
 
     BlendingKeyframes blendingKeyframes(m_keyframesName);
     blendingKeyframes.copyKeyframes(source->m_blendingKeyframes);
@@ -2126,7 +2125,7 @@ void KeyframeEffect::applyPendingAcceleratedActions()
     }
 }
 
-Ref<const Animation> KeyframeEffect::backingAnimationForCompositedRenderer() const
+Ref<const Animation> KeyframeEffect::backingAnimationForCompositedRenderer()
 {
     auto effectAnimation = animation();
 
@@ -2134,7 +2133,7 @@ Ref<const Animation> KeyframeEffect::backingAnimationForCompositedRenderer() con
     // corresponding Animation properties.
     auto animation = Animation::create();
     animation->setDuration(iterationDuration().time()->seconds());
-    animation->setDelay(delay().seconds());
+    animation->setDelay(delay().time()->seconds());
     animation->setIterationCount(iterations());
     animation->setTimingFunction(timingFunction()->clone());
     animation->setPlaybackRate(effectAnimation->playbackRate());
@@ -2400,7 +2399,7 @@ bool KeyframeEffect::ticksContinuouslyWhileActive() const
     return true;
 }
 
-Seconds KeyframeEffect::timeToNextTick(const BasicEffectTiming& timing) const
+Seconds KeyframeEffect::timeToNextTick(const BasicEffectTiming& timing)
 {
     // CSS Animations need to trigger "animationiteration" events even if there is no need to
     // update styles while animating, so if we're dealing with one we must wait until the next iteration.

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -229,7 +229,7 @@ private:
     void setAnimatedPropertiesInStyle(RenderStyle&, const ComputedEffectTiming&);
     const TimingFunction* timingFunctionForKeyframeAtIndex(size_t) const;
     const TimingFunction* timingFunctionForBlendingKeyframe(const BlendingKeyframe&) const;
-    Ref<const Animation> backingAnimationForCompositedRenderer() const;
+    Ref<const Animation> backingAnimationForCompositedRenderer();
     void computedNeedsForcedLayout();
     void computeStackingContextImpact();
     void computeSomeKeyframesUseStepsOrLinearTimingFunctionWithPoints();
@@ -276,7 +276,7 @@ private:
     void animationTimelineDidChange(const AnimationTimeline*) final;
     void animationDidFinish() final;
     void setAnimation(WebAnimation*) final;
-    Seconds timeToNextTick(const BasicEffectTiming&) const final;
+    Seconds timeToNextTick(const BasicEffectTiming&) final;
     bool ticksContinuouslyWhileActive() const final;
     std::optional<double> progressUntilNextStep(double) const final;
     bool preventsAnimationReadiness() const final;

--- a/Source/WebCore/animation/WebAnimationTime.cpp
+++ b/Source/WebCore/animation/WebAnimationTime.cpp
@@ -124,9 +124,19 @@ bool WebAnimationTime::isZero() const
     return !m_value;
 }
 
+bool WebAnimationTime::isNaN() const
+{
+    return std::isnan(m_value);
+}
+
 WebAnimationTime WebAnimationTime::matchingZero() const
 {
     return { m_type, 0 };
+}
+
+WebAnimationTime WebAnimationTime::matchingInfinity() const
+{
+    return { m_type, std::numeric_limits<double>::infinity() };
 }
 
 WebAnimationTime WebAnimationTime::matchingEpsilon() const

--- a/Source/WebCore/animation/WebAnimationTime.h
+++ b/Source/WebCore/animation/WebAnimationTime.h
@@ -47,9 +47,11 @@ public:
     bool isValid() const;
     bool isInfinity() const;
     bool isZero() const;
+    bool isNaN() const;
 
     WebAnimationTime matchingZero() const;
     WebAnimationTime matchingEpsilon() const;
+    WebAnimationTime matchingInfinity() const;
 
     bool approximatelyEqualTo(const WebAnimationTime&) const;
     bool approximatelyLessThan(const WebAnimationTime&) const;
@@ -77,7 +79,7 @@ public:
     WebAnimationTime operator*(double) const;
     WebAnimationTime operator/(double) const;
 
-    operator Seconds() const;
+    WEBCORE_EXPORT operator Seconds() const;
     operator CSSNumberish() const;
 
     void dump(TextStream&) const;

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -203,11 +203,17 @@ static Ref<Inspector::Protocol::Animation::Effect> buildObjectForEffect(Animatio
     auto effectPayload = Inspector::Protocol::Animation::Effect::create()
         .release();
 
-    if (auto startDelay = protocolValueForSeconds(effect.delay()))
-        effectPayload->setStartDelay(startDelay.value());
+    // FIXME: convert this to WebAnimationTime.
+    if (auto delayTime = effect.delay().time()) {
+        if (auto delay = protocolValueForSeconds(*delayTime))
+            effectPayload->setStartDelay(*delay);
+    }
 
-    if (auto endDelay = protocolValueForSeconds(effect.endDelay()))
-        effectPayload->setEndDelay(endDelay.value());
+    // FIXME: convert this to WebAnimationTime.
+    if (auto endDelayTime = effect.endDelay().time()) {
+        if (auto endDelay = protocolValueForSeconds(*endDelayTime))
+            effectPayload->setEndDelay(*endDelay);
+    }
 
     effectPayload->setIterationCount(effect.iterations() == std::numeric_limits<double>::infinity() ? -1 : effect.iterations());
     effectPayload->setIterationStart(effect.iterationStart());

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6536,8 +6536,11 @@ struct WebCore::AnimationEffectTiming {
     WebCore::PlaybackDirection direction;
     double iterationStart;
     double iterations;
-    Seconds delay;
-    Seconds endDelay;
+    [NotSerialized] Seconds specifiedStartDelay;
+    [NotSerialized] Seconds specifiedEndDelay;
+    [NotSerialized] std::optional<Seconds> specifiedIterationDuration;
+    WebCore::WebAnimationTime startDelay;
+    WebCore::WebAnimationTime endDelay;
     WebCore::WebAnimationTime iterationDuration;
     WebCore::WebAnimationTime intrinsicIterationDuration;
     WebCore::WebAnimationTime activeDuration;


### PR DESCRIPTION
#### 086d3e1d9aebb93b28201fdc219a1bafde5c3028
<pre>
[scroll-animations] account for start and end delays for progress-based animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=283790">https://bugs.webkit.org/show_bug.cgi?id=283790</a>
<a href="https://rdar.apple.com/140650005">rdar://140650005</a>

Reviewed by Dean Jackson.

So far, we have always assumed start and end delays for progress-based animations are irrelevant.
However, the procedure to normalize specified timing [0], which we partially implemented under
`AnimationEffect::normalizeSpecifiedTiming()`, calls out how to implement this. This incomplete
implementation causes a number of WPT failures.

To correctly normalize specified timing, we need to add the notion of a &quot;specified start delay&quot;,
&quot;specified end delay&quot; and &quot;specified iteration duration&quot;. Those are the values that come through
the JavaScript API or the relevant CSS properties. Normalizing the specified timing relies on those
properties as well as the animation playback rate, the timeline duration and the iteration count.

To correctly normalize the specified timing when required, we now add a new `m_timingDidMutate`
instance variable to `AnimationEffect` to track when one of those properties has been changed.
Then, we call `updateComputedTimingPropertiesIfNeeded()` when any of the timing properties that
depend on those is queried. This means that some methods that used to be `const` no longer are.

This in itself is an improvement because it allows us to remove the poorly-named public method
`AnimationEffect::updateStaticTimingProperties()` which was called outside of `AnimationEffect`
when other parts of the code assumed that timing may have been changed and computed properties
needed an update. Additionally, we remove the `AnimationEffect::normalizeSpecifiedTiming()`
method since this should be within the purview of the supporting `AnimationEffectTiming` object.

Now, `AnimationEffectTiming::updateComputedProperties()` deals with the normalization step as a
prelude to computing the &quot;active duration&quot; and the &quot;end time&quot;. Correctly dealing with delays for
progress-based animations also allows us to remove some special casing for percentage timing values
throughout the rest of `AnimationEffectTiming`.

This yields significant WPT progress with 57 new PASS results, one unskipped reftest on macOS and one
flaky test now proving to be stable on all platforms.

[0] <a href="https://drafts.csswg.org/web-animations-2/#normalize-specified-timing">https://drafts.csswg.org/web-animations-2/#normalize-specified-timing</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-ignored.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/progress-based-animation-animation-longhand-properties.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/intrinsic-iteration-duration.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-fill-modes.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-phases.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/zero-intrinsic-iteration-duration.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/scroll-timeline-overallProgress.tentative-expected.txt:
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::AnimationEffect::getBindingsTiming const):
(WebCore::AnimationEffect::getBasicTiming):
(WebCore::AnimationEffect::getBindingsComputedTiming):
(WebCore::AnimationEffect::getComputedTiming):
(WebCore::AnimationEffect::updateTiming):
(WebCore::AnimationEffect::setIterations):
(WebCore::AnimationEffect::delay):
(WebCore::AnimationEffect::setDelay):
(WebCore::AnimationEffect::endDelay):
(WebCore::AnimationEffect::setEndDelay):
(WebCore::AnimationEffect::iterationDuration):
(WebCore::AnimationEffect::setIterationDuration):
(WebCore::AnimationEffect::activeDuration):
(WebCore::AnimationEffect::endTime):
(WebCore::AnimationEffect::timeToNextTick):
(WebCore::AnimationEffect::animationTimelineDidChange):
(WebCore::AnimationEffect::animationPlaybackRateDidChange):
(WebCore::AnimationEffect::updateComputedTimingPropertiesIfNeeded):
(WebCore::durationAPIValue): Deleted.
(WebCore::AnimationEffect::getBasicTiming const): Deleted.
(WebCore::AnimationEffect::getBindingsComputedTiming const): Deleted.
(WebCore::AnimationEffect::getComputedTiming const): Deleted.
(WebCore::AnimationEffect::normalizeSpecifiedTiming): Deleted.
(WebCore::AnimationEffect::updateStaticTimingProperties): Deleted.
(WebCore::AnimationEffect::timeToNextTick const): Deleted.
* Source/WebCore/animation/AnimationEffect.h:
(WebCore::AnimationEffect::specifiedDelay const):
(WebCore::AnimationEffect::specifiedEndDelay const):
(WebCore::AnimationEffect::specifiedIterationDuration const):
(WebCore::AnimationEffect::delay const): Deleted.
(WebCore::AnimationEffect::endDelay const): Deleted.
(WebCore::AnimationEffect::iterationDuration const): Deleted.
(WebCore::AnimationEffect::activeDuration const): Deleted.
(WebCore::AnimationEffect::endTime const): Deleted.
* Source/WebCore/animation/AnimationEffectTiming.cpp:
(WebCore::AnimationEffectTiming::updateComputedProperties):
(WebCore::AnimationEffectTiming::getBasicTiming const):
(WebCore::AnimationEffectTiming::resolve const):
* Source/WebCore/animation/AnimationEffectTiming.h:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncPropertiesWithBackingAnimation):
* Source/WebCore/animation/CSSTransition.cpp:
(WebCore::CSSTransition::setTimingProperties):
* Source/WebCore/animation/EffectTiming.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::copyPropertiesFromSource):
(WebCore::KeyframeEffect::backingAnimationForCompositedRenderer):
(WebCore::KeyframeEffect::timeToNextTick):
(WebCore::KeyframeEffect::backingAnimationForCompositedRenderer const): Deleted.
(WebCore::KeyframeEffect::timeToNextTick const): Deleted.
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::setPlaybackRate):
(WebCore::WebAnimation::applyPendingPlaybackRate):
(WebCore::WebAnimation::playState const):
(WebCore::WebAnimation::updateFinishedState):
(WebCore::WebAnimation::overallProgress const):
* Source/WebCore/animation/WebAnimationTime.cpp:
(WebCore::WebAnimationTime::isNaN const):
(WebCore::WebAnimationTime::matchingInfinity const):
* Source/WebCore/animation/WebAnimationTime.h:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::buildObjectForEffect):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/287181@main">https://commits.webkit.org/287181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3026d4174fd3e6b9f07899b22e74e228cd295560

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83369 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29971 "Failed to checkout and rebase branch from PR 37219") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80842 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6034 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/61643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/29971 "Failed to checkout and rebase branch from PR 37219") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81776 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/51673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/70825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/41951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/49019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/25674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28311 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/70126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/26055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84738 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6074 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/69869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6236 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/67657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/69123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/13162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/11744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12144 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6019 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/11934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/6005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9441 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7793 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->