### PR TITLE
[IFC][SVG text] Move layout code out from legacy inline boxes

### DIFF
--- a/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.cpp
@@ -29,6 +29,7 @@
 #include "LayoutIntegrationLineLayout.h"
 #include "RenderSVGText.h"
 #include "SVGInlineTextBox.h"
+#include "SVGRootInlineBox.h"
 #include "SVGTextFragment.h"
 
 namespace WebCore {

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -429,22 +429,7 @@ LegacyRootInlineBox* LegacyLineLayout::createLineBoxesFromBidiRuns(unsigned bidi
 
     lineBox->setBidiLevel(bidiLevel);
 
-    bool isSVGRootInlineBox = is<SVGRootInlineBox>(*lineBox);
-    ASSERT(isSVGRootInlineBox);
-
-    // Now we position all of our text runs horizontally.
-
     removeEmptyTextBoxesAndUpdateVisualReordering(lineBox, bidiRuns.firstRun());
-
-    // SVG text layout code computes vertical & horizontal positions on its own.
-    // Note that we still need to execute computeVerticalPositionsForLine() as
-    // it calls LegacyInlineTextBox::positionLineBox(), which tracks whether the box
-    // contains reversed text or not. If we wouldn't do that editing and thus
-    // text selection in RTL boxes would not work as expected.
-    if (isSVGRootInlineBox) {
-        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(m_flow.isRenderSVGText());
-        downcast<SVGRootInlineBox>(*lineBox).computePerCharacterLayoutInformation();
-    }
 
     GlyphOverflowAndFallbackFontsMap textBoxDataMap;
     lineBox->computeOverflow(lineBox->lineTop(), lineBox->lineBottom(), textBoxDataMap);

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -33,6 +33,7 @@
 #include "HitTestRequest.h"
 #include "HitTestResult.h"
 #include "InlineIteratorBoxInlines.h"
+#include "InlineIteratorLogicalOrderTraversal.h"
 #include "InlineIteratorSVGTextBox.h"
 #include "LayoutIntegrationLineLayout.h"
 #include "LayoutRepainter.h"
@@ -47,6 +48,9 @@
 #include "RenderSVGInlineText.h"
 #include "RenderSVGRoot.h"
 #include "SVGElementTypeHelpers.h"
+#include "SVGInlineFlowBox.h"
+#include "SVGInlineTextBox.h"
+#include "SVGInlineTextBoxInlines.h"
 #include "SVGLengthList.h"
 #include "SVGRenderStyle.h"
 #include "SVGRenderingContext.h"
@@ -54,6 +58,7 @@
 #include "SVGRootInlineBox.h"
 #include "SVGTextBoxPainter.h"
 #include "SVGTextElement.h"
+#include "SVGTextLayoutEngine.h"
 #include "SVGURIReference.h"
 #include "SVGVisitedRendererTracking.h"
 #include "TransformState.h"
@@ -402,6 +407,8 @@ void RenderSVGText::layout()
     rebuildFloatingObjectSetFromIntrudingFloats();
     layoutInlineChildren(true, repaintLogicalTop, repaintLogicalBottom);
 
+    computePerCharacterLayoutInformation();
+
     // updatePositionAndOverflow() is called by SVGRootInlineBox, after forceLayoutInlineChildren() ran, before this point is reached.
     if (m_needsReordering)
         m_needsReordering = false;
@@ -433,6 +440,206 @@ void RenderSVGText::layout()
     repainter.repaintAfterLayout();
     clearNeedsLayout();
     m_hasPerformedLayout = true;
+}
+
+void RenderSVGText::computePerCharacterLayoutInformation()
+{
+    if (!hasLines())
+        return;
+
+    if (m_layoutAttributes.isEmpty())
+        return;
+
+    if (m_needsReordering)
+        reorderValueListsToLogicalOrder();
+
+    // Perform SVG text layout phase two (see SVGTextLayoutEngine for details).
+    SVGTextLayoutEngine characterLayout(m_layoutAttributes);
+    layoutCharactersInTextBoxes(legacyRootBox(), characterLayout);
+
+    // Perform SVG text layout phase three (see SVGTextChunkBuilder for details).
+    auto fragmentMap = characterLayout.finishLayout();
+
+    // Perform SVG text layout phase four
+    // Position & resize all SVGInlineText/FlowBoxes in the inline box tree, resize the root box as well as the RenderSVGText parent block.
+    auto childRect = layoutChildBoxes(legacyRootBox(), fragmentMap);
+    layoutRootBox(childRect);
+}
+
+void RenderSVGText::layoutCharactersInTextBoxes(LegacyInlineFlowBox* start, SVGTextLayoutEngine& characterLayout)
+{
+    for (auto* child = start->firstChild(); child; child = child->nextOnLine()) {
+        if (auto* legacyTextBox = dynamicDowncast<SVGInlineTextBox>(*child)) {
+            ASSERT(is<RenderSVGInlineText>(legacyTextBox->renderer()));
+            characterLayout.layoutInlineTextBox(InlineIterator::svgTextBoxFor(legacyTextBox));
+        } else {
+            // Skip generated content.
+            RefPtr node = child->renderer().node();
+            if (!node)
+                continue;
+
+            auto& flowBox = downcast<SVGInlineFlowBox>(*child);
+            bool isTextPath = node->hasTagName(SVGNames::textPathTag);
+            if (isTextPath) {
+                // Build text chunks for all <textPath> children, using the line layout algorithm.
+                // This is needeed as text-anchor is just an additional startOffset for text paths.
+                SVGTextLayoutEngine lineLayout(characterLayout.layoutAttributes());
+                layoutCharactersInTextBoxes(&flowBox, lineLayout);
+
+                characterLayout.beginTextPathLayout(downcast<RenderSVGTextPath>(child->renderer()), lineLayout);
+            }
+
+            layoutCharactersInTextBoxes(&flowBox, characterLayout);
+
+            if (isTextPath)
+                characterLayout.endTextPathLayout();
+        }
+    }
+}
+
+FloatRect RenderSVGText::layoutChildBoxes(LegacyInlineFlowBox* start, SVGTextFragmentMap& fragmentMap)
+{
+    FloatRect childRect;
+
+    for (auto* child = start->firstChild(); child; child = child->nextOnLine()) {
+        FloatRect boxRect;
+        if (auto* textBox = dynamicDowncast<SVGInlineTextBox>(*child)) {
+            ASSERT(is<RenderSVGInlineText>(textBox->renderer()));
+
+            auto it = fragmentMap.find(makeKey(*InlineIterator::svgTextBoxFor(textBox)));
+            if (it != fragmentMap.end())
+                textBox->setTextFragments(WTFMove(it->value));
+
+            boxRect = textBox->calculateBoundaries();
+            textBox->setX(boxRect.x());
+            textBox->setY(boxRect.y());
+            textBox->setLogicalWidth(boxRect.width());
+            textBox->setLogicalHeight(boxRect.height());
+        } else {
+            // Skip generated content.
+            if (!child->renderer().node())
+                continue;
+
+            auto& flowBox = downcast<SVGInlineFlowBox>(*child);
+            layoutChildBoxes(&flowBox, fragmentMap);
+
+            boxRect = flowBox.calculateBoundaries();
+            flowBox.setX(boxRect.x());
+            flowBox.setY(boxRect.y());
+            flowBox.setLogicalWidth(boxRect.width());
+            flowBox.setLogicalHeight(boxRect.height());
+        }
+        childRect.unite(boxRect);
+    }
+
+    return childRect;
+}
+
+void RenderSVGText::layoutRootBox(const FloatRect& childRect)
+{
+    // Finally, assign the root block position, now that all content is laid out.
+    updatePositionAndOverflow(childRect);
+
+    // Position all children relative to the parent block.
+    for (auto* child = legacyRootBox()->firstChild(); child; child = child->nextOnLine()) {
+        // Skip generated content.
+        if (!child->renderer().node())
+            continue;
+        child->adjustPosition(-childRect.x(), -childRect.y());
+    }
+
+    legacyRootBox()->setX(0);
+    legacyRootBox()->setY(0);
+    legacyRootBox()->setLogicalWidth(childRect.width());
+    legacyRootBox()->setLogicalHeight(childRect.height());
+
+    auto boundingRect = enclosingLayoutRect(childRect);
+    legacyRootBox()->setLineTopBottomPositions(0, boundingRect.height(), 0, boundingRect.height());
+}
+
+static inline void swapItemsInLayoutAttributes(SVGTextLayoutAttributes* firstAttributes, SVGTextLayoutAttributes* lastAttributes, unsigned firstPosition, unsigned lastPosition)
+{
+    SVGCharacterDataMap::iterator itFirst = firstAttributes->characterDataMap().find(firstPosition + 1);
+    SVGCharacterDataMap::iterator itLast = lastAttributes->characterDataMap().find(lastPosition + 1);
+    bool firstPresent = itFirst != firstAttributes->characterDataMap().end();
+    bool lastPresent = itLast != lastAttributes->characterDataMap().end();
+    // We only want to perform the swap if both inline boxes are absolutely positioned.
+    if (!firstPresent || !lastPresent)
+        return;
+
+    std::swap(itFirst->value, itLast->value);
+}
+
+static inline void findFirstAndLastAttributesInVector(Vector<SVGTextLayoutAttributes*>& attributes, RenderSVGInlineText* firstContext, RenderSVGInlineText* lastContext, SVGTextLayoutAttributes*& first, SVGTextLayoutAttributes*& last)
+{
+    first = nullptr;
+    last = nullptr;
+
+    unsigned attributesSize = attributes.size();
+    for (unsigned i = 0; i < attributesSize; ++i) {
+        SVGTextLayoutAttributes* current = attributes[i];
+        if (!first && firstContext == &current->context())
+            first = current;
+        if (!last && lastContext == &current->context())
+            last = current;
+        if (first && last)
+            break;
+    }
+
+    ASSERT(first);
+    ASSERT(last);
+}
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+static inline void reverseInlineBoxRangeAndValueListsIfNeeded(Vector<SVGTextLayoutAttributes*>& attributes, Vector<InlineIterator::LeafBoxIterator>::iterator first, Vector<InlineIterator::LeafBoxIterator>::iterator last)
+{
+    // This is a copy of std::reverse(first, last). It additionally assures that the metrics map within the renderers belonging to the InlineBoxes are reordered as well.
+    while (true)  {
+        if (first == last || first == --last)
+            return;
+        auto* legacyFirst = (*first)->legacyInlineBox();
+        auto* legacyLast = (*last)->legacyInlineBox();
+        if (!is<SVGInlineTextBox>(legacyFirst) || !is<SVGInlineTextBox>(legacyLast)) {
+            auto temp = *first;
+            *first = *last;
+            *last = temp;
+            ++first;
+            continue;
+        }
+
+        auto& firstTextBox = downcast<SVGInlineTextBox>(*legacyFirst);
+        auto& lastTextBox = downcast<SVGInlineTextBox>(*legacyLast);
+
+        // Reordering is only necessary for BiDi text that is _absolutely_ positioned.
+        if (firstTextBox.len() == 1 && firstTextBox.len() == lastTextBox.len()) {
+            RenderSVGInlineText& firstContext = firstTextBox.renderer();
+            RenderSVGInlineText& lastContext = lastTextBox.renderer();
+
+            SVGTextLayoutAttributes* firstAttributes = nullptr;
+            SVGTextLayoutAttributes* lastAttributes = nullptr;
+            findFirstAndLastAttributesInVector(attributes, &firstContext, &lastContext, firstAttributes, lastAttributes);
+            swapItemsInLayoutAttributes(firstAttributes, lastAttributes, firstTextBox.start(), lastTextBox.start());
+        }
+
+        auto temp = *first;
+        *first = *last;
+        *last = temp;
+
+        ++first;
+    }
+}
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+void RenderSVGText::reorderValueListsToLogicalOrder()
+{
+    auto lineBox = InlineIterator::LineBoxIterator(legacyRootBox());
+    if (!lineBox)
+        return;
+
+    InlineIterator::leafBoxesInLogicalOrder(lineBox, [&](auto first, auto last) {
+        reverseInlineBoxRangeAndValueListsIfNeeded(m_layoutAttributes, first, last);
+    });
+
 }
 
 bool RenderSVGText::nodeAtFloatPoint(const HitTestRequest& request, HitTestResult& result, const FloatPoint& pointInParent, HitTestAction hitTestAction)
@@ -565,7 +772,7 @@ VisiblePosition RenderSVGText::positionForPoint(const LayoutPoint& pointInConten
         return createVisiblePosition(0, Affinity::Downstream);
 
     ASSERT(childrenInline());
-    LegacyInlineBox* closestBox = downcast<SVGRootInlineBox>(*rootBox).closestLeafChildForPosition(pointInContents);
+    LegacyInlineBox* closestBox = rootBox->closestLeafChildForPosition(pointInContents);
     if (!closestBox)
         return createVisiblePosition(0, Affinity::Downstream);
 
@@ -764,5 +971,11 @@ void RenderSVGText::styleDidChange(StyleDifference diff, const RenderStyle* oldS
 
     RenderSVGBlock::styleDidChange(diff, oldStyle);
 }
+
+SVGRootInlineBox* RenderSVGText::legacyRootBox() const
+{
+    return downcast<SVGRootInlineBox>(RenderSVGBlock::legacyRootBox());
+}
+
 
 }

--- a/Source/WebCore/rendering/svg/RenderSVGText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGText.h
@@ -24,13 +24,15 @@
 #include "AffineTransform.h"
 #include "RenderSVGBlock.h"
 #include "SVGBoundingBoxComputation.h"
+#include "SVGTextChunk.h"
 #include "SVGTextLayoutAttributesBuilder.h"
 
 namespace WebCore {
 
 class RenderSVGInlineText;
+class SVGRootInlineBox;
 class SVGTextElement;
-class RenderSVGInlineText;
+class SVGTextLayoutEngine;
 
 class RenderSVGText final : public RenderSVGBlock {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RenderSVGText);
@@ -69,6 +71,8 @@ public:
 
     void updatePositionAndOverflow(const FloatRect&);
 
+    SVGRootInlineBox* legacyRootBox() const;
+
 private:
     void graphicsElement() const = delete;
 
@@ -91,6 +95,12 @@ private:
     }
 
     void layout() override;
+
+    void computePerCharacterLayoutInformation();
+    void layoutCharactersInTextBoxes(LegacyInlineFlowBox*, SVGTextLayoutEngine&);
+    FloatRect layoutChildBoxes(LegacyInlineFlowBox*, SVGTextFragmentMap&);
+    void layoutRootBox(const FloatRect&);
+    void reorderValueListsToLogicalOrder();
 
     void willBeDestroyed() override;
 

--- a/Source/WebCore/rendering/svg/SVGRootInlineBox.h
+++ b/Source/WebCore/rendering/svg/SVGRootInlineBox.h
@@ -39,18 +39,12 @@ public:
     float virtualLogicalHeight() const override { return m_logicalHeight; }
     void setLogicalHeight(float height) { m_logicalHeight = height; }
 
-    void computePerCharacterLayoutInformation();
-
     LegacyInlineBox* closestLeafChildForPosition(const LayoutPoint&);
 
 private:
     RenderSVGText& renderSVGText() const;
 
     bool isSVGRootInlineBox() const override { return true; }
-    void reorderValueListsToLogicalOrder(Vector<SVGTextLayoutAttributes*>&);
-    void layoutCharactersInTextBoxes(LegacyInlineFlowBox*, SVGTextLayoutEngine&);
-    FloatRect layoutChildBoxes(LegacyInlineFlowBox* start, SVGTextFragmentMap&);
-    void layoutRootBox(const FloatRect&);
 
     float m_logicalHeight;
 };


