### PR TITLE
[JSC] Add parsing support for RegExp Modifiers

### DIFF
--- a/JSTests/stress/regexp-modifiers-syntax.js
+++ b/JSTests/stress/regexp-modifiers-syntax.js
@@ -1,0 +1,69 @@
+//@ requireOptions("--useRegExpModifiers=1")
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (errorMessage) {
+        if (String(error) !== errorMessage)
+            throw new Error(`bad error: ${String(error)}`);
+    }
+}
+
+function checkInvalidScriptSyntax(sourceCode, errorMessage) {
+    shouldThrow(() => checkScriptSyntax(sourceCode), errorMessage);
+}
+
+checkScriptSyntax("/(?i:ba)r/");
+checkScriptSyntax("/(?-i:ba)r/i");
+checkScriptSyntax("/F(?i:oo(?-i:b)a)r/");
+checkScriptSyntax("/F(?i:oo(?i:b)a)r/");
+checkScriptSyntax("/^[a-z](?-i:[a-z])$/i");
+checkScriptSyntax("/^(?i:[a-z])[a-z]$/");
+checkScriptSyntax("/(?m:^foo$)/");
+checkScriptSyntax("/(?s:^.$)/");
+checkScriptSyntax("/(?ms-i:^f.o$)/i");
+checkScriptSyntax("/(?m:^f(?si:.o)$)/");
+checkScriptSyntax("/(?i:abc)/");
+checkScriptSyntax("/(?-i:abc)/");
+checkScriptSyntax("/(?ms:abc)/");
+checkScriptSyntax("/(?-ms:abc)/");
+checkScriptSyntax("/(?i-ms:abc)/");
+checkScriptSyntax("/(?ms-i:abc)/");
+checkScriptSyntax("/(?i:(?-m:abc))/");
+checkScriptSyntax("/(?ms:(?i:abc))/");
+checkScriptSyntax("/(?i:)/");
+checkScriptSyntax("/(?i:a|b|c)/");
+checkScriptSyntax("/(?ms:abc)+/");
+checkScriptSyntax("/(?-i:\\w+)/");
+
+checkInvalidScriptSyntax("/(?-:.)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?--:.)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?mm:.)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?ii:.)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?ss:.)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?-mm:.)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?-ii:.)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?-ss:.)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?g-:.)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?-u:.)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?m-m:.)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?i-i:.)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?s-s:.)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?msi-ims:.)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?i--m:.)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?z:abc)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?i-m+abc)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?abc)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?-:abc)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?i:(?-z:abc))/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/abc(?i)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?i)/", "SyntaxError: Invalid regular expression: unrecognized character after (?:1");
+checkInvalidScriptSyntax("/(?i:a(b/", "SyntaxError: Invalid regular expression: missing ):1");

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -608,6 +608,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useMoreCurrencyDisplayChoices, false, Normal, "Enable more currencyDisplay choices for Intl.NumberFormat"_s) \
     v(Bool, usePromiseTryMethod, true, Normal, "Expose the Promise.try() method."_s) \
     v(Bool, useRegExpEscape, true, Normal, "Expose RegExp.escape feature."_s) \
+    v(Bool, useRegExpModifiers, false, Normal, "Enable RegExp Modifiers feature"_s) \
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \
     v(Bool, useShadowRealm, false, Normal, "Expose the ShadowRealm object."_s) \
     v(Bool, useTemporal, false, Normal, "Expose the Temporal object."_s) \

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -259,6 +259,7 @@ void RegExp::compile(VM* vm, Yarr::CharSize charSize, std::optional<StringView> 
         && !pattern.m_containsBackreferences
 #endif
         && !pattern.m_containsLookbehinds
+        && !pattern.m_containsModifiers
         ) {
         auto& jitCode = ensureRegExpJITCode();
         Yarr::jitCompile(pattern, m_patternString, charSize, sampleString, vm, jitCode, Yarr::JITCompileMode::IncludeSubpatterns);

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -4885,6 +4885,11 @@ public:
             return;
         }
 
+        if (m_pattern.m_containsModifiers) {
+            codeBlock.setFallBackWithFailureReason(JITFailureReason::Modifiers);
+            return;
+        }
+
 #if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
         if (m_decodeSurrogatePairs && m_compileMode != JITCompileMode::InlineTest && !m_pattern.multiline() && !m_pattern.m_containsBOL && !m_pattern.m_containsLookbehinds) {
             ASSERT(m_regs.firstCharacterAdditionalReadSize != InvalidGPRReg);
@@ -5560,6 +5565,9 @@ static void dumpCompileFailure(JITFailureReason failure)
         break;
     case JITFailureReason::OffsetTooLarge:
         dataLog("Can't JIT because pattern exceeds string length limits\n");
+        break;
+    case JITFailureReason::Modifiers:
+        dataLog("Can't JIT a pattern containing modifiers\n");
         break;
     }
 }

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -65,6 +65,7 @@ enum class JITFailureReason : uint8_t {
     ParenthesisNestedTooDeep,
     ExecutableMemoryAllocationFailure,
     OffsetTooLarge,
+    Modifiers,
 };
 
 class BoyerMooreFastCandidates {

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1375,6 +1375,21 @@ public:
         m_pattern.m_disjunctions.append(WTFMove(parenthesesDisjunction));
     }
 
