### PR TITLE
[GTK][WPE] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from gcrypt classes

### DIFF
--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESCTRGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESCTRGCrypt.cpp
@@ -178,9 +178,7 @@ static std::optional<Vector<uint8_t>> gcryptAESCTR(PAL::GCrypt::CipherOperation 
 
         // Encrypt/decrypt this single block with the block-specific counter. Output for this
         // single block is appended to the general output vector.
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-        auto blockOutput = callOperation(operation, handle, blockCounterData, inputText.data() + i, blockInputSize);
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        auto blockOutput = callOperation(operation, handle, blockCounterData, inputText.subspan(i).data(), blockInputSize);
         if (!blockOutput)
             return std::nullopt;
 

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESGCMGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESGCMGCrypt.cpp
@@ -170,10 +170,8 @@ static std::optional<Vector<uint8_t>> gcryptDecrypt(const Vector<uint8_t>& key, 
             return std::nullopt;
         }
 
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-        if (constantTimeMemcmp(tag.data(), cipherText.data() + cipherLength, tagLength))
+        if (constantTimeMemcmp(tag.data(), cipherText.subspan(cipherLength).data(), tagLength))
             return std::nullopt;
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     return output;

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp
@@ -85,7 +85,7 @@ static std::optional<Vector<uint8_t>> gcryptSign(gcry_sexp_t keySexp, const Vect
             return std::nullopt;
 
         gcry_error_t error = gcry_sexp_build(&dataSexp, nullptr, "(data(flags raw)(hash %s %b))",
-            *shaAlgorithm, dataHash.size(), dataHash.data());
+            shaAlgorithm->characters(), dataHash.size(), dataHash.data());
         if (error != GPG_ERR_NO_ERROR) {
             PAL::GCrypt::logError(error);
             return std::nullopt;
@@ -139,10 +139,8 @@ static std::optional<bool> gcryptVerify(gcry_sexp_t keySexp, const Vector<uint8_
 
     // Construct the sig-val s-expression, extracting the r and s components from the signature vector.
     PAL::GCrypt::Handle<gcry_sexp_t> signatureSexp;
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
     gcry_error_t error = gcry_sexp_build(&signatureSexp, nullptr, "(sig-val(ecdsa(r %b)(s %b)))",
-        keySizeInBytes, signature.data(), keySizeInBytes, signature.data() + keySizeInBytes);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        keySizeInBytes, signature.data(), keySizeInBytes, signature.subspan(keySizeInBytes).data());
     if (error != GPG_ERR_NO_ERROR) {
         PAL::GCrypt::logError(error);
         return std::nullopt;
@@ -156,7 +154,7 @@ static std::optional<bool> gcryptVerify(gcry_sexp_t keySexp, const Vector<uint8_
             return std::nullopt;
 
         error = gcry_sexp_build(&dataSexp, nullptr, "(data(flags raw)(hash %s %b))",
-            *shaAlgorithm, dataHash.size(), dataHash.data());
+            shaAlgorithm->characters(), dataHash.size(), dataHash.data());
         if (error != GPG_ERR_NO_ERROR) {
             PAL::GCrypt::logError(error);
             return std::nullopt;

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp
@@ -105,10 +105,8 @@ static ExceptionOr<bool> verifyEd25519(const Vector<uint8_t>& key, size_t keyLen
 
     // Construct the sig-val s-expression, extracting the r and s components from the signature vector.
     PAL::GCrypt::Handle<gcry_sexp_t> signatureSexp;
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
     gcry_error_t error = gcry_sexp_build(&signatureSexp, nullptr, "(sig-val(eddsa(r %b)(s %b)))",
-        keyLengthInBytes, signature.data(), keyLengthInBytes, signature.data() + keyLengthInBytes);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        keyLengthInBytes, signature.data(), keyLengthInBytes, signature.subspan(keyLengthInBytes).data());
     if (error != GPG_ERR_NO_ERROR) {
         PAL::GCrypt::logError(error);
         return false;

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSASSA_PKCS1_v1_5GCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSASSA_PKCS1_v1_5GCrypt.cpp
@@ -58,7 +58,7 @@ static std::optional<Vector<uint8_t>> gcryptSign(gcry_sexp_t keySexp, const Vect
             return std::nullopt;
 
         gcry_error_t error = gcry_sexp_build(&dataSexp, nullptr, "(data(flags pkcs1)(hash %s %b))",
-            *shaAlgorithm, dataHash.size(), dataHash.data());
+            shaAlgorithm->characters(), dataHash.size(), dataHash.data());
         if (error != GPG_ERR_NO_ERROR) {
             PAL::GCrypt::logError(error);
             return std::nullopt;
@@ -118,7 +118,7 @@ static std::optional<bool> gcryptVerify(gcry_sexp_t keySexp, const Vector<uint8_
             return std::nullopt;
 
         error = gcry_sexp_build(&dataSexp, nullptr, "(data(flags pkcs1)(hash %s %b))",
-            *shaAlgorithm, dataHash.size(), dataHash.data());
+            shaAlgorithm->characters(), dataHash.size(), dataHash.data());
         if (error != GPG_ERR_NO_ERROR) {
             PAL::GCrypt::logError(error);
             return std::nullopt;

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSA_OAEPGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSA_OAEPGCrypt.cpp
@@ -44,7 +44,7 @@ static std::optional<Vector<uint8_t>> gcryptEncrypt(CryptoAlgorithmIdentifier ha
             return std::nullopt;
 
         gcry_error_t error = gcry_sexp_build(&dataSexp, nullptr, "(data(flags oaep)(hash-algo %s)(label %b)(value %b))",
-            *shaAlgorithm, labelVector.size(), labelVector.data(), plainText.size(), plainText.data());
+            shaAlgorithm->characters(), labelVector.size(), labelVector.data(), plainText.size(), plainText.data());
         if (error != GPG_ERR_NO_ERROR) {
             PAL::GCrypt::logError(error);
             return std::nullopt;
@@ -82,7 +82,7 @@ static std::optional<Vector<uint8_t>> gcryptDecrypt(CryptoAlgorithmIdentifier ha
             return std::nullopt;
 
         gcry_error_t error = gcry_sexp_build(&encValSexp, nullptr, "(enc-val(flags oaep)(hash-algo %s)(label %b)(rsa(a %b)))",
-            *shaAlgorithm, labelVector.size(), labelVector.data(), cipherText.size(), cipherText.data());
+            shaAlgorithm->characters(), labelVector.size(), labelVector.data(), cipherText.size(), cipherText.data());
         if (error != GPG_ERR_NO_ERROR) {
             PAL::GCrypt::logError(error);
             return std::nullopt;

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSA_PSSGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSA_PSSGCrypt.cpp
@@ -59,7 +59,7 @@ static std::optional<Vector<uint8_t>> gcryptSign(gcry_sexp_t keySexp, const Vect
             return std::nullopt;
 
         gcry_error_t error = gcry_sexp_build(&dataSexp, nullptr, "(data(flags pss)(salt-length %u)(hash %s %b))",
-            saltLength, *shaAlgorithm, dataHash.size(), dataHash.data());
+            saltLength, shaAlgorithm->characters(), dataHash.size(), dataHash.data());
         if (error != GPG_ERR_NO_ERROR) {
             PAL::GCrypt::logError(error);
             return std::nullopt;
@@ -119,7 +119,7 @@ static std::optional<bool> gcryptVerify(gcry_sexp_t keySexp, const Vector<uint8_
             return std::nullopt;
 
         error = gcry_sexp_build(&dataSexp, nullptr, "(data(flags pss)(salt-length %u)(hash %s %b))",
-            saltLength, *shaAlgorithm, dataHash.size(), dataHash.data());
+            saltLength, shaAlgorithm->characters(), dataHash.size(), dataHash.data());
         if (error != GPG_ERR_NO_ERROR) {
             PAL::GCrypt::logError(error);
             return std::nullopt;

--- a/Source/WebCore/crypto/gcrypt/CryptoKeyRSAGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoKeyRSAGCrypt.cpp
@@ -171,10 +171,10 @@ size_t CryptoKeyRSA::keySizeInBits() const
 static std::optional<uint32_t> exponentVectorToUInt32(const Vector<uint8_t>& exponent)
 {
     if (exponent.size() > 4) {
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-        if (std::any_of(exponent.begin(), exponent.end() - 4, [](uint8_t element) { return !!element; }))
-            return std::nullopt;
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        for (auto element : exponent.subspan(0, exponent.size() - 4)) {
+            if (!!element)
+                return std::nullopt;
+        }
     }
 
     uint32_t result = 0;

--- a/Source/WebCore/crypto/gcrypt/GCryptUtilities.cpp
+++ b/Source/WebCore/crypto/gcrypt/GCryptUtilities.cpp
@@ -31,19 +31,19 @@
 
 namespace WebCore {
 
-std::optional<const char*> hashAlgorithmName(CryptoAlgorithmIdentifier identifier)
+std::optional<ASCIILiteral> hashAlgorithmName(CryptoAlgorithmIdentifier identifier)
 {
     switch (identifier) {
     case CryptoAlgorithmIdentifier::SHA_1:
-        return "sha1";
+        return "sha1"_s;
     case CryptoAlgorithmIdentifier::SHA_224:
-        return "sha224";
+        return "sha224"_s;
     case CryptoAlgorithmIdentifier::SHA_256:
-        return "sha256";
+        return "sha256"_s;
     case CryptoAlgorithmIdentifier::SHA_384:
-        return "sha384";
+        return "sha384"_s;
     case CryptoAlgorithmIdentifier::SHA_512:
-        return "sha512";
+        return "sha512"_s;
     default:
         return std::nullopt;
     }
@@ -155,9 +155,7 @@ std::optional<Vector<uint8_t>> mpiZeroPrefixedData(gcry_mpi_t paramMPI, size_t t
     // and copy the MPI data into memory area following the prefix (if any).
     Vector<uint8_t> output(targetLength, 0);
     size_t prefixLength = targetLength - *length;
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-    gcry_error_t error = gcry_mpi_print(GCRYMPI_FMT_USG, output.data() + prefixLength, targetLength, nullptr, paramMPI);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    gcry_error_t error = gcry_mpi_print(GCRYMPI_FMT_USG, const_cast<uint8_t*>(output.subspan(prefixLength).data()), targetLength, nullptr, paramMPI);
     if (error != GPG_ERR_NO_ERROR) {
         PAL::GCrypt::logError(error);
         return std::nullopt;

--- a/Source/WebCore/crypto/gcrypt/GCryptUtilities.h
+++ b/Source/WebCore/crypto/gcrypt/GCryptUtilities.h
@@ -71,7 +71,7 @@ static inline bool matches(const void* lhs, size_t size, const std::array<uint8_
 
 } // namespace CryptoConstants
 
-std::optional<const char*> hashAlgorithmName(CryptoAlgorithmIdentifier);
+std::optional<ASCIILiteral> hashAlgorithmName(CryptoAlgorithmIdentifier);
 
 std::optional<int> hmacAlgorithm(CryptoAlgorithmIdentifier);
 std::optional<int> digestAlgorithm(CryptoAlgorithmIdentifier);


### PR DESCRIPTION
#### 775df91afc0a2cd9844d4a543e73aa8123188274
<pre>
[GTK][WPE] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from gcrypt classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=283800">https://bugs.webkit.org/show_bug.cgi?id=283800</a>

Reviewed by Adrian Perez de Castro.

Leverage Vector::subspan() and others to avoid doing pointer arithmetic,
and as a drive-by adopt ASCIILiteral for the hash algorithm names.

* Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESCBCGCrypt.cpp:
(WebCore::gcryptEncrypt):
(WebCore::gcryptDecrypt):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESCTRGCrypt.cpp:
(WebCore::gcryptAESCTR):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESGCMGCrypt.cpp:
(WebCore::gcryptDecrypt):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp:
(WebCore::gcryptSign):
(WebCore::gcryptVerify):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp:
(WebCore::verifyEd25519):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSASSA_PKCS1_v1_5GCrypt.cpp:
(WebCore::gcryptSign):
(WebCore::gcryptVerify):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSA_OAEPGCrypt.cpp:
(WebCore::gcryptEncrypt):
(WebCore::gcryptDecrypt):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSA_PSSGCrypt.cpp:
(WebCore::gcryptSign):
(WebCore::gcryptVerify):
* Source/WebCore/crypto/gcrypt/CryptoKeyRSAGCrypt.cpp:
(WebCore::exponentVectorToUInt32):
* Source/WebCore/crypto/gcrypt/GCryptUtilities.cpp:
(WebCore::hashAlgorithmName):
(WebCore::mpiZeroPrefixedData):
(): Deleted.
* Source/WebCore/crypto/gcrypt/GCryptUtilities.h:

Canonical link: <a href="https://commits.webkit.org/287164@main">https://commits.webkit.org/287164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1463f4dad7e8aedfa9b8f9940728159fe3d5ec5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83193 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29797 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80665 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61512 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19425 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69685 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41823 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48868 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25339 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28134 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69967 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25712 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84559 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5897 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4036 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69737 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67499 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68991 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13010 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11443 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12135 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5844 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/11399 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5832 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9266 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7619 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->