### PR DESCRIPTION
#### 9ec04b15a51c03dad60437b9ea2a03dcddc931cb
<pre>
[IFC][SVG text] Move layout code out from legacy inline boxes
<a href="https://bugs.webkit.org/show_bug.cgi?id=283792">https://bugs.webkit.org/show_bug.cgi?id=283792</a>
<a href="https://rdar.apple.com/problem/140651613">rdar://problem/140651613</a>

Reviewed by Alan Baradlay.

Reduce dependencies to legacy inline boxes.

* Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.cpp:
* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::LegacyLineLayout::createLineBoxesFromBidiRuns):

RenderSVGText::layout() now triggers computePerCharacterLayoutInformation() directly.

* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::layout):
(WebCore::RenderSVGText::computePerCharacterLayoutInformation):
(WebCore::RenderSVGText::layoutCharactersInTextBoxes):
(WebCore::RenderSVGText::layoutChildBoxes):
(WebCore::RenderSVGText::layoutRootBox):
(WebCore::swapItemsInLayoutAttributes):
(WebCore::findFirstAndLastAttributesInVector):
(WebCore::reverseInlineBoxRangeAndValueListsIfNeeded):
(WebCore::RenderSVGText::reorderValueListsToLogicalOrder):
(WebCore::RenderSVGText::positionForPoint):
(WebCore::RenderSVGText::legacyRootBox const):
* Source/WebCore/rendering/svg/RenderSVGText.h:
* Source/WebCore/rendering/svg/SVGRootInlineBox.cpp:
(WebCore::SVGRootInlineBox::computePerCharacterLayoutInformation): Deleted.
(WebCore::SVGRootInlineBox::layoutCharactersInTextBoxes): Deleted.
(WebCore::SVGRootInlineBox::layoutChildBoxes): Deleted.
(WebCore::SVGRootInlineBox::layoutRootBox): Deleted.
(WebCore::swapItemsInLayoutAttributes): Deleted.
(WebCore::findFirstAndLastAttributesInVector): Deleted.
(WebCore::reverseInlineBoxRangeAndValueListsIfNeeded): Deleted.
(WebCore::SVGRootInlineBox::reorderValueListsToLogicalOrder): Deleted.
* Source/WebCore/rendering/svg/SVGRootInlineBox.h:

Canonical link: <a href="https://commits.webkit.org/287151@main">https://commits.webkit.org/287151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7208c625476cb9d4626d7b7f005ce91c56581b4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31900 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83179 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29783 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80651 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61499 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19414 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51512 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69596 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41811 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48858 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25311 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28120 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69957 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84545 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4022 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69726 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6044 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/67487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68980 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17193 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13000 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11418 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5830 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/10556 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5818 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9252 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->