### PR TITLE
Port WKWebExtensionLocalization to C++

### DIFF
--- a/Source/WTF/wtf/JSONValues.h
+++ b/Source/WTF/wtf/JSONValues.h
@@ -211,7 +211,7 @@ protected:
     const_iterator begin() const { return m_map.begin(); }
     const_iterator end() const { return m_map.end(); }
 
-    DataStorage::KeysConstIteratorRange keys() const { return m_map.keys(); }
+    OrderStorage keys() const { return m_order; }
 
     unsigned size() const { return m_map.size(); }
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2421,6 +2421,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/sql/SQLiteTransaction.h
 
     platform/text/BidiContext.h
+    platform/text/PlatformLocale.h
     platform/text/StringWithDirection.h
     platform/text/TextBoundaries.h
     platform/text/TextCheckerClient.h

--- a/Source/WebCore/platform/text/PlatformLocale.h
+++ b/Source/WebCore/platform/text/PlatformLocale.h
@@ -43,7 +43,7 @@ class Locale {
     WTF_MAKE_NONCOPYABLE(Locale);
 
 public:
-    static std::unique_ptr<Locale> create(const AtomString& localeIdentifier);
+    WEBCORE_EXPORT static std::unique_ptr<Locale> create(const AtomString& localeIdentifier);
     static std::unique_ptr<Locale> createDefault();
 
     // Converts the specified number string to another number string localized
@@ -58,6 +58,17 @@ public:
     // callers of this function are responsible to check the format of the
     // resultant string.
     String convertFromLocalizedNumber(const String&);
+
+    enum class WritingDirection: uint8_t {
+        Default,
+        LeftToRight,
+        RightToLeft
+    };
+
+#if PLATFORM(COCOA)
+    // Returns the default writing direction for the specified locale.
+    virtual WritingDirection defaultWritingDirection() const = 0;
+#endif
 
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
     // Returns date format in Unicode TR35 LDML[1] containing day of month,
@@ -124,7 +135,7 @@ public:
     virtual String formatDateTime(const DateComponents&, FormatType = FormatTypeUnspecified);
 #endif
 
-    virtual ~Locale();
+    WEBCORE_EXPORT virtual ~Locale();
 
 protected:
     enum {

--- a/Source/WebCore/platform/text/cocoa/LocaleCocoa.h
+++ b/Source/WebCore/platform/text/cocoa/LocaleCocoa.h
@@ -37,8 +37,15 @@
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
+#if PLATFORM(MAC)
+#define PlatformNSParagraphStyle NSParagraphStyle.class
+#else
+#define PlatformNSParagraphStyle PAL::getNSParagraphStyleClass()
+#endif
+
 OBJC_CLASS NSCalendar;
 OBJC_CLASS NSDateFormatter;
+OBJC_CLASS NSParagraphStyle;
 OBJC_CLASS NSLocale;
 
 namespace WebCore {
@@ -50,6 +57,8 @@ class LocaleCocoa final : public Locale {
 public:
     explicit LocaleCocoa(const AtomString&);
     ~LocaleCocoa();
+
+    Locale::WritingDirection defaultWritingDirection() const override;
 
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
     String formatDateTime(const DateComponents&, FormatType = FormatTypeUnspecified) override;

--- a/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
+++ b/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
@@ -44,6 +44,11 @@
 #import <wtf/text/AtomStringHash.h>
 #import "LocalizedDateCache.h"
 
+#if PLATFORM(IOS_FAMILY)
+#import <UIKit/UIKit.h>
+#import <pal/ios/UIKitSoftLink.h>
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LocaleCocoa);
@@ -143,6 +148,18 @@ RetainPtr<NSDateFormatter> LocaleCocoa::dateTimeFormatterWithSeconds()
 RetainPtr<NSDateFormatter> LocaleCocoa::dateTimeFormatterWithoutSeconds()
 {
     return createDateTimeFormatter(m_locale.get(), m_gregorianCalendar.get(), NSDateFormatterShortStyle, NSDateFormatterShortStyle);
+}
+
+Locale::WritingDirection LocaleCocoa::defaultWritingDirection() const
+{
+    switch ([PlatformNSParagraphStyle defaultWritingDirectionForLanguage:m_locale.get().languageCode]) {
+    case NSWritingDirectionLeftToRight:
+        return WritingDirection::LeftToRight;
+    case NSWritingDirectionRightToLeft:
+        return WritingDirection::RightToLeft;
+    default:
+        return WritingDirection::Default;
+    }
 }
 
 String LocaleCocoa::dateFormat()

--- a/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h
@@ -45,7 +45,7 @@ struct WebExtensionContextParameters {
 
     HashMap<String, WallTime> grantedPermissions;
 
-    Ref<API::Data> localizationJSON;
+    RefPtr<API::Data> localizationJSON;
     Ref<API::Data> manifestJSON;
 
     double manifestVersion { 0 };

--- a/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
@@ -31,7 +31,7 @@ struct WebKit::WebExtensionContextParameters {
 
     HashMap<String, WallTime> grantedPermissions;
 
-    Ref<API::Data> localizationJSON;
+    RefPtr<API::Data> localizationJSON;
     Ref<API::Data> manifestJSON;
 
     double manifestVersion;

--- a/Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp
@@ -1,0 +1,348 @@
+/*
+ * Copyright (C) 2024 Igalia, S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebExtensionLocalization.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "Logging.h"
+#include "WebExtension.h"
+#include "WebExtensionUtilities.h"
+#include <JavaScriptCore/RegularExpression.h>
+#include <wtf/Language.h>
+#include <wtf/text/StringBuilder.h>
+#include <wtf/text/StringToIntegerConversion.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+static constexpr auto messageKey = "message"_s;
+static constexpr auto placeholdersKey = "placeholders"_s;
+static constexpr auto placeholderDictionaryContentKey = "content"_s;
+
+static constexpr auto predefinedMessageUILocale = "@@ui_locale"_s;
+static constexpr auto predefinedMessageLanguageDirection = "@@bidi_dir"_s;
+static constexpr auto predefinedMessageLanguageDirectionReversed = "@@bidi_reversed_dir"_s;
+static constexpr auto predefinedMessageTextLeadingEdge = "@@bidi_start_edge"_s;
+static constexpr auto predefinedMessageTextTrailingEdge = "@@bidi_end_edge"_s;
+static constexpr auto predefinedMessageExtensionID = "@@extension_id"_s;
+
+static constexpr auto predefinedMessageValueLeftToRight = "ltr"_s;
+static constexpr auto predefinedMessageValueRightToLeft = "rtl"_s;
+static constexpr auto predefinedMessageValueTextEdgeLeft = "left"_s;
+static constexpr auto predefinedMessageValueTextEdgeRight = "right"_s;
+
+WebExtensionLocalization::WebExtensionLocalization(WebExtension& webExtension)
+{
+    auto defaultLocaleString = webExtension.defaultLocale();
+    if (defaultLocaleString.isEmpty()) {
+        RELEASE_LOG_DEBUG(Extensions, "No default locale provided");
+        loadRegionalLocalization(nullptr, nullptr, nullptr, emptyString(), emptyString());
+        return;
+    }
+
+    RefPtr defaultLocaleJSON = localizationJSONForWebExtension(webExtension, defaultLocaleString);
+    if (!defaultLocaleJSON) {
+        RELEASE_LOG_DEBUG(Extensions, "No localization found for default locale %s", defaultLocaleString.utf8().data());
+        loadRegionalLocalization(nullptr, nullptr, nullptr, emptyString(), emptyString());
+        return;
+    }
+
+    RELEASE_LOG_DEBUG(Extensions, "Loaded default locale %s", defaultLocaleString.utf8().data());
+
+    auto bestLocaleString = webExtension.bestMatchLocale();
+    auto defaultLocaleComponents = parseLocale(defaultLocaleString);
+    auto bestLocaleComponents = parseLocale(bestLocaleString);
+    auto bestLocaleLanguageOnlyString = bestLocaleComponents.languageCode;
+
+    RELEASE_LOG_DEBUG(Extensions, "Best locale is %s", bestLocaleString.utf8().data());
+
+    RefPtr<JSON::Object> languageJSON;
+    if (!bestLocaleLanguageOnlyString.isEmpty() && bestLocaleLanguageOnlyString != defaultLocaleString) {
+        languageJSON = localizationJSONForWebExtension(webExtension, bestLocaleLanguageOnlyString);
+        if (languageJSON)
+            RELEASE_LOG_DEBUG(Extensions, "Loaded language-only locale %s", bestLocaleLanguageOnlyString.utf8().data());
+    }
+
+    RefPtr<JSON::Object> regionalJSON;
+    if (bestLocaleString != bestLocaleLanguageOnlyString && bestLocaleString != defaultLocaleString) {
+        regionalJSON = localizationJSONForWebExtension(webExtension, bestLocaleString);
+        if (regionalJSON)
+            RELEASE_LOG_DEBUG(Extensions, "Loaded regional locale %s", bestLocaleString.utf8().data());
+    }
+
+    loadRegionalLocalization(regionalJSON, languageJSON, defaultLocaleJSON, bestLocaleString);
+}
+
+WebExtensionLocalization::WebExtensionLocalization(RefPtr<JSON::Object> localizedJSON, const String& uniqueIdentifier)
+{
+    ASSERT(!uniqueIdentifier.isEmpty());
+    ASSERT(localizedJSON);
+
+    auto localeString = emptyString();
+    if (RefPtr predefinedMessages = localizedJSON->getObject(predefinedMessageUILocale))
+        localeString = predefinedMessages->getString(messageKey);
+
+    loadRegionalLocalization(localizedJSON, nullptr, nullptr, localeString, uniqueIdentifier);
+}
+
+WebExtensionLocalization::WebExtensionLocalization(RefPtr<JSON::Object> regionalLocalization, RefPtr<JSON::Object> languageLocalization, RefPtr<JSON::Object> defaultLocalization, const String& bestLocale, const String& uniqueIdentifier)
+{
+    loadRegionalLocalization(regionalLocalization, languageLocalization, defaultLocalization, bestLocale, uniqueIdentifier);
+}
+
+void WebExtensionLocalization::loadRegionalLocalization(RefPtr<JSON::Object> regionalLocalization, RefPtr<JSON::Object> languageLocalization, RefPtr<JSON::Object> defaultLocalization, const String& bestLocale, const String& uniqueIdentifier)
+{
+    m_locale = WebCore::Locale::create(AtomString { bestLocale });
+    m_localeString = bestLocale;
+    m_uniqueIdentifier = uniqueIdentifier;
+
+    RefPtr localizationJSON = predefinedMessages();
+    localizationJSON = mergeJSON(localizationJSON, jsonWithLowercaseKeys(regionalLocalization));
+    localizationJSON = mergeJSON(localizationJSON, jsonWithLowercaseKeys(languageLocalization));
+    localizationJSON = mergeJSON(localizationJSON, jsonWithLowercaseKeys(defaultLocalization));
+
+    ASSERT(localizationJSON);
+
+    m_localizationJSON = localizationJSON;
+
+    return;
+}
+
+void WebExtensionLocalization::localizedJSONforJSON(RefPtr<JSON::Object> json)
+{
+    if (!json || !json->size())
+        return;
+
+    for (auto& key : json->keys()) {
+        auto valueType = json->getValue(key)->type();
+
+        if (valueType == JSON::Value::Type::String)
+            json->setString(key, localizedStringForString(json->getString(key)));
+        else if (valueType == JSON::Value::Type::Array)
+            localizedArrayForArray(json->getArray(key));
+        else if (valueType == JSON::Value::Type::Object)
+            localizedJSONforJSON(json->getObject(key));
+    }
+}
+
+String WebExtensionLocalization::localizedStringForKey(String key, Vector<String> placeholders)
+{
+    if (placeholders.size() > 9)
+        return emptyString();
+
+    if (!m_localizationJSON || !m_localizationJSON->size())
+        return emptyString();
+
+    if (key.contains("__MSG_"_s)) {
+        key = key.substring(6, key.length());
+        key = key.substring(0, key.length() - 2);
+    }
+
+    RefPtr localizationJSON = m_localizationJSON;
+    if (!localizationJSON)
+        return emptyString();
+
+    RefPtr stringJSON = localizationJSON->getObject(key.convertToASCIILowercase());
+    if (!stringJSON)
+        return emptyString();
+
+    auto localizedString = stringJSON->getString(messageKey);
+    if (!localizedString.length())
+        return emptyString();
+
+    RefPtr namedPlaceholders = jsonWithLowercaseKeys(stringJSON->getObject(placeholdersKey));
+
+    localizedString = stringByReplacingNamedPlaceholdersInString(localizedString, namedPlaceholders);
+    localizedString = stringByReplacingPositionalPlaceholdersInString(localizedString, placeholders);
+
+    localizedString = localizedString.impl()->replace("$$"_s, "$"_s);
+
+    return localizedString;
+}
+
+void WebExtensionLocalization::localizedArrayForArray(RefPtr<JSON::Array> json)
+{
+    if (!json)
+        return;
+
+    for (Ref value : *json) {
+        auto valueType = value->type();
+
+        if (valueType == JSON::Value::Type::String)
+            value->asString() = localizedStringForString(value->asString());
+        else if (valueType == JSON::Value::Type::Array)
+            localizedArrayForArray(value->asArray());
+        else if (valueType == JSON::Value::Type::Object)
+            localizedJSONforJSON(value->asObject());
+    }
+}
+
+String WebExtensionLocalization::localizedStringForString(String sourceString)
+{
+    String localizedString = sourceString;
+
+    auto localizableStringRegularExpression = JSC::Yarr::RegularExpression("__MSG_([A-Za-z0-9_@]+)__"_s, { });
+
+    int index = 0;
+    while (index < static_cast<int>(localizedString.length())) {
+        int matchLength;
+        index = localizableStringRegularExpression.match(localizedString, index, &matchLength);
+        if (index < 0)
+            break;
+
+        auto key = localizedString.substring(index, matchLength);
+        auto localizedReplacement = localizedStringForKey(key);
+
+        localizedString = makeStringByReplacingAll(localizedString, key, localizedReplacement);
+
+        index += localizedReplacement.length();
+    }
+
+    return localizedString;
+}
+
+RefPtr<JSON::Object> WebExtensionLocalization::localizationJSONForWebExtension(WebExtension& webExtension, const String& withLocale)
+{
+    StringBuilder pathBuilder;
+    pathBuilder.append("_locales/"_s);
+    pathBuilder.append(withLocale);
+    pathBuilder.append("/messages.json"_s);
+
+    auto path = pathBuilder.toString();
+
+    RefPtr<API::Error> error;
+    RefPtr data = webExtension.resourceDataForPath(path, error, WebExtension::CacheResult::No, WebExtension::SuppressNotFoundErrors::Yes);
+    if (!data || error) {
+        webExtension.recordErrorIfNeeded(error);
+        return nullptr;
+    }
+
+    auto json = JSON::Value::parseJSON(String::fromUTF8(data->span()));
+
+    return json ? json->asObject() : nullptr;
+}
+
+Ref<JSON::Object> WebExtensionLocalization::predefinedMessages()
+{
+    Ref predefinedMessages = JSON::Object::create();
+
+    auto createMessageKey = [](String messageValue) {
+        Ref object = JSON::Object::create();
+        object->setString(messageKey, messageValue);
+        return object;
+    };
+
+    if (m_locale && !m_localeString.isEmpty()) {
+        if (m_locale->defaultWritingDirection() == WebCore::Locale::WritingDirection::LeftToRight) {
+            predefinedMessages->setObject(predefinedMessageLanguageDirection, createMessageKey(predefinedMessageValueLeftToRight));
+            predefinedMessages->setObject(predefinedMessageLanguageDirectionReversed, createMessageKey(predefinedMessageValueRightToLeft));
+            predefinedMessages->setObject(predefinedMessageTextLeadingEdge, createMessageKey(predefinedMessageValueTextEdgeLeft));
+            predefinedMessages->setObject(predefinedMessageTextTrailingEdge, createMessageKey(predefinedMessageValueTextEdgeRight));
+        } else {
+            predefinedMessages->setObject(predefinedMessageLanguageDirection, createMessageKey(predefinedMessageValueRightToLeft));
+            predefinedMessages->setObject(predefinedMessageLanguageDirectionReversed, createMessageKey(predefinedMessageValueLeftToRight));
+            predefinedMessages->setObject(predefinedMessageTextLeadingEdge, createMessageKey(predefinedMessageValueTextEdgeRight));
+            predefinedMessages->setObject(predefinedMessageTextTrailingEdge, createMessageKey(predefinedMessageValueTextEdgeLeft));
+        }
+    }
+
+    if (!m_localeString.isNull())
+        predefinedMessages->setObject(predefinedMessageUILocale, createMessageKey(m_localeString));
+
+    if (!m_uniqueIdentifier.isNull())
+        predefinedMessages->setObject(predefinedMessageExtensionID, createMessageKey(m_uniqueIdentifier));
+
+    return predefinedMessages;
+}
+
+String WebExtensionLocalization::stringByReplacingNamedPlaceholdersInString(String sourceString, RefPtr<JSON::Object> placeholders)
+{
+    String localizedString = sourceString;
+
+    auto localizableStringRegularExpression = JSC::Yarr::RegularExpression("(?:[^$]|^)(\\$([A-Za-z0-9_@]+)\\$)"_s, { });
+
+    int index = 0;
+    while (index < static_cast<int>(localizedString.length())) {
+        int matchLength;
+        index = localizableStringRegularExpression.match(localizedString, index, &matchLength);
+        if (index < 0)
+            break;
+
+        auto originalKey = localizedString.substring(index, matchLength);
+
+        if (originalKey.startsWith(' '))
+            originalKey = localizedString.substring(index + 1, matchLength - 1);
+
+        auto key = originalKey.trim(isASCIIWhitespace).substring(1, originalKey.length() - 2).convertToASCIILowercase();
+
+        auto localizedReplacement = placeholders->getObject(key) ? placeholders->getObject(key)->getString(placeholderDictionaryContentKey) : emptyString();
+
+        localizedString = makeStringByReplacingAll(localizedString, originalKey, localizedReplacement);
+
+        index += localizedReplacement.length();
+    }
+
+    return localizedString;
+}
+
+String WebExtensionLocalization::stringByReplacingPositionalPlaceholdersInString(String sourceString, Vector<String> placeholders)
+{
+    auto localizedString = sourceString;
+
+    auto localizableStringRegularExpression = JSC::Yarr::RegularExpression("(?:[^$]|^)(\\$([0-9]))"_s, { });
+
+    int index = 0;
+    while (index < static_cast<int>(localizedString.length())) {
+        int matchLength;
+        index = localizableStringRegularExpression.match(localizedString, index, &matchLength);
+        if (index < 0)
+            break;
+
+        auto originalKey = localizedString.substring(index, matchLength).trim(isASCIIWhitespace<UChar>);
+        auto key = originalKey.substring(1, originalKey.length());
+        auto keyInteger = parseInteger<size_t>(key);
+
+        String replacement;
+        if (keyInteger && placeholders.size() && *keyInteger <= placeholders.size() && keyInteger > 0)
+            replacement = placeholders[*keyInteger - 1];
+        else
+            replacement = emptyString();
+
+        localizedString = makeStringByReplacingAll(localizedString, originalKey, replacement);
+
+        if (!matchLength)
+            break;
+
+        index += replacement.length() + 2;
+    }
+
+    return localizedString;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/Shared/Extensions/WebExtensionLocalization.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionLocalization.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 Igalia, S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/PlatformLocale.h>
+#include <wtf/Forward.h>
+#include <wtf/JSONValues.h>
+#include <wtf/Noncopyable.h>
+
+namespace JSC { namespace Yarr {
+class RegularExpression;
+} }
+
+namespace WebKit {
+class WebExtension;
+
+class WebExtensionLocalization : public RefCounted<WebExtensionLocalization> {
+    WTF_MAKE_NONCOPYABLE(WebExtensionLocalization)
+
+public:
+    template<typename... Args>
+    static Ref<WebExtensionLocalization> create(Args&&... args)
+    {
+        return adoptRef(*new WebExtensionLocalization(std::forward<Args>(args)...));
+    }
+
+    explicit WebExtensionLocalization(WebKit::WebExtension&);
+    explicit WebExtensionLocalization(RefPtr<JSON::Object> localizedJSON, const String& uniqueIdentifier);
+    explicit WebExtensionLocalization(RefPtr<JSON::Object> regionalLocalization, RefPtr<JSON::Object> languageLocalization, RefPtr<JSON::Object> defaultLocalization, const String& withBestLocale, const String& uniqueIdentifier);
+
+    const String& uniqueIdentifier() { return m_uniqueIdentifier; };
+    RefPtr<JSON::Object> localizationJSON() { return m_localizationJSON; };
+
+    void localizedJSONforJSON(RefPtr<JSON::Object>);
+    String localizedStringForKey(String key, Vector<String> placeholders = { });
+    String localizedStringForString(String);
+
+private:
+    void loadRegionalLocalization(RefPtr<JSON::Object> regionalLocalization, RefPtr<JSON::Object> languageLocalization, RefPtr<JSON::Object> defaultLocalization, const String& withBestLocale = { }, const String& uniqueIdentifier = { });
+
+    RefPtr<JSON::Object> localizationJSONForWebExtension(WebKit::WebExtension&, const String& withLocale);
+    void localizedArrayForArray(RefPtr<JSON::Array>);
+    Ref<JSON::Object> predefinedMessages();
+
+    String stringByReplacingNamedPlaceholdersInString(String sourceString, RefPtr<JSON::Object> placeholders);
+    String stringByReplacingPositionalPlaceholdersInString(String sourceString, Vector<String> placeholders = { });
+
+    std::unique_ptr<WebCore::Locale> m_locale;
+    String m_localeString;
+    String m_uniqueIdentifier;
+    RefPtr<JSON::Object> m_localizationJSON;
+};
+
+}

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
@@ -72,6 +72,32 @@ double largestDisplayScale()
     return largestDisplayScale;
 }
 
+RefPtr<JSON::Object> jsonWithLowercaseKeys(RefPtr<JSON::Object> json)
+{
+    if (!json)
+        return json;
+
+    Ref newObject = JSON::Object::create();
+    for (auto& key : json->keys())
+        newObject->setValue(key.convertToASCIILowercase(), *json->getValue(key));
+
+    return newObject;
+}
+
+RefPtr<JSON::Object> mergeJSON(RefPtr<JSON::Object> jsonA, RefPtr<JSON::Object> jsonB)
+{
+    if (!jsonA || !jsonB)
+        return jsonA ?: jsonB;
+
+    RefPtr mergedObject = jsonA.copyRef();
+    for (auto& key : jsonB->keys()) {
+        if (!mergedObject->getValue(key))
+            mergedObject->setValue(key, *jsonB->getValue(key));
+    }
+
+    return mergedObject;
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
@@ -51,6 +51,9 @@ Vector<String> makeStringVector(const JSON::Array&);
 Vector<double> availableScreenScales();
 double largestDisplayScale();
 
+RefPtr<JSON::Object> jsonWithLowercaseKeys(RefPtr<JSON::Object>);
+RefPtr<JSON::Object> mergeJSON(RefPtr<JSON::Object>, RefPtr<JSON::Object>);
+
 #ifdef __OBJC__
 
 /// Verifies that a dictionary:

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -305,6 +305,7 @@ Shared/Authentication/AuthenticationManager.cpp
 Shared/Databases/IndexedDB/IDBUtilities.cpp
 
 Shared/Extensions/WebExtensionFrameIdentifier.cpp
+Shared/Extensions/WebExtensionLocalization.cpp
 Shared/Extensions/WebExtensionPermission.cpp
 Shared/Extensions/WebExtensionUtilities.cpp
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -81,7 +81,6 @@
 #import "WebUserContentControllerProxy.h"
 #import "_WKWebExtensionDeclarativeNetRequestSQLiteStore.h"
 #import "_WKWebExtensionDeclarativeNetRequestTranslator.h"
-#import "_WKWebExtensionLocalization.h"
 #import "_WKWebExtensionRegisteredScriptsSQLiteStore.h"
 #import "_WKWebExtensionStorageSQLiteStore.h"
 #import <UniformTypeIdentifiers/UTType.h>
@@ -617,11 +616,11 @@ void WebExtensionContext::setUniqueIdentifier(String&& uniqueIdentifier)
     m_uniqueIdentifier = uniqueIdentifier;
 }
 
-_WKWebExtensionLocalization *WebExtensionContext::localization()
+RefPtr<WebExtensionLocalization> WebExtensionContext::localization()
 {
     if (!m_localization)
-        m_localization = [[_WKWebExtensionLocalization alloc] initWithLocalizedDictionary:protectedExtension()->localization().localizationDictionary uniqueIdentifier:baseURL().host().toString()];
-    return m_localization.get();
+        m_localization = WebExtensionLocalization::create(protectedExtension()->localization()->localizationJSON(), baseURL().host().toString());
+    return m_localization;
 }
 
 RefPtr<API::Data> WebExtensionContext::localizedResourceData(const RefPtr<API::Data>& resourceData, const String& mimeType)
@@ -644,11 +643,11 @@ String WebExtensionContext::localizedResourceString(const String& resourceConten
     if (!equalLettersIgnoringASCIICase(mimeType, "text/css"_s) || resourceContents.isEmpty() || !resourceContents.contains("__MSG_"_s))
         return resourceContents;
 
-    auto* localization = this->localization();
+    RefPtr localization = this->localization();
     if (!localization)
         return resourceContents;
 
-    return [localization localizedStringForString:resourceContents];
+    return localization->localizedStringForString(resourceContents);
 }
 
 void WebExtensionContext::setInspectable(bool inspectable)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
@@ -46,7 +46,6 @@
 #import "WebPageProxy.h"
 #import "WebProcessProxy.h"
 #import "WebURLSchemeTask.h"
-#import "_WKWebExtensionLocalization.h"
 #import <wtf/BlockPtr.h>
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -157,6 +157,22 @@ double WebExtension::manifestVersion()
     return 0;
 }
 
+RefPtr<API::Data> WebExtension::serializeLocalization()
+{
+    if (!m_localization || !m_localization->localizationJSON())
+        return nullptr;
+
+    return API::Data::create(m_localization->localizationJSON()->toJSONString().utf8().span());
+}
+
+RefPtr<WebExtensionLocalization> WebExtension::localization()
+{
+    if (!manifestParsedSuccessfully())
+        return nullptr;
+
+    return m_localization;
+}
+
 bool WebExtension::hasRequestedPermission(String permission)
 {
     populatePermissionsPropertiesIfNeeded();

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -30,6 +30,7 @@
 #include "APIData.h"
 #include "APIObject.h"
 #include "WebExtensionContentWorldType.h"
+#include "WebExtensionLocalization.h"
 #include "WebExtensionMatchPattern.h"
 #include <WebCore/FloatSize.h>
 #include <WebCore/Icon.h>
@@ -219,7 +220,7 @@ public:
     double manifestVersion();
     bool supportsManifestVersion(double version) { ASSERT(version > 2); return manifestVersion() >= version; }
 
-    Ref<API::Data> serializeLocalization();
+    RefPtr<API::Data> serializeLocalization();
 
     NSBundle *bundle() const { return m_bundle.get(); }
     SecStaticCodeRef bundleStaticCode() const;
@@ -236,7 +237,7 @@ public:
     String resourceStringForPath(const String&, RefPtr<API::Error>&, CacheResult = CacheResult::No, SuppressNotFoundErrors = SuppressNotFoundErrors::No);
     RefPtr<API::Data> resourceDataForPath(const String&, RefPtr<API::Error>&, CacheResult = CacheResult::No, SuppressNotFoundErrors = SuppressNotFoundErrors::No);
 
-    _WKWebExtensionLocalization *localization();
+    RefPtr<WebExtensionLocalization> localization();
 
     const Vector<String>& supportedLocales();
     const String& defaultLocale();
@@ -394,7 +395,7 @@ private:
 
     String m_defaultLocale;
     Vector<String> m_supportedLocales;
-    RetainPtr<_WKWebExtensionLocalization> m_localization;
+    RefPtr<WebExtensionLocalization> m_localization;
 
     Vector<Ref<API::Error>> m_errors;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -43,6 +43,7 @@
 #include "WebExtensionEventListenerType.h"
 #include "WebExtensionFrameIdentifier.h"
 #include "WebExtensionFrameParameters.h"
+#include "WebExtensionLocalization.h"
 #include "WebExtensionMatchPattern.h"
 #include "WebExtensionMatchedRuleParameters.h"
 #include "WebExtensionMenuItem.h"
@@ -105,7 +106,6 @@ OBJC_CLASS WKWebView;
 OBJC_CLASS WKWebViewConfiguration;
 OBJC_CLASS _WKWebExtensionContextDelegate;
 OBJC_CLASS _WKWebExtensionDeclarativeNetRequestSQLiteStore;
-OBJC_CLASS _WKWebExtensionLocalization;
 OBJC_CLASS _WKWebExtensionRegisteredScriptsSQLiteStore;
 OBJC_CLASS _WKWebExtensionStorageSQLiteStore;
 OBJC_PROTOCOL(WKWebExtensionTab);
@@ -320,7 +320,7 @@ public:
     const String& uniqueIdentifier() const { return m_uniqueIdentifier; }
     void setUniqueIdentifier(String&&);
 
-    _WKWebExtensionLocalization *localization();
+    RefPtr<WebExtensionLocalization> localization();
 
     RefPtr<API::Data> localizedResourceData(const RefPtr<API::Data>&, const String& mimeType);
     String localizedResourceString(const String&, const String& mimeType);
@@ -945,7 +945,7 @@ private:
     String m_uniqueIdentifier = WTF::UUID::createVersion4().toString();
     bool m_customUniqueIdentifier { false };
 
-    RetainPtr<_WKWebExtensionLocalization> m_localization;
+    RefPtr<WebExtensionLocalization> m_localization;
 
     bool m_inspectable { false };
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -6689,6 +6689,9 @@
 		7CF47FF917275C57008ACB91 /* PageBanner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PageBanner.h; sourceTree = "<group>"; };
 		7CF47FFC17276AE3008ACB91 /* WKBundlePageBannerMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKBundlePageBannerMac.mm; sourceTree = "<group>"; };
 		7CF47FFD17276AE3008ACB91 /* WKBundlePageBannerMac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKBundlePageBannerMac.h; sourceTree = "<group>"; };
+		7D5151492CF818CA0035DD16 /* WebExtensionLocalization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionLocalization.h; sourceTree = "<group>"; };
+		7D51514A2CF818CA0035DD16 /* WebExtensionLocalization.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionLocalization.cpp; sourceTree = "<group>"; };
+		7D51514B2CF818CA0035DD16 /* WebExtensionUtilities.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionUtilities.cpp; sourceTree = "<group>"; };
 		7EC4F0F918E4A945008056AF /* NetworkProcessCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NetworkProcessCocoa.mm; sourceTree = "<group>"; };
 		831042891BD6B66F00A715E4 /* NetworkCacheSubresourcesEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkCacheSubresourcesEntry.h; sourceTree = "<group>"; };
 		8310428A1BD6B66F00A715E4 /* NetworkCacheSubresourcesEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkCacheSubresourcesEntry.cpp; sourceTree = "<group>"; };
@@ -13784,6 +13787,9 @@
 		B6114A8A293AE03600380B1B /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				7D5151492CF818CA0035DD16 /* WebExtensionLocalization.h */,
+				7D51514A2CF818CA0035DD16 /* WebExtensionLocalization.cpp */,
+				7D51514B2CF818CA0035DD16 /* WebExtensionUtilities.cpp */,
 				1CA584002CF14036002C6DAD /* Cocoa */,
 				B6217BB0299C39F000498BF8 /* _WKWebExtensionLocalization.h */,
 				B6217BB1299C3AE300498BF8 /* _WKWebExtensionLocalization.mm */,
@@ -20328,9 +20334,7 @@
 		};
 		5C400E6A29DB8AB500446F6F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				ios,
-			);
+			platformFilter = ios;
 			target = 5C139DA129DB82E500D5117B /* WebContentCaptivePortalExtension */;
 			targetProxy = 5C400E6929DB8AB500446F6F /* PBXContainerItemProxy */;
 		};
@@ -20346,25 +20350,19 @@
 		};
 		5CE4B60729CEBB760038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				ios,
-			);
+			platformFilter = ios;
 			target = 5CA5A2C929CBBA1A000F1046 /* WebContentExtension */;
 			targetProxy = 5CE4B60629CEBB760038F565 /* PBXContainerItemProxy */;
 		};
 		5CE4B62329CF880B0038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				ios,
