### PR TITLE
[SOUP] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from CertificateInfoSoup

### DIFF
--- a/Source/WTF/wtf/glib/GSpanExtras.h
+++ b/Source/WTF/wtf/glib/GSpanExtras.h
@@ -108,6 +108,21 @@ static inline std::span<char*> span(char** strv)
     return unsafeMakeSpan(strv, size);
 }
 
+template <typename T = void*, typename = std::enable_if_t<std::is_pointer_v<T>>>
+inline std::span<T> span(GPtrArray* array)
+{
+    if (!array)
+        return unsafeMakeSpan<T>(nullptr, 0);
+
+    return unsafeMakeSpan(static_cast<T*>(static_cast<void*>(array->pdata)), array->len);
+}
+
+template <typename T = void*, typename = std::enable_if_t<std::is_pointer_v<T>>>
+inline std::span<T> span(GRefPtr<GPtrArray>& array)
+{
+    return span<T>(array.get());
+}
+
 } // namespace WTF
 
 using WTF::gKeyFileGetKeys;


### PR DESCRIPTION
#### 70e26459af60c7813a3948f8cc99559e472dc9a0
<pre>
[SOUP] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE from CertificateInfoSoup
<a href="https://bugs.webkit.org/show_bug.cgi?id=283801">https://bugs.webkit.org/show_bug.cgi?id=283801</a>

Reviewed by Adrian Perez de Castro.

* Source/WTF/wtf/glib/GSpanExtras.h: Add std::span constructors that take
a GPtrArray and GRefPtr&lt;GPtrArray&gt;.
* Source/WebCore/platform/network/soup/CertificateInfoSoup.cpp:
(WebCore::CertificateInfo::summary const): Replace
raw iteration over GPtrArray data with iteration over a span.

Canonical link: <a href="https://commits.webkit.org/287167@main">https://commits.webkit.org/287167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78751e76a1bac19d15487f1242903b1c03141723

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/32001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83280 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29883 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80752 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5945 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61578 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19500 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51599 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/70194 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41888 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48945 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25494 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28222 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/71762 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/70048 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84648 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/77854 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5984 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/4115 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69804 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/6145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/69058 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/13089 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11582 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/100164 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12137 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5931 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/11872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21877 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5918 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9353 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7706 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->