+    void atomParenthesesModifiedBegin(OptionSet<Flags> addedFlags, OptionSet<Flags> removedFlags)
+    {
+        // TODO: Implement RegExp Modifiers semantics
+        UNUSED_PARAM(addedFlags);
+        UNUSED_PARAM(removedFlags);
+        ASSERT(!addedFlags.isEmpty() || !removedFlags.isEmpty());
+
+        auto parenthesesDisjunction = makeUnique<PatternDisjunction>(m_alternative);
+        m_alternative->m_terms.append(PatternTerm(PatternTerm::Type::ParenthesesSubpattern, m_pattern.m_numSubpatterns + 1, parenthesesDisjunction.get(), true, false, parenthesisMatchDirection()));
+        m_alternative = parenthesesDisjunction->addNewAlternative(m_pattern.m_numSubpatterns, parenthesisMatchDirection());
+        pushParenthesisContext();
+        m_pattern.m_containsModifiers = true;
+        m_pattern.m_disjunctions.append(WTFMove(parenthesesDisjunction));
+    }
+
     void atomParenthesesEnd()
     {
         ASSERT(m_alternative->m_parent);
@@ -2217,6 +2232,7 @@ YarrPattern::YarrPattern(StringView pattern, OptionSet<Flags> flags, ErrorCode& 
     , m_hasCopiedParenSubexpressions(false)
     , m_hasNamedCaptureGroups(false)
     , m_saveInitialStartValue(false)
+    , m_containsModifiers(false)
     , m_flags(flags)
 {
     ASSERT(m_flags != Flags::DeletedValue);

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -537,6 +537,7 @@ struct YarrPattern {
         m_hasCopiedParenSubexpressions = false;
         m_hasNamedCaptureGroups = false;
         m_saveInitialStartValue = false;
+        m_containsModifiers = false;
 
         anycharCached = nullptr;
         newlineCached = nullptr;
@@ -708,6 +709,7 @@ struct YarrPattern {
     bool m_hasCopiedParenSubexpressions : 1;
     bool m_hasNamedCaptureGroups : 1;
     bool m_saveInitialStartValue : 1;
+    bool m_containsModifiers : 1;
     OptionSet<Flags> m_flags;
     unsigned m_numSubpatterns { 0 };
     unsigned m_initialStartValueFrameLocation { 0 };

--- a/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
+++ b/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
@@ -49,6 +49,7 @@ public:
     void atomCharacterClassEnd() { }
     void atomParenthesesSubpatternBegin(bool = true, std::optional<String> = std::nullopt) { }
     void atomParentheticalAssertionBegin(bool, MatchDirection) { }
+    void atomParenthesesModifiedBegin(OptionSet<Flags>, OptionSet<Flags>) { }
     void atomParenthesesEnd() { }
     void atomBackReference(unsigned) { }
     void atomNamedBackReference(const String&) { }

--- a/Source/WebCore/contentextensions/URLFilterParser.cpp
+++ b/Source/WebCore/contentextensions/URLFilterParser.cpp
@@ -248,6 +248,11 @@ public:
         fail(URLFilterParser::Group);
     }
 
+    void atomParenthesesModifiedBegin(OptionSet<JSC::Yarr::Flags>, OptionSet<JSC::Yarr::Flags>)
+    {
+        fail(URLFilterParser::Group);
+    }
+
     void atomParenthesesEnd()
     {
         if (hasError())


### PR DESCRIPTION
#### f1971cbf62c543d023d731e76c3c615475b044e9
<pre>
[JSC] Add parsing support for RegExp Modifiers
<a href="https://bugs.webkit.org/show_bug.cgi?id=283799">https://bugs.webkit.org/show_bug.cgi?id=283799</a>

Reviewed by NOBODY (OOPS!).

RegExp Modifiers proposal is a now stage 4[1]. This patch implements
parsing support for the proposal.

[1]: <a href="https://github.com/tc39/proposal-regexp-modifiers">https://github.com/tc39/proposal-regexp-modifiers</a>

* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::parseParenthesesBegin):
* Source/JavaScriptCore/yarr/YarrParser.h.orig: Copied from Source/JavaScriptCore/yarr/YarrParser.h.
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::atomParenthesesModifiedBegin):
* Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp:
(JSC::Yarr::SyntaxChecker::atomParenthesesModifiedBegin):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1971cbf62c543d023d731e76c3c615475b044e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87633 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33568 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84606 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64298 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22063 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85569 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1598 "Found 1 new test failure: fast/forms/ios/file-upload-panel.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44575 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1496 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29248 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32602 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75495 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72788 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88995 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81559 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72704 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70874 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71920 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16060 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15072 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1189 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9759 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15280 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103967 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9633 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25220 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13099 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11403 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->