-			);
+			platformFilter = ios;
 			target = 5CE4B61529CF877F0038F565 /* GPUExtension */;
 			targetProxy = 5CE4B62229CF880B0038F565 /* PBXContainerItemProxy */;
 		};
 		5CE4B62529CF880B0038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				ios,
-			);
+			platformFilter = ios;
 			target = 5CE4B60829CF87680038F565 /* NetworkingExtension */;
 			targetProxy = 5CE4B62429CF880B0038F565 /* PBXContainerItemProxy */;
 		};

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm
@@ -36,13 +36,14 @@
 #import "MessageSenderInlines.h"
 #import "WebExtensionContextMessages.h"
 #import "WebExtensionContextProxy.h"
+#import "WebExtensionLocalization.h"
 #import "WebExtensionUtilities.h"
 #import "WebProcess.h"
-#import "_WKWebExtensionLocalization.h"
 #import <JavaScriptCore/APICast.h>
 #import <JavaScriptCore/ScriptCallStack.h>
 #import <JavaScriptCore/ScriptCallStackFactory.h>
 #import <wtf/CompletionHandler.h>
+#import <wtf/cocoa/VectorCocoa.h>
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
@@ -54,7 +55,9 @@ NSString *WebExtensionAPILocalization::getMessage(NSString* messageName, id subs
 {
     // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getMessage
 
-    _WKWebExtensionLocalization *localization = extensionContext().localization();
+    RefPtr localization = extensionContext().localization();
+    if (!localization)
+        return emptyString();
 
     NSArray<NSString *> *substitutionsArray;
     if ([substitutions isKindOfClass:NSString.class])
@@ -65,7 +68,9 @@ NSString *WebExtensionAPILocalization::getMessage(NSString* messageName, id subs
         });
     }
 
-    return [localization localizedStringForKey:messageName withPlaceholders:substitutionsArray];
+    auto substitutionsVector = makeVector<String>(substitutionsArray);
+
+    return localization->localizedStringForKey(messageName, substitutionsVector);
 }
 
 NSString *WebExtensionAPILocalization::getUILanguage()

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -40,7 +40,6 @@
 
 OBJC_CLASS JSValue;
 OBJC_CLASS NSDictionary;
-OBJC_CLASS _WKWebExtensionLocalization;
 
 namespace WebKit {
 
@@ -82,7 +81,7 @@ public:
     double manifestVersion() const { return m_manifestVersion; }
     bool supportsManifestVersion(double version) const { return manifestVersion() >= version; }
 
-    _WKWebExtensionLocalization *localization() const { return m_localization.get(); }
+    RefPtr<WebExtensionLocalization> localization() const { return m_localization; }
 
     bool isSessionStorageAllowedInContentScripts() const { return m_isSessionStorageAllowedInContentScripts; }
 
@@ -136,7 +135,7 @@ public:
 private:
     explicit WebExtensionContextProxy(const WebExtensionContextParameters&);
 
-    static _WKWebExtensionLocalization *parseLocalization(API::Data&, const URL& baseURL);
+    static RefPtr<WebExtensionLocalization> parseLocalization(RefPtr<API::Data>, const URL& baseURL);
 
     // Action
     void dispatchActionClickedEvent(const std::optional<WebExtensionTabParameters>&);
@@ -221,7 +220,7 @@ private:
     URL m_baseURL;
     String m_uniqueIdentifier;
     HashSet<String> m_unsupportedAPIs;
-    RetainPtr<_WKWebExtensionLocalization> m_localization;
+    RefPtr<WebExtensionLocalization> m_localization;
     RetainPtr<NSDictionary> m_manifest;
     double m_manifestVersion { 0 };
     bool m_isSessionStorageAllowedInContentScripts { false };


### PR DESCRIPTION
#### 944567bb72da80b8a98ac4aac76f70b700373989
<pre>
Port WKWebExtensionLocalization to C++
<a href="https://webkit.org/b/283791">https://webkit.org/b/283791</a>

Reviewed by Timothy Hatcher.

Create a new WebExtensionLocalization shared class and replace usage of WKWebExtensionLocalization with the new class wherever possible.

* Source/WTF/wtf/JSONValues.h:
* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h:
* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp: Added.
(WebKit::WebExtensionLocalization::WebExtensionLocalization):
(WebKit::WebExtensionLocalization::loadRegionalLocalization):
(WebKit::WebExtensionLocalization::localizedJSONforJSON):
(WebKit::WebExtensionLocalization::localizedStringForKey):
(WebKit::WebExtensionLocalization::localizedArrayForArray):
(WebKit::WebExtensionLocalization::localizedStringForString):
(WebKit::WebExtensionLocalization::localizationJSONForWebExtension):
(WebKit::WebExtensionLocalization::predefinedMessages):
(WebKit::WebExtensionLocalization::stringByReplacingNamedPlaceholdersInString):
(WebKit::WebExtensionLocalization::stringByReplacingPositionalPlaceholdersInString):
* Source/WebKit/Shared/Extensions/WebExtensionLocalization.h: Added.
(WebKit::WebExtensionLocalization::create):
(WebKit::WebExtensionLocalization::uniqueIdentifier):
(WebKit::WebExtensionLocalization::localizationJSON):
(WebKit::WebExtensionLocalization::localizedStringForKey):
(WebKit::WebExtensionLocalization::loadRegionalLocalization):
(WebKit::WebExtensionLocalization::stringByReplacingPositionalPlaceholdersInString):
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp:
(WebKit::JSONWithLowercaseKeys):
(WebKit::mergeJSON):
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.h:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::parseManifest):
(WebKit::WebExtension::serializeLocalization): Deleted.
(WebKit::WebExtension::localization): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::localization):
(WebKit::WebExtensionContext::localizedResourceString):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm:
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::serializeLocalization):
(WebKit::WebExtension::localization):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm:
(WebKit::WebExtensionAPILocalization::getMessage):
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::WebExtensionContextProxy::getOrCreate):
(WebKit::WebExtensionContextProxy::parseLocalization):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:

Canonical link: <a href="https://commits.webkit.org/287187@main">https://commits.webkit.org/287187@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04d703a7cf9132d124a03ff28433f935b94c33c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83394 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29996 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80867 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/6059 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61663 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19586 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/70988 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41971 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49041 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25721 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28336 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71875 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70149 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/26104 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84763 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77967 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/6099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4216 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69888 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67679 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69142 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13181 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11785 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/100279 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12149 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/6044 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/11953 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21906 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/6030 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9466 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7818 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->